### PR TITLE
Add exception handler for vera timeout

### DIFF
--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -126,5 +126,8 @@ class VeraSwitch(ToggleEntity):
     def update(self):
         # We need to debounce the status call after turning switch on or off
         # because the vera has some lag in updating the device status
-        if (self.last_command_send + 5) < time.time():
-            self.is_on_status = self.vera_device.is_switched_on()
+        try:
+            if (self.last_command_send + 5) < time.time():
+                self.is_on_status = self.vera_device.is_switched_on()
+        except RequestException:
+            _LOGGER.warning('Could not update status for %s', self.name)


### PR DESCRIPTION
Vera is cluttering up my log when there are temporary network issues - so just produce a warning trace if there is a vera timeout on status update.
