### PR TITLE
initial owntracks support

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -297,11 +297,15 @@ def process_ha_core_config(hass, config):
         else:
             _LOGGER.error('Received invalid time zone %s', time_zone_str)
 
-    for key, attr in ((CONF_LATITUDE, 'latitude'),
-                      (CONF_LONGITUDE, 'longitude'),
-                      (CONF_NAME, 'location_name')):
+    for key, attr, typ in ((CONF_LATITUDE, 'latitude', float),
+                           (CONF_LONGITUDE, 'longitude', float),
+                           (CONF_NAME, 'location_name', str)):
         if key in config:
-            setattr(hac, attr, config[key])
+            try:
+                setattr(hac, attr, typ(config[key]))
+            except ValueError:
+                _LOGGER.error('Received invalid %s value for %s: %s',
+                              typ.__name__, key, attr)
 
     set_time_zone(config.get(CONF_TIME_ZONE))
 

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -1,0 +1,31 @@
+"""
+homeassistant.components.device_tracker.owntracks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+OwnTracks platform for the device tracker.
+
+device_tracker:
+  platform: owntracks
+"""
+import json
+
+import homeassistant.components.mqtt as mqtt
+
+DEPENDENCIES = ['mqtt']
+
+LOCATION_TOPIC = 'owntracks/+/+'
+
+
+def setup_scanner(hass, config, see):
+    """ Set up a MQTT tracker. """
+
+    def owntracks_location_update(topic, payload, qos):
+        """ MQTT message received. """
+        parts = topic.split('/')
+        data = json.loads(payload)
+        dev_id = '{}_{}'.format(parts[1], parts[2])
+        see(dev_id=dev_id, host_name=parts[1], gps=[data['lat'], data['lon']])
+
+    mqtt.subscribe(hass, LOCATION_TOPIC, owntracks_location_update, 1)
+
+    return True

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -21,10 +21,21 @@ def setup_scanner(hass, config, see):
 
     def owntracks_location_update(topic, payload, qos):
         """ MQTT message received. """
+
+        # Docs on available data:
+        # http://owntracks.org/booklet/tech/json/#_typelocation
+
         parts = topic.split('/')
-        data = json.loads(payload)
+        try:
+            data = json.loads(payload)
+        except ValueError:
+            # If invalid JSON
+            return
+        if data.get('_type') != 'location':
+            return
         dev_id = '{}_{}'.format(parts[1], parts[2])
-        see(dev_id=dev_id, host_name=parts[1], gps=[data['lat'], data['lon']])
+        see(dev_id=dev_id, host_name=parts[1], gps=(data['lat'], data['lon']),
+            gps_accuracy=data['acc'], battery=data['batt'])
 
     mqtt.subscribe(hass, LOCATION_TOPIC, owntracks_location_update, 1)
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -26,6 +26,7 @@ from homeassistant.exceptions import (
     HomeAssistantError, InvalidEntityFormatError)
 import homeassistant.util as util
 import homeassistant.util.dt as date_util
+import homeassistant.util.location as location
 import homeassistant.helpers.temperature as temp_helper
 from homeassistant.config import get_default_config_dir
 
@@ -675,6 +676,10 @@ class Config(object):
 
         # Directory that holds the configuration
         self.config_dir = get_default_config_dir()
+
+    def distance(self, lat, lon):
+        """ Calculate distance from Home Assistant in meters. """
+        return location.distance(self.latitude, self.longitude, lat, lon)
 
     def path(self, *path):
         """ Returns path to the file within the config dir. """

--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -38,13 +38,11 @@ def distance(lon1, lat1, lon2, lat2):
     in decimal degrees on the earth using the Haversine algorithm.
     """
     # convert decimal degrees to radians
-    lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
+    lon1, lat1, lon2, lat2 = (radians(val) for val in (lon1, lat1, lon2, lat2))
 
-    # haversine formula
     dlon = lon2 - lon1
     dlat = lat2 - lat1
-    a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
-    c = 2 * asin(sqrt(a))
+    angle = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
     # Radius of earth in meters.
     radius = 6371000
-    return c * radius
+    return 2 * radius * asin(sqrt(angle))

--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -1,5 +1,6 @@
 """Module with location helpers."""
 import collections
+from math import radians, cos, sin, asin, sqrt
 
 import requests
 
@@ -28,3 +29,22 @@ def detect_location_info():
         'BS', 'BZ', 'KY', 'PW', 'US', 'AS', 'VI')
 
     return LocationInfo(**data)
+
+
+# From: http://stackoverflow.com/a/4913653/646416
+def distance(lon1, lat1, lon2, lat2):
+    """
+    Calculate the great circle distance in meters between two points specified
+    in decimal degrees on the earth using the Haversine algorithm.
+    """
+    # convert decimal degrees to radians
+    lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
+
+    # haversine formula
+    dlon = lon2 - lon1
+    dlat = lat2 - lat1
+    a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
+    c = 2 * asin(sqrt(a))
+    # Radius of earth in meters.
+    radius = 6371000
+    return c * radius

--- a/script/lint
+++ b/script/lint
@@ -5,14 +5,15 @@ cd "$(dirname "$0")/.."
 echo "Checking style with flake8..."
 flake8 --exclude www_static homeassistant
 
-STATUS=$?
+FLAKE8_STATUS=$?
 
 echo "Checking style with pylint..."
 pylint homeassistant
+PYLINT_STATUS=$?
 
-if [ $STATUS -eq 0 ]
+if [ $FLAKE8_STATUS -eq 0 ]
 then
-  exit $?
+  exit $FLAKE8_STATUS
 else
-  exit $STATUS
+  exit $PYLINT_STATUS
 fi

--- a/script/release
+++ b/script/release
@@ -1,0 +1,21 @@
+# Pushes a new version to PyPi
+
+cd "$(dirname "$0")/.."
+
+head -n 3 homeassistant/const.py | tail -n 1 | grep dev
+
+if [ $? -eq 0 ]
+then
+  echo "Release version should not contain dev tag"
+  exit 1
+fi
+
+CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+
+if [ "$CURRENT_BRANCH" != "master" ]
+then
+  echo "You have to be on the master branch to release."
+  exit 1
+fi
+
+python3 setup.py sdist bdist_wheel upload

--- a/script/test
+++ b/script/test
@@ -7,19 +7,21 @@ cd "$(dirname "$0")/.."
 
 script/lint
 
-STATUS=$?
+LINT_STATUS=$?
 
 echo "Running tests..."
 
 if [ "$1" = "coverage" ]; then
   py.test --cov --cov-report=
+  TEST_STATUS=$?
 else
   py.test
+  TEST_STATUS=$?
 fi
 
-if [ $STATUS -eq 0 ]
+if [ $LINT_STATUS -eq 0 ]
 then
-  exit $?
+  exit $TEST_STATUS
 else
-  exit $STATUS
+  exit $LINT_STATUS
 fi

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -103,12 +103,12 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     def test_reading_yaml_config(self):
         dev_id = 'test'
         device = device_tracker.Device(
-            self.hass, timedelta(seconds=180), True, dev_id, 'AB:CD:EF:GH:IJ',
-            'Test name', 'http://test.picture', True)
+            self.hass, timedelta(seconds=180), 0, True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', 'http://test.picture', True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
         self.assertTrue(device_tracker.setup(self.hass, {}))
         config = device_tracker.load_config(self.yaml_devices, self.hass,
-                                            device.consider_home)[0]
+                                            device.consider_home, 0)[0]
         self.assertEqual(device.dev_id, config.dev_id)
         self.assertEqual(device.track, config.track)
         self.assertEqual(device.mac, config.mac)
@@ -126,7 +126,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         self.assertTrue(device_tracker.setup(self.hass, {
             device_tracker.DOMAIN: {CONF_PLATFORM: 'test'}}))
         config = device_tracker.load_config(self.yaml_devices, self.hass,
-                                            timedelta(seconds=0))[0]
+                                            timedelta(seconds=0), 0)[0]
         self.assertEqual('dev1', config.dev_id)
         self.assertEqual(True, config.track)
 
@@ -176,7 +176,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         picture = 'http://placehold.it/200x200'
 
         device = device_tracker.Device(
-            self.hass, timedelta(seconds=180), True, dev_id, None,
+            self.hass, timedelta(seconds=180), 0, True, dev_id, None,
             friendly_name, picture, away_hide=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
 
@@ -191,7 +191,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         dev_id = 'test_entity'
         entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
         device = device_tracker.Device(
-            self.hass, timedelta(seconds=180), True, dev_id, None,
+            self.hass, timedelta(seconds=180), 0, True, dev_id, None,
             away_hide=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
 
@@ -208,7 +208,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         dev_id = 'test_entity'
         entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
         device = device_tracker.Device(
-            self.hass, timedelta(seconds=180), True, dev_id, None,
+            self.hass, timedelta(seconds=180), 0, True, dev_id, None,
             away_hide=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
 


### PR DESCRIPTION
Listens to MQTT for messages from [OwnTracks](http://owntracks.org/) and push them to device tracker. Allows real time GPS location reporting from phones to Home Assistant.

Tested with the [Android app](https://play.google.com/store/apps/details?id=org.owntracks.android)

This already exposed some use cases that are poorly supported by the device tracker. For example, we should only consider someone home if they are within a certain gps range from home.

Plan for the frontend is to add a new view that shows your home + people on a map.
