### PR TITLE
Added support for MPD to display the name before the title if it is available

### DIFF
--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -141,7 +141,15 @@ class MpdDevice(MediaPlayerDevice):
     @property
     def media_title(self):
         """ Title of current playing media. """
-        return self.currentsong['title']
+        name = self.currentsong['name']
+        title = self.currentsong['title']
+
+        if name:
+            separator = ': '
+            nameandtitle = (name, title)
+            return separator.join(nameandtitle)
+        else:
+            return title
 
     @property
     def media_artist(self):

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -141,13 +141,13 @@ class MpdDevice(MediaPlayerDevice):
     @property
     def media_title(self):
         """ Title of current playing media. """
-        name = self.currentsong['name']
+        name = self.currentsong.get('name', None)
         title = self.currentsong['title']
 
-        if name:
-            return '{}: {}'.format(name, title)
-        else:
+        if name is None:
             return title
+        else:
+            return '{}: {}'.format(name, title)
 
     @property
     def media_artist(self):

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -145,9 +145,7 @@ class MpdDevice(MediaPlayerDevice):
         title = self.currentsong['title']
 
         if name:
-            separator = ': '
-            nameandtitle = (name, title)
-            return separator.join(nameandtitle)
+            return '{}: {}'.format(name, title)
         else:
             return title
 


### PR DESCRIPTION
Added support for MPD to display the name before the title if it is available

When using a radio stream, the name of the station is often available in
currentsong['name']. Just like the 'mpc' CLI client, this change displays
the name of the station before the current song title.

For example: "Mick Jagger - Let's Work" becomes "Radio 10: Mick Jagger - Let's Work"
