### PR TITLE
Fix script regression

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -65,8 +65,10 @@ class EntityComponent(object):
             if entity is not None and entity not in self.entities.values():
                 entity.hass = self.hass
 
-                entity.entity_id = generate_entity_id(
-                    self.entity_id_format, entity.name, self.entities.keys())
+                if getattr(entity, 'entity_id', None) is None:
+                    entity.entity_id = generate_entity_id(
+                        self.entity_id_format, entity.name,
+                        self.entities.keys())
 
                 self.entities[entity.entity_id] = entity
 

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -47,7 +47,18 @@ class TestScript(unittest.TestCase):
             }
         }))
 
-        self.assertIsNone(self.hass.states.get(ENTITY_ID))
+        self.assertEqual(0, len(self.hass.states.entity_ids('script')))
+
+    def test_setup_with_invalid_object_id(self):
+        self.assertTrue(script.setup(self.hass, {
+            'script': {
+                'test hello world': {
+                    'sequence': []
+                }
+            }
+        }))
+
+        self.assertEqual(0, len(self.hass.states.entity_ids('script')))
 
     def test_firing_event(self):
         event = 'test_event'
@@ -61,6 +72,7 @@ class TestScript(unittest.TestCase):
         self.assertTrue(script.setup(self.hass, {
             'script': {
                 'test': {
+                    'alias': 'Test Script',
                     'sequence': [{
                         'event': event,
                         'event_data': {


### PR DESCRIPTION
This fixes the script regression in v0.7.6 as noticed by @stefan-jonasson 

The script component would use the alias as the key for the script instead of the key in the configuration.

``` yaml
script:
  hello:
    alias: Hello World
    sequence:
      …
```

This block used to result in a service called `script.hello`. In 0.7.6 it accidently because `script.hello_world`. This PR makes it `script.hello` again.
