### PR TITLE
Add custom entries to logbook

### DIFF
--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -63,6 +63,25 @@ class TestComponentHistory(unittest.TestCase):
             entries[0], name='Home Assistant', message='restarted',
             domain=ha.DOMAIN)
 
+    def test_process_custom_logbook_entries(self):
+        """ Tests if custom log book entries get added as an entry. """
+        name = 'Nice name'
+        message = 'has a custom entry'
+        entity_id = 'sun.sun'
+
+        entries = list(logbook.humanify((
+            ha.Event(logbook.EVENT_LOGBOOK_ENTRY, {
+                logbook.ATTR_NAME: name,
+                logbook.ATTR_MESSAGE: message,
+                logbook.ATTR_ENTITY_ID: entity_id,
+                }),
+            )))
+
+        self.assertEqual(1, len(entries))
+        self.assert_entry(
+            entries[0], name=name, message=message,
+            domain='sun', entity_id=entity_id)
+
     def assert_entry(self, entry, when=None, name=None, message=None,
                      domain=None, entity_id=None):
         """ Asserts an entry is what is expected """


### PR DESCRIPTION
This allows users to add custom entries to the logbook. This is done by firing an event.

If no domain is given but an entity id is, domain is derived from entity id.

If an entity id is given, clicking on name will open the more info dialog for that entity.

Logbook entries are printed in format: `<name> <message>`

Event type: `LOGBOOK_ENTRY`

``` json
{
  "name": "Paulus",
  "message": "has custom logbook entries working!",
  "entity_id": "sun.sun"
}
```

![image](https://cloud.githubusercontent.com/assets/1444314/9841774/2b50c3d0-5a59-11e5-93d9-014b8165cade.png)
