### PR TITLE
Add shell_command component

### DIFF
--- a/homeassistant/components/shell_command.py
+++ b/homeassistant/components/shell_command.py
@@ -1,0 +1,48 @@
+"""
+homeassistant.components.shell_command
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Component to expose shell commands as services.
+
+shell_command:
+  restart_pow: touch ~/.pow/restart.txt
+
+"""
+import logging
+import subprocess
+
+from homeassistant.util import slugify
+
+DOMAIN = 'shell_command'
+DEPENDENCIES = []
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup(hass, config):
+    """ Sets up the shell_command component. """
+    conf = config.get(DOMAIN)
+
+    if not isinstance(conf, dict):
+        _LOGGER.error('Expected configuration to be a dictionary')
+        return False
+
+    for name in conf.keys():
+        if name != slugify(name):
+            _LOGGER.error('Invalid service name: %s. Try %s',
+                          name, slugify(name))
+            return False
+
+    def service_handler(call):
+        """ Execute a shell command service. """
+        try:
+            subprocess.call(conf[call.service].split(' '),
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL)
+        except subprocess.SubprocessError:
+            _LOGGER.exception('Error running command')
+
+    for name in conf.keys():
+        hass.services.register(DOMAIN, name, service_handler)
+
+    return True

--- a/tests/components/test_shell_command.py
+++ b/tests/components/test_shell_command.py
@@ -7,6 +7,8 @@ Tests demo component.
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
+from subprocess import SubprocessError
 
 from homeassistant import core
 from homeassistant.components import shell_command
@@ -26,13 +28,44 @@ class TestShellCommand(unittest.TestCase):
         """ Test if able to call a configured service. """
         with tempfile.TemporaryDirectory() as tempdirname:
             path = os.path.join(tempdirname, 'called.txt')
-            shell_command.setup(self.hass, {
+            self.assertTrue(shell_command.setup(self.hass, {
                 'shell_command': {
                     'test_service': "touch {}".format(path)
                 }
-            })
+            }))
 
             self.hass.services.call('shell_command', 'test_service',
                                     blocking=True)
 
             self.assertTrue(os.path.isfile(path))
+
+    def test_config_not_dict(self):
+        """ Test if config is not a dict. """
+        self.assertFalse(shell_command.setup(self.hass, {
+            'shell_command': ['some', 'weird', 'list']
+            }))
+
+    def test_config_not_valid_service_names(self):
+        """ Test if config contains invalid service names. """
+        self.assertFalse(shell_command.setup(self.hass, {
+            'shell_command': {
+                'this is invalid because space': 'touch bla.txt'
+            }}))
+
+    @patch('homeassistant.components.shell_command.subprocess.call',
+           side_effect=SubprocessError)
+    @patch('homeassistant.components.shell_command._LOGGER.error')
+    def test_subprocess_raising_error(self, mock_call, mock_error):
+        with tempfile.TemporaryDirectory() as tempdirname:
+            path = os.path.join(tempdirname, 'called.txt')
+            self.assertTrue(shell_command.setup(self.hass, {
+                'shell_command': {
+                    'test_service': "touch {}".format(path)
+                }
+            }))
+
+            self.hass.services.call('shell_command', 'test_service',
+                                    blocking=True)
+
+            self.assertFalse(os.path.isfile(path))
+            self.assertEqual(1, mock_error.call_count)

--- a/tests/components/test_shell_command.py
+++ b/tests/components/test_shell_command.py
@@ -1,0 +1,38 @@
+"""
+tests.test_shell_command
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests demo component.
+"""
+import os
+import tempfile
+import unittest
+
+from homeassistant import core
+from homeassistant.components import shell_command
+
+
+class TestShellCommand(unittest.TestCase):
+    """ Test the demo module. """
+
+    def setUp(self):  # pylint: disable=invalid-name
+        self.hass = core.HomeAssistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """ Stop down stuff we started. """
+        self.hass.stop()
+
+    def test_executing_service(self):
+        """ Test if able to call a configured service. """
+        with tempfile.TemporaryDirectory() as tempdirname:
+            path = os.path.join(tempdirname, 'called.txt')
+            shell_command.setup(self.hass, {
+                'shell_command': {
+                    'test_service': "touch {}".format(path)
+                }
+            })
+
+            self.hass.services.call('shell_command', 'test_service',
+                                    blocking=True)
+
+            self.assertTrue(os.path.isfile(path))


### PR DESCRIPTION
New component, up for discussion.

Expose pre-defined shell commands as services in Home Assistant.

``` yaml
shell_command:
  curl_some_site: curl https://home-assistant.io
  restart_pow: touch /Users/paulus/.pow/restart.txt
```

This config would expose the services `shell_command.curl_some_site` and `shell_command.restart_pow`.

This component is meant as a building block. Can be called from automation or a script.

I have no intention to make this dynamic to allow people to pass input to be called from the shell.
