### PR TITLE
No longer ignore ports for Chromecasts

### DIFF
--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -1,0 +1,30 @@
+"""
+tests.component.media_player.test_cast
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests cast media_player component.
+"""
+# pylint: disable=too-many-public-methods,protected-access
+import unittest
+from unittest.mock import patch
+
+from homeassistant.components.media_player import cast
+
+
+class TestCastMediaPlayer(unittest.TestCase):
+    """ Test the media_player module. """
+
+    @patch('homeassistant.components.media_player.cast.CastDevice')
+    def test_filter_duplicates(self, mock_device):
+        cast.setup_platform(None, {
+            'host': 'some_host'
+        }, lambda _: _)
+
+        assert mock_device.called
+
+        mock_device.reset_mock()
+        assert not mock_device.called
+
+        cast.setup_platform(None, {}, lambda _: _, ('some_host',
+                                                    cast.DEFAULT_PORT))
+        assert not mock_device.called


### PR DESCRIPTION
We were ignoring discovered ports for Chromecasts. With Chromecast multiroom the Chromecast is actually hosting multiple interfaces with different ports on the same device.

Fixes #1093 
