### PR TITLE
media_player/plex fix

### DIFF
--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -51,7 +51,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         new_plex_clients = []
         for device in devices:
             # For now, let's allow all deviceClass types
-            if device.deviceClass in []:
+            if device.deviceClass in ['badClient']:
                 continue
 
             if device.machineIdentifier not in plex_clients:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -134,7 +134,7 @@ https://github.com/balloob/home-assistant-vera-api/archive/a8f823066ead6c7da6fb5
 SoCo==0.11.1
 
 # PlexAPI (media_player.plex)
-https://github.com/adrienbrault/python-plexapi/archive/df2d0847e801d6d5cda920326d693cf75f304f1a.zip#python-plexapi==1.0.2
+plexapi==1.1.0
 
 # SNMP (device_tracker.snmp)
 pysnmp==4.2.5


### PR DESCRIPTION
Hi all,

Some minor changes to have the plex media_player.
#### Fixes:
- Playback controls work
- No need for a modified plexapi
#### Differences
- Clients are fetched from the plexserver, not plex.tv/devices.xml. So only 'actual' playback clients like PlexHomeTheater, rasplex, Plex for mobiles, etc will show up. Browser sessions, 'PlexIt' etc will not show up.
- Latest plexapi version used

Any feedback is very welcome!

---

2nd attempt

Comments from previous PR
@miniconfig 

> I think the reason @adrienbrault made the change to pulling from plex.tv/devices.xml instead of querying the plex server (as it originally did) was because his server was for some reason not returning anything as the client (I think someone else may have had a similar problem, but we weren't able to confirm it). It might be helpful to determine why his wasn't returning anything, or if there's another way around the problem you were seeing, rather than switching back and forth. 

I agree, back/forth is silly.
The 'client class'-way fetches clients from the local server instead of plex.tv. I feel this is a nicer way as long as it works properly.
Talked to @adrienbrault on chat about this, and asked him to feed back on it.

Plus i had the idea to try and get local plex servers discovered through netdisco (plex uses self-created GDM). This allows for a similar detection/configuration as the Hue component, using the configurator (but instead of pushing a button you enter the auth-token). This only makes the server available though. Curious if this is something we want :)

@luxus

> i just pull your plex.py it connects to the server but no media_player got listed anymore .. i use PHT on my mac.

I 'm running rasplex and PHT myself. Didn't test well enough.
Please try again!
