### PR TITLE
Initial Thermostat Range Support

### DIFF
--- a/homeassistant/components/thermostat/__init__.py
+++ b/homeassistant/components/thermostat/__init__.py
@@ -27,6 +27,9 @@ ATTR_CURRENT_TEMPERATURE = "current_temperature"
 ATTR_AWAY_MODE = "away_mode"
 ATTR_MAX_TEMP = "max_temp"
 ATTR_MIN_TEMP = "min_temp"
+ATTR_TEMPERATURE_LOW = "target_temp_low"
+ATTR_TEMPERATURE_HIGH = "target_temp_high"
+ATTR_OPERATION = "current_operation"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -111,7 +114,7 @@ class ThermostatDevice(Entity):
     @property
     def state(self):
         """ Returns the current state. """
-        return self.target_temperature
+        return self.operation
 
     @property
     def device_state_attributes(self):
@@ -134,7 +137,20 @@ class ThermostatDevice(Entity):
                                          user_unit), 0),
             ATTR_MAX_TEMP: round(convert(self.max_temp,
                                          thermostat_unit,
-                                         user_unit), 0)
+                                         user_unit), 0),
+            ATTR_TEMPERATURE: round(convert(self.target_temperature,
+                                            thermostat_unit,
+                                            user_unit), 0),
+            ATTR_TEMPERATURE_LOW: round(convert(self.target_temperature_low,
+                                                thermostat_unit,
+                                                user_unit), 0),
+            ATTR_TEMPERATURE_HIGH: round(convert(self.target_temperature_high,
+                                                 thermostat_unit,
+                                                 user_unit), 0),
+            ATTR_OPERATION: round(convert(self.operation,
+                                          thermostat_unit,
+                                          user_unit), 0)
+
         }
 
         is_away = self.is_away_mode_on
@@ -160,9 +176,24 @@ class ThermostatDevice(Entity):
         raise NotImplementedError
 
     @property
+    def operation(self):
+        """ Returns current operation ie. heat, cool, idle """
+        return NotImplementedError
+
+    @property
     def target_temperature(self):
         """ Returns the temperature we try to reach. """
         raise NotImplementedError
+
+    @property
+    def target_temperature_low(self):
+        """ Returns the lower bound temperature we try to reach. """
+        return self.target_temperature
+
+    @property
+    def target_temperature_high(self):
+        """ Returns the upper bound temperature we try to reach. """
+        return self.target_temperature
 
     @property
     def is_away_mode_on(self):

--- a/homeassistant/components/thermostat/__init__.py
+++ b/homeassistant/components/thermostat/__init__.py
@@ -114,7 +114,7 @@ class ThermostatDevice(Entity):
     @property
     def state(self):
         """ Returns the current state. """
-        return self.operation
+        return self.target_temperature
 
     @property
     def device_state_attributes(self):
@@ -147,10 +147,7 @@ class ThermostatDevice(Entity):
             ATTR_TEMPERATURE_HIGH: round(convert(self.target_temperature_high,
                                                  thermostat_unit,
                                                  user_unit), 0),
-            ATTR_OPERATION: round(convert(self.operation,
-                                          thermostat_unit,
-                                          user_unit), 0)
-
+            ATTR_OPERATION: self.operation
         }
 
         is_away = self.is_away_mode_on

--- a/homeassistant/components/thermostat/__init__.py
+++ b/homeassistant/components/thermostat/__init__.py
@@ -23,6 +23,10 @@ SCAN_INTERVAL = 60
 SERVICE_SET_AWAY_MODE = "set_away_mode"
 SERVICE_SET_TEMPERATURE = "set_temperature"
 
+STATE_HEAT = "heat"
+STATE_COOL = "cool"
+STATE_IDLE = "idle"
+
 ATTR_CURRENT_TEMPERATURE = "current_temperature"
 ATTR_AWAY_MODE = "away_mode"
 ATTR_MAX_TEMP = "max_temp"

--- a/homeassistant/components/thermostat/nest.py
+++ b/homeassistant/components/thermostat/nest.py
@@ -123,14 +123,14 @@ class NestThermostat(ThermostatDevice):
     def target_temperature_low(self):
         """ Returns the lower bound temperature we try to reach. """
         if self.device.mode == 'range':
-            return self.device.target["low"]
+            return round(self.device.target[0], 1)
         return round(self.target_temperature, 1)
 
     @property
     def target_temperature_high(self):
         """ Returns the upper bound temperature we try to reach. """
         if self.device.mode == 'range':
-            return self.device.target["high"]
+            return round(self.device.target[1], 1)
         return round(self.target_temperature, 1)
 
     @property

--- a/homeassistant/components/thermostat/nest.py
+++ b/homeassistant/components/thermostat/nest.py
@@ -5,12 +5,9 @@ Adds support for Nest thermostats.
 """
 import logging
 
-from homeassistant.components.thermostat import ThermostatDevice
+from homeassistant.components.thermostat import (ThermostatDevice, STATE_COOL,
+                                                 STATE_IDLE, STATE_HEAT)
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD, TEMP_CELCIUS)
-
-STATE_HEAT = "heat"
-STATE_COOL = "cool"
-STATE_IDLE = "idle"
 
 REQUIREMENTS = ['python-nest==2.6.0']
 

--- a/homeassistant/components/thermostat/nest.py
+++ b/homeassistant/components/thermostat/nest.py
@@ -8,6 +8,10 @@ import logging
 from homeassistant.components.thermostat import ThermostatDevice
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD, TEMP_CELCIUS)
 
+STATE_HEAT = "heat"
+STATE_COOL = "cool"
+STATE_IDLE = "idle"
+
 REQUIREMENTS = ['python-nest==2.6.0']
 
 
@@ -84,23 +88,50 @@ class NestThermostat(ThermostatDevice):
         return round(self.device.temperature, 1)
 
     @property
+    def operation(self):
+        """ Returns current operation ie. heat, cool, idle """
+        if self.device.hvac_ac_state is True:
+            return STATE_COOL
+        elif self.device.hvac_heater_state is True:
+            return STATE_HEAT
+        else:
+            return STATE_IDLE
+
+    @property
     def target_temperature(self):
         """ Returns the temperature we try to reach. """
         target = self.device.target
 
-        if isinstance(target, tuple):
+        if self.device.mode == 'range':
             low, high = target
-
-            if self.current_temperature < low:
-                temp = low
-            elif self.current_temperature > high:
+            if self.operation == STATE_COOL:
                 temp = high
+            elif self.operation == STATE_HEAT:
+                temp = low
             else:
-                temp = (low + high)/2
+                range_average = (low + high)/2
+                if self.current_temperature < range_average:
+                    temp = low
+                elif self.current_temperature > range_average:
+                    temp = high
         else:
             temp = target
 
         return round(temp, 1)
+
+    @property
+    def target_temperature_low(self):
+        """ Returns the lower bound temperature we try to reach. """
+        if self.device.mode == 'range':
+            return self.device.target["low"]
+        return round(self.target_temperature, 1)
+
+    @property
+    def target_temperature_high(self):
+        """ Returns the upper bound temperature we try to reach. """
+        if self.device.mode == 'range':
+            return self.device.target["high"]
+        return round(self.target_temperature, 1)
 
     @property
     def is_away_mode_on(self):
@@ -109,6 +140,11 @@ class NestThermostat(ThermostatDevice):
 
     def set_temperature(self, temperature):
         """ Set new target temperature """
+        if self.device.mode == 'range':
+            if self.target_temperature == self.target_temperature_low:
+                temperature = (temperature, self.target_temperature_high)
+            elif self.target_temperature == self.target_temperature_high:
+                temperature = (self.target_temperature_low, temperature)
         self.device.target = temperature
 
     def turn_away_mode_on(self):

--- a/homeassistant/components/thermostat/nest.py
+++ b/homeassistant/components/thermostat/nest.py
@@ -112,7 +112,7 @@ class NestThermostat(ThermostatDevice):
                 range_average = (low + high)/2
                 if self.current_temperature < range_average:
                     temp = low
-                elif self.current_temperature > range_average:
+                elif self.current_temperature >= range_average:
                     temp = high
         else:
             temp = target


### PR DESCRIPTION
This is initial range thermostat support as requested in Issue #287.
In order to support ranges in a thermostat's operation, 3 new state attributes have been added

  ATTR_TEMPERATURE_LOW: min range value (defaults to target value if no range specified or not supported)
  ATTR_TEMPERATURE_HIGH: max range value (defaults to target value if no range specified or not supported)
  ATTR_OPERATION: Keeps track of current operation (cool, heat, idle)

With this, I think any thermostat can add support for range values under HA's current mode of operation for setting the target value.  In the case of a range being used, I have updated the nest to check the current operation to set the target temperature to the upper bound if cooling, the lower bound if heating, or determine if it is above or below the average of the range to set the appropriate target if idle.  I have tested the range setting for the nest successfully, but only the upper bound cooling aspect, as testing the heat in September in Phoenix might kill me. :-P

That operation attribute is set by a property called "operation" that has been added to the Thermostat Class and must be implemented by whatever thermostat inherits it.  I had initially tried setting the operation as the state attribute as mentioned in the issue, but in the UI, it set this value in place of the target value in the upper right of the card along with a unit of degrees Celsius.  So, I have kept the target temperature as the state for the thermostat for now until I better understand that change in the UI.  Please let me know what you all think!  Thanks!
