### PR TITLE
Make the entity names for systemmonitor sensors a bit nicer

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -119,7 +119,7 @@ class SystemMonitorSensor(Entity):
 
     @property
     def name(self):
-        return self._name
+        return self._name.rstrip()
 
     @property
     def state(self):


### PR DESCRIPTION
Given the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: disk_use
        arg: /Volumes/DroboMovies
      - type: disk_use
        arg: /Volumes/DroboTV
      - type: disk_use_percent
        arg: /Volumes/Movies
      - type: disk_use_percent
        arg: /Volumes/Macintosh HD
      - type: memory_use_percent
      - type: memory_free
      - type: processor_use
      - type: network_in
        arg: en0
      - type: network_out
        arg: en0
      - type: since_last_boot
```

It will have a list of entity ids such as:

``` yaml
    - sensor.disk_use_volumesdrobomovies
    - sensor.disk_use_volumesdrobotv
    - sensor.disk_use_volumesmovies
    - sensor.disk_use_volumesmacintosh_hd
    - sensor.cpu_use_
    - sensor.ram_free_
    - sensor.ram_use_
    - sensor.recieved_en0
    - sensor.sent_en0
    - sensor.since_last_boot_
```

The [name generation code](https://github.com/balloob/home-assistant/blob/bf64956265bcff5e9a206045c9aa256774b99bf3/homeassistant/components/sensor/systemmonitor.py#L113) saves it with trailing whitespace and this is the simplest way to work around it.

Reported-by: @maddox 
