### PR TITLE
Supporting electricity sensors with ELEC2/3 protocol from latest pyRFXtrx (0.4)

### DIFF
--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -21,7 +21,9 @@ DATA_TYPES = OrderedDict([
     ('Humidity', '%'),
     ('Barometer', ''),
     ('Wind direction', ''),
-    ('Rain rate', '')])
+    ('Rain rate', ''),
+    ('Energy usage', 'W'),
+    ('Total usage', 'W')])
 _LOGGER = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Provide Units to electricity sensors supported by latest pyRFXtrx(0.4)
This is sensors like:
CM119
CM160
CM180
Protocol used is ELEC2/3
Do not merge until  #1143 is merged.
