### PR TITLE
Sensor template startup error

### DIFF
--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -128,7 +128,7 @@ class SensorTemplate(Entity):
             self._state = STATE_ERROR
             if ex.args and ex.args[0].startswith(
                     "UndefinedError: 'None' has no attribute"):
-                # Common during HA startup - so just a trace
-                _LOGGER.info(ex)
+                # Common during HA startup - so just a warning
+                _LOGGER.warning(ex)
                 return
             _LOGGER.error(ex)

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -126,4 +126,9 @@ class SensorTemplate(Entity):
             self._state = template.render(self.hass, self._template)
         except TemplateError as ex:
             self._state = STATE_ERROR
+            if ex.args and ex.args[0].startswith(
+                    "UndefinedError: 'None' has no attribute"):
+                # Common during HA startup - so just a trace
+                _LOGGER.info(ex)
+                return
             _LOGGER.error(ex)

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -26,19 +26,19 @@ class TestTemplateSensor:
                 'sensors': {
                     'test_template_sensor': {
                         'value_template':
-                            "{{ states.sensor.test_state.state }}"
+                            "It {{ states.sensor.test_state.state }}."
                     }
                 }
             }
         })
 
         state = self.hass.states.get('sensor.test_template_sensor')
-        assert state.state == ''
+        assert state.state == 'It .'
 
         self.hass.states.set('sensor.test_state', 'Works')
         self.hass.pool.block_till_done()
         state = self.hass.states.get('sensor.test_template_sensor')
-        assert state.state == 'Works'
+        assert state.state == 'It Works.'
 
     def test_template_syntax_error(self):
         assert sensor.setup(self.hass, {
@@ -55,6 +55,22 @@ class TestTemplateSensor:
 
         self.hass.states.set('sensor.test_state', 'Works')
         self.hass.pool.block_till_done()
+        state = self.hass.states.get('sensor.test_template_sensor')
+        assert state.state == 'error'
+
+    def test_template_attribute_missing(self):
+        assert sensor.setup(self.hass, {
+            'sensor': {
+                'platform': 'template',
+                'sensors': {
+                    'test_template_sensor': {
+                        'value_template':
+                            "It {{ states.sensor.test_state.attributes.missing }}."
+                    }
+                }
+            }
+        })
+
         state = self.hass.states.get('sensor.test_template_sensor')
         assert state.state == 'error'
 


### PR DESCRIPTION
Avoid giving errors where attributes are missing on startup.

I've made this a warning - since it could be a real template error if it happens when everything is set up.
