### PR TITLE
Add STATE_OPEN/STATE_CLOSED to groupable states

### DIFF
--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -12,7 +12,8 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.util as util
 from homeassistant.const import (
     ATTR_ENTITY_ID, STATE_ON, STATE_OFF,
-    STATE_HOME, STATE_NOT_HOME, STATE_UNKNOWN)
+    STATE_HOME, STATE_NOT_HOME, STATE_OPEN, STATE_CLOSED,
+    STATE_UNKNOWN)
 
 DOMAIN = "group"
 DEPENDENCIES = []
@@ -22,7 +23,8 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 ATTR_AUTO = "auto"
 
 # List of ON/OFF state tuples for groupable states
-_GROUP_TYPES = [(STATE_ON, STATE_OFF), (STATE_HOME, STATE_NOT_HOME)]
+_GROUP_TYPES = [(STATE_ON, STATE_OFF), (STATE_HOME, STATE_NOT_HOME),
+                (STATE_OPEN, STATE_CLOSED)]
 
 
 def _get_group_on_off(state):


### PR DESCRIPTION
I would like to be able to group alarm contact reed switch based sensors (via mqtt) for doors and windows.   STATE_ON/STATE_OFF seemed confusing so the PR adds STATE_OPEN/STATE_CLOSED to the list of groupable states.

  doors:
      - sensor.Front_Door
      - sensor.Back_Door
