### PR TITLE
Lib clean on upgrade

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -300,7 +300,9 @@ def process_ha_config_upgrade(hass):
     _LOGGER.info('Upgrading config directory from %s to %s', conf_version,
                  __version__)
 
-    shutil.rmtree(hass.config.path('lib'))
+    lib_path = hass.config.path('lib')
+    if os.path.isdir(lib_path):
+        shutil.rmtree(lib_path)
 
     with open(version_path, 'wt') as outp:
         outp.write(__version__)

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -10,6 +10,7 @@ from functools import partial
 import logging
 import os
 
+import homeassistant.bootstrap as bootstrap
 from homeassistant.config import load_yaml_config_file
 from homeassistant.loader import get_component
 from homeassistant.helpers import config_per_platform
@@ -45,8 +46,8 @@ def setup(hass, config):
 
     for platform, p_config in config_per_platform(config, DOMAIN, _LOGGER):
         # get platform
-        notify_implementation = get_component(
-            'notify.{}'.format(platform))
+        notify_implementation = bootstrap.prepare_setup_platform(
+            hass, config, DOMAIN, platform)
 
         if notify_implementation is None:
             _LOGGER.error("Unknown notification service specified.")

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -12,7 +12,6 @@ import os
 
 import homeassistant.bootstrap as bootstrap
 from homeassistant.config import load_yaml_config_file
-from homeassistant.loader import get_component
 from homeassistant.helpers import config_per_platform
 
 from homeassistant.const import CONF_NAME

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -29,6 +29,7 @@ def install_package(package, upgrade=True, target=None):
         try:
             return 0 == subprocess.call(args)
         except subprocess.SubprocessError:
+            _LOGGER.exception('Unable to install pacakge %s', package)
             return False
 
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -5,11 +5,13 @@ tests.test_bootstrap
 Tests bootstrap.
 """
 # pylint: disable=too-many-public-methods,protected-access
+import os
 import tempfile
 import unittest
 from unittest import mock
 
-from homeassistant import bootstrap
+from homeassistant import core, bootstrap
+from homeassistant.const import __version__
 import homeassistant.util.dt as dt_util
 
 from tests.common import mock_detect_location_info
@@ -39,3 +41,45 @@ class TestBootstrap(unittest.TestCase):
 
             self.assertEqual(sorted(components),
                              sorted(hass.config.components))
+
+    def test_remove_lib_on_upgrade(self):
+        with tempfile.TemporaryDirectory() as config_dir:
+            version_path = os.path.join(config_dir, '.HA_VERSION')
+            lib_dir = os.path.join(config_dir, 'lib')
+            check_file = os.path.join(lib_dir, 'check')
+
+            with open(version_path, 'wt') as outp:
+                outp.write('0.7.0')
+
+            os.mkdir(lib_dir)
+
+            with open(check_file, 'w'):
+                pass
+
+            hass = core.HomeAssistant()
+            hass.config.config_dir = config_dir
+
+            self.assertTrue(os.path.isfile(check_file))
+            bootstrap.process_ha_config_upgrade(hass)
+            self.assertFalse(os.path.isfile(check_file))
+
+    def test_not_remove_lib_if_not_upgrade(self):
+        with tempfile.TemporaryDirectory() as config_dir:
+            version_path = os.path.join(config_dir, '.HA_VERSION')
+            lib_dir = os.path.join(config_dir, 'lib')
+            check_file = os.path.join(lib_dir, 'check')
+
+            with open(version_path, 'wt') as outp:
+                outp.write(__version__)
+
+            os.mkdir(lib_dir)
+
+            with open(check_file, 'w'):
+                pass
+
+            hass = core.HomeAssistant()
+            hass.config.config_dir = config_dir
+
+            bootstrap.process_ha_config_upgrade(hass)
+
+            self.assertTrue(os.path.isfile(check_file))


### PR DESCRIPTION
This release includes a fix where Home Assistant will check if a package exists in the global scope besides also checking the config lib dir.

This introduced a bug preventing the newer version to be used. For example If your system has `package==0.5` installed globally and `package==0.4` installed in config lib dir (installed by an older HA dir). The platform expects `package==0.5` so HA will check for it. It is installed globally so no installation will be done.

When you import a package in Python, you only specify a name, not a version. Home Assistant will setup Python so that it will prefer packages from the config lib dir over the global dir. This would result in the platform loading version 0.4 from package instead of 0.5 :beetle: 

Possible solutions:
1. In `check_page_exists` uninstall any version in config lib dir if a version in global packages is found that matches.
2. When Home Assistant is upgraded, delete the old `lib` directory and install the platform dependencies from scratch. Because of pip caching this should not result in unnecessary downloads. 

Solution 1 might sound less destructive but uninstalling a package is not trivial. It can't be done from pip because we use our own install dir.

That's why I think solution 2 is the way to go and that's what this PR implements.

I am planning to  add some tests before merging.
