### PR TITLE
app: add --loglevel command line argument

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -86,6 +86,12 @@ def get_arguments():
         action='store_true',
         help="Enable verbose logging to file.")
     parser.add_argument(
+        '--loglevel',
+        action='append',
+        default=[],
+        help="Set loglevel on modules or root logger: "
+        "module1.module2.module3=DEBUG, DEBUG")
+    parser.add_argument(
         '--pid-file',
         metavar='path_to_pid_file',
         default=None,
@@ -241,13 +247,14 @@ def main():
         hass = bootstrap.from_config_dict(
             config, config_dir=config_dir, daemon=args.daemon,
             verbose=args.verbose, skip_pip=args.skip_pip,
-            log_rotate_days=args.log_rotate_days)
+            log_rotate_days=args.log_rotate_days, log_level=args.loglevel)
     else:
         config_file = ensure_config_file(config_dir)
         print('Config directory:', config_dir)
         hass = bootstrap.from_config_file(
             config_file, daemon=args.daemon, verbose=args.verbose,
-            skip_pip=args.skip_pip, log_rotate_days=args.log_rotate_days)
+            skip_pip=args.skip_pip, log_rotate_days=args.log_rotate_days,
+            log_level=args.loglevel)
 
     if args.open_ui:
         def open_browser(event):

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -155,7 +155,7 @@ def mount_local_lib_path(config_dir):
 # pylint: disable=too-many-branches, too-many-statements, too-many-arguments
 def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
                      verbose=False, daemon=False, skip_pip=False,
-                     log_rotate_days=None):
+                     log_rotate_days=None, log_level=False):
     """
     Tries to configure Home Assistant from a config dict.
 
@@ -172,7 +172,7 @@ def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
     process_ha_core_config(hass, config.get(core.DOMAIN, {}))
 
     if enable_log:
-        enable_logging(hass, verbose, daemon, log_rotate_days)
+        enable_logging(hass, verbose, daemon, log_rotate_days, log_level)
 
     hass.config.skip_pip = skip_pip
     if skip_pip:
@@ -207,7 +207,7 @@ def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
 
 
 def from_config_file(config_path, hass=None, verbose=False, daemon=False,
-                     skip_pip=True, log_rotate_days=None):
+                     skip_pip=True, log_rotate_days=None, log_level=False):
     """
     Reads the configuration file and tries to start all the required
     functionality. Will add functionality to 'hass' parameter if given,
@@ -221,18 +221,19 @@ def from_config_file(config_path, hass=None, verbose=False, daemon=False,
     hass.config.config_dir = config_dir
     mount_local_lib_path(config_dir)
 
-    enable_logging(hass, verbose, daemon, log_rotate_days)
+    enable_logging(hass, verbose, daemon, log_rotate_days, log_level=log_level)
 
     config_dict = config_util.load_config_file(config_path)
 
     return from_config_dict(config_dict, hass, enable_log=False,
-                            skip_pip=skip_pip)
+                            skip_pip=skip_pip, log_level=log_level)
 
 
-def enable_logging(hass, verbose=False, daemon=False, log_rotate_days=None):
+def enable_logging(hass, verbose=False, daemon=False, log_rotate_days=None,
+                   log_level=False):
     """ Setup the logging for home assistant. """
     if not daemon:
-        logging.basicConfig(level=logging.INFO)
+        logging.basicConfig(level=logging.DEBUG)
         fmt = ("%(log_color)s%(asctime)s %(levelname)s (%(threadName)s) "
                "[%(name)s] %(message)s%(reset)s")
         try:
@@ -252,6 +253,26 @@ def enable_logging(hass, verbose=False, daemon=False, log_rotate_days=None):
         except ImportError:
             _LOGGER.warning(
                 "Colorlog package not found, console coloring disabled")
+
+        logging.getLogger().handlers[0].setLevel(logging.DEBUG)
+        logging.getLogger().setLevel(logging.INFO)
+
+        if log_level:
+            for cmd in log_level:
+                info = cmd.rsplit("=", 1)
+                if len(info) == 1:
+                    level = logging.INFO
+                    if hasattr(logging, info[0]):
+                        level = getattr(logging, info[0])
+                    logging.getLogger().setLevel(level)
+                    _LOGGER.info("Setting loglevel %s on root logger", level)
+                elif len(info) == 2:
+                    level = logging.INFO
+                    if hasattr(logging, info[1]):
+                        level = getattr(logging, info[1])
+                    logging.getLogger(info[0]).setLevel(level)
+                    _LOGGER.info("Setting loglevel %s on module %s", level,
+                                 info[0])
 
     # Log errors to a file if we have write access to file or config dir
     err_log_path = hass.config.path(ERROR_LOG_FILENAME)


### PR DESCRIPTION
With this argument the loglevel on individual modules can be set
or for the entire set.

Some examples:
--loglevel="components=DEBUG" # Will set DEBUG on all compenents
--loglevel="DEBUG"            # Will set DEBUG on all modules
--loglevel="components.notify.smtp=DEBUG" # Will set DEBUG on module components.notify.smtp

You can specify this argument multiple times for diffrent modules.
--loglevel="WARNING" --loglevel="components.notify.smtp=DEBUG" # Quiet all but components.notify.smtp module

Signed-off-by: Robert Marklund robbelibobban@gmail.com
