### PR TITLE
Zwave inclusion / exclusion events

### DIFF
--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -26,8 +26,8 @@ CONF_POLLING_INTERVAL = "polling_interval"
 DEFAULT_ZWAVE_CONFIG_PATH = os.path.join(sys.prefix, 'share',
                                          'python-openzwave', 'config')
 
-EVENT_ZWAVE_ADD_NODE = "zwave_add_node"
-EVENT_ZWAVE_REMOVE_NODE = "zwave_remove_node"
+SERVICE_ADD_NODE = "add_node"
+SERVICE_REMOVE_NODE = "remove_node"
 
 DISCOVER_SENSORS = "zwave.sensors"
 DISCOVER_SWITCHES = "zwave.switch"
@@ -201,10 +201,10 @@ def setup(hass, config):
 
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_zwave)
 
-        # listen for add/remove events, for zwave sticks without
+        # register add / remove node services for zwave sticks without
         # hardware inclusion button
-        hass.bus.listen(EVENT_ZWAVE_ADD_NODE, add_node)
-        hass.bus.listen(EVENT_ZWAVE_REMOVE_NODE, remove_node)
+        hass.services.register(DOMAIN, SERVICE_ADD_NODE, add_node)
+        hass.services.register(DOMAIN, SERVICE_REMOVE_NODE, remove_node)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_zwave)
 

--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -26,6 +26,9 @@ CONF_POLLING_INTERVAL = "polling_interval"
 DEFAULT_ZWAVE_CONFIG_PATH = os.path.join(sys.prefix, 'share',
                                          'python-openzwave', 'config')
 
+EVENT_ZWAVE_ADD_NODE = "zwave_add_node"
+EVENT_ZWAVE_REMOVE_NODE = "zwave_remove_node"
+
 DISCOVER_SENSORS = "zwave.sensors"
 DISCOVER_SWITCHES = "zwave.switch"
 DISCOVER_LIGHTS = "zwave.light"
@@ -176,6 +179,14 @@ def setup(hass, config):
     dispatcher.connect(
         value_added, ZWaveNetwork.SIGNAL_VALUE_ADDED, weak=False)
 
+    def add_node(event):
+        """ Switch into inclusion mode """
+        NETWORK.controller.begin_command_add_device()
+
+    def remove_node(event):
+        """ Switch into exclusion mode"""
+        NETWORK.controller.begin_command_remove_device()
+
     def stop_zwave(event):
         """ Stop Z-wave. """
         NETWORK.stop()
@@ -189,6 +200,11 @@ def setup(hass, config):
             NETWORK.setPollInterval(polling_interval)
 
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_zwave)
+
+        # listen for add/remove events, for zwave sticks without
+        # hardware inclusion button
+        hass.bus.listen(EVENT_ZWAVE_ADD_NODE, add_node)
+        hass.bus.listen(EVENT_ZWAVE_REMOVE_NODE, remove_node)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_zwave)
 


### PR DESCRIPTION
The new events "zwave_add_node" and "zwave_remove_node" may be used to trigger inclusion / exclusion of zwave devices.

This is especially useful in the case of a Z-Wave stick without "hardware" inclusion button.
