### PR TITLE
Add optional QoS config parameter to MQTT sensor and switch

### DIFF
--- a/homeassistant/components/mqtt.py
+++ b/homeassistant/components/mqtt.py
@@ -60,7 +60,6 @@ MQTT_CLIENT = None
 
 DEFAULT_PORT = 1883
 DEFAULT_KEEPALIVE = 60
-DEFAULT_QOS = 0
 
 SERVICE_PUBLISH = 'publish'
 EVENT_MQTT_MESSAGE_RECEIVED = 'MQTT_MESSAGE_RECEIVED'
@@ -75,16 +74,17 @@ CONF_KEEPALIVE = 'keepalive'
 CONF_USERNAME = 'username'
 CONF_PASSWORD = 'password'
 
-ATTR_QOS = 'qos'
 ATTR_TOPIC = 'topic'
 ATTR_PAYLOAD = 'payload'
+ATTR_QOS = 'qos'
 
 
-def publish(hass, topic, payload):
+def publish(hass, topic, payload, qos=0):
     """ Send an MQTT message. """
     data = {
         ATTR_TOPIC: topic,
         ATTR_PAYLOAD: payload,
+        ATTR_QOS: qos,
     }
     hass.services.call(DOMAIN, SERVICE_PUBLISH, data)
 
@@ -141,9 +141,10 @@ def setup(hass, config):
         """ Handle MQTT publish service calls. """
         msg_topic = call.data.get(ATTR_TOPIC)
         payload = call.data.get(ATTR_PAYLOAD)
+        qos = call.data.get(ATTR_QOS)
         if msg_topic is None or payload is None:
             return
-        MQTT_CLIENT.publish(msg_topic, payload)
+        MQTT_CLIENT.publish(msg_topic, payload, qos)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_mqtt)
 
@@ -177,9 +178,9 @@ class MQTT(object):  # pragma: no cover
         self._mqttc.on_message = self._mqtt_on_message
         self._mqttc.connect(broker, port, keepalive)
 
-    def publish(self, topic, payload):
+    def publish(self, topic, payload, qos):
         """ Publish a MQTT message. """
-        self._mqttc.publish(topic, payload)
+        self._mqttc.publish(topic, payload, qos)
 
     def unsubscribe(self, topic):
         """ Unsubscribe from topic. """

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -13,7 +13,7 @@ sensor:
   platform: mqtt
   name: "MQTT Sensor"
   state_topic: "home/bedroom/temperature"
-  qos: 2
+  qos: 0
   unit_of_measurement: "ºC"
 
 Variables:
@@ -64,6 +64,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         config.get('unit_of_measurement'))])
 
 
+# pylint: disable=too-many-arguments, too-many-instance-attributes
 class MqttSensor(Entity):
     """ Represents a sensor that can be updated using MQTT """
     def __init__(self, hass, name, state_topic, qos, unit_of_measurement):

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -13,6 +13,7 @@ sensor:
   platform: mqtt
   name: "MQTT Sensor"
   state_topic: "home/bedroom/temperature"
+  qos: 2
   unit_of_measurement: "ºC"
 
 Variables:
@@ -24,6 +25,10 @@ The name of the sensor. Default is 'MQTT Sensor'.
 state_topic
 *Required
 The MQTT topic subscribed to receive sensor values.
+
+qos
+*Optional
+The maximum QoS level of the state topic. Default is 0.
 
 unit_of_measurement
 *Optional
@@ -38,6 +43,7 @@ import homeassistant.components.mqtt as mqtt
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "MQTT Sensor"
+DEFAULT_QOS = 0
 
 DEPENDENCIES = ['mqtt']
 
@@ -54,16 +60,18 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         hass,
         config.get('name', DEFAULT_NAME),
         config.get('state_topic'),
+        config.get('qos', DEFAULT_QOS),
         config.get('unit_of_measurement'))])
 
 
 class MqttSensor(Entity):
     """ Represents a sensor that can be updated using MQTT """
-    def __init__(self, hass, name, state_topic, unit_of_measurement):
+    def __init__(self, hass, name, state_topic, qos, unit_of_measurement):
         self._state = "-"
         self._hass = hass
         self._name = name
         self._state_topic = state_topic
+        self._qos = qos
         self._unit_of_measurement = unit_of_measurement
 
         def message_received(topic, payload, qos):
@@ -71,7 +79,7 @@ class MqttSensor(Entity):
             self._state = payload
             self.update_ha_state()
 
-        mqtt.subscribe(hass, self._state_topic, message_received)
+        mqtt.subscribe(hass, self._state_topic, message_received, self._qos)
 
     @property
     def should_poll(self):

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -26,7 +26,7 @@ switch:
   name: "Bedroom Switch"
   state_topic: "home/bedroom/switch1"
   command_topic: "home/bedroom/switch1/set"
-  qos: 2
+  qos: 0
   payload_on: "ON"
   payload_off: "OFF"
   optimistic: false
@@ -128,7 +128,7 @@ class MqttSwitch(SwitchDevice):
             self._optimistic = True
         else:
             # subscribe the state_topic
-            mqtt.subscribe(hass, self._state_topic, message_received, 
+            mqtt.subscribe(hass, self._state_topic, message_received,
                            self._qos)
 
     @property
@@ -148,7 +148,7 @@ class MqttSwitch(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """ Turn the device on. """
-        mqtt.publish(self.hass, self._command_topic, self._payload_on, 
+        mqtt.publish(self.hass, self._command_topic, self._payload_on,
                      self._qos)
         if self._optimistic:
             # optimistically assume that switch has changed state
@@ -157,7 +157,7 @@ class MqttSwitch(SwitchDevice):
 
     def turn_off(self, **kwargs):
         """ Turn the device off. """
-        mqtt.publish(self.hass, self._command_topic, self._payload_off, 
+        mqtt.publish(self.hass, self._command_topic, self._payload_off,
                      self._qos)
         if self._optimistic:
             # optimistically assume that switch has changed state

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -26,6 +26,7 @@ switch:
   name: "Bedroom Switch"
   state_topic: "home/bedroom/switch1"
   command_topic: "home/bedroom/switch1/set"
+  qos: 2
   payload_on: "ON"
   payload_off: "OFF"
   optimistic: false
@@ -44,6 +45,11 @@ If not specified, optimistic mode will be forced.
 command_topic
 *Required
 The MQTT topic to publish commands to change the switch state.
+
+qos
+*Optional
+The maximum QoS level of the state topic. Default is 0.
+This QoS will also be used to publishing messages.
 
 payload_on
 *Optional
@@ -66,6 +72,7 @@ from homeassistant.components.switch import SwitchDevice
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "MQTT Switch"
+DEFAULT_QOS = 0
 DEFAULT_PAYLOAD_ON = "ON"
 DEFAULT_PAYLOAD_OFF = "OFF"
 DEFAULT_OPTIMISTIC = False
@@ -86,6 +93,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         config.get('name', DEFAULT_NAME),
         config.get('state_topic'),
         config.get('command_topic'),
+        config.get('qos', DEFAULT_QOS),
         config.get('payload_on', DEFAULT_PAYLOAD_ON),
         config.get('payload_off', DEFAULT_PAYLOAD_OFF),
         config.get('optimistic', DEFAULT_OPTIMISTIC))])
@@ -94,13 +102,14 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 # pylint: disable=too-many-arguments, too-many-instance-attributes
 class MqttSwitch(SwitchDevice):
     """ Represents a switch that can be togggled using MQTT """
-    def __init__(self, hass, name, state_topic, command_topic,
+    def __init__(self, hass, name, state_topic, command_topic, qos,
                  payload_on, payload_off, optimistic):
         self._state = False
         self._hass = hass
         self._name = name
         self._state_topic = state_topic
         self._command_topic = command_topic
+        self._qos = qos
         self._payload_on = payload_on
         self._payload_off = payload_off
         self._optimistic = optimistic
@@ -119,7 +128,8 @@ class MqttSwitch(SwitchDevice):
             self._optimistic = True
         else:
             # subscribe the state_topic
-            mqtt.subscribe(hass, self._state_topic, message_received)
+            mqtt.subscribe(hass, self._state_topic, message_received, 
+                           self._qos)
 
     @property
     def should_poll(self):
@@ -138,7 +148,8 @@ class MqttSwitch(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """ Turn the device on. """
-        mqtt.publish(self.hass, self._command_topic, self._payload_on)
+        mqtt.publish(self.hass, self._command_topic, self._payload_on, 
+                     self._qos)
         if self._optimistic:
             # optimistically assume that switch has changed state
             self._state = True
@@ -146,7 +157,8 @@ class MqttSwitch(SwitchDevice):
 
     def turn_off(self, **kwargs):
         """ Turn the device off. """
-        mqtt.publish(self.hass, self._command_topic, self._payload_off)
+        mqtt.publish(self.hass, self._command_topic, self._payload_off, 
+                     self._qos)
         if self._optimistic:
             # optimistically assume that switch has changed state
             self._state = False


### PR DESCRIPTION
This PR will allow to set the maximum QoS level in MQTT sensor and switch, when subscribing to `state_topic` .
