### PR TITLE
have thermostat component state to include current_temp

### DIFF
--- a/homeassistant/components/thermostat/__init__.py
+++ b/homeassistant/components/thermostat/__init__.py
@@ -133,7 +133,9 @@ class ThermostatDevice(Entity):
     @property
     def state(self):
         """ Returns the current state. """
-        return self.target_temperature or STATE_UNKNOWN
+        return "Current: %s, Target: %s" % (
+            self.current_temperature or STATE_UNKNOWN,
+            self.target_temperature or STATE_UNKNOWN)
 
     @property
     def device_state_attributes(self):

--- a/tests/components/thermostat/test_heat_control.py
+++ b/tests/components/thermostat/test_heat_control.py
@@ -44,7 +44,9 @@ class TestThermostatHeatControl(unittest.TestCase):
         self.hass.stop()
 
     def test_setup_defaults_to_unknown(self):
-        self.assertEqual('unknown', self.hass.states.get(entity).state)
+        self.assertEqual(
+            'Current: unknown, Target: unknown',
+            self.hass.states.get(entity).state)
 
     def test_default_setup_params(self):
         state = self.hass.states.get(entity)
@@ -66,12 +68,16 @@ class TestThermostatHeatControl(unittest.TestCase):
         self.assertEqual(min_temp, state.attributes.get('min_temp'))
         self.assertEqual(max_temp, state.attributes.get('max_temp'))
         self.assertEqual(target_temp, state.attributes.get('temperature'))
-        self.assertEqual(str(target_temp), self.hass.states.get(entity).state)
+        self.assertEqual(
+            'Current: unknown, Target: %s' % target_temp,
+            self.hass.states.get(entity).state)
 
     def test_set_target_temp(self):
         thermostat.set_temperature(self.hass, 30)
         self.hass.pool.block_till_done()
-        self.assertEqual('30.0', self.hass.states.get(entity).state)
+        self.assertEqual(
+            "Current: unknown, Target: 30.0",
+            self.hass.states.get(entity).state)
 
     def test_set_target_temp_turns_on_heater(self):
         self._setup_switch(False)
@@ -138,4 +144,3 @@ class TestThermostatHeatControl(unittest.TestCase):
 
         self.hass.services.register('switch', SERVICE_TURN_ON, log_call)
         self.hass.services.register('switch', SERVICE_TURN_OFF, log_call)
-


### PR DESCRIPTION
The thermostat component has a concept of both target and current
temp. However previously state was only listed as target_temp, which
means that a change event is only logged on target_temp changes (with
a standard programmable thermostat this is 2 - 4 times a day). We thus
loose the information about the temp sensor in the thermostat itself.

By making it a composite string of both temps, this will log an event
on the change of either. That will make the thermostat graphs be more
sensible for most people.
