### PR TITLE
sonos: add hosts and interface_addr to sonos config

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -38,12 +38,23 @@ SUPPORT_SONOS = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE |\
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """ Sets up the Sonos platform. """
     import soco
+    import socket
 
     if discovery_info:
         add_devices([SonosDevice(hass, soco.SoCo(discovery_info))])
         return True
 
-    players = soco.discover()
+    players = None
+    hosts = config.get('hosts', None)
+    if hosts:
+        players = []
+        for host in hosts.split(","):
+            host = socket.gethostbyname(host)
+            players.append(soco.SoCo(host))
+
+    if not players:
+        players = soco.discover(interface_addr=config.get('interface_addr',
+                                                          None))
 
     if not players:
         _LOGGER.warning('No Sonos speakers found.')


### PR DESCRIPTION
Config can now specify one or more hosts to connect and
also a interface_addr to multicast on if multiple interfaces exists.

Signed-off-by: Robert Marklund robbelibobban@gmail.com
