### PR TITLE
Fix adding devices on the fly

### DIFF
--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -143,28 +143,24 @@ def pf_callback_factory(
         if gateway.sensors[node_id].sketch_name is None:
             _LOGGER.info('No sketch_name: node %s', node_id)
             return
-        # previously discovered, just update state with latest info
-        if node_id in devices:
-            for entity in devices[node_id]:
-                entity.update_ha_state(True)
-            return
 
-        # First time we see this node, detect sensors
         for child in gateway.sensors[node_id].children.values():
-            name = '{} {}.{}'.format(
-                gateway.sensors[node_id].sketch_name, node_id, child.id)
-
             for value_type in child.values.keys():
+                key = node_id, child.id, value_type
                 if child.type not in s_types or value_type not in v_types:
                     continue
+                if key in devices:
+                    devices[key].update_ha_state(True)
+                    continue
+                name = '{} {}.{}'.format(
+                    gateway.sensors[node_id].sketch_name, node_id, child.id)
+                devices[key] = entity_class(
+                    gateway, node_id, child.id, name, value_type)
 
-                devices[node_id].append(
-                    entity_class(gateway, node_id, child.id, name, value_type))
-        if devices[node_id]:
-            _LOGGER.info('adding new devices: %s', devices[node_id])
-            add_devices(devices[node_id])
-        for entity in devices[node_id]:
-            entity.update_ha_state(True)
+                _LOGGER.info('Adding new devices: %s', devices[key])
+                add_devices([devices[key]])
+                if key in devices:
+                    devices[key].update_ha_state(True)
     return mysensors_callback
 
 

--- a/homeassistant/components/sensor/mysensors.py
+++ b/homeassistant/components/sensor/mysensors.py
@@ -7,7 +7,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.mysensors/
 """
 import logging
-from collections import defaultdict
 
 from homeassistant.helpers.entity import Entity
 
@@ -72,7 +71,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         v_types = [member for member in gateway.const.SetReq
                    if member.value not in not_v_types]
 
-        devices = defaultdict(list)
+        devices = {}
         gateway.platform_callbacks.append(mysensors.pf_callback_factory(
             s_types, v_types, devices, add_devices, MySensorsSensor))
 

--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -7,7 +7,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.mysensors.html
 """
 import logging
-from collections import defaultdict
 
 from homeassistant.components.switch import SwitchDevice
 
@@ -54,7 +53,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             ])
             v_types.extend([gateway.const.SetReq.V_STATUS, ])
 
-        devices = defaultdict(list)
+        devices = {}
         gateway.platform_callbacks.append(mysensors.pf_callback_factory(
             s_types, v_types, devices, add_devices, MySensorsSwitch))
 


### PR DESCRIPTION
Devices were not added without persistence enabled and restart of HA.
Node id was added to defaultdict(list) by mistake when checking if list
of defaultdict was empty. Only solving that mistake would only make
the first sensor encountered to be added to devices. The fix had to
include evaluating node_id, child.id and value_type, each update.
- Fix adding devices in mysensors_callback.
- Change devices to regular dict.
