### PR TITLE
Scene component

### DIFF
--- a/config/configuration.yaml.example
+++ b/config/configuration.yaml.example
@@ -120,3 +120,21 @@ sensor:
     - type: 'processor_use'
     - type: 'process'
       arg: 'octave-cli'
+
+scene:
+  # Turns on the bedroom lights and then the living room lights 1 minute later
+  wakeup:
+    alias: Wake Up
+    sequence:
+      # alias is optional
+      - alias: Bedroom lights on
+        execute_service: light.turn_on
+        service_data:
+          entity_id: group.bedroom
+      - delay:
+          # supports seconds, milliseconds, minutes, hours, etc.
+          minutes: 1
+      - alias: Living room lights on
+        execute_service: light.turn_on
+        service_data:
+          entity_id: group.living_room

--- a/homeassistant/components/scene.py
+++ b/homeassistant/components/scene.py
@@ -1,0 +1,82 @@
+"""
+homeassistant.components.scene
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Scenes are a sequence of actions that can be triggered manually
+by the user or automatically based upon automation events, etc.
+"""
+import logging
+from datetime import datetime, timedelta
+
+from homeassistant.util import split_entity_id
+
+DOMAIN = "scene"
+DEPENDENCIES = ["group"]
+
+SERVICE_RUN = "run"
+CONF_ALIAS = "alias"
+CONF_SCENE_NAME = "scene_name"
+CONF_SERVICE = "execute_service"
+CONF_SERVICE_DATA = "service_data"
+CONF_SEQUENCE = "sequence"
+CONF_DELAY = "delay"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup(hass, config):
+    """ Load the scenes from the configuration. """
+
+    scenes = {}
+    for name, cfg in config.get(DOMAIN, {}).items():
+        scene = create_scene(name, cfg)
+        if scene:
+            _LOGGER.info("Registered scene %s", name)
+            scenes[name] = scene
+
+    def handle_scene_service(service):
+        """ Handle a scene service call. """
+        data = service.data
+        name = data.get(CONF_SCENE_NAME)
+        if name in scenes:
+            scenes[name](hass)
+        else:
+            _LOGGER.warn("Unknown scene: %s", name)
+
+    hass.services.register(DOMAIN, SERVICE_RUN, handle_scene_service)
+
+    return True
+
+
+def create_scene(scene_name, config):
+    """ Returns a scene. """
+
+    if not CONF_SEQUENCE in config:
+        _LOGGER.warn("Missing key 'sequence' for scene %s", scene_name)
+        return
+
+    def run_scene(hass):
+        """ Executes a sequence of actions for a scene. """
+        _LOGGER.info("Executing scene %s", config.get(CONF_ALIAS, scene_name))
+        point_in_time = datetime.now()
+        for action in config[CONF_SEQUENCE]:
+            if CONF_SERVICE in action:
+                call_service(hass, scene_name, action, point_in_time)
+            elif CONF_DELAY in action:
+                point_in_time += timedelta(**action[CONF_DELAY])
+
+    return run_scene
+
+
+def call_service(hass, scene_name, config, point_in_time):
+    """ Calls a service at some point in time. """
+    domain, service = split_entity_id(config[CONF_SERVICE])
+    data = config.get(CONF_SERVICE_DATA, {})
+
+    def call(now):
+        """ Actually calls the service. """
+        _LOGGER.info("Executing scene %s step %s", scene_name,
+                     config.get(CONF_ALIAS, ""))
+        hass.services.call(domain, service, data)
+
+    hass.track_point_in_time(call, point_in_time)

--- a/homeassistant/helpers/__init__.py
+++ b/homeassistant/helpers/__init__.py
@@ -98,14 +98,17 @@ def config_per_platform(config, domain, logger):
 
     while config_key in config:
         platform_config = config[config_key]
+        if type(platform_config) is not list:
+            platform_config = [platform_config]
 
-        platform_type = platform_config.get(CONF_PLATFORM)
+        for item in platform_config:
+            platform_type = item.get(CONF_PLATFORM)
 
-        if platform_type is None:
-            logger.warning('No platform specified for %s', config_key)
-            break
+            if platform_type is None:
+                logger.warning('No platform specified for %s', config_key)
+                break
 
-        yield platform_type, platform_config
+            yield platform_type, item
 
         found += 1
         config_key = "{} {}".format(domain, found)


### PR DESCRIPTION
The scene component allows users to specify a sequence of actions, or service calls, in the configuration file and run those in order with the scene.run service.  Previously this would have required a custom module, but now simple configurations be expressed in just the configuration.yaml file.

I also updated config_per_platform to handle lists.  This isn't required by the scene component (which is why it is in a separate commit), but it makes expressing automation rules in the new yaml config file a little better.  The old format is still supported too.

I would really like to add a UI component for scenes, but I wanted to get some feedback first.  I'm not sure of the best approach.  Scenes could be "states" in that they are either running or not running.  However, it would be kind of nice to have them grouped separately from other devices/states in the UI.
