### PR TITLE
Expose baud rate config for MySensors component

### DIFF
--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -24,7 +24,9 @@ CONF_DEBUG = 'debug'
 CONF_PERSISTENCE = 'persistence'
 CONF_PERSISTENCE_FILE = 'persistence_file'
 CONF_VERSION = 'version'
+CONF_BAUD_RATE = 'baud_rate'
 DEFAULT_VERSION = '1.4'
+DEFAULT_BAUD_RATE = 115200
 
 DOMAIN = 'mysensors'
 DEPENDENCIES = []
@@ -60,12 +62,13 @@ def setup(hass, config):
     version = str(config[DOMAIN].get(CONF_VERSION, DEFAULT_VERSION))
     is_metric = (hass.config.temperature_unit == TEMP_CELCIUS)
 
-    def setup_gateway(port, persistence, persistence_file, version):
+    def setup_gateway(port, persistence, persistence_file, version, baud_rate):
         """Return gateway after setup of the gateway."""
         gateway = mysensors.SerialGateway(port, event_callback=None,
                                           persistence=persistence,
                                           persistence_file=persistence_file,
-                                          protocol_version=version)
+                                          protocol_version=version,
+                                          baud=baud_rate)
         gateway.metric = is_metric
         gateway.debug = config[DOMAIN].get(CONF_DEBUG, False)
         gateway = GatewayWrapper(gateway, version)
@@ -98,8 +101,9 @@ def setup(hass, config):
         persistence_file = gway.get(
             CONF_PERSISTENCE_FILE,
             hass.config.path('mysensors{}.pickle'.format(index + 1)))
+        baud_rate = gway.get(CONF_BAUD_RATE, DEFAULT_BAUD_RATE)
         GATEWAYS[port] = setup_gateway(
-            port, persistence, persistence_file, version)
+            port, persistence, persistence_file, version, baud_rate)
 
     for (component, discovery_service) in DISCOVERY_COMPONENTS:
         # Ensure component is loaded


### PR DESCRIPTION
Hi guys! First of all thanks **a lot** for the great job you're doing. I've been following the project for a while now and I admire how fast and nicely is growing!

Back to the topic.
As discussed here: https://github.com/theolind/pymysensors/issues/21, it would be useful to be able to specify the baud rate setting in the MySensors component configuration to avoid communication issues between Home Assistant and a slow Serial Gateway (e.g. Arduino Pro Mini 8MHz).

@balloob, @MartinHjelmare please review.
