### PR TITLE
Tweak visibility config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,18 +33,16 @@ These attributes are defined in [homeassistant.components](https://github.com/ba
 
 ## Proper Visibility Handling ##
 
-Generally, when creating a new entity for Home Assistant you will want it to be a class that inherits the [homeassistant.helpers.entity.Entity](https://github.com/balloob/home-assistant/blob/master/homeassistant/helpers/entity.py] Class. If this is done, visibility will be handled for you. 
-You can set a suggestion for your entitie's visibility by setting the hidden property by doing something similar to the following.
+Generally, when creating a new entity for Home Assistant you will want it to be a class that inherits the [homeassistant.helpers.entity.Entity](https://github.com/balloob/home-assistant/blob/master/homeassistant/helpers/entity.py) Class. If this is done, visibility will be handled for you. 
+You can set a suggestion for your entity's visibility by setting the hidden property by doing something similar to the following.
 
 ```python
 self.hidden = True
 ```
 
-This will SUGGEST that the active frontend hide the entity. This requires that the active frontend support hidden cards (the default frontend does) and that the value of hidden be included in your attributes dictionary (see above). The Entity abstract class will take care of this for you.
+This will SUGGEST that the active frontend hides the entity. This requires that the active frontend support hidden cards (the default frontend does) and that the value of hidden be included in your attributes dictionary (see above). The Entity abstract class will take care of this for you.
 
-Remember: The suggestion set by your component's code will always be overwritten by manual settings in the configuration.yaml file. This is why you may set hidden to be False, but the property may remain True (or vice-versa).
-
-If you would not like to use the Entity Abstract Class, you may also inherity the Visibility Abstract Class which will include the logic for the hidden property but not automatically add the hidden property to the attributes dictionary. If you use this class, ensure that your class correctly adds the hidden property to the attributes.
+Remember: The suggestion set by your component's code will always be overwritten by user settings in the configuration.yaml file. This is why you may set hidden to be False, but the property may remain True (or vice-versa).
 
 ## Working on the frontend
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -20,11 +20,11 @@ import homeassistant
 import homeassistant.loader as loader
 import homeassistant.components as core_components
 import homeassistant.components.group as group
-from homeassistant.helpers.entity import VisibilityABC
+from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
     EVENT_COMPONENT_LOADED, CONF_LATITUDE, CONF_LONGITUDE,
-    CONF_TEMPERATURE_UNIT, CONF_NAME, CONF_TIME_ZONE, TEMP_CELCIUS,
-    TEMP_FAHRENHEIT)
+    CONF_TEMPERATURE_UNIT, CONF_NAME, CONF_TIME_ZONE, CONF_VISIBILITY,
+    TEMP_CELCIUS, TEMP_FAHRENHEIT)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -208,7 +208,8 @@ def process_ha_core_config(hass, config):
         if key in config:
             setattr(hass.config, attr, config[key])
 
-    VisibilityABC.visibility.update(config.get('visibility', {}))
+    for entity_id, hidden in config.get(CONF_VISIBILITY, {}).items():
+        Entity.overwrite_hidden(entity_id, hidden == 'hide')
 
     if CONF_TEMPERATURE_UNIT in config:
         unit = config[CONF_TEMPERATURE_UNIT]

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -11,6 +11,7 @@ CONF_LONGITUDE = "longitude"
 CONF_TEMPERATURE_UNIT = "temperature_unit"
 CONF_NAME = "name"
 CONF_TIME_ZONE = "time_zone"
+CONF_VISIBILITY = "visibility"
 
 CONF_PLATFORM = "platform"
 CONF_HOST = "host"

--- a/tests/test_component_group.py
+++ b/tests/test_component_group.py
@@ -54,7 +54,7 @@ class TestComponentsGroup(unittest.TestCase):
             self.hass, 'light_and_nothing',
             ['light.Bowl', 'non.existing'])
 
-        self.assertEqual(STATE_ON, grp.state.state)
+        self.assertEqual(STATE_ON, grp.state)
 
     def test_setup_group_with_non_groupable_states(self):
         self.hass.states.set('cast.living_room', "Plex")
@@ -64,13 +64,13 @@ class TestComponentsGroup(unittest.TestCase):
             self.hass, 'chromecasts',
             ['cast.living_room', 'cast.bedroom'])
 
-        self.assertEqual(STATE_UNKNOWN, grp.state.state)
+        self.assertEqual(STATE_UNKNOWN, grp.state)
 
     def test_setup_empty_group(self):
         """ Try to setup an empty group. """
         grp = group.setup_group(self.hass, 'nothing', [])
 
-        self.assertEqual(STATE_UNKNOWN, grp.state.state)
+        self.assertEqual(STATE_UNKNOWN, grp.state)
 
     def test_monitor_group(self):
         """ Test if the group keeps track of states. """

--- a/tests/test_helper_entity.py
+++ b/tests/test_helper_entity.py
@@ -20,15 +20,15 @@ class TestHelpersEntity(unittest.TestCase):
         self.entity = entity.Entity()
         self.entity.entity_id = 'test.overwrite_hidden_true'
         self.hass = self.entity.hass = ha.HomeAssistant()
+        self.entity.update_ha_state()
 
     def tearDown(self):  # pylint: disable=invalid-name
         """ Stop down stuff we started. """
         self.hass.stop()
+        entity.Entity.overwrite_hidden(self.entity.entity_id, None)
 
     def test_default_hidden_not_in_attributes(self):
         """ Test that the default hidden property is set to False. """
-        self.entity.update_ha_state()
-
         self.assertNotIn(
             ATTR_HIDDEN,
             self.hass.states.get(self.entity.entity_id).attributes)
@@ -41,29 +41,20 @@ class TestHelpersEntity(unittest.TestCase):
 
         self.assertTrue(state.attributes.get(ATTR_HIDDEN))
 
-        self.entity.hidden = False
-
     def test_overwriting_hidden_property_to_true(self):
         """ Test we can overwrite hidden property to True. """
         entity.Entity.overwrite_hidden(self.entity.entity_id, True)
-
         self.entity.update_ha_state()
 
         state = self.hass.states.get(self.entity.entity_id)
-
         self.assertTrue(state.attributes.get(ATTR_HIDDEN))
-
-        entity.Entity.overwrite_hidden(self.entity.entity_id, None)
 
     def test_overwriting_hidden_property_to_false(self):
         """ Test we can overwrite hidden property to True. """
         entity.Entity.overwrite_hidden(self.entity.entity_id, False)
-
         self.entity.hidden = True
         self.entity.update_ha_state()
 
         self.assertNotIn(
             ATTR_HIDDEN,
             self.hass.states.get(self.entity.entity_id).attributes)
-
-        entity.Entity.overwrite_hidden(self.entity.entity_id, None)

--- a/tests/test_helper_entity.py
+++ b/tests/test_helper_entity.py
@@ -1,0 +1,69 @@
+"""
+tests.test_helper_entity
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests the entity helper.
+"""
+# pylint: disable=protected-access,too-many-public-methods
+import unittest
+
+import homeassistant as ha
+import homeassistant.helpers.entity as entity
+from homeassistant.const import ATTR_HIDDEN
+
+
+class TestHelpersEntity(unittest.TestCase):
+    """ Tests homeassistant.helpers.entity module. """
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """ Init needed objects. """
+        self.entity = entity.Entity()
+        self.entity.entity_id = 'test.overwrite_hidden_true'
+        self.hass = self.entity.hass = ha.HomeAssistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """ Stop down stuff we started. """
+        self.hass.stop()
+
+    def test_default_hidden_not_in_attributes(self):
+        """ Test that the default hidden property is set to False. """
+        self.entity.update_ha_state()
+
+        self.assertNotIn(
+            ATTR_HIDDEN,
+            self.hass.states.get(self.entity.entity_id).attributes)
+
+    def test_setting_hidden_to_true(self):
+        self.entity.hidden = True
+        self.entity.update_ha_state()
+
+        state = self.hass.states.get(self.entity.entity_id)
+
+        self.assertTrue(state.attributes.get(ATTR_HIDDEN))
+
+        self.entity.hidden = False
+
+    def test_overwriting_hidden_property_to_true(self):
+        """ Test we can overwrite hidden property to True. """
+        entity.Entity.overwrite_hidden(self.entity.entity_id, True)
+
+        self.entity.update_ha_state()
+
+        state = self.hass.states.get(self.entity.entity_id)
+
+        self.assertTrue(state.attributes.get(ATTR_HIDDEN))
+
+        entity.Entity.overwrite_hidden(self.entity.entity_id, None)
+
+    def test_overwriting_hidden_property_to_false(self):
+        """ Test we can overwrite hidden property to True. """
+        entity.Entity.overwrite_hidden(self.entity.entity_id, False)
+
+        self.entity.hidden = True
+        self.entity.update_ha_state()
+
+        self.assertNotIn(
+            ATTR_HIDDEN,
+            self.hass.states.get(self.entity.entity_id).attributes)
+
+        entity.Entity.overwrite_hidden(self.entity.entity_id, None)


### PR DESCRIPTION
After migrating group to use entity I was looking at the VisibilityABC class. In my opinion it fits better integrated into Entity instead of being a standalone class. Also figured that comparing to a string 'hide' should be part of the config parsing (bootstrap module) and not in the helper.

This pull request fixes both. Added some tests to make sure I didn't break anything.
