### PR TITLE
No need to call update() here

### DIFF
--- a/homeassistant/components/sensor/eliqonline.py
+++ b/homeassistant/components/sensor/eliqonline.py
@@ -46,7 +46,6 @@ class EliqSensor(Entity):
 
         self.api = api
         self.channel_id = channel_id
-        self.update()
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/eliqonline.py
+++ b/homeassistant/components/sensor/eliqonline.py
@@ -46,6 +46,7 @@ class EliqSensor(Entity):
 
         self.api = api
         self.channel_id = channel_id
+        self.update()
 
     @property
     def name(self):
@@ -69,5 +70,8 @@ class EliqSensor(Entity):
 
     def update(self):
         """ Gets the latest data. """
-        response = self.api.get_data_now(channelid=self.channel_id)
-        self._state = int(response.power)
+        try:
+            response = self.api.get_data_now(channelid=self.channel_id)
+            self._state = int(response.power)
+        except:
+            pass

--- a/homeassistant/components/sensor/eliqonline.py
+++ b/homeassistant/components/sensor/eliqonline.py
@@ -73,5 +73,5 @@ class EliqSensor(Entity):
         try:
             response = self.api.get_data_now(channelid=self.channel_id)
             self._state = int(response.power)
-        except TypeError: # raised by eliqonline library on any HTTP error
+        except TypeError:  # raised by eliqonline library on any HTTP error
             pass

--- a/homeassistant/components/sensor/eliqonline.py
+++ b/homeassistant/components/sensor/eliqonline.py
@@ -73,5 +73,5 @@ class EliqSensor(Entity):
         try:
             response = self.api.get_data_now(channelid=self.channel_id)
             self._state = int(response.power)
-        except:
+        except TypeError: # raised by eliqonline library on any HTTP error
             pass


### PR DESCRIPTION
This also fixes a problem where the sensor is left uninitialized when the energy meter temporarily has lost connection with the hub. This caused the ELIQ Online server to return HTTP error 400: "user have no current power data", which in turn caused the used eliq library to fail during JSON parsing (issue reported).
