### PR TITLE
Fix InfluxDB field type conflict

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -85,7 +85,7 @@ def setup(hass, config):
 
         measurement = state.attributes.get('unit_of_measurement')
         if measurement in (None, ''):
-            measurement = '{}.{}'.format(state.domain, state.object_id)
+            measurement = state.entity_id
 
         json_body = [
             {

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -7,7 +7,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.mqtt/
 """
 import logging
-from homeassistant.const import CONF_VALUE_TEMPLATE
+from homeassistant.const import CONF_VALUE_TEMPLATE, STATE_UNKNOWN
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import template
 import homeassistant.components.mqtt as mqtt
@@ -42,7 +42,7 @@ class MqttSensor(Entity):
     """ Represents a sensor that can be updated using MQTT. """
     def __init__(self, hass, name, state_topic, qos, unit_of_measurement,
                  value_template):
-        self._state = "-"
+        self._state = STATE_UNKNOWN
         self._hass = hass
         self._name = name
         self._state_topic = state_topic


### PR DESCRIPTION
This PR fixes #852.

Influx does not allow two values with the same measurement (or in terms of Home Assistant, unit of measure) to have different data types. For example, if one sensor has no unit of measure and its state is  "on", the the value inserted into InfluxDB will be 1 (int). If another sensor with no unit of measure and has a state of 8.0 (float), then there is going to be a problem.

Here is a summary of changes that I made related to this problem:
- If there is no unit of measure (`None` or `''`), use the domain name and entity id (i.e. domain.entity_id) as the unit of measure. Previously, if the unit of measure was `''` it was inserted and if the unit of measure was `None`, _just_ the domain name was used as the unit of measure.
- Ignore `STATE_UNKNOWN` values. Previously, when the state was unknown, 0 was inserted into InfluxDB.  Inserting a 0 is ambiguous because you don't know if the value was actually 0 or the state was not known. This also causes problems when later the value is known and the data type is a float or string.
- I slightly refactored the code to simplify the logic
- I modified mqtt sensor component to use `STATE_UNKNOWN` as it's initial state instead of `"-"`, which was causing problems for InfluxDB. This follows the pattern of other sensors.

Any thoughts on if these changes are acceptable?
