### PR TITLE
Update Travis to test on Python 3.5 too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: false
 language: python
 cache:
   directories:
-    - $HOME/virtualenv/python3.4.2/
+    - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/
 python:
-  - "3.4"
+  - 3.4.2
+  - 3.5.0
 install:
   - script/bootstrap_server
 script:


### PR DESCRIPTION
PyLint has been updated to work with Python 3.5 so we can finally upgrade our Travis config.

To cache different things between the Python builds, we have to match our Python versions with their virtualenv directories, so they are now specified in 3 digits instead of 2.
