### PR TITLE
Decimal places

### DIFF
--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -127,15 +127,12 @@ class ArestSensor(Entity):
         if 'error' in values:
             return values['error']
         elif 'value' in values:
-            if self._corr_factor is not None \
-                    and self._decimal_places is not None:
-                return round((float(values['value']) *
-                              float(self._corr_factor)), self._decimal_places)
-            elif self._corr_factor is not None \
-                    and self._decimal_places is None:
-                return round(float(values['value']) * float(self._corr_factor))
-            else:
-                return values['value']
+            value = values['value']
+            if self._corr_factor is not None:
+                value = float(value) * float(self._corr_factor)
+            if self._decimal_places is not None:
+                value = round(value, self._decimal_places)
+            return value
         else:
             return values.get(self._variable, 'n/a')
 

--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -132,6 +132,8 @@ class ArestSensor(Entity):
                 value = float(value) * float(self._corr_factor)
             if self._decimal_places is not None:
                 value = round(value, self._decimal_places)
+            if self._decimal_places == 0:
+                value = int(value)
             return value
         else:
             return values.get(self._variable, 'n/a')

--- a/homeassistant/components/sensor/command_sensor.py
+++ b/homeassistant/components/sensor/command_sensor.py
@@ -35,8 +35,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         data,
         config.get('name', DEFAULT_NAME),
         config.get('unit_of_measurement'),
-        config.get('correction_factor', 1.0),
-        config.get('decimal_places', 0)
+        config.get('correction_factor', None),
+        config.get('decimal_places', None)
     )])
 
 
@@ -49,7 +49,7 @@ class CommandSensor(Entity):
         self._name = name
         self._state = False
         self._unit_of_measurement = unit_of_measurement
-        self._corr_factor = float(corr_factor)
+        self._corr_factor = corr_factor
         self._decimal_places = decimal_places
         self.update()
 
@@ -76,10 +76,10 @@ class CommandSensor(Entity):
         try:
             if value is not None:
                 if self._corr_factor is not None:
-                    self._state = round((float(value) * self._corr_factor),
-                                        self._decimal_places)
-                else:
-                    self._state = value
+                    value = float(value) * float(self._corr_factor)
+                if self._decimal_places is not None:
+                    value = round(value, self._decimal_places)
+                self._state = value
         except ValueError:
             self._state = value
 

--- a/homeassistant/components/sensor/command_sensor.py
+++ b/homeassistant/components/sensor/command_sensor.py
@@ -79,6 +79,8 @@ class CommandSensor(Entity):
                     value = float(value) * float(self._corr_factor)
                 if self._decimal_places is not None:
                     value = round(value, self._decimal_places)
+                if self._decimal_places == 0:
+                    value = int(value)
                 self._state = value
         except ValueError:
             self._state = value

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -136,18 +136,11 @@ class RestSensor(Entity):
             try:
                 if value is not None:
                     value = RestSensor.extract_value(value, self._variable)
-                    if self._corr_factor is not None \
-                            and self._decimal_places is not None:
-                        self._state = round(
-                            (float(value) *
-                             float(self._corr_factor)),
-                            self._decimal_places)
-                    elif self._corr_factor is not None \
-                            and self._decimal_places is None:
-                        self._state = round(float(value) *
-                                            float(self._corr_factor))
-                    else:
-                        self._state = value
+                    if self._corr_factor is not None:
+                        value = float(value) * float(self._corr_factor)
+                    if self._decimal_places is not None:
+                        value = round(value, self._decimal_places)
+                    self._state = value
             except ValueError:
                 self._state = RestSensor.extract_value(value, self._variable)
 

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -140,6 +140,8 @@ class RestSensor(Entity):
                         value = float(value) * float(self._corr_factor)
                     if self._decimal_places is not None:
                         value = round(value, self._decimal_places)
+                    if self._decimal_places == 0:
+                        value = int(value)
                     self._state = value
             except ValueError:
                 self._state = RestSensor.extract_value(value, self._variable)


### PR DESCRIPTION
Fix for #714. Decimal places can be used independently of correction factor. Also, if decimal places is specified as zero, the value is cast to an `int` (after rounding) so that the trailing zero will be removed.
