### PR TITLE
Revise OwnTracks to better handle iBeacons

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -92,7 +92,10 @@ def setup_scanner(hass, config, see):
                     acc = 1
 
         elif data['event'] == 'leave':
-            location = STATE_NOT_HOME
+            if data['t'] == 'b':
+                location = None
+            else:
+                location = STATE_NOT_HOME
         else:
             logging.getLogger(__name__).error(
                 'Misformatted mqtt msgs, _type=transition, event=%s',
@@ -104,8 +107,9 @@ def setup_scanner(hass, config, see):
             'dev_id': '{}_{}'.format(parts[1], parts[2]),
             'host_name': parts[1],
             'gps': (latitude, longitude),
-            'location_name': location,
         }
+        if location is not None:
+            kwargs['location_name'] = location
         if acc is not None:
             kwargs['gps_accuracy'] = acc
 

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -86,7 +86,7 @@ def setup_scanner(hass, config, see):
             if data['t'] == 'b':
                 zone = hass.states.get("zone.{}".format(data['desc'].lower()))
                 zone = hass.states.get("zone.{}".format(data['desc'].lower()))
-                if not zone is None:
+                if zone is not None:
                     latitude = zone.attributes['latitude']
                     longitude = zone.attributes['longitude']
                     acc = 1
@@ -106,7 +106,7 @@ def setup_scanner(hass, config, see):
             'gps': (latitude, longitude),
             'location_name': location,
         }
-        if not acc is None:
+        if acc is not None:
             kwargs['gps_accuracy'] = acc
 
         see(**kwargs)

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -69,12 +69,27 @@ def setup_scanner(hass, config, see):
 
         # check if in "home" fence or other zone
         location = ''
+        latitude = data['lat']
+        longitude = data['lon']
+        acc = data.get('acc')
+
         if data['event'] == 'enter':
 
             if data['desc'].lower() == 'home':
                 location = STATE_HOME
             else:
                 location = data['desc']
+
+            # Transition events can be c=circular  b=beacon w=wifi
+            # For beacon events - assume the zone location is more
+            # accurate that lat / long - so pull location from the zone
+            if data['t'] == 'b':
+                zone = hass.states.get("zone.{}".format(data['desc'].lower()))
+                zone = hass.states.get("zone.{}".format(data['desc'].lower()))
+                if not zone is None:
+                    latitude = zone.attributes['latitude']
+                    longitude = zone.attributes['longitude']
+                    acc = 1
 
         elif data['event'] == 'leave':
             location = STATE_NOT_HOME
@@ -88,11 +103,11 @@ def setup_scanner(hass, config, see):
         kwargs = {
             'dev_id': '{}_{}'.format(parts[1], parts[2]),
             'host_name': parts[1],
-            'gps': (data['lat'], data['lon']),
+            'gps': (latitude, longitude),
             'location_name': location,
         }
-        if 'acc' in data:
-            kwargs['gps_accuracy'] = data['acc']
+        if not acc is None:
+            kwargs['gps_accuracy'] = acc
 
         see(**kwargs)
 


### PR DESCRIPTION
I've just started to investigate using iBeacons for OwnTracks.
I'm still testing how iBeacons, OwnTracks and HA interact, so may be more changes.

Initially it looks good - when owntracks on IOS sees a beacon that matches a region it knows - it will send an `enter` or `leave` with the gps location. This means you get events from OwnTracks that you otherwise don't see in 'major moves' mode.

The first change I've made is that when you hit an OwnTracks beacon region - you get an `enter` event. But the GPS location isn't necessarily at the beacon location. I think it's a good assumption that you are at the beacon location zone location. This will allow smaller zones than regular GPS supports.

The second is not to set location to `NOT_HOME` when `leaving` a beacon region. 

I'm not sure this is safe anyway (regions can overlap) - but it certainly isn't safe with beacon regions which can be close to each other. For a beacon `leave` - I just process it as a standard location update and let HA work out what to do. (This should perhaps be the case with any `leave` event)
