### PR TITLE
Add if-condition to automation

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.bootstrap import prepare_setup_platform
 from homeassistant.helpers import config_per_platform
 from homeassistant.util import split_entity_id
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM
 
 DOMAIN = "automation"
 
@@ -19,6 +19,7 @@ CONF_ALIAS = "alias"
 CONF_SERVICE = "execute_service"
 CONF_SERVICE_ENTITY_ID = "service_entity_id"
 CONF_SERVICE_DATA = "service_data"
+CONF_IF = "if"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +35,12 @@ def setup(hass, config):
             _LOGGER.error("Unknown automation platform specified: %s", p_type)
             continue
 
-        if platform.register(hass, p_config, _get_action(hass, p_config)):
+        action = _get_action(hass, p_config)
+
+        if CONF_IF in p_config:
+            action = _process_if(hass, config, p_config[CONF_IF], action)
+
+        if platform.trigger(hass, p_config, action):
             _LOGGER.info(
                 "Initialized %s rule %s", p_type, p_config.get(CONF_ALIAS, ""))
             success = True
@@ -70,5 +76,30 @@ def _get_action(hass, config):
                         config[CONF_SERVICE_ENTITY_ID]
 
             hass.services.call(domain, service, service_data)
+
+    return action
+
+
+def _process_if(hass, config, if_configs, action):
+    """ Processes if checks. """
+
+    if isinstance(if_configs, dict):
+        if_configs = [if_configs]
+
+    for if_config in if_configs:
+        p_type = if_config.get(CONF_PLATFORM)
+        if p_type is None:
+            _LOGGER.error("No platform defined found for if-statement %s",
+                          if_config)
+            continue
+
+        platform = prepare_setup_platform(hass, config, DOMAIN, p_type)
+
+        if platform is None or not hasattr(platform, 'if_action'):
+            _LOGGER.error("Unsupported if-statement platform specified: %s",
+                          p_type)
+            continue
+
+        action = platform.if_action(hass, if_config, action)
 
     return action

--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -12,7 +12,7 @@ CONF_EVENT_DATA = "event_data"
 _LOGGER = logging.getLogger(__name__)
 
 
-def register(hass, config, action):
+def trigger(hass, config, action):
     """ Listen for events based on config. """
     event_type = config.get(CONF_EVENT_TYPE)
 

--- a/homeassistant/components/automation/mqtt.py
+++ b/homeassistant/components/automation/mqtt.py
@@ -14,7 +14,7 @@ CONF_TOPIC = 'mqtt_topic'
 CONF_PAYLOAD = 'mqtt_payload'
 
 
-def register(hass, config, action):
+def trigger(hass, config, action):
     """ Listen for state changes based on `config`. """
     topic = config.get(CONF_TOPIC)
     payload = config.get(CONF_PAYLOAD)

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -16,7 +16,7 @@ CONF_ABOVE = "state_above"
 _LOGGER = logging.getLogger(__name__)
 
 
-def register(hass, config, action):
+def trigger(hass, config, action):
     """ Listen for state changes based on `config`. """
     entity_id = config.get(CONF_ENTITY_ID)
 

--- a/homeassistant/components/automation/time.py
+++ b/homeassistant/components/automation/time.py
@@ -4,15 +4,23 @@ homeassistant.components.automation.time
 
 Offers time listening automation rules.
 """
+import logging
+
 from homeassistant.util import convert
+import homeassistant.util.dt as dt_util
 from homeassistant.helpers.event import track_time_change
 
 CONF_HOURS = "time_hours"
 CONF_MINUTES = "time_minutes"
 CONF_SECONDS = "time_seconds"
+CONF_BEFORE = "before"
+CONF_AFTER = "after"
+CONF_WEEKDAY = "weekday"
+
+WEEKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
 
 
-def register(hass, config, action):
+def trigger(hass, config, action):
     """ Listen for state changes based on `config`. """
     hours = convert(config.get(CONF_HOURS), int)
     minutes = convert(config.get(CONF_MINUTES), int)
@@ -26,3 +34,49 @@ def register(hass, config, action):
                       hour=hours, minute=minutes, second=seconds)
 
     return True
+
+
+def if_action(hass, config, action):
+    """ Wraps action method with time based condition. """
+    before = config.get(CONF_BEFORE)
+    after = config.get(CONF_AFTER)
+    weekday = config.get(CONF_WEEKDAY)
+
+    if before is None and after is None and weekday is None:
+        logging.getLogger(__name__).error(
+            "Missing if-condition configuration key %s, %s or %s",
+            CONF_BEFORE, CONF_AFTER, CONF_WEEKDAY)
+
+    def time_if():
+        """ Validate time based if-condition """
+        now = dt_util.now()
+
+        if before is not None:
+            # Strip seconds if given
+            before_h, before_m = before.split(':')[0:2]
+
+            before_point = now.replace(hour=int(before_h),
+                                       minute=int(before_m))
+
+            if now > before_point:
+                return
+
+        if after is not None:
+            # Strip seconds if given
+            after_h, after_m = after.split(':')[0:2]
+
+            after_point = now.replace(hour=int(after_h), minute=int(after_m))
+
+            if now < after_point:
+                return
+
+        if weekday is not None:
+            now_weekday = WEEKDAYS[now.weekday()]
+
+            if isinstance(weekday, str) and weekday != now_weekday or \
+               now_weekday not in weekday:
+                return
+
+        action()
+
+    return time_if

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -4,13 +4,14 @@ tests.test_component_demo
 
 Tests demo component.
 """
+from datetime import timedelta
 import unittest
+from unittest.mock import patch
 
 import homeassistant.core as ha
-import homeassistant.loader as loader
 import homeassistant.util.dt as dt_util
 import homeassistant.components.automation as automation
-import homeassistant.components.automation.time as time
+from homeassistant.components.automation import time, event
 from homeassistant.const import CONF_PLATFORM
 
 from tests.common import fire_time_changed
@@ -94,3 +95,133 @@ class TestAutomationTime(unittest.TestCase):
         self.hass.states.set('test.entity', 'world')
         self.hass.pool.block_till_done()
         self.assertEqual(1, len(self.calls))
+
+    def test_if_action_before(self):
+        automation.setup(self.hass, {
+            automation.DOMAIN: {
+                CONF_PLATFORM: 'event',
+                event.CONF_EVENT_TYPE: 'test_event',
+                automation.CONF_SERVICE: 'test.automation',
+                automation.CONF_IF: {
+                    CONF_PLATFORM: 'time',
+                    time.CONF_BEFORE: '10:00'
+                }
+            }
+        })
+
+        before_10 = dt_util.now().replace(hour=8)
+        after_10 = dt_util.now().replace(hour=14)
+
+        with patch('homeassistant.components.automation.time.dt_util.now',
+                   return_value=before_10):
+            self.hass.bus.fire('test_event')
+            self.hass.pool.block_till_done()
+
+        self.assertEqual(1, len(self.calls))
+
+        with patch('homeassistant.components.automation.time.dt_util.now',
+                   return_value=after_10):
+            self.hass.bus.fire('test_event')
+            self.hass.pool.block_till_done()
+
+        self.assertEqual(1, len(self.calls))
+
+    def test_if_action_after(self):
+        automation.setup(self.hass, {
+            automation.DOMAIN: {
+                CONF_PLATFORM: 'event',
+                event.CONF_EVENT_TYPE: 'test_event',
+                automation.CONF_SERVICE: 'test.automation',
+                automation.CONF_IF: {
+                    CONF_PLATFORM: 'time',
+                    time.CONF_AFTER: '10:00'
+                }
+            }
+        })
+
+        before_10 = dt_util.now().replace(hour=8)
+        after_10 = dt_util.now().replace(hour=14)
+
+        with patch('homeassistant.components.automation.time.dt_util.now',
+                   return_value=before_10):
+            self.hass.bus.fire('test_event')
+            self.hass.pool.block_till_done()
+
+        self.assertEqual(0, len(self.calls))
+
+        with patch('homeassistant.components.automation.time.dt_util.now',
+                   return_value=after_10):
+            self.hass.bus.fire('test_event')
+            self.hass.pool.block_till_done()
+
+        self.assertEqual(1, len(self.calls))
+
+    def test_if_action_one_weekday(self):
+        automation.setup(self.hass, {
+            automation.DOMAIN: {
+                CONF_PLATFORM: 'event',
+                event.CONF_EVENT_TYPE: 'test_event',
+                automation.CONF_SERVICE: 'test.automation',
+                automation.CONF_IF: {
+                    CONF_PLATFORM: 'time',
+                    time.CONF_WEEKDAY: 'mon',
+                }
+            }
+        })
+
+        days_past_monday = dt_util.now().weekday()
+        monday = dt_util.now() - timedelta(days=days_past_monday)
+        tuesday = monday + timedelta(days=1)
+
+        with patch('homeassistant.components.automation.time.dt_util.now',
+                   return_value=monday):
+            self.hass.bus.fire('test_event')
+            self.hass.pool.block_till_done()
+
+        self.assertEqual(1, len(self.calls))
+
+        with patch('homeassistant.components.automation.time.dt_util.now',
+                   return_value=tuesday):
+            self.hass.bus.fire('test_event')
+            self.hass.pool.block_till_done()
+
+        self.assertEqual(1, len(self.calls))
+
+    def test_if_action_list_weekday(self):
+        automation.setup(self.hass, {
+            automation.DOMAIN: {
+                CONF_PLATFORM: 'event',
+                event.CONF_EVENT_TYPE: 'test_event',
+                automation.CONF_SERVICE: 'test.automation',
+                automation.CONF_IF: {
+                    CONF_PLATFORM: 'time',
+                    time.CONF_WEEKDAY: ['mon', 'tue'],
+                }
+            }
+        })
+
+        days_past_monday = dt_util.now().weekday()
+        monday = dt_util.now() - timedelta(days=days_past_monday)
+        tuesday = monday + timedelta(days=1)
+        wednesday = tuesday + timedelta(days=1)
+
+        with patch('homeassistant.components.automation.time.dt_util.now',
+                   return_value=monday):
+            self.hass.bus.fire('test_event')
+            self.hass.pool.block_till_done()
+
+        self.assertEqual(1, len(self.calls))
+
+        with patch('homeassistant.components.automation.time.dt_util.now',
+                   return_value=tuesday):
+            self.hass.bus.fire('test_event')
+            self.hass.pool.block_till_done()
+
+        self.assertEqual(2, len(self.calls))
+
+        with patch('homeassistant.components.automation.time.dt_util.now',
+                   return_value=wednesday):
+            self.hass.bus.fire('test_event')
+            self.hass.pool.block_till_done()
+
+        self.assertEqual(2, len(self.calls))


### PR DESCRIPTION
This PR adds the ability to specify if-conditions when specifying automation. Each configuration entry for automation can have 0, 1 or many if-conditions. They all have to be met for the action to be performed. 

For now there will be 4 supported checks:

``` yaml
automation:
  # Optional alias that the logs will use to refer to the entry
  alias: Sunset notification

  # Type of trigger and information for the trigger
  platform: state
  state_entity_id: sun.sun
  state_from: 'above_horizon'
  state_to: 'below_horizon'

  if:
    - platform: time
      weekday:
        - mon
        - tue
        - wed
      before: '11:00'
      after: '9:00'
    - platform: state
      entity_id: light.kitchen
      state: 'on'

  # Action to be done when trigger activated
  execute_service: notify.NOTIFIER_NAME
  service_data: {"message":"The sun has set"}
```

Or if you just want to specify 1 check:

``` yaml
automation:
  # Optional alias that the logs will use to refer to the entry
  alias: Sunset notification

  # Type of trigger and information for the trigger
  platform: state
  state_entity_id: sun.sun
  state_from: 'above_horizon'
  state_to: 'below_horizon'

  if:
    platform: time
    weekday: sat

  # Action to be done when trigger activated
  execute_service: notify.NOTIFIER_NAME
  service_data: {"message":"The sun has set"}
```
