### PR TITLE
First cut of switch.template

### DIFF
--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -94,10 +94,7 @@ class SensorTemplate(Entity):
 
         def _update_callback(_event):
             """ Called when the target device changes state. """
-            # This can be called before the entity is properly
-            # initialised, so check before updating state,
-            if self.entity_id:
-                self.update_ha_state(True)
+            self.update_ha_state(True)
 
         self.hass.bus.listen(EVENT_STATE_CHANGED, _update_callback)
 

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -35,9 +35,6 @@ STATE_ERROR = 'error'
 ON_ACTION = 'turn_on'
 OFF_ACTION = 'turn_off'
 
-STATE_TRUE = 'True'
-STATE_FALSE = 'False'
-
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -139,26 +136,27 @@ class SwitchTemplate(SwitchDevice):
     @property
     def is_on(self):
         """ True if device is on. """
-        return self._state == STATE_TRUE or self._state == STATE_ON
+        return self._value.lower() == 'true' or self._value == STATE_ON
 
     @property
     def is_off(self):
         """ True if device is off. """
-        return self._state == STATE_FALSE or self._state == STATE_OFF
+        return self._value.lower() == 'false' or self._value == STATE_OFF
 
     @property
-    def state(self):
-        """ Returns the state. """
-        if self.is_on:
-            return STATE_ON
-        if self.is_off:
-            return STATE_OFF
-        return self._state
+    def available(self):
+        """Return True if entity is available."""
+        return self.is_on or self.is_off
 
     def update(self):
         """ Updates the state from the template. """
         try:
-            self._state = template.render(self.hass, self._template)
+            self._value = template.render(self.hass, self._template)
+            if not self.available:
+                _LOGGER.error(
+                    "`%s` is not a switch state, setting %s to unavailable",
+                    self._value, self.entity_id)
+
         except TemplateError as ex:
-            self._state = STATE_ERROR
+            self._value = STATE_ERROR
             _LOGGER.error(ex)

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -41,6 +41,7 @@ OFF_ACTION = 'turn_off'
 STATE_TRUE = 'True'
 STATE_FALSE = 'False'
 
+
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """ Sets up the switches. """
@@ -122,7 +123,6 @@ class SwitchTemplate(SwitchDevice):
                 self.update_ha_state(True)
 
         self.hass.bus.listen(EVENT_STATE_CHANGED, _update_callback)
-
 
     @property
     def name(self):

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -135,9 +135,11 @@ class SwitchTemplate(SwitchDevice):
         return False
 
     def turn_on(self, **kwargs):
+        """ Fires the on action. """
         call_from_config(self.hass, self._on_action, True)
 
     def turn_off(self, **kwargs):
+        """ Fires the off action. """
         call_from_config(self.hass, self._off_action, True)
 
     @property
@@ -147,7 +149,7 @@ class SwitchTemplate(SwitchDevice):
 
     @property
     def is_off(self):
-        """ True if device is on. """
+        """ True if device is off. """
         return self._state == STATE_FALSE or self._state == STATE_OFF
 
     @property
@@ -160,6 +162,7 @@ class SwitchTemplate(SwitchDevice):
         return self._state
 
     def update(self):
+        """ Updates the state from the template. """
         try:
             self._state = template.render(self.hass, self._template)
         except TemplateError as ex:

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -20,11 +20,8 @@ from homeassistant.const import (
     CONF_VALUE_TEMPLATE)
 
 from homeassistant.helpers.service import call_from_config
-
 from homeassistant.util import template, slugify
-
 from homeassistant.exceptions import TemplateError
-
 from homeassistant.components.switch import DOMAIN
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
@@ -117,10 +114,7 @@ class SwitchTemplate(SwitchDevice):
 
         def _update_callback(_event):
             """ Called when the target device changes state. """
-            # This can be called before the entity is properly
-            # initialised, so check before updating state,
-            if self.entity_id:
-                self.update_ha_state(True)
+            self.update_ha_state(True)
 
         self.hass.bus.listen(EVENT_STATE_CHANGED, _update_callback)
 

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -19,7 +19,10 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     CONF_VALUE_TEMPLATE)
 
+from homeassistant.helpers.service import call_from_config
+
 from homeassistant.util import template, slugify
+
 from homeassistant.exceptions import TemplateError
 
 from homeassistant.components.switch import DOMAIN
@@ -132,10 +135,10 @@ class SwitchTemplate(SwitchDevice):
         return False
 
     def turn_on(self, **kwargs):
-        _LOGGER.error("TURN ON not implemented yet")
+        call_from_config(self.hass, self._on_action, True)
 
     def turn_off(self, **kwargs):
-        _LOGGER.error("TURN OFF not implemented yet")
+        call_from_config(self.hass, self._off_action, True)
 
     @property
     def is_on(self):

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -14,6 +14,8 @@ from homeassistant.components.switch import SwitchDevice
 
 from homeassistant.core import EVENT_STATE_CHANGED
 from homeassistant.const import (
+    STATE_ON,
+    STATE_OFF,
     ATTR_FRIENDLY_NAME,
     CONF_VALUE_TEMPLATE)
 
@@ -33,6 +35,8 @@ STATE_ERROR = 'error'
 ON_ACTION = 'turn_on'
 OFF_ACTION = 'turn_off'
 
+STATE_TRUE = 'True'
+STATE_FALSE = 'False'
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -116,15 +120,11 @@ class SwitchTemplate(SwitchDevice):
 
         self.hass.bus.listen(EVENT_STATE_CHANGED, _update_callback)
 
+
     @property
     def name(self):
         """ Returns the name of the device. """
         return self._name
-
-    @property
-    def state(self):
-        """ Returns the state of the device. """
-        return self._state
 
     @property
     def should_poll(self):
@@ -138,15 +138,23 @@ class SwitchTemplate(SwitchDevice):
         _LOGGER.error("TURN OFF not implemented yet")
 
     @property
-    def should_poll(self):
-        """ Tells Home Assistant not to poll this entity. """
-        return False
-
-    @property
     def is_on(self):
         """ True if device is on. """
-        _LOGGER.error("IS ON CALLED %s", self._state)
-        return self._state == STATE_ON
+        return self._state == STATE_TRUE or self._state == STATE_ON
+
+    @property
+    def is_off(self):
+        """ True if device is on. """
+        return self._state == STATE_FALSE or self._state == STATE_OFF
+
+    @property
+    def state(self):
+        """ Returns the state. """
+        if self.is_on:
+            return STATE_ON
+        if self.is_off:
+            return STATE_OFF
+        return self._state
 
     def update(self):
         try:

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -1,0 +1,156 @@
+"""
+homeassistant.components.switch.template
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Allows the creation of a switch that integrates other components together
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.template/
+"""
+import logging
+
+from homeassistant.helpers.entity import generate_entity_id
+
+from homeassistant.components.switch import SwitchDevice
+
+from homeassistant.core import EVENT_STATE_CHANGED
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
+    CONF_VALUE_TEMPLATE)
+
+from homeassistant.util import template, slugify
+from homeassistant.exceptions import TemplateError
+
+from homeassistant.components.switch import DOMAIN
+
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_SWITCHES = 'switches'
+
+STATE_ERROR = 'error'
+
+ON_ACTION = 'turn_on'
+OFF_ACTION = 'turn_off'
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """ Sets up the switches. """
+
+    switches = []
+    if config.get(CONF_SWITCHES) is None:
+        _LOGGER.error("Missing configuration data for switch platform")
+        return False
+
+    for device, device_config in config[CONF_SWITCHES].items():
+
+        if device != slugify(device):
+            _LOGGER.error("Found invalid key for switch.template: %s. "
+                          "Use %s instead", device, slugify(device))
+            continue
+
+        if not isinstance(device_config, dict):
+            _LOGGER.error("Missing configuration data for switch %s", device)
+            continue
+
+        friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
+        state_template = device_config.get(CONF_VALUE_TEMPLATE)
+        on_action = device_config.get(ON_ACTION)
+        off_action = device_config.get(OFF_ACTION)
+        if state_template is None:
+            _LOGGER.error(
+                "Missing %s for switch %s", CONF_VALUE_TEMPLATE, device)
+            continue
+
+        if on_action is None or off_action is None:
+            _LOGGER.error(
+                "Missing action for switch %s", device)
+            continue
+
+        switches.append(
+            SwitchTemplate(
+                hass,
+                device,
+                friendly_name,
+                state_template,
+                on_action,
+                off_action)
+            )
+    if not switches:
+        _LOGGER.error("No switches added")
+        return False
+    add_devices(switches)
+    return True
+
+
+class SwitchTemplate(SwitchDevice):
+    """ Represents a Template Switch. """
+
+    # pylint: disable=too-many-arguments
+    def __init__(self,
+                 hass,
+                 device_id,
+                 friendly_name,
+                 state_template,
+                 on_action,
+                 off_action):
+
+        self.entity_id = generate_entity_id(
+            ENTITY_ID_FORMAT, device_id,
+            hass=hass)
+
+        self.hass = hass
+        self._name = friendly_name
+        self._template = state_template
+        self._on_action = on_action
+        self._off_action = off_action
+        self.update()
+
+        def _update_callback(_event):
+            """ Called when the target device changes state. """
+            # This can be called before the entity is properly
+            # initialised, so check before updating state,
+            if self.entity_id:
+                self.update_ha_state(True)
+
+        self.hass.bus.listen(EVENT_STATE_CHANGED, _update_callback)
+
+    @property
+    def name(self):
+        """ Returns the name of the device. """
+        return self._name
+
+    @property
+    def state(self):
+        """ Returns the state of the device. """
+        return self._state
+
+    @property
+    def should_poll(self):
+        """ Tells Home Assistant not to poll this entity. """
+        return False
+
+    def turn_on(self, **kwargs):
+        _LOGGER.error("TURN ON not implemented yet")
+
+    def turn_off(self, **kwargs):
+        _LOGGER.error("TURN OFF not implemented yet")
+
+    @property
+    def should_poll(self):
+        """ Tells Home Assistant not to poll this entity. """
+        return False
+
+    @property
+    def is_on(self):
+        """ True if device is on. """
+        _LOGGER.error("IS ON CALLED %s", self._state)
+        return self._state == STATE_ON
+
+    def update(self):
+        try:
+            self._state = template.render(self.hass, self._template)
+        except TemplateError as ex:
+            self._state = STATE_ERROR
+            _LOGGER.error(ex)

--- a/tests/components/switch/test_template.py
+++ b/tests/components/switch/test_template.py
@@ -139,7 +139,7 @@ class TestTemplateSwitch:
         state = self.hass.states.set('switch.test_state', STATE_ON)
         self.hass.pool.block_till_done()
         state = self.hass.states.get('switch.test_template_switch')
-        assert state.state == 'error'
+        assert state.state == 'unavailable'
 
     def test_invalid_name_does_not_create(self):
         assert switch.setup(self.hass, {

--- a/tests/components/switch/test_template.py
+++ b/tests/components/switch/test_template.py
@@ -8,6 +8,10 @@ Tests template switch.
 import homeassistant.core as ha
 import homeassistant.components.switch as switch
 
+from homeassistant.const import (
+    STATE_ON,
+    STATE_OFF)
+
 
 class TestTemplateSwitch:
     """ Test the Template switch. """
@@ -19,7 +23,7 @@ class TestTemplateSwitch:
         """ Stop down stuff we started. """
         self.hass.stop()
 
-    def test_template_state(self):
+    def test_template_state_text(self):
         assert switch.setup(self.hass, {
             'switch': {
                 'platform': 'template',
@@ -41,18 +45,66 @@ class TestTemplateSwitch:
         })
 
 
-        state = self.hass.states.set('switch.test_state', 'On')
+        state = self.hass.states.set('switch.test_state', STATE_ON)
         self.hass.pool.block_till_done()
 
         state = self.hass.states.get('switch.test_template_switch')
-        assert state.state == 'On'
+        assert state.state == STATE_ON
 
-        state = self.hass.states.set('switch.test_state', 'Off')
+        state = self.hass.states.set('switch.test_state', STATE_OFF)
         self.hass.pool.block_till_done()
 
         state = self.hass.states.get('switch.test_template_switch')
-        assert state.state == 'Off'
+        assert state.state == STATE_OFF
 
+
+    def test_template_state_boolean_on(self):
+        assert switch.setup(self.hass, {
+            'switch': {
+                'platform': 'template',
+                'switches': {
+                    'test_template_switch': {
+                        'value_template':
+                            "{{ 1 == 1 }}",
+                        'turn_on': {
+                            'service': 'switch.turn_on',
+                            'entity_id': 'switch.test_state'
+                        },
+                        'turn_off': {
+                            'service': 'switch.turn_off',
+                            'entity_id': 'switch.test_state'
+                        },
+                    }
+                }
+            }
+        })
+
+        state = self.hass.states.get('switch.test_template_switch')
+        assert state.state == STATE_ON
+
+    def test_template_state_boolean_off(self):
+        assert switch.setup(self.hass, {
+            'switch': {
+                'platform': 'template',
+                'switches': {
+                    'test_template_switch': {
+                        'value_template':
+                            "{{ 1 == 2 }}",
+                        'turn_on': {
+                            'service': 'switch.turn_on',
+                            'entity_id': 'switch.test_state'
+                        },
+                        'turn_off': {
+                            'service': 'switch.turn_off',
+                            'entity_id': 'switch.test_state'
+                        },
+                    }
+                }
+            }
+        })
+
+        state = self.hass.states.get('switch.test_template_switch')
+        assert state.state == STATE_OFF
 
     def test_template_syntax_error(self):
         assert switch.setup(self.hass, {
@@ -75,7 +127,7 @@ class TestTemplateSwitch:
             }
         })
 
-        state = self.hass.states.set('switch.test_state', 'On')
+        state = self.hass.states.set('switch.test_state', STATE_ON)
         self.hass.pool.block_till_done()
         state = self.hass.states.get('switch.test_template_switch')
         assert state.state == 'error'

--- a/tests/components/switch/test_template.py
+++ b/tests/components/switch/test_template.py
@@ -6,6 +6,7 @@ Tests template switch.
 """
 
 import homeassistant.core as ha
+import homeassistant.components as core
 import homeassistant.components.switch as switch
 
 from homeassistant.const import (
@@ -18,6 +19,14 @@ class TestTemplateSwitch:
 
     def setup_method(self, method):
         self.hass = ha.HomeAssistant()
+
+        self.calls = []
+
+        def record_call(service):
+            self.calls.append(service)
+
+        self.hass.services.register('test', 'automation', record_call)
+
 
     def teardown_method(self, method):
         """ Stop down stuff we started. """
@@ -238,3 +247,65 @@ class TestTemplateSwitch:
             }
         })
         assert self.hass.states.all() == []
+
+    def test_on_action(self):
+        assert switch.setup(self.hass, {
+            'switch': {
+                'platform': 'template',
+                'switches': {
+                    'test_template_switch': {
+                        'value_template':
+                            "{{ states.switch.test_state.state }}",
+                        'turn_on': {
+                            'service': 'test.automation'
+                        },
+                        'turn_off': {
+                            'service': 'switch.turn_off',
+                            'entity_id': 'switch.test_state'
+                        },
+                    }
+                }
+            }
+        })
+        self.hass.states.set('switch.test_state', STATE_OFF)
+        self.hass.pool.block_till_done()
+
+        state = self.hass.states.get('switch.test_template_switch')
+        assert state.state == STATE_OFF
+
+        core.switch.turn_on(self.hass, 'switch.test_template_switch')
+        self.hass.pool.block_till_done()
+
+        assert 1 == len(self.calls)
+
+
+    def test_off_action(self):
+        assert switch.setup(self.hass, {
+            'switch': {
+                'platform': 'template',
+                'switches': {
+                    'test_template_switch': {
+                        'value_template':
+                            "{{ states.switch.test_state.state }}",
+                        'turn_on': {
+                            'service': 'switch.turn_on',
+                            'entity_id': 'switch.test_state'
+
+                        },
+                        'turn_off': {
+                            'service': 'test.automation'
+                        },
+                    }
+                }
+            }
+        })
+        self.hass.states.set('switch.test_state', STATE_ON)
+        self.hass.pool.block_till_done()
+
+        state = self.hass.states.get('switch.test_template_switch')
+        assert state.state == STATE_ON
+
+        core.switch.turn_off(self.hass, 'switch.test_template_switch')
+        self.hass.pool.block_till_done()
+
+        assert 1 == len(self.calls)

--- a/tests/components/switch/test_template.py
+++ b/tests/components/switch/test_template.py
@@ -1,0 +1,188 @@
+"""
+tests.components.switch.template
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests template switch.
+"""
+
+import homeassistant.core as ha
+import homeassistant.components.switch as switch
+
+
+class TestTemplateSwitch:
+    """ Test the Template switch. """
+
+    def setup_method(self, method):
+        self.hass = ha.HomeAssistant()
+
+    def teardown_method(self, method):
+        """ Stop down stuff we started. """
+        self.hass.stop()
+
+    def test_template_state(self):
+        assert switch.setup(self.hass, {
+            'switch': {
+                'platform': 'template',
+                'switches': {
+                    'test_template_switch': {
+                        'value_template':
+                            "{{ states.switch.test_state.state }}",
+                        'turn_on': {
+                            'service': 'switch.turn_on',
+                            'entity_id': 'switch.test_state'
+                        },
+                        'turn_off': {
+                            'service': 'switch.turn_off',
+                            'entity_id': 'switch.test_state'
+                        },
+                    }
+                }
+            }
+        })
+
+
+        state = self.hass.states.set('switch.test_state', 'On')
+        self.hass.pool.block_till_done()
+
+        state = self.hass.states.get('switch.test_template_switch')
+        assert state.state == 'On'
+
+        state = self.hass.states.set('switch.test_state', 'Off')
+        self.hass.pool.block_till_done()
+
+        state = self.hass.states.get('switch.test_template_switch')
+        assert state.state == 'Off'
+
+
+    def test_template_syntax_error(self):
+        assert switch.setup(self.hass, {
+            'switch': {
+                'platform': 'template',
+                'switches': {
+                    'test_template_switch': {
+                        'value_template':
+                            "{% if rubbish %}",
+                        'turn_on': {
+                            'service': 'switch.turn_on',
+                            'entity_id': 'switch.test_state'
+                        },
+                        'turn_off': {
+                            'service': 'switch.turn_off',
+                            'entity_id': 'switch.test_state'
+                        },
+                    }
+                }
+            }
+        })
+
+        state = self.hass.states.set('switch.test_state', 'On')
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('switch.test_template_switch')
+        assert state.state == 'error'
+
+    def test_invalid_name_does_not_create(self):
+        assert switch.setup(self.hass, {
+            'switch': {
+                'platform': 'template',
+                'switches': {
+                    'test INVALID switch': {
+                        'value_template':
+                            "{{ rubbish }",
+                        'turn_on': {
+                            'service': 'switch.turn_on',
+                            'entity_id': 'switch.test_state'
+                        },
+                        'turn_off': {
+                            'service': 'switch.turn_off',
+                            'entity_id': 'switch.test_state'
+                        },
+                    }
+                }
+            }
+        })
+        assert self.hass.states.all() == []
+
+    def test_invalid_switch_does_not_create(self):
+        assert switch.setup(self.hass, {
+            'switch': {
+                'platform': 'template',
+                'switches': {
+                    'test_template_switch': 'Invalid'
+                }
+            }
+        })
+        assert self.hass.states.all() == []
+
+    def test_no_switches_does_not_create(self):
+        assert switch.setup(self.hass, {
+            'switch': {
+                'platform': 'template'
+            }
+        })
+        assert self.hass.states.all() == []
+
+    def test_missing_template_does_not_create(self):
+        assert switch.setup(self.hass, {
+            'switch': {
+                'platform': 'template',
+                'switches': {
+                    'test_template_switch': {
+                        'not_value_template':
+                            "{{ states.switch.test_state.state }}",
+                        'turn_on': {
+                            'service': 'switch.turn_on',
+                            'entity_id': 'switch.test_state'
+                        },
+                        'turn_off': {
+                            'service': 'switch.turn_off',
+                            'entity_id': 'switch.test_state'
+                        },
+                    }
+                }
+            }
+        })
+        assert self.hass.states.all() == []
+
+    def test_missing_on_does_not_create(self):
+        assert switch.setup(self.hass, {
+            'switch': {
+                'platform': 'template',
+                'switches': {
+                    'test_template_switch': {
+                        'value_template':
+                            "{{ states.switch.test_state.state }}",
+                        'not_on': {
+                            'service': 'switch.turn_on',
+                            'entity_id': 'switch.test_state'
+                        },
+                        'turn_off': {
+                            'service': 'switch.turn_off',
+                            'entity_id': 'switch.test_state'
+                        },
+                    }
+                }
+            }
+        })
+        assert self.hass.states.all() == []
+
+    def test_missing_off_does_not_create(self):
+        assert switch.setup(self.hass, {
+            'switch': {
+                'platform': 'template',
+                'switches': {
+                    'test_template_switch': {
+                        'value_template':
+                            "{{ states.switch.test_state.state }}",
+                        'turn_on': {
+                            'service': 'switch.turn_on',
+                            'entity_id': 'switch.test_state'
+                        },
+                        'not_off': {
+                            'service': 'switch.turn_off',
+                            'entity_id': 'switch.test_state'
+                        },
+                    }
+                }
+            }
+        })
+        assert self.hass.states.all() == []


### PR DESCRIPTION
A first implementation of the meta component described here https://github.com/balloob/home-assistant/issues/949. This is in the same family as `sensor.template`.

The main purpose is to allow you to integrate several devices into a single switch, but I expect it will have other uses.

The state of the switch is set from a template. Either a logical value, or `on` / `off` will set the value of the switch in the gui. Turning on or off the switch will fire an action in the same format as automation.

Best to make sure firing the on or off actions will update the template, otherwise it doesn't make much of a switch!

Here is an example that turns on and off a script (just as a demo)

```
switch:
    - platform: template
      switches:
          test_switch:
              friendly_name: 'Slow script'
              value_template: "{{ states.script.slow.state }}"
              turn_on:
                service: script.turn_on
                entity_id: script.slow
              turn_off:
                service: script.turn_off
                entity_id: script.slow
```

Here is something I expect to use. My skylight has a sensor to show if it's open or closed - and two momentary switches to operate the open and close. I can replace my custom component with something like this:- 

```
switch:
    - platform: template
      switches:
          skylight:
              value_template: "{{ states.sensor.skylight == 'tripped' }}"
              turn_on:
                service: switch.turn_on
                entity_id: switch.skylight_open
              turn_off:
                service: switch.turn_on
                entity_id: switch.skylight_close
```
