### PR TITLE
Set the root logger to lowest level in logger component.

### DIFF
--- a/homeassistant/components/logger.py
+++ b/homeassistant/components/logger.py
@@ -76,6 +76,9 @@ def setup(hass, config=None):
 
         logfilter[LOGGER_LOGS] = logs
 
+    logger = logging.getLogger('')
+    logger.setLevel(logging.NOTSET)
+
     # Set log filter for all log handler
     for handler in logging.root.handlers:
         handler.setLevel(logging.NOTSET)


### PR DESCRIPTION
In combination with resetting the log level on the handlers, this
allows messages lower than the default INFO to be logged when using
the logger component.

This is from the discussion on pull request #790.  I tested it briefly and it seems to allow debug messages for me.
