### PR TITLE
Use xy_color instead of color in the configuration example

### DIFF
--- a/config/configuration.yaml.example
+++ b/config/configuration.yaml.example
@@ -159,5 +159,5 @@ scene:
       light.tv_back_light: on
       light.ceiling:
         state: on
-        color: [0.33, 0.66]
+        xy_color: [0.33, 0.66]
         brightness: 200


### PR DESCRIPTION
The scene config in configuration.yaml.example is wrong. `color` should be `xy_color` (or `rgb_color`).
