### PR TITLE
Default to MQTT protocol v3.1.1

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -149,9 +149,9 @@ class MQTT(object):
         }
 
         if client_id is None:
-            self._mqttc = mqtt.Client()
+            self._mqttc = mqtt.Client(protocol=mqtt.MQTTv311)
         else:
-            self._mqttc = mqtt.Client(client_id)
+            self._mqttc = mqtt.Client(client_id, protocol=mqtt.MQTTv311)
 
         self._mqttc.user_data_set(self.userdata)
 


### PR DESCRIPTION
Fixes #854.

By setting the default protocol of MQTT to v3.1.1, the MQTT library will fallback to v3.1 if a protocol version occurs while connecting.
