### PR TITLE
Tweak mFi switch behavior to avoid false states

### DIFF
--- a/homeassistant/components/sensor/mfi.py
+++ b/homeassistant/components/sensor/mfi.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import DOMAIN
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers import validate_config
 
-REQUIREMENTS = ['mficlient==0.2']
+REQUIREMENTS = ['mficlient==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/mfi.py
+++ b/homeassistant/components/switch/mfi.py
@@ -12,7 +12,7 @@ from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.helpers import validate_config
 
-REQUIREMENTS = ['mficlient==0.2']
+REQUIREMENTS = ['mficlient==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,6 +56,7 @@ class MfiSwitch(SwitchDevice):
     """ An mFi switch-able device. """
     def __init__(self, port):
         self._port = port
+        self._target_state = None
 
     @property
     def should_poll(self):
@@ -75,14 +76,17 @@ class MfiSwitch(SwitchDevice):
 
     def update(self):
         self._port.refresh()
+        if self._target_state is not None:
+            self._port.data['output'] = float(self._target_state)
+            self._target_state = None
 
     def turn_on(self):
         self._port.control(True)
-        self._port.data['output'] = 1.0
+        self._target_state = True
 
     def turn_off(self):
         self._port.control(False)
-        self._port.data['output'] = 0.0
+        self._target_state = False
 
     @property
     def current_power_mwh(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -107,7 +107,7 @@ limitlessled==1.0.0
 
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi
-mficlient==0.2
+mficlient==0.2.1
 
 # homeassistant.components.discovery
 netdisco==0.5.2


### PR DESCRIPTION
When we update the mFi server for the state of a switch, the new
state is not always reported immediately if we update right after
the action (the server is not RESTful).

This patch adds some internal target-state handling to report the
desired state on the next poll, allowing any subsequent polls to
override that state.

Also, bump the version requirement for mficlient to 0.2.1 to absorb
a bug fix.
