### PR TITLE
Prioritize play_media over state change

### DIFF
--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -59,14 +59,14 @@ def reproduce_state(hass, states, blocking=False):
                             state.entity_id)
             continue
 
-        if state.domain == 'media_player' and state.state == STATE_PAUSED:
-            service = SERVICE_MEDIA_PAUSE
-        elif state.domain == 'media_player' and state.state == STATE_PLAYING:
-            service = SERVICE_MEDIA_PLAY
-        elif state.domain == 'media_player' and state.attributes and \
+        if state.domain == 'media_player' and state.attributes and \
             'media_type' in state.attributes and \
                 'media_id' in state.attributes:
             service = SERVICE_PLAY_MEDIA
+        elif state.domain == 'media_player' and state.state == STATE_PAUSED:
+            service = SERVICE_MEDIA_PAUSE
+        elif state.domain == 'media_player' and state.state == STATE_PLAYING:
+            service = SERVICE_MEDIA_PLAY
         elif state.state == STATE_ON:
             service = SERVICE_TURN_ON
         elif state.state == STATE_OFF:


### PR DESCRIPTION
This moves the `play_media` service call to the top to prioritize it over any kind of state change for the `media_player`. This is fine since playing any kind of media assumes it will in fact, be `playing`.
