### PR TITLE
Fix issue with some bulbs missing 'xy' attribute.

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -159,7 +159,8 @@ class HueLight(ToggleDevice):
 
         if self.is_on:
             attr[ATTR_BRIGHTNESS] = self.info['state']['bri']
-            attr[ATTR_XY_COLOR] = self.info['state']['xy']
+            if 'xy' in self.info['state']:
+                attr[ATTR_XY_COLOR] = self.info['state']['xy']
 
         return attr
 


### PR DESCRIPTION
Philips Lux bulbs (as well as other dimmable bulbs that work with the Hue hub) do not have an 'xy' attribute.
