### PR TITLE
Updated to support Nest API changes and fix set_temp and away_mode an…

### DIFF
--- a/homeassistant/components/thermostat/nest.py
+++ b/homeassistant/components/thermostat/nest.py
@@ -4,7 +4,6 @@ Adds support for Nest thermostats.
 import logging
 
 from homeassistant.components.thermostat import ThermostatDevice
-from homeassistant.helpers.temperature import convert
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD, TEMP_CELCIUS)
 
 REQUIREMENTS = ['python-nest>=2.4.0']
@@ -63,7 +62,7 @@ class NestThermostat(ThermostatDevice):
 
     @property
     def unit_of_measurement(self):
-        """ Returns the unit of measurement. """
+        """ Unit of measurement this thermostat expresses itself in. """
         return TEMP_CELCIUS
 
     @property
@@ -107,9 +106,7 @@ class NestThermostat(ThermostatDevice):
         return self.structure.away
 
     def set_temperature(self, temperature):
-        """ Set new target temperature ensuring it is in proper units """
-        temperature = convert(temperature, self.hass.config.temperature_unit,
-                              self.unit_of_measurement)
+        """ Set new target temperature """
         self.device.target = temperature
 
     def turn_away_mode_on(self):
@@ -127,7 +124,7 @@ class NestThermostat(ThermostatDevice):
         if temp is None:
             return super().min_temp
         else:
-            return round(self.hass.config.temperature(temp, TEMP_CELCIUS)[0])
+            return temp
 
     @property
     def max_temp(self):
@@ -136,7 +133,7 @@ class NestThermostat(ThermostatDevice):
         if temp is None:
             return super().max_temp
         else:
-            return round(self.hass.config.temperature(temp, TEMP_CELCIUS)[0])
+            return temp
 
     def update(self):
         """ Python-nest has its own mechanism for staying up to date. """

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ python-libnmap>=0.6.2
 pushbullet.py>=0.7.1
 
 # Nest Thermostat bindings (thermostat.nest)
-python-nest>=2.3.1
+python-nest>=2.4.0
 
 # Z-Wave (*.zwave)
 pydispatcher>=2.0.5


### PR DESCRIPTION
Hello.  I have made some changes to the Nest implementation in order to fix setting the temperature, grab the min and max temps from the Nest API, grab the correct Device name based on changes to the Nest API, and enforce sending all temperatures to the Nest API in celsius.  This requires the most recent version of python-nest, now at 2.4.0.  I have tested these changes with an actual Nest using the Home Assistant frontend interface.  Let me know if you would like me to make any changes to the request.  Thanks!
