### PR TITLE
Change automation action config keys

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -16,9 +16,9 @@ DOMAIN = 'automation'
 DEPENDENCIES = ['group']
 
 CONF_ALIAS = 'alias'
-CONF_SERVICE = 'execute_service'
-CONF_SERVICE_ENTITY_ID = 'service_entity_id'
-CONF_SERVICE_DATA = 'service_data'
+CONF_SERVICE = 'service'
+CONF_SERVICE_ENTITY_ID = 'entity_id'
+CONF_SERVICE_DATA = 'data'
 
 CONF_CONDITION = 'condition'
 CONF_ACTION = 'action'
@@ -118,7 +118,10 @@ def _migrate_old_config(config):
                               ('trigger', 'state_from', 'from'),
                               ('trigger', 'state_hours', 'hours'),
                               ('trigger', 'state_minutes', 'minutes'),
-                              ('trigger', 'state_seconds', 'seconds')):
+                              ('trigger', 'state_seconds', 'seconds'),
+                              ('action', 'execute_service', 'service'),
+                              ('action', 'service_entity_id', 'entity_id'),
+                              ('action', 'service_data', 'data')):
         if key in new_conf[cat]:
             new_conf[cat][new_key] = new_conf[cat].pop(key)
 

--- a/tests/components/automation/test_event.py
+++ b/tests/components/automation/test_event.py
@@ -75,7 +75,7 @@ class TestAutomationEvent(unittest.TestCase):
                     'event_type': 'test_event',
                 },
                 'action': {
-                    'execute_service': 'test.automation',
+                    'service': 'test.automation',
                 }
             }
         }))
@@ -93,7 +93,7 @@ class TestAutomationEvent(unittest.TestCase):
                     'event_data': {'some_attr': 'some_value'}
                 },
                 'action': {
-                    'execute_service': 'test.automation',
+                    'service': 'test.automation',
                 }
             }
         }))
@@ -111,7 +111,7 @@ class TestAutomationEvent(unittest.TestCase):
                     'event_data': {'some_attr': 'some_value'}
                 },
                 'action': {
-                    'execute_service': 'test.automation',
+                    'service': 'test.automation',
                 }
             }
         }))

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -10,7 +10,7 @@ import homeassistant.components.automation as automation
 from homeassistant.const import ATTR_ENTITY_ID
 
 
-class TestAutomationEvent(unittest.TestCase):
+class TestAutomation(unittest.TestCase):
     """ Test the event automation. """
 
     def setUp(self):  # pylint: disable=invalid-name
@@ -26,7 +26,7 @@ class TestAutomationEvent(unittest.TestCase):
         """ Stop down stuff we started. """
         self.hass.stop()
 
-    def test_service_data_not_a_dict(self):
+    def test_old_config_service_data_not_a_dict(self):
         automation.setup(self.hass, {
             automation.DOMAIN: {
                 'platform': 'event',
@@ -87,6 +87,24 @@ class TestAutomationEvent(unittest.TestCase):
         self.assertEqual(['hello.world', 'hello.world2'],
                          self.calls[0].data.get(ATTR_ENTITY_ID))
 
+    def test_service_data_not_a_dict(self):
+        automation.setup(self.hass, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'event',
+                    'event_type': 'test_event',
+                },
+                'action': {
+                    'service': 'test.automation',
+                    'data': 100,
+                }
+            }
+        })
+
+        self.hass.bus.fire('test_event')
+        self.hass.pool.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
     def test_service_specify_data(self):
         automation.setup(self.hass, {
             automation.DOMAIN: {
@@ -95,8 +113,8 @@ class TestAutomationEvent(unittest.TestCase):
                     'event_type': 'test_event',
                 },
                 'action': {
-                    'execute_service': 'test.automation',
-                    'service_data': {'some': 'data'}
+                    'service': 'test.automation',
+                    'data': {'some': 'data'}
                 }
             }
         })
@@ -114,8 +132,8 @@ class TestAutomationEvent(unittest.TestCase):
                     'event_type': 'test_event',
                 },
                 'action': {
-                    'execute_service': 'test.automation',
-                    'service_entity_id': 'hello.world'
+                    'service': 'test.automation',
+                    'entity_id': 'hello.world'
                 }
             }
         })
@@ -134,8 +152,8 @@ class TestAutomationEvent(unittest.TestCase):
                     'event_type': 'test_event',
                 },
                 'action': {
-                    'execute_service': 'test.automation',
-                    'service_entity_id': ['hello.world', 'hello.world2']
+                    'service': 'test.automation',
+                    'entity_id': ['hello.world', 'hello.world2']
                 }
             }
         })
@@ -160,7 +178,7 @@ class TestAutomationEvent(unittest.TestCase):
                     }
                 ],
                 'action': {
-                    'execute_service': 'test.automation',
+                    'service': 'test.automation',
                 }
             }
         })
@@ -195,7 +213,7 @@ class TestAutomationEvent(unittest.TestCase):
                     }
                 ],
                 'action': {
-                    'execute_service': 'test.automation',
+                    'service': 'test.automation',
                 }
             }
         })
@@ -239,7 +257,7 @@ class TestAutomationEvent(unittest.TestCase):
                     }
                 ],
                 'action': {
-                    'execute_service': 'test.automation',
+                    'service': 'test.automation',
                 }
             }
         })
@@ -278,7 +296,7 @@ class TestAutomationEvent(unittest.TestCase):
                 ],
                 'condition': 'use_trigger_values',
                 'action': {
-                    'execute_service': 'test.automation',
+                    'service': 'test.automation',
                 }
             }
         })
@@ -314,7 +332,7 @@ class TestAutomationEvent(unittest.TestCase):
                 ],
                 'condition': 'use_trigger_values',
                 'action': {
-                    'execute_service': 'test.automation',
+                    'service': 'test.automation',
                 }
             }
         })

--- a/tests/components/automation/test_mqtt.py
+++ b/tests/components/automation/test_mqtt.py
@@ -77,7 +77,7 @@ class TestAutomationState(unittest.TestCase):
                     'topic': 'test-topic'
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -95,7 +95,7 @@ class TestAutomationState(unittest.TestCase):
                     'payload': 'hello'
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -113,7 +113,7 @@ class TestAutomationState(unittest.TestCase):
                     'payload': 'hello'
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -35,7 +35,7 @@ class TestAutomationNumericState(unittest.TestCase):
                     'below': 10,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -56,7 +56,7 @@ class TestAutomationNumericState(unittest.TestCase):
                     'below': 10,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -78,7 +78,7 @@ class TestAutomationNumericState(unittest.TestCase):
                     'below': 10,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -97,7 +97,7 @@ class TestAutomationNumericState(unittest.TestCase):
                     'above': 10,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -119,7 +119,7 @@ class TestAutomationNumericState(unittest.TestCase):
                     'above': 10,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -142,7 +142,7 @@ class TestAutomationNumericState(unittest.TestCase):
                     'above': 10,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -162,7 +162,7 @@ class TestAutomationNumericState(unittest.TestCase):
                     'above': 5,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -181,7 +181,7 @@ class TestAutomationNumericState(unittest.TestCase):
                     'above': 5,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -203,7 +203,7 @@ class TestAutomationNumericState(unittest.TestCase):
                     'above': 5,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -226,7 +226,7 @@ class TestAutomationNumericState(unittest.TestCase):
                     'above': 5,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -244,7 +244,7 @@ class TestAutomationNumericState(unittest.TestCase):
                     'entity_id': 'test.another_entity',
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -269,7 +269,7 @@ class TestAutomationNumericState(unittest.TestCase):
                     'below': test_state + 2
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         })

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -164,7 +164,7 @@ class TestAutomationState(unittest.TestCase):
                     'entity_id': 'test.entity',
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -182,7 +182,7 @@ class TestAutomationState(unittest.TestCase):
                     'from': 'hello'
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -200,7 +200,7 @@ class TestAutomationState(unittest.TestCase):
                     'to': 'world'
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -218,7 +218,7 @@ class TestAutomationState(unittest.TestCase):
                     'state': 'world'
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -237,7 +237,7 @@ class TestAutomationState(unittest.TestCase):
                     'to': 'world'
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -256,7 +256,7 @@ class TestAutomationState(unittest.TestCase):
                     'to': 'world'
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -277,7 +277,7 @@ class TestAutomationState(unittest.TestCase):
                     'to': 'world'
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -294,7 +294,7 @@ class TestAutomationState(unittest.TestCase):
                     'entity_id': 'test.anoter_entity',
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -318,7 +318,7 @@ class TestAutomationState(unittest.TestCase):
                     'state': test_state
                 }],
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         })

--- a/tests/components/automation/test_sun.py
+++ b/tests/components/automation/test_sun.py
@@ -51,7 +51,7 @@ class TestAutomationSun(unittest.TestCase):
                         'event': 'sunset',
                     },
                     'action': {
-                        'execute_service': 'test.automation',
+                        'service': 'test.automation',
                     }
                 }
             }))
@@ -77,7 +77,7 @@ class TestAutomationSun(unittest.TestCase):
                         'event': 'sunrise',
                     },
                     'action': {
-                        'execute_service': 'test.automation',
+                        'service': 'test.automation',
                     }
                 }
             }))
@@ -104,7 +104,7 @@ class TestAutomationSun(unittest.TestCase):
                         'offset': '0:30:00'
                     },
                     'action': {
-                        'execute_service': 'test.automation',
+                        'service': 'test.automation',
                     }
                 }
             }))
@@ -131,7 +131,7 @@ class TestAutomationSun(unittest.TestCase):
                         'offset': '-0:30:00'
                     },
                     'action': {
-                        'execute_service': 'test.automation',
+                        'service': 'test.automation',
                     }
                 }
             }))

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -36,9 +36,9 @@ class TestAutomationTime(unittest.TestCase):
     def test_old_config_if_fires_when_hour_matches(self):
         self.assertTrue(automation.setup(self.hass, {
             automation.DOMAIN: {
-                CONF_PLATFORM: 'time',
+                'platform': 'time',
                 time.CONF_HOURS: 0,
-                automation.CONF_SERVICE: 'test.automation'
+                'execute_service': 'test.automation'
             }
         }))
 
@@ -51,9 +51,9 @@ class TestAutomationTime(unittest.TestCase):
     def test_old_config_if_fires_when_minute_matches(self):
         self.assertTrue(automation.setup(self.hass, {
             automation.DOMAIN: {
-                CONF_PLATFORM: 'time',
+                'platform': 'time',
                 time.CONF_MINUTES: 0,
-                automation.CONF_SERVICE: 'test.automation'
+                'execute_service': 'test.automation'
             }
         }))
 
@@ -66,9 +66,9 @@ class TestAutomationTime(unittest.TestCase):
     def test_old_config_if_fires_when_second_matches(self):
         self.assertTrue(automation.setup(self.hass, {
             automation.DOMAIN: {
-                CONF_PLATFORM: 'time',
+                'platform': 'time',
                 time.CONF_SECONDS: 0,
-                automation.CONF_SERVICE: 'test.automation'
+                'execute_service': 'test.automation'
             }
         }))
 
@@ -85,7 +85,7 @@ class TestAutomationTime(unittest.TestCase):
                 time.CONF_HOURS: 0,
                 time.CONF_MINUTES: 0,
                 time.CONF_SECONDS: 0,
-                automation.CONF_SERVICE: 'test.automation'
+                'execute_service': 'test.automation'
             }
         }))
 
@@ -101,7 +101,7 @@ class TestAutomationTime(unittest.TestCase):
             automation.DOMAIN: {
                 CONF_PLATFORM: 'event',
                 event.CONF_EVENT_TYPE: 'test_event',
-                automation.CONF_SERVICE: 'test.automation',
+                'execute_service': 'test.automation',
                 'if': {
                     CONF_PLATFORM: 'time',
                     time.CONF_BEFORE: '10:00'
@@ -131,7 +131,7 @@ class TestAutomationTime(unittest.TestCase):
             automation.DOMAIN: {
                 CONF_PLATFORM: 'event',
                 event.CONF_EVENT_TYPE: 'test_event',
-                automation.CONF_SERVICE: 'test.automation',
+                'execute_service': 'test.automation',
                 'if': {
                     CONF_PLATFORM: 'time',
                     time.CONF_AFTER: '10:00'
@@ -161,7 +161,7 @@ class TestAutomationTime(unittest.TestCase):
             automation.DOMAIN: {
                 CONF_PLATFORM: 'event',
                 event.CONF_EVENT_TYPE: 'test_event',
-                automation.CONF_SERVICE: 'test.automation',
+                'execute_service': 'test.automation',
                 'if': {
                     CONF_PLATFORM: 'time',
                     time.CONF_WEEKDAY: 'mon',
@@ -192,7 +192,7 @@ class TestAutomationTime(unittest.TestCase):
             automation.DOMAIN: {
                 CONF_PLATFORM: 'event',
                 event.CONF_EVENT_TYPE: 'test_event',
-                automation.CONF_SERVICE: 'test.automation',
+                'execute_service': 'test.automation',
                 'if': {
                     CONF_PLATFORM: 'time',
                     time.CONF_WEEKDAY: ['mon', 'tue'],
@@ -234,7 +234,7 @@ class TestAutomationTime(unittest.TestCase):
                     'hours': 0,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -252,7 +252,7 @@ class TestAutomationTime(unittest.TestCase):
                     'minutes': 0,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -270,7 +270,7 @@ class TestAutomationTime(unittest.TestCase):
                     'seconds': 0,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -290,7 +290,7 @@ class TestAutomationTime(unittest.TestCase):
                     'seconds': 3,
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -309,7 +309,7 @@ class TestAutomationTime(unittest.TestCase):
                     'after': '5:00:00',
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -332,7 +332,7 @@ class TestAutomationTime(unittest.TestCase):
                     # Total seconds. Hour = 3600 second
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         }))
@@ -356,7 +356,7 @@ class TestAutomationTime(unittest.TestCase):
                     'before': '10:00',
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         })
@@ -390,7 +390,7 @@ class TestAutomationTime(unittest.TestCase):
                     'after': '10:00',
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         })
@@ -424,7 +424,7 @@ class TestAutomationTime(unittest.TestCase):
                     'weekday': 'mon',
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         })
@@ -459,7 +459,7 @@ class TestAutomationTime(unittest.TestCase):
                     'weekday': ['mon', 'tue'],
                 },
                 'action': {
-                    'execute_service': 'test.automation'
+                    'service': 'test.automation'
                 }
             }
         })


### PR DESCRIPTION
This updates the config keys in the automation component for the action section. Fixes #402.

Before:

``` yaml
action:
  execute_service: homeassistant.turn_on
  service_entity_id: light.kitchen
  service_data:
    transition: 90
```

After:

``` yaml
action:
  service: homeassistant.turn_on
  entity_id: light.kitchen
  data:
    transition: 90
```
