### PR TITLE
Support media_player Play States When Resolving/Reproducing State

### DIFF
--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -9,7 +9,8 @@ import logging
 from homeassistant.core import State
 import homeassistant.util.dt as dt_util
 from homeassistant.const import (
-    STATE_ON, STATE_OFF, SERVICE_TURN_ON, SERVICE_TURN_OFF, ATTR_ENTITY_ID)
+    STATE_ON, STATE_OFF, SERVICE_TURN_ON, SERVICE_TURN_OFF,
+    STATE_PLAYING, STATE_PAUSED, ATTR_ENTITY_ID)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,14 +56,19 @@ def reproduce_state(hass, states, blocking=False):
                             state.entity_id)
             continue
 
-        if state.state == STATE_ON:
-            service = SERVICE_TURN_ON
-        elif state.state == STATE_OFF:
-            service = SERVICE_TURN_OFF
-        else:
-            _LOGGER.warning("reproduce_state: Unable to reproduce state %s",
-                            state)
-            continue
+        if state.domain == 'media_player' and state == STATE_PAUSED:
+            service = 'media_pause'
+        elif state.domain == 'media_player' and state == STATE_PLAYING:
+            service = 'media_play'
+        elif
+            if state.state == STATE_ON:
+                service = SERVICE_TURN_ON
+            elif state.state == STATE_OFF:
+                service = SERVICE_TURN_OFF
+            else:
+                _LOGGER.warning("reproduce_state: Unable to reproduce state %s",
+                                state)
+                continue
 
         service_data = dict(state.attributes)
         service_data[ATTR_ENTITY_ID] = state.entity_id

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -61,15 +61,14 @@ def reproduce_state(hass, states, blocking=False):
             service = SERVICE_MEDIA_PAUSE
         elif state.domain == 'media_player' and state == STATE_PLAYING:
             service = SERVICE_MEDIA_PLAY
+        elif state.state == STATE_ON:
+            service = SERVICE_TURN_ON
+        elif state.state == STATE_OFF:
+            service = SERVICE_TURN_OFF
         else:
-            if state.state == STATE_ON:
-                service = SERVICE_TURN_ON
-            elif state.state == STATE_OFF:
-                service = SERVICE_TURN_OFF
-            else:
-                _LOGGER.warning("reproduce_state: Unable to reproduce \
-                                state %s", state)
-                continue
+            _LOGGER.warning("reproduce_state: Unable to reproduce state %s",
+                            state)
+            continue
 
         service_data = dict(state.attributes)
         service_data[ATTR_ENTITY_ID] = state.entity_id

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -67,8 +67,8 @@ def reproduce_state(hass, states, blocking=False):
             elif state.state == STATE_OFF:
                 service = SERVICE_TURN_OFF
             else:
-                _LOGGER.warning("reproduce_state: Unable to reproduce state %s",
-                                state)
+                _LOGGER.warning("reproduce_state: Unable to reproduce \
+                                state %s", state)
                 continue
 
         service_data = dict(state.attributes)

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -60,7 +60,7 @@ def reproduce_state(hass, states, blocking=False):
             service = 'media_pause'
         elif state.domain == 'media_player' and state == STATE_PLAYING:
             service = 'media_play'
-        elif
+        else
             if state.state == STATE_ON:
                 service = SERVICE_TURN_ON
             elif state.state == STATE_OFF:

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -10,6 +10,7 @@ from homeassistant.core import State
 import homeassistant.util.dt as dt_util
 from homeassistant.const import (
     STATE_ON, STATE_OFF, SERVICE_TURN_ON, SERVICE_TURN_OFF,
+    SERVICE_MEDIA_PLAY, SERVICE_MEDIA_PAUSE,
     STATE_PLAYING, STATE_PAUSED, ATTR_ENTITY_ID)
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,9 +58,9 @@ def reproduce_state(hass, states, blocking=False):
             continue
 
         if state.domain == 'media_player' and state == STATE_PAUSED:
-            service = 'media_pause'
+            service = SERVICE_MEDIA_PAUSE
         elif state.domain == 'media_player' and state == STATE_PLAYING:
-            service = 'media_play'
+            service = SERVICE_MEDIA_PLAY
         else
             if state.state == STATE_ON:
                 service = SERVICE_TURN_ON

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -61,7 +61,7 @@ def reproduce_state(hass, states, blocking=False):
             service = SERVICE_MEDIA_PAUSE
         elif state.domain == 'media_player' and state == STATE_PLAYING:
             service = SERVICE_MEDIA_PLAY
-        else
+        else:
             if state.state == STATE_ON:
                 service = SERVICE_TURN_ON
             elif state.state == STATE_OFF:


### PR DESCRIPTION
This allows the state helper to call the correct service call for `media_player`s when attempting to resolve state. 

A specific case is when setting a Scene. Currently, the only state that can be set is `on`/`off`. With this addition, you would now be able to use play state for their state in a scene.

This fix was [suggested](https://github.com/balloob/home-assistant/issues/432#issuecomment-142795327) on #432.

``` yaml
- name: Good Night
  entities:
    media_player.itunes: paused
    light.kitchen_light: off
    switch.kitchen_tv: off
```
