### PR TITLE
Vera updates

### DIFF
--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -7,7 +7,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.vera/
 """
 import logging
-import time
 
 from requests.exceptions import RequestException
 from homeassistant.components.switch.vera import VeraSwitch

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -14,7 +14,7 @@ from homeassistant.components.switch.vera import VeraSwitch
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, STATE_ON
 
 REQUIREMENTS = ['pyvera==0.2.3']
 
@@ -59,7 +59,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     lights = []
     for device in devices:
-        extra_data = device_data.get(device.deviceId, {})
+        extra_data = device_data.get(device.device_id, {})
         exclude = extra_data.get('exclude', False)
 
         if exclude is not True:
@@ -86,4 +86,5 @@ class VeraLight(VeraSwitch):
         else:
             self.vera_device.switch_on()
 
-        self.is_on_status = True
+        self._state = STATE_ON
+        self.update_ha_state()

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -86,5 +86,4 @@ class VeraLight(VeraSwitch):
         else:
             self.vera_device.switch_on()
 
-        self.last_command_send = time.time()
         self.is_on_status = True

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -16,7 +16,7 @@ from homeassistant.components.light import ATTR_BRIGHTNESS
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pyvera==0.2.2']
+REQUIREMENTS = ['pyvera==0.2.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -119,18 +119,18 @@ class VeraSensor(Entity):
             attr[ATTR_BATTERY_LEVEL] = self.vera_device.battery_level + '%'
 
         if self.vera_device.is_armable:
-            armed = self.vera_device.refresh_value('Armed')
+            armed = self.vera_device.get_value('Armed')
             attr[ATTR_ARMED] = 'True' if armed == '1' else 'False'
 
         if self.vera_device.is_trippable:
-            last_tripped = self.vera_device.refresh_value('LastTrip')
+            last_tripped = self.vera_device.get_value('LastTrip')
             if last_tripped is not None:
                 utc_time = dt_util.utc_from_timestamp(int(last_tripped))
                 attr[ATTR_LAST_TRIP_TIME] = dt_util.datetime_to_str(
                     utc_time)
             else:
                 attr[ATTR_LAST_TRIP_TIME] = None
-            tripped = self.vera_device.refresh_value('Tripped')
+            tripped = self.vera_device.get_value('Tripped')
             attr[ATTR_TRIPPED] = 'True' if tripped == '1' else 'False'
 
         attr['Vera Device Id'] = self.vera_device.vera_device_id
@@ -143,7 +143,6 @@ class VeraSensor(Entity):
 
     def update(self):
         if self.vera_device.category == "Temperature Sensor":
-            self.vera_device.refresh_value('CurrentTemperature')
             current_temp = self.vera_device.get_value('CurrentTemperature')
             vera_temp_units = self.vera_device.veraController.temperature_units
 
@@ -161,10 +160,9 @@ class VeraSensor(Entity):
 
             self.current_value = current_temp
         elif self.vera_device.category == "Light Sensor":
-            self.vera_device.refresh_value('CurrentLevel')
             self.current_value = self.vera_device.get_value('CurrentLevel')
         elif self.vera_device.category == "Sensor":
-            tripped = self.vera_device.refresh_value('Tripped')
+            tripped = self.vera_device.get_value('Tripped')
             self.current_value = 'Tripped' if tripped == '1' else 'Not Tripped'
         else:
             self.current_value = 'Unknown'

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -56,7 +56,7 @@ def get_devices(hass, config):
 
     vera_sensors = []
     for device in devices:
-        extra_data = device_data.get(device.deviceId, {})
+        extra_data = device_data.get(device.device_id, {})
         exclude = extra_data.get('exclude', False)
 
         if exclude is not True:
@@ -89,12 +89,10 @@ class VeraSensor(Entity):
 
     def _update_callback(self, _device):
         """ Called by the vera device callback to update state. """
-        _LOGGER.info(
-            'Subscription update for  %s', self.name)
         self.update_ha_state(True)
 
     def __str__(self):
-        return "%s %s %s" % (self.name, self.vera_device.deviceId, self.state)
+        return "%s %s %s" % (self.name, self.vera_device.device_id, self.state)
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     ATTR_BATTERY_LEVEL, ATTR_TRIPPED, ATTR_ARMED, ATTR_LAST_TRIP_TIME,
     TEMP_CELCIUS, TEMP_FAHRENHEIT, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pyvera==0.2.2']
+REQUIREMENTS = ['pyvera==0.2.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,9 +85,7 @@ class VeraSensor(Entity):
         self.current_value = ''
         self._temperature_units = None
 
-        self.controller.register(vera_device)
-        self.controller.on(
-            vera_device, self._update_callback)
+        self.controller.register(vera_device, self._update_callback)
 
     def _update_callback(self, _device):
         """ Called by the vera device callback to update state. """

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -87,8 +87,6 @@ class VeraSwitch(ToggleEntity):
         else:
             self._name = self.vera_device.name
         self.is_on_status = False
-        # for debouncing status check after command is sent
-        self.last_command_send = 0
 
         self.controller.register(vera_device)
         self.controller.on(
@@ -132,12 +130,10 @@ class VeraSwitch(ToggleEntity):
         return attr
 
     def turn_on(self, **kwargs):
-        self.last_command_send = time.time()
         self.vera_device.switch_on()
         self.is_on_status = True
 
     def turn_off(self, **kwargs):
-        self.last_command_send = time.time()
         self.vera_device.switch_off()
         self.is_on_status = False
 
@@ -152,10 +148,7 @@ class VeraSwitch(ToggleEntity):
         return self.is_on_status
 
     def update(self):
-        # We need to debounce the status call after turning switch on or off
-        # because the vera has some lag in updating the device status
         try:
-            if (self.last_command_send + 5) < time.time():
-                self.is_on_status = self.vera_device.is_switched_on()
+            self.is_on_status = self.vera_device.is_switched_on()
         except RequestException:
             _LOGGER.warning('Could not update status for %s', self.name)

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -7,11 +7,9 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.vera/
 """
 import logging
-import time
 from requests.exceptions import RequestException
 import homeassistant.util.dt as dt_util
 
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.components.switch import SwitchDevice
 
 from homeassistant.const import (
@@ -138,7 +136,6 @@ class VeraSwitch(SwitchDevice):
         self._state = STATE_ON
         self.update_ha_state()
 
-
     def turn_off(self, **kwargs):
         self.vera_device.switch_off()
         self._state = STATE_OFF
@@ -153,4 +150,3 @@ class VeraSwitch(SwitchDevice):
     def is_on(self):
         """ True if device is on. """
         return self._state == STATE_ON
-

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -111,18 +111,18 @@ class VeraSwitch(ToggleEntity):
             attr[ATTR_BATTERY_LEVEL] = self.vera_device.battery_level + '%'
 
         if self.vera_device.is_armable:
-            armed = self.vera_device.refresh_value('Armed')
+            armed = self.vera_device.get_value('Armed')
             attr[ATTR_ARMED] = 'True' if armed == '1' else 'False'
 
         if self.vera_device.is_trippable:
-            last_tripped = self.vera_device.refresh_value('LastTrip')
+            last_tripped = self.vera_device.get_value('LastTrip')
             if last_tripped is not None:
                 utc_time = dt_util.utc_from_timestamp(int(last_tripped))
                 attr[ATTR_LAST_TRIP_TIME] = dt_util.datetime_to_str(
                     utc_time)
             else:
                 attr[ATTR_LAST_TRIP_TIME] = None
-            tripped = self.vera_device.refresh_value('Tripped')
+            tripped = self.vera_device.get_value('Tripped')
             attr[ATTR_TRIPPED] = 'True' if tripped == '1' else 'False'
 
         attr['Vera Device Id'] = self.vera_device.vera_device_id
@@ -132,6 +132,7 @@ class VeraSwitch(ToggleEntity):
     def turn_on(self, **kwargs):
         self.vera_device.switch_on()
         self.is_on_status = True
+
 
     def turn_off(self, **kwargs):
         self.vera_device.switch_off()
@@ -148,7 +149,4 @@ class VeraSwitch(ToggleEntity):
         return self.is_on_status
 
     def update(self):
-        try:
-            self.is_on_status = self.vera_device.is_switched_on()
-        except RequestException:
-            _LOGGER.warning('Could not update status for %s', self.name)
+        self.is_on_status = self.vera_device.is_switched_on()

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     ATTR_LAST_TRIP_TIME,
     EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pyvera==0.2.2']
+REQUIREMENTS = ['pyvera==0.2.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,9 +88,7 @@ class VeraSwitch(ToggleEntity):
             self._name = self.vera_device.name
         self.is_on_status = False
 
-        self.controller.register(vera_device)
-        self.controller.on(
-            vera_device, self._update_callback)
+        self.controller.register(vera_device, self._update_callback)
 
     def _update_callback(self, _device):
         """ Called by the vera device callback to update state. """

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -59,7 +59,7 @@ tellcore-py==1.1.2
 # homeassistant.components.light.vera
 # homeassistant.components.sensor.vera
 # homeassistant.components.switch.vera
-pyvera==0.2.2
+pyvera==0.2.3
 
 # homeassistant.components.wink
 # homeassistant.components.light.wink


### PR DESCRIPTION
This PR updates HA to use pyvera 0.2.3.

This contains the following:-
1. Fixed a bug where the throttle and subscriptions  clashed to not update device states.
2. A change to get device state from the subscription update - rather than calling back the device
3. A slightly simplified subscription interface
4. Tidied code including a couple of renamed properties
5. A small refactor to VeraSwitch/VeraLight states to allow optimistic switch states (so the gui switches don't bounce)

The overall impact is to make HA work better and faster with Vera. Generally by loading Vera less, particularly when changing scenes.

The library changes are pretty significant - I've tested with switches and lights - but I don't have any sensors - so there is a chance there is something I've missed there.
