### PR TITLE
Discover sonos devices

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -19,22 +19,22 @@ from homeassistant.const import (
 
 DOMAIN = "discovery"
 DEPENDENCIES = []
-REQUIREMENTS = ['netdisco==0.3']
+REQUIREMENTS = ['netdisco==0.4']
 
 SCAN_INTERVAL = 300  # seconds
 
-# Next 3 lines for now a mirror from netdisco.const
-# Should setup a mapping netdisco.const -> own constants
 SERVICE_WEMO = 'belkin_wemo'
 SERVICE_HUE = 'philips_hue'
 SERVICE_CAST = 'google_cast'
 SERVICE_NETGEAR = 'netgear_router'
+SERVICE_SONOS = 'sonos'
 
 SERVICE_HANDLERS = {
     SERVICE_WEMO: "switch",
     SERVICE_CAST: "media_player",
     SERVICE_HUE: "light",
     SERVICE_NETGEAR: 'device_tracker',
+    SERVICE_SONOS: 'media_player',
 }
 
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -25,6 +25,7 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 DISCOVERY_PLATFORMS = {
     discovery.SERVICE_CAST: 'cast',
+    discovery.SERVICE_SONOS: 'sonos',
 }
 
 SERVICE_YOUTUBE_VIDEO = 'play_youtube_video'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -86,7 +86,7 @@ https://github.com/theolind/pymysensors/archive/35b87d880147a34107da0d40cb815d75
 pynetgear==0.3
 
 # Netdisco (discovery)
-netdisco==0.3
+netdisco==0.4
 
 # Wemo (switch.wemo)
 pywemo==0.3


### PR DESCRIPTION
This allows Sonos devices to be automatically discovered and loaded by Home Assistant
