### PR TITLE
Expose API to view error log

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -34,6 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_COMPONENT = 'component'
 
 PLATFORM_FORMAT = '{}.{}'
+ERROR_LOG_FILENAME = 'home-assistant.log'
 
 
 def setup_component(hass, domain, config=None):
@@ -252,7 +253,7 @@ def enable_logging(hass, verbose=False, daemon=False, log_rotate_days=None):
                 "Colorlog package not found, console coloring disabled")
 
     # Log errors to a file if we have write access to file or config dir
-    err_log_path = hass.config.path('home-assistant.log')
+    err_log_path = hass.config.path(ERROR_LOG_FILENAME)
     err_path_exists = os.path.isfile(err_log_path)
 
     # Check if we can write to the error log if it exists or that

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -151,6 +151,7 @@ URL_API_SERVICES_SERVICE = "/api/services/{}/{}"
 URL_API_EVENT_FORWARD = "/api/event_forwarding"
 URL_API_COMPONENTS = "/api/components"
 URL_API_BOOTSTRAP = "/api/bootstrap"
+URL_API_ERROR_LOG = "/api/error_log"
 
 HTTP_OK = 200
 HTTP_CREATED = 201
@@ -173,3 +174,4 @@ HTTP_HEADER_EXPIRES = "Expires"
 
 CONTENT_TYPE_JSON = "application/json"
 CONTENT_TYPE_MULTIPART = 'multipart/x-mixed-replace; boundary={}'
+CONTENT_TYPE_TEXT_PLAIN = 'text/plain'


### PR DESCRIPTION
This will expose API endpoing `/api/error_log` that will print the current content of `<config_dir>/home-assistant.log`.

This will allow you to monitor the content remotely. Idea is to integrate this endpoint into a new dev tool.
