### PR TITLE
Function support for aREST backend

### DIFF
--- a/homeassistant/components/switch/arest.py
+++ b/homeassistant/components/switch/arest.py
@@ -34,29 +34,32 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
     dev = []
-    pins = config.get('pins')
+    pins = config.get('pins', {})
     for pinnum, pin in pins.items():
-        dev.append(ArestSwitch(resource,
-                               config.get('name', response.json()['name']),
-                               pin.get('name'),
-                               pinnum))
+        dev.append(ArestSwitchPin(resource,
+                                  config.get('name', response.json()['name']),
+                                  pin.get('name'),
+                                  pinnum))
+
+    functions = config.get('functions', {})
+    for funcname, func in functions.items():
+        dev.append(ArestSwitchFunction(resource,
+                                       config.get('name',
+                                                  response.json()['name']),
+                                       func.get('name'),
+                                       funcname))
+
     add_devices(dev)
 
 
-class ArestSwitch(SwitchDevice):
+class ArestSwitchBase(SwitchDevice):
     """ Implements an aREST switch. """
 
-    def __init__(self, resource, location, name, pin):
+    def __init__(self, resource, location, name):
         self._resource = resource
         self._name = '{} {}'.format(location.title(), name.title()) \
                      or DEVICE_DEFAULT_NAME
-        self._pin = pin
         self._state = None
-
-        request = requests.get('{}/mode/{}/o'.format(self._resource,
-                                                     self._pin), timeout=10)
-        if request.status_code is not 200:
-            _LOGGER.error("Can't set mode. Is device offline?")
 
     @property
     def name(self):
@@ -67,6 +70,72 @@ class ArestSwitch(SwitchDevice):
     def is_on(self):
         """ True if device is on. """
         return self._state
+
+
+class ArestSwitchFunction(ArestSwitchBase):
+    """ Implements an aREST switch. Based on functions. """
+
+    def __init__(self, resource, location, name, func):
+        super().__init__(resource, location, name)
+        self._func = func
+
+        request = requests.get('{}/{}'.format(self._resource, self._func),
+                               timeout=10)
+
+        if request.status_code is not 200:
+            _LOGGER.error("Can't find function. Is device offline?")
+            return
+
+        try:
+            request.json()['return_value']
+        except KeyError:
+            _LOGGER.error("No return_value received. "
+                          "Is the function name correct.")
+        except ValueError:
+            _LOGGER.error("Response invalid. Is the function name correct.")
+
+    def turn_on(self, **kwargs):
+        """ Turn the device on. """
+        request = requests.get('{}/{}'.format(self._resource, self._func),
+                               timeout=10, params={"params": "1"})
+
+        if request.status_code == 200:
+            self._state = True
+        else:
+            _LOGGER.error("Can't turn on function %s at %s. "
+                          "Is device offline?",
+                          self._func, self._resource)
+
+    def turn_off(self, **kwargs):
+        """ Turn the device off. """
+        request = requests.get('{}/{}'.format(self._resource, self._func),
+                               timeout=10, params={"params": "0"})
+
+        if request.status_code == 200:
+            self._state = False
+        else:
+            _LOGGER.error("Can't turn off function %s at %s. "
+                          "Is device offline?",
+                          self._func, self._resource)
+
+    def update(self):
+        """ Gets the latest data from aREST API and updates the state. """
+        request = requests.get('{}/{}'.format(self._resource,
+                                              self._func), timeout=10)
+        self._state = request.json()['return_value'] != 0
+
+
+class ArestSwitchPin(ArestSwitchBase):
+    """ Implements an aREST switch. Based on digital I/O """
+
+    def __init__(self, resource, location, name, pin):
+        super().__init__(resource, location, name)
+        self._pin = pin
+
+        request = requests.get('{}/mode/{}/o'.format(self._resource,
+                                                     self._pin), timeout=10)
+        if request.status_code is not 200:
+            _LOGGER.error("Can't set mode. Is device offline?")
 
     def turn_on(self, **kwargs):
         """ Turn the device on. """


### PR DESCRIPTION
The implementation sends /<name>?params=1 for turn_on and /<name>?params=0 for turn_off
It uses the return value of the function to determine the current state.
0=Off, 1=On
