### PR TITLE
Allow to customize the scan interval

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
     EVENT_COMPONENT_LOADED, CONF_LATITUDE, CONF_LONGITUDE,
     CONF_TEMPERATURE_UNIT, CONF_NAME, CONF_TIME_ZONE, CONF_CUSTOMIZE,
-    TEMP_CELCIUS, TEMP_FAHRENHEIT)
+    CONF_SCAN_INTERVAL, TEMP_CELCIUS, TEMP_FAHRENHEIT)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -310,6 +310,20 @@ def process_ha_core_config(hass, config):
     set_time_zone(config.get(CONF_TIME_ZONE))
 
     customize = config.get(CONF_CUSTOMIZE)
+
+    if isinstance(customize, dict):
+        for entity_id, attrs in config.get(CONF_CUSTOMIZE, {}).items():
+            if not isinstance(attrs, dict):
+                continue
+            Entity.overwrite_attribute(entity_id, attrs.keys(), attrs.values())
+
+    scan_interval = config.get(CONF_SCAN_INTERVAL)
+
+    if isinstance(scan_interval, dict):
+        for component, current_scan_interval in scan_interval.items():
+            hac.overwrite_scan_interval(current_scan_interval, component)
+    elif scan_interval is not None:
+        hac.overwrite_scan_interval(scan_interval)
 
     if isinstance(customize, dict):
         for entity_id, attrs in config.get(CONF_CUSTOMIZE, {}).items():

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -16,6 +16,7 @@ CONF_TEMPERATURE_UNIT = "temperature_unit"
 CONF_NAME = "name"
 CONF_TIME_ZONE = "time_zone"
 CONF_CUSTOMIZE = "customize"
+CONF_SCAN_INTERVAL = "scan_interval"
 
 CONF_PLATFORM = "platform"
 CONF_HOST = "host"

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -14,7 +14,7 @@ import threading
 import enum
 import re
 import functools as ft
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
@@ -707,6 +707,8 @@ class Config(object):
         # Directory that holds the configuration
         self.config_dir = get_default_config_dir()
 
+        self.scan_intervals = defaultdict(dict)
+
     def distance(self, lat, lon):
         """ Calculate distance from Home Assistant in meters. """
         return location.distance(self.latitude, self.longitude, lat, lon)
@@ -729,6 +731,20 @@ class Config(object):
         return (
             round(temp_helper.convert(temp, unit, self.temperature_unit), 1),
             self.temperature_unit)
+
+    def overwrite_scan_interval(self, scan_interval, component=None):
+        """ Overwrites the scan interval of a component """
+        if component is None:
+            component = ''
+        self.scan_intervals[component] = scan_interval
+
+    def scan_interval(self, component, default):
+        """ Returns the scan interval to use for a given component """
+        if component in self.scan_intervals:
+            return self.scan_intervals[component]
+        elif '' in self.scan_intervals:
+            return self.scan_intervals['']
+        return default
 
     def as_dict(self):
         """ Converts config to a dictionary. """

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -115,10 +115,12 @@ class EntityComponent(object):
             return
 
         self.is_polling = True
+        scan_interval = self.hass.config.scan_interval(self.domain,
+                                                       self.scan_interval)
 
         track_utc_time_change(
             self.hass, self._update_entity_states,
-            second=range(0, 60, self.scan_interval))
+            second=range(0, 60, scan_interval))
 
     def _setup_platform(self, platform_type, platform_config,
                         discovery_info=None):


### PR DESCRIPTION
It is now possible to do:
- override all the components scan interval:

``` yaml
homeassistant:
  scan_interval: 10
```
- override specific components scan interval:

``` yaml
homeassistant:
  scan_interval:
    light: 5
    media_player: 5
```
