### PR TITLE
Color temperature support for light component and hue platform

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -253,7 +253,7 @@ def setup(hass, config):
             # Without this check, a ctcolor with value '99' would work
             # These values are based on Philips Hue, may need ajustment later
             if isinstance(colortemp, int) and 154 <= colortemp <= 500:
-                    params[ATTR_COLOR_TEMP] = colortemp
+                params[ATTR_COLOR_TEMP] = colortemp
 
         if ATTR_RGB_COLOR in dat:
             try:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -252,8 +252,7 @@ def setup(hass, config):
 
             # Without this check, a ctcolor with value '99' would work
             # These values are based on Philips Hue, may need ajustment later
-            if isinstance(colortemp, int):
-                if 154 <= colortemp <= 500:
+            if isinstance(colortemp, int) and 154 <= colortemp <= 500:
                     params[ATTR_COLOR_TEMP] = colortemp
 
         if ATTR_RGB_COLOR in dat:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -43,7 +43,7 @@ Supports following parameters:
    A list containing three integers representing the xy color you want the
    light to be.
 
- - ct_color
+ - color_temp
    An INT in mireds represending the color temperature you want the light to be
 
  - brightness
@@ -80,7 +80,7 @@ ATTR_TRANSITION = "transition"
 # lists holding color values
 ATTR_RGB_COLOR = "rgb_color"
 ATTR_XY_COLOR = "xy_color"
-ATTR_CT_COLOR = "ct_color"
+ATTR_COLOR_TEMP = "color_temp"
 
 # int with value 0 .. 255 representing brightness of the light
 ATTR_BRIGHTNESS = "brightness"
@@ -109,7 +109,7 @@ DISCOVERY_PLATFORMS = {
 PROP_TO_ATTR = {
     'brightness': ATTR_BRIGHTNESS,
     'color_xy': ATTR_XY_COLOR,
-    'color_ct': ATTR_CT_COLOR,
+    'color_temp': ATTR_COLOR_TEMP,
 }
 
 _LOGGER = logging.getLogger(__name__)
@@ -124,7 +124,7 @@ def is_on(hass, entity_id=None):
 
 # pylint: disable=too-many-arguments
 def turn_on(hass, entity_id=None, transition=None, brightness=None,
-            rgb_color=None, xy_color=None, ct_color=None, profile=None,
+            rgb_color=None, xy_color=None, color_temp=None, profile=None,
             flash=None, effect=None):
     """ Turns all or specified light on. """
     data = {
@@ -135,7 +135,7 @@ def turn_on(hass, entity_id=None, transition=None, brightness=None,
             (ATTR_BRIGHTNESS, brightness),
             (ATTR_RGB_COLOR, rgb_color),
             (ATTR_XY_COLOR, xy_color),
-            (ATTR_CT_COLOR, ct_color),
+            (ATTR_COLOR_TEMP, color_temp),
             (ATTR_FLASH, flash),
             (ATTR_EFFECT, effect),
         ] if value is not None
@@ -246,15 +246,15 @@ def setup(hass, config):
                 # ValueError if value could not be converted to float
                 pass
 
-        if ATTR_CT_COLOR in dat:
-            # ct_color should be an int of mirads value
-            ctcolor = dat.get(ATTR_CT_COLOR)
+        if ATTR_COLOR_TEMP in dat:
+            # color_temp should be an int of mirads value
+            colortemp = dat.get(ATTR_COLOR_TEMP)
 
             # Without this check, a ctcolor with value '99' would work
             # These values are based on Philips Hue, may need ajustment later
-            if isinstance(ctcolor, int):
-                if 154 <= ctcolor <= 500:
-                    params[ATTR_CT_COLOR] = ctcolor
+            if isinstance(colortemp, int):
+                if 154 <= colortemp <= 500:
+                    params[ATTR_COLOR_TEMP] = colortemp
 
         if ATTR_RGB_COLOR in dat:
             try:
@@ -318,7 +318,7 @@ class Light(ToggleEntity):
         return None
 
     @property
-    def color_ct(self):
+    def color_temp(self):
         """ CT color value in mirads. """
         return None
 

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -43,6 +43,9 @@ Supports following parameters:
    A list containing three integers representing the xy color you want the
    light to be.
 
+ - ct_color
+   An INT in mireds represending the color temperature you want the light to be
+
  - brightness
    Integer between 0 and 255 representing how bright you want the light to be.
 
@@ -77,6 +80,7 @@ ATTR_TRANSITION = "transition"
 # lists holding color values
 ATTR_RGB_COLOR = "rgb_color"
 ATTR_XY_COLOR = "xy_color"
+ATTR_CT_COLOR = "ct_color"
 
 # int with value 0 .. 255 representing brightness of the light
 ATTR_BRIGHTNESS = "brightness"
@@ -105,6 +109,7 @@ DISCOVERY_PLATFORMS = {
 PROP_TO_ATTR = {
     'brightness': ATTR_BRIGHTNESS,
     'color_xy': ATTR_XY_COLOR,
+    'color_ct': ATTR_CT_COLOR,
 }
 
 _LOGGER = logging.getLogger(__name__)
@@ -119,8 +124,8 @@ def is_on(hass, entity_id=None):
 
 # pylint: disable=too-many-arguments
 def turn_on(hass, entity_id=None, transition=None, brightness=None,
-            rgb_color=None, xy_color=None, profile=None, flash=None,
-            effect=None):
+            rgb_color=None, xy_color=None, ct_color=None, profile=None,
+            flash=None, effect=None):
     """ Turns all or specified light on. """
     data = {
         key: value for key, value in [
@@ -130,6 +135,7 @@ def turn_on(hass, entity_id=None, transition=None, brightness=None,
             (ATTR_BRIGHTNESS, brightness),
             (ATTR_RGB_COLOR, rgb_color),
             (ATTR_XY_COLOR, xy_color),
+            (ATTR_CT_COLOR, ct_color),
             (ATTR_FLASH, flash),
             (ATTR_EFFECT, effect),
         ] if value is not None
@@ -240,6 +246,16 @@ def setup(hass, config):
                 # ValueError if value could not be converted to float
                 pass
 
+        if ATTR_CT_COLOR in dat:
+            # ct_color should be an int of mirads value
+            ctcolor = dat.get(ATTR_CT_COLOR)
+
+            # Without this check, a ctcolor with value '99' would work
+            # These values are based on Philips Hue, may need ajustment later
+            if isinstance(ctcolor, int):
+                if 154 <= ctcolor <= 500:
+                    params[ATTR_CT_COLOR] = ctcolor
+
         if ATTR_RGB_COLOR in dat:
             try:
                 # rgb_color should be a list containing 3 ints
@@ -299,6 +315,11 @@ class Light(ToggleEntity):
     @property
     def color_xy(self):
         """ XY color value [float, float]. """
+        return None
+
+    @property
+    def color_ct(self):
+        """ CT color value in mirads. """
         return None
 
     @property

--- a/homeassistant/components/light/demo.py
+++ b/homeassistant/components/light/demo.py
@@ -8,7 +8,7 @@ Demo platform that implements lights.
 import random
 
 from homeassistant.components.light import (
-    Light, ATTR_BRIGHTNESS, ATTR_XY_COLOR, ATTR_CT_COLOR)
+    Light, ATTR_BRIGHTNESS, ATTR_XY_COLOR, ATTR_COLOR_TEMP)
 
 
 LIGHT_COLORS = [
@@ -59,7 +59,7 @@ class DemoLight(Light):
         return self._xy
 
     @property
-    def color_ct(self):
+    def color_temp(self):
         """ CT color temperature. """
         return self._ct
 
@@ -75,8 +75,8 @@ class DemoLight(Light):
         if ATTR_XY_COLOR in kwargs:
             self._xy = kwargs[ATTR_XY_COLOR]
 
-        if ATTR_CT_COLOR in kwargs:
-            self._ct = kwargs[ATTR_CT_COLOR]
+        if ATTR_COLOR_TEMP in kwargs:
+            self._ct = kwargs[ATTR_COLOR_TEMP]
 
         if ATTR_BRIGHTNESS in kwargs:
             self._brightness = kwargs[ATTR_BRIGHTNESS]

--- a/homeassistant/components/light/demo.py
+++ b/homeassistant/components/light/demo.py
@@ -30,6 +30,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
 class DemoLight(Light):
     """ Provides a demo switch. """
+    # pylint: disable=too-many-arguments
     def __init__(self, name, state, xy=None, ct=None, brightness=180):
         self._name = name
         self._state = state

--- a/homeassistant/components/light/demo.py
+++ b/homeassistant/components/light/demo.py
@@ -8,7 +8,7 @@ Demo platform that implements lights.
 import random
 
 from homeassistant.components.light import (
-    Light, ATTR_BRIGHTNESS, ATTR_XY_COLOR)
+    Light, ATTR_BRIGHTNESS, ATTR_XY_COLOR, ATTR_CT_COLOR)
 
 
 LIGHT_COLORS = [
@@ -16,22 +16,25 @@ LIGHT_COLORS = [
     [0.460, 0.470],
 ]
 
+LIGHT_TEMPS = [160, 300, 500]
+
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """ Find and return demo lights. """
     add_devices_callback([
         DemoLight("Bed Light", False),
-        DemoLight("Ceiling Lights", True, LIGHT_COLORS[0]),
-        DemoLight("Kitchen Lights", True, LIGHT_COLORS[1])
+        DemoLight("Ceiling Lights", True, LIGHT_TEMPS[1], LIGHT_COLORS[0]),
+        DemoLight("Kitchen Lights", True, LIGHT_TEMPS[0], LIGHT_COLORS[1])
     ])
 
 
 class DemoLight(Light):
     """ Provides a demo switch. """
-    def __init__(self, name, state, xy=None, brightness=180):
+    def __init__(self, name, state, xy=None, ct=None, brightness=180):
         self._name = name
         self._state = state
         self._xy = xy or random.choice(LIGHT_COLORS)
+        self._ct = ct or random.choice(LIGHT_TEMPS)
         self._brightness = brightness
 
     @property
@@ -55,6 +58,11 @@ class DemoLight(Light):
         return self._xy
 
     @property
+    def color_ct(self):
+        """ CT color temperature. """
+        return self._ct
+
+    @property
     def is_on(self):
         """ True if device is on. """
         return self._state
@@ -65,6 +73,9 @@ class DemoLight(Light):
 
         if ATTR_XY_COLOR in kwargs:
             self._xy = kwargs[ATTR_XY_COLOR]
+
+        if ATTR_CT_COLOR in kwargs:
+            self._ct = kwargs[ATTR_CT_COLOR]
 
         if ATTR_BRIGHTNESS in kwargs:
             self._brightness = kwargs[ATTR_BRIGHTNESS]

--- a/homeassistant/components/light/demo.py
+++ b/homeassistant/components/light/demo.py
@@ -16,7 +16,7 @@ LIGHT_COLORS = [
     [0.460, 0.470],
 ]
 
-LIGHT_TEMPS = [160, 300, 500]
+LIGHT_TEMPS = [160, 500]
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -124,6 +124,7 @@ def request_configuration(host, hass, add_devices_callback):
             _CONFIGURING[host], "Failed to register, please try again.")
 
         return
+
     # pylint: disable=unused-argument
     def hue_configuration_callback(data):
         """ Actions to do when our configuration callback is called. """

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -14,7 +14,7 @@ from homeassistant.loader import get_component
 import homeassistant.util as util
 from homeassistant.const import CONF_HOST, DEVICE_DEFAULT_NAME
 from homeassistant.components.light import (
-    Light, ATTR_BRIGHTNESS, ATTR_XY_COLOR, ATTR_CT_COLOR,
+    Light, ATTR_BRIGHTNESS, ATTR_XY_COLOR, ATTR_COLOR_TEMP,
     ATTR_TRANSITION, ATTR_FLASH, FLASH_LONG, FLASH_SHORT,
     ATTR_EFFECT, EFFECT_COLORLOOP)
 
@@ -124,7 +124,7 @@ def request_configuration(host, hass, add_devices_callback):
             _CONFIGURING[host], "Failed to register, please try again.")
 
         return
-
+    # pylint: disable=unused-argument
     def hue_configuration_callback(data):
         """ Actions to do when our configuration callback is called. """
         setup_bridge(host, hass, add_devices_callback)
@@ -147,16 +147,6 @@ class HueLight(Light):
         self.bridge = bridge
         self.update_lights = update_lights
 
-        # Hue can control multiple type of lights
-        capability_map = {
-            'Dimmable light': ['bri'],
-            'Dimmable plug-in unit': ['bri'],
-            'Color light': ['bri', 'xy'],
-            'Extended color light': ['bri', 'xy', 'ct'],
-            'unknown': []}
-        self.capabilities = capability_map.get(
-            self.info['type'], 'unknown')
-
     @property
     def unique_id(self):
         """ Returns the id of this Hue light """
@@ -171,26 +161,17 @@ class HueLight(Light):
     @property
     def brightness(self):
         """ Brightness of this light between 0..255. """
-        if 'bri' in self.capabilities:
-            return self.info['state']['bri']
-        else:
-            return None
+        return self.info['state']['bri']
 
     @property
     def color_xy(self):
         """ XY color value. """
-        if 'xy' in self.capabilities:
-            return self.info['state'].get('xy')
-        else:
-            return None
+        return self.info['state'].get('xy')
 
     @property
-    def color_ct(self):
+    def color_temp(self):
         """ CT color value. """
-        if 'ct' in self.capabilities:
-            return self.info['state'].get('ct')
-        else:
-            return None
+        return self.info['state'].get('ct')
 
     @property
     def is_on(self):
@@ -214,8 +195,8 @@ class HueLight(Light):
         if ATTR_XY_COLOR in kwargs:
             command['xy'] = kwargs[ATTR_XY_COLOR]
 
-        if ATTR_CT_COLOR in kwargs:
-            command['ct'] = kwargs[ATTR_CT_COLOR]
+        if ATTR_COLOR_TEMP in kwargs:
+            command['ct'] = kwargs[ATTR_COLOR_TEMP]
 
         flash = kwargs.get(ATTR_FLASH)
 

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -20,7 +20,7 @@ turn_on:
       description: Color for the light in XY-format
       example: '[0.52, 0.43]'
 
-    ct_color:
+    color_temp:
       description: Color temperature for the light in mireds (154-500)
       example: '250'
 

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -20,6 +20,10 @@ turn_on:
       description: Color for the light in XY-format
       example: '[0.52, 0.43]'
 
+    ct_color:
+      description: Color temperature for the light in mireds (154-500)
+      example: '250'
+
     brightness:
       description: Number between 0..255 indicating brightness
       example: 120


### PR DESCRIPTION
Hi all
#### This PR brings the following:
- Color temperature support in the light component
- Color temperature support in the Hue platform
#### This PR is dependent on:
- https://github.com/balloob/home-assistant-polymer/pull/12
##### Color temperature

It's set by mired number (https://en.wikipedia.org/wiki/Mired). The number limits used in the polymer slider and light component are based on Hue (154-500). This may need to be made dynamic depending on other component needs / limits.
_You can either set xy_color **or** color_temp, not both_
Example of color_temp:

```
scene:
  - name: Livingroom morning
    entities:
        light.dining:
            state: on
            brightness: 150
            color_temp: 160
        light.kitchen:
            state: on
            xy_color: [ 0.4448, 0.4066 ]
```
