### PR TITLE
Fix KeyError on 'title' when title is empty

### DIFF
--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -144,13 +144,14 @@ class MpdDevice(MediaPlayerDevice):
         name = self.currentsong.get('name', None)
         title = self.currentsong.get('title', None)
 
-        if name is None:
+        if name is None and title is None:
+            return "No information received from MPD" 
+        elif name is None:
             return title
+        elif title is None:
+            return name 
         else:
-            if title is None:
-                return name
-            else:
-                return '{}: {}'.format(name, title)
+            return '{}: {}'.format(name, title)
 
     @property
     def media_artist(self):

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -145,7 +145,7 @@ class MpdDevice(MediaPlayerDevice):
         title = self.currentsong.get('title', None)
 
         if name is None and title is None:
-             return "None"
+            return "None"
         elif name is None:
             return title
         elif title is None:

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -145,11 +145,11 @@ class MpdDevice(MediaPlayerDevice):
         title = self.currentsong.get('title', None)
 
         if name is None and title is None:
-            return "No information received from MPD" 
+             return "None"
         elif name is None:
             return title
         elif title is None:
-            return name 
+            return name
         else:
             return '{}: {}'.format(name, title)
 

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -142,12 +142,15 @@ class MpdDevice(MediaPlayerDevice):
     def media_title(self):
         """ Title of current playing media. """
         name = self.currentsong.get('name', None)
-        title = self.currentsong['title']
+        title = self.currentsong.get('title', None)
 
         if name is None:
             return title
         else:
-            return '{}: {}'.format(name, title)
+            if title is None:
+                return name
+            else:
+                return '{}: {}'.format(name, title)
 
     @property
     def media_artist(self):


### PR DESCRIPTION
When title is empty, a KeyError is thrown

---

ERROR:homeassistant.components.media_player:Error while setting up platform mpd
Traceback (most recent call last):
  File "/home/richard/home-assistant/homeassistant/helpers/entity_component.py", line 145, in _setup_platform
    self.hass, platform_config, self.add_entities, discovery_info)
  File "/home/richard/home-assistant/homeassistant/components/media_player/mpd.py", line 75, in setup_platform
    add_devices([MpdDevice(daemon, port, location, password)])
  File "/home/richard/home-assistant/homeassistant/helpers/entity_component.py", line 81, in add_entities
    entity.update_ha_state()
  File "/home/richard/home-assistant/homeassistant/helpers/entity.py", line 102, in update_ha_state
    attr = self.state_attributes or {}
  File "/home/richard/home-assistant/homeassistant/components/media_player/__init__.py", line 561, in state_attributes
    in ATTR_TO_PROPERTY if getattr(self, attr) is not None
  File "/home/richard/home-assistant/homeassistant/components/media_player/**init**.py", line 561, in <dictcomp>
    in ATTR_TO_PROPERTY if getattr(self, attr) is not None
  File "/home/richard/home-assistant/homeassistant/components/media_player/mpd.py", line 145, in media_title
    title = self.currentsong['title']
## KeyError: 'title'
