### PR TITLE
limitlessled: add color support

### DIFF
--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -24,7 +24,9 @@ light:
 import logging
 
 from homeassistant.const import DEVICE_DEFAULT_NAME
-from homeassistant.components.light import Light, ATTR_BRIGHTNESS
+from homeassistant.components.light import (Light, ATTR_BRIGHTNESS,
+                                            ATTR_XY_COLOR)
+from homeassistant.util.color import color_RGB_to_xy
 
 _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = ['ledcontroller>=1.0.7']
@@ -57,6 +59,29 @@ class LimitlessLED(Light):
         self._name = name or DEVICE_DEFAULT_NAME
         self._state = False
         self._brightness = 100
+        self._xy_color = color_RGB_to_xy(255, 255, 255)
+
+        # Build a color table that maps an RGB color to a color string
+        # recognized by LedController's set_color method
+        self._color_table = [(color_RGB_to_xy(*x[0]), x[1]) for x in [
+            ((0xFF, 0xFF, 0xFF), 'white'),
+            ((0xEE, 0x82, 0xEE), 'violet'),
+            ((0x41, 0x69, 0xE1), 'royal_blue'),
+            ((0x87, 0xCE, 0xFA), 'baby_blue'),
+            ((0x00, 0xFF, 0xFF), 'aqua'),
+            ((0x7F, 0xFF, 0xD4), 'royal_mint'),
+            ((0x2E, 0x8B, 0x57), 'seafoam_green'),
+            ((0x00, 0x80, 0x00), 'green'),
+            ((0x32, 0xCD, 0x32), 'lime_green'),
+            ((0xFF, 0xFF, 0x00), 'yellow'),
+            ((0xDA, 0xA5, 0x20), 'yellow_orange'),
+            ((0xFF, 0xA5, 0x00), 'orange'),
+            ((0xFF, 0x00, 0x00), 'red'),
+            ((0xFF, 0xC0, 0xCB), 'pink'),
+            ((0xFF, 0x00, 0xFF), 'fusia'),
+            ((0xDA, 0x70, 0xD6), 'lilac'),
+            ((0xE6, 0xE6, 0xFA), 'lavendar'),
+        ]]
 
     @property
     def should_poll(self):
@@ -73,6 +98,21 @@ class LimitlessLED(Light):
         return self._brightness
 
     @property
+    def color_xy(self):
+        return self._xy_color
+
+    def _xy_to_led_color(self, xy_color):
+        """ Convert an XY color to the closest LedController color string """
+        def abs_dist_squared(p_0, p_1):
+            return abs((p_0[0] - p_1[0])**2 + (p_0[1] - p_1[1])**2)
+
+        candidates = [(abs_dist_squared(xy_color, x[0]), x[1]) for x in
+                      self._color_table]
+
+        # First candidate in the sorted list is closest to desired color:
+        return sorted(candidates)[0][1]
+
+    @property
     def is_on(self):
         """ True if device is on. """
         return self._state
@@ -84,6 +124,10 @@ class LimitlessLED(Light):
         if ATTR_BRIGHTNESS in kwargs:
             self._brightness = kwargs[ATTR_BRIGHTNESS]
 
+        if ATTR_XY_COLOR in kwargs:
+            self._xy_color = kwargs[ATTR_XY_COLOR]
+
+        self.led.set_color(self._xy_to_led_color(self._xy_color), self.group)
         self.led.set_brightness(self._brightness / 255.0, self.group)
         self.update_ha_state()
 

--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -104,6 +104,7 @@ class LimitlessLED(Light):
     def _xy_to_led_color(self, xy_color):
         """ Convert an XY color to the closest LedController color string """
         def abs_dist_squared(p_0, p_1):
+            """ Returns the absolute value of the squared distance """
             return abs((p_0[0] - p_1[0])**2 + (p_0[1] - p_1[1])**2)
 
         candidates = [(abs_dist_squared(xy_color, x[0]), x[1]) for x in


### PR DESCRIPTION
Add support for setting the color of a LimitlessLED light.
Currently this implementation is limited to the subset of 16 colors
exposed by the ledcontroller package that is used to interact with the
light itself. Technically the lights themselves support 255 colors.
