### PR TITLE
Upgrade PyChromecast version

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -20,7 +20,7 @@ from homeassistant.components.media_player import (
     SUPPORT_PREVIOUS_TRACK, SUPPORT_NEXT_TRACK,
     MEDIA_TYPE_MUSIC, MEDIA_TYPE_TVSHOW, MEDIA_TYPE_VIDEO)
 
-REQUIREMENTS = ['pychromecast==0.6.12']
+REQUIREMENTS = ['pychromecast==0.6.13']
 CONF_IGNORE_CEC = 'ignore_cec'
 CAST_SPLASH = 'https://home-assistant.io/images/cast/splash.png'
 SUPPORT_CAST = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -69,7 +69,7 @@ https://github.com/pavoni/home-assistant-vera-api/archive/efdba4e63d58a30bc9b36d
 python-wink==0.3.1
 
 # homeassistant.components.media_player.cast
-# pychromecast==0.6.12
+pychromecast==0.6.13
 
 # homeassistant.components.media_player.kodi
 jsonrpc-requests==0.1

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -13,7 +13,6 @@ import sys
 COMMENT_REQUIREMENTS = [
     'RPi.GPIO',
     'Adafruit_Python_DHT',
-    'pychromecast==0.6.12'
 ]
 
 


### PR DESCRIPTION
PyChromecast was causing CI issues earlier this week. A new version of PyChromecast was released that upgrades to use the latest protobuf version. This PR will enable it again and will merge when tests pass.
