### PR TITLE
Correct target temp for ecobee in heat or cool mode

### DIFF
--- a/homeassistant/components/thermostat/ecobee.py
+++ b/homeassistant/components/thermostat/ecobee.py
@@ -87,7 +87,13 @@ class Thermostat(ThermostatDevice):
     @property
     def target_temperature(self):
         """ Returns the temperature we try to reach. """
-        return (self.target_temperature_low + self.target_temperature_high) / 2
+        if self.hvac_mode == 'heat' or self.hvac_mode == 'auxHeatOnly':
+            return self.target_temperature_low
+        elif self.hvac_mode == 'cool':
+            return self.target_temperature_high
+        else:
+            return (self.target_temperature_low +
+                    self.target_temperature_high) / 2
 
     @property
     def target_temperature_low(self):


### PR DESCRIPTION
The target temperature shown in an ecobee Thermostat card is calculated by taking the average of target_temperature_low and target_temperature_high. This is ok if the HVAC mode of the device is auto, because there is a high and low temp limit. However, the target temp should only use target_temperature_low or target_temperature_high if the thermostat is running in a heat or cool mode.
