### PR TITLE
Improve wemo subscription error handling.

### DIFF
--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -12,7 +12,7 @@ from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (
     STATE_ON, STATE_OFF, STATE_STANDBY, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pywemo==0.3.4']
+REQUIREMENTS = ['pywemo==0.3.5']
 _LOGGER = logging.getLogger(__name__)
 
 _WEMO_SUBSCRIPTION_REGISTRY = None

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -12,7 +12,7 @@ from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (
     STATE_ON, STATE_OFF, STATE_STANDBY, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pywemo==0.3.5']
+REQUIREMENTS = ['pywemo==0.3.7']
 _LOGGER = logging.getLogger(__name__)
 
 _WEMO_SUBSCRIPTION_REGISTRY = None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -173,7 +173,7 @@ hikvision==0.4
 orvibo==1.1.0
 
 # homeassistant.components.switch.wemo
-pywemo==0.3.4
+pywemo==0.3.5
 
 # homeassistant.components.tellduslive
 tellive-py==0.5.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -173,7 +173,7 @@ hikvision==0.4
 orvibo==1.1.0
 
 # homeassistant.components.switch.wemo
-pywemo==0.3.5
+pywemo==0.3.7
 
 # homeassistant.components.tellduslive
 tellive-py==0.5.2


### PR DESCRIPTION
Update the pywemo library to 0.3.5 whichhandles subscription errors better.

Part of my effort to be able to remove polling from wemo (not there yet).
