### PR TITLE
Clean up state_attributes vs device_state_attributes

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -301,11 +301,6 @@ class Light(ToggleEntity):
         return None
 
     @property
-    def device_state_attributes(self):
-        """ Returns device specific state attributes. """
-        return None
-
-    @property
     def state_attributes(self):
         """ Returns optional state attributes. """
         data = {}
@@ -321,10 +316,5 @@ class Light(ToggleEntity):
                 data[ATTR_RGB_COLOR] = color_util.color_xy_brightness_to_RGB(
                     data[ATTR_XY_COLOR][0], data[ATTR_XY_COLOR][1],
                     data[ATTR_BRIGHTNESS])
-
-        device_attr = self.device_state_attributes
-
-        if device_attr is not None:
-            data.update(device_attr)
 
         return data

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -71,13 +71,9 @@ class VeraLight(VeraSwitch):
     """ Represents a Vera Light, including dimmable. """
 
     @property
-    def state_attributes(self):
-        attr = super().state_attributes or {}
-
-        if self.vera_device.is_dimmable:
-            attr[ATTR_BRIGHTNESS] = self.vera_device.get_brightness()
-
-        return attr
+    def brightness(self):
+        """Brightness of the light."""
+        return self.vera_device.get_brightness()
 
     def turn_on(self, **kwargs):
         if ATTR_BRIGHTNESS in kwargs and self.vera_device.is_dimmable:

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -37,6 +37,11 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 class WinkLight(WinkToggleDevice):
     """ Represents a Wink light. """
 
+    @property
+    def brightness(self):
+        """Brightness of the light."""
+        return int(self.wink.brightness() * 255)
+
     # pylint: disable=too-few-public-methods
     def turn_on(self, **kwargs):
         """ Turns the switch on. """
@@ -47,15 +52,3 @@ class WinkLight(WinkToggleDevice):
 
         else:
             self.wink.set_state(True)
-
-    @property
-    def state_attributes(self):
-        attr = super().state_attributes
-
-        if self.is_on:
-            brightness = self.wink.brightness()
-
-            if brightness is not None:
-                attr[ATTR_BRIGHTNESS] = int(brightness * 255)
-
-        return attr

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -425,11 +425,6 @@ class MediaPlayerDevice(Entity):
         """ Flags of media commands that are supported. """
         return 0
 
-    @property
-    def device_state_attributes(self):
-        """ Extra attributes a device wants to expose. """
-        return None
-
     def turn_on(self):
         """ turn the media player on. """
         raise NotImplementedError()
@@ -545,10 +540,5 @@ class MediaPlayerDevice(Entity):
 
             if self.media_image_url:
                 state_attr[ATTR_ENTITY_PICTURE] = self.media_image_url
-
-        device_attr = self.device_state_attributes
-
-        if device_attr:
-            state_attr.update(device_attr)
 
         return state_attr

--- a/homeassistant/components/sensor/cpuspeed.py
+++ b/homeassistant/components/sensor/cpuspeed.py
@@ -54,7 +54,7 @@ class CpuSpeedSensor(Entity):
         return self._unit_of_measurement
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """ Returns the state attributes. """
         if self.info is not None:
             return {

--- a/homeassistant/components/sensor/demo.py
+++ b/homeassistant/components/sensor/demo.py
@@ -46,7 +46,7 @@ class DemoSensor(Entity):
         return self._unit_of_measurement
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """ Returns the state attributes. """
         if self._battery:
             return {

--- a/homeassistant/components/sensor/mysensors.py
+++ b/homeassistant/components/sensor/mysensors.py
@@ -161,34 +161,24 @@ class MySensorsSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        set_req = self.gateway.const.SetReq
-        device_attr = {}
-        for value_type, value in self._values.items():
-            if value_type != self.value_type:
-                try:
-                    device_attr[set_req(value_type).name] = value
-                except ValueError:
-                    _LOGGER.error('value_type %s is not valid for mysensors '
-                                  'version %s', value_type,
-                                  self.gateway.version)
-        return device_attr
-
-    @property
-    def state_attributes(self):
-        """Return the state attributes."""
-        data = {
+        attr = {
             mysensors.ATTR_PORT: self.gateway.port,
             mysensors.ATTR_NODE_ID: self.node_id,
             mysensors.ATTR_CHILD_ID: self.child_id,
             ATTR_BATTERY_LEVEL: self.battery_level,
         }
 
-        device_attr = self.device_state_attributes
+        set_req = self.gateway.const.SetReq
 
-        if device_attr is not None:
-            data.update(device_attr)
-
-        return data
+        for value_type, value in self._values.items():
+            if value_type != self.value_type:
+                try:
+                    attr[set_req(value_type).name] = value
+                except ValueError:
+                    _LOGGER.error('value_type %s is not valid for mysensors '
+                                  'version %s', value_type,
+                                  self.gateway.version)
+        return attr
 
     def update(self):
         """Update the controller with the latest values from a sensor."""

--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -87,7 +87,7 @@ class RfxtrxSensor(Entity):
         return self._name
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         return self.event.values
 
     @property

--- a/homeassistant/components/sensor/swiss_public_transport.py
+++ b/homeassistant/components/sensor/swiss_public_transport.py
@@ -75,7 +75,7 @@ class SwissPublicTransportSensor(Entity):
         return self._state
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """ Returns the state attributes. """
         if self._times is not None:
             return {

--- a/homeassistant/components/sensor/tellduslive.py
+++ b/homeassistant/components/sensor/tellduslive.py
@@ -113,8 +113,8 @@ class TelldusLiveSensor(Entity):
             return self._value_as_humidity
 
     @property
-    def state_attributes(self):
-        attrs = dict()
+    def device_state_attributes(self):
+        attrs = {}
         if self._battery_level is not None:
             attrs[ATTR_BATTERY_LEVEL] = self._battery_level
         if self._last_updated is not None:

--- a/homeassistant/components/sensor/twitch.py
+++ b/homeassistant/components/sensor/twitch.py
@@ -67,7 +67,7 @@ class TwitchSensor(Entity):
             self._state = STATE_OFFLINE
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """ Returns the state attributes. """
         if self._state == STATE_STREAMING:
             return {

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -118,7 +118,7 @@ class VeraSensor(Entity):
             return '%'
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         attr = {}
         if self.vera_device.has_battery:
             attr[ATTR_BATTERY_LEVEL] = self.vera_device.battery_level + '%'

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -100,7 +100,7 @@ class YrSensor(Entity):
         return self._state
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """ Returns state attributes. """
         data = {
             'about': "Weather forecast from yr.no, delivered by the"

--- a/homeassistant/components/sensor/zwave.py
+++ b/homeassistant/components/sensor/zwave.py
@@ -112,11 +112,6 @@ class ZWaveSensor(ZWaveDeviceEntity, Entity):
         return self._value.data
 
     @property
-    def state_attributes(self):
-        """ Returns optional state attributes. """
-        return self.device_state_attributes
-
-    @property
     def unit_of_measurement(self):
         return self._value.units
 

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -130,11 +130,6 @@ class SwitchDevice(ToggleEntity):
         return None
 
     @property
-    def device_state_attributes(self):
-        """ Returns device specific state attributes. """
-        return None
-
-    @property
     def state_attributes(self):
         """ Returns optional state attributes. """
         data = {}
@@ -143,10 +138,5 @@ class SwitchDevice(ToggleEntity):
             value = getattr(self, prop)
             if value:
                 data[attr] = value
-
-        device_attr = self.device_state_attributes
-
-        if device_attr is not None:
-            data.update(device_attr)
 
         return data

--- a/homeassistant/components/switch/mfi.py
+++ b/homeassistant/components/switch/mfi.py
@@ -114,8 +114,8 @@ class MfiSwitch(SwitchDevice):
         return int(self._port.data.get('active_pwr', 0) * 1000)
 
     @property
-    def state_attributes(self):
-        attr = super().state_attributes or {}
+    def device_state_attributes(self):
+        attr = {}
         attr['volts'] = self._port.data.get('v_rms', 0)
         attr['amps'] = self._port.data.get('i_rms', 0)
         return attr

--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -100,34 +100,24 @@ class MySensorsSwitch(SwitchDevice):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        set_req = self.gateway.const.SetReq
-        device_attr = {}
-        for value_type, value in self._values.items():
-            if value_type != self.value_type:
-                try:
-                    device_attr[set_req(value_type).name] = value
-                except ValueError:
-                    _LOGGER.error('value_type %s is not valid for mysensors '
-                                  'version %s', value_type,
-                                  self.gateway.version)
-        return device_attr
-
-    @property
-    def state_attributes(self):
-        """Return the state attributes."""
-        data = {
+        attr = {
             mysensors.ATTR_PORT: self.gateway.port,
             mysensors.ATTR_NODE_ID: self.node_id,
             mysensors.ATTR_CHILD_ID: self.child_id,
             ATTR_BATTERY_LEVEL: self.battery_level,
         }
 
-        device_attr = self.device_state_attributes
+        set_req = self.gateway.const.SetReq
 
-        if device_attr is not None:
-            data.update(device_attr)
-
-        return data
+        for value_type, value in self._values.items():
+            if value_type != self.value_type:
+                try:
+                    attr[set_req(value_type).name] = value
+                except ValueError:
+                    _LOGGER.error('value_type %s is not valid for mysensors '
+                                  'version %s', value_type,
+                                  self.gateway.version)
+        return attr
 
     @property
     def is_on(self):

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -8,8 +8,7 @@ https://home-assistant.io/components/switch.tellstick/
 """
 import logging
 
-from homeassistant.const import (EVENT_HOMEASSISTANT_STOP,
-                                 ATTR_FRIENDLY_NAME)
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.entity import ToggleEntity
 
 SIGNAL_REPETITIONS = 1
@@ -63,7 +62,6 @@ class TellstickSwitchDevice(ToggleEntity):
         import tellcore.constants as tellcore_constants
 
         self.tellstick_device = tellstick_device
-        self.state_attr = {ATTR_FRIENDLY_NAME: tellstick_device.name}
         self.signal_repetitions = signal_repetitions
 
         self.last_sent_command_mask = (tellcore_constants.TELLSTICK_TURNON |
@@ -78,11 +76,6 @@ class TellstickSwitchDevice(ToggleEntity):
     def name(self):
         """ Returns the name of the switch if any. """
         return self.tellstick_device.name
-
-    @property
-    def state_attributes(self):
-        """ Returns optional state attributes. """
-        return self.state_attr
 
     @property
     def is_on(self):

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -102,8 +102,8 @@ class VeraSwitch(SwitchDevice):
         return self._name
 
     @property
-    def state_attributes(self):
-        attr = super().state_attributes or {}
+    def device_state_attributes(self):
+        attr = {}
 
         if self.vera_device.has_battery:
             attr[ATTR_BATTERY_LEVEL] = self.vera_device.battery_level + '%'

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -95,8 +95,8 @@ class WemoSwitch(SwitchDevice):
         return self.wemo.name
 
     @property
-    def state_attributes(self):
-        attr = super().state_attributes or {}
+    def device_state_attributes(self):
+        attr = {}
         if self.maker_params:
             # Is the maker sensor on or off.
             if self.maker_params['hassensor']:

--- a/homeassistant/components/thermostat/__init__.py
+++ b/homeassistant/components/thermostat/__init__.py
@@ -179,11 +179,6 @@ class ThermostatDevice(Entity):
         return self.target_temperature or STATE_UNKNOWN
 
     @property
-    def device_state_attributes(self):
-        """ Returns device specific state attributes. """
-        return None
-
-    @property
     def state_attributes(self):
         """ Returns optional state attributes. """
 
@@ -210,11 +205,6 @@ class ThermostatDevice(Entity):
         is_fan_on = self.is_fan_on
         if is_fan_on is not None:
             data[ATTR_FAN] = STATE_ON if is_fan_on else STATE_OFF
-
-        device_attr = self.device_state_attributes
-
-        if device_attr is not None:
-            data.update(device_attr)
 
         return data
 

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import validate_config
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.const import (
     EVENT_PLATFORM_DISCOVERED, CONF_ACCESS_TOKEN,
-    ATTR_SERVICE, ATTR_DISCOVERED, ATTR_FRIENDLY_NAME)
+    ATTR_SERVICE, ATTR_DISCOVERED)
 
 DOMAIN = "wink"
 REQUIREMENTS = ['python-wink==0.5.0']
@@ -79,13 +79,6 @@ class WinkToggleDevice(ToggleEntity):
     def is_on(self):
         """ True if light is on. """
         return self.wink.state()
-
-    @property
-    def state_attributes(self):
-        """ Returns optional state attributes. """
-        return {
-            ATTR_FRIENDLY_NAME: self.wink.name()
-        }
 
     def turn_on(self, **kwargs):
         """ Turns the switch on. """

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -80,7 +80,20 @@ class Entity(object):
 
     @property
     def state_attributes(self):
-        """Return the state attributes."""
+        """
+        Return the state attributes.
+
+        Implemented by component base class.
+        """
+        return None
+
+    @property
+    def device_state_attributes(self):
+        """
+        Return device specific state attributes.
+
+        Implemented by platform classes.
+        """
         return None
 
     @property
@@ -134,6 +147,11 @@ class Entity(object):
 
         state = str(self.state)
         attr = self.state_attributes or {}
+
+        device_attr = self.device_state_attributes
+
+        if device_attr is not None:
+            attr.update(device_attr)
 
         if ATTR_UNIT_OF_MEASUREMENT not in attr and \
            self.unit_of_measurement is not None:


### PR DESCRIPTION
We were being inconsistent with the use of properties `state_attributes` and `device_state_attributes`.

The correct definition of both are:

| Property | Description |
| --- | --- |
| **`state_attributes`** | Attributes that represent an entity type. This is implemented by the entity base class, for example Switch, Light. |
| **`device_state_attributes`** | Attributes unique for the entity. |

`device_state_attributes` used to be implemented on a per abstract component class basis. This has been moved to the entity class to formalize behavior.
