### PR TITLE
Z-Wave Regression: Fix state attributes of lights and switches.

### DIFF
--- a/homeassistant/components/sensor/zwave.py
+++ b/homeassistant/components/sensor/zwave.py
@@ -100,6 +100,11 @@ class ZWaveSensor(ZWaveDeviceEntity, Entity):
         return self._value.data
 
     @property
+    def state_attributes(self):
+        """ Returns optional state attributes. """
+        return self.device_state_attributes
+
+    @property
     def unit_of_measurement(self):
         return self._value.units
 

--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -255,8 +255,8 @@ class ZWaveDeviceEntity:
         return object_id
 
     @property
-    def state_attributes(self):
-        """ Returns the state attributes. """
+    def device_state_attributes(self):
+        """ Returns device specific state attributes. """
         attrs = {
             ATTR_NODE_ID: self._value.node.node_id,
         }


### PR DESCRIPTION
Pull request #982 unfortunately broke the Zwave Dimmer component.

Light and ZWaveDeviceEntity both have overwritten the property state_attributes
Make sure to include the values of both superclasses - the light component will look in
device_state_attributes for device specific attributes. These are now the state attributes of the zwave device
