### PR TITLE
Enhancement: targeted notifications in pushbullet

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -23,6 +23,9 @@ DEPENDENCIES = []
 ATTR_TITLE = "title"
 ATTR_TITLE_DEFAULT = "Home Assistant"
 
+# Target of the notification (user, device, etc)
+ATTR_TARGET = 'target'
+
 # Text to notify user of
 ATTR_MESSAGE = "message"
 
@@ -69,8 +72,9 @@ def setup(hass, config):
                 return
 
             title = call.data.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
+            target = call.data.get(ATTR_TARGET)
 
-            notify_service.send_message(message, title=title)
+            notify_service.send_message(message, title=title, target=target)
 
         # register service
         service_call_handler = partial(notify_message, notify_service)

--- a/homeassistant/components/notify/pushbullet.py
+++ b/homeassistant/components/notify/pushbullet.py
@@ -81,7 +81,7 @@ class PushBulletNotificationService(BaseNotificationService):
                 targets = [targets]
 
             # Main loop, Process all targets specified
-            for ttype, tname in [target.split('.') for target in targets]:
+            for ttype, tname in [target.split('.', 1) for target in targets]:
                 if ttype == 'device' and not tname:
                     # Allow for 'normal' push, combined with other targets
                     self.pushbullet.push_note(title, message)

--- a/homeassistant/components/notify/pushbullet.py
+++ b/homeassistant/components/notify/pushbullet.py
@@ -8,12 +8,13 @@ https://home-assistant.io/components/notify.pushbullet/
 """
 import logging
 
-from homeassistant.components.notify import ATTR_TITLE, BaseNotificationService
+from homeassistant.components.notify import (
+    ATTR_TITLE, ATTR_TARGET, BaseNotificationService)
 from homeassistant.const import CONF_API_KEY
 
 _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = ['pushbullet.py==0.9.0']
-ATTR_TARGET = 'target'
+
 
 # pylint: disable=unused-argument
 def get_service(hass, config):
@@ -61,8 +62,8 @@ class PushBulletNotificationService(BaseNotificationService):
     def send_message(self, message=None, **kwargs):
         """ Send a message to a user. """
         targets = kwargs.get(ATTR_TARGET)
-        title = kwargs.get(ATTR_TITLE)
         # Disabeling title
+        title = kwargs.get(ATTR_TITLE)
         title = None
 
         if targets:

--- a/homeassistant/components/notify/pushbullet.py
+++ b/homeassistant/components/notify/pushbullet.py
@@ -47,9 +47,14 @@ class PushBulletNotificationService(BaseNotificationService):
         self.refresh()
 
     def refresh(self):
-        ''' Refresh devices, contacts, channels, etc '''
-        self.pushbullet.refresh()
+        '''
+        Refresh devices, contacts, channels, etc
 
+        pbtargets stores all targets available from this pushbullet instance
+        into a dict. These are PB objects!. It sacrifices a bit of memory
+        for faster processing at send_message
+        '''
+        self.pushbullet.refresh()
         self.pbtargets = {
             'devices':
                 {tgt.nickname: tgt for tgt in self.pushbullet.devices},
@@ -60,7 +65,11 @@ class PushBulletNotificationService(BaseNotificationService):
         }
 
     def send_message(self, message=None, **kwargs):
-        """ Send a message to a user. """
+        """
+        Send a message to a specified target.
+        If no target specified, a 'normal' push will be sent to all devices
+        linked to the PB account.
+        """
         targets = kwargs.get(ATTR_TARGET)
         # Disabeling title
         title = kwargs.get(ATTR_TITLE)
@@ -79,6 +88,8 @@ class PushBulletNotificationService(BaseNotificationService):
                     _LOGGER.info('Sent notification to self')
                     continue
 
+                # Attempt push_note on a dict value. Keys are types & target
+                # name. The pbtargets have all *actual* targets.
                 try:
                     self.pbtargets[ttype+'s'][tname].push_note(title, message)
                 except KeyError:

--- a/homeassistant/components/notify/pushbullet.py
+++ b/homeassistant/components/notify/pushbullet.py
@@ -93,9 +93,17 @@ class PushBulletNotificationService(BaseNotificationService):
                 _LOGGER.info('Sent notification to self')
                 continue
 
-            ttype, tname = target.split('/', 1)
+            try:
+                ttype, tname = target.split('/', 1)
+            except ValueError:
+                _LOGGER.error('Invalid target syntax: %s', target)
+                continue
 
-            # Refresh if name not found. Poor mans refresh ;)
+            # Refresh if name not found. While awaiting periodic refresh
+            # solution in component, poor mans refresh ;)
+            if ttype not in self.pbtargets:
+                _LOGGER.error('Invalid target syntax: %s', target)
+                continue
             if tname not in self.pbtargets[ttype] and not refreshed:
                 self.refresh()
                 refreshed = True

--- a/homeassistant/components/notify/services.yaml
+++ b/homeassistant/components/notify/services.yaml
@@ -9,3 +9,7 @@ notify:
     title:
       description: Optional title for your notification.
       example: 'Your Garage Door Friend'
+
+    target:
+      description: Target of the notification. Optional depending on the platform
+      example: platform specific

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -29,7 +29,7 @@ tellcore-py==1.1.2
 python-nmap==0.4.3
 
 # PushBullet (notify.pushbullet)
-pushbullet.py==0.8.1
+pushbullet.py==0.9.0
 
 # Nest Thermostat (thermostat.nest)
 python-nest==2.6.0


### PR DESCRIPTION
This PR enhances functionality to the pushbullet notification platform
### Component changes:
- Ability to specify target in service_data
### Enhancements:
- Ability to send to different target types:
  - devices (uses nickname as identifier)
  - channels (uses channel tag as identifier)
  - contacts ( uses email address as identifier)
- Use format `target: <type>/<target>`
- If you specify a list of targets, but still want to send to all your own devices, use `device/`
### Notes:
- Title is set to `None` hard right now. Please feed back on this. The notify component sets the title to `home assistent` if not specified. This causes the message to be suppressed on mobile phones, etc when viewing the alert.
- refresh function should be called periodically, to prevent requiring HASS restarts for updates. Don;t think this is possible right now.
### Examples:

```
notify:
  - name: mypb
    platform: pushbullet
    api_key: sdffwofjwo4fijwo4fj

script:
    message_1:
        alias: 'PB: Notify my mobile'
        sequence:
          - service: notify.mypb
            service_data:
                message: 'Hello mobile telephone!'
                target: 'device/my_telephone'
    message_2:
        alias: 'PB: Notify multiple'
        sequence:
          - service: notify.mypb
            service_data:
                message: 'Oh noos, someone pushed the button!'
                target:
                  - 'device/my_telephone'
                  - 'contact/some@one.com'
    message_3:
        alias: 'PB: Channel HASS and self'
        sequence:
          - service: notify.pushbullet
            service_data:
                message: 'Message to all subscribers, it works!'
                target:
                  - 'channel/hass'
                  - 'device/'

```
