### PR TITLE
Add sun condition to automation

### DIFF
--- a/homeassistant/components/automation/sun.py
+++ b/homeassistant/components/automation/sun.py
@@ -67,8 +67,8 @@ def if_action(hass, config):
         return None
 
     # Make sure configuration keys have the right value
-    if before is not None and before not in (EVENT_SUNRISE, EVENT_SUNSET) or \
-       after is not None and after not in (EVENT_SUNRISE, EVENT_SUNSET):
+    if before not in (None, EVENT_SUNRISE, EVENT_SUNSET) or \
+       after not in (None, EVENT_SUNRISE, EVENT_SUNSET):
         logging.getLogger(__name__).error(
             "%s and %s can only be set to %s or %s",
             CONF_BEFORE, CONF_AFTER, EVENT_SUNRISE, EVENT_SUNSET)

--- a/homeassistant/components/automation/sun.py
+++ b/homeassistant/components/automation/sun.py
@@ -17,6 +17,10 @@ DEPENDENCIES = ['sun']
 
 CONF_OFFSET = 'offset'
 CONF_EVENT = 'event'
+CONF_BEFORE = "before"
+CONF_BEFORE_OFFSET = "before_offset"
+CONF_AFTER = "after"
+CONF_AFTER_OFFSET = "after_offset"
 
 EVENT_SUNSET = 'sunset'
 EVENT_SUNRISE = 'sunrise'
@@ -37,26 +41,9 @@ def trigger(hass, config, action):
         _LOGGER.error("Invalid value for %s: %s", CONF_EVENT, event)
         return False
 
-    if CONF_OFFSET in config:
-        raw_offset = config.get(CONF_OFFSET)
-
-        negative_offset = False
-        if raw_offset.startswith('-'):
-            negative_offset = True
-            raw_offset = raw_offset[1:]
-
-        try:
-            (hour, minute, second) = [int(x) for x in raw_offset.split(':')]
-        except ValueError:
-            _LOGGER.error('Could not parse offset %s', raw_offset)
-            return False
-
-        offset = timedelta(hours=hour, minutes=minute, seconds=second)
-
-        if negative_offset:
-            offset *= -1
-    else:
-        offset = timedelta(0)
+    offset = _parse_offset(config.get(CONF_OFFSET))
+    if offset is False:
+        return False
 
     # Do something to call action
     if event == EVENT_SUNRISE:
@@ -65,6 +52,70 @@ def trigger(hass, config, action):
         trigger_sunset(hass, action, offset)
 
     return True
+
+
+def if_action(hass, config):
+    """ Wraps action method with sun based condition. """
+    before = config.get(CONF_BEFORE)
+    after = config.get(CONF_AFTER)
+
+    # Make sure required configuration keys are present
+    if before is None and after is None:
+        logging.getLogger(__name__).error(
+            "Missing if-condition configuration key %s or %s",
+            CONF_BEFORE, CONF_AFTER)
+        return None
+
+    # Make sure configuration keys have the right value
+    if before is not None and before not in (EVENT_SUNRISE, EVENT_SUNSET) or \
+       after is not None and after not in (EVENT_SUNRISE, EVENT_SUNSET):
+        logging.getLogger(__name__).error(
+            "%s and %s can only be set to %s or %s",
+            CONF_BEFORE, CONF_AFTER, EVENT_SUNRISE, EVENT_SUNSET)
+        return None
+
+    before_offset = _parse_offset(config.get(CONF_BEFORE_OFFSET))
+    after_offset = _parse_offset(config.get(CONF_AFTER_OFFSET))
+    if before_offset is False or after_offset is False:
+        return None
+
+    if before is None:
+        before_func = lambda: None
+    elif before == EVENT_SUNRISE:
+        before_func = lambda: sun.next_rising_utc(hass) + before_offset
+    else:
+        before_func = lambda: sun.next_setting_utc(hass) + before_offset
+
+    if after is None:
+        after_func = lambda: None
+    elif after == EVENT_SUNRISE:
+        after_func = lambda: sun.next_rising_utc(hass) + after_offset
+    else:
+        after_func = lambda: sun.next_setting_utc(hass) + after_offset
+
+    # This is needed for testing
+    time_func = dt_util.utcnow
+
+    def time_if():
+        """ Validate time based if-condition """
+
+        # This is needed for testing.
+        nonlocal time_func
+        now = time_func()
+        before = before_func()
+        after = after_func()
+
+        if before is not None and now > now.replace(hour=before.hour,
+                                                    minute=before.minute):
+            return False
+
+        if after is not None and now < now.replace(hour=after.hour,
+                                                   minute=after.minute):
+            return False
+
+        return True
+
+    return time_if
 
 
 def trigger_sunrise(hass, action, offset):
@@ -103,3 +154,26 @@ def trigger_sunset(hass, action, offset):
         action()
 
     track_point_in_utc_time(hass, sunset_automation_listener, next_set())
+
+
+def _parse_offset(raw_offset):
+    if raw_offset is None:
+        return timedelta(0)
+
+    negative_offset = False
+    if raw_offset.startswith('-'):
+        negative_offset = True
+        raw_offset = raw_offset[1:]
+
+    try:
+        (hour, minute, second) = [int(x) for x in raw_offset.split(':')]
+    except ValueError:
+        _LOGGER.error('Could not parse offset %s', raw_offset)
+        return False
+
+    offset = timedelta(hours=hour, minutes=minute, seconds=second)
+
+    if negative_offset:
+        offset *= -1
+
+    return offset

--- a/tests/components/automation/test_sun.py
+++ b/tests/components/automation/test_sun.py
@@ -139,3 +139,251 @@ class TestAutomationSun(unittest.TestCase):
         fire_time_changed(self.hass, trigger_time)
         self.hass.pool.block_till_done()
         self.assertEqual(1, len(self.calls))
+
+    def test_if_action_before_before(self):
+        self.hass.states.set(sun.ENTITY_ID, sun.STATE_ABOVE_HORIZON, {
+            sun.STATE_ATTR_NEXT_RISING: '14:00:00 16-09-2015',
+        })
+
+        now = datetime(2015, 9, 16, 10, tzinfo=dt_util.UTC)
+        entity_id = 'domain.test_entity'
+
+        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+                   return_value=now):
+            automation.setup(self.hass, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'event',
+                        'event_type': 'test_event',
+                    },
+                    'condition': {
+                        'platform': 'sun',
+                        'before': 'sunrise',
+                    },
+                    'action': {
+                        'service': 'test.automation'
+                    }
+                }
+            })
+
+        self.hass.bus.fire('test_event')
+        self.hass.pool.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
+    def test_if_action_after_before(self):
+        self.hass.states.set(sun.ENTITY_ID, sun.STATE_ABOVE_HORIZON, {
+            sun.STATE_ATTR_NEXT_RISING: '14:00:00 16-09-2015',
+        })
+
+        now = datetime(2015, 9, 16, 15, tzinfo=dt_util.UTC)
+        entity_id = 'domain.test_entity'
+
+        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+                   return_value=now):
+            automation.setup(self.hass, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'event',
+                        'event_type': 'test_event',
+                    },
+                    'condition': {
+                        'platform': 'sun',
+                        'before': 'sunrise',
+                    },
+                    'action': {
+                        'service': 'test.automation'
+                    }
+                }
+            })
+
+        self.hass.bus.fire('test_event')
+        self.hass.pool.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
+    def test_if_action_before_after(self):
+        self.hass.states.set(sun.ENTITY_ID, sun.STATE_ABOVE_HORIZON, {
+            sun.STATE_ATTR_NEXT_RISING: '14:00:00 16-09-2015',
+        })
+
+        now = datetime(2015, 9, 16, 13, tzinfo=dt_util.UTC)
+        entity_id = 'domain.test_entity'
+
+        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+                   return_value=now):
+            automation.setup(self.hass, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'event',
+                        'event_type': 'test_event',
+                    },
+                    'condition': {
+                        'platform': 'sun',
+                        'after': 'sunrise',
+                    },
+                    'action': {
+                        'service': 'test.automation'
+                    }
+                }
+            })
+
+        self.hass.bus.fire('test_event')
+        self.hass.pool.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
+    def test_if_action_before_and_after_during(self):
+        self.hass.states.set(sun.ENTITY_ID, sun.STATE_ABOVE_HORIZON, {
+            sun.STATE_ATTR_NEXT_RISING: '10:00:00 16-09-2015',
+            sun.STATE_ATTR_NEXT_SETTING: '15:00:00 16-09-2015',
+        })
+
+        now = datetime(2015, 9, 16, 12, tzinfo=dt_util.UTC)
+        entity_id = 'domain.test_entity'
+
+        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+                   return_value=now):
+            automation.setup(self.hass, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'event',
+                        'event_type': 'test_event',
+                    },
+                    'condition': {
+                        'platform': 'sun',
+                        'after': 'sunrise',
+                        'before': 'sunset'
+                    },
+                    'action': {
+                        'service': 'test.automation'
+                    }
+                }
+            })
+
+        self.hass.bus.fire('test_event')
+        self.hass.pool.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
+    def test_if_action_before_and_after_before(self):
+        self.hass.states.set(sun.ENTITY_ID, sun.STATE_ABOVE_HORIZON, {
+            sun.STATE_ATTR_NEXT_RISING: '10:00:00 16-09-2015',
+            sun.STATE_ATTR_NEXT_SETTING: '15:00:00 16-09-2015',
+        })
+
+        now = datetime(2015, 9, 16, 8, tzinfo=dt_util.UTC)
+        entity_id = 'domain.test_entity'
+
+        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+                   return_value=now):
+            automation.setup(self.hass, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'event',
+                        'event_type': 'test_event',
+                    },
+                    'condition': {
+                        'platform': 'sun',
+                        'after': 'sunrise',
+                        'before': 'sunset'
+                    },
+                    'action': {
+                        'service': 'test.automation'
+                    }
+                }
+            })
+
+        self.hass.bus.fire('test_event')
+        self.hass.pool.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
+    def test_if_action_before_and_after_after(self):
+        self.hass.states.set(sun.ENTITY_ID, sun.STATE_ABOVE_HORIZON, {
+            sun.STATE_ATTR_NEXT_RISING: '10:00:00 16-09-2015',
+            sun.STATE_ATTR_NEXT_SETTING: '15:00:00 16-09-2015',
+        })
+
+        now = datetime(2015, 9, 16, 16, tzinfo=dt_util.UTC)
+        entity_id = 'domain.test_entity'
+
+        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+                   return_value=now):
+            automation.setup(self.hass, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'event',
+                        'event_type': 'test_event',
+                    },
+                    'condition': {
+                        'platform': 'sun',
+                        'after': 'sunrise',
+                        'before': 'sunset'
+                    },
+                    'action': {
+                        'service': 'test.automation'
+                    }
+                }
+            })
+
+        self.hass.bus.fire('test_event')
+        self.hass.pool.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
+    def test_if_action_offset_before(self):
+        self.hass.states.set(sun.ENTITY_ID, sun.STATE_ABOVE_HORIZON, {
+            sun.STATE_ATTR_NEXT_RISING: '14:00:00 16-09-2015',
+        })
+
+        now = datetime(2015, 9, 16, 14, 59, tzinfo=dt_util.UTC)
+        entity_id = 'domain.test_entity'
+
+        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+                   return_value=now):
+            automation.setup(self.hass, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'event',
+                        'event_type': 'test_event',
+                    },
+                    'condition': {
+                        'platform': 'sun',
+                        'before': 'sunrise',
+                        'before_offset': '+1:00:00'
+                    },
+                    'action': {
+                        'service': 'test.automation'
+                    }
+                }
+            })
+
+        self.hass.bus.fire('test_event')
+        self.hass.pool.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
+    def test_if_action_offset_after(self):
+        self.hass.states.set(sun.ENTITY_ID, sun.STATE_ABOVE_HORIZON, {
+            sun.STATE_ATTR_NEXT_RISING: '14:00:00 16-09-2015',
+        })
+
+        now = datetime(2015, 9, 16, 15, tzinfo=dt_util.UTC)
+        entity_id = 'domain.test_entity'
+
+        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+                   return_value=now):
+            automation.setup(self.hass, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'event',
+                        'event_type': 'test_event',
+                    },
+                    'condition': {
+                        'platform': 'sun',
+                        'after': 'sunrise',
+                        'after_offset': '+1:00:00'
+                    },
+                    'action': {
+                        'service': 'test.automation'
+                    }
+                }
+            })
+
+        self.hass.bus.fire('test_event')
+        self.hass.pool.block_till_done()
+        self.assertEqual(1, len(self.calls))

--- a/tests/components/automation/test_sun.py
+++ b/tests/components/automation/test_sun.py
@@ -230,6 +230,36 @@ class TestAutomationSun(unittest.TestCase):
         self.hass.pool.block_till_done()
         self.assertEqual(0, len(self.calls))
 
+    def test_if_action_after_after(self):
+        self.hass.states.set(sun.ENTITY_ID, sun.STATE_ABOVE_HORIZON, {
+            sun.STATE_ATTR_NEXT_SETTING: '14:00:00 16-09-2015',
+        })
+
+        now = datetime(2015, 9, 16, 15, tzinfo=dt_util.UTC)
+        entity_id = 'domain.test_entity'
+
+        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+                   return_value=now):
+            automation.setup(self.hass, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'event',
+                        'event_type': 'test_event',
+                    },
+                    'condition': {
+                        'platform': 'sun',
+                        'after': 'sunset',
+                    },
+                    'action': {
+                        'service': 'test.automation'
+                    }
+                }
+            })
+
+        self.hass.bus.fire('test_event')
+        self.hass.pool.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
     def test_if_action_before_and_after_during(self):
         self.hass.states.set(sun.ENTITY_ID, sun.STATE_ABOVE_HORIZON, {
             sun.STATE_ATTR_NEXT_RISING: '10:00:00 16-09-2015',


### PR DESCRIPTION
This adds the ability to use the sun as a condition for automation. For example:

``` yaml
trigger:
  platform: state
  entity_id: group.family
  state: 'home'
condition:
  platform: sun
  after: sunset
  after_offset: '-1:00:00'
action:
  service: scene.turn_on
  entity_id: scene.evening
```

This will turn on the lights when someone gets home as long as it is after an hour before sunset. 

Previously, you could use the state platform to check if the sun is in the state `above_horizon` or `below_horizon`, but the offset value would not be possible.

This introduces four new configurations when using the sun as a condition: `after`, `after_offset`, `before`, `before_offset`. `after` and `before` can only be set to `sunrise` or `sunset` with the corresponding offset to offset the time of those events.
