### PR TITLE
Issue with blank password

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -111,7 +111,7 @@ def setup(hass, config=None):
     if config is None or DOMAIN not in config:
         config = {DOMAIN: {}}
 
-    api_password = str(config[DOMAIN].get(CONF_API_PASSWORD))
+    api_password = util.convert(config[DOMAIN].get(CONF_API_PASSWORD), str)
 
     no_password_set = api_password is None
 


### PR DESCRIPTION
A recent change broke blank passwords, since casting None to a str results in a password of 'None'.
