### PR TITLE
Allow & ignore non JSON body in API Requests

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -217,13 +217,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
             try:
                 data.update(json.loads(body_content))
             except (TypeError, ValueError):
-                # TypeError if JSON object is not a dict
-                # ValueError if we could not parse JSON
-                _LOGGER.exception(
-                    "Exception parsing JSON: %s", body_content)
-                self.write_json_message(
-                    "Error parsing JSON", HTTP_UNPROCESSABLE_ENTITY)
-                return
+                _LOGGER.info("POST Request body not JSON - ignoring.");
 
         if self.server.no_password_set:
             api_password = self.server.api_password


### PR DESCRIPTION
Many apps like geofency send POST requests and attach their own parameters in non-JSON format. Previously such POST requests were aborted and not processed by the API. Now the error is logged, but the request is not aborted. The API can still use the parameters from the URL query parameters in the data dictionary
