### PR TITLE
Fix pip not detecting package installed

### DIFF
--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -1,6 +1,6 @@
 """Helpers to install PyPi packages."""
-import os
 import logging
+import os
 import pkg_resources
 import subprocess
 import sys
@@ -15,25 +15,24 @@ def install_package(package, upgrade=True, target=None):
     """Install a package on PyPi. Accepts pip compatible package strings.
     Return boolean if install successfull."""
     # Not using 'import pip; pip.main([])' because it breaks the logger
-    args = [sys.executable, '-m', 'pip', 'install', '--quiet', package]
-
-    if upgrade:
-        args.append('--upgrade')
-    if target:
-        args += ['--target', os.path.abspath(target)]
-
     with INSTALL_LOCK:
         if check_package_exists(package, target):
             return True
 
         _LOGGER.info('Attempting install of %s', package)
+        args = [sys.executable, '-m', 'pip', 'install', '--quiet', package]
+        if upgrade:
+            args.append('--upgrade')
+        if target:
+            args += ['--target', os.path.abspath(target)]
+
         try:
             return 0 == subprocess.call(args)
         except subprocess.SubprocessError:
             return False
 
 
-def check_package_exists(package, target=None):
+def check_package_exists(package, target):
     """Check if a package exists.
     Returns True when the requirement is met.
     Returns False when the package is not installed or doesn't meet req."""
@@ -43,16 +42,5 @@ def check_package_exists(package, target=None):
         # This is a zip file
         req = pkg_resources.Requirement.parse(urlparse(package).fragment)
 
-    if target:
-        work_set = pkg_resources.WorkingSet([target])
-        search_fun = work_set.find
-
-    else:
-        search_fun = pkg_resources.get_distribution
-
-    try:
-        result = search_fun(req)
-    except (pkg_resources.DistributionNotFound, pkg_resources.VersionConflict):
-        return False
-
-    return bool(result)
+    return any(dist in req for dist in
+               pkg_resources.find_distributions(target))


### PR DESCRIPTION
This will fix the pip installation issues that surfaced:

Pip is unable to uninstall existing packages from a target dir. When we install a newer version of a packge, it will overwrite the new version over the old version but will not remove the installation record of the old one. HA uses `pkg_resources` from `setuptools` to detect installed version. `pkg_resources` will only report the first version that it finds, which is the lower version.

We now use a new way to detect which version is installed which reports all installed versions. This is not solving the issue but is working around it.

In `<config>/lib`, for every package there is a folder with the installation records, ie `netdisco-0.3.dist-info`. Each of these folders contain a CSV file called `RECORD` with each file that got installed. A proper uninstall method would load in the RECORD, remove each entry and then remove the folders. This could be done in the future. However I do not have enough knowledge of the Python package system to know if these assumptions always hold true.
