### PR TITLE
Fix sensor.forecastio with Fahrenheit values

### DIFF
--- a/homeassistant/components/sensor/forecast.py
+++ b/homeassistant/components/sensor/forecast.py
@@ -215,5 +215,6 @@ class ForeCastData(object):
 
         forecast = forecastio.load_forecast(self._api_key,
                                             self.latitude,
-                                            self.longitude)
+                                            self.longitude,
+                                            units='si')
         self.data = forecast.currently()


### PR DESCRIPTION
Makes sure we always request Celsius values.

Fixes #245 
