### PR TITLE
Light update to PyISY version 1.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ python-nest>=2.3.1
 pydispatcher>=2.0.5
 
 # ISY994 bindings (*.isy994)
-PyISY>=1.0.2
+PyISY>=1.0.5
 
 # PSutil (sensor.systemmonitor)
 psutil>=2.2.1


### PR DESCRIPTION
This is a lighter update to version 1.0.5 to fix Issue #201 more immediately. HTTPS will not work until the dev branch is next merged.
