### PR TITLE
Convert MAC addresses to uppercase on load

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -236,7 +236,7 @@ class DeviceTracker(object):
 
             try:
                 for row in csv.DictReader(inp):
-                    device = row['device']
+                    device = row['device'].upper()
 
                     if row['track'] == '1':
                         if device in self.tracked:


### PR DESCRIPTION
This fixed an issue for me where my known_devices file had lowercase MAC
addresses, but the device tracker returns uppercase MAC addresses.
