### PR TITLE
Splitting hue

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -31,7 +31,7 @@ SERVICE_PLEX = 'plex_mediaserver'
 SERVICE_HANDLERS = {
     SERVICE_WEMO: "switch",
     SERVICE_CAST: "media_player",
-    SERVICE_HUE: "light",
+    SERVICE_HUE: "hue",
     SERVICE_NETGEAR: 'device_tracker',
     SERVICE_SONOS: 'media_player',
     SERVICE_PLEX: 'media_player',

--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -1,0 +1,211 @@
+"""
+homeassistant.components.hue
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Support for Philips Hue bridge.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/hue/
+"""
+
+import logging
+import socket
+from datetime import timedelta
+from urllib.parse import urlparse
+
+from homeassistant import bootstrap
+from homeassistant.util import Throttle
+from homeassistant.loader import get_component
+from homeassistant.helpers import validate_config
+from homeassistant.components import discovery
+from homeassistant.const import (
+    CONF_HOST, ATTR_SERVICE, ATTR_DISCOVERED, EVENT_PLATFORM_DISCOVERED)
+
+DOMAIN = 'hue'
+
+REQUIREMENTS = ['phue==0.8']
+
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
+MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
+
+PHUE_CONFIG_FILE = "phue.conf"
+
+DISCOVER_LIGHTS = 'hue.lights'
+
+_LOGGER = logging.getLogger(__name__)
+
+# Map ip to request id for configuring
+_CONFIGURING = {}
+
+
+def setup(hass, config):
+    """
+    Setup a Hue bridge
+
+    Set up a 'global' to contain bridge instances to be called.
+    If the bridge is non-local, it cannot be discovered. Multiple bridge can be
+    listed in configuration.
+    Setup discovery
+    """
+
+    # This dict will hold all bridges. The dict key is the bridgeid.
+    # It's much easier to just use 'host', but deals better with multiple IPs
+    # or DHCP swtiching bridge ip?
+    global HUEBRIDGE
+    HUEBRIDGE = {}
+
+    # FIXME / This needs cleanup / better config loading
+    #hosts = config.get(CONF_HOST, None)
+    hosts = config[DOMAIN][CONF_HOST]
+    if hosts is not None:
+        if not isinstance(hosts, list):
+            hosts = [hosts]
+
+        for host in hosts:
+            # FIXME / This can only happen when discovery beats configuration
+            # loading right?
+            if host in _CONFIGURING:
+                continue
+
+            _LOGGER.info('Attepring bridge set for %s', host)
+            setup_huebridge(hass, host)
+    else:
+        _LOGGER.info('No hosts configured for hue component, it\'s up to discovery now')
+
+    comp_name = 'light'
+    component = get_component(comp_name)
+    bootstrap.setup_component(hass, component.DOMAIN, config)
+
+    def huebridge_discovered(service, info):
+        """
+        Called when a Hue bridge is discovered.
+        Response from netdisco recovery is an URI, we just need the host/ip
+        ro initialize the python bridge module
+        """
+        hostname = urlparse(info[1]).hostname
+        setup_huebridge(hass, hostname)
+    discovery.listen(hass, discovery.SERVICE_HUE, huebridge_discovered)
+
+    return True
+
+
+def setup_huebridge(hass, host):
+    """ Setup a phue bridge based on host parameter. """
+    import phue
+
+    # Create bridge object which will try and connect to the referenced host/ip
+    # If we're not allowed (registration exception), start a config request
+    try:
+        bridge = phue.Bridge(
+            host,
+            config_file_path=hass.config.path(PHUE_CONFIG_FILE))
+    except ConnectionRefusedError:  # Wrong host was given
+        _LOGGER.exception("Error connecting to the Hue bridge at %s", host)
+        return
+    except phue.PhueRegistrationException:
+        _LOGGER.warning("Connected to Hue at %s but not registered.", host)
+        request_configuration(hass, host)
+        return
+
+    # If we came here and configuring this host, mark as done
+    if host in _CONFIGURING:
+        request_id = _CONFIGURING.pop(host)
+        configurator = get_component('configurator')
+        configurator.request_done(request_id)
+
+    # Add instanciated bridge to our own control global
+    bridge_id = bridge.get_api().get('config').get('bridgeid')
+    if HUEBRIDGE.get(bridge_id):
+        _LOGGER.warning('Bridge already exists in global: %s',bridge_id)
+        return
+    HUEBRIDGE[bridge_id] = HueBridge(hass, bridge)
+
+
+def request_configuration(hass, host):
+    """ Request configuration steps from the user. """
+    configurator = get_component('configurator')
+
+    # We got an error if this method is called while we are configuring
+    if host in _CONFIGURING:
+        configurator.notify_errors(
+            _CONFIGURING[host], "Failed to register, please try again.")
+        return
+
+    # pylint: disable=unused-argument
+    def hue_configuration_callback(data):
+        """ Actions to do when our configuration callback is called. """
+        setup_huebridge(hass, host)
+
+    _CONFIGURING[host] = configurator.request_config(
+        hass, "Philips Hue", hue_configuration_callback,
+        description=("Press the button on the bridge to register Philips Hue "
+                     "with Home Assistant."),
+        description_image="/static/images/config_philips_hue.jpg",
+        submit_caption="I have pressed the button"
+    )
+
+
+class HueBridge(object):
+    """
+    This manages a Hue bridge
+    Gets the latest data and update the states
+    """
+
+    def __init__(self, hass, bridge):
+        # This will be used to control devices from their platform modules
+        self.hass = hass
+        self._bridge = bridge
+        self.set_light = self._bridge.set_light
+        self.lights = {}
+
+        bconfig = self.get_apidata().get('config')
+        self.bridge_id = bconfig.get('bridgeid')
+
+        # Support limitations in DiY zigbee bridge 'deconz'
+        if bconfig.get('name') == 'RaspBee-GW':
+            self.bridge_type = 'deconz'
+        else:
+            self.bridge_type = 'hue'
+
+        # FIXME / debuglog
+        _LOGGER.warning('Successfully initialized new bridge: %s/%s, discovering attached devices', self._bridge.ip, self.bridge_id)
+        self.process_apidata()
+
+    def get_apidata(self):
+        """ Refresh bridge data from API """
+        try:
+            apidata = self._bridge.get_api()
+        except socket.error:
+            # socket.error when we cannot reach Hue
+            _LOGGER.error("Cannot reach the bridge")
+            return
+        return apidata
+
+    def process_apidata(self):
+        """ Updates the Hue light objects with latest info from the bridge. """
+        api_states = self.get_apidata().get('lights')
+        if not isinstance(api_states, dict):
+            _LOGGER.error("Got unexpected result from Hue API")
+            return
+
+        new_lights = []
+        for light_id, info in api_states.items():
+            # FIXME / debuglog
+            _LOGGER.warning('Update: processing light %s on bridge %s', light_id, self.bridge_id)
+            if light_id not in self.lights.keys():
+                new_lights.append(light_id)
+            self.lights[light_id] = info
+
+        if new_lights:
+            # FIXME / debuglog
+            _LOGGER.warning('Sending discovery event for new light: %s',new_lights)
+            self.hass.bus.fire(EVENT_PLATFORM_DISCOVERED, {
+                ATTR_SERVICE: DISCOVER_LIGHTS,
+                ATTR_DISCOVERED: {
+                    'bridge_id': self.bridge_id,
+                    'lights': new_lights,
+                }
+            })
+
+    @Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
+    def update(self):
+        self.process_apidata()

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -11,7 +11,7 @@ import os
 import csv
 
 from homeassistant.components import (
-    group, discovery, wink, isy994, zwave, insteon_hub)
+    group, discovery, wink, isy994, zwave, insteon_hub, hue)
 from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (
     STATE_ON, SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE,
@@ -61,8 +61,8 @@ LIGHT_PROFILES_FILE = "light_profiles.csv"
 DISCOVERY_PLATFORMS = {
     wink.DISCOVER_LIGHTS: 'wink',
     insteon_hub.DISCOVER_LIGHTS: 'insteon_hub',
+    hue.DISCOVER_LIGHTS: 'hue',
     isy994.DISCOVER_LIGHTS: 'isy994',
-    discovery.SERVICE_HUE: 'hue',
     zwave.DISCOVER_LIGHTS: 'zwave',
 }
 

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -43,6 +43,8 @@ class HueLight(Light):
     def __init__(self, bridge_id, light_id):
         self.bridge = HUEBRIDGE.get(bridge_id)
         self.light_id = light_id
+        # FIXME / debuglog
+        _LOGGER.warning('init new light %s on hub %s', light_id, bridge_id)
 
     def info(self):
         return self.bridge.get_state(ATTR_HUE_LIGHTS, self.light_id)


### PR DESCRIPTION
## Feedback request

I'd like to get some feedback on certain things in this PR. Depending on the amount of fixes, I may submit a new one after fixes.
## Purpose of PR

So, feature of this branch is to split the existing Hue platform into it's own component and a light platform.
Reasons are as follows:
- Prepare for supporting Hue Tap, wall switch, wall dimmer, etc
- The bridge is now split off from the light allowing for separate polling
  - Add new lights on the fly after initial setup
  - Don't require at least one initialised light for the bridge to pol (still the case, want to find a solution)

Some minor fixes
- Support multiple hue bridges in configuration and phue.conf

Features (not new, but still working)
- discovery of bridge via netdisco
- multiple bridges supported
- Use of configurator when new bridge is detected
