### PR TITLE
Fix the asuswrt device tracker for dhcp leases with no hostname

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -157,11 +157,19 @@ class AsusWrtDeviceScanner(object):
         devices = {}
         for lease in leases_result:
             match = _LEASES_REGEX.search(lease.decode('utf-8'))
+
+            # For leases where the client doesn't set a hostname, ensure
+            # it is blank and not '*', which breaks the entity_id down
+            # the line
+            host = match.group('host')
+            if host == '*':
+                host = ''
+
             devices[match.group('ip')] = {
+                'host': host,
+                'status': '',
                 'ip': match.group('ip'),
                 'mac': match.group('mac').upper(),
-                'host': match.group('host'),
-                'status': ''
                 }
 
         for neighbor in neighbors:


### PR DESCRIPTION
Sometimes, hosts request dhcp leases without sending the hostname
they want to the dhcp server. This results in the entity_id being
`device_tracker.` as the dev_id is empty and things go downhill
from there.

The dhcp lease file looks like:
    admin@RT-AC66R:/tmp/home/root# cat /var/lib/misc/dnsmasq.leases
    86400 5c:c5:d4:79:4c:ad 192.168.1.226 chit-jsl3 *
    85242 8c:77:12:ad:d9:23 192.168.1.126 android-2c94abebaab16255 01:8c:77:12:ad:d9:23
    61985 b8:e9:37:73:47:f0 192.168.1.204 \* 01:b8:e9:37:73:47:f0
    61982 b8:e9:37:ec:0d:7e 192.168.1.132 \* 01:b8:e9:37:ec:0d:7e
    84584 00:20:6b:ca:31:c1 192.168.1.182 MC4650-CA31C1 01:00:20:6b:ca:31:c1
    86306 fc:e9:98:d6:4b:90 192.168.1.173 iLol 01:fc:e9:98:d6:4b:90
    74343 20:3a:07:f3:7e:ae 192.168.1.246 gatekeeper 01:20:3a:07:f3:7e:ae
    72374 b8:e9:37:5f:3d:06 192.168.1.34 SonosZP 01:b8:e9:37:5f:3d:06
    64697 00:0e:58:6f:59:d2 192.168.1.171 SonosZB 01:00:0e:58:6f:59:d2

Confirmed working on an Asus RT-AC66R with fw version: 3.0.0.4.376_3861
