### PR TITLE
Append 'AirTunes Speaker' to Name of Devices Shared via itunes-api MediaPlayer

### DIFF
--- a/homeassistant/components/media_player/itunes.py
+++ b/homeassistant/components/media_player/itunes.py
@@ -357,9 +357,7 @@ class AirPlayDevice(MediaPlayerDevice):
 
         if 'name' in state_hash:
             name = state_hash.get('name', '')
-            kind = state_hash.get('kind', 'AirPlay')
-
-            self.device_name = (name + ' ' + kind).strip()
+            self.device_name = (name + ' AirTunes Speaker').strip()
 
         if 'kind' in state_hash:
             self.kind = state_hash.get('kind', None)

--- a/homeassistant/components/media_player/itunes.py
+++ b/homeassistant/components/media_player/itunes.py
@@ -356,7 +356,10 @@ class AirPlayDevice(MediaPlayerDevice):
             self.player_state = state_hash.get('player_state', None)
 
         if 'name' in state_hash:
-            self.device_name = state_hash.get('name', 'AirPlay')
+            name = state_hash.get('name', '')
+            kind = state_hash.get('kind', 'AirPlay')
+
+            self.device_name = (name + ' ' + kind).strip()
 
         if 'kind' in state_hash:
             self.kind = state_hash.get('kind', None)


### PR DESCRIPTION
This helps the media player be more explicit about itself and what it is. It also namespaces it self a little better in the system. 

Rather than be `media_player.family_room` it is `media_player.family_room_airtunes_speaker`. This helps for cases when there’s another actual media player like Kodi or Chromecast in there.

**edited after discussion with myself**
