### PR TITLE
Use Dobson Units for ozone

### DIFF
--- a/homeassistant/components/sensor/forecast.py
+++ b/homeassistant/components/sensor/forecast.py
@@ -71,7 +71,7 @@ SENSOR_TYPES = {
     'humidity': ['Humidity', '%'],
     'pressure': ['Pressure', 'mBar'],
     'visibility': ['Visibility', 'km'],
-    'ozone': ['Ozone', ''],
+    'ozone': ['Ozone', 'DU'],
 }
 
 # Return cached results if last scan was less then this time ago


### PR DESCRIPTION
Without units, HA seems to treat each different value for ozone as a discrete state.  The forecast.io API says that values are returned in Dobson Units.  This change causes ozone to be shown as an analogue value, and its historical information to be shown as a line chart.
