### PR TITLE
Bump pyvera version to fix vera dimmer off bug, and avoid shutdown race condition

### DIFF
--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -16,7 +16,7 @@ from homeassistant.components.light import ATTR_BRIGHTNESS
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pyvera==0.2.1']
+REQUIREMENTS = ['pyvera==0.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     ATTR_BATTERY_LEVEL, ATTR_TRIPPED, ATTR_ARMED, ATTR_LAST_TRIP_TIME,
     TEMP_CELCIUS, TEMP_FAHRENHEIT, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pyvera==0.2.1']
+REQUIREMENTS = ['pyvera==0.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     ATTR_LAST_TRIP_TIME,
     EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pyvera==0.2.1']
+REQUIREMENTS = ['pyvera==0.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -59,7 +59,7 @@ tellcore-py==1.1.2
 # homeassistant.components.light.vera
 # homeassistant.components.sensor.vera
 # homeassistant.components.switch.vera
-pyvera==0.2.1
+pyvera==0.2.2
 
 # homeassistant.components.wink
 # homeassistant.components.light.wink


### PR DESCRIPTION
Just updates to a bug fix version of pyvera. Been tested by me and rhooper on gitter!

@balloob just a library change - so will just merge (unless you don't agree).
