### PR TITLE
Restart service

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -1,7 +1,10 @@
 """ Starts home assistant. """
 from __future__ import print_function
 
+from multiprocessing import Process
+import signal
 import sys
+import threading
 import os
 import argparse
 
@@ -204,6 +207,61 @@ def uninstall_osx():
     print("Home Assistant has been uninstalled.")
 
 
+def setup_and_run_hass(config_dir, args):
+    """ Setup HASS and run. Block until stopped. """
+    if args.demo_mode:
+        config = {
+            'frontend': {},
+            'demo': {}
+        }
+        hass = bootstrap.from_config_dict(
+            config, config_dir=config_dir, daemon=args.daemon,
+            verbose=args.verbose, skip_pip=args.skip_pip,
+            log_rotate_days=args.log_rotate_days)
+    else:
+        config_file = ensure_config_file(config_dir)
+        print('Config directory:', config_dir)
+        hass = bootstrap.from_config_file(
+            config_file, daemon=args.daemon, verbose=args.verbose,
+            skip_pip=args.skip_pip, log_rotate_days=args.log_rotate_days)
+
+    if args.open_ui:
+        def open_browser(event):
+            """ Open the webinterface in a browser. """
+            if hass.config.api is not None:
+                import webbrowser
+                webbrowser.open(hass.config.api.base_url)
+
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_START, open_browser)
+
+    hass.start()
+    sys.exit(int(hass.block_till_stopped()))
+
+
+def run_hass_process(hass_proc):
+    """ Runs a child hass process. Returns True if it should be restarted.  """
+    requested_stop = threading.Event()
+    hass_proc.daemon = True
+
+    def request_stop():
+        """ request hass stop """
+        requested_stop.set()
+        hass_proc.terminate()
+
+    try:
+        signal.signal(signal.SIGTERM, request_stop)
+    except ValueError:
+        print('Could not bind to SIGQUIT. Are you running in a thread?')
+
+    hass_proc.start()
+    try:
+        hass_proc.join()
+    except KeyboardInterrupt:
+        request_stop()
+        hass_proc.join()
+    return not requested_stop.isSet() and hass_proc.exitcode > 0
+
+
 def main():
     """ Starts Home Assistant. """
     validate_python()
@@ -233,33 +291,12 @@ def main():
     if args.pid_file:
         write_pid(args.pid_file)
 
-    if args.demo_mode:
-        config = {
-            'frontend': {},
-            'demo': {}
-        }
-        hass = bootstrap.from_config_dict(
-            config, config_dir=config_dir, daemon=args.daemon,
-            verbose=args.verbose, skip_pip=args.skip_pip,
-            log_rotate_days=args.log_rotate_days)
-    else:
-        config_file = ensure_config_file(config_dir)
-        print('Config directory:', config_dir)
-        hass = bootstrap.from_config_file(
-            config_file, daemon=args.daemon, verbose=args.verbose,
-            skip_pip=args.skip_pip, log_rotate_days=args.log_rotate_days)
+    # Run hass is child process. Restart if necessary.
+    keep_running = True
+    while keep_running:
+        hass_proc = Process(target=setup_and_run_hass, args=(config_dir, args))
+        keep_running = run_hass_process(hass_proc)
 
-    if args.open_ui:
-        def open_browser(event):
-            """ Open the webinterface in a browser. """
-            if hass.config.api is not None:
-                import webbrowser
-                webbrowser.open(hass.config.api.base_url)
-
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_START, open_browser)
-
-    hass.start()
-    hass.block_till_stopped()
 
 if __name__ == "__main__":
     main()

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -251,7 +251,7 @@ def run_hass_process(hass_proc):
     try:
         signal.signal(signal.SIGTERM, request_stop)
     except ValueError:
-        print('Could not bind to SIGQUIT. Are you running in a thread?')
+        print('Could not bind to SIGTERM. Are you running in a thread?')
 
     hass_proc.start()
     try:
@@ -262,7 +262,7 @@ def run_hass_process(hass_proc):
             hass_proc.join()
         except KeyboardInterrupt:
             return False
-    return not requested_stop.isSet() and hass_proc.exitcode > 0
+    return not requested_stop.isSet() and hass_proc.exitcode == 100
 
 
 def main():
@@ -294,7 +294,7 @@ def main():
     if args.pid_file:
         write_pid(args.pid_file)
 
-    # Run hass is child process. Restart if necessary.
+    # Run hass as child process. Restart if necessary.
     keep_running = True
     while keep_running:
         hass_proc = Process(target=setup_and_run_hass, args=(config_dir, args))

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -258,7 +258,10 @@ def run_hass_process(hass_proc):
         hass_proc.join()
     except KeyboardInterrupt:
         request_stop()
-        hass_proc.join()
+        try:
+            hass_proc.join()
+        except KeyboardInterrupt:
+            return False
     return not requested_stop.isSet() and hass_proc.exitcode > 0
 
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -10,7 +10,6 @@ MATCH_ALL = '*'
 DEVICE_DEFAULT_NAME = "Unnamed Device"
 
 # #### CONFIG ####
-CONF_ICON = "icon"
 CONF_LATITUDE = "latitude"
 CONF_LONGITUDE = "longitude"
 CONF_TEMPERATURE_UNIT = "temperature_unit"
@@ -124,6 +123,7 @@ ATTR_GPS_ACCURACY = 'gps_accuracy'
 
 # #### SERVICES ####
 SERVICE_HOMEASSISTANT_STOP = "stop"
+SERVICE_HOMEASSISTANT_RESTART = "restart"
 
 SERVICE_TURN_ON = 'turn_on'
 SERVICE_TURN_OFF = 'turn_off'

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -10,6 +10,7 @@ MATCH_ALL = '*'
 DEVICE_DEFAULT_NAME = "Unnamed Device"
 
 # #### CONFIG ####
+CONF_ICON = "icon"
 CONF_LATITUDE = "latitude"
 CONF_LONGITUDE = "longitude"
 CONF_TEMPERATURE_UNIT = "temperature_unit"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,6 +7,7 @@ Provides tests to verify that Home Assistant core works.
 # pylint: disable=protected-access,too-many-public-methods
 # pylint: disable=too-few-public-methods
 import os
+import signal
 import unittest
 from unittest.mock import patch
 import time
@@ -79,15 +80,15 @@ class TestHomeAssistant(unittest.TestCase):
 
         self.assertFalse(blocking_thread.is_alive())
 
-    def test_stopping_with_keyboardinterrupt(self):
+    def test_stopping_with_sigterm(self):
         calls = []
         self.hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP,
                                   lambda event: calls.append(1))
 
-        def raise_keyboardinterrupt(length):
-            raise KeyboardInterrupt
+        def send_sigterm(length):
+            os.kill(os.getpid(), signal.SIGTERM)
 
-        with patch('homeassistant.core.time.sleep', raise_keyboardinterrupt):
+        with patch('homeassistant.core.time.sleep', send_sigterm):
             self.hass.block_till_stopped()
 
         self.assertEqual(1, len(calls))


### PR DESCRIPTION
So... I did a bad thing. I haven't convinced even myself that this is a good idea. I really just wanted to see if I could do it...

And I did. The long requested homeassistant.restart service call. 

The way this is implemented should be safe for all OS's and all configurations. This works by running Home Assistant in a child process. If the child process terminates with an exit code > 0, HASS is restarted. SIGTERM and KeyboardInterrupts to the parent process are forwarded to the child process. KeyboardInterrupts will only be forwarded once. The second KeyboardInterrupt will be handled by the parent.

Now we just need to convince ourselves that this is a good idea.
