### PR TITLE
Fix #863 - Added a check for good pull from OWM and return if the object is None

### DIFF
--- a/homeassistant/components/sensor/openweathermap.py
+++ b/homeassistant/components/sensor/openweathermap.py
@@ -165,6 +165,10 @@ class WeatherData(object):
     def update(self):
         """ Gets the latest data from OpenWeatherMap. """
         obs = self.owm.weather_at_coords(self.latitude, self.longitude)
+        if obs is None:
+            _LOGGER.warning('Failed to fetch data from OWM')
+            return
+
         self.data = obs.get_weather()
 
         if self.forecast == 1:


### PR DESCRIPTION
If the OWM API returns an empty or None response, we will log the error and return.  The sensor will refresh at another time.

Possible future enhancement is to overrule the `@Throttle` decorator to retry, but probably not necessary at this time.  (I couldn't get it to fail unless I deliberately did something dumb)
