### PR TITLE
Implement the colorloop effect for hue lights

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -88,6 +88,10 @@ ATTR_FLASH = "flash"
 FLASH_SHORT = "short"
 FLASH_LONG = "long"
 
+# Apply an effect to the light, can be EFFECT_COLORLOOP
+ATTR_EFFECT = "effect"
+EFFECT_COLORLOOP = "colorloop"
+
 LIGHT_PROFILES_FILE = "light_profiles.csv"
 
 # Maps discovered services to their platforms
@@ -114,7 +118,8 @@ def is_on(hass, entity_id=None):
 
 # pylint: disable=too-many-arguments
 def turn_on(hass, entity_id=None, transition=None, brightness=None,
-            rgb_color=None, xy_color=None, profile=None, flash=None):
+            rgb_color=None, xy_color=None, profile=None, flash=None,
+            effect=None):
     """ Turns all or specified light on. """
     data = {
         key: value for key, value in [
@@ -125,6 +130,7 @@ def turn_on(hass, entity_id=None, transition=None, brightness=None,
             (ATTR_RGB_COLOR, rgb_color),
             (ATTR_XY_COLOR, xy_color),
             (ATTR_FLASH, flash),
+            (ATTR_EFFECT, effect),
         ] if value is not None
     }
 
@@ -252,6 +258,10 @@ def setup(hass, config):
 
                 elif dat[ATTR_FLASH] == FLASH_LONG:
                     params[ATTR_FLASH] = FLASH_LONG
+
+            if ATTR_EFFECT in dat:
+                if dat[ATTR_EFFECT] == EFFECT_COLORLOOP:
+                    params[ATTR_EFFECT] = EFFECT_COLORLOOP
 
             for light in target_lights:
                 light.turn_on(**params)

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -9,7 +9,8 @@ import homeassistant.util as util
 from homeassistant.const import CONF_HOST, DEVICE_DEFAULT_NAME
 from homeassistant.components.light import (
     Light, ATTR_BRIGHTNESS, ATTR_XY_COLOR, ATTR_TRANSITION,
-    ATTR_FLASH, FLASH_LONG, FLASH_SHORT)
+    ATTR_FLASH, FLASH_LONG, FLASH_SHORT, ATTR_EFFECT,
+    EFFECT_COLORLOOP)
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
@@ -190,6 +191,13 @@ class HueLight(Light):
             command['alert'] = 'select'
         else:
             command['alert'] = 'none'
+
+        effect = kwargs.get(ATTR_EFFECT)
+
+        if effect == EFFECT_COLORLOOP:
+            command['effect'] = 'colorloop'
+        else:
+            command['effect'] = 'none'
 
         self.bridge.set_light(self.light_id, command)
 


### PR DESCRIPTION
The Philips Hue lights support an option called colorloop. The colorloop causes the bulb to loop over all colors (hence the name :)), making it usefull for mood-lights that cause the color to change slowly over time. This PR allows this easily, since it's already available in the phue library.

This effect can be enabled by calling the service light_on with the following data:

`{"entity_id": "light.lightname", "effect": "colorloop"}`
