### PR TITLE
Adds Wemo event support - so wemo devices update HA more quickly

### DIFF
--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -27,6 +27,11 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     if _WEMO_SUBSCRIPTION_REGISTRY is None:
         _WEMO_SUBSCRIPTION_REGISTRY = pywemo.SubscriptionRegistry()
         _WEMO_SUBSCRIPTION_REGISTRY.start()
+        def stop_wemo(event):
+            """ Shutdown Wemo subscriptions and subscription thread on exit"""
+            _WEMO_SUBSCRIPTION_REGISTRY.stop()
+
+        hass.bus.listen_once(hass.EVENT_HOMEASSISTANT_STOP, stop_wemo)
 
     if discovery_info is not None:
         location = discovery_info[2]
@@ -63,8 +68,7 @@ class WemoSwitch(SwitchDevice):
         _LOGGER.info(
             'Subscription update for  %s, sevice=%s params=%s',
             self.name, _device, _params)
-        self.update()
-        self.update_ha_state()
+        self.update_ha_state(True)
 
     @property
     def should_poll(self):

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -66,6 +66,7 @@ class WemoSwitch(SwitchDevice):
             'Subscription update for  %s, sevice=%s params=%s',
             self.name, _device, _params)
         self.update()
+        self.update_ha_state()
 
     @property
     def should_poll(self):

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -9,7 +9,7 @@ https://home-assistant.io/components/switch.wemo/
 import logging
 
 from homeassistant.components.switch import SwitchDevice
-from homeassistant.const import STATE_ON, STATE_OFF, STATE_STANDBY
+from homeassistant.const import STATE_ON, STATE_OFF, STATE_STANDBY, EVENT_HOMEASSISTANT_STOP
 
 REQUIREMENTS = ['pywemo==0.3.4']
 _LOGGER = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             _LOGGER.info("Shutting down subscriptions.")
             _WEMO_SUBSCRIPTION_REGISTRY.stop()
 
-        hass.bus.listen_once(hass.EVENT_HOMEASSISTANT_STOP, stop_wemo)
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_wemo)
 
     if discovery_info is not None:
         location = discovery_info[2]

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import STATE_ON, STATE_OFF, STATE_STANDBY
 
-# REQUIREMENTS = ['pywemo==0.3.3']
+REQUIREMENTS = ['pywemo==0.3.4']
 _LOGGER = logging.getLogger(__name__)
 
 _WEMO_SUBSCRIPTION_REGISTRY = None
@@ -56,9 +56,7 @@ class WemoSwitch(SwitchDevice):
 
         _WEMO_SUBSCRIPTION_REGISTRY.register(wemo)
         _WEMO_SUBSCRIPTION_REGISTRY.on(
-            wemo, 'BinaryState', self._update_callback)
-        _WEMO_SUBSCRIPTION_REGISTRY.on(
-            wemo, 'attributeList', self._update_callback)
+            wemo, None, self._update_callback)
 
     def _update_callback(self, _device, _params):
         """ Called by the wemo device callback to update state. """

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -16,6 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 _WEMO_SUBSCRIPTION_REGISTRY = None
 
+
 # pylint: disable=unused-argument, too-many-function-args
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """ Find and return WeMo switches. """
@@ -23,7 +24,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     import pywemo.discovery as discovery
 
     global _WEMO_SUBSCRIPTION_REGISTRY
-    if  _WEMO_SUBSCRIPTION_REGISTRY is None:
+    if _WEMO_SUBSCRIPTION_REGISTRY is None:
         _WEMO_SUBSCRIPTION_REGISTRY = pywemo.SubscriptionRegistry()
         _WEMO_SUBSCRIPTION_REGISTRY.start()
 
@@ -53,19 +54,23 @@ class WemoSwitch(SwitchDevice):
         self.insight_params = None
         self.maker_params = None
 
-        global _WEMO_SUBSCRIPTION_REGISTRY
         _WEMO_SUBSCRIPTION_REGISTRY.register(wemo)
-        _WEMO_SUBSCRIPTION_REGISTRY.on(wemo, 'BinaryState', self._update_callback)
-        _WEMO_SUBSCRIPTION_REGISTRY.on(wemo, 'attributeList', self._update_callback)
+        _WEMO_SUBSCRIPTION_REGISTRY.on(
+            wemo, 'BinaryState', self._update_callback)
+        _WEMO_SUBSCRIPTION_REGISTRY.on(
+            wemo, 'attributeList', self._update_callback)
 
     def _update_callback(self, _device, _params):
-        _LOGGER.info('Subscription update for  %s, sevice=%s params=%s', self.name, _device, _params)
-        # import pdb; pdb.set_trace()
+        """ Called by the wemo device callback to update state. """
+        _LOGGER.info(
+            'Subscription update for  %s, sevice=%s params=%s',
+            self.name, _device, _params)
         self.update()
 
     @property
     def should_poll(self):
-        """ No polling should be needed with subscriptions, but leave in for initial version in case of issues. """
+        """ No polling should be needed with subscriptions """
+        # but leave in for initial version in case of issues.
         return True
 
     @property

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -29,6 +29,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         _WEMO_SUBSCRIPTION_REGISTRY.start()
         def stop_wemo(event):
             """ Shutdown Wemo subscriptions and subscription thread on exit"""
+            _LOGGER.info("Shutting down subscriptions.")
             _WEMO_SUBSCRIPTION_REGISTRY.stop()
 
         hass.bus.listen_once(hass.EVENT_HOMEASSISTANT_STOP, stop_wemo)
@@ -66,8 +67,8 @@ class WemoSwitch(SwitchDevice):
     def _update_callback(self, _device, _params):
         """ Called by the wemo device callback to update state. """
         _LOGGER.info(
-            'Subscription update for  %s, sevice=%s params=%s',
-            self.name, _device, _params)
+            'Subscription update for  %s, sevice=%s',
+            self.name, _device)
         self.update_ha_state(True)
 
     @property

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -9,7 +9,8 @@ https://home-assistant.io/components/switch.wemo/
 import logging
 
 from homeassistant.components.switch import SwitchDevice
-from homeassistant.const import STATE_ON, STATE_OFF, STATE_STANDBY, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import (
+    STATE_ON, STATE_OFF, STATE_STANDBY, EVENT_HOMEASSISTANT_STOP)
 
 REQUIREMENTS = ['pywemo==0.3.4']
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -27,6 +27,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     if _WEMO_SUBSCRIPTION_REGISTRY is None:
         _WEMO_SUBSCRIPTION_REGISTRY = pywemo.SubscriptionRegistry()
         _WEMO_SUBSCRIPTION_REGISTRY.start()
+
         def stop_wemo(event):
             """ Shutdown Wemo subscriptions and subscription thread on exit"""
             _LOGGER.info("Shutting down subscriptions.")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -174,7 +174,7 @@ hikvision==0.4
 orvibo==1.1.0
 
 # homeassistant.components.switch.wemo
-pywemo==0.3.3
+pywemo==0.3.4
 
 # homeassistant.components.thermostat.heatmiser
 heatmiserV3==0.9.1


### PR DESCRIPTION
This PR adds support for WeMo event handling. It requires a new version of pywemo (https://github.com/balloob/pywemo/pulls)

I've left the should_poll true so that the worst case is this defaults to the current code. I suspect that some of this might not survive WeMo devices changing their port number etc. As I see issues I'll update the code.

There is one thing outstanding, I need to shutdown the wemo subscriptions on exit - but I'm not sure how best to call the close down code when HA exits. I'll add this is someone can point me in the right direction.
