### PR TITLE
Templates in configuration

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -190,7 +190,7 @@ def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
 
     # Filter out the repeating and common config section [homeassistant]
     components = set(key.split(' ')[0] for key in config.keys()
-                     if key != core.DOMAIN)
+                     if key not in [core.DOMAIN, config_util.CONST_DOMAIN])
 
     if not core_components.setup(hass, config):
         _LOGGER.error('Home Assistant core failed to initialize. '

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -12,12 +12,14 @@ from homeassistant.const import (
     CONF_LATITUDE, CONF_LONGITUDE, CONF_TEMPERATURE_UNIT, CONF_NAME,
     CONF_TIME_ZONE)
 import homeassistant.util.location as loc_util
+from homeassistant.util.template import render_config
 from homeassistant.util.yaml import load_yaml
 
 _LOGGER = logging.getLogger(__name__)
 
 YAML_CONFIG_FILE = 'configuration.yaml'
 CONFIG_DIR_NAME = '.homeassistant'
+CONST_DOMAIN = 'const'
 
 DEFAULT_CONFIG = (
     # Tuples (attribute, default, auto detect property, description)
@@ -124,4 +126,5 @@ def load_yaml_config_file(config_path):
             os.path.basename(config_path))
         raise HomeAssistantError()
 
+    render_config(conf_dict, conf_dict)
     return conf_dict

--- a/homeassistant/util/template.py
+++ b/homeassistant/util/template.py
@@ -49,6 +49,23 @@ def render(hass, template, variables=None, **kwargs):
         raise TemplateError(err)
 
 
+def render_config(root, data):
+    """ Render templates in configuration. """
+    if isinstance(data, dict):
+        it = data.items()
+    elif isinstance(data, list):
+        it = enumerate(data)
+    for key, value in it:
+        if isinstance(value, str):
+            try:
+                data[key] = ENV.from_string(value).render(conf=root)
+            except jinja2.exceptions.UndefinedError:
+                # Not in the conf namespace.
+                pass
+        elif isinstance(value, (dict, list)):
+            render_config(root, value)
+
+
 class AllStates(object):
     """ Class to expose all HA states as attributes. """
     def __init__(self, hass):

--- a/homeassistant/util/template.py
+++ b/homeassistant/util/template.py
@@ -52,10 +52,10 @@ def render(hass, template, variables=None, **kwargs):
 def render_config(root, data):
     """ Render templates in configuration. """
     if isinstance(data, dict):
-        it = data.items()
+        iterator = data.items()
     elif isinstance(data, list):
-        it = enumerate(data)
-    for key, value in it:
+        iterator = enumerate(data)
+    for key, value in iterator:
         if isinstance(value, str):
             try:
                 data[key] = ENV.from_string(value).render(conf=root)


### PR DESCRIPTION
Allow any configuration value to use a template value derived from the configuration itself. For example:

configuration.yaml

``` yaml
const:
  sun_elevation: 2
  motion_wait: 30
  my_name: happyleavesaoc
  secrets: !include secrets.yaml

sensor:
- platform: some_sensor
  password: "{{ conf.const.secrets.password }}"
  name: "{{ conf.const.my_name }}'s cool  {{ conf.sensor[0].platform }} sensor"
```

secrets.yaml

``` yaml
password: as23df
special_key: as9sdf09asd
```

This PR is meant to foster some discussion about how to implement this feature. The presented code works, but maybe there is a better way, or maybe this is not safe.
