### PR TITLE
Add support for white LimitlessLED devices and multiple bridges

### DIFF
--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -89,7 +89,7 @@ class LimitlessLED(Light):
 
     @property
     def should_poll(self):
-        """ No polling needed for a demo light. """
+        """ No polling needed. """
         return False
 
     @property

--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -43,6 +43,9 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """ Gets the LimitlessLED lights. """
     import ledcontroller
 
+    # Handle old configuration format:
+    bridges = config.get('bridges', [config])
+
     for bridge_id, bridge in enumerate(bridges):
         bridge['id'] = bridge_id
 

--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -19,11 +19,14 @@ configuration.yaml file.
 
 light:
   platform: limitlessled
-  host: 192.168.1.10
-  group_1_name: Living Room
-  group_2_name: Bedroom
-  group_3_name: Office
-  group_4_name: Kitchen
+  bridges:
+    - host: 192.168.1.10
+      group_1_name: Living Room
+      group_2_name: Bedroom
+      group_3_name: Office
+      group_4_name: Kitchen
+    - host: 192.168.1.11
+      group_2_name: Basement
 """
 import logging
 
@@ -40,12 +43,16 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """ Gets the LimitlessLED lights. """
     import ledcontroller
 
-    pool = ledcontroller.LedControllerPool([config['host']])
+    for bridge_id, bridge in enumerate(bridges):
+        bridge['id'] = bridge_id
+
+    pool = ledcontroller.LedControllerPool([x['host'] for x in bridges])
 
     lights = []
-    for i in range(1, 5):
-        if 'group_%d_name' % (i) in config:
-            lights.append(LimitlessLED(pool, 0, i, config['group_%d_name' % (i)]))
+    for bridge in bridges:
+        for i in range(1, 5):
+            if 'group_%d_name' % (i) in bridge:
+                lights.append(LimitlessLED(pool, bridge['id'], i, bridge['group_%d_name' % (i)]))
 
     add_devices_callback(lights)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -14,7 +14,7 @@ astral==0.8.1
 phue==0.8
 
 # Limitlessled/Easybulb/Milight library (lights.limitlessled)
-ledcontroller==1.0.7
+ledcontroller==1.1.0
 
 # Chromecast bindings (media_player.cast)
 pychromecast==0.6.12


### PR DESCRIPTION
This adds support for the White (in addition to the previously supported RGBW) LimitlessLED lights, as well as support for multiple LimitlessLED bridges.

This changes the configuration format for these lights slightly, in order to support multiple bridges, but I added a bit of compatability code so that existing configurations will still work. I'm not sure what sort of compatability guarantees HA tries to make release-to-release, so I'm particularly interested in any feedback about this.
