### PR TITLE
Added retry logic if the SMTP connection is disconnected by the server.

### DIFF
--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -171,7 +171,6 @@ class MailNotificationService(BaseNotificationService):
                 self.mail.sendmail(self._sender, self.recipient,
                                    msg.as_string())
                 break
-            except smtplib.SMTPException as err:
-                _LOGGER.warning('SMTP Exception sending mail: {0}:{1}'
-                                .format(err.smtp_code, err.smtp_error))
+            except smtplib.SMTPException:
+                _LOGGER.warning('SMTPException sending mail: retrying connection')
                 self.connect()

--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -172,5 +172,6 @@ class MailNotificationService(BaseNotificationService):
                                    msg.as_string())
                 break
             except smtplib.SMTPException:
-                _LOGGER.warning('SMTPException sending mail: retrying connection')
+                _LOGGER.warning('SMTPException sending mail: '
+                                'retrying connection')
                 self.connect()


### PR DESCRIPTION
SMTP notify would work initially after HA was started, but if no notifies were sent, the server would disconnect the connection.  This reestablishes the connection to the server and auth if the sendmail fails.
