### PR TITLE
Remove sensor state

### DIFF
--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -30,7 +30,6 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 ATTR_TODAY_MWH = "today_mwh"
 ATTR_CURRENT_POWER_MWH = "current_power_mwh"
-ATTR_SENSOR_STATE = "sensor_state"
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
@@ -48,7 +47,6 @@ DISCOVERY_PLATFORMS = {
 PROP_TO_ATTR = {
     'current_power_mwh': ATTR_CURRENT_POWER_MWH,
     'today_power_mw': ATTR_TODAY_MWH,
-    'sensor_state': ATTR_SENSOR_STATE
 }
 
 _LOGGER = logging.getLogger(__name__)
@@ -129,11 +127,6 @@ class SwitchDevice(ToggleEntity):
     @property
     def is_standby(self):
         """ Is the device in standby. """
-        return None
-
-    @property
-    def sensor_state(self):
-        """ Is the sensor on or off. """
         return None
 
     @property

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -99,7 +99,6 @@ class WemoSwitch(SwitchDevice):
         attr = super().state_attributes or {}
         if self.maker_params:
             # Is the maker sensor on or off.
-            if self.entity_id == 'switch.hi_fi_systemline_sensor':
             if self.maker_params['hassensor']:
                 # Note a state of 1 matches the WeMo app 'not triggered'!
                 if self.maker_params['sensorstate']:

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -23,6 +23,7 @@ ATTR_SWITCH_MODE = "switch_mode"
 MAKER_SWITCH_MOMENTARY = "momentary"
 MAKER_SWITCH_TOGGLE = "toggle"
 
+
 # pylint: disable=unused-argument, too-many-function-args
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """ Find and return WeMo switches. """

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -109,9 +109,9 @@ class WemoSwitch(SwitchDevice):
             # Is the maker switch configured as toggle(0) or momentary (1).
             if self.maker_params['switchmode']:
                 if self.maker_params['switchmode'] == '1':
-                    attr[ATTR_SWITCH_MODE] =  MAKER_SWITCH_MOMENTARY
+                    attr[ATTR_SWITCH_MODE] = MAKER_SWITCH_MOMENTARY
                 else:
-                    attr[ATTR_SWITCH_MODE] =  MAKER_SWITCH_TOGGLE
+                    attr[ATTR_SWITCH_MODE] = MAKER_SWITCH_TOGGLE
 
         return attr
 

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -17,6 +17,11 @@ _LOGGER = logging.getLogger(__name__)
 
 _WEMO_SUBSCRIPTION_REGISTRY = None
 
+ATTR_SENSOR_STATE = "sensor_state"
+ATTR_SWITCH_MODE = "switch_mode"
+
+MAKER_SWITCH_MOMENTARY = "momentary"
+MAKER_SWITCH_TOGGLE = "toggle"
 
 # pylint: disable=unused-argument, too-many-function-args
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
@@ -89,6 +94,28 @@ class WemoSwitch(SwitchDevice):
         return self.wemo.name
 
     @property
+    def state_attributes(self):
+        attr = super().state_attributes or {}
+
+        if self.maker_params:
+            # Is the maker sensor on or off.
+            if self.maker_params['hassensor']:
+                # Note a state of 1 matches the WeMo app 'not triggered'!
+                if self.maker_params['sensorstate'] == '1':
+                    attr[ATTR_SENSOR_STATE] = STATE_OFF
+                else:
+                    attr[ATTR_SENSOR_STATE] = STATE_ON
+
+            # Is the maker switch configured as toggle(0) or momentary (1).
+            if self.maker_params['switchmode']:
+                if self.maker_params['switchmode'] == '1':
+                    attr[ATTR_SWITCH_MODE] =  MAKER_SWITCH_MOMENTARY
+                else:
+                    attr[ATTR_SWITCH_MODE] =  MAKER_SWITCH_TOGGLE
+
+        return attr
+
+    @property
     def state(self):
         """ Returns the state. """
         is_on = self.is_on
@@ -121,28 +148,6 @@ class WemoSwitch(SwitchDevice):
                 return False
             else:
                 return True
-
-    @property
-    def sensor_state(self):
-        """ Is the sensor on or off. """
-        if self.maker_params and self.has_sensor:
-            # Note a state of 1 matches the WeMo app 'not triggered'!
-            if self.maker_params['sensorstate']:
-                return STATE_OFF
-            else:
-                return STATE_ON
-
-    @property
-    def switch_mode(self):
-        """ Is the switch configured as toggle(0) or momentary (1). """
-        if self.maker_params:
-            return self.maker_params['switchmode']
-
-    @property
-    def has_sensor(self):
-        """ Is the sensor present? """
-        if self.maker_params:
-            return self.maker_params['hassensor']
 
     @property
     def is_on(self):

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -97,22 +97,21 @@ class WemoSwitch(SwitchDevice):
     @property
     def state_attributes(self):
         attr = super().state_attributes or {}
-
         if self.maker_params:
             # Is the maker sensor on or off.
+            if self.entity_id == 'switch.hi_fi_systemline_sensor':
             if self.maker_params['hassensor']:
                 # Note a state of 1 matches the WeMo app 'not triggered'!
-                if self.maker_params['sensorstate'] == '1':
+                if self.maker_params['sensorstate']:
                     attr[ATTR_SENSOR_STATE] = STATE_OFF
                 else:
                     attr[ATTR_SENSOR_STATE] = STATE_ON
 
             # Is the maker switch configured as toggle(0) or momentary (1).
             if self.maker_params['switchmode']:
-                if self.maker_params['switchmode'] == '1':
-                    attr[ATTR_SWITCH_MODE] = MAKER_SWITCH_MOMENTARY
-                else:
-                    attr[ATTR_SWITCH_MODE] = MAKER_SWITCH_TOGGLE
+                attr[ATTR_SWITCH_MODE] = MAKER_SWITCH_MOMENTARY
+            else:
+                attr[ATTR_SWITCH_MODE] = MAKER_SWITCH_TOGGLE
 
         return attr
 


### PR DESCRIPTION
This PR removes 'sensor_state' from the base switch, and puts into a device specific attribute. 
