### PR TITLE
Turn off correct lights

### DIFF
--- a/homeassistant/components/device_sun_light_trigger.py
+++ b/homeassistant/components/device_sun_light_trigger.py
@@ -153,7 +153,7 @@ def setup(hass, config):
             logger.info(
                 "Everyone has left but there are lights on. Turning them off")
 
-            light.turn_off(hass)
+            light.turn_off(hass, light_ids)
 
     # Track home coming of each device
     hass.states.track_change(


### PR DESCRIPTION
Only turn off the lights specified in the sun light trigger.
I use this to turn off my bedroom lights when I leave, even if my
housemates are still home.
