### PR TITLE
Update for new liffylights release

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -28,7 +28,7 @@ from homeassistant.components.light import \
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['liffylights==0.9.2']
+REQUIREMENTS = ['liffylights==0.9.3']
 DEPENDENCIES = []
 
 CONF_SERVER = "server"        # server address configuration item
@@ -70,6 +70,8 @@ class LIFX():
         bulb = self.find_bulb(ipaddr)
 
         if bulb is None:
+            _LOGGER.debug("new bulb %s %s %d %d %d %d %d",
+                          ipaddr, name, power, hue, sat, bri, kel)
             bulb = LIFXLight(self._liffylights, ipaddr, name,
                              power, hue, sat, bri, kel)
             self._devices.append(bulb)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -52,7 +52,7 @@ blinkstick==1.1.7
 phue==0.8
 
 # homeassistant.components.light.lifx
-liffylights==0.9.2
+liffylights==0.9.3
 
 # homeassistant.components.light.limitlessled
 limitlessled==1.0.0


### PR DESCRIPTION
Fix incorrect packet timeout/ack code causing flooding when no bulbs were online, which consumed all WorkerPool threads
