### PR TITLE
Bump pyvera, pywemo, add available for wemo

### DIFF
--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -15,7 +15,7 @@ from homeassistant.components.light import ATTR_BRIGHTNESS
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, STATE_ON
 
-REQUIREMENTS = ['pyvera==0.2.7']
+REQUIREMENTS = ['pyvera==0.2.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     ATTR_BATTERY_LEVEL, ATTR_TRIPPED, ATTR_ARMED, ATTR_LAST_TRIP_TIME,
     TEMP_CELCIUS, TEMP_FAHRENHEIT, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pyvera==0.2.7']
+REQUIREMENTS = ['pyvera==0.2.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_OFF)
 
-REQUIREMENTS = ['pyvera==0.2.7']
+REQUIREMENTS = ['pyvera==0.2.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -12,7 +12,7 @@ from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (
     STATE_ON, STATE_OFF, STATE_STANDBY, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pywemo==0.3.8']
+REQUIREMENTS = ['pywemo==0.3.9']
 _LOGGER = logging.getLogger(__name__)
 
 _WEMO_SUBSCRIPTION_REGISTRY = None
@@ -152,6 +152,18 @@ class WemoSwitch(SwitchDevice):
     def is_on(self):
         """ True if switch is on. """
         return self.wemo.get_state()
+
+    @property
+    def available(self):
+        """ True if switch is available. """
+        if (self.wemo.model_name == 'Insight' and
+                self.insight_params is None):
+            return False
+
+        if (self.wemo.model_name == 'Maker' and
+                self.maker_params is None):
+            return False
+        return True
 
     def turn_on(self, **kwargs):
         """ Turns the switch on. """

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -196,10 +196,10 @@ pyuserinput==0.1.9
 # homeassistant.components.light.vera
 # homeassistant.components.sensor.vera
 # homeassistant.components.switch.vera
-pyvera==0.2.7
+pyvera==0.2.8
 
 # homeassistant.components.switch.wemo
-pywemo==0.3.8
+pywemo==0.3.9
 
 # homeassistant.components.thermostat.radiotherm
 radiotherm==1.2


### PR DESCRIPTION
The pywemo version has slightly better retry logic when a call fails.

The pyvera version has slightly better tracing - I think that the pyvera thread can sometimes terminate - this has a little extra tracing that will help track down.

This PR also adds `available` support for wemo insight and maker devices. The state of these devices depends on getting parameter from the devices - so mark them as unavailable if this is not available. Generally only happens when first connecting to the devices.
