### PR TITLE
Actiontec device_tracker bugfix and removed home_interval

### DIFF
--- a/homeassistant/components/device_tracker/actiontec.py
+++ b/homeassistant/components/device_tracker/actiontec.py
@@ -57,7 +57,6 @@ class ActiontecDeviceScanner(object):
         self.password = config[CONF_PASSWORD]
         self.lock = threading.Lock()
         self.last_results = []
-        # Test the router is accessible
         data = self.get_actiontec_data()
         self.success_init = data is not None
         _LOGGER.info("actiontec scanner initialized")
@@ -90,21 +89,13 @@ class ActiontecDeviceScanner(object):
             return False
 
         with self.lock:
-            exclude_targets = set()
-            exclude_target_list = []
             now = dt_util.now()
             actiontec_data = self.get_actiontec_data()
             if not actiontec_data:
                 return False
-            self.last_results = []
-            for client in exclude_target_list:
-                if client in actiontec_data:
-                    actiontec_data.pop(client)
-            for name, data in actiontec_data.items():
-                if data['timevalid'] > 0:
-                    device = Device(data['mac'], name, now)
-                    self.last_results.append(device)
-            self.last_results.extend(exclude_targets)
+            self.last_results = [Device(data['mac'], name, now)
+                                 for name, data in actiontec_data.items()
+                                 if data['timevalid'] > -60]
             _LOGGER.info("actiontec scan successful")
             return True
 

--- a/homeassistant/components/device_tracker/actiontec.py
+++ b/homeassistant/components/device_tracker/actiontec.py
@@ -23,9 +23,6 @@ from homeassistant.components.device_tracker import DOMAIN
 # Return cached results if last scan was less then this time ago
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
-# Interval in minutes to exclude devices from a scan while they are home
-CONF_HOME_INTERVAL = "home_interval"
-
 _LOGGER = logging.getLogger(__name__)
 
 _LEASES_REGEX = re.compile(
@@ -58,16 +55,12 @@ class ActiontecDeviceScanner(object):
         self.host = config[CONF_HOST]
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
-        minutes = convert(config.get(CONF_HOME_INTERVAL), int, 0)
-        self.home_interval = timedelta(minutes=minutes)
         self.lock = threading.Lock()
         self.last_results = []
         # Test the router is accessible
         data = self.get_actiontec_data()
         self.success_init = data is not None
         _LOGGER.info("actiontec scanner initialized")
-        if self.home_interval:
-            _LOGGER.info("home_interval set to: %s", self.home_interval)
 
     def scan_devices(self):
         """
@@ -100,12 +93,6 @@ class ActiontecDeviceScanner(object):
             exclude_targets = set()
             exclude_target_list = []
             now = dt_util.now()
-            if self.home_interval:
-                for host in self.last_results:
-                    if host.last_update + self.home_interval > now:
-                        exclude_targets.add(host)
-                if len(exclude_targets) > 0:
-                    exclude_target_list = [t.ip for t in exclude_targets]
             actiontec_data = self.get_actiontec_data()
             if not actiontec_data:
                 return False

--- a/homeassistant/components/device_tracker/actiontec.py
+++ b/homeassistant/components/device_tracker/actiontec.py
@@ -17,7 +17,7 @@ import telnetlib
 import homeassistant.util.dt as dt_util
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.helpers import validate_config
-from homeassistant.util import Throttle, convert
+from homeassistant.util import Throttle
 from homeassistant.components.device_tracker import DOMAIN
 
 # Return cached results if last scan was less then this time ago


### PR DESCRIPTION
In previous versions of the actiontec tracker the tracker would count some devices as home when they were really not.  When we read the 'firewall mac_cache_dump' from the router, each entry has a 'valid for:' time value in seconds.  If the 'valid for' time is less then zero, then the client is considered 'not active' by the router and should be considered away by the device tracker.  This pull request should fix that.

I've also removed all the home_interval stuff since @balloob added it to the main device tracker component.
