### PR TITLE
Fix device_state_attributes

### DIFF
--- a/homeassistant/components/sensor/mysensors.py
+++ b/homeassistant/components/sensor/mysensors.py
@@ -153,8 +153,10 @@ class MySensorsSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        device_attr = dict(self._values)
-        device_attr.pop(self.value_type, None)
+        device_attr = {}
+        for value_type, value in self._values.items():
+            if value_type != self.value_type:
+                device_attr[self.gateway.const.SetReq(value_type).name] = value
         return device_attr
 
     @property

--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -103,8 +103,10 @@ class MySensorsSwitch(SwitchDevice):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        device_attr = dict(self._values)
-        device_attr.pop(self.value_type, None)
+        device_attr = {}
+        for value_type, value in self._values.items():
+            if value_type != self.value_type:
+                device_attr[self.gateway.const.SetReq(value_type).name] = value
         return device_attr
 
     @property


### PR DESCRIPTION
- Return a dict with keys as the names of the enum members instead of
  the member values.
- This fixes a TypeError: unorderable types: int() < str()
