### PR TITLE
Super small hotfix

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -82,7 +82,11 @@ class HomeAssistant(object):
             DOMAIN, SERVICE_HOMEASSISTANT_STOP, stop_homeassistant)
 
         if os.name != "nt":
-            signal.signal(signal.SIGQUIT, stop_homeassistant)
+            try:
+                signal.signal(signal.SIGQUIT, stop_homeassistant)
+            except ValueError:
+                _LOGGER.warning(
+                    'Could not bind to SIGQUIT. Are you running in a thread?')
 
         while not request_shutdown.isSet():
             try:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(HERE, PACKAGE_NAME, 'const.py')) as fp:
 DOWNLOAD_URL = \
     'https://github.com/balloob/home-assistant/archive/{}.zip'.format(VERSION)
 
-PACKAGES = find_packages() + \
+PACKAGES = find_packages(exclude=['tests', 'tests.*']) + \
     ['homeassistant.external', 'homeassistant.external.noop',
      'homeassistant.external.nzbclients', 'homeassistant.external.vera']
 


### PR DESCRIPTION
- fix warning when running `block_till_stopped` in a thread.
- Exclude tests from package
