### PR TITLE
Fix Ctrl+C with Subprocesses

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -95,7 +95,10 @@ class HomeAssistant(object):
                 'Could not bind to SIGTERM. Are you running in a thread?')
 
         while not request_shutdown.isSet():
-            time.sleep(1)
+            try:
+                time.sleep(1)
+            except KeyboardInterrupt:
+                break
 
         self.stop()
         return RESTART_EXIT_CODE if request_restart.isSet() else 0


### PR DESCRIPTION
Added KeyboardInterrupt handling back to block_till_stopped method.
This is because Keyboard Interrupts are sent to both the parent and
child process in no particular order so both need to handle the
interrupt.
