### PR TITLE
Add a configuration option to track new devices by default

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -41,6 +41,8 @@ CONF_SECONDS = "interval_seconds"
 
 DEFAULT_CONF_SECONDS = 12
 
+TRACK_NEW_DEVICES = "track_new_devices"
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -78,7 +80,10 @@ def setup(hass, config):
     seconds = util.convert(config[DOMAIN].get(CONF_SECONDS), int,
                            DEFAULT_CONF_SECONDS)
 
-    tracker = DeviceTracker(hass, device_scanner, seconds)
+    track_new_devices = config[DOMAIN].get(TRACK_NEW_DEVICES) or False
+    _LOGGER.info("Tracking new devices: %s", track_new_devices)
+
+    tracker = DeviceTracker(hass, device_scanner, seconds, track_new_devices)
 
     # We only succeeded if we got to parse the known devices file
     return not tracker.invalid_known_devices_file
@@ -87,12 +92,15 @@ def setup(hass, config):
 class DeviceTracker(object):
     """ Class that tracks which devices are home and which are not. """
 
-    def __init__(self, hass, device_scanner, seconds):
+    def __init__(self, hass, device_scanner, seconds, track_new_devices):
         self.hass = hass
 
         self.device_scanner = device_scanner
 
         self.lock = threading.Lock()
+
+        # Do we track new devices by default?
+        self.track_new_devices = track_new_devices
 
         # Dictionary to keep track of known devices and devices we track
         self.tracked = {}
@@ -176,7 +184,8 @@ class DeviceTracker(object):
         new_devices = found_devices - self.untracked_devices
 
         if new_devices:
-            self.untracked_devices.update(new_devices)
+            if not self.track_new_devices:
+                self.untracked_devices.update(new_devices)
 
             # Write new devices to known devices file
             if not self.invalid_known_devices_file:
@@ -204,7 +213,15 @@ class DeviceTracker(object):
                             dname = self.device_scanner.get_device_name(device)
                             name = dname or "unknown device"
 
-                            writer.writerow((device, name, 0, ""))
+                            track = 0
+                            if self.track_new_devices:
+                                self._track_device(device, name)
+                                track = 1
+
+                            writer.writerow((device, name, track, ""))
+
+                    if self.track_new_devices:
+                        self._generate_entity_ids(new_devices)
 
                 except IOError:
                     _LOGGER.exception(
@@ -227,7 +244,6 @@ class DeviceTracker(object):
         self.untracked_devices.clear()
 
         with open(known_dev_path) as inp:
-            default_last_seen = dt_util.utcnow().replace(year=1990)
 
             # To track which devices need an entity_id assigned
             need_entity_id = []
@@ -248,10 +264,7 @@ class DeviceTracker(object):
                             # We found a new device
                             need_entity_id.append(device)
 
-                            self.tracked[device] = {
-                                'name': row['name'],
-                                'last_seen': default_last_seen
-                            }
+                            self._track_device(device, row['name'])
 
                         # Update state_attr with latest from file
                         state_attr = {
@@ -276,21 +289,7 @@ class DeviceTracker(object):
 
                     self.tracked.pop(device)
 
-                # Setup entity_ids for the new devices
-                used_entity_ids = [info['entity_id'] for device, info
-                                   in self.tracked.items()
-                                   if device not in need_entity_id]
-
-                for device in need_entity_id:
-                    name = self.tracked[device]['name']
-
-                    entity_id = util.ensure_unique_string(
-                        ENTITY_ID_FORMAT.format(util.slugify(name)),
-                        used_entity_ids)
-
-                    used_entity_ids.append(entity_id)
-
-                    self.tracked[device]['entity_id'] = entity_id
+                self._generate_entity_ids(need_entity_id)
 
                 if not self.tracked:
                     _LOGGER.warning(
@@ -309,3 +308,34 @@ class DeviceTracker(object):
 
             finally:
                 self.lock.release()
+
+    def _track_device(self, device, name):
+        """
+        Add a device to the list of tracked devices.
+        Does not generate the entity id yet.
+        """
+        default_last_seen = dt_util.utcnow().replace(year=1990)
+
+        self.tracked[device] = {
+            'name': name,
+            'last_seen': default_last_seen,
+            'state_attr': {ATTR_FRIENDLY_NAME: name}
+        }
+
+    def _generate_entity_ids(self, need_entity_id):
+        """ Generate entity ids for a list of devices. """
+        # Setup entity_ids for the new devices
+        used_entity_ids = [info['entity_id'] for device, info
+                           in self.tracked.items()
+                           if device not in need_entity_id]
+
+        for device in need_entity_id:
+            name = self.tracked[device]['name']
+
+            entity_id = util.ensure_unique_string(
+                ENTITY_ID_FORMAT.format(util.slugify(name)),
+                used_entity_ids)
+
+            used_entity_ids.append(entity_id)
+
+            self.tracked[device]['entity_id'] = entity_id


### PR DESCRIPTION
As you may have noticed from my other mails/issues/pull requests, I found it very counter-intuitive that new devices are not added automatically.

This patch adds a configuration option to track new devices by default. Without the configuration option, it works as it always has.
