### PR TITLE
Use fuzzy matching for conversation entity matching

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -12,6 +12,9 @@ PyMata==2.07a
 # homeassistant.components.device_tracker.icloud
 https://github.com/picklepete/pyicloud/archive/80f6cd6decc950514b8dc43b30c5bded81b34d5f.zip#pyicloud==0.8.0
 
+# homeassistant.components.conversation
+fuzzywuzzy==0.8.0
+
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.3
 


### PR DESCRIPTION
eThe Entity name may not be picked up exactly by the speech recognition.

Instead of doing an exact string match, this patch looks for names which are phonetically
similar and choose the best match above a certain threshold.

This helps as entity names may often be pronoun's (Dave's bedroom) and
this also allows for some minor mistakes i.e "the bedroom" will successfully
match against a switch called "bedroom".
