### PR TITLE
Fixed development mode for http component not working correctly

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -123,7 +123,7 @@ def setup(hass, config=None):
 
     server_port = config[DOMAIN].get(CONF_SERVER_PORT, SERVER_PORT)
 
-    development = config[DOMAIN].get(CONF_DEVELOPMENT, "") == "1"
+    development = str(config[DOMAIN].get(CONF_DEVELOPMENT, "")) == "1"
 
     server = HomeAssistantHTTPServer(
         (server_host, server_port), RequestHandler, hass, api_password,


### PR DESCRIPTION
When using the new YAML format for the config file the development mode for the http component was not working correctly because when the YAML is parsed the "development" config variable is an int and not a string so the comparison always failed.  It worked fine with the old config file format so I have converted the config value to a string to keep backwards compatibility rather than just change the compared value to an int.  I have tested with both the old and new versions of the config files.  This one drove me nuts, took a while to track down, I hope I save someone else some time.
