### PR TITLE
Add shebang line to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 from setuptools import setup, find_packages
 from homeassistant.const import __version__


### PR DESCRIPTION
So typing" ./setup.py install" 
runs in python not bash.
