### PR TITLE
Disable location queries

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,11 @@
 import betamax
 
+from homeassistant.util import location
+
+from .common import mock_detect_location_info
+
 with betamax.Betamax.configure() as config:
     config.cassette_library_dir = 'tests/cassettes'
+
+# This hits a 3rd party server. Always mock it.
+location.detect_location_info = mock_detect_location_info

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -8,15 +8,12 @@ Tests bootstrap.
 import os
 import tempfile
 import unittest
-from unittest import mock
 
 from homeassistant import core, bootstrap
 from homeassistant.const import (__version__, CONF_LATITUDE, CONF_LONGITUDE,
                                  CONF_NAME, CONF_CUSTOMIZE)
 import homeassistant.util.dt as dt_util
 from homeassistant.helpers.entity import Entity
-
-from tests.common import mock_detect_location_info
 
 
 class TestBootstrap(unittest.TestCase):
@@ -35,9 +32,7 @@ class TestBootstrap(unittest.TestCase):
                 fp.write('{}:\n'.format(comp).encode('utf-8'))
             fp.flush()
 
-            with mock.patch('homeassistant.util.location.detect_location_info',
-                            mock_detect_location_info):
-                hass = bootstrap.from_config_file(fp.name)
+            hass = bootstrap.from_config_file(fp.name)
 
             components.append('group')
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_LATITUDE, CONF_LONGITUDE, CONF_TEMPERATURE_UNIT, CONF_NAME,
     CONF_TIME_ZONE)
 
-from tests.common import get_test_config_dir, mock_detect_location_info
+from tests.common import get_test_config_dir
 
 CONFIG_DIR = get_test_config_dir()
 YAML_PATH = os.path.join(CONFIG_DIR, config_util.YAML_CONFIG_FILE)
@@ -112,8 +112,6 @@ class TestConfig(unittest.TestCase):
             [('hello', 0), ('world', 1)],
             list(config_util.load_yaml_config_file(YAML_PATH).items()))
 
-    @mock.patch('homeassistant.util.location.detect_location_info',
-                mock_detect_location_info)
     @mock.patch('builtins.print')
     def test_create_default_config_detect_location(self, mock_print):
         """ Test that detect location sets the correct config keys. """


### PR DESCRIPTION
There was 1 test that forgot to mock out a location query. This kind of thing is too easy to sneak in so I'm going to mock it by default when we run our tests.
