### PR TITLE
radiotherm platform bug fix and configuration parameter

### DIFF
--- a/homeassistant/components/thermostat/radiotherm.py
+++ b/homeassistant/components/thermostat/radiotherm.py
@@ -6,7 +6,8 @@ Adds support for Radio Thermostat wifi-enabled home thermostats
 Config:
 thermostat:
     platform: radiotherm
-    hold_temp: boolean to control if hass temp adjustments hold(True) or are temporary(False)
+    hold_temp: boolean to control if hass temp adjustments hold(True) or are
+    temporary(False)
     host: list of thermostat host/ips to control
 
 Example:
@@ -17,10 +18,10 @@ thermostat:
         - 192.168.99.137
         - 192.168.99.202
 
-Configure two thermostats via the configuration.yaml.  Temperature settings sent from
-hass will be sent to thermostat and then hold at that temp.  Set to False if you set
-a thermostat schedule on the tstat itself and just want hass to send temporary temp
-changes.
+Configure two thermostats via the configuration.yaml.  Temperature settings
+sent from hass will be sent to thermostat and then hold at that temp.  Set
+to False if you set a thermostat schedule on the tstat itself and just want
+hass to send temporary temp changes.
 
 """
 import logging

--- a/homeassistant/components/thermostat/radiotherm.py
+++ b/homeassistant/components/thermostat/radiotherm.py
@@ -2,6 +2,18 @@
 homeassistant.components.thermostat.radiotherm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Adds support for Radio Thermostat wifi-enabled home thermostats
+
+Config:
+
+Example:
+thermostat:
+    platform: radiotherm
+    host:
+        - 192.168.99.137
+        - 192.168.99.202
+
+Configure two thermostats via the configuration.yaml
+
 """
 import logging
 import datetime
@@ -22,7 +34,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     hosts = []
     if CONF_HOST in config:
-        hosts = [config[CONF_HOST]]
+        hosts = config[CONF_HOST]
     else:
         hosts.append(radiotherm.discover.discover_address())
 


### PR DESCRIPTION
1. Corrected bug when adding multiple radiotherm hosts via configuration.yaml
2. Added new configuration parameter hold_temp to control if setting the temperature from home-assistant is set to hold.  Setting hold_temp to True is useful if the thermostat will be treated as  a dumb device and all temp adjustments will be controlled by a home-assistant component.  Setting hold_temp to False can be used if you just want home-assistant to make temporary thermostat adjustments (temperature change when all people leave the house) but return to thermostat program.
3. Added configuration example and docs to radiotherm.py
