### PR TITLE
Update Locative component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -41,7 +41,6 @@ omit =
     homeassistant/components/device_tracker/asuswrt.py
     homeassistant/components/device_tracker/ddwrt.py
     homeassistant/components/device_tracker/fritz.py
-    homeassistant/components/device_tracker/locative.py
     homeassistant/components/device_tracker/icloud.py
     homeassistant/components/device_tracker/luci.py
     homeassistant/components/device_tracker/netgear.py

--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -33,7 +33,6 @@ def setup_scanner(hass, config, see):
     return True
 
 
-# TODO: What happens with HA turns off?
 def _handle_get_api_locative(hass, see, handler, path_match, data):
     """ Locative message received. """
 
@@ -58,26 +57,31 @@ def _handle_get_api_locative(hass, see, handler, path_match, data):
 
         if "zone.{}".format(location_name.lower()) in zones:
             see(dev_id=device, location_name=location_name)
-            handler.write_json_message("Set new location to {}".format(location_name))
+            handler.write_json_message(
+                "Set new location to {}".format(location_name))
         else:
             see(dev_id=device, gps=gps_coords)
-            handler.write_json_message("Set new location to {}".format(gps_coords))
+            handler.write_json_message(
+                "Set new location to {}".format(gps_coords))
 
     elif direction == 'exit':
-        current_zone = hass.states.get("{}.{}".format("device_tracker", device)).state
+        current_zone = hass.states.get(
+            "{}.{}".format("device_tracker", device)).state
 
         if current_zone.lower() == location_name.lower():
             see(dev_id=device, location_name=STATE_NOT_HOME)
             handler.write_json_message("Set new location to not home")
         else:
-            # Ignore the message if it is telling us to exit a zone that we aren't
-            # currently in. This occurs when a zone is entered before the previous
-            # zone was exited. The enter message will be sent first, then the exit
-            # message will be sent second.
-            handler.write_json_message("Ignoring transition to {}".format(location_name))
+            # Ignore the message if it is telling us to exit a zone that we
+            # aren't currently in. This occurs when a zone is entered before
+            # the previous zone was exited. The enter message will be sent
+            # first, then the exit message will be sent second.
+            handler.write_json_message(
+                "Ignoring transition to {}".format(location_name))
 
     else:
-        handler.write_json_message("Received unidentified message: {}".format(direction))
+        handler.write_json_message(
+            "Received unidentified message: {}".format(direction))
         _LOGGER.error("Received unidentified message from Locative: %s",
                       direction)
 
@@ -115,4 +119,3 @@ def _check_data(handler, data):
         return False
 
     return True
-

--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -10,7 +10,7 @@ import logging
 from functools import partial
 
 from homeassistant.const import (
-    HTTP_UNPROCESSABLE_ENTITY, HTTP_INTERNAL_SERVER_ERROR, STATE_NOT_HOME)
+    HTTP_UNPROCESSABLE_ENTITY, STATE_NOT_HOME)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,11 +57,11 @@ def _handle_get_api_locative(hass, see, handler, path_match, data):
         if "zone.{}".format(location_name) in zones:
             see(dev_id=device, location_name=location_name)
             handler.write_text(
-                "Set new location to {}".format(location_name))
+                "Setting location to {}".format(location_name))
         else:
             see(dev_id=device, gps=gps_coords)
             handler.write_text(
-                "Set new location to {}".format(gps_coords))
+                "Setting location to {}".format(gps_coords))
 
     elif direction == 'exit':
         current_zone = hass.states.get(
@@ -69,14 +69,14 @@ def _handle_get_api_locative(hass, see, handler, path_match, data):
 
         if current_zone == location_name:
             see(dev_id=device, location_name=STATE_NOT_HOME)
-            handler.write_text("Set new location to not home")
+            handler.write_text("Setting location to not home")
         else:
             # Ignore the message if it is telling us to exit a zone that we
             # aren't currently in. This occurs when a zone is entered before
             # the previous zone was exited. The enter message will be sent
             # first, then the exit message will be sent second.
             handler.write_text(
-                'Ignoring exit from "{}". Already in "{}".'.format(
+                'Ignoring exit from {} (already in {})'.format(
                     location_name,
                     current_zone.split('.')[-1]))
 
@@ -94,13 +94,6 @@ def _handle_get_api_locative(hass, see, handler, path_match, data):
 
 
 def _check_data(handler, data):
-    if not isinstance(data, dict):
-        handler.write_text("Error while parsing Locative message.",
-                           HTTP_INTERNAL_SERVER_ERROR)
-        _LOGGER.error("Error while parsing Locative message: "
-                      "data is not a dict.")
-        return False
-
     if 'latitude' not in data or 'longitude' not in data:
         handler.write_text("Latitude and longitude not specified.",
                            HTTP_UNPROCESSABLE_ENTITY)

--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -77,7 +77,12 @@ def _handle_get_api_locative(hass, see, handler, path_match, data):
             # the previous zone was exited. The enter message will be sent
             # first, then the exit message will be sent second.
             handler.write_json_message(
-                "Ignoring transition to {}".format(location_name))
+                "Ignoring transition from {}".format(location_name))
+
+    elif direction == 'test':
+        # In the app, a test message can be sent. Just return something to
+        # the user to let them know that it works.
+        handler.write_text("Received test message.")
 
     else:
         handler.write_json_message(

--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -46,8 +46,8 @@ def _handle_get_api_locative(hass, see, handler, path_match, data):
     try:
         gps_coords = (float(data['latitude']), float(data['longitude']))
     except ValueError:
-        handler.write_json_message("Invalid latitude / longitude format.",
-                                   HTTP_UNPROCESSABLE_ENTITY)
+        handler.write_text("Invalid latitude / longitude format.",
+                           HTTP_UNPROCESSABLE_ENTITY)
         _LOGGER.error("Received invalid latitude / longitude format.")
         return
 
@@ -57,11 +57,11 @@ def _handle_get_api_locative(hass, see, handler, path_match, data):
 
         if "zone.{}".format(location_name.lower()) in zones:
             see(dev_id=device, location_name=location_name)
-            handler.write_json_message(
+            handler.write_text(
                 "Set new location to {}".format(location_name))
         else:
             see(dev_id=device, gps=gps_coords)
-            handler.write_json_message(
+            handler.write_text(
                 "Set new location to {}".format(gps_coords))
 
     elif direction == 'exit':
@@ -70,13 +70,13 @@ def _handle_get_api_locative(hass, see, handler, path_match, data):
 
         if current_zone.lower() == location_name.lower():
             see(dev_id=device, location_name=STATE_NOT_HOME)
-            handler.write_json_message("Set new location to not home")
+            handler.write_text("Set new location to not home")
         else:
             # Ignore the message if it is telling us to exit a zone that we
             # aren't currently in. This occurs when a zone is entered before
             # the previous zone was exited. The enter message will be sent
             # first, then the exit message will be sent second.
-            handler.write_json_message(
+            handler.write_text(
                 "Ignoring transition from {}".format(location_name))
 
     elif direction == 'test':
@@ -85,7 +85,7 @@ def _handle_get_api_locative(hass, see, handler, path_match, data):
         handler.write_text("Received test message.")
 
     else:
-        handler.write_json_message(
+        handler.write_text(
             "Received unidentified message: {}".format(direction))
         _LOGGER.error("Received unidentified message from Locative: %s",
                       direction)
@@ -93,33 +93,33 @@ def _handle_get_api_locative(hass, see, handler, path_match, data):
 
 def _check_data(handler, data):
     if not isinstance(data, dict):
-        handler.write_json_message("Error while parsing Locative message.",
-                                   HTTP_INTERNAL_SERVER_ERROR)
+        handler.write_text("Error while parsing Locative message.",
+                           HTTP_INTERNAL_SERVER_ERROR)
         _LOGGER.error("Error while parsing Locative message: "
                       "data is not a dict.")
         return False
 
     if 'latitude' not in data or 'longitude' not in data:
-        handler.write_json_message("Latitude and longitude not specified.",
-                                   HTTP_UNPROCESSABLE_ENTITY)
+        handler.write_text("Latitude and longitude not specified.",
+                           HTTP_UNPROCESSABLE_ENTITY)
         _LOGGER.error("Latitude and longitude not specified.")
         return False
 
     if 'device' not in data:
-        handler.write_json_message("Device id not specified.",
-                                   HTTP_UNPROCESSABLE_ENTITY)
+        handler.write_text("Device id not specified.",
+                           HTTP_UNPROCESSABLE_ENTITY)
         _LOGGER.error("Device id not specified.")
         return False
 
     if 'id' not in data:
-        handler.write_json_message("Location id not specified.",
-                                   HTTP_UNPROCESSABLE_ENTITY)
+        handler.write_text("Location id not specified.",
+                           HTTP_UNPROCESSABLE_ENTITY)
         _LOGGER.error("Location id not specified.")
         return False
 
     if 'trigger' not in data:
-        handler.write_json_message("Trigger is not specified.",
-                                   HTTP_UNPROCESSABLE_ENTITY)
+        handler.write_text("Trigger is not specified.",
+                           HTTP_UNPROCESSABLE_ENTITY)
         _LOGGER.error("Trigger is not specified.")
         return False
 

--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -6,12 +6,15 @@ Locative platform for the device tracker.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.locative/
 """
+import logging
+from functools import partial
+
 from homeassistant.const import (
-    HTTP_UNPROCESSABLE_ENTITY, HTTP_INTERNAL_SERVER_ERROR)
+    HTTP_UNPROCESSABLE_ENTITY, HTTP_INTERNAL_SERVER_ERROR, STATE_NOT_HOME)
 
-DEPENDENCIES = ['http']
+_LOGGER = logging.getLogger(__name__)
 
-_SEE = 0
+DEPENDENCIES = ['http', 'zone']
 
 URL_API_LOCATIVE_ENDPOINT = "/api/locative"
 
@@ -19,52 +22,97 @@ URL_API_LOCATIVE_ENDPOINT = "/api/locative"
 def setup_scanner(hass, config, see):
     """ Set up an endpoint for the Locative app. """
 
-    # Use a global variable to keep setup_scanner compact when using a callback
-    global _SEE
-    _SEE = see
-
     # POST would be semantically better, but that currently does not work
     # since Locative sends the data as key1=value1&key2=value2
     # in the request body, while Home Assistant expects json there.
 
     hass.http.register_path(
-        'GET', URL_API_LOCATIVE_ENDPOINT, _handle_get_api_locative)
+        'GET', URL_API_LOCATIVE_ENDPOINT,
+        partial(_handle_get_api_locative, hass, see))
 
     return True
 
 
-def _handle_get_api_locative(handler, path_match, data):
+# TODO: What happens with HA turns off?
+def _handle_get_api_locative(hass, see, handler, path_match, data):
     """ Locative message received. """
 
-    if not isinstance(data, dict):
-        handler.write_json_message(
-            "Error while parsing Locative message.",
-            HTTP_INTERNAL_SERVER_ERROR)
+    if not _check_data(handler, data):
         return
-    if 'latitude' not in data or 'longitude' not in data:
-        handler.write_json_message(
-            "Location not specified.",
-            HTTP_UNPROCESSABLE_ENTITY)
-        return
-    if 'device' not in data or 'id' not in data:
-        handler.write_json_message(
-            "Device id or location id not specified.",
-            HTTP_UNPROCESSABLE_ENTITY)
-        return
+
+    device = data['device'].replace('-', '')
+    location_name = data['id']
+    direction = data['trigger']
 
     try:
         gps_coords = (float(data['latitude']), float(data['longitude']))
     except ValueError:
-        # If invalid latitude / longitude format
-        handler.write_json_message(
-            "Invalid latitude / longitude format.",
-            HTTP_UNPROCESSABLE_ENTITY)
+        handler.write_json_message("Invalid latitude / longitude format.",
+                                   HTTP_UNPROCESSABLE_ENTITY)
+        _LOGGER.error("Received invalid latitude / longitude format.")
         return
 
-    # entity id's in Home Assistant must be alphanumerical
-    device_uuid = data['device']
-    device_entity_id = device_uuid.replace('-', '')
+    if direction == 'enter':
+        zones = [state for state in hass.states.entity_ids('zone')]
+        _LOGGER.info(zones)
 
-    _SEE(dev_id=device_entity_id, gps=gps_coords, location_name=data['id'])
+        if "zone.{}".format(location_name.lower()) in zones:
+            see(dev_id=device, location_name=location_name)
+            handler.write_json_message("Set new location to {}".format(location_name))
+        else:
+            see(dev_id=device, gps=gps_coords)
+            handler.write_json_message("Set new location to {}".format(gps_coords))
 
-    handler.write_json_message("Locative message processed")
+    elif direction == 'exit':
+        current_zone = hass.states.get("{}.{}".format("device_tracker", device)).state
+
+        if current_zone.lower() == location_name.lower():
+            see(dev_id=device, location_name=STATE_NOT_HOME)
+            handler.write_json_message("Set new location to not home")
+        else:
+            # Ignore the message if it is telling us to exit a zone that we aren't
+            # currently in. This occurs when a zone is entered before the previous
+            # zone was exited. The enter message will be sent first, then the exit
+            # message will be sent second.
+            handler.write_json_message("Ignoring transition to {}".format(location_name))
+
+    else:
+        handler.write_json_message("Received unidentified message: {}".format(direction))
+        _LOGGER.error("Received unidentified message from Locative: %s",
+                      direction)
+
+
+def _check_data(handler, data):
+    if not isinstance(data, dict):
+        handler.write_json_message("Error while parsing Locative message.",
+                                   HTTP_INTERNAL_SERVER_ERROR)
+        _LOGGER.error("Error while parsing Locative message: "
+                      "data is not a dict.")
+        return False
+
+    if 'latitude' not in data or 'longitude' not in data:
+        handler.write_json_message("Latitude and longitude not specified.",
+                                   HTTP_UNPROCESSABLE_ENTITY)
+        _LOGGER.error("Latitude and longitude not specified.")
+        return False
+
+    if 'device' not in data:
+        handler.write_json_message("Device id not specified.",
+                                   HTTP_UNPROCESSABLE_ENTITY)
+        _LOGGER.error("Device id not specified.")
+        return False
+
+    if 'id' not in data:
+        handler.write_json_message("Location id not specified.",
+                                   HTTP_UNPROCESSABLE_ENTITY)
+        _LOGGER.error("Location id not specified.")
+        return False
+
+    if 'trigger' not in data:
+        handler.write_json_message("Trigger is not specified.",
+                                   HTTP_UNPROCESSABLE_ENTITY)
+        _LOGGER.error("Trigger is not specified.")
+        return False
+
+    return True
+

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -21,7 +21,7 @@ from urllib.parse import urlparse, parse_qs
 
 import homeassistant.core as ha
 from homeassistant.const import (
-    SERVER_PORT, CONTENT_TYPE_JSON,
+    SERVER_PORT, CONTENT_TYPE_JSON, CONTENT_TYPE_TEXT_PLAIN,
     HTTP_HEADER_HA_AUTH, HTTP_HEADER_CONTENT_TYPE, HTTP_HEADER_ACCEPT_ENCODING,
     HTTP_HEADER_CONTENT_ENCODING, HTTP_HEADER_VARY, HTTP_HEADER_CONTENT_LENGTH,
     HTTP_HEADER_CACHE_CONTROL, HTTP_HEADER_EXPIRES, HTTP_OK, HTTP_UNAUTHORIZED,
@@ -292,6 +292,18 @@ class RequestHandler(SimpleHTTPRequestHandler):
             self.wfile.write(
                 json.dumps(data, indent=4, sort_keys=True,
                            cls=rem.JSONEncoder).encode("UTF-8"))
+
+    def write_text(self, message, status_code=HTTP_OK):
+        """ Helper method to return a text message to the caller. """
+        self.send_response(status_code)
+        self.send_header(HTTP_HEADER_CONTENT_TYPE, CONTENT_TYPE_TEXT_PLAIN)
+
+        self.set_session_cookie_header()
+
+        self.end_headers()
+
+        if message is not None:
+            self.wfile.write(message.encode("UTF-8"))
 
     def write_file(self, path, cache_headers=True):
         """ Returns a file to the user. """

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -302,8 +302,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
 
         self.end_headers()
 
-        if message is not None:
-            self.wfile.write(message.encode("UTF-8"))
+        self.wfile.write(message.encode("UTF-8"))
 
     def write_file(self, path, cache_headers=True):
         """ Returns a file to the user. """

--- a/tests/components/device_tracker/test_locative.py
+++ b/tests/components/device_tracker/test_locative.py
@@ -1,0 +1,246 @@
+"""
+tests.components.device_tracker.locative
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests the locative device tracker component.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import requests
+
+from homeassistant import bootstrap, const
+import homeassistant.core as ha
+import homeassistant.components.device_tracker as device_tracker
+import homeassistant.components.http as http
+import homeassistant.components.zone as zone
+
+SERVER_PORT = 8126
+HTTP_BASE_URL = "http://127.0.0.1:{}".format(SERVER_PORT)
+
+hass = None
+
+
+def _url(data={}):
+    """ Helper method to generate urls. """
+    data = "&".join(["{}={}".format(name, value) for name, value in data.items()])
+    return "{}{}locative?{}".format(HTTP_BASE_URL, const.URL_API, data)
+
+
+@patch('homeassistant.components.http.util.get_local_ip',
+       return_value='127.0.0.1')
+def setUpModule(mock_get_local_ip):   # pylint: disable=invalid-name
+    """ Initalizes a Home Assistant server. """
+    global hass
+
+    hass = ha.HomeAssistant()
+
+    # Set up a couple of zones
+    bootstrap.setup_component(hass, zone.DOMAIN, {
+        zone.DOMAIN: [
+            {
+                'name': 'Home',
+                'latitude': 41.7855,
+                'longitude': -110.7367,
+                'radius': 200
+            },
+            {
+                'name': 'Work',
+                'latitude': 41.5855,
+                'longitude': -110.9367,
+                'radius': 100
+            }
+        ]
+    })
+
+    # Set up server
+    bootstrap.setup_component(hass, http.DOMAIN, {
+        http.DOMAIN: {
+            http.CONF_SERVER_PORT: SERVER_PORT
+        }
+    })
+
+    # Set up API
+    bootstrap.setup_component(hass, 'api')
+
+    # Set up device tracker
+    bootstrap.setup_component(hass, device_tracker.DOMAIN, {
+        device_tracker.DOMAIN: {
+            'platform': 'locative'
+        }
+    })
+
+    hass.start()
+
+
+def tearDownModule():   # pylint: disable=invalid-name
+    """ Stops the Home Assistant server. """
+    hass.stop()
+
+
+class TestLocative(unittest.TestCase):
+    """ Test Locative """
+
+    def test_missing_data(self):
+        data = {
+            'latitude': 1.0,
+            'longitude': 1.1,
+            'device': '123',
+            'id': 'Home',
+            'trigger': 'enter'
+        }
+
+        # No data
+        req = requests.get(_url({}))
+        self.assertEqual(422, req.status_code)
+
+        # No latitude
+        copy = data.copy()
+        del copy['latitude']
+        req = requests.get(_url(copy))
+        self.assertEqual(422, req.status_code)
+
+        # No device
+        copy = data.copy()
+        del copy['device']
+        req = requests.get(_url(copy))
+        self.assertEqual(422, req.status_code)
+
+        # No location
+        copy = data.copy()
+        del copy['id']
+        req = requests.get(_url(copy))
+        self.assertEqual(422, req.status_code)
+
+        # No trigger
+        copy = data.copy()
+        del copy['trigger']
+        req = requests.get(_url(copy))
+        self.assertEqual(422, req.status_code)
+
+        # Bad longitude
+        copy = data.copy()
+        copy['longitude'] = 'hello world'
+        req = requests.get(_url(copy))
+        self.assertEqual(422, req.status_code)
+
+        # Test message
+        copy = data.copy()
+        copy['trigger'] = 'test'
+        req = requests.get(_url(copy))
+        self.assertEqual(200, req.status_code)
+
+        # Unknown trigger
+        copy = data.copy()
+        copy['trigger'] = 'foobar'
+        req = requests.get(_url(copy))
+        self.assertEqual(422, req.status_code)
+
+
+    def test_known_zone(self):
+        """ Test when there is a known zone """
+        data = {
+            'latitude': 40.7855,
+            'longitude': -111.7367,
+            'device': '123',
+            'id': 'Home',
+            'trigger': 'enter'
+        }
+
+        # Enter the Home
+        req = requests.get(_url(data))
+        self.assertEqual(200, req.status_code)
+        state_name = hass.states.get('{}.{}'.format('device_tracker', data['device'])).state
+        self.assertEqual(state_name, 'home')
+
+        data['id'] = 'HOME'
+        data['trigger'] = 'exit'
+
+        # Exit Home
+        req = requests.get(_url(data))
+        self.assertEqual(200, req.status_code)
+        state_name = hass.states.get('{}.{}'.format('device_tracker', data['device'])).state
+        self.assertEqual(state_name, 'not_home')
+
+        data['id'] = 'hOmE'
+        data['trigger'] = 'enter'
+
+        # Enter Home again
+        req = requests.get(_url(data))
+        self.assertEqual(200, req.status_code)
+        state_name = hass.states.get('{}.{}'.format('device_tracker', data['device'])).state
+        self.assertEqual(state_name, 'home')
+
+
+    def test_unknown_zone(self):
+        """ Test when there is no known zone """
+        data = {
+            'latitude': 40.7855,
+            'longitude': -111.7367,
+            'device': '123',
+            'id': 'Foobar',
+            'trigger': 'enter'
+        }
+
+        # Enter Foobar
+        req = requests.get(_url(data))
+        self.assertEqual(200, req.status_code)
+
+        state = hass.states.get('{}.{}'.format('device_tracker', data['device']))
+        self.assertEqual(state.state, 'not_home')
+        self.assertEqual(state.attributes['latitude'], data['latitude'])
+        self.assertEqual(state.attributes['longitude'], data['longitude'])
+
+        data['trigger'] = 'exit'
+
+        # Exit Foobar
+        req = requests.get(_url(data))
+        self.assertEqual(200, req.status_code)
+
+        state = hass.states.get('{}.{}'.format('device_tracker', data['device']))
+        self.assertEqual(state.state, 'not_home')
+        self.assertEqual(state.attributes['latitude'], data['latitude'])
+        self.assertEqual(state.attributes['longitude'], data['longitude'])
+
+
+    def test_exit_after_enter(self):
+        """ Test when an exit message comes after an enter message """
+
+        data = {
+            'latitude': 40.7855,
+            'longitude': -111.7367,
+            'device': '123',
+            'id': 'Home',
+            'trigger': 'enter'
+        }
+
+        # Enter Home
+        req = requests.get(_url(data))
+        self.assertEqual(200, req.status_code)
+
+        state = hass.states.get('{}.{}'.format('device_tracker', data['device']))
+        self.assertEqual(state.state, 'home')
+
+        data['id'] = 'Work'
+
+        # Enter Work
+        req = requests.get(_url(data))
+        self.assertEqual(200, req.status_code)
+
+        state = hass.states.get('{}.{}'.format('device_tracker', data['device']))
+        self.assertEqual(state.state, 'work')
+
+        data['id'] = 'Home'
+        data['trigger'] = 'exit'
+
+        # Exit Home
+        req = requests.get(_url(data))
+        self.assertEqual(200, req.status_code)
+
+        state = hass.states.get('{}.{}'.format('device_tracker', data['device']))
+        self.assertEqual(state.state, 'work')
+
+        print(req.text)
+
+

--- a/tests/components/device_tracker/test_locative.py
+++ b/tests/components/device_tracker/test_locative.py
@@ -78,11 +78,12 @@ def tearDownModule():   # pylint: disable=invalid-name
     """ Stops the Home Assistant server. """
     hass.stop()
 
-
+# Stub out update_config or else Travis CI raises an exception
+@patch('homeassistant.components.device_tracker.update_config')
 class TestLocative(unittest.TestCase):
     """ Test Locative """
 
-    def test_missing_data(self):
+    def test_missing_data(self, update_config):
         data = {
             'latitude': 1.0,
             'longitude': 1.1,
@@ -138,7 +139,7 @@ class TestLocative(unittest.TestCase):
         self.assertEqual(422, req.status_code)
 
 
-    def test_known_zone(self):
+    def test_known_zone(self, update_config):
         """ Test when there is a known zone """
         data = {
             'latitude': 40.7855,
@@ -173,7 +174,7 @@ class TestLocative(unittest.TestCase):
         self.assertEqual(state_name, 'home')
 
 
-    def test_unknown_zone(self):
+    def test_unknown_zone(self, update_config):
         """ Test when there is no known zone """
         data = {
             'latitude': 40.7855,
@@ -204,7 +205,7 @@ class TestLocative(unittest.TestCase):
         self.assertEqual(state.attributes['longitude'], data['longitude'])
 
 
-    def test_exit_after_enter(self):
+    def test_exit_after_enter(self, update_config):
         """ Test when an exit message comes after an enter message """
 
         data = {
@@ -240,7 +241,3 @@ class TestLocative(unittest.TestCase):
 
         state = hass.states.get('{}.{}'.format('device_tracker', data['device']))
         self.assertEqual(state.state, 'work')
-
-        print(req.text)
-
-


### PR DESCRIPTION
I have updated the Locative (previously Geofancy) component. Previously, when a geofence was crossed, the name of that geofence was set as the location in HA. This wasn't super useful because there was no logic to handle when you exit a geofence, just entering. These changes would close PR #537 and #543.

I have set up the component to now handle entering and exiting a geofence (Locative can detect both events). The general logic goes as follows:
- If you enter a geofence, the name of the geofence in Locative is used as the location name in HA.
- If you exit a geofence and name of the geofence in Locative you are exiting is the same as your current location in HA, your location is set to "not home". The extra condition is to protect when you enter a zone before exiting another zone. Locative will first send an enter message, followed by an exit message.

One thing I am struggling with is how to set the state when HA is first started. Currently it defaults to "not home". This isn't a problem if Locative is used with another device tracker (like nmap), but if it is used by itself, your location will be "not home" until you enter a geofence. Is there any way around this?

If this PR gets accepted, I will write documentation on how to set up Locative to work with HA.
