### PR TITLE
Interpolate what we are sending to influx so its not always a string

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -7,7 +7,6 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/influxdb/
 """
 import logging
-
 import homeassistant.util as util
 from homeassistant.helpers import validate_config
 from homeassistant.const import (EVENT_STATE_CHANGED, STATE_ON, STATE_OFF,
@@ -77,6 +76,10 @@ def setup(hass, config):
             _state = 0
         else:
             _state = state.state
+            try:
+                _state = float(_state)
+            except ValueError:
+                pass
 
         measurement = state.attributes.get('unit_of_measurement', state.domain)
 


### PR DESCRIPTION
Fixes: #821 
Currently everything we send to influx is a string. It seems like the events that are triggered always have a _state value of string. Although other places in the system where we generate JSON it is generated with the correct types. 

Also in cases where we send an integer for something like degrees F and other sensors send an integer influx gets upset about types. So if I see an integer I just convert it to a float so that different sensors reporting data to the same measurement all end up having the same type in influx. 

On restarting the service I still see a few initial influxdb errors that i haven't squashed yet.... they are also related to the type of data being pushed to the influxdb database. I just have not figured out why it only happens on startup yet.  
