### PR TITLE
Add support for deCONZ (Raspbee-GW hue-like API)

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -124,9 +124,7 @@ def setup_bridge(host, hass, add_devices_callback):
         api_name = api.get('config').get('name')
         if api_name == 'RaspBee-GW':
             bridge_type = 'deconz'
-            _LOGGER.info("Found DeCONZ gateway (%s)", api_name)
         else:
-            _LOGGER.info("Found Hue bridge (%s)", api_name)
             bridge_type = 'hue'
 
         for light_id, info in api_states.items():

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -121,10 +121,19 @@ def setup_bridge(host, hass, add_devices_callback):
 
         new_lights = []
 
+        api_name = api.get('config').get('name')
+        if api_name == 'RaspBee-GW':
+            bridge_type = 'deconz'
+            _LOGGER.info("Found DeCONZ gateway (%s)", api_name)
+        else:
+            _LOGGER.info("Found Hue bridge (%s)", api_name)
+            bridge_type = 'hue'
+
         for light_id, info in api_states.items():
             if light_id not in lights:
                 lights[light_id] = HueLight(int(light_id), info,
-                                            bridge, update_lights)
+                                            bridge, update_lights,
+                                            bridge_type=bridge_type)
                 new_lights.append(lights[light_id])
             else:
                 lights[light_id].info = info
@@ -163,11 +172,13 @@ def request_configuration(host, hass, add_devices_callback):
 class HueLight(Light):
     """ Represents a Hue light """
 
-    def __init__(self, light_id, info, bridge, update_lights):
+    # pylint: disable=too-many-arguments
+    def __init__(self, light_id, info, bridge, update_lights, bridge_type='hue'):
         self.light_id = light_id
         self.info = info
         self.bridge = bridge
         self.update_lights = update_lights
+        self.bridge_type = bridge_type
 
     @property
     def unique_id(self):
@@ -227,7 +238,7 @@ class HueLight(Light):
             command['alert'] = 'lselect'
         elif flash == FLASH_SHORT:
             command['alert'] = 'select'
-        else:
+        elif self.bridge_type == 'hue':
             command['alert'] = 'none'
 
         effect = kwargs.get(ATTR_EFFECT)
@@ -237,7 +248,7 @@ class HueLight(Light):
         elif effect == EFFECT_RANDOM:
             command['hue'] = random.randrange(0, 65535)
             command['sat'] = random.randrange(150, 254)
-        else:
+        elif self.bridge_type == 'hue':
             command['effect'] = 'none'
 
         self.bridge.set_light(self.light_id, command)

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -173,7 +173,8 @@ class HueLight(Light):
     """ Represents a Hue light """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, light_id, info, bridge, update_lights, bridge_type='hue'):
+    def __init__(self, light_id, info, bridge, update_lights,
+                 bridge_type='hue'):
         self.light_id = light_id
         self.info = info
         self.bridge = bridge


### PR DESCRIPTION
The hue-like [deCONZ API](http://dresden-elektronik.github.io/deconz-rest-doc/) for deCONZ for the [RaspBee](https://www.dresden-elektronik.de/funktechnik/solutions/wireless-light-control/raspbee/?L=1) doesn't support the none transition type, so don't send it.

This patch doesn't change behaviour with Philips hue bridges.
