### PR TITLE
fix sigterm crash

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -243,8 +243,8 @@ def run_hass_process(hass_proc):
     requested_stop = threading.Event()
     hass_proc.daemon = True
 
-    def request_stop():
-        """ request hass stop """
+    def request_stop(*args):
+        """ request hass stop, *args is for signal handler callback """
         requested_stop.set()
         hass_proc.terminate()
 


### PR DESCRIPTION
Lately I have got a crash when killing home assistant. 

```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/lib/python3.5/multiprocessing/popen_fork.py", line 29, in poll
    pid, sts = os.waitpid(self.pid, flag)
TypeError: request_stop() takes 0 positional arguments but 2 were given
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 170, in _run_module_as_main
[per@alarmpi home-assistant]$     "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/per/home-assistant/homeassistant/__main__.py", line 305, in <module>
    main()
  File "/home/per/home-assistant/homeassistant/__main__.py", line 301, in main
    keep_running = run_hass_process(hass_proc)
  File "/home/per/home-assistant/homeassistant/__main__.py", line 258, in run_hass_process
    hass_proc.join()
  File "/usr/lib/python3.5/multiprocessing/process.py", line 121, in join
    res = self._popen.wait(timeout)
  File "/usr/lib/python3.5/multiprocessing/popen_fork.py", line 51, in wait
    return self.poll(os.WNOHANG if timeout == 0.0 else 0)
  File "/usr/lib/python3.5/multiprocessing/popen_fork.py", line 29, in poll
    pid, sts = os.waitpid(self.pid, flag)
TypeError: request_stop() takes 0 positional arguments but 2 were given
```

This should fix that 
