### PR TITLE
Fix gen_requirements_all

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,38 +6,89 @@ pip>=7.0.0
 vincenty==0.1.3
 jinja2>=2.8
 
-# homeassistant.components.alarm_control_panel.alarmdotcom
-https://github.com/Xorso/pyalarmdotcom/archive/0.0.7.zip#pyalarmdotcom==0.0.7
+# homeassistant.components.isy994
+PyISY==1.0.5
 
 # homeassistant.components.arduino
 PyMata==2.07a
 
-# homeassistant.components.conversation
-fuzzywuzzy==0.8.0
+# homeassistant.components.rpi_gpio
+# RPi.GPIO==0.6.1
+
+# homeassistant.components.media_player.sonos
+SoCo==0.11.1
+
+# homeassistant.components.notify.twitter
+TwitterAPI==2.3.6
+
+# homeassistant.components.sun
+astral==0.9
+
+# homeassistant.components.light.blinksticklight
+blinkstick==1.1.7
+
+# homeassistant.components.sensor.bitcoin
+blockchain==1.2.1
+
+# homeassistant.components.notify.xmpp
+dnspython3==1.12.0
+
+# homeassistant.components.sensor.dweet
+dweepy==0.2.0
+
+# homeassistant.components.sensor.eliqonline
+eliqonline==1.0.11
+
+# homeassistant.components.thermostat.honeywell
+evohomeclient==0.2.4
+
+# homeassistant.components.notify.free_mobile
+freesms==0.1.0
 
 # homeassistant.components.device_tracker.fritz
 # fritzconnection==0.4.6
 
-# homeassistant.components.device_tracker.icloud
-pyicloud==0.7.2
+# homeassistant.components.conversation
+fuzzywuzzy==0.8.0
 
-# homeassistant.components.device_tracker.netgear
-pynetgear==0.3.2
+# homeassistant.components.thermostat.heatmiser
+heatmiserV3==0.9.1
 
-# homeassistant.components.device_tracker.nmap_tracker
-python-nmap==0.4.3
+# homeassistant.components.switch.hikvisioncam
+hikvision==0.4
 
-# homeassistant.components.device_tracker.snmp
-pysnmp==4.2.5
+# homeassistant.components.sensor.dht
+# http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
 
-# homeassistant.components.discovery
-netdisco==0.5.2
+# homeassistant.components.rfxtrx
+https://github.com/Danielhiversen/pyRFXtrx/archive/0.2.zip#RFXtrx==0.2
+
+# homeassistant.components.sensor.netatmo
+https://github.com/HydrelioxGitHub/netatmo-api-python/archive/43ff238a0122b0939a0dc4e8836b6782913fb6e2.zip#lnetatmo==0.4.0
+
+# homeassistant.components.alarm_control_panel.alarmdotcom
+https://github.com/Xorso/pyalarmdotcom/archive/0.0.7.zip#pyalarmdotcom==0.0.7
+
+# homeassistant.components.modbus
+https://github.com/bashwork/pymodbus/archive/d7fc4f1cc975631e0a9011390e8017f64b612661.zip#pymodbus==1.2.0
+
+# homeassistant.components.sensor.sabnzbd
+https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
 
 # homeassistant.components.ecobee
 https://github.com/nkgilley/python-ecobee-api/archive/92a2f330cbaf601d0618456fdd97e5a8c42c1c47.zip#python-ecobee==0.0.4
 
-# homeassistant.components.ifttt
-pyfttt==0.3
+# homeassistant.components.switch.edimax
+https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f3700.zip#pyedimax==0.1
+
+# homeassistant.components.sensor.temper
+https://github.com/rkabadi/temper-python/archive/3dbdaf2d87b8db9a3cd6e5585fc704537dd2d09b.zip#temperusb==1.2.3
+
+# homeassistant.components.mysensors
+https://github.com/theolind/pymysensors/archive/005bff4c5ca7a56acd30e816bc3bcdb5cb2d46fd.zip#pymysensors==0.4
+
+# homeassistant.components.notify.googlevoice
+https://github.com/w1ll1am23/pygooglevoice-sms/archive/7c5ee9969b97a7992fc86a753fe9f20e3ffa3f7c.zip#pygooglevoice-sms==0.0.1
 
 # homeassistant.components.influxdb
 influxdb==2.11.0
@@ -45,17 +96,8 @@ influxdb==2.11.0
 # homeassistant.components.insteon_hub
 insteon_hub==0.4.5
 
-# homeassistant.components.isy994
-PyISY==1.0.5
-
-# homeassistant.components.keyboard
-pyuserinput==0.1.9
-
-# homeassistant.components.light.blinksticklight
-blinkstick==1.1.7
-
-# homeassistant.components.light.hue
-phue==0.8
+# homeassistant.components.media_player.kodi
+jsonrpc-requests==0.1
 
 # homeassistant.components.light.lifx
 liffylights==0.9.3
@@ -63,15 +105,80 @@ liffylights==0.9.3
 # homeassistant.components.light.limitlessled
 limitlessled==1.0.0
 
-# homeassistant.components.light.tellstick
-# homeassistant.components.sensor.tellstick
-# homeassistant.components.switch.tellstick
-tellcore-py==1.1.2
+# homeassistant.components.discovery
+netdisco==0.5.2
 
-# homeassistant.components.light.vera
-# homeassistant.components.sensor.vera
-# homeassistant.components.switch.vera
-pyvera==0.2.7
+# homeassistant.components.switch.orvibo
+orvibo==1.1.1
+
+# homeassistant.components.mqtt
+paho-mqtt==1.1
+
+# homeassistant.components.light.hue
+phue==0.8
+
+# homeassistant.components.media_player.plex
+plexapi==1.1.0
+
+# homeassistant.components.thermostat.proliphix
+proliphix==0.1.0
+
+# homeassistant.components.sensor.systemmonitor
+psutil==3.4.2
+
+# homeassistant.components.notify.pushbullet
+pushbullet.py==0.9.0
+
+# homeassistant.components.notify.pushetta
+pushetta==1.0.15
+
+# homeassistant.components.sensor.cpuspeed
+py-cpuinfo==0.1.8
+
+# homeassistant.components.media_player.cast
+pychromecast==0.7.1
+
+# homeassistant.components.zwave
+pydispatcher==2.0.5
+
+# homeassistant.components.ifttt
+pyfttt==0.3
+
+# homeassistant.components.device_tracker.icloud
+pyicloud==0.7.2
+
+# homeassistant.components.device_tracker.netgear
+pynetgear==0.3.2
+
+# homeassistant.components.sensor.openweathermap
+pyowm==2.3.0
+
+# homeassistant.components.device_tracker.snmp
+pysnmp==4.2.5
+
+# homeassistant.components.sensor.forecast
+python-forecastio==1.3.3
+
+# homeassistant.components.media_player.mpd
+python-mpd2==0.5.4
+
+# homeassistant.components.nest
+python-nest==2.6.0
+
+# homeassistant.components.device_tracker.nmap_tracker
+python-nmap==0.4.3
+
+# homeassistant.components.notify.pushover
+python-pushover==0.2
+
+# homeassistant.components.statsd
+python-statsd==1.7.2
+
+# homeassistant.components.notify.telegram
+python-telegram-bot==3.2.0
+
+# homeassistant.components.sensor.twitch
+python-twitch==1.2.0
 
 # homeassistant.components.wink
 # homeassistant.components.light.wink
@@ -80,150 +187,43 @@ pyvera==0.2.7
 # homeassistant.components.switch.wink
 python-wink==0.4.2
 
-# homeassistant.components.media_player.cast
-pychromecast==0.7.1
+# homeassistant.components.keyboard
+pyuserinput==0.1.9
 
-# homeassistant.components.media_player.kodi
-jsonrpc-requests==0.1
-
-# homeassistant.components.media_player.mpd
-python-mpd2==0.5.4
-
-# homeassistant.components.media_player.plex
-plexapi==1.1.0
-
-# homeassistant.components.media_player.samsungtv
-samsungctl==0.5.1
-
-# homeassistant.components.media_player.sonos
-SoCo==0.11.1
-
-# homeassistant.components.modbus
-https://github.com/bashwork/pymodbus/archive/d7fc4f1cc975631e0a9011390e8017f64b612661.zip#pymodbus==1.2.0
-
-# homeassistant.components.mqtt
-paho-mqtt==1.1
-
-# homeassistant.components.mysensors
-https://github.com/theolind/pymysensors/archive/005bff4c5ca7a56acd30e816bc3bcdb5cb2d46fd.zip#pymysensors==0.4
-
-# homeassistant.components.nest
-python-nest==2.6.0
-
-# homeassistant.components.notify.free_mobile
-freesms==0.1.0
-
-# homeassistant.components.notify.googlevoice
-https://github.com/w1ll1am23/pygooglevoice-sms/archive/7c5ee9969b97a7992fc86a753fe9f20e3ffa3f7c.zip#pygooglevoice-sms==0.0.1
-
-# homeassistant.components.notify.pushbullet
-pushbullet.py==0.9.0
-
-# homeassistant.components.notify.pushetta
-pushetta==1.0.15
-
-# homeassistant.components.notify.pushover
-python-pushover==0.2
-
-# homeassistant.components.notify.slack
-slacker==0.6.8
-
-# homeassistant.components.notify.telegram
-python-telegram-bot==3.2.0
-
-# homeassistant.components.notify.twitter
-TwitterAPI==2.3.6
-
-# homeassistant.components.notify.xmpp
-sleekxmpp==1.3.1
-
-# homeassistant.components.notify.xmpp
-dnspython3==1.12.0
-
-# homeassistant.components.rfxtrx
-https://github.com/Danielhiversen/pyRFXtrx/archive/0.2.zip#RFXtrx==0.2
-
-# homeassistant.components.rpi_gpio
-# RPi.GPIO==0.6.1
-
-# homeassistant.components.scsgate
-scsgate==0.1.0
-
-# homeassistant.components.sensor.bitcoin
-blockchain==1.2.1
-
-# homeassistant.components.sensor.cpuspeed
-py-cpuinfo==0.1.8
-
-# homeassistant.components.sensor.dht
-# http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
-
-# homeassistant.components.sensor.dweet
-dweepy==0.2.0
-
-# homeassistant.components.sensor.eliqonline
-eliqonline==1.0.11
-
-# homeassistant.components.sensor.forecast
-python-forecastio==1.3.3
-
-# homeassistant.components.sensor.netatmo
-https://github.com/HydrelioxGitHub/netatmo-api-python/archive/43ff238a0122b0939a0dc4e8836b6782913fb6e2.zip#lnetatmo==0.4.0
-
-# homeassistant.components.sensor.openweathermap
-pyowm==2.3.0
-
-# homeassistant.components.sensor.sabnzbd
-https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
-
-# homeassistant.components.sensor.systemmonitor
-psutil==3.4.2
-
-# homeassistant.components.sensor.temper
-https://github.com/rkabadi/temper-python/archive/3dbdaf2d87b8db9a3cd6e5585fc704537dd2d09b.zip#temperusb==1.2.3
-
-# homeassistant.components.sensor.transmission
-# homeassistant.components.switch.transmission
-transmissionrpc==0.11
-
-# homeassistant.components.sensor.twitch
-python-twitch==1.2.0
-
-# homeassistant.components.sensor.yr
-xmltodict
-
-# homeassistant.components.statsd
-python-statsd==1.7.2
-
-# homeassistant.components.sun
-astral==0.9
-
-# homeassistant.components.switch.edimax
-https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f3700.zip#pyedimax==0.1
-
-# homeassistant.components.switch.hikvisioncam
-hikvision==0.4
-
-# homeassistant.components.switch.orvibo
-orvibo==1.1.1
+# homeassistant.components.light.vera
+# homeassistant.components.sensor.vera
+# homeassistant.components.switch.vera
+pyvera==0.2.7
 
 # homeassistant.components.switch.wemo
 pywemo==0.3.8
 
+# homeassistant.components.thermostat.radiotherm
+radiotherm==1.2
+
+# homeassistant.components.media_player.samsungtv
+samsungctl==0.5.1
+
+# homeassistant.components.scsgate
+scsgate==0.1.0
+
+# homeassistant.components.notify.slack
+slacker==0.6.8
+
+# homeassistant.components.notify.xmpp
+sleekxmpp==1.3.1
+
+# homeassistant.components.light.tellstick
+# homeassistant.components.sensor.tellstick
+# homeassistant.components.switch.tellstick
+tellcore-py==1.1.2
+
 # homeassistant.components.tellduslive
 tellive-py==0.5.2
 
-# homeassistant.components.thermostat.heatmiser
-heatmiserV3==0.9.1
-
-# homeassistant.components.thermostat.honeywell
-evohomeclient==0.2.4
-
-# homeassistant.components.thermostat.proliphix
-proliphix==0.1.0
-
-# homeassistant.components.thermostat.radiotherm
-radiotherm==1.2
+# homeassistant.components.sensor.transmission
+# homeassistant.components.switch.transmission
+transmissionrpc==0.11
 
 # homeassistant.components.verisure
 vsure==0.5.0
@@ -231,5 +231,5 @@ vsure==0.5.0
 # homeassistant.components.zigbee
 xbee-helper==0.0.6
 
-# homeassistant.components.zwave
-pydispatcher==2.0.5
+# homeassistant.components.sensor.yr
+xmltodict

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -3,7 +3,6 @@
 Generate an updated requirements_all.txt
 """
 
-from collections import OrderedDict
 import importlib
 import os
 import pkgutil
@@ -50,7 +49,7 @@ def comment_requirement(req):
 
 def gather_modules():
     """ Collect the information and construct the output. """
-    reqs = OrderedDict()
+    reqs = {}
 
     errors = []
     output = []
@@ -68,6 +67,10 @@ def gather_modules():
         for req in module.REQUIREMENTS:
             reqs.setdefault(req, []).append(package)
 
+    for key in reqs:
+        reqs[key] = sorted(reqs[key],
+                           key=lambda name: (len(name.split('.')), name))
+
     if errors:
         print("******* ERROR")
         print("Errors while importing: ", ', '.join(errors))
@@ -78,7 +81,7 @@ def gather_modules():
     output.append('\n')
     output.append('\n'.join(core_requirements()))
     output.append('\n')
-    for pkg, requirements in reqs.items():
+    for pkg, requirements in sorted(reqs.items(), key=lambda item: item[0]):
         for req in sorted(requirements,
                           key=lambda name: (len(name.split('.')), name)):
             output.append('\n# {}'.format(req))


### PR DESCRIPTION
There could be certain cases where we would not be deterministic in generating `requirements_all.txt`. This improves it by ordering `requirements_all.txt` by package name instead of component that depends on it.
