### PR TITLE
SSL support for ha

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -125,7 +125,7 @@ class HomeAssistantHTTPServer(ThreadingMixIn, HTTPServer):
         self.hass.bus.listen_once(ha.EVENT_HOMEASSISTANT_STOP, stop_http)
 
         _LOGGER.info(
-            "Starting web interface at http://%s:%d", *self.server_address)
+            "Starting web interface at %s", self.hass.config.api.base_url)
 
         # 31-1-2015: Refactored frontend/api components out of this component
         # To prevent stuff from breaking, load the two extracted components

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -103,6 +103,7 @@ class HomeAssistantHTTPServer(ThreadingMixIn, HTTPServer):
         self.development = development
         self.paths = []
         self.sessions = SessionStore()
+        self.use_ssl = ssl_certificate is not None
 
         # We will lazy init this one if needed
         self.event_forwarder = None
@@ -124,8 +125,11 @@ class HomeAssistantHTTPServer(ThreadingMixIn, HTTPServer):
 
         self.hass.bus.listen_once(ha.EVENT_HOMEASSISTANT_STOP, stop_http)
 
+        protocol = 'https' if self.use_ssl else 'http'
+
         _LOGGER.info(
-            "Starting web interface at %s", self.hass.config.api.base_url)
+            "Starting web interface at %s://%s:%d",
+            protocol, self.server_address[0], self.server_address[1])
 
         # 31-1-2015: Refactored frontend/api components out of this component
         # To prevent stuff from breaking, load the two extracted components

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -76,7 +76,8 @@ def setup(hass, config):
         threading.Thread(target=server.start, daemon=True).start())
 
     hass.http = server
-    hass.config.api = rem.API(util.get_local_ip(), api_password, server_port)
+    hass.config.api = rem.API(util.get_local_ip(), api_password, server_port,
+                              certificate is not None)
 
     return True
 

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -51,11 +51,14 @@ class API(object):
     """ Object to pass around Home Assistant API location and credentials. """
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, host, api_password=None, port=None):
+    def __init__(self, host, api_password=None, port=None, use_ssl=False):
         self.host = host
         self.port = port or SERVER_PORT
         self.api_password = api_password
-        self.base_url = "http://{}:{}".format(host, self.port)
+        if use_ssl:
+            self.base_url = "https://{}:{}".format(host, self.port)
+        else:
+            self.base_url = "http://{}:{}".format(host, self.port)
         self.status = None
         self._headers = {}
 


### PR DESCRIPTION
This will add SSL support to Home Assistant.

This branch needs testing - I have not tested this. I might get to it later but if someone else wants to test it, that would be great.

Thanks to @TooAngel for testing

``` yaml
http:
  ssl_certificate: /etc/letsencrypt/live/hass.example.com/fullchain.pem
  ssl_key: /etc/letsencrypt/live/hass.example.com/privkey.pem
```
