### PR TITLE
Resolve Wemo connect logic 

### DIFF
--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -24,7 +24,6 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     if discovery_info is not None:
         location = discovery_info[2]
         mac = discovery_info[3]
-        # pylint: disable=too-many-function-args
         device = discovery.device_from_description(location, mac)
 
         if device:

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import STATE_ON, STATE_OFF, STATE_STANDBY
 
-REQUIREMENTS = ['pywemo==0.3.1']
+REQUIREMENTS = ['pywemo==0.3.2']
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -22,7 +22,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     import pywemo.discovery as discovery
 
     if discovery_info is not None:
-        device = discovery.device_from_description(discovery_info[2])
+        device = discovery.device_from_description(discovery_info[2], discovery_info[3])
 
         if device:
             add_devices_callback([WemoSwitch(device)])

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -22,7 +22,10 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     import pywemo.discovery as discovery
 
     if discovery_info is not None:
-        device = discovery.device_from_description(discovery_info[2], discovery_info[3])
+        location = discovery_info[2]
+        mac = discovery_info[3]
+        # pylint: disable=too-many-function-args
+        device = discovery.device_from_description(location, mac)
 
         if device:
             add_devices_callback([WemoSwitch(device)])

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -90,7 +90,7 @@ pynetgear==0.3
 netdisco==0.5
 
 # Wemo (switch.wemo)
-pywemo==0.3.1
+pywemo==0.3.2
 
 # Wink (*.wink)
 https://github.com/balloob/python-wink/archive/c2b700e8ca866159566ecf5e644d9c297f69f257.zip#python-wink==0.1


### PR DESCRIPTION
This PR closes this issue ttps://github.com/balloob/home-assistant/issues/476

It requires the new version of pywemo which is already included.

However it also requires https://github.com/balloob/netdisco/pull/6

The issue was related to how 'lost' wemo devices are found. Some type of change had resulted in the old scanning approach never to find the device. This revision matches on MAC address.
