### PR TITLE
Added app name display to Chromecast component.

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -153,7 +153,8 @@ class CastDevice(MediaPlayerDevice):
     @property
     def media_title(self):
         """ Title of current playing media. """
-        return self.media_status.title if self.media_status else None
+        title = self.media_status.title if self.media_status else None
+        return title if title else self.cast.app_display_name
 
     @property
     def media_artist(self):


### PR DESCRIPTION
Just a small change. Modified the Chromecast component to display the current applications name if the media title could not be retrieved. This is useful for apps like Netflix that cannot be reverse engineered. HA won't show exactly what is playing, but at least it will say Netflix... or... you know.. whatever else.
