### PR TITLE
artwork fixes

### DIFF
--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -201,11 +201,18 @@ class SqueezeBoxDevice(MediaPlayerDevice):
     def media_image_url(self):
         """ Image url of current playing media. """
         if 'artwork_url' in self._status:
-            return self._status['artwork_url']
-        return ('http://{server}:{port}/music/current/cover.jpg?'
-                'player={player}').format(server=self._lms.host,
-                                          port=self._lms.http_port,
-                                          player=self._id)
+            media_url = self._status['artwork_url']
+        else:
+            media_url = ('/music/current/cover.jpg?'
+                         'player={player}&'
+                         'nocache={nocache}').format(
+                             player=self._id,
+                             nocache=hash(self.media_title))
+
+        base_url = 'http://{server}:{port}/'.format(server=self._lms.host,
+                                                    port=self._lms.http_port)
+
+        return urllib.parse.urljoin(base_url, media_url)
 
     @property
     def media_title(self):

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -203,14 +203,12 @@ class SqueezeBoxDevice(MediaPlayerDevice):
         if 'artwork_url' in self._status:
             media_url = self._status['artwork_url']
         else:
-            media_url = ('/music/current/cover.jpg?'
-                         'player={player}&'
-                         'nocache={nocache}').format(
-                             player=self._id,
-                             nocache=hash(self.media_title))
+            media_url = ('/music/{track_id}/cover.jpg').format(
+                track_id=self._status["id"])
 
-        base_url = 'http://{server}:{port}/'.format(server=self._lms.host,
-                                                    port=self._lms.http_port)
+        base_url = 'http://{server}:{port}/'.format(
+            server=self._lms.host,
+            port=self._lms.http_port)
 
         return urllib.parse.urljoin(base_url, media_url)
 


### PR DESCRIPTION
1) artwork_url might be a relative url (such as /imageproxy). in that case, join it with the base url. note: urllib.parse.urljoin can handle the case when the artwork url is absolute.

2) artwork would not be replaced in the user interface because the url did not change between tracks (always http://server/cover.jpg). solved by appending internal hash of the media title to the url to force a reload.
