### PR TITLE
0.7.7

### DIFF
--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -28,10 +28,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     resource = config.get(CONF_RESOURCE)
     var_conf = config.get(CONF_MONITORED_VARIABLES)
+    pins = config.get('pins', None)
 
-    if None in (resource, var_conf):
+
+    if resource is None:
         _LOGGER.error('Not all required config keys present: %s',
-                      ', '.join((CONF_RESOURCE, CONF_MONITORED_VARIABLES)))
+                      CONF_RESOURCE)
         return False
 
     try:
@@ -49,31 +51,35 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     arest = ArestData(resource)
 
     dev = []
-    pins = config.get('pins', None)
 
-    for variable in config['monitored_variables']:
-        if variable['name'] not in response['variables']:
-            _LOGGER.error('Variable: "%s" does not exist', variable['name'])
-            continue
+    if var_conf is not None:
+        for variable in config['monitored_variables']:
+            if variable['name'] not in response['variables']:
+                _LOGGER.error('Variable: "%s" does not exist',
+                              variable['name'])
+                continue
 
-        dev.append(ArestSensor(arest,
-                               resource,
-                               config.get('name', response['name']),
-                               variable['name'],
-                               variable=variable['name'],
-                               unit_of_measurement=variable.get(
-                                   'unit_of_measurement')))
+            dev.append(ArestSensor(arest,
+                                   resource,
+                                   config.get('name', response['name']),
+                                   variable['name'],
+                                   variable=variable['name'],
+                                   unit_of_measurement=variable.get(
+                                       'unit_of_measurement')))
 
-    for pinnum, pin in pins.items():
-        dev.append(ArestSensor(ArestData(resource, pinnum),
-                               resource,
-                               config.get('name', response['name']),
-                               pin.get('name'),
-                               pin=pinnum,
-                               unit_of_measurement=pin.get(
-                                   'unit_of_measurement'),
-                               corr_factor=pin.get('correction_factor', None),
-                               decimal_places=pin.get('decimal_places', None)))
+    if pins is not None:
+        for pinnum, pin in pins.items():
+            dev.append(ArestSensor(ArestData(resource, pinnum),
+                                   resource,
+                                   config.get('name', response['name']),
+                                   pin.get('name'),
+                                   pin=pinnum,
+                                   unit_of_measurement=pin.get(
+                                       'unit_of_measurement'),
+                                   corr_factor=pin.get('correction_factor',
+                                                       None),
+                                   decimal_places=pin.get('decimal_places',
+                                                          None)))
 
     add_devices(dev)
 

--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -30,7 +30,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     var_conf = config.get(CONF_MONITORED_VARIABLES)
     pins = config.get('pins', None)
 
-
     if resource is None:
         _LOGGER.error('Not all required config keys present: %s',
                       CONF_RESOURCE)

--- a/homeassistant/components/sensor/efergy.py
+++ b/homeassistant/components/sensor/efergy.py
@@ -8,7 +8,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.efergy.html
 """
 import logging
-from requests import get
+from requests import get, RequestException
 
 from homeassistant.helpers.entity import Entity
 
@@ -80,19 +80,22 @@ class EfergySensor(Entity):
 
     def update(self):
         """ Gets the Efergy monitor data from the web service. """
-        if self.type == 'instant_readings':
-            url_string = _RESOURCE + 'getInstant?token=' + self.app_token
-            response = get(url_string)
-            self._state = response.json()['reading'] / 1000
-        elif self.type == 'budget':
-            url_string = _RESOURCE + 'getBudget?token=' + self.app_token
-            response = get(url_string)
-            self._state = response.json()['status']
-        elif self.type == 'cost':
-            url_string = _RESOURCE + 'getCost?token=' + self.app_token \
-                + '&offset=' + self.utc_offset + '&period=' \
-                + self.period
-            response = get(url_string)
-            self._state = response.json()['sum']
-        else:
-            self._state = 'Unknown'
+        try:
+            if self.type == 'instant_readings':
+                url_string = _RESOURCE + 'getInstant?token=' + self.app_token
+                response = get(url_string)
+                self._state = response.json()['reading'] / 1000
+            elif self.type == 'budget':
+                url_string = _RESOURCE + 'getBudget?token=' + self.app_token
+                response = get(url_string)
+                self._state = response.json()['status']
+            elif self.type == 'cost':
+                url_string = _RESOURCE + 'getCost?token=' + self.app_token \
+                    + '&offset=' + self.utc_offset + '&period=' \
+                    + self.period
+                response = get(url_string)
+                self._state = response.json()['sum']
+            else:
+                self._state = 'Unknown'
+        except RequestException:
+            _LOGGER.warning('Could not update status for %s', self.name)

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -15,7 +15,7 @@ REQUIREMENTS = ['pywemo==0.3.2']
 _LOGGER = logging.getLogger(__name__)
 
 
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument, too-many-function-args
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """ Find and return WeMo switches. """
     import pywemo

--- a/homeassistant/components/thermostat/services.yaml
+++ b/homeassistant/components/thermostat/services.yaml
@@ -1,0 +1,24 @@
+
+set_away_mode:
+  description: Turn away mode on/off for a thermostat
+
+  fields:
+    entity_id:
+      description: Name(s) of entities to change
+      example: 'light.kitchen'
+
+    away_mode:
+      description: New value of away mode
+      example: true
+
+set_temperature:
+  description: Set temperature of thermostat
+
+  fields:
+    entity_id:
+      description: Name(s) of entities to change
+      example: 'light.kitchen'
+
+    temperature:
+      description: New target temperature for thermostat
+      example: 25

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """ Constants used by Home Assistant components. """
 
-__version__ = "0.7.7.dev0"
+__version__ = "0.7.7"
 
 # Can be used to specify a catch all when registering state or event listeners.
 MATCH_ALL = '*'

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """ Constants used by Home Assistant components. """
 
-__version__ = "0.7.6"
+__version__ = "0.7.7.dev0"
 
 # Can be used to specify a catch all when registering state or event listeners.
 MATCH_ALL = '*'

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -65,8 +65,10 @@ class EntityComponent(object):
             if entity is not None and entity not in self.entities.values():
                 entity.hass = self.hass
 
-                entity.entity_id = generate_entity_id(
-                    self.entity_id_format, entity.name, self.entities.keys())
+                if getattr(entity, 'entity_id', None) is None:
+                    entity.entity_id = generate_entity_id(
+                        self.entity_id_format, entity.name,
+                        self.entities.keys())
 
                 self.entities[entity.entity_id] = entity
 

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -47,7 +47,18 @@ class TestScript(unittest.TestCase):
             }
         }))
 
-        self.assertIsNone(self.hass.states.get(ENTITY_ID))
+        self.assertEqual(0, len(self.hass.states.entity_ids('script')))
+
+    def test_setup_with_invalid_object_id(self):
+        self.assertTrue(script.setup(self.hass, {
+            'script': {
+                'test hello world': {
+                    'sequence': []
+                }
+            }
+        }))
+
+        self.assertEqual(0, len(self.hass.states.entity_ids('script')))
 
     def test_firing_event(self):
         event = 'test_event'
@@ -61,6 +72,7 @@ class TestScript(unittest.TestCase):
         self.assertTrue(script.setup(self.hass, {
             'script': {
                 'test': {
+                    'alias': 'Test Script',
                     'sequence': [{
                         'event': event,
                         'event_data': {


### PR DESCRIPTION
Yep, that's version 0.7.7 right there. We caught a major regression that caused scripts to stop working. This is being fixed now.

The script component would use the alias as the key for the script instead of the key in the configuration.

``` yaml
script:
  hello:
    alias: Hello World
    sequence:
      …
```

This block used to result in a service called `script.hello`. In 0.7.6 it accidently because `script.hello_world`. This PR makes it `script.hello` again.

Also fixes another regression where the aRest component expects pins config key, even if no pins are wanted to be observed.
