### PR TITLE
Fix Event Trigger

### DIFF
--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -24,6 +24,7 @@ def trigger(hass, config, action):
 
     def handle_event(event):
         """ Listens for events and calls the action when data matches. """
+        event.data.pop('service_call_id')
         if event_data == event.data:
             action()
 


### PR DESCRIPTION
Pop the `service_call_id` id out of an Event's data before comparing it to the `event_data` config of an automation.

This hopes to resolve #400.

Maybe this is a different bug and the `service_call_id` shouldn't even be in the data anymore? I'm not sure. But this fixes event triggers.
