### PR TITLE
Changing battery level unit to "V" instead of "%" 

### DIFF
--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -21,7 +21,7 @@ SENSOR_TYPES = ['humidity',
                 'last_connection',
                 'battery_level']
 
-SENSOR_UNITS = {'humidity': '%', 'battery_level': '%'}
+SENSOR_UNITS = {'humidity': '%', 'battery_level': 'V'}
 
 SENSOR_TEMP_TYPES = ['temperature',
                      'target',


### PR DESCRIPTION
The as the API reports output voltage, not percentage.
This value matches with Settings > Technical Information's Battery information.
