### PR TITLE
Add python-version file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+.python-version


### PR DESCRIPTION
This file is an artifact of pyenv and should likely be in the gitignore.
