### PR TITLE
add statecmd to command_switch

### DIFF
--- a/homeassistant/components/switch/command_switch.py
+++ b/homeassistant/components/switch/command_switch.py
@@ -115,14 +115,14 @@ class CommandSwitch(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """ Turn the device on. """
-        if CommandSwitch._switch(self._command_on):
-            if not self._command_state:
-                self._state = True
-                self.update_ha_state()
+        if (CommandSwitch._switch(self._command_on) and
+                not self._command_state):
+            self._state = True
+            self.update_ha_state()
 
     def turn_off(self, **kwargs):
         """ Turn the device off. """
-        if CommandSwitch._switch(self._command_off):
-            if not self._command_state:
-                self._state = False
-                self.update_ha_state()
+        if (CommandSwitch._switch(self._command_off) and
+                not self._command_state):
+            self._state = False
+            self.update_ha_state()

--- a/homeassistant/components/switch/command_switch.py
+++ b/homeassistant/components/switch/command_switch.py
@@ -25,8 +25,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     for dev_name, properties in switches.items():
         if 'statecmd' in properties and CONF_VALUE_TEMPLATE not in properties:
-            _LOGGER.warn("Specify a %s when using statemcd",
-                         CONF_VALUE_TEMPLATE)
+            _LOGGER.warning("Specify a %s when using statemcd",
+                            CONF_VALUE_TEMPLATE)
             continue
         devices.append(
             CommandSwitch(

--- a/tests/components/switch/test_command_switch.py
+++ b/tests/components/switch/test_command_switch.py
@@ -1,0 +1,158 @@
+"""
+tests.components.switch.test_command_switch
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests command switch.
+"""
+import json
+import os
+import tempfile
+import unittest
+
+from homeassistant import core
+from homeassistant.const import STATE_ON, STATE_OFF
+import homeassistant.components.switch as switch
+
+
+class TestCommandSwitch(unittest.TestCase):
+    """ Test the command switch. """
+
+    def setUp(self):  # pylint: disable=invalid-name
+        self.hass = core.HomeAssistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """ Stop down stuff we started. """
+        self.hass.stop()
+
+    def test_state_none(self):
+        with tempfile.TemporaryDirectory() as tempdirname:
+            path = os.path.join(tempdirname, 'switch_status')
+            test_switch = {
+                'oncmd': 'echo 1 > {}'.format(path),
+                'offcmd': 'echo 0 > {}'.format(path),
+            }
+            self.assertTrue(switch.setup(self.hass, {
+                'switch': {
+                    'platform': 'command_switch',
+                    'switches': {
+                        'test': test_switch
+                    }
+                }
+            }))
+
+            state = self.hass.states.get('switch.test')
+            self.assertEqual(STATE_OFF, state.state)
+
+            switch.turn_on(self.hass, 'switch.test')
+            self.hass.pool.block_till_done()
+
+            state = self.hass.states.get('switch.test')
+            self.assertEqual(STATE_ON, state.state)
+
+            switch.turn_off(self.hass, 'switch.test')
+            self.hass.pool.block_till_done()
+
+            state = self.hass.states.get('switch.test')
+            self.assertEqual(STATE_OFF, state.state)
+
+
+    def test_state_value(self):
+        with tempfile.TemporaryDirectory() as tempdirname:
+            path = os.path.join(tempdirname, 'switch_status')
+            test_switch = {
+                'statecmd': 'cat {}'.format(path),
+                'oncmd': 'echo 1 > {}'.format(path),
+                'offcmd': 'echo 0 > {}'.format(path),
+                'value_template': '{{ value=="1" }}'
+            }
+            self.assertTrue(switch.setup(self.hass, {
+                'switch': {
+                    'platform': 'command_switch',
+                    'switches': {
+                        'test': test_switch
+                    }
+                }
+            }))
+
+            state = self.hass.states.get('switch.test')
+            self.assertEqual(STATE_OFF, state.state)
+
+            switch.turn_on(self.hass, 'switch.test')
+            self.hass.pool.block_till_done()
+        
+            state = self.hass.states.get('switch.test')
+            self.assertEqual(STATE_ON, state.state)
+
+            switch.turn_off(self.hass, 'switch.test')
+            self.hass.pool.block_till_done()
+
+            state = self.hass.states.get('switch.test')
+            self.assertEqual(STATE_OFF, state.state)
+
+
+    def test_state_json_value(self):
+        with tempfile.TemporaryDirectory() as tempdirname:
+            path = os.path.join(tempdirname, 'switch_status')
+            oncmd = json.dumps({'status': 'ok'})
+            offcmd = json.dumps({'status': 'nope'})
+            test_switch = {
+                'statecmd': 'cat {}'.format(path),
+                'oncmd': 'echo \'{}\' > {}'.format(oncmd, path),
+                'offcmd': 'echo \'{}\' > {}'.format(offcmd, path),
+                'value_template': '{{ value_json.status=="ok" }}'
+            }
+            self.assertTrue(switch.setup(self.hass, {
+                'switch': {
+                    'platform': 'command_switch',
+                    'switches': {
+                        'test': test_switch
+                    }
+                }
+            }))
+
+            state = self.hass.states.get('switch.test')
+            self.assertEqual(STATE_OFF, state.state)
+
+            switch.turn_on(self.hass, 'switch.test')
+            self.hass.pool.block_till_done()
+
+            state = self.hass.states.get('switch.test')
+            self.assertEqual(STATE_ON, state.state)
+
+            switch.turn_off(self.hass, 'switch.test')
+            self.hass.pool.block_till_done()
+
+            state = self.hass.states.get('switch.test')
+            self.assertEqual(STATE_OFF, state.state)
+
+    def test_state_code(self):
+        with tempfile.TemporaryDirectory() as tempdirname:
+            path = os.path.join(tempdirname, 'switch_status')
+            test_switch = {
+                'statecmd': 'cat {}'.format(path),
+                'oncmd': 'echo 1 > {}'.format(path),
+                'offcmd': 'echo 0 > {}'.format(path),
+            }
+            self.assertTrue(switch.setup(self.hass, {
+                'switch': {
+                    'platform': 'command_switch',
+                    'switches': {
+                        'test': test_switch
+                    }
+                }
+            }))
+
+            state = self.hass.states.get('switch.test')
+            self.assertEqual(STATE_OFF, state.state)
+
+            switch.turn_on(self.hass, 'switch.test')
+            self.hass.pool.block_till_done()
+
+            state = self.hass.states.get('switch.test')
+            self.assertEqual(STATE_ON, state.state)
+
+            switch.turn_off(self.hass, 'switch.test')
+            self.hass.pool.block_till_done()
+
+            state = self.hass.states.get('switch.test')
+            self.assertEqual(STATE_ON, state.state)


### PR DESCRIPTION
First draft for a `statecmd` attribute for the `command_switch`, relating to comments on #379 and many in the gitter chat. First time using the new value templates - let me know if I misused.

Here's the test configuration I used:

``` yaml
switch:
  platform: command_switch
  switches:
    nostate:
      oncmd: 'true'
      offcmd: 'true'
    test:
      oncmd: 'echo 1 > my_switch'
      offcmd: 'echo 0 > my_switch'
      statecmd: 'cat my_switch'
      value_template: '{{ value=="1" }}'
    test_json:
      oncmd: 'cat on_f > json_switch'
      offcmd: 'cat off_f > json_switch'
      statecmd: 'cat json_switch'
      value_template: '{{ value_json.status=="ok" }}'
```

and `on_f`:

```
{"status": "ok"}
```

and `off_f`:

```
{"status": "nope"}
```
