### PR TITLE
Updated notifier component.

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -4,12 +4,13 @@ homeassistant.components.notify
 
 Provides functionality to notify people.
 """
+from functools import partial
 import logging
 
 from homeassistant.loader import get_component
-from homeassistant.helpers import validate_config
+from homeassistant.helpers import config_per_platform
 
-from homeassistant.const import CONF_PLATFORM
+from homeassistant.const import CONF_PLATFORM, CONF_NAME
 
 DOMAIN = "notify"
 DEPENDENCIES = []
@@ -33,42 +34,46 @@ def send_message(hass, message):
 
 def setup(hass, config):
     """ Sets up notify services. """
+    success = False
 
-    if not validate_config(config, {DOMAIN: [CONF_PLATFORM]}, _LOGGER):
-        return False
+    for platform, p_config in config_per_platform(config, DOMAIN, _LOGGER):
+        # create platform
+        platform = p_config[CONF_PLATFORM]
+        notify_implementation = get_component(
+            'notify.{}'.format(platform))
 
-    platform = config[DOMAIN].get(CONF_PLATFORM)
+        if notify_implementation is None:
+            _LOGGER.error("Unknown notification service specified.")
+            continue
 
-    notify_implementation = get_component(
-        'notify.{}'.format(platform))
+        # create platform service
+        notify_service = notify_implementation.get_service(
+            hass, {DOMAIN: p_config})
 
-    if notify_implementation is None:
-        _LOGGER.error("Unknown notification service specified.")
+        if notify_service is None:
+            _LOGGER.error("Failed to initialize notification service %s",
+                          platform)
+            continue
 
-        return False
+        # create service handler
+        def notify_message(notify_service, call):
+            """ Handle sending notification message service calls. """
+            message = call.data.get(ATTR_MESSAGE)
 
-    notify_service = notify_implementation.get_service(hass, config)
+            if message is None:
+                return
 
-    if notify_service is None:
-        _LOGGER.error("Failed to initialize notification service %s",
-                      platform)
+            title = call.data.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
 
-        return False
+            notify_service.send_message(message, title=title)
 
-    def notify_message(call):
-        """ Handle sending notification message service calls. """
-        message = call.data.get(ATTR_MESSAGE)
+        # register service
+        service_call_handler = partial(notify_message, notify_service)
+        service_notify = p_config.get(CONF_NAME, SERVICE_NOTIFY)
+        hass.services.register(DOMAIN, service_notify, service_call_handler)
+        success = True
 
-        if message is None:
-            return
-
-        title = call.data.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
-
-        notify_service.send_message(message, title=title)
-
-    hass.services.register(DOMAIN, SERVICE_NOTIFY, notify_message)
-
-    return True
+    return success
 
 
 # pylint: disable=too-few-public-methods

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -37,8 +37,7 @@ def setup(hass, config):
     success = False
 
     for platform, p_config in config_per_platform(config, DOMAIN, _LOGGER):
-        # create platform
-        platform = p_config[CONF_PLATFORM]
+        # get platform
         notify_implementation = get_component(
             'notify.{}'.format(platform))
 

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -10,7 +10,7 @@ import logging
 from homeassistant.loader import get_component
 from homeassistant.helpers import config_per_platform
 
-from homeassistant.const import CONF_PLATFORM, CONF_NAME
+from homeassistant.const import CONF_NAME
 
 DOMAIN = "notify"
 DEPENDENCIES = []


### PR DESCRIPTION
This update to the notifier component allows multiple notifiers to be
configured. In order to support this, an optional property “name” has
been added to all the notifier’s configurations. The notifier can now
be called with the service “notify.NAME”. If the name is not provided,
the service will be mapped to “notify.notify”. Because of this, this
update should be fully backwards compatible.

This addresses issue #269.
