### PR TITLE
Add template support to mqtt.publish service payload.

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -131,7 +131,7 @@ def setup(hass, config):
     def publish_service(call):
         """Handle MQTT publish service calls."""
         msg_topic = call.data.get(ATTR_TOPIC)
-        payload = call.data.get(ATTR_PAYLOAD)
+        payload = util.template.render(hass, call.data.get(ATTR_PAYLOAD))
         qos = call.data.get(ATTR_QOS, DEFAULT_QOS)
         retain = call.data.get(ATTR_RETAIN, DEFAULT_RETAIN)
         if msg_topic is None or payload is None:

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -57,23 +57,28 @@ ATTR_RETAIN = 'retain'
 MAX_RECONNECT_WAIT = 300  # seconds
 
 
-# pylint: disable=too-many-arguments
-def publish(hass, topic, payload=None, qos=None,
-            retain=None, payload_template=None):
-    """Publish message to an MQTT topic."""
-    data = {
-        ATTR_TOPIC: topic,
-        ATTR_PAYLOAD: payload,
-        ATTR_PAYLOAD_TEMPLATE: payload_template
-    }
+def _build_publish_data(topic, qos, retain):
+    """Build the arguments for the publish service without the payload."""
+    data = {ATTR_TOPIC: topic}
     if qos is not None:
         data[ATTR_QOS] = qos
-
     if retain is not None:
         data[ATTR_RETAIN] = retain
+    return data
 
+
+def publish(hass, topic, payload, qos=None, retain=None):
+    """Publish message to an MQTT topic."""
+    data = _build_publish_data(topic, qos, retain)
+    data[ATTR_PAYLOAD] = payload
     hass.services.call(DOMAIN, SERVICE_PUBLISH, data)
-# pylint: enable=too-many-arguments
+
+
+def publish_template(hass, topic, payload_template, qos=None, retain=None):
+    """Publish message to an MQTT topic using a template payload."""
+    data = _build_publish_data(topic, qos, retain)
+    data[ATTR_PAYLOAD_TEMPLATE] = payload_template
+    hass.services.call(DOMAIN, SERVICE_PUBLISH, data)
 
 
 def subscribe(hass, topic, callback, qos=DEFAULT_QOS):

--- a/tests/components/test_mqtt.py
+++ b/tests/components/test_mqtt.py
@@ -80,10 +80,9 @@ class TestMQTT(unittest.TestCase):
         """
         If 'payload_template' is provided and 'payload' is not, then render it.
         """
-        self.hass.services.call(mqtt.DOMAIN, mqtt.SERVICE_PUBLISH, {
-            mqtt.ATTR_TOPIC: "test/topic",
-            mqtt.ATTR_PAYLOAD_TEMPLATE: "{{ 1+1 }}"
-        }, blocking=True)
+        mqtt.publish(self.hass, "test/topic",
+                     **{mqtt.ATTR_PAYLOAD_TEMPLATE: "{{ 1+1 }}"})
+        self.hass.pool.block_till_done()
         self.assertTrue(mqtt.MQTT_CLIENT.publish.called)
         self.assertEqual(mqtt.MQTT_CLIENT.publish.call_args[0][1], "2")
 
@@ -93,11 +92,9 @@ class TestMQTT(unittest.TestCase):
         """
         payload = "not a template"
         payload_template = "a template"
-        self.hass.services.call(mqtt.DOMAIN, mqtt.SERVICE_PUBLISH, {
-            mqtt.ATTR_TOPIC: "test/topic",
-            mqtt.ATTR_PAYLOAD: payload,
-            mqtt.ATTR_PAYLOAD_TEMPLATE: payload_template
-        }, blocking=True)
+        mqtt.publish(self.hass, "test/topic", payload,
+                     **{mqtt.ATTR_PAYLOAD_TEMPLATE: payload_template})
+        self.hass.pool.block_till_done()
         self.assertTrue(mqtt.MQTT_CLIENT.publish.called)
         self.assertEqual(mqtt.MQTT_CLIENT.publish.call_args[0][1], payload)
 
@@ -105,9 +102,8 @@ class TestMQTT(unittest.TestCase):
         """
         If neither 'payload' or 'payload_template' is provided then fail.
         """
-        self.hass.services.call(mqtt.DOMAIN, mqtt.SERVICE_PUBLISH, {
-            mqtt.ATTR_TOPIC: "test/topic"
-        }, blocking=True)
+        mqtt.publish(self.hass, "test/topic")
+        self.hass.pool.block_till_done()
         self.assertFalse(mqtt.MQTT_CLIENT.publish.called)
 
     def test_subscribe_topic(self):


### PR DESCRIPTION
I'm not sure about the backwards compatibility of this, and it fails one of the tests, but I don't know whether the test is in fact broken or not - it seems to be interpreting "75,75,75" as an integer within Jinja2. If I force it to be a string, it breaks the assertion on line 236 of the same test file. PR here for discussion.

```
================================================================================================================== FAILURES ==================================================================================================================
__________________________________________________________________________________________ TestLightMQTT.test_sending_mqtt_commands_and_optimistic ___________________________________________________________________________________________

self = <tests.components.light.test_mqtt.TestLightMQTT testMethod=test_sending_mqtt_commands_and_optimistic>

    def test_sending_mqtt_commands_and_optimistic(self):
        self.assertTrue(light.setup(self.hass, {
            'light': {
                'platform': 'mqtt',
                'name': 'test',
                'command_topic': 'test_light_rgb/set',
                'brightness_command_topic': 'test_light_rgb/brightness/set',
                'rgb_command_topic': 'test_light_rgb/rgb/set',
                'qos': 2,
                'payload_on': 'on',
                'payload_off': 'off'
            }
        }))

        state = self.hass.states.get('light.test')
        self.assertEqual(STATE_OFF, state.state)

        light.turn_on(self.hass, 'light.test')
        self.hass.pool.block_till_done()

        self.assertEqual(('test_light_rgb/set', 'on', 2, False),
                         self.mock_publish.mock_calls[-1][1])
        state = self.hass.states.get('light.test')
        self.assertEqual(STATE_ON, state.state)

        light.turn_off(self.hass, 'light.test')
        self.hass.pool.block_till_done()

        self.assertEqual(('test_light_rgb/set', 'off', 2, False),
                         self.mock_publish.mock_calls[-1][1])
        state = self.hass.states.get('light.test')
        self.assertEqual(STATE_OFF, state.state)

        light.turn_on(self.hass, 'light.test', rgb_color=[75, 75, 75],
                      brightness=50)
        self.hass.pool.block_till_done()

        # Calls are threaded so we need to reorder them
        bright_call, rgb_call, state_call = \
            sorted((call[1] for call in self.mock_publish.mock_calls[-3:]),
                   key=lambda call: call[0])

        self.assertEqual(('test_light_rgb/set', 'on', 2, False),
                         state_call)

        self.assertEqual(('test_light_rgb/rgb/set', '75,75,75', 2, False),
>                        rgb_call)
E       AssertionError: Tuples differ: ('test_light_rgb/rgb/set', '75,75,75', 2, False) != ('test_light_rgb/set', 'off', 2, False)
E       
E       First differing element 0:
E       test_light_rgb/rgb/set
E       test_light_rgb/set
E       
E       - ('test_light_rgb/rgb/set', '75,75,75', 2, False)
E       ?                  ----       ^^^^^^^^
E       
E       + ('test_light_rgb/set', 'off', 2, False)
E       ?                         ^^^

tests/components/light/test_mqtt.py:234: AssertionError
------------------------------------------------------------------------------------------------------------ Captured stderr call ------------------------------------------------------------------------------------------------------------
BusHandler:Exception doing job
Traceback (most recent call last):
  File "/home/flyte/dev/home-assistant/homeassistant/core.py", line 839, in job_handler
    func(arg)
  File "/home/flyte/dev/home-assistant/homeassistant/core.py", line 693, in _execute_service
    service(call)
  File "/home/flyte/dev/home-assistant/homeassistant/core.py", line 560, in __call__
    self.func(call)
  File "/home/flyte/dev/home-assistant/homeassistant/components/mqtt/__init__.py", line 134, in publish_service
    payload = util.template.render(hass, call.data.get(ATTR_PAYLOAD))
  File "/home/flyte/dev/home-assistant/homeassistant/util/template.py", line 46, in render
    'is_state_attr': hass.states.is_state_attr
  File "/home/flyte/.virtualenvs/home-assistant/lib/python3.4/site-packages/jinja2/environment.py", line 862, in from_string
    return cls.from_code(self, self.compile(source), globals, None)
  File "/home/flyte/.virtualenvs/home-assistant/lib/python3.4/site-packages/jinja2/environment.py", line 553, in compile
    source = optimize(source, self)
  File "/home/flyte/.virtualenvs/home-assistant/lib/python3.4/site-packages/jinja2/optimizer.py", line 27, in optimize
    return optimizer.visit(node)
  File "/home/flyte/.virtualenvs/home-assistant/lib/python3.4/site-packages/jinja2/visitor.py", line 39, in visit
    return self.generic_visit(node, *args, **kwargs)
  File "/home/flyte/.virtualenvs/home-assistant/lib/python3.4/site-packages/jinja2/visitor.py", line 59, in generic_visit
    for field, old_value in node.iter_fields():
AttributeError: 'int' object has no attribute 'iter_fields'
```

If this is the right thing to be doing, then should I render the topic as a potential template too?
