### PR TITLE
kodi: remove traceback on state check

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -72,7 +72,8 @@ class KodiDevice(MediaPlayerDevice):
         try:
             return self._server.Player.GetActivePlayers()
         except jsonrpc_requests.jsonrpc.TransportError:
-            _LOGGER.exception('Unable to fetch kodi data')
+            _LOGGER.warning('Unable to fetch kodi data')
+            _LOGGER.debug('Unable to fetch kodi data', exc_info=True)
             return None
 
     @property


### PR DESCRIPTION
If the computer is sleeping that are running xbmc then
the traceback is printed in the log all the time.
Keep the traceback in debug mode of the module if needed.

Signed-off-by: Robert Marklund robbelibobban@gmail.com
