### PR TITLE
Mock switch

### DIFF
--- a/homeassistant/components/switch/mock.py
+++ b/homeassistant/components/switch/mock.py
@@ -1,0 +1,54 @@
+"""
+homeassistant.components.switch.mock
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Mock platform that has switches that have no effect
+
+# Config takes in name of switch and initial state.
+switch:
+  platform: mock
+  switches:
+    Do the laundry: on
+    Alarm active: off
+
+"""
+from homeassistant.components.switch import SwitchDevice
+
+CONF_SWITCHES = 'switches'
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """ Find and return demo switches. """
+    add_devices_callback(MockSwitch(name, state) for name, state
+                         in config.get(CONF_SWITCHES, {}).items())
+
+
+class MockSwitch(SwitchDevice):
+    """ Provides a mock switch. """
+    def __init__(self, name, state):
+        self._name = name
+        self._state = state
+
+    @property
+    def should_poll(self):
+        return False
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def is_on(self):
+        """ True if device is on. """
+        return self._state
+
+    def turn_on(self, **kwargs):
+        """ Turn the device on. """
+        self._state = True
+        self.update_ha_state()
+
+    def turn_off(self, **kwargs):
+        """ Turn the device off. """
+        self._state = False
+        self.update_ha_state()


### PR DESCRIPTION
This PR adds a mock switch, a switch that does absolutely nothing. By using it as a condition in your automations this allows you to turn your automations on/off. This was inspired by [this comment](https://github.com/balloob/home-assistant.io/issues/61#issuecomment-147019415) by @kwetiaw.

Configuration example how one would use the mock switch to have the laundry be done 7:30 in the morning.

``` yaml
switch:
  platform: mock
  switches:
    Do Laundry: off

script:
  laundry:
    sequence:
      # Turn off the mock switch so the automation won't trigger tomorrow
      - execute_service: switch.turn_off
        service_data:
          entity_id: switch.do_laundry
      # do the laundry
      - execute_service: switch.turn_on
        service_data:
          entity_id: switch.laundry_machine

# Every morning at 7:30, if the mock switch is turned on, we will do the laundry
automation:
  trigger:
    platform: time
    after: 07:30:00
  condition:
    platform: state
    entity_id: switch.do_laundry
    state: 'on'
  trigger:
    service: script.turn_on
    entity_id: script.laundry
```
