### PR TITLE
Fix calling turn_on for groups with mixed content

### DIFF
--- a/homeassistant/helpers/__init__.py
+++ b/homeassistant/helpers/__init__.py
@@ -36,7 +36,7 @@ def extract_entity_ids(hass, service):
     service_ent_id = service.data[ATTR_ENTITY_ID]
 
     if isinstance(service_ent_id, str):
-        return group.expand_entity_ids(hass, [service_ent_id.lower()])
+        return group.expand_entity_ids(hass, [service_ent_id])
 
     return [ent_id for ent_id in group.expand_entity_ids(hass, service_ent_id)]
 

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -6,12 +6,14 @@ Tests core compoments.
 """
 # pylint: disable=protected-access,too-many-public-methods
 import unittest
+from unittest.mock import patch
 
 import homeassistant.core as ha
-import homeassistant.loader as loader
 from homeassistant.const import (
     STATE_ON, STATE_OFF, SERVICE_TURN_ON, SERVICE_TURN_OFF)
 import homeassistant.components as comps
+
+from tests.common import get_test_home_assistant
 
 
 class TestComponentsCore(unittest.TestCase):
@@ -19,7 +21,7 @@ class TestComponentsCore(unittest.TestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         """ Init needed objects. """
-        self.hass = ha.HomeAssistant()
+        self.hass = get_test_home_assistant()
         self.assertTrue(comps.setup(self.hass, {}))
 
         self.hass.states.set('light.Bowl', STATE_ON)
@@ -58,3 +60,24 @@ class TestComponentsCore(unittest.TestCase):
         self.hass.pool.block_till_done()
 
         self.assertEqual(1, len(runs))
+
+    @patch('homeassistant.core.ServiceRegistry.call')
+    def test_turn_on_to_not_block_for_domains_without_service(self, mock_call):
+        self.hass.services.register('light', SERVICE_TURN_ON, lambda x: x)
+
+        # We can't test if our service call results in services being called
+        # because by mocking out the call service method, we mock out all
+        # So we mimick how the service registry calls services
+        service_call = ha.ServiceCall('homeassistant', 'turn_on', {
+            'entity_id': ['light.test', 'sensor.bla', 'light.bla']
+        })
+        self.hass.services._services['homeassistant']['turn_on'](service_call)
+
+        self.assertEqual(2, mock_call.call_count)
+        self.assertEqual(
+            ('light', 'turn_on', {'entity_id': ['light.bla', 'light.test']},
+             True),
+            mock_call.call_args_list[0][0])
+        self.assertEqual(
+            ('sensor', 'turn_on', {'entity_id': ['sensor.bla']}, False),
+            mock_call.call_args_list[1][0])


### PR DESCRIPTION
The frontend will always call `homeassistant.turn_on` when turning on an entity from the frontend. This service breaks up the entity list and forwards calls to the appropriate domains. So if you call `homeassistant.turn_on` on `light.kitchen, switch.ac` it will result in two blocking service calls. One to `light.turn_on` and one to `switch.turn_on`. They are blocking because that way the call to `homeassistant.turn_on` can guarantee that the commands have been processed when the API call finishes and return the changed states.

The problem arises when there are groups that contain domains that do not have a `turn_on` service, like for example `sensor`. The `homeassistant.turn_on` service would still make a blocking call to `sensor.turn_on`. Since the service didn't exist, the call would timeout after 10 seconds and return. This affected every call to turn a group on or off that had a sensor. This was first reported by @leoc in #626.

The solution I chose is to make calls to services that do not exist in the current instance non-blocking. I chose not to omit the calls at all because there can be multiple connected instances and they are not aware of all registered services.

Fixes #626.
