### PR TITLE
Binary HTTP sensor

### DIFF
--- a/homeassistant/components/binary_sensor/http.py
+++ b/homeassistant/components/binary_sensor/http.py
@@ -9,15 +9,17 @@ https://home-assistant.io/components/binary_sensor.http/
 Configuration sample:
   - platform: http
     endpoint: radio
-    method: GET
+    method: GET or POST
     name: Radio
     value_template: '{{ value_json.payload }}'
 
 To test it:
 curl -X GET -H "x-ha-access: mypass" \
-      -d '{"payload": "1"}' \
-      http://localhost:8123/api/binary_sensor/radio
-curl -X POST -d '{"payload": "1"}' http://localhost:8123/api/binary_sensor/radio
+    -d '{"payload": "1"}' \
+    http://localhost:8123/api/binary_sensor/radio
+curl -X POST -d '{"payload": "1"}' \
+    http://localhost:8123/api/binary_sensor/radio
+curl -X POST http://127.0.0.1:8123/api/binary_sensor/radio?payload=1
 """
 import logging
 import json

--- a/homeassistant/components/binary_sensor/http.py
+++ b/homeassistant/components/binary_sensor/http.py
@@ -1,0 +1,107 @@
+"""
+homeassistant.components.binary_sensor.http
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The http binary sensor will consume value sent by a Home Assistant endpoint.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.http/
+
+Configuration sample:
+  - platform: http
+    endpoint: radio
+    method: GET
+    name: Radio
+    value_template: '{{ value_json.payload }}'
+
+To test it:
+curl -X GET -H "x-ha-access: mypass" \
+      -d '{"payload": "1"}' \
+      http://localhost:8123/api/binary_sensor/radio
+curl -X POST -d '{"payload": "1"}' http://localhost:8123/api/binary_sensor/radio
+"""
+import logging
+import json
+from functools import partial
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.const import (CONF_VALUE_TEMPLATE,
+                                 HTTP_INTERNAL_SERVER_ERROR,
+                                 HTTP_UNPROCESSABLE_ENTITY)
+from homeassistant.util import template
+
+DEPENDENCIES = ['http']
+URL_API_BINARY_SENSOR_ENDPOINT = '/api/binary_sensor'
+DEFAULT_NAME = 'HTTP Binary Sensor'
+DEFAULT_METHOD = 'GET'
+_LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=unused-variable
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """ Get the HTTP binary sensor. """
+
+    if config.get('endpoint') is None:
+        _LOGGER.error('Missing required variable: endpoint')
+        return False
+
+    method = config.get('method', DEFAULT_METHOD)
+    endpoint = '{}/{}'.format(URL_API_BINARY_SENSOR_ENDPOINT,
+                              config.get('endpoint'))
+
+    add_devices([HttpBinarySensor(hass,
+                                  endpoint,
+                                  method,
+                                  config.get('name', DEFAULT_NAME),
+                                  config.get(CONF_VALUE_TEMPLATE))])
+
+
+# pylint: disable=too-many-arguments
+class HttpBinarySensor(BinarySensorDevice):
+    """ Implements a HTTP binary sensor. """
+
+    def __init__(self, hass, endpoint, method, name, value_template):
+        self._endpoint = endpoint
+        self._method = method
+        self._name = name
+        self._state = False
+
+        def _handle_get_api_binary_sensor(hass, handler, path_match, data):
+            """ Message for binary sensor received. """
+
+            if not isinstance(data, dict):
+                handler.write_json_message(
+                    "Error while parsing HTTP message",
+                    HTTP_INTERNAL_SERVER_ERROR)
+                return
+
+            if value_template is not None:
+                data = template.render_with_possible_json_value(
+                    hass, value_template, json.dumps(data))
+
+            if not data:
+                handler.write_json_message("Key unknown.",
+                                           HTTP_UNPROCESSABLE_ENTITY)
+                _LOGGER.error("Key unknown")
+                return
+
+            self._state = bool(int(data))
+
+            handler.write_json_message("Binary sensor value processed.")
+            self.update_ha_state()
+
+        if self._method == 'GET':
+            hass.http.register_path(
+                'GET', endpoint, partial(_handle_get_api_binary_sensor, hass))
+        elif self._method == 'POST':
+            hass.http.register_path(
+                'POST', endpoint, partial(_handle_get_api_binary_sensor, hass))
+
+    @property
+    def name(self):
+        """ The name of the binary sensor. """
+        return self._name
+
+    @property
+    def is_on(self):
+        """ True if the binary sensor is on. """
+        return self._state

--- a/homeassistant/components/binary_sensor/http.py
+++ b/homeassistant/components/binary_sensor/http.py
@@ -1,44 +1,34 @@
 """
 homeassistant.components.binary_sensor.http
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The http binary sensor will consume value sent by a Home Assistant endpoint.
+The http binary sensor will consume value sent through the Home Assistant API.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.http/
 
 Configuration sample:
   - platform: http
-    endpoint: radio
-    method: GET or POST
     name: Radio
-    payload_on: "1"
-    payload_off: "0"
-    value_template: '{{ value_json.payload }}'
 
 To test it:
-curl -X GET -H "x-ha-access: mypass" \
-    -d '{"payload": "1"}' \
-    http://localhost:8123/api/binary_sensor/radio
-curl -X POST -d '{"payload": "1"}' \
-    http://localhost:8123/api/binary_sensor/radio
-curl -X POST http://127.0.0.1:8123/api/binary_sensor/radio?payload=1
+
+$ curl -X POST -H "x-ha-access: YOUR_PASSWORD" \
+    -d '{"state": "on", "attributes": {"friendly_name": "Radio"}}' \
+    http://localhost:8123/api/states/binary_sensor.radio
+
+$ curl -X POST -H "x-ha-access: YOUR_PASSWORD" \
+    -d '{"state": "off", "attributes": {"friendly_name": "Radio"}}' \
+    http://localhost:8123/api/states/binary_sensor.radio
 """
 import logging
-import json
-from functools import partial
 
-from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.const import (CONF_VALUE_TEMPLATE,
-                                 HTTP_INTERNAL_SERVER_ERROR,
-                                 HTTP_UNPROCESSABLE_ENTITY)
-from homeassistant.util import template
+from homeassistant.components.binary_sensor import (BinarySensorDevice, DOMAIN)
+from homeassistant.util import slugify
+from homeassistant.const import URL_API_STATES
 
 DEPENDENCIES = ['http']
-URL_API_BINARY_SENSOR_ENDPOINT = '/api/binary_sensor'
 DEFAULT_NAME = 'HTTP Binary Sensor'
-DEFAULT_METHOD = 'GET'
-DEFAULT_PAYLOAD_ON = 'ON'
-DEFAULT_PAYLOAD_OFF = 'OFF'
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -46,79 +36,34 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """ Get the HTTP binary sensor. """
 
-    if config.get('endpoint') is None:
-        _LOGGER.error('Missing required variable: endpoint')
+    if config.get('name') is None:
+        _LOGGER.error('Missing required variable: name')
         return False
 
-    method = config.get('method', DEFAULT_METHOD)
-    endpoint = '{}/{}'.format(URL_API_BINARY_SENSOR_ENDPOINT,
-                              config.get('endpoint'))
+    name = config.get('name', DEFAULT_NAME)
+    entity_id = '{}.{}'.format(DOMAIN, slugify(name.lower()))
+    url = '{}/{}'.format(URL_API_STATES, entity_id)
 
-    add_devices(
-        [HttpBinarySensor(hass,
-                          endpoint,
-                          method,
-                          config.get('name', DEFAULT_NAME),
-                          config.get('payload_on', DEFAULT_PAYLOAD_ON),
-                          config.get('payload_off', DEFAULT_PAYLOAD_OFF),
-                          config.get(CONF_VALUE_TEMPLATE))])
+    _LOGGER.info("""
+    Binary HTTP sensor '%s' created.
+    Send all HTTP POST messages to: %s""", name, url)
+
+    add_devices([HttpBinarySensor(name)])
 
 
-# pylint: disable=too-many-arguments
 class HttpBinarySensor(BinarySensorDevice):
     """ Implements a HTTP binary sensor. """
 
-    def __init__(self, hass, endpoint, method, name, payload_on,
-                 payload_off, value_template):
-        self._endpoint = endpoint
-        self._method = method
+    def __init__(self, name):
         self._name = name
         self._state = False
-        self._payload_on = payload_on
-        self._payload_off = payload_off
 
-        def _handle_get_api_binary_sensor(hass, handler, path_match, data):
-            """ Message for binary sensor received. """
-
-            if not isinstance(data, dict):
-                handler.write_json_message(
-                    "Error while parsing HTTP message",
-                    HTTP_INTERNAL_SERVER_ERROR)
-                return
-
-            if value_template is not None:
-                data = template.render_with_possible_json_value(
-                    hass, value_template, json.dumps(data))
-
-            if not data:
-                handler.write_json_message("Key unknown.",
-                                           HTTP_UNPROCESSABLE_ENTITY)
-                _LOGGER.error("Key unknown")
-                return
-
-            if data == self._payload_on:
-                self._state = True
-            elif data == self._payload_off:
-                self._state = False
-            else:
-                self._state = bool(int(data))
-
-            handler.write_json_message("Binary sensor value processed.")
-            self.update_ha_state()
-
-        if self._method == 'GET':
-            hass.http.register_path(
-                'GET', endpoint, partial(_handle_get_api_binary_sensor, hass))
-        elif self._method == 'POST':
-            hass.http.register_path(
-                'POST', endpoint, partial(_handle_get_api_binary_sensor, hass))
+    @property
+    def should_poll(self):
+        """ No polling needed. """
+        return False
 
     @property
     def name(self):
         """ The name of the binary sensor. """
         return self._name
-
-    @property
-    def is_on(self):
-        """ True if the binary sensor is on. """
-        return self._state

--- a/tests/components/binary_sensor/test_http.py
+++ b/tests/components/binary_sensor/test_http.py
@@ -2,10 +2,11 @@
 tests.components.binary_sensor.test_http
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tests Home Assistant HTTP binary sensor does what it should do.
+Tests HTTP binary sensor.
 """
 # pylint: disable=protected-access,too-many-public-methods
 import unittest
+import json
 from unittest.mock import patch
 
 import requests
@@ -21,13 +22,15 @@ from tests.common import get_test_home_assistant
 
 SERVER_PORT = 8127
 HTTP_BASE_URL = "http://127.0.0.1:{}".format(SERVER_PORT)
+API_PASSWORD = "test1234"
+HA_HEADERS = {const.HTTP_HEADER_HA_AUTH: API_PASSWORD}
+ENTITY_ID = 'binary_sensor.test'
 
 hass = None
 
-
-def _url(endpoint=""):
-    """ Helper method to generate URLs. """
-    return '{}/{}/{}'.format(HTTP_BASE_URL, 'api/binary_sensor', endpoint)
+def _url(path=""):
+    """ Helper method to generate urls. """
+    return '{}{}'.format(HTTP_BASE_URL, path)
 
 
 @patch('homeassistant.components.http.util.get_local_ip',
@@ -37,6 +40,7 @@ def setUpModule(mock_get_local_ip):   # pylint: disable=invalid-name
     global hass
 
     hass = get_test_home_assistant()
+    hass.states.set(ENTITY_ID, 'off')
 
     # Set up server
     bootstrap.setup_component(hass, http.DOMAIN, {
@@ -62,45 +66,63 @@ def tearDownModule():   # pylint: disable=invalid-name
     """ Stops the Home Assistant server. """
     hass.stop()
 
+
 class TestBinarySensorHTTP(unittest.TestCase):
     """ Test the HTTP binary sensor. """
 
     def setup_method(self, method):
         self.hass = ha.HomeAssistant()
 
-    def test_wrong_endpoint(self):
-        """ Test with unknown endpoint (GET & POST). """
-        req = requests.get(_url(endpoint="another_sensor"))
-        self.assertEqual(404, req.status_code)
-        req = requests.post(_url(endpoint="another_sensor"))
-        self.assertEqual(404, req.status_code)
-
-    # Doesn't work because something is wrong with the URL...i assume...
-    def test_setting_sensor_value_via_http_message(self):
+    def test_sensor(self):
         """ Test for setting the sensor value. """
-        self.assertTrue(binary_sensor.setup(self.hass, {
+        self.assertTrue(binary_sensor.setup(hass, {
             'binary_sensor': {
                 'platform': 'http',
                 'name': 'test',
-                'endpoint': 'test',
-                'method': 'GET',
-                'value_template': '{{ value_json.payload }}',
             }
         }))
 
-        params_on = {'state': '1'}
-        params_off = {'state': '0'}
+        state = hass.states.get(ENTITY_ID)
+        self.assertEqual(STATE_OFF, state.state)
 
-        req = requests.get(_url(endpoint="test"), params=params_on)
-        self.assertEqual(404, req.status_code)
-        self.hass.states.set('binary_sensor.test', params_on['state'])
-        self.hass.pool.block_till_done()
-        state = self.hass.states.get('binary_sensor.test')
-        self.assertEqual(True, bool(int(state.state)))
+        hass.states.set(ENTITY_ID, 'on')
+        state = hass.states.get('binary_sensor.test')
+        self.assertEqual(STATE_ON, state.state)
 
-        req = requests.get(_url(endpoint="test"), params=params_off)
-        self.assertEqual(404, req.status_code)
-        self.hass.states.set('binary_sensor.test', params_off['state'])
-        self.hass.pool.block_till_done()
-        state = self.hass.states.get('binary_sensor.test')
-        self.assertEqual(False, bool(int(state.state)))
+        hass.states.set(ENTITY_ID, 'off')
+        state = hass.states.get('binary_sensor.test')
+        self.assertEqual(STATE_OFF, state.state)
+
+    def test_api_get_state(self):
+        """ Test if the sensor allows us to get a state. """
+        req = requests.get(
+            _url(const.URL_API_STATES_ENTITY.format(ENTITY_ID)),
+            headers=HA_HEADERS)
+
+        data = ha.State.from_dict(req.json())
+        state = hass.states.get(ENTITY_ID)
+
+        self.assertEqual(state.state, data.state)
+        self.assertEqual(state.last_changed, data.last_changed)
+        self.assertEqual(state.attributes, data.attributes)
+
+    def test_api_set_state(self):
+        """ Test if we can set the state of an binary sensor. """
+        hass.states.set(ENTITY_ID, 'not_to_be_set')
+
+        requests.post(_url(const.URL_API_STATES_ENTITY.format(ENTITY_ID)),
+                      data=json.dumps({"state": "off"}),
+                      headers=HA_HEADERS)
+
+        self.assertEqual("off", hass.states.get(ENTITY_ID).state)
+
+    # pylint: disable=invalid-name
+    def test_api_state_change_with_no_data(self):
+        """ Test if API sends appropriate error if we omit state. """
+        req = requests.post(
+            _url(const.URL_API_STATES_ENTITY.format(
+                ENTITY_ID)),
+            data=json.dumps({}),
+            headers=HA_HEADERS)
+
+        self.assertEqual(400, req.status_code)

--- a/tests/components/binary_sensor/test_http.py
+++ b/tests/components/binary_sensor/test_http.py
@@ -1,0 +1,106 @@
+"""
+tests.components.binary_sensor.test_http
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests Home Assistant HTTP binary sensor does what it should do.
+"""
+# pylint: disable=protected-access,too-many-public-methods
+import unittest
+from unittest.mock import patch
+
+import requests
+import homeassistant.core as ha
+
+from homeassistant import bootstrap, const
+import homeassistant.components.binary_sensor as binary_sensor
+import homeassistant.components.http as http
+from homeassistant.const import (STATE_OFF, STATE_ON)
+
+from tests.common import get_test_home_assistant
+
+
+SERVER_PORT = 8127
+HTTP_BASE_URL = "http://127.0.0.1:{}".format(SERVER_PORT)
+
+hass = None
+
+
+def _url(endpoint=""):
+    """ Helper method to generate URLs. """
+    return '{}/{}/{}'.format(HTTP_BASE_URL, 'api/binary_sensor', endpoint)
+
+
+@patch('homeassistant.components.http.util.get_local_ip',
+       return_value='127.0.0.1')
+def setUpModule(mock_get_local_ip):   # pylint: disable=invalid-name
+    """ Initializes a Home Assistant server. """
+    global hass
+
+    hass = get_test_home_assistant()
+
+    # Set up server
+    bootstrap.setup_component(hass, http.DOMAIN, {
+        http.DOMAIN: {
+            http.CONF_SERVER_PORT: SERVER_PORT
+        }
+    })
+
+    # Set up API
+    bootstrap.setup_component(hass, 'api')
+
+    # Set up HTTP binary sensor
+    bootstrap.setup_component(hass, binary_sensor.DOMAIN, {
+        binary_sensor.DOMAIN: {
+            'platform': 'http'
+        }
+    })
+
+    hass.start()
+
+
+def tearDownModule():   # pylint: disable=invalid-name
+    """ Stops the Home Assistant server. """
+    hass.stop()
+
+class TestBinarySensorHTTP(unittest.TestCase):
+    """ Test the HTTP binary sensor. """
+
+    def setup_method(self, method):
+        self.hass = ha.HomeAssistant()
+
+    def test_wrong_endpoint(self):
+        """ Test with unknown endpoint (GET & POST). """
+        req = requests.get(_url(endpoint="another_sensor"))
+        self.assertEqual(404, req.status_code)
+        req = requests.post(_url(endpoint="another_sensor"))
+        self.assertEqual(404, req.status_code)
+
+    # Doesn't work because something is wrong with the URL...i assume...
+    def test_setting_sensor_value_via_http_message(self):
+        """ Test for setting the sensor value. """
+        self.assertTrue(binary_sensor.setup(self.hass, {
+            'binary_sensor': {
+                'platform': 'http',
+                'name': 'test',
+                'endpoint': 'test',
+                'method': 'GET',
+                'value_template': '{{ value_json.payload }}',
+            }
+        }))
+
+        params_on = {'state': '1'}
+        params_off = {'state': '0'}
+
+        req = requests.get(_url(endpoint="test"), params=params_on)
+        self.assertEqual(404, req.status_code)
+        self.hass.states.set('binary_sensor.test', params_on['state'])
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('binary_sensor.test')
+        self.assertEqual(True, bool(int(state.state)))
+
+        req = requests.get(_url(endpoint="test"), params=params_off)
+        self.assertEqual(404, req.status_code)
+        self.hass.states.set('binary_sensor.test', params_off['state'])
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('binary_sensor.test')
+        self.assertEqual(False, bool(int(state.state)))


### PR DESCRIPTION
This platform is exposing an API endpoint (eg. `api/binary_sensor/radio`) that is consuming incoming HTTP messages of a binary sensor.

Configuration sample:

``` yaml
  - platform: http
    endpoint: radio
    method: GET
    name: Radio
    payload_on: "1"
    payload_off: "0"
    value_template: '{{ value_json.payload }}'
```

To test it:

``` bash
curl -X GET -H "x-ha-access: mypass" -d '{"payload": "1"}' http://localhost:8123/api/binary_sensor/radio
curl -X GET -d '{"payload": "1"}' http://localhost:8123/api/binary_sensor/radio
curl -X GET http://127.0.0.1:8123/api/binary_sensor/radio?payload=1
```

The test is only working partially at the moment.
