### PR TITLE
asuswrt gives a traceback when ipv6 is enabled on the router

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -161,9 +161,10 @@ class AsusWrtDeviceScanner(object):
             # For leases where the client doesn't set a hostname, ensure
             # it is blank and not '*', which breaks the entity_id down
             # the line
-            host = match.group('host')
-            if host == '*':
-                host = ''
+            if match:
+                host = match.group('host')
+                if host == '*':
+                    host = ''
 
             devices[match.group('ip')] = {
                 'host': host,
@@ -174,6 +175,6 @@ class AsusWrtDeviceScanner(object):
 
         for neighbor in neighbors:
             match = _IP_NEIGH_REGEX.search(neighbor.decode('utf-8'))
-            if match.group('ip') in devices:
+            if match and match.group('ip') in devices:
                 devices[match.group('ip')]['status'] = match.group('status')
         return devices


### PR DESCRIPTION
When IPv6 is enabled, dnsmasq has a configuration line with the DUID.
This looks like this
61072 b8:27:eb:e1:4e:4d 192.168.0.4 domotycoon *
61072 b8:27:eb:b8:10:6b 192.168.0.5 pimonitor *
duid 00:03:00:01:ac:22:0b:e9:98:50
When using match.group() without testing if match != None, you get a traceback.
