### PR TITLE
Re-order Dockerfile for faster rebuild on code changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,27 @@
-FROM python:3-onbuild
+FROM python:3
 MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
 
 VOLUME /config
 
-RUN pip3 install --no-cache-dir -r requirements_all.txt
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
 
 # For the nmap tracker
 RUN apt-get update && \
     apt-get install -y --no-install-recommends nmap net-tools && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+COPY script/build_python_openzwave script/build_python_openzwave
 RUN apt-get update && \
    apt-get install -y cython3 libudev-dev && \
    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
    pip3 install "cython<0.23" && \
    script/build_python_openzwave
+
+COPY requirements_all.txt requirements_all.txt
+RUN pip3 install --no-cache-dir -r requirements_all.txt
+
+# Copy source
+COPY . .
 
 CMD [ "python", "-m", "homeassistant", "--config", "/config" ]


### PR DESCRIPTION
Changed the Dockerfile to use the python:3 base image instead of the python:3-onbuild base image.  This provides control over the docker build order so that it is much faster to rebuild the image after updating the home-assistant source.  

Previously the home-assistant source was copied during the ONBUILD trigger resulting in the Docker cache being invalidated for all subsequent steps.   This change puts the slower apt-get and pip commands first so that a source change can use the cache.
