### PR TITLE
Update __init__.py

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -84,6 +84,6 @@ def setup(hass, config):
     discovery.listen(hass, DISCOVERY_PLATFORMS.keys(), sensor_discovered)
 
     # Fire every 3 seconds
-    hass.track_time_change(update_sensor_states, seconds=range(0, 60, 3))
+    hass.track_time_change(update_sensor_states, second=range(0, 60, 3))
 
     return True


### PR DESCRIPTION
Updated to fix the following error when loading sensors:

"home-assistant/homeassistant/components/sensor/**init**.py", line 87, in setup
    hass.track_time_change(update_sensor_states, seconds=range(0, 60, 3))
TypeError: track_time_change() got an unexpected keyword argument 'seconds'"

the named parameter was using seconds instead of second
