### PR TITLE
Increase security of using SSL

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -112,10 +112,10 @@ class HomeAssistantHTTPServer(ThreadingMixIn, HTTPServer):
             _LOGGER.info("running http in development mode")
 
         if ssl_certificate is not None:
-            wrap_kwargs = {'certfile': ssl_certificate}
-            if ssl_key is not None:
-                wrap_kwargs['keyfile'] = ssl_key
-            self.socket = ssl.wrap_socket(self.socket, **wrap_kwargs)
+            context = ssl.create_default_context(
+                purpose=ssl.Purpose.CLIENT_AUTH)
+            context.load_cert_chain(ssl_certificate, keyfile=ssl_key)
+            self.socket = context.wrap_socket(self.socket, server_side=True)
 
     def start(self):
         """ Starts the HTTP server. """


### PR DESCRIPTION
When providing a SSL certificate and key to HA (following steps [here](https://home-assistant.io/blog/2015/12/13/setup-encryption-using-lets-encrypt/)), there are some security issues (results from [SSL Labs](https://www.ssllabs.com/ssltest/)):

![screen_shot_2016-01-15_at_1_29_52_pm](https://cloud.githubusercontent.com/assets/1527647/12364870/70a34ade-bb8e-11e5-8f0a-25d83b0c12eb.png)

By using Python's [`create_default_context`](https://docs.python.org/3/library/ssl.html#ssl.create_default_context), the security can be improved quite a bit:

![screen_shot_2016-01-15_at_1_36_13_pm](https://cloud.githubusercontent.com/assets/1527647/12364911/ae454de2-bb8e-11e5-9da8-59d33a848969.png)

I'm not a security expert so I am not sure if there are any drawbacks to this change. The device support using this configuration is still good—the only configuration it doesn't support is IE 6 on Windows XP.
