### PR TITLE
Support manually-defined WeMo devices

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -210,7 +210,7 @@ pyuserinput==0.1.9
 pyvera==0.2.8
 
 # homeassistant.components.switch.wemo
-pywemo==0.3.9
+pywemo==0.3.10
 
 # homeassistant.components.thermostat.radiotherm
 radiotherm==1.2


### PR DESCRIPTION
This is extremely useful if you want to support wemos that are on
another subnet or across a VPN. It also lets you sidestep the discovery
process, which is problematic for a lot of people and situations.

In order for this to work, we need to bump the pywemo requirement to
0.3.10, which includes my changes to make this possible.

WeMo devices can be manually configured by adding a static section to
the config, like this:

  switch:
    platform: wemo
    static:
       - 192.168.100.5
       - 192.168.100.6
