### PR TITLE
Telldus libary version update + added callback cleanup

### DIFF
--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -6,7 +6,9 @@ Support for Tellstick lights.
 import logging
 # pylint: disable=no-name-in-module, import-error
 from homeassistant.components.light import Light, ATTR_BRIGHTNESS
-from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
+    ATTR_FRIENDLY_NAME)
 import tellcore.constants as tellcore_constants
 from tellcore.library import DirectCallbackDispatcher
 REQUIREMENTS = ['tellcore-py==1.1.2']

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -13,7 +13,6 @@ import tellcore.constants as tellcore_constants
 from tellcore.library import DirectCallbackDispatcher
 REQUIREMENTS = ['tellcore-py==1.1.2']
 
-
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """ Find and return Tellstick lights. """
@@ -26,11 +25,11 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         return []
 
     # pylint: disable=no-member
-    if telldus.TelldusCore.callback_dispatcher is None:
-        dispatcher = DirectCallbackDispatcher()
-        core = telldus.TelldusCore(callback_dispatcher=dispatcher)
-    else:
-        core = telldus.TelldusCore()
+    #if telldus.TelldusCore.callback_dispatcher is None:
+    #dispatcher = DirectCallbackDispatcher()
+    #core = telldus.TelldusCore(callback_dispatcher=dispatcher)
+    #else:
+    core = telldus.TelldusCore()
 
     switches_and_lights = core.devices()
     lights = []

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -24,12 +24,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             "Failed to import tellcore")
         return []
 
-    # pylint: disable=no-member
-    #if telldus.TelldusCore.callback_dispatcher is None:
-    #dispatcher = DirectCallbackDispatcher()
-    #core = telldus.TelldusCore(callback_dispatcher=dispatcher)
-    #else:
-    core = telldus.TelldusCore()
+    core = telldus.TelldusCore(callback_dispatcher=DirectCallbackDispatcher())
 
     switches_and_lights = core.devices()
     lights = []
@@ -48,7 +43,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     callback_id = core.register_device_event(_device_event_callback)
 
-    def unload_telldus_lib():
+    def unload_telldus_lib(event):
         if callback_id is not None:
             core.unregister_callback(callback_id)
 

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -9,7 +9,7 @@ from homeassistant.components.light import Light, ATTR_BRIGHTNESS
 from homeassistant.const import ATTR_FRIENDLY_NAME
 import tellcore.constants as tellcore_constants
 from tellcore.library import DirectCallbackDispatcher
-REQUIREMENTS = ['tellcore-py==1.0.4']
+REQUIREMENTS = ['tellcore-py==1.1.2']
 
 
 # pylint: disable=unused-argument

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -35,6 +35,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     def _device_event_callback(id_, method, data, cid):
         """ Called from the TelldusCore library to update one device """
+        logging.getLogger(__name__).info(
+            "got TellCore callback {} {} {} {}".format(id_, method, data, cid))
         for light_device in lights:
             if light_device.tellstick_device.id == id_:
                 # Execute the update in another thread

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -35,15 +35,11 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     def _device_event_callback(id_, method, data, cid):
         """ Called from the TelldusCore library to update one device """
-        logging.getLogger(__name__).info(
-            "got TellCore callback {} {} {} {}".format(id_, method, data, cid))
         for light_device in lights:
             if light_device.tellstick_device.id == id_:
                 # Execute the update in another thread
-                logging.getLogger(__name__).info(
-                    "Updating state to {}".switch_device.state())
-                threading.Thread(target=light_device.update_ha_state, daemon=False, args=(True,)).start()
                 light_device.update_ha_state(True)
+                break
 
     callback_id = core.register_device_event(_device_event_callback)
 

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -6,8 +6,8 @@ Support for Tellstick lights.
 import logging
 # pylint: disable=no-name-in-module, import-error
 from homeassistant.components.light import Light, ATTR_BRIGHTNESS
-from homeassistant.const import ( EVENT_HOMEASSISTANT_STOP,
-                                  ATTR_FRIENDLY_NAME)
+from homeassistant.const import (EVENT_HOMEASSISTANT_STOP,
+                                 ATTR_FRIENDLY_NAME)
 import tellcore.constants as tellcore_constants
 from tellcore.library import DirectCallbackDispatcher
 REQUIREMENTS = ['tellcore-py==1.1.2']

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -40,6 +40,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         for light_device in lights:
             if light_device.tellstick_device.id == id_:
                 # Execute the update in another thread
+                logging.getLogger(__name__).info(
+                    "Updating state to {}".switch_device.state())
                 threading.Thread(target=light_device.update_ha_state, daemon=False, args=(True,)).start()
                 light_device.update_ha_state(True)
 

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -6,12 +6,12 @@ Support for Tellstick lights.
 import logging
 # pylint: disable=no-name-in-module, import-error
 from homeassistant.components.light import Light, ATTR_BRIGHTNESS
-from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
-    ATTR_FRIENDLY_NAME)
+from homeassistant.const import ( EVENT_HOMEASSISTANT_STOP,
+                                  ATTR_FRIENDLY_NAME)
 import tellcore.constants as tellcore_constants
 from tellcore.library import DirectCallbackDispatcher
 REQUIREMENTS = ['tellcore-py==1.1.2']
+
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
@@ -44,6 +44,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     callback_id = core.register_device_event(_device_event_callback)
 
     def unload_telldus_lib(event):
+        """ Un-register the callback bindings """
         if callback_id is not None:
             core.unregister_callback(callback_id)
 

--- a/homeassistant/components/sensor/tellstick.py
+++ b/homeassistant/components/sensor/tellstick.py
@@ -34,7 +34,7 @@ import homeassistant.util as util
 
 DatatypeDescription = namedtuple("DatatypeDescription", ['name', 'unit'])
 
-REQUIREMENTS = ['tellcore-py==1.0.4']
+REQUIREMENTS = ['tellcore-py==1.1.2']
 
 
 # pylint: disable=unused-argument

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -91,8 +91,6 @@ class TellstickSwitchDevice(ToggleEntity):
     @property
     def is_on(self):
         """ True if switch is on. """
-        logging.getLogger(__name__).info(
-                    "Returning state for {}".format(self.tellstick_device.id))
         last_command = self.tellstick_device.last_sent_command(
             self.last_sent_command_mask)
 

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -56,7 +56,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                 # Execute the update in another thread
                 logging.getLogger(__name__).info(
                     "Updating state to {}".fromat(method))
-                threading.Thread(target=switch_device.update_ha_state, daemon=False).start()
+                #threading.Thread(target=switch_device.update_ha_state, daemon=False).start()
                 break
 
     callback_id = core.register_device_event(_device_event_callback)

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -47,13 +47,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     def _device_event_callback(id_, method, data, cid):
         """ Called from the TelldusCore library to update one device """
-        logging.getLogger(__name__).info(
-            "got TellCore callback {} {} {} {}".format(id_, method, data, cid))
         for switch_device in switches:
-            logging.getLogger(__name__).info("checking switch {}: ".format(switch_device.tellstick_device.id))
             if switch_device.tellstick_device.id == id_:
-                # Execute the update in another thread
-                logging.getLogger(__name__).info("Updating state to: {}".format(switch_device.state))
                 switch_device.update_ha_state()
                 break
 

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -52,6 +52,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         for switch_device in switches:
             if switch_device.tellstick_device.id == id_:
                 # Execute the update in another thread
+                logging.getLogger(__name__).info(
+                    "Updating state to {}".switch_device.state())
                 threading.Thread(target=switch_device.update_ha_state, daemon=False).start()
                 break
 

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -53,8 +53,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             logging.getLogger(__name__).info("checking switch {}: ".format(switch_device.tellstick_device.id))
             if switch_device.tellstick_device.id == id_:
                 # Execute the update in another thread
-                logging.getLogger(__name__).info("Updating state to: {}".format(method))
-                threading.Thread(target=switch_device.update_ha_state, daemon=False).start()
+                logging.getLogger(__name__).info("Updating state to: {}".format(switch_device.state))
+                switch_device.update_ha_state()
                 break
 
     callback_id = core.register_device_event(_device_event_callback)

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -50,6 +50,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         logging.getLogger(__name__).info(
             "got TellCore callback {} {} {} {}".format(id_, method, data, cid))
         for switch_device in switches:
+            logging.getLogger(__name__).info(
+                "checking switch {}".format(switch_device.tellstick_device.id))
             if switch_device.tellstick_device.id == id_:
                 # Execute the update in another thread
                 logging.getLogger(__name__).info(

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -33,11 +33,11 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         return
 
     # pylint: disable=no-member
-    if telldus.TelldusCore.callback_dispatcher is None:
+    #if telldus.TelldusCore.callback_dispatcher is None:
         dispatcher = DirectCallbackDispatcher()
-        core = telldus.TelldusCore(callback_dispatcher=dispatcher)
-    else:
-        core = telldus.TelldusCore()
+    core = telldus.TelldusCore(callback_dispatcher=dispatcher)
+    #else:
+    #    core = telldus.TelldusCore()
 
     signal_repetitions = config.get('signal_repetitions', SINGAL_REPETITIONS)
 

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -11,7 +11,9 @@ signal_repetitions: 3
 """
 import logging
 
-from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
+    ATTR_FRIENDLY_NAME)
 from homeassistant.helpers.entity import ToggleEntity
 import tellcore.constants as tellcore_constants
 from tellcore.library import DirectCallbackDispatcher

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -17,7 +17,7 @@ import tellcore.constants as tellcore_constants
 from tellcore.library import DirectCallbackDispatcher
 SINGAL_REPETITIONS = 1
 
-REQUIREMENTS = ['tellcore-py==1.0.4']
+REQUIREMENTS = ['tellcore-py==1.1.2']
 
 
 # pylint: disable=unused-argument

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -11,9 +11,8 @@ signal_repetitions: 3
 """
 import logging
 
-from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
-    ATTR_FRIENDLY_NAME)
+from homeassistant.const import (EVENT_HOMEASSISTANT_STOP,
+                                 ATTR_FRIENDLY_NAME)
 from homeassistant.helpers.entity import ToggleEntity
 import tellcore.constants as tellcore_constants
 from tellcore.library import DirectCallbackDispatcher
@@ -55,6 +54,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     callback_id = core.register_device_event(_device_event_callback)
 
     def unload_telldus_lib(event):
+        """ Un-register the callback bindings """
         if callback_id is not None:
             core.unregister_callback(callback_id)
 

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -50,14 +50,11 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         logging.getLogger(__name__).info(
             "got TellCore callback {} {} {} {}".format(id_, method, data, cid))
         for switch_device in switches:
-            logging.getLogger(__name__).info(
-                "checking switch {}".format(switch_device.tellstick_device.id))
+            logging.getLogger(__name__).info("checking switch {}: ".format(switch_device.tellstick_device.id))
             if switch_device.tellstick_device.id == id_:
                 # Execute the update in another thread
-                logging.getLogger(__name__).info(
-                    "Updating state to {}".fromat(method))
+                logging.getLogger(__name__).info("Updating state to: {}".fromat(method))
                 #threading.Thread(target=switch_device.update_ha_state, daemon=False).start()
-                break
 
     callback_id = core.register_device_event(_device_event_callback)
 

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -47,6 +47,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     def _device_event_callback(id_, method, data, cid):
         """ Called from the TelldusCore library to update one device """
+        logging.getLogger(__name__).info(
+            "got TellCore callback {} {} {} {}".format(id_, method, data, cid))
         for switch_device in switches:
             if switch_device.tellstick_device.id == id_:
                 # Execute the update in another thread

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -53,8 +53,9 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             logging.getLogger(__name__).info("checking switch {}: ".format(switch_device.tellstick_device.id))
             if switch_device.tellstick_device.id == id_:
                 # Execute the update in another thread
-                logging.getLogger(__name__).info("Updating state to: {}".fromat(method))
-                #threading.Thread(target=switch_device.update_ha_state, daemon=False).start()
+                logging.getLogger(__name__).info("Updating state to: {}".format(method))
+                threading.Thread(target=switch_device.update_ha_state, daemon=False).start()
+                break
 
     callback_id = core.register_device_event(_device_event_callback)
 

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -55,8 +55,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             if switch_device.tellstick_device.id == id_:
                 # Execute the update in another thread
                 logging.getLogger(__name__).info(
-                    "Updating state to {}".switch_device.state())
-                threading.Thread(target=switch_device.update_ha_state, daemon=False).start()
+                    "Updating state to {}".fromat(switch_device.state()))
+                #threading.Thread(target=switch_device.update_ha_state, daemon=False).start()
                 break
 
     callback_id = core.register_device_event(_device_event_callback)
@@ -98,6 +98,8 @@ class TellstickSwitchDevice(ToggleEntity):
     @property
     def is_on(self):
         """ True if switch is on. """
+        logging.getLogger(__name__).info(
+                    "Returning state for {}".format(self.tellstick_device.id))
         last_command = self.tellstick_device.last_sent_command(
             self.last_sent_command_mask)
 

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -34,7 +34,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     # pylint: disable=no-member
     #if telldus.TelldusCore.callback_dispatcher is None:
-        dispatcher = DirectCallbackDispatcher()
+    dispatcher = DirectCallbackDispatcher()
     core = telldus.TelldusCore(callback_dispatcher=dispatcher)
     #else:
     #    core = telldus.TelldusCore()

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -55,8 +55,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             if switch_device.tellstick_device.id == id_:
                 # Execute the update in another thread
                 logging.getLogger(__name__).info(
-                    "Updating state to {}".fromat(switch_device.state()))
-                #threading.Thread(target=switch_device.update_ha_state, daemon=False).start()
+                    "Updating state to {}".fromat(method))
+                threading.Thread(target=switch_device.update_ha_state, daemon=False).start()
                 break
 
     callback_id = core.register_device_event(_device_event_callback)

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -32,12 +32,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             "Failed to import tellcore")
         return
 
-    # pylint: disable=no-member
-    #if telldus.TelldusCore.callback_dispatcher is None:
-    dispatcher = DirectCallbackDispatcher()
-    core = telldus.TelldusCore(callback_dispatcher=dispatcher)
-    #else:
-    #    core = telldus.TelldusCore()
+    core = telldus.TelldusCore(callback_dispatcher=DirectCallbackDispatcher())
 
     signal_repetitions = config.get('signal_repetitions', SINGAL_REPETITIONS)
 
@@ -60,7 +55,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     callback_id = core.register_device_event(_device_event_callback)
 
-    def unload_telldus_lib():
+    def unload_telldus_lib(event):
         if callback_id is not None:
             core.unregister_callback(callback_id)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -22,7 +22,7 @@ pychromecast==0.6.12
 pyuserinput==0.1.9
 
 # Tellstick bindings (*.tellstick)
-tellcore-py==1.0.4
+tellcore-py==1.1.2
 
 # Nmap bindings (device_tracker.nmap)
 python-nmap==0.4.3


### PR DESCRIPTION
The old version did not release all resources when restarting hass. This broke the callback functionality after the restart if not the telldusd daemon was restarted as well.
