### PR TITLE
Add ability to respond to events from Vera hub

### DIFF
--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -14,6 +14,8 @@ from homeassistant.components.switch.vera import VeraSwitch
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
 
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+
 REQUIREMENTS = ['https://github.com/pavoni/home-assistant-vera-api/archive/'
                 'efdba4e63d58a30bc9b36d9e01e69858af9130b8.zip'
                 '#python-vera==0.1.1']
@@ -36,10 +38,19 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     device_data = config.get('device_data', {})
 
-    controller = veraApi.VeraController(base_url)
+    vera_controller, created = veraApi.init_controller(base_url)
+
+    if created:
+        def stop_subscription(event):
+            """ Shutdown Vera subscriptions and subscription thread on exit"""
+            _LOGGER.info("Shutting down subscriptions.")
+            vera_controller.stop()
+
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_subscription)
+
     devices = []
     try:
-        devices = controller.get_devices([
+        devices = vera_controller.get_devices([
             'Switch',
             'On/Off Switch',
             'Dimmable Switch'])
@@ -54,7 +65,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         exclude = extra_data.get('exclude', False)
 
         if exclude is not True:
-            lights.append(VeraLight(device, extra_data))
+            lights.append(VeraLight(device, vera_controller, extra_data))
 
     add_devices_callback(lights)
 

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -16,7 +16,7 @@ from homeassistant.components.light import ATTR_BRIGHTNESS
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['#pyvera==0.2.1']
+REQUIREMENTS = ['pyvera==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -16,7 +16,7 @@ from homeassistant.components.light import ATTR_BRIGHTNESS
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['#pyvera==0.2.0']
+REQUIREMENTS = ['#pyvera==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -16,9 +16,7 @@ from homeassistant.components.light import ATTR_BRIGHTNESS
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['https://github.com/pavoni/home-assistant-vera-api/archive/'
-                'efdba4e63d58a30bc9b36d9e01e69858af9130b8.zip'
-                '#python-vera==0.1.1']
+REQUIREMENTS = ['#pyvera==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     ATTR_BATTERY_LEVEL, ATTR_TRIPPED, ATTR_ARMED, ATTR_LAST_TRIP_TIME,
     TEMP_CELCIUS, TEMP_FAHRENHEIT, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['#pyvera==0.2.1']
+REQUIREMENTS = ['pyvera==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -136,6 +136,11 @@ class VeraSensor(Entity):
         attr['Vera Device Id'] = self.vera_device.vera_device_id
         return attr
 
+    @property
+    def should_poll(self):
+        """ Tells Home Assistant not to poll this entity. """
+        return False
+
     def update(self):
         if self.vera_device.category == "Temperature Sensor":
             self.vera_device.refresh_value('CurrentTemperature')

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -13,7 +13,7 @@ import homeassistant.util.dt as dt_util
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL, ATTR_TRIPPED, ATTR_ARMED, ATTR_LAST_TRIP_TIME,
-    TEMP_CELCIUS, TEMP_FAHRENHEIT)
+    TEMP_CELCIUS, TEMP_FAHRENHEIT, EVENT_HOMEASSISTANT_STOP)
 
 REQUIREMENTS = ['#pyvera==0.2.0']
 
@@ -60,7 +60,8 @@ def get_devices(hass, config):
         exclude = extra_data.get('exclude', False)
 
         if exclude is not True:
-            vera_sensors.append(VeraSensor(device, controller, extra_data))
+            vera_sensors.append(
+                VeraSensor(device, vera_controller, extra_data))
 
     return vera_sensors
 

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     ATTR_BATTERY_LEVEL, ATTR_TRIPPED, ATTR_ARMED, ATTR_LAST_TRIP_TIME,
     TEMP_CELCIUS, TEMP_FAHRENHEIT, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['#pyvera==0.2.0']
+REQUIREMENTS = ['#pyvera==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -15,9 +15,7 @@ from homeassistant.const import (
     ATTR_BATTERY_LEVEL, ATTR_TRIPPED, ATTR_ARMED, ATTR_LAST_TRIP_TIME,
     TEMP_CELCIUS, TEMP_FAHRENHEIT)
 
-REQUIREMENTS = ['https://github.com/pavoni/home-assistant-vera-api/archive/'
-                'efdba4e63d58a30bc9b36d9e01e69858af9130b8.zip'
-                '#python-vera==0.1.1']
+REQUIREMENTS = ['#pyvera==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,7 +35,16 @@ def get_devices(hass, config):
 
     device_data = config.get('device_data', {})
 
-    vera_controller = veraApi.VeraController(base_url)
+    vera_controller, created = veraApi.init_controller(base_url)
+
+    if created:
+        def stop_subscription(event):
+            """ Shutdown Vera subscriptions and subscription thread on exit"""
+            _LOGGER.info("Shutting down subscriptions.")
+            vera_controller.stop()
+
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_subscription)
+
     categories = ['Temperature Sensor', 'Light Sensor', 'Sensor']
     devices = []
     try:
@@ -53,7 +60,7 @@ def get_devices(hass, config):
         exclude = extra_data.get('exclude', False)
 
         if exclude is not True:
-            vera_sensors.append(VeraSensor(device, extra_data))
+            vera_sensors.append(VeraSensor(device, controller, extra_data))
 
     return vera_sensors
 
@@ -66,8 +73,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class VeraSensor(Entity):
     """ Represents a Vera Sensor. """
 
-    def __init__(self, vera_device, extra_data=None):
+    def __init__(self, vera_device, controller, extra_data=None):
         self.vera_device = vera_device
+        self.controller = controller
         self.extra_data = extra_data
         if self.extra_data and self.extra_data.get('name'):
             self._name = self.extra_data.get('name')
@@ -75,6 +83,16 @@ class VeraSensor(Entity):
             self._name = self.vera_device.name
         self.current_value = ''
         self._temperature_units = None
+
+        self.controller.register(vera_device)
+        self.controller.on(
+            vera_device, self._update_callback)
+
+    def _update_callback(self, _device):
+        """ Called by the vera device callback to update state. """
+        _LOGGER.info(
+            'Subscription update for  %s', self.name)
+        self.update_ha_state(True)
 
     def __str__(self):
         return "%s %s %s" % (self.name, self.vera_device.deviceId, self.state)

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     ATTR_LAST_TRIP_TIME,
     EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['#pyvera==0.2.1']
+REQUIREMENTS = ['pyvera==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -13,7 +13,11 @@ import homeassistant.util.dt as dt_util
 
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.const import (
-    ATTR_BATTERY_LEVEL, ATTR_TRIPPED, ATTR_ARMED, ATTR_LAST_TRIP_TIME)
+    ATTR_BATTERY_LEVEL,
+    ATTR_TRIPPED,
+    ATTR_ARMED,
+    ATTR_LAST_TRIP_TIME,
+    EVENT_HOMEASSISTANT_STOP)
 
 REQUIREMENTS = ['https://github.com/pavoni/home-assistant-vera-api/archive/'
                 'efdba4e63d58a30bc9b36d9e01e69858af9130b8.zip'
@@ -37,7 +41,16 @@ def get_devices(hass, config):
 
     device_data = config.get('device_data', {})
 
-    vera_controller = veraApi.VeraController(base_url)
+    vera_controller, created = veraApi.init_controller(base_url)
+
+    if created:
+        def stop_subscription(event):
+            """ Shutdown Vera subscriptions and subscription thread on exit"""
+            _LOGGER.info("Shutting down subscriptions.")
+            vera_controller.stop()
+
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_subscription)
+
     devices = []
     try:
         devices = vera_controller.get_devices([
@@ -53,7 +66,8 @@ def get_devices(hass, config):
         exclude = extra_data.get('exclude', False)
 
         if exclude is not True:
-            vera_switches.append(VeraSwitch(device, extra_data))
+            vera_switches.append(
+                VeraSwitch(device, vera_controller, extra_data))
 
     return vera_switches
 
@@ -66,9 +80,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class VeraSwitch(ToggleEntity):
     """ Represents a Vera Switch. """
 
-    def __init__(self, vera_device, extra_data=None):
+    def __init__(self, vera_device, controller, extra_data=None):
         self.vera_device = vera_device
         self.extra_data = extra_data
+        self.controller = controller
         if self.extra_data and self.extra_data.get('name'):
             self._name = self.extra_data.get('name')
         else:
@@ -76,6 +91,16 @@ class VeraSwitch(ToggleEntity):
         self.is_on_status = False
         # for debouncing status check after command is sent
         self.last_command_send = 0
+
+        self.controller.register(vera_device)
+        self.controller.on(
+            vera_device, self._update_callback)
+
+    def _update_callback(self, _device):
+        """ Called by the vera device callback to update state. """
+        _LOGGER.info(
+            'Subscription update for  %s', self.name)
+        self.update_ha_state(True)
 
     @property
     def name(self):

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     ATTR_LAST_TRIP_TIME,
     EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['#pyvera==0.2.0']
+REQUIREMENTS = ['#pyvera==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -19,9 +19,7 @@ from homeassistant.const import (
     ATTR_LAST_TRIP_TIME,
     EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['https://github.com/pavoni/home-assistant-vera-api/archive/'
-                'efdba4e63d58a30bc9b36d9e01e69858af9130b8.zip'
-                '#python-vera==0.1.1']
+REQUIREMENTS = ['#pyvera==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -144,6 +144,11 @@ class VeraSwitch(ToggleEntity):
         self.is_on_status = False
 
     @property
+    def should_poll(self):
+        """ Tells Home Assistant not to poll this entity. """
+        return False
+
+    @property
     def is_on(self):
         """ True if device is on. """
         return self.is_on_status

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -59,7 +59,7 @@ tellcore-py==1.1.2
 # homeassistant.components.light.vera
 # homeassistant.components.sensor.vera
 # homeassistant.components.switch.vera
-#pyvera==0.2.0
+#pyvera==0.2.1
 
 # homeassistant.components.wink
 # homeassistant.components.light.wink

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -59,7 +59,7 @@ tellcore-py==1.1.2
 # homeassistant.components.light.vera
 # homeassistant.components.sensor.vera
 # homeassistant.components.switch.vera
-https://github.com/pavoni/home-assistant-vera-api/archive/efdba4e63d58a30bc9b36d9e01e69858af9130b8.zip#python-vera==0.1.1
+#pyvera==0.2.0
 
 # homeassistant.components.wink
 # homeassistant.components.light.wink

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -59,7 +59,7 @@ tellcore-py==1.1.2
 # homeassistant.components.light.vera
 # homeassistant.components.sensor.vera
 # homeassistant.components.switch.vera
-#pyvera==0.2.1
+pyvera==0.2.1
 
 # homeassistant.components.wink
 # homeassistant.components.light.wink


### PR DESCRIPTION
This PR, based on the code from pywemo, adds an ability to respond to events from a Vera controller. 

The events come from a 'long poll' which runs on a dedicated thread - and fires events when it gets them, based on the approach described here:-
http://wiki.micasaverde.com/index.php/UI_Simple

It also switches to an updated pyvera library released into pipy as suggested by @balloob 
