### PR TITLE
Added basic http sessions for authentication

### DIFF
--- a/config/configuration.yaml.example
+++ b/config/configuration.yaml.example
@@ -19,6 +19,7 @@ http:
   api_password: mypass
   # Set to 1 to enable development mode
   # development: 1
+  # sessions_enabled: True
 
 light:
 #  platform: hue
@@ -68,7 +69,7 @@ device_sun_light_trigger:
 
 # A comma separated list of states that have to be tracked as a single group
 # Grouped states should share the same type of states (ON/OFF or HOME/NOT_HOME)
-group: 
+group:
   living_room:
     - light.Bowl
     - light.Ceiling

--- a/config/configuration.yaml.example
+++ b/config/configuration.yaml.example
@@ -19,7 +19,6 @@ http:
   api_password: mypass
   # Set to 1 to enable development mode
   # development: 1
-  # sessions_enabled: True
 
 light:
 #  platform: hue

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -216,8 +216,8 @@ class RequestHandler(SimpleHTTPRequestHandler):
 
     def __init__(self, req, client_addr, server):
         """ Contructor, call the base constructor and set up session """
-        SimpleHTTPRequestHandler.__init__(self, req, client_addr, server)
         self._session = None
+        SimpleHTTPRequestHandler.__init__(self, req, client_addr, server)
 
     def _handle_request(self, method):  # pylint: disable=too-many-branches
         """ Does some common checks and calls appropriate method. """
@@ -433,8 +433,8 @@ class RequestHandler(SimpleHTTPRequestHandler):
             if session is not None:
                 session.reset_expiry()
             return session
-        else:
-            return None
+
+        return None
 
     def get_current_session_id(self):
         """

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -154,6 +154,7 @@ def setup(hass, config=None):
 
     return True
 
+
 # pylint: disable=too-many-instance-attributes
 class HomeAssistantHTTPServer(ThreadingMixIn, HTTPServer):
     """ Handle HTTP requests in a threaded fashion. """


### PR DESCRIPTION
Added basic support for HTTP sessions.  This can be used for securing assets such as images where the request header options for security can not be set without the need to pass the api_password on the query string.
