### PR TITLE
Add calling service functionality to Alexa

### DIFF
--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -11,6 +11,7 @@ import logging
 
 from homeassistant.const import HTTP_OK, HTTP_UNPROCESSABLE_ENTITY
 from homeassistant.util import template
+from homeassistant.helpers.service import call_from_config
 
 DOMAIN = 'alexa'
 DEPENDENCIES = ['http']
@@ -23,6 +24,7 @@ API_ENDPOINT = '/api/alexa'
 CONF_INTENTS = 'intents'
 CONF_CARD = 'card'
 CONF_SPEECH = 'speech'
+CONF_ACTION = 'action'
 
 
 def setup(hass, config):
@@ -80,6 +82,7 @@ def _handle_alexa(handler, path_match, data):
 
     speech = config.get(CONF_SPEECH)
     card = config.get(CONF_CARD)
+    action = config.get(CONF_ACTION)
 
     # pylint: disable=unsubscriptable-object
     if speech is not None:
@@ -88,6 +91,9 @@ def _handle_alexa(handler, path_match, data):
     if card is not None:
         response.add_card(CardType[card['type']], card['title'],
                           card['content'])
+
+    if action is not None:
+        call_from_config(handler.server.hass, action, True)
 
     handler.write_json(response.as_dict())
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -9,9 +9,9 @@ https://home-assistant.io/components/automation/
 import logging
 
 from homeassistant.bootstrap import prepare_setup_platform
-from homeassistant.util import split_entity_id
-from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM
+from homeassistant.const import CONF_PLATFORM
 from homeassistant.components import logbook
+from homeassistant.helpers.service import call_from_config
 
 DOMAIN = 'automation'
 
@@ -19,8 +19,6 @@ DEPENDENCIES = ['group']
 
 CONF_ALIAS = 'alias'
 CONF_SERVICE = 'service'
-CONF_SERVICE_ENTITY_ID = 'entity_id'
-CONF_SERVICE_DATA = 'data'
 
 CONF_CONDITION = 'condition'
 CONF_ACTION = 'action'
@@ -96,22 +94,7 @@ def _get_action(hass, config, name):
         _LOGGER.info('Executing %s', name)
         logbook.log_entry(hass, name, 'has been triggered', DOMAIN)
 
-        domain, service = split_entity_id(config[CONF_SERVICE])
-        service_data = config.get(CONF_SERVICE_DATA, {})
-
-        if not isinstance(service_data, dict):
-            _LOGGER.error("%s should be a dictionary", CONF_SERVICE_DATA)
-            service_data = {}
-
-        if CONF_SERVICE_ENTITY_ID in config:
-            try:
-                service_data[ATTR_ENTITY_ID] = \
-                    config[CONF_SERVICE_ENTITY_ID].split(",")
-            except AttributeError:
-                service_data[ATTR_ENTITY_ID] = \
-                    config[CONF_SERVICE_ENTITY_ID]
-
-        hass.services.call(domain, service, service_data)
+        call_from_config(hass, config)
 
     return action
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1,0 +1,37 @@
+"""Service calling related helpers."""
+import logging
+
+from homeassistant.util import split_entity_id
+from homeassistant.const import ATTR_ENTITY_ID
+
+CONF_SERVICE = 'service'
+CONF_SERVICE_ENTITY_ID = 'entity_id'
+CONF_SERVICE_DATA = 'data'
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def call_from_config(hass, config, blocking=False):
+    """Call a service based on a config hash."""
+    if CONF_SERVICE not in config:
+        _LOGGER.error('Missing key %s: %s', CONF_SERVICE, config)
+        return
+
+    domain, service = split_entity_id(config[CONF_SERVICE])
+    service_data = config.get(CONF_SERVICE_DATA)
+
+    if service_data is None:
+        service_data = {}
+    elif isinstance(service_data, dict):
+        service_data = dict(service_data)
+    else:
+        _LOGGER.error("%s should be a dictionary", CONF_SERVICE_DATA)
+        service_data = {}
+
+    entity_id = config.get(CONF_SERVICE_ENTITY_ID)
+    if isinstance(entity_id, str):
+        service_data[ATTR_ENTITY_ID] = entity_id.split(",")
+    elif entity_id is not None:
+        service_data[ATTR_ENTITY_ID] = entity_id
+
+    hass.services.call(domain, service, service_data, blocking)

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -30,7 +30,8 @@ def call_from_config(hass, config, blocking=False):
 
     entity_id = config.get(CONF_SERVICE_ENTITY_ID)
     if isinstance(entity_id, str):
-        service_data[ATTR_ENTITY_ID] = entity_id.split(",")
+        service_data[ATTR_ENTITY_ID] = [ent.strip() for ent in
+                                        entity_id.split(",")]
     elif entity_id is not None:
         service_data[ATTR_ENTITY_ID] = entity_id
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -13,11 +13,16 @@ _LOGGER = logging.getLogger(__name__)
 
 def call_from_config(hass, config, blocking=False):
     """Call a service based on a config hash."""
-    if CONF_SERVICE not in config:
+    if not isinstance(config, dict) or CONF_SERVICE not in config:
         _LOGGER.error('Missing key %s: %s', CONF_SERVICE, config)
         return
 
-    domain, service = split_entity_id(config[CONF_SERVICE])
+    try:
+        domain, service = split_entity_id(config[CONF_SERVICE])
+    except ValueError:
+        _LOGGER.error('Invalid service specified: %s', config[CONF_SERVICE])
+        return
+
     service_data = config.get(CONF_SERVICE_DATA)
 
     if service_data is None:

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -1,0 +1,39 @@
+"""
+tests.helpers.test_service
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Test service helpers.
+"""
+from datetime import timedelta
+import unittest
+from unittest.mock import patch
+
+import homeassistant.core as ha
+from homeassistant.const import SERVICE_TURN_ON
+from homeassistant.helpers import service
+
+from tests.common import get_test_home_assistant, mock_service
+
+
+class TestServiceHelpers(unittest.TestCase):
+    """
+    Tests the Home Assistant service helpers.
+    """
+
+    def setUp(self):     # pylint: disable=invalid-name
+        """ things to be run when tests are started. """
+        self.hass = get_test_home_assistant()
+        self.calls = mock_service(self.hass, 'test_domain', 'test_service')
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """ Stop down stuff we started. """
+        self.hass.stop()
+
+    def test_split_entity_string(self):
+        service.call_from_config(self.hass, {
+            'service': 'test_domain.test_service',
+            'entity_id': 'hello.world, sensor.beer'
+        })
+        self.hass.pool.block_till_done()
+        self.assertEqual(['hello.world', 'sensor.beer'],
+                         self.calls[-1].data.get('entity_id'))


### PR DESCRIPTION
This adds functionality to call services before responding to an alexa service call. This can be used to have Alexa turn on the lights or run any other script/service.

To add this functionality I have extracted the call-service-from-config-logic from automation so that both components will use the same config format.

Example:

``` yaml
alexa:
  intents:
    CallServiceIntent:
      speech:
        type: plaintext
        text: Lights turned on.
      action:
        service: light.turn_on
```
