### PR TITLE
new fritzbox device traker

### DIFF
--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -42,10 +42,10 @@ class FritzBoxScanner():
         try:
             import fritzconnection as fc
         except ImportError:
-            _LOGGER.exception(
-                ("Failed to import fritzconnection. Did you install\n
-                  fritzconnection with the bugfix from\n
-                  'https://bitbucket.org/Fettlaus/fritzconnection'"))
+            _LOGGER.exception('Failed to import fritzconnection.')
+            _LOGGER.exception('Did you install fritzconnection with the')
+            _LOGGER.exception('bugfix from')
+            _LOGGER.exception('"https://bitbucket.org/Fettlaus/fritzconnection"')
             self.success_init = False
             return
 

--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -1,0 +1,95 @@
+""" Supports scanning a FritzBox router"""
+import logging
+import json
+from datetime import timedelta
+from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
+from homeassistant.helpers import validate_config
+from homeassistant.util import Throttle
+from homeassistant.components.device_tracker import DOMAIN
+
+
+# Return cached results if last scan was less then this time ago
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_scanner(hass, config):
+    """ Validates config and returns FritzBoxScanner obj"""
+    if not validate_config(config,
+                           {DOMAIN: [CONF_HOST, CONF_USERNAME, CONF_PASSWORD]},
+                           _LOGGER):
+        return None
+    scanner = FritzBoxScanner(config[DOMAIN])
+    return scanner if scanner.success_init else None
+
+
+# pylint: disable=too-many-instance-attributes
+class FritzBoxScanner():
+    """ This class queries a FritzBox router. Adapted from luci.py and
+    using fritzconnection as comunication backend with the router
+
+    The API describtion can be found under:
+    https://pypi.python.org/pypi/fritzconnection/0.4.6
+
+    This scanner asks the fritzbox for its known hosts and returns
+    theis state (on, or off)
+
+    Due to a bug in the fritzbox api (router side), not more than 
+    16 hosts are returned. """
+    def __init__(self, config):
+        self.last_results = []
+
+        try:
+            import fritzconnection as fc
+        except ImportError:
+            _LOGGER.exception(
+                ("Failed to import fritzconnection. Did you install fritzconnection with the bugfix from https://bitbucket.org/Fettlaus/fritzconnection"))
+            self.success_init = False
+            return 
+            
+        
+        host = '169.254.1.1' ### this is valid for all fritzboxes
+        if  CONF_HOST in config.keys(): host = config[CONF_HOST]
+        password = ''
+        if CONF_PASSWORD in config.keys(): password = config[CONF_PASSWORD]
+        self._fritzBox = fc.FritzHosts(address=host, password=password)
+        ### I have not found a way to validate login, at atleast for
+        ### my fritzbox, i can get the list of known hosts even without
+        ### password 
+        self.success_init = True
+
+        if self.success_init:
+            self._update_info()
+        else:
+            _LOGGER.error("Failed to login into FritzBox")
+        
+
+    def scan_devices(self):
+        """ Scans for new devices and return a
+            list containing found device ids. """
+        self._update_info()
+        activeHosts = []
+        for knownHost in self.last_results:
+            if knownHost["status"] == "1":
+                activeHosts.append(knownHost["mac"])
+        return activeHosts
+        
+
+    def get_device_name(self, mac):
+        """ Returns the name of the given device or None if not known. """
+
+        ret = self._fritzBox.get_specific_host_entry(mac)["NewHostName"]
+        if ret == {}:
+            return None
+        return ret
+
+    @Throttle(MIN_TIME_BETWEEN_SCANS)
+    def _update_info(self):
+        """ Retrieves latest information from the FritzBox.
+            Returns boolean if scanning successful. """
+        if not self.success_init:
+            return
+
+        _LOGGER.info("Scanning")
+        self.last_results = self._fritzBox.get_hosts_info()

--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -43,14 +43,14 @@ class FritzBoxScanner():
             import fritzconnection as fc
         except ImportError:
             _LOGGER.exception(
-                ("Failed to import fritzconnection. Did you install
-                  fritzconnection with the bugfix from 
-                  https://bitbucket.org/Fettlaus/fritzconnection"))
+                ("Failed to import fritzconnection. Did you install\n
+                  fritzconnection with the bugfix from\n
+                  'https://bitbucket.org/Fettlaus/fritzconnection'"))
             self.success_init = False
             return
-        
+
         host = '169.254.1.1'  # this is valid for all fritzboxes
-        if  CONF_HOST in config.keys():
+        if CONF_HOST in config.keys():
             host = config[CONF_HOST]
         password = ''
         if CONF_PASSWORD in config.keys():

--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -42,6 +42,7 @@ class FritzBoxScanner():
         try:
             import fritzconnection as fc
         except ImportError:
+            # pylint: disable=line-too-long
             _LOGGER.exception('Failed to import fritzconnection. Did you install fritzconnection with the bugfix from "https://bitbucket.org/Fettlaus/fritzconnection"') # flake8: noqa
             self.success_init = False
             return

--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -1,6 +1,5 @@
 """ Supports scanning a FritzBox router"""
 import logging
-import json
 from datetime import timedelta
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.helpers import validate_config
@@ -35,8 +34,8 @@ class FritzBoxScanner():
     This scanner asks the fritzbox for its known hosts and returns
     theis state (on, or off)
 
-    Due to a bug in the fritzbox api (router side), not more than 
-    16 hosts are returned. """
+    Due to a bug in the fritzbox api (router side), not more than
+    16 hosts are returned."""
     def __init__(self, config):
         self.last_results = []
 
@@ -44,26 +43,28 @@ class FritzBoxScanner():
             import fritzconnection as fc
         except ImportError:
             _LOGGER.exception(
-                ("Failed to import fritzconnection. Did you install fritzconnection with the bugfix from https://bitbucket.org/Fettlaus/fritzconnection"))
+                ("Failed to import fritzconnection. Did you install
+                  fritzconnection with the bugfix from 
+                  https://bitbucket.org/Fettlaus/fritzconnection"))
             self.success_init = False
-            return 
-            
+            return
         
-        host = '169.254.1.1' ### this is valid for all fritzboxes
-        if  CONF_HOST in config.keys(): host = config[CONF_HOST]
+        host = '169.254.1.1'  # this is valid for all fritzboxes
+        if  CONF_HOST in config.keys():
+            host = config[CONF_HOST]
         password = ''
-        if CONF_PASSWORD in config.keys(): password = config[CONF_PASSWORD]
+        if CONF_PASSWORD in config.keys():
+            password = config[CONF_PASSWORD]
         self._fritzBox = fc.FritzHosts(address=host, password=password)
-        ### I have not found a way to validate login, at atleast for
-        ### my fritzbox, i can get the list of known hosts even without
-        ### password 
+        # I have not found a way to validate login, atleast for
+        # my fritzbox, i can get the list of known hosts even without
+        # password
         self.success_init = True
 
         if self.success_init:
             self._update_info()
         else:
             _LOGGER.error("Failed to login into FritzBox")
-        
 
     def scan_devices(self):
         """ Scans for new devices and return a
@@ -74,7 +75,6 @@ class FritzBoxScanner():
             if knownHost["status"] == "1":
                 activeHosts.append(knownHost["mac"])
         return activeHosts
-        
 
     def get_device_name(self, mac):
         """ Returns the name of the given device or None if not known. """

--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -12,6 +12,7 @@ MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 _LOGGER = logging.getLogger(__name__)
 
+REQUIREMENTS = ['fritzconnection==0.4.6']
 
 def get_scanner(hass, config):
     """ Validates config and returns FritzBoxScanner obj"""

--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -42,10 +42,7 @@ class FritzBoxScanner():
         try:
             import fritzconnection as fc
         except ImportError:
-            _LOGGER.exception('Failed to import fritzconnection.')
-            _LOGGER.exception('Did you install fritzconnection with the')
-            _LOGGER.exception('bugfix from')
-            _LOGGER.exception('"https://bitbucket.org/Fettlaus/fritzconnection"')
+            _LOGGER.exception('Failed to import fritzconnection. Did you install fritzconnection with the bugfix from "https://bitbucket.org/Fettlaus/fritzconnection"') # flake8: noqa
             self.success_init = False
             return
 
@@ -55,7 +52,7 @@ class FritzBoxScanner():
         password = ''
         if CONF_PASSWORD in config.keys():
             password = config[CONF_PASSWORD]
-        self._fritzBox = fc.FritzHosts(address=host, password=password)
+        self._fritz_box = fc.FritzHosts(address=host, password=password)
         # I have not found a way to validate login, atleast for
         # my fritzbox, i can get the list of known hosts even without
         # password
@@ -70,16 +67,16 @@ class FritzBoxScanner():
         """ Scans for new devices and return a
             list containing found device ids. """
         self._update_info()
-        activeHosts = []
-        for knownHost in self.last_results:
-            if knownHost["status"] == "1":
-                activeHosts.append(knownHost["mac"])
-        return activeHosts
+        active_hosts = []
+        for known_host in self.last_results:
+            if known_host["status"] == "1":
+                active_hosts.append(known_host["mac"])
+        return active_hosts
 
     def get_device_name(self, mac):
         """ Returns the name of the given device or None if not known. """
 
-        ret = self._fritzBox.get_specific_host_entry(mac)["NewHostName"]
+        ret = self._fritz_box.get_specific_host_entry(mac)["NewHostName"]
         if ret == {}:
             return None
         return ret
@@ -92,4 +89,4 @@ class FritzBoxScanner():
             return
 
         _LOGGER.info("Scanning")
-        self.last_results = self._fritzBox.get_hosts_info()
+        self.last_results = self._fritz_box.get_hosts_info()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -137,5 +137,5 @@ SoCo==0.11.1
 # PlexAPI (media_player.plex)
 https://github.com/miniconfig/python-plexapi/archive/437e36dca3b7780dc0cb73941d662302c0cd2fa9.zip#python-plexapi==1.0.2
 
-# FritzconnectionAPI
+# FritzconnectionAPI (device_tracker.fritz)
 https://github.com/deisi/fritzconnection/archive/b5c14515e1c8e2652b06b6316a7f3913df942841.zip#fritzconnection==0.4.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -136,3 +136,6 @@ SoCo==0.11.1
 
 # PlexAPI (media_player.plex)
 https://github.com/miniconfig/python-plexapi/archive/437e36dca3b7780dc0cb73941d662302c0cd2fa9.zip#python-plexapi==1.0.2
+
+# FritzconnectionAPI
+https://github.com/deisi/fritzconnection/archive/b5c14515e1c8e2652b06b6316a7f3913df942841.zip#fritzconnection==0.4.6


### PR DESCRIPTION
A long time a go in a far away galaxy....
Okay here it is. The fritzbox device traker I wanted to commit since long ago. However I think I will need some help with it.
1. Fritzconnection from pip is still buggy when using python 3 but the fork from [Fettlaus](https://bitbucket.org/Fettlaus/fritzconnection) is working. This can be manually installed, or via script. What is the way we do this here?
2. The fritzboxes have a bug in there internal API. They do not return all known hosts, but rather the first 16 they have ever connected to. This can be resolved by manually removing all the uninteresting hosts from the fritzbox webinterface. If one needs to track more then 16 devices, the nmap_tracker must be used.
3. The fritzbox has a default ip adress so it can allways be reached. This ip adress is independed of the configured network. For username and password this is similar. It is just optional but not mandatory. The list of connected devices can be accessed at all time. Therefore I would like to make the setup in the config file to be a simple:
   
   fritz:

currently the use of the  validate_config() function requires a host, username and password. Can I just remove this?
4. I get a lot of logging from the device_scanner. It is about 40x this message per request.

```
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 192.168.123.1
```

can you tell me where it comes from? I think we want to remove it, but I don't understand it.
