### PR TITLE
limitlessled: scale brightness to meet ledcontroller expectations

### DIFF
--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -84,7 +84,7 @@ class LimitlessLED(Light):
         if ATTR_BRIGHTNESS in kwargs:
             self._brightness = kwargs[ATTR_BRIGHTNESS]
 
-        self.led.set_brightness(self._brightness, self.group)
+        self.led.set_brightness(self._brightness / 255.0, self.group)
         self.update_ha_state()
 
     def turn_off(self, **kwargs):


### PR DESCRIPTION
LedController's set_brightness() method expects either an int between 0 and
100, or a float between 0.0 and 1.0, but the brightness here is an int between
0-255. Scale the brightness appropriately.
