### PR TITLE
Fix memory issue in SNMP device tracker

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -45,9 +45,12 @@ class SnmpScanner(object):
     This class queries any SNMP capable Acces Point for connected devices.
     """
     def __init__(self, config):
-        self.host = config[CONF_HOST]
-        self.community = config[CONF_COMMUNITY]
-        self.baseoid = config[CONF_BASEOID]
+        from pysnmp.entity.rfc3413.oneliner import cmdgen
+        self.snmp = cmdgen.CommandGenerator()
+
+        self.host = cmdgen.UdpTransportTarget((config[CONF_HOST], 161))
+        self.community = cmdgen.CommunityData(config[CONF_COMMUNITY])
+        self.baseoid = cmdgen.MibVariable(config[CONF_BASEOID])
 
         self.lock = threading.Lock()
 
@@ -91,16 +94,11 @@ class SnmpScanner(object):
 
     def get_snmp_data(self):
         """ Fetch mac addresses from WAP via SNMP. """
-        from pysnmp.entity.rfc3413.oneliner import cmdgen
 
         devices = []
 
-        snmp = cmdgen.CommandGenerator()
-        errindication, errstatus, errindex, restable = snmp.nextCmd(
-            cmdgen.CommunityData(self.community),
-            cmdgen.UdpTransportTarget((self.host, 161)),
-            cmdgen.MibVariable(self.baseoid)
-        )
+        errindication, errstatus, errindex, restable = self.snmp.nextCmd(
+            self.community, self.host, self.baseoid)
 
         if errindication:
             _LOGGER.error("SNMPLIB error: %s", errindication)


### PR DESCRIPTION
Platform was instantiating pysnmp on each scan, consuming an increasing amount of memory.
This PR instantiates just one per device instance.
