### PR TITLE
Wink power strip support

### DIFF
--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -12,7 +12,7 @@ from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.wink import WinkToggleDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.4.0']
+REQUIREMENTS = ['python-wink==0.4.1']
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -12,7 +12,7 @@ from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.wink import WinkToggleDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.3.1']
+REQUIREMENTS = ['python-wink==0.4.0']
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.3.1']
+REQUIREMENTS = ['python-wink==0.4.0']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.4.0']
+REQUIREMENTS = ['python-wink==0.4.1']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import CONF_ACCESS_TOKEN, STATE_OPEN, STATE_CLOSED
 
-REQUIREMENTS = ['python-wink==0.4.0']
+REQUIREMENTS = ['python-wink==0.4.1']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import CONF_ACCESS_TOKEN, STATE_OPEN, STATE_CLOSED
 
-REQUIREMENTS = ['python-wink==0.3.1']
+REQUIREMENTS = ['python-wink==0.4.0']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -30,3 +30,5 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         pywink.set_bearer_token(token)
 
     add_devices(WinkToggleDevice(switch) for switch in pywink.get_switches())
+    add_devices(WinkToggleDevice(switch) for switch in
+                pywink.get_powerstrip_outlets())

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.wink import WinkToggleDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.3.1']
+REQUIREMENTS = ['python-wink==0.4.0']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -30,5 +30,4 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         pywink.set_bearer_token(token)
 
     add_devices(WinkToggleDevice(switch) for switch in pywink.get_switches())
-    add_devices(WinkToggleDevice(switch) for switch in
-                pywink.get_powerstrip_outlets())
+    add_devices(WinkToggleDevice(switch) for switch in pywink.get_powerstrip_outlets())

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.wink import WinkToggleDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.4.0']
+REQUIREMENTS = ['python-wink==0.4.1']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -30,4 +30,5 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         pywink.set_bearer_token(token)
 
     add_devices(WinkToggleDevice(switch) for switch in pywink.get_switches())
-    add_devices(WinkToggleDevice(switch) for switch in pywink.get_powerstrip_outlets())
+    add_devices(WinkToggleDevice(switch) for switch in
+                pywink.get_powerstrip_outlets())

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     ATTR_SERVICE, ATTR_DISCOVERED, ATTR_FRIENDLY_NAME)
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.4.0']
+REQUIREMENTS = ['python-wink==0.4.1']
 
 DISCOVER_LIGHTS = "wink.lights"
 DISCOVER_SWITCHES = "wink.switches"

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -37,9 +37,10 @@ def setup(hass, config):
     # Load components for the devices in the Wink that we support
     for component_name, func_exists, discovery_type in (
             ('light', pywink.get_bulbs, DISCOVER_LIGHTS),
-            ('switch', pywink.get_switches, DISCOVER_SWITCHES),
-            ('sensor', lambda: pywink.get_sensors or pywink.get_eggtrays,
-             DISCOVER_SENSORS),
+            ('switch', lambda: pywink.get_switches or
+             pywink.get_powerstrip_outlets, DISCOVER_SWITCHES),
+            ('sensor', lambda: pywink.get_sensors or
+             pywink.get_eggtrays, DISCOVER_SENSORS),
             ('lock', pywink.get_locks, DISCOVER_LOCKS)):
 
         if func_exists():

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     ATTR_SERVICE, ATTR_DISCOVERED, ATTR_FRIENDLY_NAME)
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.3.1']
+REQUIREMENTS = ['python-wink==0.4.0']
 
 DISCOVER_LIGHTS = "wink.lights"
 DISCOVER_SWITCHES = "wink.switches"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -66,7 +66,7 @@ pyvera==0.2.2
 # homeassistant.components.lock.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.3.1
+python-wink==0.4.0
 
 # homeassistant.components.media_player.cast
 pychromecast==0.6.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -66,7 +66,7 @@ pyvera==0.2.2
 # homeassistant.components.lock.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.4.0
+python-wink==0.4.1
 
 # homeassistant.components.media_player.cast
 pychromecast==0.6.13


### PR DESCRIPTION
Added support for Wink Power strips as another Wink switch device. Pywink requirements updated to 0.4.0 which includes support for Wink garage doors as well. 

I updated the pywink requirements in all wink.py files and re-ran gen_requirements_all.py and the requirements_all.txt file was created however pywink version wasn't updated? I manually updated the file with the updated version. I grepped all of the files and didn't see anything with a version of pywink != 0.4.0 so I am not sure why the gen script didn't update the file?
