### PR TITLE
Trigger on device groups

### DIFF
--- a/homeassistant/components/device_sun_light_trigger.py
+++ b/homeassistant/components/device_sun_light_trigger.py
@@ -21,6 +21,7 @@ LIGHT_PROFILE = 'relax'
 
 CONF_LIGHT_PROFILE = 'light_profile'
 CONF_LIGHT_GROUP = 'light_group'
+CONF_DEVICE_GROUP = 'device_group'
 
 
 # pylint: disable=too-many-branches
@@ -34,9 +35,13 @@ def setup(hass, config):
 
     light_profile = config[DOMAIN].get(CONF_LIGHT_PROFILE, LIGHT_PROFILE)
 
+    device_group = config[DOMAIN].get(CONF_LIGHT_GROUP,
+                                      device_tracker.GROUP_NAME_ALL_DEVICES)
+
     logger = logging.getLogger(__name__)
 
-    device_entity_ids = hass.states.entity_ids(device_tracker.DOMAIN)
+    device_entity_ids = group.get_entity_ids(hass, device_group,
+                                             device_tracker.DOMAIN)
 
     if not device_entity_ids:
         logger.error("No devices found to track")

--- a/homeassistant/components/device_sun_light_trigger.py
+++ b/homeassistant/components/device_sun_light_trigger.py
@@ -31,11 +31,12 @@ def setup(hass, config):
     disable_turn_off = 'disable_turn_off' in config[DOMAIN]
 
     light_group = config[DOMAIN].get(CONF_LIGHT_GROUP,
-                                     light.GROUP_NAME_ALL_LIGHTS)
+                                     'group.' + light.GROUP_NAME_ALL_LIGHTS)
 
     light_profile = config[DOMAIN].get(CONF_LIGHT_PROFILE, LIGHT_PROFILE)
 
-    device_group = config[DOMAIN].get(CONF_LIGHT_GROUP,
+    device_group = config[DOMAIN].get(CONF_DEVICE_GROUP,
+                                      'group.' +
                                       device_tracker.GROUP_NAME_ALL_DEVICES)
 
     logger = logging.getLogger(__name__)

--- a/homeassistant/components/device_sun_light_trigger.py
+++ b/homeassistant/components/device_sun_light_trigger.py
@@ -31,13 +31,12 @@ def setup(hass, config):
     disable_turn_off = 'disable_turn_off' in config[DOMAIN]
 
     light_group = config[DOMAIN].get(CONF_LIGHT_GROUP,
-                                     'group.' + light.GROUP_NAME_ALL_LIGHTS)
+                                     light.ENTITY_ID_ALL_LIGHTS)
 
     light_profile = config[DOMAIN].get(CONF_LIGHT_PROFILE, LIGHT_PROFILE)
 
     device_group = config[DOMAIN].get(CONF_DEVICE_GROUP,
-                                      'group.' +
-                                      device_tracker.GROUP_NAME_ALL_DEVICES)
+                                      device_tracker.ENTITY_ID_ALL_DEVICES)
 
     logger = logging.getLogger(__name__)
 

--- a/homeassistant/components/device_sun_light_trigger.py
+++ b/homeassistant/components/device_sun_light_trigger.py
@@ -147,7 +147,7 @@ def setup(hass, config):
                         break
 
         # Did all devices leave the house?
-        elif (entity == device_tracker.ENTITY_ID_ALL_DEVICES and
+        elif (entity == device_group and
               new_state.state == STATE_NOT_HOME and lights_are_on
               and not disable_turn_off):
 
@@ -163,8 +163,7 @@ def setup(hass, config):
 
     # Track when all devices are gone to shut down lights
     hass.states.track_change(
-        device_tracker.ENTITY_ID_ALL_DEVICES,
-        check_light_on_dev_state_change,
+        device_group, check_light_on_dev_state_change,
         STATE_HOME, STATE_NOT_HOME)
 
     return True


### PR DESCRIPTION
Update the device_sun_light_trigger so that it can trigger on a group of users, instead of triggering on all users.

This is useful for turning on my bedroom lights when I get home, even if my roommate is already home.
