### PR TITLE
Improve NMAP lock issues

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -157,7 +157,8 @@ class DeviceTracker(object):
 
     def update_devices(self, now):
         """ Update device states based on the found devices. """
-        self.lock.acquire()
+        if not self.lock.acquire(False):
+            return
 
         found_devices = set(dev.upper() for dev in
                             self.device_scanner.scan_devices())


### PR DESCRIPTION
The following changes should help in preventing the device tracker and NMAP platform crashing the bus.

The changes to nmap_tracker.py are mainly indentation changes after the lock has been removed (which is not needed because of the Throttle annotation). Only difference is adding `--host-timeout 5` to the options.
