### PR TITLE
Fix issue in Timer thread caused by variable name.

### DIFF
--- a/homeassistant/__init__.py
+++ b/homeassistant/__init__.py
@@ -776,7 +776,7 @@ class Timer(threading.Thread):
         self.daemon = True
         self.hass = hass
         self.interval = interval or TIMER_INTERVAL
-        self._stop = threading.Event()
+        self._stop_event = threading.Event()
 
         # We want to be able to fire every time a minute starts (seconds=0).
         # We want this so other modules can use that to make sure they fire
@@ -790,7 +790,7 @@ class Timer(threading.Thread):
         """ Start the timer. """
 
         self.hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP,
-                                  lambda event: self._stop.set())
+                                  lambda event: self._stop_event.set())
 
         _LOGGER.info("Timer:starting")
 
@@ -799,7 +799,7 @@ class Timer(threading.Thread):
         calc_now = dt.datetime.now
         interval = self.interval
 
-        while not self._stop.isSet():
+        while not self._stop_event.isSet():
             now = calc_now()
 
             # First check checks if we are not on a second matching the


### PR DESCRIPTION
threading.Thread already contains a _stop() function which is called in threading._after_fork().  Assigning an Event object to _stop caused periodic exceptions to be thrown.  This renames the _stop variable to _stop_event to prevent a naming collision.
