### PR TITLE
Template support for aRest sensor

### DIFF
--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -56,8 +56,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if value_template is None:
             return lambda value: value
         else:
-            return lambda value: template.render_with_possible_json_value(
-                hass, value_template, value, 'N/A')
+            return lambda value: template.render(hass,
+                                                 value_template,
+                                                 {'value': value})
 
     dev = []
 

--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -13,6 +13,7 @@ import requests
 
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE, \
     DEVICE_DEFAULT_NAME
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import template, Throttle
 
@@ -55,10 +56,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         """ Creates renderer based on variable_template value """
         if value_template is None:
             return lambda value: value
-        else:
-            return lambda value: template.render(hass,
-                                                 value_template,
-                                                 {'value': value})
+
+        def _render(value):
+            try:
+                return template.render(hass, value_template, {'value': value})
+            except TemplateError:
+                _LOGGER.exception('Error parsing value')
+                return value
+
+        return _render
 
     dev = []
 

--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -11,9 +11,10 @@ import logging
 
 import requests
 
-from homeassistant.const import DEVICE_DEFAULT_NAME
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE, \
+    DEVICE_DEFAULT_NAME
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
+from homeassistant.util import template, Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,36 +51,44 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     arest = ArestData(resource)
 
+    def make_renderer(value_template):
+        """ Creates renderer based on variable_template value """
+        if value_template is None:
+            return lambda value: value
+        else:
+            return lambda value: template.render_with_possible_json_value(
+                hass, value_template, value, 'N/A')
+
     dev = []
 
     if var_conf is not None:
-        for variable in config['monitored_variables']:
+        for variable in var_conf:
             if variable['name'] not in response['variables']:
                 _LOGGER.error('Variable: "%s" does not exist',
                               variable['name'])
                 continue
 
+            renderer = make_renderer(variable.get(CONF_VALUE_TEMPLATE))
             dev.append(ArestSensor(arest,
                                    resource,
                                    config.get('name', response['name']),
                                    variable['name'],
                                    variable=variable['name'],
                                    unit_of_measurement=variable.get(
-                                       'unit_of_measurement')))
+                                       ATTR_UNIT_OF_MEASUREMENT),
+                                   renderer=renderer))
 
     if pins is not None:
         for pinnum, pin in pins.items():
+            renderer = make_renderer(pin.get(CONF_VALUE_TEMPLATE))
             dev.append(ArestSensor(ArestData(resource, pinnum),
                                    resource,
                                    config.get('name', response['name']),
                                    pin.get('name'),
                                    pin=pinnum,
                                    unit_of_measurement=pin.get(
-                                       'unit_of_measurement'),
-                                   corr_factor=pin.get('correction_factor',
-                                                       None),
-                                   decimal_places=pin.get('decimal_places',
-                                                          None)))
+                                       ATTR_UNIT_OF_MEASUREMENT),
+                                   renderer=renderer))
 
     add_devices(dev)
 
@@ -89,8 +98,7 @@ class ArestSensor(Entity):
     """ Implements an aREST sensor for exposed variables. """
 
     def __init__(self, arest, resource, location, name, variable=None,
-                 pin=None, unit_of_measurement=None, corr_factor=None,
-                 decimal_places=None):
+                 pin=None, unit_of_measurement=None, renderer=None):
         self.arest = arest
         self._resource = resource
         self._name = '{} {}'.format(location.title(), name.title()) \
@@ -99,8 +107,7 @@ class ArestSensor(Entity):
         self._pin = pin
         self._state = 'n/a'
         self._unit_of_measurement = unit_of_measurement
-        self._corr_factor = corr_factor
-        self._decimal_places = decimal_places
+        self._renderer = renderer
         self.update()
 
         if self._pin is not None:
@@ -126,17 +133,11 @@ class ArestSensor(Entity):
 
         if 'error' in values:
             return values['error']
-        elif 'value' in values:
-            value = values['value']
-            if self._corr_factor is not None:
-                value = float(value) * float(self._corr_factor)
-            if self._decimal_places is not None:
-                value = round(value, self._decimal_places)
-            if self._decimal_places == 0:
-                value = int(value)
-            return value
-        else:
-            return values.get(self._variable, 'n/a')
+
+        value = self._renderer(values.get('value',
+                                          values.get(self._variable,
+                                                     'N/A')))
+        return value
 
     def update(self):
         """ Gets the latest data from aREST API. """


### PR DESCRIPTION
Adds support for templates for aRest sensor (#730). A template is allowed for each monitored variable or pin.

For example:

```
sensor:
  - platform: arest
    resource: http://127.0.0.1:5000/arest
    name: Home
    monitored_variables:
    - name: temperature
      unit_of_measurement: '°C'
      value_template: '{{ value | multiply(0.3) | round(0) }}'
    - name: humidity
      unit_of_measurement: '%'
      value_template: '{{ value | multiply(1.1324) | round(0) }}'
    pins:
        A0:
          name: Pin 0 analog
          unit_of_measurement: "ca"
          value_template: '{{ value | round(10) }}'
        3:
          name: Pin 3 digital
          value_template: '{{ value > 100 }}'
```
