### PR TITLE
Remove wemo polling

### DIFF
--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -12,7 +12,7 @@ from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (
     STATE_ON, STATE_OFF, STATE_STANDBY, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pywemo==0.3.7']
+REQUIREMENTS = ['pywemo==0.3.8']
 _LOGGER = logging.getLogger(__name__)
 
 _WEMO_SUBSCRIPTION_REGISTRY = None
@@ -69,15 +69,14 @@ class WemoSwitch(SwitchDevice):
     def _update_callback(self, _device, _params):
         """ Called by the wemo device callback to update state. """
         _LOGGER.info(
-            'Subscription update for  %s, sevice=%s',
-            self.name, _device)
+            'Subscription update for  %s',
+            _device)
         self.update_ha_state(True)
 
     @property
     def should_poll(self):
-        """ No polling should be needed with subscriptions """
-        # but leave in for initial version in case of issues.
-        return True
+        """ No polling needed with subscriptions """
+        return False
 
     @property
     def unique_id(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -173,7 +173,7 @@ hikvision==0.4
 orvibo==1.1.0
 
 # homeassistant.components.switch.wemo
-pywemo==0.3.7
+pywemo==0.3.8
 
 # homeassistant.components.tellduslive
 tellive-py==0.5.2


### PR DESCRIPTION
This PR removes polling from wemo devices.

Previous PRs added subscriptions so that wemos we updated in real time rather than waiting for a poll. 

However there was still some code used only in the polling code path that rediscovered wemos, and updated their url and ports if they went missing. Version 0.3.8 of the pywemo library linked here adds this rediscovery code to the subscription. I've tested that this works ok.

The wemos in my house have been running without polling for more than a week - and they have been working fine - so I'm pretty certain it's safe.
