### PR TITLE
fixes MPD play/pause

### DIFF
--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -189,11 +189,11 @@ class MpdDevice(MediaPlayerDevice):
 
     def media_play(self):
         """ Service to send the MPD the command for play/pause. """
-        self.client.start()
+        self.client.pause(0)
 
     def media_pause(self):
         """ Service to send the MPD the command for play/pause. """
-        self.client.pause()
+        self.client.pause(1)
 
     def media_next_track(self):
         """ Service to send the MPD the command for next track. """


### PR DESCRIPTION
There is no `start` command / method.
Also, according to [MPD command reference](http://www.musicpd.org/doc/protocol/playback_commands.html), calling `pause` without an argument is deprecated.
