### PR TITLE
Home Assistant templates

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -14,14 +14,16 @@ import json
 import homeassistant.core as ha
 from homeassistant.helpers.state import TrackStates
 import homeassistant.remote as rem
+from homeassistant.util import template
 from homeassistant.bootstrap import ERROR_LOG_FILENAME
 from homeassistant.const import (
     URL_API, URL_API_STATES, URL_API_EVENTS, URL_API_SERVICES, URL_API_STREAM,
     URL_API_EVENT_FORWARD, URL_API_STATES_ENTITY, URL_API_COMPONENTS,
     URL_API_CONFIG, URL_API_BOOTSTRAP, URL_API_ERROR_LOG, URL_API_LOG_OUT,
-    EVENT_TIME_CHANGED, EVENT_HOMEASSISTANT_STOP, MATCH_ALL,
+    URL_API_TEMPLATE, EVENT_TIME_CHANGED, EVENT_HOMEASSISTANT_STOP, MATCH_ALL,
     HTTP_OK, HTTP_CREATED, HTTP_BAD_REQUEST, HTTP_NOT_FOUND,
-    HTTP_UNPROCESSABLE_ENTITY)
+    HTTP_UNPROCESSABLE_ENTITY, HTTP_HEADER_CONTENT_TYPE,
+    CONTENT_TYPE_TEXT_PLAIN)
 
 
 DOMAIN = 'api'
@@ -90,6 +92,9 @@ def setup(hass, config):
                             _handle_get_api_error_log)
 
     hass.http.register_path('POST', URL_API_LOG_OUT, _handle_post_api_log_out)
+
+    hass.http.register_path('POST', URL_API_TEMPLATE,
+                            _handle_post_api_template)
 
     return True
 
@@ -357,6 +362,17 @@ def _handle_post_api_log_out(handler, path_match, data):
     handler.send_response(HTTP_OK)
     handler.destroy_session()
     handler.end_headers()
+
+
+def _handle_post_api_template(handler, path_match, data):
+    """ Log user out. """
+    template_string = data.get('template', '')
+
+    handler.send_response(HTTP_OK)
+    handler.send_header(HTTP_HEADER_CONTENT_TYPE, CONTENT_TYPE_TEXT_PLAIN)
+    handler.end_headers()
+    handler.wfile.write(
+        template.render(handler.server.hass, template_string).encode('utf-8'))
 
 
 def _services_json(hass):

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -6,7 +6,6 @@ MQTT component, using paho-mqtt.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/mqtt/
 """
-import json
 import logging
 import os
 import socket
@@ -33,7 +32,7 @@ DEFAULT_RETAIN = False
 SERVICE_PUBLISH = 'publish'
 EVENT_MQTT_MESSAGE_RECEIVED = 'MQTT_MESSAGE_RECEIVED'
 
-REQUIREMENTS = ['paho-mqtt==1.1', 'jsonpath-rw==1.4.0']
+REQUIREMENTS = ['paho-mqtt==1.1']
 
 CONF_BROKER = 'broker'
 CONF_PORT = 'port'
@@ -136,33 +135,6 @@ def setup(hass, config):
     return True
 
 
-# pylint: disable=too-few-public-methods
-class _JsonFmtParser(object):
-    """ Implements a JSON parser on xpath. """
-    def __init__(self, jsonpath):
-        import jsonpath_rw
-        self._expr = jsonpath_rw.parse(jsonpath)
-
-    def __call__(self, payload):
-        match = self._expr.find(json.loads(payload))
-        return match[0].value if len(match) > 0 else payload
-
-
-# pylint: disable=too-few-public-methods
-class FmtParser(object):
-    """ Wrapper for all supported formats. """
-    def __init__(self, fmt):
-        self._parse = lambda x: x
-        if fmt:
-            if fmt.startswith('json:'):
-                self._parse = _JsonFmtParser(fmt[5:])
-
-    def __call__(self, payload):
-        return self._parse(payload)
-
-
-# This is based on one of the paho-mqtt examples:
-# http://git.eclipse.org/c/paho/org.eclipse.paho.mqtt.python.git/tree/examples/sub-class.py
 # pylint: disable=too-many-arguments
 class MQTT(object):
     """ Implements messaging service for MQTT. """

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -165,6 +165,7 @@ URL_API_COMPONENTS = "/api/components"
 URL_API_BOOTSTRAP = "/api/bootstrap"
 URL_API_ERROR_LOG = "/api/error_log"
 URL_API_LOG_OUT = "/api/log_out"
+URL_API_TEMPLATE = "/api/template"
 
 HTTP_OK = 200
 HTTP_CREATED = 201

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -25,6 +25,8 @@ CONF_PASSWORD = "password"
 CONF_API_KEY = "api_key"
 CONF_ACCESS_TOKEN = "access_token"
 
+CONF_VALUE_TEMPLATE = "value_template"
+
 # #### EVENTS ####
 EVENT_HOMEASSISTANT_START = "homeassistant_start"
 EVENT_HOMEASSISTANT_STOP = "homeassistant_stop"

--- a/homeassistant/util/template.py
+++ b/homeassistant/util/template.py
@@ -5,7 +5,22 @@ homeassistant.util.template
 Template utility methods for rendering strings with HA data.
 """
 # pylint: disable=too-few-public-methods
+import json
 from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+
+def render_with_possible_json_value(hass, template, value):
+    """ Renders template with value exposed.
+        If valid JSON will expose value_json too. """
+    variables = {
+        'value': value
+    }
+    try:
+        variables['value_json'] = json.loads(value)
+    except ValueError:
+        pass
+
+    return render(hass, template, variables)
 
 
 def render(hass, template, variables=None, **kwargs):

--- a/homeassistant/util/template.py
+++ b/homeassistant/util/template.py
@@ -13,7 +13,8 @@ ENV = SandboxedEnvironment()
 def forgiving_round(value, precision=0):
     """ Rounding method that accepts strings. """
     try:
-        return int(value) if precision == 0 else round(float(value), precision)
+        return int(float(value)) if precision == 0 else round(float(value),
+                                                              precision)
     except ValueError:
         # If value can't be converted to float
         return value

--- a/homeassistant/util/template.py
+++ b/homeassistant/util/template.py
@@ -10,16 +10,25 @@ from jinja2.sandbox import SandboxedEnvironment
 ENV = SandboxedEnvironment()
 
 
-def forgiving_round(value, precision):
+def forgiving_round(value, precision=0):
     """ Rounding method that accepts strings. """
     try:
-        return round(float(value), precision)
+        return int(value) if precision == 0 else round(float(value), precision)
     except ValueError:
         # If value can't be converted to float
         return value
 
 
+def multiply(value, amount):
+    """ Converts to float and multiplies value. """
+    try:
+        return float(value) * amount
+    except ValueError:
+        # If value can't be converted to float
+        return value
+
 ENV.filters['round'] = forgiving_round
+ENV.filters['multiply'] = multiply
 
 
 def render(hass, template):

--- a/homeassistant/util/template.py
+++ b/homeassistant/util/template.py
@@ -1,0 +1,58 @@
+"""
+homeassistant.util.template
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Template utility methods for rendering strings with HA data.
+"""
+# pylint: disable=too-few-public-methods
+from jinja2.sandbox import SandboxedEnvironment
+
+ENV = SandboxedEnvironment()
+
+
+def forgiving_round(value, precision):
+    """ Rounding method that accepts strings. """
+    try:
+        return round(float(value), precision)
+    except ValueError:
+        # If value can't be converted to float
+        return value
+
+
+ENV.filters['round'] = forgiving_round
+
+
+def render(hass, template):
+    """ Render given template. """
+    return ENV.from_string(template).render(
+        states=AllStates(hass))
+
+
+class AllStates(object):
+    """ Class to expose all HA states as attributes. """
+    def __init__(self, hass):
+        self._hass = hass
+
+    def __getattr__(self, name):
+        return DomainStates(self._hass, name)
+
+    def __iter__(self):
+        return iter(sorted(self._hass.states.all(),
+                           key=lambda state: state.entity_id))
+
+
+class DomainStates(object):
+    """ Class to expose a specific HA domain as attributes. """
+
+    def __init__(self, hass, domain):
+        self._hass = hass
+        self._domain = domain
+
+    def __getattr__(self, name):
+        return self._hass.states.get('{}.{}'.format(self._domain, name))
+
+    def __iter__(self):
+        return iter(sorted(
+            (state for state in self._hass.states.all()
+             if state.domain == self._domain),
+            key=lambda state: state.entity_id))

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,6 +4,7 @@ pyyaml>=3.11,<4
 pytz>=2015.4
 pip>=7.0.0
 vincenty==0.1.3
+jinja2>=2.8
 
 # homeassistant.components.arduino
 PyMata==2.07a

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ REQUIRES = [
     'pyyaml>=3.11,<4',
     'pytz>=2015.4',
     'pip>=7.0.0',
-    'vincenty==0.1.3'
+    'vincenty==0.1.3',
+    'jinja2>=2.8'
 ]
 
 setup(

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -1,0 +1,41 @@
+"""
+tests.components.notify.test_demo
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Tests notify demo component
+"""
+import unittest
+
+import homeassistant.core as ha
+import homeassistant.components.notify as notify
+from homeassistant.components.notify import demo
+
+
+class TestNotifyDemo(unittest.TestCase):
+    """ Test the demo notify. """
+
+    def setUp(self):  # pylint: disable=invalid-name
+        self.hass = ha.HomeAssistant()
+        self.assertTrue(notify.setup(self.hass, {
+            'notify': {
+                'platform': 'demo'
+            }
+        }))
+        self.events = []
+
+        def record_event(event):
+            self.events.append(event)
+
+        self.hass.bus.listen(demo.EVENT_NOTIFY, record_event)
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """ Stop down stuff we started. """
+        self.hass.stop()
+
+    def test_sending_templated_message(self):
+        self.hass.states.set('sensor.temperature', 10)
+        notify.send_message(self.hass, '{{ states.sensor.temperature.state }}',
+                            '{{ states.sensor.temperature.name }}')
+        self.hass.pool.block_till_done()
+        last_event = self.events[-1]
+        self.assertEqual(last_event.data[notify.ATTR_TITLE], 'temperature')
+        self.assertEqual(last_event.data[notify.ATTR_MESSAGE], '10')

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -47,7 +47,7 @@ class TestSensorMQTT(unittest.TestCase):
                 'name': 'test',
                 'state_topic': 'test-topic',
                 'unit_of_measurement': 'fav unit',
-                'state_format': 'json:val'
+                'value_template': '{{ value_json.val }}'
             }
         }))
 
@@ -56,4 +56,3 @@ class TestSensorMQTT(unittest.TestCase):
         state = self.hass.states.get('sensor.test')
 
         self.assertEqual('100', state.state)
-

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -90,7 +90,7 @@ class TestSensorMQTT(unittest.TestCase):
                 'command_topic': 'command-topic',
                 'payload_on': 'beer on',
                 'payload_off': 'beer off',
-                'state_format': 'json:val'
+                'value_template': '{{ value_json.val }}'
             }
         }))
 

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -326,6 +326,20 @@ class TestAPI(unittest.TestCase):
 
         self.assertEqual(1, len(test_value))
 
+    def test_api_template(self):
+        """ Test template API. """
+        hass.states.set('sensor.temperature', 10)
+
+        req = requests.post(
+            _url(const.URL_API_TEMPLATE),
+            data=json.dumps({"template":
+                            '{{ states.sensor.temperature.state }}'}),
+            headers=HA_HEADERS)
+
+        hass.pool.block_till_done()
+
+        self.assertEqual('10', req.text)
+
     def test_api_event_forward(self):
         """ Test setting up event forwarding. """
 

--- a/tests/util/test_template.py
+++ b/tests/util/test_template.py
@@ -64,3 +64,11 @@ class TestUtilTemplate(unittest.TestCase):
             template.render(
                 self.hass,
                 '{{ states.sensor.temperature.state | multiply(10) | round }}'))
+
+    def test_passing_vars_as_keywords(self):
+        self.assertEqual(
+            '127', template.render(self.hass, '{{ hello }}', hello=127))
+
+    def test_passing_vars_as_vars(self):
+        self.assertEqual(
+            '127', template.render(self.hass, '{{ hello }}', {'hello': 127}))

--- a/tests/util/test_template.py
+++ b/tests/util/test_template.py
@@ -55,3 +55,12 @@ class TestUtilTemplate(unittest.TestCase):
             template.render(
                 self.hass,
                 '{{ states.sensor.temperature.state | round(1) }}'))
+
+    def test_rounding_value2(self):
+        self.hass.states.set('sensor.temperature', 12.34)
+
+        self.assertEqual(
+            '123',
+            template.render(
+                self.hass,
+                '{{ states.sensor.temperature.state | multiply(10) | round }}'))

--- a/tests/util/test_template.py
+++ b/tests/util/test_template.py
@@ -48,19 +48,19 @@ class TestUtilTemplate(unittest.TestCase):
                 '{% for state in states.sensor %}{{ state.state }}{% endfor %}'))
 
     def test_rounding_value(self):
-        self.hass.states.set('sensor.temperature', 12.34)
+        self.hass.states.set('sensor.temperature', 12.78)
 
         self.assertEqual(
-            '12.3',
+            '12.8',
             template.render(
                 self.hass,
                 '{{ states.sensor.temperature.state | round(1) }}'))
 
     def test_rounding_value2(self):
-        self.hass.states.set('sensor.temperature', 12.34)
+        self.hass.states.set('sensor.temperature', 12.72)
 
         self.assertEqual(
-            '123',
+            '127',
             template.render(
                 self.hass,
                 '{{ states.sensor.temperature.state | multiply(10) | round }}'))

--- a/tests/util/test_template.py
+++ b/tests/util/test_template.py
@@ -72,3 +72,15 @@ class TestUtilTemplate(unittest.TestCase):
     def test_passing_vars_as_vars(self):
         self.assertEqual(
             '127', template.render(self.hass, '{{ hello }}', {'hello': 127}))
+
+    def test_render_with_possible_json_value_with_valid_json(self):
+        self.assertEqual(
+            'world',
+            template.render_with_possible_json_value(
+                self.hass, '{{ value_json.hello }}', '{"hello": "world"}'))
+
+    def test_render_with_possible_json_value_with_invalid_json(self):
+        self.assertEqual(
+            '',
+            template.render_with_possible_json_value(
+                self.hass, '{{ value_json }}', '{ I AM NOT JSON }'))

--- a/tests/util/test_template.py
+++ b/tests/util/test_template.py
@@ -1,0 +1,57 @@
+"""
+tests.test_util
+~~~~~~~~~~~~~~~~~
+
+Tests Home Assistant util methods.
+"""
+# pylint: disable=too-many-public-methods
+import unittest
+import homeassistant.core as ha
+
+from homeassistant.util import template
+
+
+class TestUtilTemplate(unittest.TestCase):
+
+    def setUp(self):  # pylint: disable=invalid-name
+        self.hass = ha.HomeAssistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """ Stop down stuff we started. """
+        self.hass.stop()
+
+    def test_referring_states_by_entity_id(self):
+        self.hass.states.set('test.object', 'happy')
+        self.assertEqual(
+            'happy',
+            template.render(self.hass, '{{ states.test.object.state }}'))
+
+    def test_iterating_all_states(self):
+        self.hass.states.set('test.object', 'happy')
+        self.hass.states.set('sensor.temperature', 10)
+
+        self.assertEqual(
+            '10happy',
+            template.render(
+                self.hass,
+                '{% for state in states %}{{ state.state }}{% endfor %}'))
+
+    def test_iterating_domain_states(self):
+        self.hass.states.set('test.object', 'happy')
+        self.hass.states.set('sensor.back_door', 'open')
+        self.hass.states.set('sensor.temperature', 10)
+
+        self.assertEqual(
+            'open10',
+            template.render(
+                self.hass,
+                '{% for state in states.sensor %}{{ state.state }}{% endfor %}'))
+
+    def test_rounding_value(self):
+        self.hass.states.set('sensor.temperature', 12.34)
+
+        self.assertEqual(
+            '12.3',
+            template.render(
+                self.hass,
+                '{{ states.sensor.temperature.state | round(1) }}'))


### PR DESCRIPTION
Ever since jsonpath was implemented for MQTT sensors and switches, I wanted to make this available for all things. Then yesterday, someone on the mailing list asked for variables in notifications and then it struck me: templates will be the solution for everything.

Templates will:
- replace options like precision or correction in platforms like `arest`, `rest`, `mqtt`
- replace jsonpath for MQTT switches and sensors

This PR will add MVP Template support. On top of Jinja2 I've added the special `states` variable:
- Iterating `states` will yield each state sorted alphabetically by entity id
- Iterating `states.domain` will yield each state of that domain sorted alphabetically by entity id
- `states.sensor.temperature` returns state object for `sensor.temperature`

I've also added two methods `multiply` and `round`. Both which convert strings to numbers before doing their job.

Example templates and what they could result in:

| Template | Output |
| --- | --- |
| `{{ states.device_tracker.paulus.state }}` | home |
| `{% for state in states.sensor %}{{ state.entity_id }}={{ state.state }}, {% endfor %}` | senor.thermostat=24, sensor.humidity=40, |
| `{{ value['hello'][0] | multiply(10) | round(1) }}` | 10.2 |

[Jinja2 Template documentation](http://jinja.pocoo.org/docs/dev/templates/)

MVP will consist of:
- [x] Add template util methods + tests
- [x] Notification component should use templates + tests
- [x] Add template API endpoint `/api/template`
- [x] Replace jsonpath support in MQTT with templates

Version 2 (not this PR):
- Allow template inclusion from the config dir
- Add template support to rest, aRest
- Add template support to numeric state automation
- Add template automation rule.
