### PR TITLE
Support for legacy nmap.

### DIFF
--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -98,7 +98,7 @@ class NmapDeviceScanner(object):
         from nmap import PortScanner, PortScannerError
         scanner = PortScanner()
 
-        options = "-F --host-timeout 5"
+        options = "-F --host-timeout 5s"
 
         if self.home_interval:
             boundary = dt_util.now() - self.home_interval


### PR DESCRIPTION
Older nmap like the one bundled with Ubuntu Precise (12.04), 5.21
requires that you specify what unit the value to --host-timeout is.

```
$ nmap -v localhost --host-timeout 5
--host-timeout is specified in milliseconds unless you qualify it by
appending 's', 'm', or 'h'. The value must be greater than 1500
milliseconds
QUITTING!

$nmap -v localhost --host-timeout 5
host-timeout is given in milliseconds, so you specified less than 15 seconds (5000ms). This is allowed but not recommended.

Starting Nmap 5.21 ( http://nmap.org ) at 2015-11-28 20:18 CET
Initiating SYN Stealth Scan at 20:18
Scanning localhost (127.0.0.1) [1000 ports]
Discovered open port 22/tcp on 127.0.0.1
Completed SYN Stealth Scan at 20:18, 0.01s elapsed (1000 total ports)
Nmap scan report for localhost (127.0.0.1)
Host is up (0.0000040s latency).
Not shown: 995 closed ports
PORT     STATE SERVICE
22/tcp   open  ssh

Read data files from: /usr/share/nmap
Nmap done: 1 IP address (1 host up) scanned in 0.05 seconds
           Raw packets sent: 1000 (44.000KB) | Rcvd: 2005 (84.220KB)
$ nmap --version
Nmap version 5.21 ( http://nmap.org )

$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 12.04.5 LTS
Release:        12.04
Codename:       precise
```

This behaivor was changed in
[5.35DC1[2010-07-16]](https://nmap.org/changelog.html#5.35DC1)
but I think is a good idea to support the older versions. 
Newer version also supports if you specify an unit:

```
$ nmap -v localhost --host-timeout 5
Starting Nmap 6.00 ( http://nmap.org ) at 2015-11-28 20:16 CET
Initiating SYN Stealth Scan at 20:16
Scanning localhost (127.0.0.1) [1000 ports]
Discovered open port 22/tcp on 127.0.0.1
Completed SYN Stealth Scan at 20:16, 0.03s elapsed (1000 total ports)
Nmap scan report for localhost (127.0.0.1)
Host is up (0.000011s latency).
Not shown: 997 closed ports
PORT     STATE SERVICE
22/tcp   open  ssh

Read data files from: /usr/bin/../share/nmap
Nmap done: 1 IP address (1 host up) scanned in 0.11 seconds
           Raw packets sent: 1000 (44.000KB) | Rcvd: 2003 (84.132KB)

$ nmap --version
Nmap version 6.00 ( http://nmap.org )
Platform: i686-pc-linux-gnu
Compiled with: liblua-5.1.5 openssl-1.0.1e libpcre-8.30 libpcap-1.3.0 nmap-libdnet-1.12 ipv6
Compiled without:

$ lsb_release -a
No LSB modules are available.
Distributor ID: Debian
Description:    Debian GNU/Linux 7.9 (wheezy)
Release:        7.9
```
