### PR TITLE
Event automation fuzzy matches on data

### DIFF
--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -20,11 +20,12 @@ def trigger(hass, config, action):
         _LOGGER.error("Missing configuration key %s", CONF_EVENT_TYPE)
         return False
 
-    event_data = config.get(CONF_EVENT_DATA, {})
+    event_data = config.get(CONF_EVENT_DATA)
 
     def handle_event(event):
         """ Listens for events and calls the action when data matches. """
-        if event_data == event.data:
+        if not event_data or all(val == event.data.get(key) for key, val
+                                 in event_data.items()):
             action()
 
     hass.bus.listen(event_type, handle_event)

--- a/tests/components/automation/test_event.py
+++ b/tests/components/automation/test_event.py
@@ -98,7 +98,8 @@ class TestAutomationEvent(unittest.TestCase):
             }
         }))
 
-        self.hass.bus.fire('test_event', {'some_attr': 'some_value'})
+        self.hass.bus.fire('test_event', {'some_attr': 'some_value',
+                                          'another': 'value'})
         self.hass.pool.block_till_done()
         self.assertEqual(1, len(self.calls))
 


### PR DESCRIPTION
This PR supersedes #401 and makes event automation rules more flexible. Now given event data is used as a filter, if all given event data is present in the fired event, the automation will fire.

CC @maddox 
