### PR TITLE
Support expanding nested groups

### DIFF
--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -71,7 +71,7 @@ def expand_entity_ids(hass, entity_ids):
             if domain == DOMAIN:
                 found_ids.extend(
                     ent_id for ent_id
-                    in get_entity_ids(hass, entity_id)
+                    in expand_entity_ids(hass, get_entity_ids(hass, entity_id))
                     if ent_id not in found_ids)
 
             else:

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -236,3 +236,14 @@ class TestComponentsGroup(unittest.TestCase):
         grp2 = group.Group(self.hass, 'Je suis Charlie')
 
         self.assertNotEqual(grp1.entity_id, grp2.entity_id)
+
+    def test_expand_entity_ids_expands_nested_groups(self):
+        group.Group(self.hass, 'light', ['light.test_1', 'light.test_2'])
+        group.Group(self.hass, 'switch', ['switch.test_1', 'switch.test_2'])
+        group.Group(self.hass, 'group_of_groups', ['group.light',
+                                                   'group.switch'])
+
+        self.assertEqual(
+            ['light.test_1', 'light.test_2', 'switch.test_1', 'switch.test_2'],
+            sorted(group.expand_entity_ids(self.hass,
+                                           ['group.group_of_groups'])))


### PR DESCRIPTION
Our method to expand groups into their entity ids now handles a group that contained another group.

This will fix an issue that users were experiencing where they were unable to turn a group of groups on or off in the frontend.

Fixes #440 
Fixes #808 
Fixes #1183 
