### PR TITLE
use yaml safe loader

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -19,7 +19,7 @@ def load_yaml(fname):
         with open(fname, encoding='utf-8') as conf_file:
             # If configuration file is empty YAML returns None
             # We convert that to an empty dict
-            return yaml.load(conf_file) or {}
+            return yaml.safe_load(conf_file) or {}
     except yaml.YAMLError:
         error = 'Error reading YAML configuration file {}'.format(fname)
         _LOGGER.exception(error)
@@ -45,6 +45,6 @@ def _ordered_dict(loader, node):
     return OrderedDict(loader.construct_pairs(node))
 
 
-yaml.add_constructor('!include', _include_yaml)
-yaml.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-                     _ordered_dict)
+yaml.SafeLoader.add_constructor('!include', _include_yaml)
+yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+                                _ordered_dict)


### PR DESCRIPTION
Prevent execution of code inside yaml configuration file.

Local configuration files should be considered trusted, I guess. But there are no practical reasons to allow this anyway, since it doesn't make sense to allow arbitrary code to be executed as a side effect of reading a configuration file.

example:

```
foo: !!python/object/apply:os.system 
  args: ['echo hello > /tmp/foobar'] # or something more evil
```
