### PR TITLE
Added LuciDeviceScanner to scan OpenWrt Luci-RPC enabled router's state.

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -83,6 +83,16 @@ def from_config_file(config_path):
                 get_opt('device_tracker.netgear', 'username'),
                 get_opt('device_tracker.netgear', 'password'))
 
+        elif has_section('device_tracker.luci'):
+            device_tracker = load_module('device_tracker')
+
+            dev_scan_name = "Luci"
+
+            dev_scan = device_tracker.LuciDeviceScanner(
+                get_opt('device_tracker.luci', 'host'),
+                get_opt('device_tracker.luci', 'username'),
+                get_opt('device_tracker.luci', 'password'))
+
     except configparser.NoOptionError:
         # If one of the options didn't exist
         logger.exception(("Error initializing {}DeviceScanner, "


### PR DESCRIPTION
Just to play with it, implemented tracker for devices on Luci-based router.

For the time being, just getting MAC addresses from ARP table, and name->MAC mappings from dhcp configuration. As I'm planning to write my own logic backend for which this is sufficient, it's enough for me, but it may not work that well with the vanilla logic (due to ARP entries having short lifetime and quiet devices not sending any).

I'm not sure there's any low-power approach how to ensure that devices are present in the first place though.. (DHCP leases for example aren't that good way to track presence of hosts either.)
