### PR TITLE
Handle passive zones correctly.

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -95,7 +95,8 @@ def setup_scanner(hass, config, see):
                         MOBILE_BEACONS_ACTIVE[dev_id].append(location)
                 else:
                     # Normal region
-                    kwargs['location_name'] = location
+                    if not zone.attributes.get('passive'):
+                        kwargs['location_name'] = location
 
                     regions = REGIONS_ENTERED[dev_id]
                     if location not in regions:
@@ -115,7 +116,8 @@ def setup_scanner(hass, config, see):
             if new_region:
                 # Exit to previous region
                 zone = hass.states.get("zone.{}".format(new_region))
-                kwargs['location_name'] = new_region
+                if not zone.attributes.get('passive'):
+                    kwargs['location_name'] = new_region
                 _set_gps_from_zone(kwargs, zone)
                 _LOGGER.info("Exit from to %s", new_region)
 

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -109,6 +109,16 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
                 'longitude': 1.0,
                 'radius': 100000
             })
+
+        self.hass.states.set(
+        'zone.passive', 'zoning',
+        {
+            'name': 'zone',
+            'latitude': 3.0,
+            'longitude': 1.0,
+            'radius': 10,
+            'passive': True
+        })
         # Clear state between teste
         self.hass.states.set(DEVICE_TRACKER_STATE, None)
         owntracks.REGIONS_ENTERED = defaultdict(list)
@@ -247,6 +257,42 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         message['desc'] = "inner_2"
         self.send_message(EVENT_TOPIC, message)
         self.assert_location_state('outer')
+
+    def test_event_entry_exit_passive_zone(self):
+        # Enter passive zone
+        message = REGION_ENTER_MESSAGE.copy()
+        message['desc'] = "passive"
+        self.send_message(EVENT_TOPIC, message)
+
+        # Should pick up gps put not zone
+        self.assert_location_state('not_home')
+        self.assert_location_latitude(3.0)
+        self.assert_location_accuracy(10.0)
+
+        # Enter inner2 zone
+        message = REGION_ENTER_MESSAGE.copy()
+        message['desc'] = "inner_2"
+        self.send_message(EVENT_TOPIC, message)
+        self.assert_location_state('inner_2')
+        self.assert_location_latitude(2.1)
+        self.assert_location_accuracy(10.0)
+
+        # Exit inner_2 - should be in 'passive'
+        # ie gps co-ords - but not zone
+        message = REGION_LEAVE_MESSAGE.copy()
+        message['desc'] = "inner_2"
+        self.send_message(EVENT_TOPIC, message)
+        self.assert_location_state('not_home')
+        self.assert_location_latitude(3.0)
+        self.assert_location_accuracy(10.0)
+
+        # Exit passive - should be in 'outer'
+        message = REGION_LEAVE_MESSAGE.copy()
+        message['desc'] = "passive"
+        self.send_message(EVENT_TOPIC, message)
+        self.assert_location_state('outer')
+        self.assert_location_latitude(2.0)
+        self.assert_location_accuracy(60.0)
 
     def test_event_entry_unknown_zone(self):
         # Just treat as location update


### PR DESCRIPTION
This PR stops enter events in own tracks entering passive zones.

As discussed here https://github.com/balloob/home-assistant/issues/1191
