### PR TITLE
IGNORE_CEC Parameter for Cast device

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ phue>=0.8
 ledcontroller>=1.0.7
 
 # Chromecast bindings (media_player.cast)
-pychromecast>=0.6.7
+pychromecast>=0.6.9
 
 # Keyboard (keyboard)
 pyuserinput>=0.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ phue>=0.8
 ledcontroller>=1.0.7
 
 # Chromecast bindings (media_player.cast)
-pychromecast>=0.6.6
+pychromecast>=0.6.7
 
 # Keyboard (keyboard)
 pyuserinput>=0.1.9


### PR DESCRIPTION
This PR primarily adds the capability to Ignore CEC data using a pending update to PyChromecast. This PR assumes that the modifications will be pulled into PyChromecast with no major modifications and that PyChromecast will be submitted to PyPI as version 0.6.7. The code will work with PyChromecast 0.6.6, but the ignore CEC values will be ignored.

This PR also fixes a small bug that would cause Chromecasts to be imported twice if they were manually configured in the configuration.yaml file while the discovery component was active.

DO NOT PULL THIS PR... until the updates to PyChromecast are finalized.
