### PR TITLE
round min / max values for temperature

### DIFF
--- a/homeassistant/components/thermostat/__init__.py
+++ b/homeassistant/components/thermostat/__init__.py
@@ -224,12 +224,12 @@ class ThermostatDevice(Entity):
     @property
     def min_temp(self):
         """ Return minimum temperature. """
-        return convert(7, TEMP_CELCIUS, self.unit_of_measurement)
+        return round(convert(7, TEMP_CELCIUS, self.unit_of_measurement))
 
     @property
     def max_temp(self):
         """ Return maxmum temperature. """
-        return convert(35, TEMP_CELCIUS, self.unit_of_measurement)
+        return round(convert(35, TEMP_CELCIUS, self.unit_of_measurement))
 
     def _convert(self, temp, round_dec=None):
         """ Convert temperature from this thermost into user preferred


### PR DESCRIPTION
In order for the polymer thermostat component to have sensible step
values the min / max values have to be round numbers. The current code
only does that for systems running in degrees C. For those of us in
silly land that still function in degrees F, this causes some
oddities in the UI.

Always round mix / max values to make it good no matter what
fundamental units we are in.
