### PR TITLE
Template support for numeric state

### DIFF
--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -41,7 +41,7 @@ def trigger(hass, config, action):
     if value_template is not None:
         renderer = lambda value: template.render(hass,
                                                  value_template,
-                                                 {'value': value})
+                                                 {'state': value})
     else:
         renderer = lambda value: value.state
 
@@ -82,7 +82,7 @@ def if_action(hass, config):
     if value_template is not None:
         renderer = lambda value: template.render(hass,
                                                  value_template,
-                                                 {'value': value})
+                                                 {'state': value})
     else:
         renderer = lambda value: value.state
 

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -85,8 +85,7 @@ def if_action(hass, config):
     def if_numeric_state():
         """ Test numeric state condition. """
         state = hass.states.get(entity_id)
-        return state is not None and _in_range(state, above, below,
-                                               renderer)
+        return state is not None and _in_range(state, above, below, renderer)
 
     return if_numeric_state
 

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -92,12 +92,7 @@ def if_action(hass, config):
 
 def _in_range(state, range_start, range_end, renderer):
     """ Checks if value is inside the range """
-
-    if renderer is not None:
-        value = renderer({'value': state})
-    else:
-        # If no renderer is provided, just assume they want the state
-        value = state.state
+    value = state.state if renderer is None else renderer({'value': state})
 
     try:
         value = float(value)

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -8,13 +8,14 @@ at https://home-assistant.io/components/automation/#numeric-state-trigger
 """
 import logging
 
+from homeassistant.const import CONF_VALUE_TEMPLATE
 from homeassistant.helpers.event import track_state_change
+from homeassistant.util import template
 
 
 CONF_ENTITY_ID = "entity_id"
 CONF_BELOW = "below"
 CONF_ABOVE = "above"
-CONF_ATTRIBUTE = "attribute"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ def trigger(hass, config, action):
 
     below = config.get(CONF_BELOW)
     above = config.get(CONF_ABOVE)
-    attribute = config.get(CONF_ATTRIBUTE)
+    value_template = config.get(CONF_VALUE_TEMPLATE)
 
     if below is None and above is None:
         _LOGGER.error("Missing configuration key."
@@ -37,13 +38,18 @@ def trigger(hass, config, action):
                       CONF_BELOW, CONF_ABOVE)
         return False
 
+    if value_template is not None:
+        renderer = lambda value: template.render(hass, value_template, value)
+    else:
+        renderer = None
+
     # pylint: disable=unused-argument
     def state_automation_listener(entity, from_s, to_s):
         """ Listens for state changes and calls action. """
 
         # Fire action if we go from outside range into range
-        if _in_range(to_s, above, below, attribute) and \
-           (from_s is None or not _in_range(from_s, above, below, attribute)):
+        if _in_range(to_s, above, below, renderer) and \
+           (from_s is None or not _in_range(from_s, above, below, renderer)):
             action()
 
     track_state_change(
@@ -63,7 +69,7 @@ def if_action(hass, config):
 
     below = config.get(CONF_BELOW)
     above = config.get(CONF_ABOVE)
-    attribute = config.get(CONF_ATTRIBUTE)
+    value_template = config.get(CONF_VALUE_TEMPLATE)
 
     if below is None and above is None:
         _LOGGER.error("Missing configuration key."
@@ -71,18 +77,29 @@ def if_action(hass, config):
                       CONF_BELOW, CONF_ABOVE)
         return None
 
+    if value_template is not None:
+        renderer = lambda value: template.render(hass, value_template, value)
+    else:
+        renderer = None
+
     def if_numeric_state():
         """ Test numeric state condition. """
         state = hass.states.get(entity_id)
-        return state is not None and _in_range(state, above, below, attribute)
+        return state is not None and _in_range(state, above, below,
+                                               renderer)
 
     return if_numeric_state
 
 
-def _in_range(state, range_start, range_end, attribute):
+def _in_range(state, range_start, range_end, renderer):
     """ Checks if value is inside the range """
-    value = (state.state if attribute is None
-             else state.attributes.get(attribute))
+
+    if renderer is not None:
+        value = renderer({'value': state})
+    else:
+        # If no renderer is provided, just assume they want the state
+        value = state.state
+
     try:
         value = float(value)
     except ValueError:

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -295,7 +295,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'value_template': '{{ value.attributes.test_attribute }}',
+                    'value_template': '{{ state.attributes.test_attribute }}',
                     'below': 10,
                 },
                 'action': {
@@ -314,7 +314,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'value_template': '{{ value.attributes.test_attribute }}',
+                    'value_template': '{{ state.attributes.test_attribute }}',
                     'below': 10,
                 },
                 'action': {
@@ -333,7 +333,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'value_template': '{{ value.attributes.test_attribute }}',
+                    'value_template': '{{ state.attributes.test_attribute }}',
                     'below': 10,
                 },
                 'action': {
@@ -352,7 +352,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'value_template': '{{ value.attributes.test_attribute }}',
+                    'value_template': '{{ state.attributes.test_attribute }}',
                     'below': 10,
                 },
                 'action': {
@@ -371,7 +371,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'value_template': '{{ value.attributes.test_attribute }}',
+                    'value_template': '{{ state.attributes.test_attribute }}',
                     'below': 10,
                 },
                 'action': {
@@ -390,7 +390,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'value_template': '{{ value.attributes.test_attribute[2] }}',
+                    'value_template': '{{ state.attributes.test_attribute[2] }}',
                     'below': 10,
                 },
                 'action': {
@@ -409,7 +409,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'value_template': '{{ value.attributes.test_attribute | multiply(10) }}',
+                    'value_template': '{{ state.attributes.test_attribute | multiply(10) }}',
                     'below': 10,
                 },
                 'action': {
@@ -428,7 +428,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'value_template': '{{ value.attributes.test_attribute }}',
+                    'value_template': '{{ state.attributes.test_attribute }}',
                     'below': 10,
                 },
                 'action': {

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -295,7 +295,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'attribute': 'test_attribute',
+                    'value_template': '{{ value.attributes.test_attribute }}',
                     'below': 10,
                 },
                 'action': {
@@ -314,7 +314,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'attribute': 'test_attribute',
+                    'value_template': '{{ value.attributes.test_attribute }}',
                     'below': 10,
                 },
                 'action': {
@@ -333,7 +333,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'attribute': 'test_attribute',
+                    'value_template': '{{ value.attributes.test_attribute }}',
                     'below': 10,
                 },
                 'action': {
@@ -352,7 +352,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'attribute': 'test_attribute',
+                    'value_template': '{{ value.attributes.test_attribute }}',
                     'below': 10,
                 },
                 'action': {
@@ -371,7 +371,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'attribute': 'test_attribute',
+                    'value_template': '{{ value.attributes.test_attribute }}',
                     'below': 10,
                 },
                 'action': {
@@ -384,13 +384,51 @@ class TestAutomationNumericState(unittest.TestCase):
         self.hass.pool.block_till_done()
         self.assertEqual(1, len(self.calls))
 
+    def test_template_list(self):
+        self.assertTrue(automation.setup(self.hass, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'numeric_state',
+                    'entity_id': 'test.entity',
+                    'value_template': '{{ value.attributes.test_attribute[2] }}',
+                    'below': 10,
+                },
+                'action': {
+                    'service': 'test.automation'
+                }
+            }
+        }))
+        # 3 is below 10
+        self.hass.states.set('test.entity', 'entity', { 'test_attribute': [11, 15, 3] })
+        self.hass.pool.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
+    def test_template_string(self):
+        self.assertTrue(automation.setup(self.hass, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'numeric_state',
+                    'entity_id': 'test.entity',
+                    'value_template': '{{ value.attributes.test_attribute | multiply(10) }}',
+                    'below': 10,
+                },
+                'action': {
+                    'service': 'test.automation'
+                }
+            }
+        }))
+        # 9 is below 10
+        self.hass.states.set('test.entity', 'entity', { 'test_attribute': '0.9' })
+        self.hass.pool.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
     def test_if_not_fires_on_attribute_change_with_attribute_not_below_multiple_attributes(self):
         self.assertTrue(automation.setup(self.hass, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
                     'entity_id': 'test.entity',
-                    'attribute': 'test_attribute',
+                    'value_template': '{{ value.attributes.test_attribute }}',
                     'below': 10,
                 },
                 'action': {


### PR DESCRIPTION
Add template support for numeric state trigger and condition (#730).

I wasn't sure the best way of exposing the state data in the template. I ended up having a `value` key, similar to `render_with_possible_json_value`. The value of this key is the actual state object. It works, but it makes for long templates. For example, to get an attribute of the state, the template would be this:

```
{{ value.attributes.name_of_attribute }}
```

Or if you just want to get the state of the state object, it would be:

```
{{ value.state }}
```

An alternative that I considered was to use the `state.as_dict()` method and expose all of its properties to the template directly, rather than having to go through the `value` key first. I chose to go with `value` because it is more consistent with other templates, but I am open to suggestions.
