### PR TITLE
Fix bug in sensor.template entity_id

### DIFF
--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -9,15 +9,19 @@ https://home-assistant.io/components/sensor.template/
 """
 import logging
 
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity import Entity, generate_entity_id
 from homeassistant.core import EVENT_STATE_CHANGED
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     CONF_VALUE_TEMPLATE,
     ATTR_UNIT_OF_MEASUREMENT)
 
-from homeassistant.util import template
+from homeassistant.util import template, slugify
 from homeassistant.exceptions import TemplateError
+
+from homeassistant.components.sensor import DOMAIN
+
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 _LOGGER = logging.getLogger(__name__)
 CONF_SENSORS = 'sensors'
@@ -34,9 +38,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
     for device, device_config in config[CONF_SENSORS].items():
+
+        if device != slugify(device):
+            _LOGGER.error("Found invalid key for sensor.template: %s. "
+                          "Use %s instead", device, slugify(device))
+            continue
+
         if not isinstance(device_config, dict):
             _LOGGER.error("Missing configuration data for sensor %s", device)
             continue
+
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         unit_of_measurement = device_config.get(ATTR_UNIT_OF_MEASUREMENT)
         state_template = device_config.get(CONF_VALUE_TEMPLATE)
@@ -44,9 +55,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             _LOGGER.error(
                 "Missing %s for sensor %s", CONF_VALUE_TEMPLATE, device)
             continue
+
         sensors.append(
             SensorTemplate(
                 hass,
+                device,
                 friendly_name,
                 unit_of_measurement,
                 state_template)
@@ -64,9 +77,14 @@ class SensorTemplate(Entity):
     # pylint: disable=too-many-arguments
     def __init__(self,
                  hass,
+                 device_id,
                  friendly_name,
                  unit_of_measurement,
                  state_template):
+
+        self.entity_id = generate_entity_id(
+            ENTITY_ID_FORMAT, device_id,
+            hass=hass)
 
         self.hass = hass
         self._name = friendly_name

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -64,7 +64,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 unit_of_measurement,
                 state_template)
             )
-    if sensors is None:
+    if not sensors:
         _LOGGER.error("No sensors added")
         return False
     add_devices(sensors)

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -72,13 +72,21 @@ class TestTemplateSensor:
         })
         assert self.hass.states.all() == []
 
-    def test_invalid_config_does_not_create(self):
+    def test_invalid_sensor_does_not_create(self):
         assert sensor.setup(self.hass, {
             'sensor': {
                 'platform': 'template',
                 'sensors': {
-                    'test_template_sensor': {}
+                    'test_template_sensor': 'invalid'
                 }
+            }
+        })
+        assert self.hass.states.all() == []
+
+    def test_no_sensors_does_not_create(self):
+        assert sensor.setup(self.hass, {
+            'sensor': {
+                'platform': 'template'
             }
         })
         assert self.hass.states.all() == []

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -4,9 +4,6 @@ tests.components.sensor.template
 
 Tests template sensor.
 """
-from unittest.mock import patch
-
-import pytest
 
 import homeassistant.core as ha
 import homeassistant.components.sensor as sensor
@@ -56,8 +53,46 @@ class TestTemplateSensor:
             }
         })
 
-
         self.hass.states.set('sensor.test_state', 'Works')
         self.hass.pool.block_till_done()
         state = self.hass.states.get('sensor.test_template_sensor')
         assert state.state == 'error'
+
+    def test_invalid_name_does_not_create(self):
+        assert sensor.setup(self.hass, {
+            'sensor': {
+                'platform': 'template',
+                'sensors': {
+                    'test INVALID sensor': {
+                        'value_template':
+                            "{{ states.sensor.test_state.state }}"
+                    }
+                }
+            }
+        })
+        assert self.hass.states.all() == []
+
+    def test_invalid_config_does_not_create(self):
+        assert sensor.setup(self.hass, {
+            'sensor': {
+                'platform': 'template',
+                'sensors': {
+                    'test_template_sensor': {}
+                }
+            }
+        })
+        assert self.hass.states.all() == []
+
+    def test_missing_template_does_not_create(self):
+        assert sensor.setup(self.hass, {
+            'sensor': {
+                'platform': 'template',
+                'sensors': {
+                    'test_template_sensor': {
+                        'not_value_template':
+                            "{{ states.sensor.test_state.state }}"
+                    }
+                }
+            }
+        })
+        assert self.hass.states.all() == []


### PR DESCRIPTION
Generate entity id correctly was using friendly_name.

Closes https://github.com/balloob/home-assistant/issues/1088
