### PR TITLE
Fix imports and rename insteon to insteon_hub

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,8 +10,8 @@ omit =
     homeassistant/components/arduino.py
     homeassistant/components/*/arduino.py
 
-    homeassistant/components/insteon.py
-    homeassistant/components/*/insteon.py
+    homeassistant/components/insteon_hub.py
+    homeassistant/components/*/insteon_hub.py
 
     homeassistant/components/isy994.py
     homeassistant/components/*/isy994.py

--- a/homeassistant/components/arduino.py
+++ b/homeassistant/components/arduino.py
@@ -9,11 +9,6 @@ https://home-assistant.io/components/arduino/
 """
 import logging
 
-try:
-    from PyMata.pymata import PyMata
-except ImportError:
-    PyMata = None
-
 from homeassistant.helpers import validate_config
 from homeassistant.const import (EVENT_HOMEASSISTANT_START,
                                  EVENT_HOMEASSISTANT_STOP)
@@ -27,18 +22,12 @@ _LOGGER = logging.getLogger(__name__)
 def setup(hass, config):
     """ Setup the Arduino component. """
 
-    global PyMata  # pylint: disable=invalid-name
-    if PyMata is None:
-        from PyMata.pymata import PyMata as PyMata_
-        PyMata = PyMata_
-
-    import serial
-
     if not validate_config(config,
                            {DOMAIN: ['port']},
                            _LOGGER):
         return False
 
+    import serial
     global BOARD
     try:
         BOARD = ArduinoBoard(config[DOMAIN]['port'])
@@ -67,6 +56,7 @@ class ArduinoBoard(object):
     """ Represents an Arduino board. """
 
     def __init__(self, port):
+        from PyMata.pymata import PyMata
         self._port = port
         self._board = PyMata(self._port, verbose=False)
 

--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -15,6 +15,8 @@ from homeassistant.helpers import validate_config
 from homeassistant.util import Throttle
 from homeassistant.components.device_tracker import DOMAIN
 
+REQUIREMENTS = ['fritzconnection==0.4.6']
+
 # Return cached results if last scan was less then this time ago
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
@@ -55,16 +57,8 @@ class FritzBoxScanner(object):
         self.password = ''
         self.success_init = True
 
-        # Try to import the fritzconnection library
-        try:
-            # noinspection PyPackageRequirements,PyUnresolvedReferences
-            import fritzconnection as fc
-        except ImportError:
-            _LOGGER.exception("""Failed to import Python library
-                                fritzconnection. Please run
-                                <home-assistant>/setup to install it.""")
-            self.success_init = False
-            return
+        # pylint: disable=import-error
+        import fritzconnection as fc
 
         # Check for user specific configuration
         if CONF_HOST in config.keys():

--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -11,6 +11,8 @@ import logging
 import re
 import threading
 
+import requests
+
 from homeassistant.helpers import validate_config
 from homeassistant.util import sanitize_filename
 
@@ -29,14 +31,6 @@ def setup(hass, config):
     """ Listens for download events to download files. """
 
     logger = logging.getLogger(__name__)
-
-    try:
-        import requests
-    except ImportError:
-        logger.exception(("Failed to import requests. "
-                          "Did you maybe not execute 'pip install requests'?"))
-
-        return False
 
     if not validate_config(config, {DOMAIN: [CONF_DOWNLOAD_DIR]}, logger):
         return False

--- a/homeassistant/components/insteon_hub.py
+++ b/homeassistant/components/insteon_hub.py
@@ -15,10 +15,10 @@ from homeassistant.const import (
     CONF_USERNAME, CONF_PASSWORD, CONF_API_KEY, ATTR_DISCOVERED,
     ATTR_SERVICE, EVENT_PLATFORM_DISCOVERED)
 
-DOMAIN = "insteon"
+DOMAIN = "insteon_hub"
 REQUIREMENTS = ['insteon_hub==0.4.5']
 INSTEON = None
-DISCOVER_LIGHTS = "insteon.lights"
+DISCOVER_LIGHTS = "insteon_hub.lights"
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -37,11 +37,7 @@ def setup(hass, config):
     Setup ISY994 component.
     This will automatically import associated lights, switches, and sensors.
     """
-    try:
-        import PyISY
-    except ImportError:
-        _LOGGER.error("Error while importing dependency PyISY.")
-        return False
+    import PyISY
 
     # pylint: disable=global-statement
     # check for required values in configuration file

--- a/homeassistant/components/keyboard.py
+++ b/homeassistant/components/keyboard.py
@@ -6,8 +6,6 @@ Provides functionality to emulate keyboard presses on host machine.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/keyboard/
 """
-import logging
-
 from homeassistant.const import (
     SERVICE_VOLUME_UP, SERVICE_VOLUME_DOWN, SERVICE_VOLUME_MUTE,
     SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PREVIOUS_TRACK,
@@ -50,13 +48,7 @@ def media_prev_track(hass):
 
 def setup(hass, config):
     """ Listen for keyboard events. """
-    try:
-        import pykeyboard
-    except ImportError:
-        logging.getLogger(__name__).exception(
-            "Error while importing dependency PyUserInput.")
-
-        return False
+    import pykeyboard
 
     keyboard = pykeyboard.PyKeyboard()
     keyboard.special_key_assignment()

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -11,7 +11,7 @@ import os
 import csv
 
 from homeassistant.components import (
-    group, discovery, wink, isy994, zwave, insteon)
+    group, discovery, wink, isy994, zwave, insteon_hub)
 from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (
     STATE_ON, SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE,
@@ -60,7 +60,7 @@ LIGHT_PROFILES_FILE = "light_profiles.csv"
 # Maps discovered services to their platforms
 DISCOVERY_PLATFORMS = {
     wink.DISCOVER_LIGHTS: 'wink',
-    insteon.DISCOVER_LIGHTS: 'insteon',
+    insteon_hub.DISCOVER_LIGHTS: 'insteon',
     isy994.DISCOVER_LIGHTS: 'isy994',
     discovery.SERVICE_HUE: 'hue',
     zwave.DISCOVER_LIGHTS: 'zwave',

--- a/homeassistant/components/light/insteon_hub.py
+++ b/homeassistant/components/light/insteon_hub.py
@@ -4,7 +4,7 @@ homeassistant.components.light.insteon
 Support for Insteon Hub lights.
 """
 
-from homeassistant.components.insteon import (INSTEON, InsteonToggleDevice)
+from homeassistant.components.insteon_hub import (INSTEON, InsteonToggleDevice)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -9,11 +9,6 @@ https://home-assistant.io/components/media_player.mpd/
 import logging
 import socket
 
-try:
-    import mpd
-except ImportError:
-    mpd = None
-
 
 from homeassistant.const import (
     STATE_PLAYING, STATE_PAUSED, STATE_OFF)
@@ -40,10 +35,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     location = config.get('location', 'MPD')
     password = config.get('password', None)
 
-    global mpd  # pylint: disable=invalid-name
-    if mpd is None:
-        import mpd as mpd_
-        mpd = mpd_
+    import mpd
 
     # pylint: disable=no-member
     try:
@@ -82,6 +74,8 @@ class MpdDevice(MediaPlayerDevice):
     # pylint: disable=no-member, abstract-method
 
     def __init__(self, server, port, location, password):
+        import mpd
+
         self.server = server
         self.port = port
         self._name = location
@@ -95,6 +89,7 @@ class MpdDevice(MediaPlayerDevice):
         self.update()
 
     def update(self):
+        import mpd
         try:
             self.status = self.client.status()
             self.currentsong = self.client.currentsong()

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -48,11 +48,7 @@ def setup(hass, config):
             subscriber(event)
 
     # Try to load the RFXtrx module
-    try:
-        import RFXtrx as rfxtrxmod
-    except ImportError:
-        _LOGGER.exception("Failed to import rfxtrx")
-        return False
+    import RFXtrx as rfxtrxmod
 
     # Init the rfxtrx module
     global RFXOBJECT
@@ -74,11 +70,7 @@ def setup(hass, config):
 
 def get_rfx_object(packetid):
     """ Return the RFXObject with the packetid. """
-    try:
-        import RFXtrx as rfxtrxmod
-    except ImportError:
-        _LOGGER.exception("Failed to import rfxtrx")
-        return False
+    import RFXtrx as rfxtrxmod
 
     binarypacket = bytearray.fromhex(packetid)
 

--- a/homeassistant/components/sensor/bitcoin.py
+++ b/homeassistant/components/sensor/bitcoin.py
@@ -47,16 +47,8 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=120)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """ Get the Bitcoin sensor. """
 
-    try:
-        from blockchain.wallet import Wallet
-        from blockchain import exchangerates, exceptions
-
-    except ImportError:
-        _LOGGER.exception(
-            "Unable to import blockchain. "
-            "Did you maybe not install the 'blockchain' package?")
-
-        return False
+    from blockchain.wallet import Wallet
+    from blockchain import exchangerates, exceptions
 
     wallet_id = config.get('wallet', None)
     password = config.get('password', None)

--- a/homeassistant/components/sensor/cpuspeed.py
+++ b/homeassistant/components/sensor/cpuspeed.py
@@ -25,14 +25,6 @@ ATTR_HZ = 'GHz Advertised'
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """ Sets up the CPU speed sensor. """
 
-    try:
-        import cpuinfo  # noqa
-    except ImportError:
-        _LOGGER.exception(
-            "Unable to import cpuinfo. "
-            "Did you maybe not install the 'py-cpuinfo' package?")
-        return False
-
     add_devices([CpuSpeedSensor(config.get('name', DEFAULT_NAME))])
 
 

--- a/homeassistant/components/sensor/dht.py
+++ b/homeassistant/components/sensor/dht.py
@@ -31,15 +31,8 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """ Get the DHT sensor. """
 
-    try:
-        import Adafruit_DHT
-
-    except ImportError:
-        _LOGGER.exception(
-            "Unable to import Adafruit_DHT. "
-            "Did you maybe not install the 'Adafruit_DHT' package?")
-
-        return False
+    # pylint: disable=import-error
+    import Adafruit_DHT
 
     SENSOR_TYPES['temperature'][1] = hass.config.temperature_unit
     unit = hass.config.temperature_unit

--- a/homeassistant/components/sensor/openweathermap.py
+++ b/homeassistant/components/sensor/openweathermap.py
@@ -37,15 +37,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error("Latitude or longitude not set in Home Assistant config")
         return False
 
-    try:
-        from pyowm import OWM
-
-    except ImportError:
-        _LOGGER.exception(
-            "Unable to import pyowm. "
-            "Did you maybe not install the 'PyOWM' package?")
-
-        return False
+    from pyowm import OWM
 
     SENSOR_TYPES['temperature'][1] = hass.config.temperature_unit
     unit = hass.config.temperature_unit

--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -20,12 +20,7 @@ REQUIREMENTS = ['https://github.com/rkabadi/temper-python/archive/'
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """ Find and return Temper sensors. """
-    try:
-        # pylint: disable=no-name-in-module, import-error
-        from temperusb.temper import TemperHandler
-    except ImportError:
-        _LOGGER.error('Failed to import temperusb')
-        return False
+    from temperusb.temper import TemperHandler
 
     temp_unit = hass.config.temperature_unit
     name = config.get(CONF_NAME, DEVICE_DEFAULT_NAME)

--- a/homeassistant/components/switch/edimax.py
+++ b/homeassistant/components/switch/edimax.py
@@ -27,12 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """ Find and return Edimax Smart Plugs. """
-    try:
-        # pylint: disable=no-name-in-module, import-error
-        from pyedimax.smartplug import SmartPlug
-    except ImportError:
-        _LOGGER.error('Failed to import pyedimax')
-        return False
+    from pyedimax.smartplug import SmartPlug
 
     # pylint: disable=global-statement
     # check for required values in configuration file

--- a/homeassistant/components/thermostat/radiotherm.py
+++ b/homeassistant/components/thermostat/radiotherm.py
@@ -21,13 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """ Sets up the Radio Thermostat. """
-    try:
-        import radiotherm
-    except ImportError:
-        _LOGGER.exception(
-            "Unable to import radiotherm. "
-            "Did you maybe not install the 'radiotherm' package?")
-        return False
+    import radiotherm
 
     hosts = []
     if CONF_HOST in config:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -15,6 +15,9 @@ PyMata==2.07a
 # homeassistant.components.conversation
 fuzzywuzzy==0.8.0
 
+# homeassistant.components.device_tracker.fritz
+# fritzconnection==0.4.6
+
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.7.2
 
@@ -39,7 +42,7 @@ pyfttt==0.3
 # homeassistant.components.influxdb
 influxdb==2.11.0
 
-# homeassistant.components.insteon
+# homeassistant.components.insteon_hub
 insteon_hub==0.4.5
 
 # homeassistant.components.isy994

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -13,6 +13,7 @@ import sys
 COMMENT_REQUIREMENTS = [
     'RPi.GPIO',
     'Adafruit_Python_DHT',
+    'fritzconnection',
 ]
 
 


### PR DESCRIPTION
This fixes unnecessary defensive import statements throughout the code. They used to be necessary in the past.

Also renames the `insteon` component to `insteon_hub` (See discussion in #1022)
