### PR TITLE
Fix for sun if condition

### DIFF
--- a/homeassistant/components/automation/sun.py
+++ b/homeassistant/components/automation/sun.py
@@ -82,21 +82,21 @@ def if_action(hass, config):
     if before is None:
         before_func = lambda: None
     elif before == EVENT_SUNRISE:
-        before_func = lambda: sun.next_rising_utc(hass) + before_offset
+        before_func = lambda: sun.next_rising(hass) + before_offset
     else:
-        before_func = lambda: sun.next_setting_utc(hass) + before_offset
+        before_func = lambda: sun.next_setting(hass) + before_offset
 
     if after is None:
         after_func = lambda: None
     elif after == EVENT_SUNRISE:
-        after_func = lambda: sun.next_rising_utc(hass) + after_offset
+        after_func = lambda: sun.next_rising(hass) + after_offset
     else:
-        after_func = lambda: sun.next_setting_utc(hass) + after_offset
+        after_func = lambda: sun.next_setting(hass) + after_offset
 
     def time_if():
         """ Validate time based if-condition """
 
-        now = dt_util.utcnow()
+        now = dt_util.now()
         before = before_func()
         after = after_func()
 

--- a/tests/components/automation/test_sun.py
+++ b/tests/components/automation/test_sun.py
@@ -162,14 +162,14 @@ class TestAutomationSun(unittest.TestCase):
         })
 
         now = datetime(2015, 9, 16, 15, tzinfo=dt_util.UTC)
-        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+        with patch('homeassistant.components.automation.sun.dt_util.now',
                    return_value=now):
             self.hass.bus.fire('test_event')
             self.hass.pool.block_till_done()
             self.assertEqual(0, len(self.calls))
 
         now = datetime(2015, 9, 16, 10, tzinfo=dt_util.UTC)
-        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+        with patch('homeassistant.components.automation.sun.dt_util.now',
                    return_value=now):
             self.hass.bus.fire('test_event')
             self.hass.pool.block_till_done()
@@ -197,14 +197,14 @@ class TestAutomationSun(unittest.TestCase):
         })
 
         now = datetime(2015, 9, 16, 13, tzinfo=dt_util.UTC)
-        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+        with patch('homeassistant.components.automation.sun.dt_util.now',
                    return_value=now):
             self.hass.bus.fire('test_event')
             self.hass.pool.block_till_done()
             self.assertEqual(0, len(self.calls))
 
         now = datetime(2015, 9, 16, 15, tzinfo=dt_util.UTC)
-        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+        with patch('homeassistant.components.automation.sun.dt_util.now',
                    return_value=now):
             self.hass.bus.fire('test_event')
             self.hass.pool.block_till_done()
@@ -233,14 +233,14 @@ class TestAutomationSun(unittest.TestCase):
         })
 
         now = datetime(2015, 9, 16, 15, 1, tzinfo=dt_util.UTC)
-        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+        with patch('homeassistant.components.automation.sun.dt_util.now',
                    return_value=now):
             self.hass.bus.fire('test_event')
             self.hass.pool.block_till_done()
             self.assertEqual(0, len(self.calls))
 
         now = datetime(2015, 9, 16, 15, tzinfo=dt_util.UTC)
-        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+        with patch('homeassistant.components.automation.sun.dt_util.now',
                    return_value=now):
             self.hass.bus.fire('test_event')
             self.hass.pool.block_till_done()
@@ -269,14 +269,14 @@ class TestAutomationSun(unittest.TestCase):
         })
 
         now = datetime(2015, 9, 16, 14, 59, tzinfo=dt_util.UTC)
-        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+        with patch('homeassistant.components.automation.sun.dt_util.now',
                    return_value=now):
             self.hass.bus.fire('test_event')
             self.hass.pool.block_till_done()
             self.assertEqual(0, len(self.calls))
 
         now = datetime(2015, 9, 16, 15, tzinfo=dt_util.UTC)
-        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+        with patch('homeassistant.components.automation.sun.dt_util.now',
                    return_value=now):
             self.hass.bus.fire('test_event')
             self.hass.pool.block_till_done()
@@ -306,21 +306,60 @@ class TestAutomationSun(unittest.TestCase):
         })
 
         now = datetime(2015, 9, 16, 9, 59, tzinfo=dt_util.UTC)
-        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+        with patch('homeassistant.components.automation.sun.dt_util.now',
                    return_value=now):
             self.hass.bus.fire('test_event')
             self.hass.pool.block_till_done()
             self.assertEqual(0, len(self.calls))
 
         now = datetime(2015, 9, 16, 15, 1, tzinfo=dt_util.UTC)
-        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+        with patch('homeassistant.components.automation.sun.dt_util.now',
                    return_value=now):
             self.hass.bus.fire('test_event')
             self.hass.pool.block_till_done()
             self.assertEqual(0, len(self.calls))
 
         now = datetime(2015, 9, 16, 12, tzinfo=dt_util.UTC)
-        with patch('homeassistant.components.automation.sun.dt_util.utcnow',
+        with patch('homeassistant.components.automation.sun.dt_util.now',
+                   return_value=now):
+            self.hass.bus.fire('test_event')
+            self.hass.pool.block_till_done()
+            self.assertEqual(1, len(self.calls))
+
+    def test_if_action_after_different_tz(self):
+        import pytz
+
+        self.hass.states.set(sun.ENTITY_ID, sun.STATE_ABOVE_HORIZON, {
+            sun.STATE_ATTR_NEXT_SETTING: '17:30:00 16-09-2015',
+        })
+
+        automation.setup(self.hass, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'event',
+                    'event_type': 'test_event',
+                },
+                'condition': {
+                    'platform': 'sun',
+                    'after': 'sunset',
+                },
+                'action': {
+                    'service': 'test.automation'
+                }
+            }
+        })
+
+        # Before
+        now = datetime(2015, 9, 16, 17, tzinfo=pytz.timezone('US/Mountain'))
+        with patch('homeassistant.components.automation.sun.dt_util.now',
+                   return_value=now):
+            self.hass.bus.fire('test_event')
+            self.hass.pool.block_till_done()
+            self.assertEqual(0, len(self.calls))
+
+        # After
+        now = datetime(2015, 9, 16, 18, tzinfo=pytz.timezone('US/Mountain'))
+        with patch('homeassistant.components.automation.sun.dt_util.now',
                    return_value=now):
             self.hass.bus.fire('test_event')
             self.hass.pool.block_till_done()


### PR DESCRIPTION
Fix a bug in the sun condition and added a test. The problem was that it was using UTC time rather than local time. This caused the day boundaries to be shifted. Here is an example:

```
automation:
  trigger:
    platform: event
    event_type: custom_event
  condition:
    platform: sun
    after: sunset
```

Say the event fired at 20:00 MST and the sun set at 16:00 MST. Clearly the event fired after the sun set (20:00 > 16:00). For UTC, the event fired at 03:00 and the sun set at 23:00. According to this, the event occurred before the sunset. Only using local time solves this problem.
