### PR TITLE
Add option to skip pip install on startup.

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -78,6 +78,10 @@ def get_arguments():
         action='store_true',
         help='Open the webinterface in a browser')
     parser.add_argument(
+        '--skip-pip',
+        action='store_true',
+        help='Skips pip install of required packages on startup')
+    parser.add_argument(
         '-v', '--verbose',
         action='store_true',
         help="Enable verbose logging to file.")
@@ -161,15 +165,19 @@ def main():
         write_pid(args.pid_file)
 
     if args.demo_mode:
-        hass = bootstrap.from_config_dict({
+        config = {
             'frontend': {},
             'demo': {}
-        }, config_dir=config_dir, daemon=args.daemon, verbose=args.verbose)
+        }
+        hass = bootstrap.from_config_dict(
+            config, config_dir=config_dir, daemon=args.daemon,
+            verbose=args.verbose, skip_pip=args.skip_pip)
     else:
         config_file = ensure_config_file(config_dir)
         print('Config directory:', config_dir)
         hass = bootstrap.from_config_file(
-            config_file, daemon=args.daemon, verbose=args.verbose)
+            config_file, daemon=args.daemon, verbose=args.verbose,
+            skip_pip=args.skip_pip)
 
     if args.open_ui:
         def open_browser(event):

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -61,7 +61,7 @@ def setup_component(hass, domain, config=None):
 
 def _handle_requirements(hass, component, name):
     """ Installs requirements for component. """
-    if not hasattr(component, 'REQUIREMENTS'):
+    if hass.config.skip_pip or not hasattr(component, 'REQUIREMENTS'):
         return True
 
     for req in component.REQUIREMENTS:
@@ -151,7 +151,7 @@ def mount_local_lib_path(config_dir):
 
 # pylint: disable=too-many-branches, too-many-statements, too-many-arguments
 def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
-                     verbose=False, daemon=False):
+                     verbose=False, daemon=False, skip_pip=False):
     """
     Tries to configure Home Assistant from a config dict.
 
@@ -168,6 +168,11 @@ def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
 
     if enable_log:
         enable_logging(hass, verbose, daemon)
+
+    hass.config.skip_pip = skip_pip
+    if skip_pip:
+        _LOGGER.warning('Skipping pip installation of required modules. '
+                        'This may cause issues.')
 
     _ensure_loader_prepared(hass)
 
@@ -196,7 +201,8 @@ def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
     return hass
 
 
-def from_config_file(config_path, hass=None, verbose=False, daemon=False):
+def from_config_file(config_path, hass=None, verbose=False, daemon=False,
+                     skip_pip=True):
     """
     Reads the configuration file and tries to start all the required
     functionality. Will add functionality to 'hass' parameter if given,
@@ -214,7 +220,8 @@ def from_config_file(config_path, hass=None, verbose=False, daemon=False):
 
     config_dict = config_util.load_config_file(config_path)
 
-    return from_config_dict(config_dict, hass, enable_log=False)
+    return from_config_dict(config_dict, hass, enable_log=False,
+                            skip_pip=skip_pip)
 
 
 def enable_logging(hass, verbose=False, daemon=False):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -664,6 +664,9 @@ class Config(object):
         self.location_name = None
         self.time_zone = None
 
+        # If True, pip install is skipped for requirements on startup
+        self.skip_pip = False
+
         # List of loaded components
         self.components = []
 


### PR DESCRIPTION
Since the requirements only change when the software is updated,
this adds a command line switch to disable pip installs on
startup.  The default behavior is maintained when the switch is
not specified.  Skipping pip helps a lot with startup on older RPi
hardware.
