### PR TITLE
Add support for displaying actual weather forecast instead of only current weather

### DIFF
--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -126,7 +126,6 @@ class YrSensor(Entity):
         """ Gets the latest data from yr.no and updates the states. """
 
         now = dt_util.utcnow()
-
         # check if data should be updated
         if self._update is not None and now <= self._update:
             return

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -8,7 +8,8 @@ https://home-assistant.io/components/sensor.yr/
 """
 import logging
 
-from datetime import timedelta
+import datetime
+import time
 import requests
 
 from homeassistant.const import (ATTR_ENTITY_PICTURE,
@@ -20,7 +21,7 @@ from homeassistant.util import location, dt as dt_util
 _LOGGER = logging.getLogger(__name__)
 
 
-REQUIREMENTS = ['xmltodict']
+REQUIREMENTS = ['xmltodict', 'parsedatetime']
 
 # Sensor types are defined like so:
 SENSOR_TYPES = {
@@ -39,6 +40,20 @@ SENSOR_TYPES = {
     'highClouds': ['High clouds', '%'],
     'dewpointTemperature': ['Dewpoint temperature', '°C'],
 }
+
+
+def parse_relative_time(utc_ref, str_rel):
+    """ Return a new datetime relative to utc_ref """
+    import parsedatetime
+    cal = parsedatetime.Calendar()
+
+    loc_ref = dt_util.as_local(utc_ref)
+    loc_res = cal.parse(str_rel, loc_ref)[0]
+    loc_res = time.mktime(loc_res)
+    loc_res = datetime.datetime.fromtimestamp(loc_res)
+    utc_res = dt_util.as_utc(loc_res)
+
+    return utc_res
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -83,14 +98,16 @@ class YrSensor(Entity):
 
     def __init__(self, sensor_type, weather, forecast):
         self.client_name = 'yr'
-        self._name = "{}{}".format(SENSOR_TYPES[sensor_type][0],
-                                   " forecast" if forecast else "")
+        self._name = SENSOR_TYPES[sensor_type][0]
         self.type = sensor_type
         self._state = None
         self._weather = weather
-        self._forecast = forecast or {}
+        self._forecast = forecast
         self._unit_of_measurement = SENSOR_TYPES[self.type][1]
         self._update = None
+
+        if forecast:
+            self._name += " " + forecast
 
         self.update()
 
@@ -131,16 +148,8 @@ class YrSensor(Entity):
         if self._update is not None and now <= self._update:
             return
 
-        if 'in' in self._forecast:
-            now += timedelta(hours=self._forecast['in'])
-
-        if 'at' in self._forecast:
-            now = dt_util.as_local(now)
-            now = now.replace(hour=self._forecast['at'],
-                              minute=0,
-                              second=0,
-                              microsecond=0)
-            now = dt_util.as_utc(now)
+        if self._forecast:
+            now = parse_relative_time(now, self._forecast)
 
         self._weather.update()
 

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -47,7 +47,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
     elevation = config.get('elevation')
-    forecast = config.get('forecast', {})
+    forecast = config.get('forecast')
 
     if None in (latitude, longitude):
         _LOGGER.error("Latitude or longitude not set in Home Assistant config")
@@ -83,11 +83,12 @@ class YrSensor(Entity):
 
     def __init__(self, sensor_type, weather, forecast):
         self.client_name = 'yr'
-        self._name = SENSOR_TYPES[sensor_type][0]
+        self._name = "{}{}".format(SENSOR_TYPES[sensor_type][0],
+                                   " forecast" if forecast else "")
         self.type = sensor_type
         self._state = None
         self._weather = weather
-        self._forecast = forecast
+        self._forecast = forecast or {}
         self._unit_of_measurement = SENSOR_TYPES[self.type][1]
         self._update = None
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -180,6 +180,9 @@ python-twitch==1.2.0
 # homeassistant.components.sensor.yr
 xmltodict
 
+# homeassistant.components.sensor.yr
+parsedatetime
+
 # homeassistant.components.statsd
 python-statsd==1.7.2
 

--- a/tests/components/sensor/test_yr.py
+++ b/tests/components/sensor/test_yr.py
@@ -64,16 +64,16 @@ class TestSensorYr:
             })
 
         state = self.hass.states.get('sensor.yr_pressure')
-        assert 'hPa', state.attributes.get('unit_of_measurement')
+        assert 'mbar' == state.attributes.get('unit_of_measurement')
 
         state = self.hass.states.get('sensor.yr_wind_direction')
-        assert '°', state.attributes.get('unit_of_measurement')
+        assert '°' == state.attributes.get('unit_of_measurement')
 
         state = self.hass.states.get('sensor.yr_humidity')
-        assert '%', state.attributes.get('unit_of_measurement')
+        assert '%' == state.attributes.get('unit_of_measurement')
 
         state = self.hass.states.get('sensor.yr_fog')
-        assert '%', state.attributes.get('unit_of_measurement')
+        assert '%' == state.attributes.get('unit_of_measurement')
 
         state = self.hass.states.get('sensor.yr_wind_speed')
-        assert 'm/s', state.attributes.get('unit_of_measurement')
+        assert 'm/s' == state.attributes.get('unit_of_measurement')


### PR DESCRIPTION
Add 'forecast' key to the sensor to display actual forecast, i.e. predicted weather in the future.
Default is to display current weather conditions.

examples:

```
# current temperature
- platform: yr
  monitored_conditions:
  - temperature

# temperature in one hour
- platform: yr
  forecast: in one hour
  monitored_conditions:
  - temperature

# temperature in 4 hours
- platform: yr
  forecast: in 4 hours
  monitored_conditions:
  - temperature

# temperature next day
- platform: yr
  forecast: tomorrow
  monitored_conditions:
  - temperature

# temperature at noon
- platform: yr
  forecast: at noon
  monitored_conditions:
  - temperature

# temperature this evening
- platform: yr
  forecast: at 18
  monitored_conditions:
  - temperature

# temperature tomorrow morning
- platform: yr
  forecast: tomorrow morning
  monitored_conditions:
  - temperature

# temperature tomorrow at noon
- platform: yr
  forecast: tomorrow at noon
  monitored_conditions:
  - temperature
```
