### PR TITLE
Handle UTF-8 in config file

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -124,7 +124,7 @@ def load_yaml_config_file(config_path):
     def parse(fname):
         """ Parse a YAML file.  """
         try:
-            with open(fname) as conf_file:
+            with open(fname, encoding='utf-8') as conf_file:
                 # If configuration file is empty YAML returns None
                 # We convert that to an empty dict
                 return yaml.load(conf_file) or {}


### PR DESCRIPTION
This tiny patch fixes loading of config files with utf-8 chars on Python 3.4.1 on FreeBSD, and has no effect on OS X with Python 3.4.3.  May help other platforms.

Fix for #334 
