### PR TITLE
Upstream bug fixed that caused error adding some nest thermostats

### DIFF
--- a/homeassistant/components/thermostat/nest.py
+++ b/homeassistant/components/thermostat/nest.py
@@ -6,7 +6,7 @@ import logging
 from homeassistant.components.thermostat import ThermostatDevice
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD, TEMP_CELCIUS)
 
-REQUIREMENTS = ['python-nest==2.4.0']
+REQUIREMENTS = ['python-nest==2.6.0']
 
 
 # pylint: disable=unused-argument

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -31,7 +31,7 @@ python-nmap==0.4.1
 pushbullet.py==0.7.1
 
 # Nest Thermostat bindings (thermostat.nest)
-python-nest==2.4.0
+python-nest==2.6.0
 
 # Z-Wave (*.zwave)
 pydispatcher==2.0.5


### PR DESCRIPTION
This is to change the python-nest requirement to the latest version on pypi to fix an issue with certain serial IDs for structures in the nest API.  This was causing KeyErrors when trying to identify the name of the Nest.
