### PR TITLE
fix typo in log message

### DIFF
--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -112,7 +112,7 @@ def setup_plexserver(host, token, hass, add_devices_callback):
             {host: {'token': token}}):
         _LOGGER.error('failed to save config file')
 
-    _LOGGER.info('Connected to: htts://%s', host)
+    _LOGGER.info('Connected to: http://%s', host)
 
     plex_clients = {}
     plex_sessions = {}


### PR DESCRIPTION
The plex component logs an htts url, which is confusing to people, as
they think something is broken, when it is not.

Closes #959
