### PR TITLE
Make  only_named: 0  work

### DIFF
--- a/homeassistant/components/sensor/tellstick.py
+++ b/homeassistant/components/sensor/tellstick.py
@@ -77,7 +77,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         try:
             sensor_name = config[ts_sensor.id]
         except KeyError:
-            if 'only_named' in config:
+            if util.convert(config.get('only_named'), bool, False):
                 continue
             sensor_name = str(ts_sensor.id)
 


### PR DESCRIPTION
Fix of small bug in Tellstick sensor
