### PR TITLE
update pyicloud version for icloud tracker

### DIFF
--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -14,9 +14,7 @@ from homeassistant.helpers.event import track_utc_time_change
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['https://github.com/picklepete/pyicloud/archive/'
-                '80f6cd6decc950514b8dc43b30c5bded81b34d5f.zip'
-                '#pyicloud==0.8.0']
+REQUIREMENTS = ['pyicloud==0.7.2']
 
 CONF_INTERVAL = 'interval'
 DEFAULT_INTERVAL = 8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -10,7 +10,7 @@ jinja2>=2.8
 PyMata==2.07a
 
 # homeassistant.components.device_tracker.icloud
-https://github.com/picklepete/pyicloud/archive/80f6cd6decc950514b8dc43b30c5bded81b34d5f.zip#pyicloud==0.8.0
+pyicloud==0.7.2
 
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.3


### PR DESCRIPTION
0.8.0 doesn't exist. pyicloud was updated couple days ago to fix what 0.8.0 claimed to fix. gets rid of urllib3 error, and certificate validation warning.
