### PR TITLE
add pytest-timeout to test runs

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,7 @@
 flake8>=2.5.1
 pylint>=1.5.3
 coveralls>=1.1
-pytest>=2.6.4
+pytest>=2.8.0
 pytest-cov>=2.2.0
+pytest-timeout>=1.0.0
 betamax>=0.5.1

--- a/script/test
+++ b/script/test
@@ -8,10 +8,10 @@ cd "$(dirname "$0")/.."
 echo "Running tests..."
 
 if [ "$1" = "coverage" ]; then
-  py.test --cov --cov-report=
+  py.test -v --timeout=30 --cov --cov-report=
   TEST_STATUS=$?
 else
-  py.test
+  py.test -v --timeout=30
   TEST_STATUS=$?
 fi
 


### PR DESCRIPTION
This adds a default 30 second timeout on every test method so that
deadlocks or broken threads are move obvious in travis. It also passes
-v by default to make things a little more verbose on where things
fail when they are failing.
