### PR TITLE
Expose version through API

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -99,6 +99,7 @@ def _handle_get_api(handler, path_match, data):
     """ Renders the debug interface. """
     handler.write_json_message("API running.")
 
+
 def _handle_get_api_stream(handler, path_match, data):
     """ Provide a streaming interface for the event bus. """
     gracefully_closed = False

--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -17,10 +17,10 @@ import homeassistant.remote as rem
 from homeassistant.const import (
     URL_API, URL_API_STATES, URL_API_EVENTS, URL_API_SERVICES, URL_API_STREAM,
     URL_API_EVENT_FORWARD, URL_API_STATES_ENTITY, URL_API_COMPONENTS,
-    URL_API_CONFIG, URL_API_BOOTSTRAP,
+    URL_API_CONFIG, URL_API_BOOTSTRAP, URL_API_VERSION,
     EVENT_TIME_CHANGED, EVENT_HOMEASSISTANT_STOP, MATCH_ALL,
     HTTP_OK, HTTP_CREATED, HTTP_BAD_REQUEST, HTTP_NOT_FOUND,
-    HTTP_UNPROCESSABLE_ENTITY)
+    HTTP_UNPROCESSABLE_ENTITY, __version__)
 
 
 DOMAIN = 'api'
@@ -47,6 +47,9 @@ def setup(hass, config):
 
     # /api/config
     hass.http.register_path('GET', URL_API_CONFIG, _handle_get_api_config)
+
+    # /api/version
+    hass.http.register_path('GET', URL_API_VERSION, _handle_get_api_version)
 
     # /api/bootstrap
     hass.http.register_path(
@@ -95,7 +98,6 @@ def setup(hass, config):
 def _handle_get_api(handler, path_match, data):
     """ Renders the debug interface. """
     handler.write_json_message("API running.")
-
 
 def _handle_get_api_stream(handler, path_match, data):
     """ Provide a streaming interface for the event bus. """
@@ -158,6 +160,11 @@ def _handle_get_api_stream(handler, path_match, data):
 def _handle_get_api_config(handler, path_match, data):
     """ Returns the Home Assistant config. """
     handler.write_json(handler.server.hass.config.as_dict())
+
+
+def _handle_get_api_version(handler, path_match, data):
+    """ Returns the Home Assistant version. """
+    handler.write_json({'version': __version__})
 
 
 def _handle_get_api_bootstrap(handler, path_match, data):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -151,6 +151,7 @@ URL_API_SERVICES_SERVICE = "/api/services/{}/{}"
 URL_API_EVENT_FORWARD = "/api/event_forwarding"
 URL_API_COMPONENTS = "/api/components"
 URL_API_BOOTSTRAP = "/api/bootstrap"
+URL_API_VERSION = "/api/version"
 
 HTTP_OK = 200
 HTTP_CREATED = 201

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -24,7 +24,8 @@ import homeassistant.bootstrap as bootstrap
 from homeassistant.const import (
     SERVER_PORT, HTTP_HEADER_HA_AUTH, URL_API, URL_API_STATES,
     URL_API_STATES_ENTITY, URL_API_EVENTS, URL_API_EVENTS_EVENT,
-    URL_API_SERVICES, URL_API_SERVICES_SERVICE, URL_API_EVENT_FORWARD)
+    URL_API_SERVICES, URL_API_SERVICES_SERVICE, URL_API_EVENT_FORWARD,
+    URL_API_VERSION)
 
 METHOD_GET = "get"
 METHOD_POST = "post"
@@ -296,6 +297,20 @@ def validate_api(api):
 
     except HomeAssistantError:
         return APIStatus.CANNOT_CONNECT
+
+
+def get_version(api):
+    """ Returns the Home Assistant version. """
+    try:
+        req = api(METHOD_GET, URL_API_VERSION)
+
+        return req.json() if req.status_code == 200 else {}
+
+    except (HomeAssistantError, ValueError):
+        # ValueError if req.json() can't parse the json
+        _LOGGER.exception("Unexpected result retrieving version")
+
+        return {}
 
 
 def connect_remote_events(from_api, to_api):


### PR DESCRIPTION
This Pull request add the Home Assistant version to the Python and the REST API.

Unfortunately this will not fix #510 but let one use a [command_sensor](https://home-assistant.io/components/sensor.command_sensor/) with something like the script below:

``` python
import homeassistant.remote as remote
api = remote.API('host', 'password')
print(remote.get_version(api)['version'])
```
