### PR TITLE
Media Player play_media function

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -189,6 +189,15 @@ def media_previous_track(hass, entity_id=None):
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
     hass.services.call(DOMAIN, SERVICE_MEDIA_PREVIOUS_TRACK, data)
 
+def play_media(hass, media_type, media_id, entity_id=None):
+    """ Send the media player the command for playing media. """
+    data = {"media_type": media_type, "media_id": media_id}
+
+    if entity_id:
+        data[ATTR_ENTITY_ID] = entity_id
+
+    hass.services.call(DOMAIN, SERVICE_PLAY_MEDIA, data)
+
 
 def setup(hass, config):
     """ Track states and offer events for media_players. """

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -450,6 +450,10 @@ class MediaPlayerDevice(Entity):
         """ Plays a YouTube media. """
         raise NotImplementedError()
 
+    def play_media(self, media_type, media_id):
+        """ Plays a piece of media. """
+        raise NotImplementedError()
+
     # No need to overwrite these.
     @property
     def support_pause(self):

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -83,6 +83,7 @@ SERVICE_TO_METHOD = {
     SERVICE_MEDIA_PAUSE: 'media_pause',
     SERVICE_MEDIA_NEXT_TRACK: 'media_next_track',
     SERVICE_MEDIA_PREVIOUS_TRACK: 'media_previous_track',
+    SERVICE_PLAY_MEDIA: 'play_media',
 }
 
 ATTR_TO_PROPERTY = [
@@ -284,6 +285,23 @@ def setup(hass, config):
             if player.should_poll:
                 player.update_ha_state(True)
 
+    def play_media_service(service):
+        """ Plays specified media_id on the media player. """
+        media_type = service.data['media_type']
+        media_id = service.data['media_id']
+
+        if media_type is None:
+            return
+
+        if media_id is None:
+            return
+
+        for player in component.extract_from_service(service):
+            player.play_media(media_type, media_id)
+
+            if player.should_poll:
+                player.update_ha_state(True)
+
     hass.services.register(
         DOMAIN, "start_fireplace",
         lambda service: play_youtube_video_service(service, "eyU3bRy2x44"),
@@ -297,6 +315,10 @@ def setup(hass, config):
     hass.services.register(
         DOMAIN, SERVICE_YOUTUBE_VIDEO, play_youtube_video_service,
         descriptions.get(SERVICE_YOUTUBE_VIDEO))
+
+    hass.services.register(
+        DOMAIN, SERVICE_PLAY_MEDIA, play_media_service,
+        descriptions.get(SERVICE_PLAY_MEDIA))
 
     return True
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -53,6 +53,9 @@ ATTR_SUPPORTED_MEDIA_COMMANDS = 'supported_media_commands'
 MEDIA_TYPE_MUSIC = 'music'
 MEDIA_TYPE_TVSHOW = 'tvshow'
 MEDIA_TYPE_VIDEO = 'movie'
+MEDIA_TYPE_EPISODE = 'episode'
+MEDIA_TYPE_CHANNEL = 'channel'
+MEDIA_TYPE_PLAYLIST = 'playlist'
 
 SUPPORT_PAUSE = 1
 SUPPORT_SEEK = 2

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -287,8 +287,8 @@ def setup(hass, config):
 
     def play_media_service(service):
         """ Plays specified media_id on the media player. """
-        media_type = service.data['media_type']
-        media_id = service.data['media_id']
+        media_type = service.data.get('media_type')
+        media_id = service.data.get('media_id')
 
         if media_type is None:
             return

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -189,6 +189,7 @@ def media_previous_track(hass, entity_id=None):
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
     hass.services.call(DOMAIN, SERVICE_MEDIA_PREVIOUS_TRACK, data)
 
+
 def play_media(hass, media_type, media_id, entity_id=None):
     """ Send the media player the command for playing media. """
     data = {"media_type": media_type, "media_id": media_id}

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -31,6 +31,7 @@ DISCOVERY_PLATFORMS = {
 }
 
 SERVICE_YOUTUBE_VIDEO = 'play_youtube_video'
+SERVICE_PLAY_MEDIA = 'play_media'
 
 ATTR_MEDIA_VOLUME_LEVEL = 'volume_level'
 ATTR_MEDIA_VOLUME_MUTED = 'is_volume_muted'
@@ -68,6 +69,7 @@ SUPPORT_NEXT_TRACK = 32
 SUPPORT_YOUTUBE = 64
 SUPPORT_TURN_ON = 128
 SUPPORT_TURN_OFF = 256
+SUPPORT_PLAY_MEDIA = 512
 
 YOUTUBE_COVER_URL_FORMAT = 'https://img.youtube.com/vi/{}/1.jpg'
 
@@ -489,6 +491,11 @@ class MediaPlayerDevice(Entity):
     def support_youtube(self):
         """ Boolean if YouTube is supported. """
         return bool(self.supported_media_commands & SUPPORT_YOUTUBE)
+
+    @property
+    def support_play_media(self):
+        """ Boolean if play media command supported. """
+        return bool(self.supported_media_commands & SUPPORT_PLAY_MEDIA)
 
     def volume_up(self):
         """ volume_up media player. """

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -46,6 +46,8 @@ ATTR_MEDIA_TRACK = 'media_track'
 ATTR_MEDIA_SERIES_TITLE = 'media_series_title'
 ATTR_MEDIA_SEASON = 'media_season'
 ATTR_MEDIA_EPISODE = 'media_episode'
+ATTR_MEDIA_CHANNEL = 'media_channel'
+ATTR_MEDIA_PLAYLIST = 'media_playlist'
 ATTR_APP_ID = 'app_id'
 ATTR_APP_NAME = 'app_name'
 ATTR_SUPPORTED_MEDIA_COMMANDS = 'supported_media_commands'
@@ -95,6 +97,8 @@ ATTR_TO_PROPERTY = [
     ATTR_MEDIA_SERIES_TITLE,
     ATTR_MEDIA_SEASON,
     ATTR_MEDIA_EPISODE,
+    ATTR_MEDIA_CHANNEL,
+    ATTR_MEDIA_PLAYLIST,
     ATTR_APP_ID,
     ATTR_APP_NAME,
     ATTR_SUPPORTED_MEDIA_COMMANDS,
@@ -374,6 +378,16 @@ class MediaPlayerDevice(Entity):
     @property
     def media_episode(self):
         """ Episode of current playing media. (TV Show only) """
+        return None
+
+    @property
+    def media_channel(self):
+        """ Channel currently playing. """
+        return None
+
+    @property
+    def media_playlist(self):
+        """ Title of Playlist currently playing. """
         return None
 
     @property

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -90,6 +90,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class CastDevice(MediaPlayerDevice):
     """ Represents a Cast device on the network. """
 
+    # pylint: disable=abstract-method
     # pylint: disable=too-many-public-methods
 
     def __init__(self, host):

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -63,7 +63,8 @@ def reproduce_state(hass, states, blocking=False):
             service = SERVICE_MEDIA_PAUSE
         elif state.domain == 'media_player' and state.state == STATE_PLAYING:
             service = SERVICE_MEDIA_PLAY
-        elif state.domain == 'media_player' and state.attributes and state.attributes['media_type'] and state.attributes['media_id']:
+        elif state.domain == 'media_player' and state.attributes and
+            'media_type' in state.attributes and 'media_id' in state.attributes
             service = SERVICE_PLAY_MEDIA
         elif state.state == STATE_ON:
             service = SERVICE_TURN_ON

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -64,7 +64,8 @@ def reproduce_state(hass, states, blocking=False):
         elif state.domain == 'media_player' and state.state == STATE_PLAYING:
             service = SERVICE_MEDIA_PLAY
         elif state.domain == 'media_player' and state.attributes and \
-            'media_type' in state.attributes and 'media_id' in state.attributes:
+            'media_type' in state.attributes and \
+            'media_id' in state.attributes:
             service = SERVICE_PLAY_MEDIA
         elif state.state == STATE_ON:
             service = SERVICE_TURN_ON

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -63,8 +63,8 @@ def reproduce_state(hass, states, blocking=False):
             service = SERVICE_MEDIA_PAUSE
         elif state.domain == 'media_player' and state.state == STATE_PLAYING:
             service = SERVICE_MEDIA_PLAY
-        elif state.domain == 'media_player' and state.attributes and
-            'media_type' in state.attributes and 'media_id' in state.attributes
+        elif state.domain == 'media_player' and state.attributes and \
+            'media_type' in state.attributes and 'media_id' in state.attributes:
             service = SERVICE_PLAY_MEDIA
         elif state.state == STATE_ON:
             service = SERVICE_TURN_ON

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -13,6 +13,8 @@ from homeassistant.const import (
     SERVICE_MEDIA_PLAY, SERVICE_MEDIA_PAUSE,
     STATE_PLAYING, STATE_PAUSED, ATTR_ENTITY_ID)
 
+from homeassistant.components.media_player import (SERVICE_PLAY_MEDIA)
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -61,6 +63,8 @@ def reproduce_state(hass, states, blocking=False):
             service = SERVICE_MEDIA_PAUSE
         elif state.domain == 'media_player' and state.state == STATE_PLAYING:
             service = SERVICE_MEDIA_PLAY
+        elif state.domain == 'media_player' and state.attributes and state.attributes['media_type'] and state.attributes['media_id']:
+            service = SERVICE_PLAY_MEDIA
         elif state.state == STATE_ON:
             service = SERVICE_TURN_ON
         elif state.state == STATE_OFF:

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -65,7 +65,7 @@ def reproduce_state(hass, states, blocking=False):
             service = SERVICE_MEDIA_PLAY
         elif state.domain == 'media_player' and state.attributes and \
             'media_type' in state.attributes and \
-            'media_id' in state.attributes:
+                'media_id' in state.attributes:
             service = SERVICE_PLAY_MEDIA
         elif state.state == STATE_ON:
             service = SERVICE_TURN_ON

--- a/tests/components/test_media_player.py
+++ b/tests/components/test_media_player.py
@@ -52,7 +52,7 @@ class TestMediaPlayer(unittest.TestCase):
             SERVICE_MEDIA_PLAY: media_player.media_play,
             SERVICE_MEDIA_PAUSE: media_player.media_pause,
             SERVICE_MEDIA_NEXT_TRACK: media_player.media_next_track,
-            SERVICE_MEDIA_PREVIOUS_TRACK: media_player.media_previous_track
+            SERVICE_MEDIA_PREVIOUS_TRACK: media_player.media_previous_track,
             SERVICE_PLAY_MEDIA: media_player.play_media
         }
 

--- a/tests/components/test_media_player.py
+++ b/tests/components/test_media_player.py
@@ -13,7 +13,6 @@ from homeassistant.const import (
     SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_VOLUME_UP, SERVICE_VOLUME_DOWN,
     SERVICE_MEDIA_PLAY_PAUSE, SERVICE_MEDIA_PLAY, SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PREVIOUS_TRACK, ATTR_ENTITY_ID)
-from homeassistant.components.media_player import (SERVICE_PLAY_MEDIA)
 import homeassistant.components.media_player as media_player
 from tests.common import mock_service
 
@@ -52,8 +51,7 @@ class TestMediaPlayer(unittest.TestCase):
             SERVICE_MEDIA_PLAY: media_player.media_play,
             SERVICE_MEDIA_PAUSE: media_player.media_pause,
             SERVICE_MEDIA_NEXT_TRACK: media_player.media_next_track,
-            SERVICE_MEDIA_PREVIOUS_TRACK: media_player.media_previous_track,
-            SERVICE_PLAY_MEDIA: media_player.play_media
+            SERVICE_MEDIA_PREVIOUS_TRACK: media_player.media_previous_track
         }
 
         for service_name, service_method in services.items():

--- a/tests/components/test_media_player.py
+++ b/tests/components/test_media_player.py
@@ -41,7 +41,7 @@ class TestMediaPlayer(unittest.TestCase):
 
     def test_services(self):
         """
-        Test if the call service methods conver to correct service calls.
+        Test if the call service methods convert to correct service calls.
         """
         services = {
             SERVICE_TURN_ON: media_player.turn_on,

--- a/tests/components/test_media_player.py
+++ b/tests/components/test_media_player.py
@@ -12,8 +12,8 @@ from homeassistant.const import (
     STATE_OFF,
     SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_VOLUME_UP, SERVICE_VOLUME_DOWN,
     SERVICE_MEDIA_PLAY_PAUSE, SERVICE_MEDIA_PLAY, SERVICE_MEDIA_PAUSE,
-    SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PREVIOUS_TRACK, SERVICE_PLAY_MEDIA,
-    ATTR_ENTITY_ID)
+    SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PREVIOUS_TRACK, ATTR_ENTITY_ID)
+from homeassistant.components.media_player import (SERVICE_PLAY_MEDIA)
 import homeassistant.components.media_player as media_player
 from tests.common import mock_service
 

--- a/tests/components/test_media_player.py
+++ b/tests/components/test_media_player.py
@@ -12,7 +12,8 @@ from homeassistant.const import (
     STATE_OFF,
     SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_VOLUME_UP, SERVICE_VOLUME_DOWN,
     SERVICE_MEDIA_PLAY_PAUSE, SERVICE_MEDIA_PLAY, SERVICE_MEDIA_PAUSE,
-    SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PREVIOUS_TRACK, ATTR_ENTITY_ID)
+    SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PREVIOUS_TRACK, SERVICE_PLAY_MEDIA,
+    ATTR_ENTITY_ID)
 import homeassistant.components.media_player as media_player
 from tests.common import mock_service
 
@@ -52,6 +53,7 @@ class TestMediaPlayer(unittest.TestCase):
             SERVICE_MEDIA_PAUSE: media_player.media_pause,
             SERVICE_MEDIA_NEXT_TRACK: media_player.media_next_track,
             SERVICE_MEDIA_PREVIOUS_TRACK: media_player.media_previous_track
+            SERVICE_PLAY_MEDIA: media_player.play_media
         }
 
         for service_name, service_method in services.items():


### PR DESCRIPTION
This adds the ability to tell a media player to play a specific piece of media.

It takes 2 arguments. `media_type`, and `media_id`. Why the first argument? There are a couple good reasons.
#### 1. Put a switch on it.

Chances are, playing different types of media types will take different types of function or API calls. Providing the implementer with a `media_type` allows them to switch off of it and do the things they need to do.
#### 2. Clarity

Sure we could take a single argument, but how does the function know what to do with it? Serialization! Sure, we can just pass `episode-2322` and parse it. Ahh, but now we have no standard. And no standard means every media player will use whatever serialization the implementer picks. 

This is bad. This puts the work on the implementer. By having the `media_type` argument, its clear. There's nothing to think about. And all the media player implementations will be roughly the same :)
#### 3. Discovery

Having the argument there will turn a lightbulb above the head of the implementer and let them know immediately how they can handle playing different types of media with a single abstract function.
### Samples

``` python
music_player.play_media('playlist', 'Party Time')
```

``` python
def play_media(self, media_type:None, media_id:None):
    self.client.play_playlist(media_id)
```

``` python
media_center_player.play_media('episode', '2322')
media_center_player.play_media('movie', '211')
```

``` python
def play_media(self, media_type:None, media_id:None):
    if media_type == 'episode':
        self.client.play_episode(media_id)
    elif media_type == 'episode'::
        self.client.play_movie(media_id)
```
### Scene Support

Scene support was also added so state restoration can work. This is especially great for music players.

``` yaml
scene:
  - name: Cooking
    entities:
      media_player.itunes:
        media_type: playlist
        media_id: Cooking
      light.kitchen:
        state: on
        brightness: 200
```
