### PR TITLE
Fix for aruba device tracker

### DIFF
--- a/homeassistant/components/device_tracker/aruba.py
+++ b/homeassistant/components/device_tracker/aruba.py
@@ -51,15 +51,7 @@ _LOGGER = logging.getLogger(__name__)
 _DEVICES_REGEX = re.compile(
     r'(?P<name>([^\s]+))\s+' +
     r'(?P<ip>([0-9]{1,3}[\.]){3}[0-9]{1,3})\s+' +
-    r'(?P<mac>(([0-9a-f]{2}[:-]){5}([0-9a-f]{2})))\s+' +
-    r'(?P<os>([^\s]+))\s+' +
-    r'(?P<network>([^\s]+))\s+' +
-    r'(?P<ap>([^\s]+))\s+' +
-    r'(?P<channel>([^\s]+))\s+' +
-    r'(?P<type>([^\s]+))\s+' +
-    r'(?P<role>([^\s]+))\s+' +
-    r'(?P<signal>([^\s]+))\s+' +
-    r'(?P<speed>([^\s]+))')
+    r'(?P<mac>(([0-9a-f]{2}[:-]){5}([0-9a-f]{2})))\s+')
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
The aruba device_tracker fetches a list of connected clients, and parses the complete table. Some entries can be empty (like detected OS). This caused the regex to not match for that line, leaving the client undetected.

This PR removes those fields from the regex, leaving only the hostname, mac and IP.

Sorry I didn't catch that in my original PR.
