### PR TITLE
numeric_state: add ability to expand groups

### DIFF
--- a/homeassistant/components/automation/helpers.py
+++ b/homeassistant/components/automation/helpers.py
@@ -1,0 +1,32 @@
+"""
+homeassistant.components.automation.helpers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Offers helper functions for automation rules.
+
+"""
+import logging
+
+from homeassistant.helpers import service
+
+CONF_ENTITY_ID = "entity_id"
+CONF_EXPAND_IDS = "expand_ids"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_entity_ids(hass, config):
+    """ Get entity ids from the conf and expand if wanted. """
+    entity_id = config.get(CONF_ENTITY_ID)
+    expand = config.get(CONF_EXPAND_IDS, None)
+
+    if entity_id is None:
+        _LOGGER.error("Missing configuration key %s", CONF_ENTITY_ID)
+        return None
+
+    if expand:
+        entity_id_old = entity_id
+        entity_id = service.expand_entity_ids(hass, entity_id=entity_id)
+        _LOGGER.debug("Expanded entity_ids %s to %s", entity_id_old,
+                      entity_id)
+
+    return entity_id

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -12,9 +12,8 @@ import logging
 from homeassistant.const import CONF_VALUE_TEMPLATE
 from homeassistant.helpers.event import track_state_change
 from homeassistant.util import template
+from .helpers import get_entity_ids
 
-
-CONF_ENTITY_ID = "entity_id"
 CONF_BELOW = "below"
 CONF_ABOVE = "above"
 
@@ -31,11 +30,13 @@ def _renderer(hass, value_template, state):
 
 def trigger(hass, config, action):
     """ Listen for state changes based on `config`. """
-    entity_id = config.get(CONF_ENTITY_ID)
+    entity_id = get_entity_ids(hass, config)
 
     if entity_id is None:
-        _LOGGER.error("Missing configuration key %s", CONF_ENTITY_ID)
         return False
+
+    _LOGGER.debug("Adding trigger on entity_id %s(%s), action %s", entity_id,
+                  type(entity_id), action)
 
     below = config.get(CONF_BELOW)
     above = config.get(CONF_ABOVE)
@@ -52,8 +53,17 @@ def trigger(hass, config, action):
     # pylint: disable=unused-argument
     def state_automation_listener(entity, from_s, to_s):
         """ Listens for state changes and calls action. """
-
         # Fire action if we go from outside range into range
+
+        _LOGGER.debug("above: %s, below: %s, from_value: %s, to_value: %s, "
+                      "in_range_from: %s, in_range_to: %s", repr(above),
+                      repr(below),
+                      repr(renderer(from_s)) if from_s else None,
+                      repr(renderer(to_s)),
+                      _in_range(above, below, renderer(from_s)) if from_s
+                      else None,
+                      _in_range(above, below, renderer(to_s)))
+
         if _in_range(above, below, renderer(to_s)) and \
            (from_s is None or not _in_range(above, below, renderer(from_s))):
             action()
@@ -67,10 +77,9 @@ def trigger(hass, config, action):
 def if_action(hass, config):
     """ Wraps action method with state based condition. """
 
-    entity_id = config.get(CONF_ENTITY_ID)
+    entity_id = get_entity_ids(hass, config)
 
     if entity_id is None:
-        _LOGGER.error("Missing configuration key %s", CONF_ENTITY_ID)
         return None
 
     below = config.get(CONF_BELOW)
@@ -88,6 +97,12 @@ def if_action(hass, config):
     def if_numeric_state():
         """ Test numeric state condition. """
         state = hass.states.get(entity_id)
+
+        _LOGGER.debug("above: %s, below: %s, state_value: %s, "
+                      "in_range: %s", repr(above), repr(below),
+                      repr(renderer(state)),
+                      _in_range(above, below, renderer(state)))
+
         return state is not None and _in_range(above, below, renderer(state))
 
     return if_numeric_state

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -59,6 +59,19 @@ def call_from_config(hass, config, blocking=False):
     hass.services.call(domain, service_name, service_data, blocking)
 
 
+def expand_entity_ids(hass, entity_id):
+    """
+        Helper method for expanding entity_ids from groups.
+    """
+
+    group = get_component('group')
+
+    if isinstance(entity_id, str):
+        return group.expand_entity_ids(hass, [entity_id])
+
+    return [ent_id for ent_id in group.expand_entity_ids(hass, entity_id)]
+
+
 def extract_entity_ids(hass, service_call):
     """
     Helper method to extract a list of entity ids from a service call.
@@ -67,12 +80,10 @@ def extract_entity_ids(hass, service_call):
     if not (service_call.data and ATTR_ENTITY_ID in service_call.data):
         return []
 
-    group = get_component('group')
-
     # Entity ID attr can be a list or a string
     service_ent_id = service_call.data[ATTR_ENTITY_ID]
 
-    if isinstance(service_ent_id, str):
-        return group.expand_entity_ids(hass, [service_ent_id])
+    if not service_ent_id:
+        return []
 
-    return [ent_id for ent_id in group.expand_entity_ids(hass, service_ent_id)]
+    return expand_entity_ids(hass, service_ent_id)


### PR DESCRIPTION
Can have expand_ids: true in config to expand entity id in
triggers and condtitions.

Add as helper so it can be used in other automation components also.

Signed-off-by: Robert Marklund robbelibobban@gmail.com
