### PR TITLE
Let the nmap device tracker return upper case MAC addresses.

### DIFF
--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -120,7 +120,7 @@ class NmapDeviceScanner(object):
                     else:
                         mac = _arp(host.ipv4)
                     if mac:
-                        device = Device(mac, name, host.ipv4, now)
+                        device = Device(mac.upper(), name, host.ipv4, now)
                         self.last_results.append(device)
             _LOGGER.info("nmap scan successful")
             return True


### PR DESCRIPTION
I noticed this bug because my known_devices.csv always contained "unknown device". After this patch, it is filled with the correct names.

The webinterface is still not showing my devices, but I'm still investigating that.
