### PR TITLE
Vera fixes for UI7 firmware update

### DIFF
--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -77,7 +77,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     controller = veraApi.VeraController(base_url)
     devices = []
     try:
-        devices = controller.get_devices('Switch')
+        devices = controller.get_devices(['Switch', 'On/Off Switch'])
     except RequestException:
         # There was a network related error connecting to the vera controller
         _LOGGER.exception("Error communicating with Vera API")

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -148,7 +148,7 @@ class VeraSensor(Entity):
             last_tripped = self.vera_device.refresh_value('LastTrip')
             if last_tripped is not None:
                 utc_time = dt_util.utc_from_timestamp(int(last_tripped))
-                attr[ATTR_LAST_TRIP_TIME] = dt_util.datetime_to_local_str(
+                attr[ATTR_LAST_TRIP_TIME] = dt_util.datetime_to_str(
                     utc_time)
             else:
                 attr[ATTR_LAST_TRIP_TIME] = None

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -51,8 +51,8 @@ it should be set to "true" if you want this device excluded
 
 """
 import logging
-import time
 from requests.exceptions import RequestException
+import homeassistant.util.dt as dt_util
 
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
@@ -146,11 +146,12 @@ class VeraSensor(Entity):
 
         if self.vera_device.is_trippable:
             last_tripped = self.vera_device.refresh_value('LastTrip')
-            trip_time_str = time.strftime(
-                "%Y-%m-%d %H:%M",
-                time.localtime(int(last_tripped))
-            )
-            attr[ATTR_LAST_TRIP_TIME] = trip_time_str
+            if last_tripped is not None:
+                utc_time = dt_util.utc_from_timestamp(int(last_tripped))
+                attr[ATTR_LAST_TRIP_TIME] = dt_util.datetime_to_local_str(
+                    utc_time)
+            else:
+                attr[ATTR_LAST_TRIP_TIME] = None
             tripped = self.vera_device.refresh_value('Tripped')
             attr[ATTR_TRIPPED] = 'True' if tripped == '1' else 'False'
 

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -136,7 +136,7 @@ class VeraSwitch(ToggleEntity):
             last_tripped = self.vera_device.refresh_value('LastTrip')
             if last_tripped is not None:
                 utc_time = dt_util.utc_from_timestamp(int(last_tripped))
-                attr[ATTR_LAST_TRIP_TIME] = dt_util.datetime_to_local_str(
+                attr[ATTR_LAST_TRIP_TIME] = dt_util.datetime_to_str(
                     utc_time)
             else:
                 attr[ATTR_LAST_TRIP_TIME] = None

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -51,6 +51,7 @@ it should be set to "true" if you want this device excluded
 import logging
 import time
 from requests.exceptions import RequestException
+import homeassistant.util.dt as dt_util
 
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.const import (
@@ -78,7 +79,8 @@ def get_devices(hass, config):
     vera_controller = veraApi.VeraController(base_url)
     devices = []
     try:
-        devices = vera_controller.get_devices(['Switch', 'Armable Sensor'])
+        devices = vera_controller.get_devices([
+            'Switch', 'Armable Sensor', 'On/Off Switch'])
     except RequestException:
         # There was a network related error connecting to the vera controller
         _LOGGER.exception("Error communicating with Vera API")
@@ -132,11 +134,12 @@ class VeraSwitch(ToggleEntity):
 
         if self.vera_device.is_trippable:
             last_tripped = self.vera_device.refresh_value('LastTrip')
-            trip_time_str = time.strftime(
-                "%Y-%m-%d %H:%M",
-                time.localtime(int(last_tripped))
-            )
-            attr[ATTR_LAST_TRIP_TIME] = trip_time_str
+            if last_tripped is not None:
+                utc_time = dt_util.utc_from_timestamp(int(last_tripped))
+                attr[ATTR_LAST_TRIP_TIME] = dt_util.datetime_to_local_str(
+                    utc_time)
+            else:
+                attr[ATTR_LAST_TRIP_TIME] = None
             tripped = self.vera_device.refresh_value('Tripped')
             attr[ATTR_TRIPPED] = 'True' if tripped == '1' else 'False'
 


### PR DESCRIPTION
This pull request has a number of changes:
- Fix the exception when a parsing date for trippable device that has never been tripped
- Add the new switch category for the UI7 firmware update
- Point the submodule reference to the latest vera api commit

This maintains backwards compatibility with the previous firmware version.
