### PR TITLE
ASUSWRT - Exception when client not in leases

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -157,7 +157,8 @@ class AsusWrtDeviceScanner(object):
             devices[match.group('ip')] = {
                 'ip': match.group('ip'),
                 'mac': match.group('mac').upper(),
-                'host': match.group('host')
+                'host': match.group('host'),
+                'status': ''
                 }
 
         for neighbor in neighbors:


### PR DESCRIPTION
Client can be dropped from leases list from where the status is
retreived before it is dropped from the ip neigh list.
The client needs a default status.
