### PR TITLE
Add install prefix to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ testpaths = tests
 
 [pep257]
 ignore = D203,D105
+
+[install]
+prefix=


### PR DESCRIPTION
I was playing with Amazon lambdas tonight and read this in [their docs](http://docs.aws.amazon.com/lambda/latest/dg/lambda-python-how-to-create-deployment-package.html):

> If using Mac OS X and you have Python installed using Homebrew (see Homebrew), the preceding command will not work. A simple workaround is to add a setup.cfg file in your /path/to/project-dir with the following content.
> 
> ```
> [install]
> prefix= 
> ```

This is a common issue for our OS X users as many people use Homebrew to acquire Python 3. I am just not sure what the side effects would be of this. @rmkraus do you know?
