### PR TITLE
Reset log handlers to lowest level.

### DIFF
--- a/homeassistant/components/logger.py
+++ b/homeassistant/components/logger.py
@@ -78,6 +78,7 @@ def setup(hass, config=None):
 
     # Set log filter for all log handler
     for handler in logging.root.handlers:
+        handler.setLevel(logging.NOTSET)
         handler.addFilter(HomeAssistantLogFilter(logfilter))
 
     return True


### PR DESCRIPTION
This is necessary to enable logging lower than INFO for the error log file.

The fix in 5ff6eb8 is incomplete since the error handler in line 272 also has a log level set.  Rather than also modifying that line, which would affect other users not using the logger component, this just resets all the handlers' log levels in the logger component itself.
