### PR TITLE
Trap and trace error rather than throwing exception when efergy server

### DIFF
--- a/homeassistant/components/sensor/efergy.py
+++ b/homeassistant/components/sensor/efergy.py
@@ -97,5 +97,5 @@ class EfergySensor(Entity):
                 self._state = response.json()['sum']
             else:
                 self._state = 'Unknown'
-        except RequestException:
+        except (RequestException, ValueError):
             _LOGGER.warning('Could not update status for %s', self.name)


### PR DESCRIPTION
Sometimes efergy have short periods when they don't return good data. 

This just traces the issue so the log doesn't trace an exception.
