### PR TITLE
HDMI CEC platform

### DIFF
--- a/homeassistant/components/cec.py
+++ b/homeassistant/components/cec.py
@@ -1,0 +1,176 @@
+import re
+import logging
+import threading
+from concurrent.futures import thread
+
+import homeassistant
+from homeassistant import bootstrap
+from homeassistant.const import EVENT_PLATFORM_DISCOVERED, ATTR_SERVICE, ATTR_DISCOVERED
+
+DOMAIN = "cec"
+#REQUIREMENTS = ['cec']
+DISCOVER_OPTION = 'cec.option'
+
+SERVICE_CEC_SET_STREAM_PATH = 'set_stream_path'
+
+EVENT_CEC_DEVICE_CHANGED = 'cec_device_changed'
+
+ATTR_CEC_LOGICAL_ADDRESS = 'logical_address'
+ATTR_CEC_PHYSICAL_ADDRESS = 'physical_address'
+
+_LOGGER = logging.getLogger(__name__)
+
+PHYSICAL_ADRESS_REGEX = re.compile('([\dA-F])\.([\dA-F]).([\dA-F]).([\dA-F])')
+CEC = None
+DEVICES = {}
+
+
+def physical_address_to_string(physical_address):
+    return '.'.join(('%X' % (physical_address)))
+
+class CecDevice(object):
+    def __init__(self, logical_address):
+        self.set_logical_address(logical_address)
+
+    def __eq__(self, other):
+        return isinstance(other, CecDevice) and \
+               self.logical_address == other.logical_address and \
+               self.vendor == other.vendor and \
+               self.physical_address == other.physical_address and \
+               self.active == other.active and \
+               self.power == other.power and \
+               self.osd == other.osd and \
+               self.cec_version == other.cec_version
+
+    def __str__(self):
+        return "Device(logical=%s (%s); physical=%s; vendor=%s; osd=%s; cec_version=%s power=%s; active=%s)" % (
+            self.logical_address, self.logical_address_string, self.physical_address, self.vendor, self.osd,
+            self.cec_version, self.power, self.active
+        )
+
+    def set_logical_address(self, logical_address):
+        self.logical_address = logical_address
+        self._update_from_logical_address(logical_address)
+
+    def _update_from_logical_address(self, logical_address):
+        self.logical_address_string = CEC.LogicalAddressToString(self.logical_address)
+        self.vendor = CEC.VendorIdToString(CEC.GetDeviceVendorId(logical_address))
+        self.physical_address = physical_address_to_string(CEC.GetDevicePhysicalAddress(logical_address))
+        self.active = CEC.IsActiveSource(logical_address)
+        self.power = CEC.PowerStatusToString(CEC.GetDevicePowerStatus(logical_address))
+        self.osd = CEC.GetDeviceOSDName(logical_address)
+        self.cec_version = CEC.CecVersionToString(CEC.GetDeviceCecVersion(logical_address))
+
+
+def set_stream_path(service):
+    if CEC is None:
+        return False
+
+    dat = service.data
+
+    if ATTR_CEC_PHYSICAL_ADDRESS not in dat:
+        return
+
+    physical_address = dat[ATTR_CEC_PHYSICAL_ADDRESS]
+    print(type(physical_address), physical_address)
+
+    # CEC.SetStreamPath(physical_address) results in the following error:
+    # only the TV is allowed to send CEC_OPCODE_SET_STREAM_PATH
+    # Technically, this is correct.. But this is the only possibility I found to
+    # switch devices
+
+    match = PHYSICAL_ADRESS_REGEX.match(physical_address)
+    if not match:
+        return
+
+    a, b, c, d = match.groups()
+    # From: Reserved (E)
+    # To: Broadcast
+    # Message: Routing Control - Set Stream Path
+    CEC.Transmit(CEC.CommandFromString("EF:86:" + a + b + ":" + c + d))
+
+def setup(hass, config):
+    """
+    Setup HDMI-CEC.
+    Will automatically load components to support devices found on the network.
+    """
+    global CEC
+    import cec
+
+    map_log_level = {
+        cec.CEC_LOG_ERROR: logging.ERROR,
+        cec.CEC_LOG_WARNING: logging.WARNING,
+        cec.CEC_LOG_NOTICE: logging.INFO,
+        cec.CEC_LOG_TRAFFIC: logging.DEBUG,
+        cec.CEC_LOG_DEBUG: logging.DEBUG
+    }
+
+    def update_devices(now):
+        _LOGGER.info('\n\n\nUpdating CEC devices...')
+        addresses = CEC.GetActiveDevices()
+        for x in range(15):
+            old_dev = DEVICES.get(x)
+            new_dev = CecDevice(x) if addresses.IsSet(x) else None
+
+            if old_dev != new_dev:
+                if new_dev is not None:
+                    DEVICES[x] = new_dev
+                else:
+                    DEVICES.pop(x, None)
+                _LOGGER.info('CEC device %s changed:' % x)
+                _LOGGER.info('old[%s]: %s' % (x, old_dev))
+                _LOGGER.info('new[%s]: %s' % (x, new_dev))
+                hass.bus.fire(EVENT_CEC_DEVICE_CHANGED, {ATTR_CEC_LOGICAL_ADDRESS: x})
+
+    def log_callback(level, time, message):
+        level = map_log_level.get(level, logging.WARNING)
+        _LOGGER.log(level, '[%s] %s' % (str(time), message))
+
+    cecconfig = cec.libcec_configuration()
+    cecconfig.strDeviceName = 'homeassistant'
+
+    # do not make it the active source on the bus when loading the component
+    cecconfig.bActivateSource = 0
+
+    #cecconfig.deviceTypes.Add(cec.CEC_DEVICE_TYPE_RECORDING_DEVICE)
+    cecconfig.bMonitorOnly = 1
+    cecconfig.clientVersion = cec.LIBCEC_VERSION_CURRENT
+
+    #cecconfig.SetLogCallback(log_callback)
+    #cecconfig.SetCommandCallback(received_command)
+
+    CEC = cec.ICECAdapter.Create(cecconfig)
+
+    _LOGGER.info('libCEC version ' + CEC.VersionToString(cecconfig.serverVersion) + ' loaded: ' + CEC.GetLibInfo())
+
+    adapters = CEC.DetectAdapters()
+
+    if len(adapters) == 0:
+        _LOGGER.info('No compatible HDMI-CEC adapter found!')
+        return
+
+    if len(adapters) > 1:
+        _LOGGER.warning('More than one HDMI-CEC adapter found! Using first one!')
+
+    adapter = adapters[0]
+
+    _LOGGER.info('Using adapter: ' + adapter.strComName)
+
+    if not CEC.Open(adapter.strComName):
+        _LOGGER.error('failed to open a connection to the CEC adapter')
+        return
+
+    # Fire every 5 seconds
+    homeassistant.helpers.event.track_time_change(hass, update_devices, second=range(0, 60, 5))
+
+    # Ensure component is loaded
+    bootstrap.setup_component(hass, 'option', config)
+
+    hass.bus.fire(EVENT_PLATFORM_DISCOVERED, {
+        ATTR_SERVICE: DISCOVER_OPTION,
+        ATTR_DISCOVERED: {}
+    })
+
+    hass.services.register(DOMAIN, SERVICE_CEC_SET_STREAM_PATH, set_stream_path)
+
+    return True

--- a/homeassistant/components/option/__init__.py
+++ b/homeassistant/components/option/__init__.py
@@ -1,0 +1,121 @@
+"""
+homeassistant.components.option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Component to interface with options, where one option out of an option group can be selected.
+
+For more details about this component, please refer to the documentation
+at https://home-assistant.io/components/option/
+"""
+import logging
+
+import os
+
+from homeassistant.config import load_yaml_config_file
+from homeassistant.const import SERVICE_SET_OPTION, ATTR_ENTITY_ID
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+
+DOMAIN = 'option'
+SCAN_INTERVAL = 30
+
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
+# strings that represents the desired option
+ATTR_OPTION = "option"
+ATTR_OPTIONS = "options"
+
+_LOGGER = logging.getLogger(__name__)
+
+DISCOVERY_PLATFORMS = {
+}
+
+DEVICE_NAME = 'Active HDMI device'
+
+
+def set_option(hass, option, entity_id=None):
+    """ Will select the specified option. """
+    data = {ATTR_OPTION: option}
+
+    if entity_id:
+        data[ATTR_ENTITY_ID] = entity_id
+
+    hass.services.call(DOMAIN, SERVICE_SET_OPTION, data)
+
+
+def setup(hass, config):
+    """ Setup options. """
+    component = EntityComponent(_LOGGER, DOMAIN, hass,
+                                SCAN_INTERVAL, DISCOVERY_PLATFORMS)
+    component.setup(config)
+
+    def option_service(service):
+        """ Handles calls to the services. """
+        # Get and validate data
+        dat = service.data
+
+        # Convert the entity ids to valid light ids
+        target_options = component.extract_from_service(service)
+
+        option = service.data.get(ATTR_OPTION)
+
+        if option is None:
+            _LOGGER.error(
+                "Received call to %s without attribute %s",
+                SERVICE_SET_OPTION, ATTR_OPTION)
+
+        else:
+            for target_option in target_options:
+                target_option.switch(option)
+
+            for target_option in target_options:
+                if target_option.should_poll:
+                    target_option.update_ha_state(True)
+
+    descriptions = load_yaml_config_file(
+        os.path.join(os.path.dirname(__file__), 'services.yaml'))
+
+    print("descriptions", descriptions)
+
+    hass.services.register(
+        DOMAIN, SERVICE_SET_OPTION, option_service,
+        descriptions.get(SERVICE_SET_OPTION))
+
+    return True
+
+
+class OptionDevice(Entity):
+    """ Represents an option within Home Assistant. """
+
+    @property
+    def name(self):
+        """ Returns the name of the entity. """
+        return DEVICE_NAME
+
+    @property
+    def state(self):
+        """ Returns the state of the entity. """
+        return self.option
+
+    @property
+    def option(self):
+        """ Returns the active option of the entity. """
+        return None
+
+    @property
+    def options(self):
+        """ Returns the list of available options for this entity. """
+        return []
+
+    def switch(self, option, **kwargs):
+        """ Select the option 'option' for this entity. """
+        pass
+
+    @property
+    def state_attributes(self):
+        """ Returns optional state attributes. """
+        data = {
+            ATTR_OPTION: self.option,
+            ATTR_OPTIONS: self.options,
+        }
+
+        return data

--- a/homeassistant/components/option/__init__.py
+++ b/homeassistant/components/option/__init__.py
@@ -10,6 +10,7 @@ import logging
 
 import os
 
+from homeassistant.components import cec
 from homeassistant.config import load_yaml_config_file
 from homeassistant.const import SERVICE_SET_OPTION, ATTR_ENTITY_ID
 from homeassistant.helpers.entity import Entity
@@ -27,6 +28,7 @@ ATTR_OPTIONS = "options"
 _LOGGER = logging.getLogger(__name__)
 
 DISCOVERY_PLATFORMS = {
+    cec.DISCOVER_OPTION: 'cec',
 }
 
 DEVICE_NAME = 'Active HDMI device'

--- a/homeassistant/components/option/cec.py
+++ b/homeassistant/components/option/cec.py
@@ -1,0 +1,57 @@
+"""
+homeassistant.components.option.cec
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+CEC platform that handles options.
+"""
+# Because we do not compile cec on CI
+# pylint: disable=import-error
+import homeassistant.components.cec as cec
+
+from homeassistant.components.option import OptionDevice
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """ Find and return demo switches. """
+
+    cec_option = CecOption(hass)
+
+    hass.bus.listen_once(cec.EVENT_CEC_DEVICE_CHANGED, lambda event: cec_option.update_ha_state(True))
+
+    print("cec OPTION setup_platform", hass, config, add_devices, discovery_info)
+    if discovery_info is None:
+        return
+
+    add_devices([cec_option])
+
+
+class CecOption(OptionDevice):
+    def __init__(self, hass):
+        self._hass = hass
+        self._option = None
+        self._options = []
+
+    @property
+    def option(self):
+        """ Returns the active option of the entity. """
+        return self._option
+
+    @property
+    def options(self):
+        """ Returns the list of available options for this entity. """
+        return self._options
+
+    def switch(self, option, **kwargs):
+        """ Select the option 'option' for this entity. """
+        for d in cec.DEVICES.values():
+            if d.osd == option:
+                data = {cec.ATTR_CEC_PHYSICAL_ADDRESS: d.physical_address}
+                self._hass.services.call(cec.DOMAIN, cec.SERVICE_CEC_SET_STREAM_PATH, data)
+                return True
+        return False
+
+    def update(self):
+        self._options = [d.osd for d in cec.DEVICES.values()]
+        active_device = next(filter(lambda d: d.active, cec.DEVICES.values()), None)
+        self._option = active_device.osd if active_device else None

--- a/homeassistant/components/option/command_option.py
+++ b/homeassistant/components/option/command_option.py
@@ -1,0 +1,70 @@
+"""
+homeassistant.components.option.command_option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Allows to configure custom shell commands to select an option.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/option.command_option/
+"""
+import logging
+import subprocess
+
+from homeassistant.components.option import OptionDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """ Find and return options controlled by shell commands. """
+
+    options = config.get('options', {})
+    devices = []
+
+    commands = []
+    for dev_name, properties in options.items():
+        name = properties.get('name', dev_name)
+        for cmd in properties.get('options', []):
+            commands.append((cmd.get('name', name), cmd.get('cmd', 'true')))
+        devices.append(CommandOption(name, commands))
+
+    add_devices_callback(devices)
+
+
+class CommandOption(OptionDevice):
+    """ Represents an option that can be triggered by shell commands. """
+
+    def __init__(self, name, commands):
+        self._name = name
+        self._commands = commands
+        self._option = None
+
+    @property
+    def name(self):
+        """ The name of the option. """
+        return self._name
+
+    @property
+    def option(self):
+        """ Returns none, because every option can be triggered. """
+        return self._option
+
+    @property
+    def options(self):
+        """ Returns the list of available options for this entity. """
+        return [c[0] for c in self._commands]
+
+    def switch(self, option, **kwargs):
+        """ Select the option 'option' for this entity. """
+        cmd = [c[1] for c in self._commands if c[0] == option][0]
+
+        _LOGGER.info('Running command: %s', cmd)
+
+        success = (subprocess.call(cmd, shell=True) == 0)
+
+        if success:
+            self._option = option
+        else:
+            _LOGGER.error('Command failed: %s', cmd)
+
+        return success
+

--- a/homeassistant/components/option/demo.py
+++ b/homeassistant/components/option/demo.py
@@ -1,0 +1,56 @@
+"""
+homeassistant.components.option.demo
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Demo platform that has two fake options.
+"""
+from homeassistant.components.option import OptionDevice
+from homeassistant.const import DEVICE_DEFAULT_NAME
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """ Find and return demo switches. """
+    add_devices_callback([
+        DemoOption('Channel', ['Channel 1', 'Channel 2', 'Channel 3'], 'Channel 1', None),
+        DemoOption('Level', ['Level 1', 'Level 2'], 'Level 2', 'mdi:air-conditioner')
+    ])
+
+
+class DemoOption(OptionDevice):
+    """ Provides a demo option. """
+    def __init__(self, name, options, active_option, icon):
+        self._name = name or DEVICE_DEFAULT_NAME
+        self._options = options
+        self._active_option = active_option
+        self._icon = icon
+
+    @property
+    def should_poll(self):
+        """ No polling needed for a demo switch. """
+        return False
+
+    @property
+    def name(self):
+        """ Returns the name of the device if any. """
+        return self._name
+
+    @property
+    def icon(self):
+        """ Returns the icon to use for device if any. """
+        return self._icon
+
+    @property
+    def option(self):
+        """ Returns the state of the entity. """
+        return self._active_option
+
+    @property
+    def options(self):
+        """ Returns the state of the entity. """
+        return self._options
+
+    def switch(self, option, **kwargs):
+        """ Turn the entity to option 'option'. """
+        self._active_option = option
+        self.update_ha_state()

--- a/homeassistant/components/option/services.yaml
+++ b/homeassistant/components/option/services.yaml
@@ -1,0 +1,13 @@
+# Describes the format for available options
+
+set_option:
+  description: Select an option
+
+  fields:
+    entity_id:
+      description: Name(s) of entities to turn on
+      example: 'fan.option'
+
+    option:
+      description: Name of the option to select
+      example: 'Level 1'

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -147,6 +147,8 @@ SERVICE_MOVE_UP = 'move_up'
 SERVICE_MOVE_DOWN = 'move_down'
 SERVICE_STOP = 'stop'
 
+SERVICE_SET_OPTION = 'set_option'
+
 # #### API / REMOTE ####
 SERVER_PORT = 8123
 


### PR DESCRIPTION
This pull requests adds the first implementation of the HDMI CEC bus.
It is not ready to be merged yet, but it should be the initial step to start a discussion for supporting this component.

It requires the libcec library from Pulse-Eight (from https://github.com/Pulse-Eight/libcec), including the wrappers for Python 3 of the same repositories (there don't exist any precompiled binaries, neither is it installable using pip).

Please ignore the "option"-component commits, I will rebase it as soon as this component gets merged.

Homeassistant is registered as monitoring-only unregistered device on the bus. According to the CEC specification only the TV is allowed to switch to different devices. Nevertheless, I managed to switch inputs using the "Set Stream Path" command. I don't know if this works in any combination of HDMI CEC switch-devices and TVs, so I'd be happy if this could be tested by someone else.
