### PR TITLE
Fix reference known_devices.yaml in service description

### DIFF
--- a/homeassistant/components/device_tracker/services.yaml
+++ b/homeassistant/components/device_tracker/services.yaml
@@ -9,7 +9,7 @@ see:
       example: 'FF:FF:FF:FF:FF:FF'
 
     dev_id:
-      description: Id of device (find id in tracked_devices.yaml)
+      description: Id of device (find id in known_devices.yaml)
       example: 'phonedave'
 
     host_name:


### PR DESCRIPTION
Fix for a bad reference to known_devices.yaml in device tracker see service description.
