### PR TITLE
Support for json messages in mqtt switches and sensors

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -31,7 +31,7 @@ SERVICE_PUBLISH = 'publish'
 EVENT_MQTT_MESSAGE_RECEIVED = 'MQTT_MESSAGE_RECEIVED'
 
 DEPENDENCIES = []
-REQUIREMENTS = ['paho-mqtt==1.1'
+REQUIREMENTS = ['paho-mqtt==1.1',
                 'jsonpath-rw==1.4.0']
 
 CONF_BROKER = 'broker'

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -9,6 +9,8 @@ https://home-assistant.io/components/mqtt/
 import logging
 import os
 import socket
+import json
+import jsonpath_rw
 
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util as util
@@ -125,6 +127,15 @@ def setup(hass, config):
     hass.services.register(DOMAIN, SERVICE_PUBLISH, publish_service)
 
     return True
+
+
+class JsonFmtParser(object):
+  """ Implements a json parser on xpath"""
+  def __init__(self, jsonpath):
+    self._expr = jsonpath_rw.parse(jsonpath)
+  def __call__(self, payload):
+    match = self._expr.find(json.loads(payload))
+    return match[0].value if len(match) > 0 else None
 
 
 # This is based on one of the paho-mqtt examples:

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -129,13 +129,24 @@ def setup(hass, config):
     return True
 
 
-class JsonFmtParser(object):
-  """ Implements a json parser on xpath"""
-  def __init__(self, jsonpath):
-    self._expr = jsonpath_rw.parse(jsonpath)
+class FmtParser(object):
+  """ wrapper for all supported formats """
+  
+  class _JsonFmtParser(object):
+    """ Implements a json parser on xpath"""
+    def __init__(self, jsonpath):
+      self._expr = jsonpath_rw.parse(jsonpath)
+    def __call__(self, payload):
+      match = self._expr.find(json.loads(payload))
+      return match[0].value if len(match) > 0 else None 
+      
+  def __init__(self, fmt):
+    if fmt.startswith('json:'):
+      self._parser = FmtParser._JsonFmtParser(fmt[5:])
+    else:
+      self._parser = lambda x: x
   def __call__(self, payload):
-    match = self._expr.find(json.loads(payload))
-    return match[0].value if len(match) > 0 else None
+    return self._parser(payload)
 
 
 # This is based on one of the paho-mqtt examples:

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -142,10 +142,10 @@ class _JsonFmtParser(object):
 class FmtParser(object):
     """ wrapper for all supported formats """
     def __init__(self, fmt):
-        if fmt.startswith('json:'):
-            self._parser = _JsonFmtParser(fmt[5:])
-        else:
-            self._parser = lambda x: x
+        self._parser = lambda x: x
+        if fmt:
+            if fmt.startswith('json:'):
+                self._parser = _JsonFmtParser(fmt[5:])
 
     def __call__(self, payload):
         return self._parser(payload)

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -10,7 +10,6 @@ import logging
 import os
 import socket
 import json
-import jsonpath_rw
 
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util as util
@@ -32,7 +31,8 @@ SERVICE_PUBLISH = 'publish'
 EVENT_MQTT_MESSAGE_RECEIVED = 'MQTT_MESSAGE_RECEIVED'
 
 DEPENDENCIES = []
-REQUIREMENTS = ['paho-mqtt==1.1']
+REQUIREMENTS = ['paho-mqtt==1.1'
+                'jsonpath-rw==1.4.0']
 
 CONF_BROKER = 'broker'
 CONF_PORT = 'port'
@@ -133,6 +133,7 @@ def setup(hass, config):
 class _JsonFmtParser(object):
     """ Implements a json parser on xpath"""
     def __init__(self, jsonpath):
+        import jsonpath_rw
         self._expr = jsonpath_rw.parse(jsonpath)
 
     def __call__(self, payload):

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -31,8 +31,7 @@ SERVICE_PUBLISH = 'publish'
 EVENT_MQTT_MESSAGE_RECEIVED = 'MQTT_MESSAGE_RECEIVED'
 
 DEPENDENCIES = []
-REQUIREMENTS = ['paho-mqtt==1.1',
-                'jsonpath-rw==1.4.0']
+REQUIREMENTS = ['paho-mqtt==1.1', 'jsonpath-rw==1.4.0']
 
 CONF_BROKER = 'broker'
 CONF_PORT = 'port'

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -129,6 +129,7 @@ def setup(hass, config):
     return True
 
 
+# pylint: disable=too-few-public-methods
 class _JsonFmtParser(object):
     """ Implements a json parser on xpath"""
     def __init__(self, jsonpath):
@@ -139,16 +140,17 @@ class _JsonFmtParser(object):
         return match[0].value if len(match) > 0 else payload
 
 
+# pylint: disable=too-few-public-methods
 class FmtParser(object):
     """ wrapper for all supported formats """
     def __init__(self, fmt):
-        self._parser = lambda x: x
+        self._parse = lambda x: x
         if fmt:
             if fmt.startswith('json:'):
-                self._parser = _JsonFmtParser(fmt[5:])
+                self._parse = _JsonFmtParser(fmt[5:])
 
     def __call__(self, payload):
-        return self._parser(payload)
+        return self._parse(payload)
 
 
 # This is based on one of the paho-mqtt examples:

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -129,24 +129,26 @@ def setup(hass, config):
     return True
 
 
-class FmtParser(object):
-  """ wrapper for all supported formats """
-  
-  class _JsonFmtParser(object):
+class _JsonFmtParser(object):
     """ Implements a json parser on xpath"""
     def __init__(self, jsonpath):
-      self._expr = jsonpath_rw.parse(jsonpath)
+        self._expr = jsonpath_rw.parse(jsonpath)
+
     def __call__(self, payload):
-      match = self._expr.find(json.loads(payload))
-      return match[0].value if len(match) > 0 else None 
-      
-  def __init__(self, fmt):
-    if fmt.startswith('json:'):
-      self._parser = FmtParser._JsonFmtParser(fmt[5:])
-    else:
-      self._parser = lambda x: x
-  def __call__(self, payload):
-    return self._parser(payload)
+        match = self._expr.find(json.loads(payload))
+        return match[0].value if len(match) > 0 else payload
+
+
+class FmtParser(object):
+    """ wrapper for all supported formats """
+    def __init__(self, fmt):
+        if fmt.startswith('json:'):
+            self._parser = _JsonFmtParser(fmt[5:])
+        else:
+            self._parser = lambda x: x
+
+    def __call__(self, payload):
+        return self._parser(payload)
 
 
 # This is based on one of the paho-mqtt examples:

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -7,8 +7,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.mqtt/
 """
 import logging
-import json
-import jsonpath_rw
 from homeassistant.helpers.entity import Entity
 import homeassistant.components.mqtt as mqtt
 
@@ -40,7 +38,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 # pylint: disable=too-many-arguments, too-many-instance-attributes
 class MqttSensor(Entity):
     """ Represents a sensor that can be updated using MQTT. """
-    def __init__(self, hass, name, state_topic, qos, unit_of_measurement,state_format):
+    def __init__(self, hass, name, state_topic, qos, unit_of_measurement,
+                 state_format):
         self._state = "-"
         self._hass = hass
         self._name = name

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -46,11 +46,11 @@ class MqttSensor(Entity):
         self._state_topic = state_topic
         self._qos = qos
         self._unit_of_measurement = unit_of_measurement
-        self._parser = mqtt.FmtParser(state_format)
+        self._parse = mqtt.FmtParser(state_format)
 
         def message_received(topic, payload, qos):
             """ A new MQTT message has been received. """
-            self._state = self._parser(payload)
+            self._state = self._parse(payload)
             self.update_ha_state()
 
         mqtt.subscribe(hass, self._state_topic, message_received, self._qos)

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -47,12 +47,7 @@ class MqttSensor(Entity):
         self._state_topic = state_topic
         self._qos = qos
         self._unit_of_measurement = unit_of_measurement
-        self._state_format = state_format
-        
-        if self._state_format.startswith('json:'):
-          self._parser = mqtt.JsonFmtParser(self._state_format[5:])
-        else:
-          self._parser = lambda x: x
+        self._parser = mqtt.FmtParser(state_format)
 
         def message_received(topic, payload, qos):
             """ A new MQTT message has been received. """

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -55,11 +55,11 @@ class MqttSwitch(SwitchDevice):
         self._payload_on = payload_on
         self._payload_off = payload_off
         self._optimistic = optimistic
-        self._parser = mqtt.FmtParser(state_format)
+        self._parse = mqtt.FmtParser(state_format)
 
         def message_received(topic, payload, qos):
             """ A new MQTT message has been received. """
-            payload = self._parser(payload)
+            payload = self._parse(payload)
             if payload == self._payload_on:
                 self._state = True
                 self.update_ha_state()

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -55,13 +55,7 @@ class MqttSwitch(SwitchDevice):
         self._payload_on = payload_on
         self._payload_off = payload_off
         self._optimistic = optimistic
-        
-        self._state_format = state_format
-        
-        if self._state_format.startswith('json:'):
-          self._parser = mqtt.JsonFmtParser(self._state_format[5:])
-        else:
-          self._parser = lambda x: x
+        self._parser = mqtt.FmtParser(state_format)
 
         def message_received(topic, payload, qos):
             """ A new MQTT message has been received. """

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -74,6 +74,7 @@ https://github.com/bashwork/pymodbus/archive/d7fc4f1cc975631e0a9011390e8017f64b6
 
 # homeassistant.components.mqtt
 paho-mqtt==1.1
+jsonpath-rw==1.4.0
 
 # homeassistant.components.notify.pushbullet
 pushbullet.py==0.9.0

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -39,3 +39,22 @@ class TestSensorMQTT(unittest.TestCase):
         self.assertEqual('100', state.state)
         self.assertEqual('fav unit',
                          state.attributes.get('unit_of_measurement'))
+
+    def test_setting_sensor_value_via_mqtt_json_message(self):
+        self.assertTrue(sensor.setup(self.hass, {
+            'sensor': {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'unit_of_measurement': 'fav unit',
+                'state_format': 'json:val'
+            }
+        }))
+
+        fire_mqtt_message(self.hass, 'test-topic', '{ "val": "100" }')
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('sensor.test')
+
+        self.assertEqual('100', state.state)
+        self.assertEqual('fav unit',
+                         state.attributes.get('unit_of_measurement'))

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -56,5 +56,4 @@ class TestSensorMQTT(unittest.TestCase):
         state = self.hass.states.get('sensor.test')
 
         self.assertEqual('100', state.state)
-        self.assertEqual('fav unit',
-                         state.attributes.get('unit_of_measurement'))
+

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -80,3 +80,31 @@ class TestSensorMQTT(unittest.TestCase):
                          self.mock_publish.mock_calls[-1][1])
         state = self.hass.states.get('switch.test')
         self.assertEqual(STATE_OFF, state.state)
+
+    def test_controlling_state_via_topic_and_json_message(self):
+        self.assertTrue(switch.setup(self.hass, {
+            'switch': {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'state-topic',
+                'command_topic': 'command-topic',
+                'payload_on': 'beer on',
+                'payload_off': 'beer off',
+                'state_format': 'json:val'
+            }
+        }))
+
+        state = self.hass.states.get('switch.test')
+        self.assertEqual(STATE_OFF, state.state)
+
+        fire_mqtt_message(self.hass, 'state-topic', '{"val":"beer on"}')
+        self.hass.pool.block_till_done()
+
+        state = self.hass.states.get('switch.test')
+        self.assertEqual(STATE_ON, state.state)
+
+        fire_mqtt_message(self.hass, 'state-topic', '{"val":"beer off"}')
+        self.hass.pool.block_till_done()
+
+        state = self.hass.states.get('switch.test')
+        self.assertEqual(STATE_OFF, state.state)


### PR DESCRIPTION
I am currently working on connecting a Homematic CCU2 to Home Assistant via MQTT. I am using hm2mqtt (https://github.com/owagner/hm2mqtt/) for this on the CCU2 side.

However, the way that is implemented, it sends a json string in the state topic (e.g. `hm/status/mydevice/STATE`) that looks like the following

> {"val":0,"ts":"1448049600608","lc":"1448049600608","hm_addr":"LEQXXXXXXX:1"}

What I needed for HA was only the val, so I implemented a generic mechanism to access parts of a json message in a message by adding a new key "state_format" to the config where you can specify the type of message (json:) followed by a parsing rule (jsonpath in the json case, based on jsonpath_rw).
