### PR TITLE
Re-allow splunk to report string states

### DIFF
--- a/homeassistant/components/splunk.py
+++ b/homeassistant/components/splunk.py
@@ -65,7 +65,7 @@ def setup(hass, config):
         try:
             _state = state_helper.state_as_number(state)
         except ValueError:
-            return
+            _state = state.state
 
         json_body = [
             {

--- a/tests/components/test_splunk.py
+++ b/tests/components/test_splunk.py
@@ -64,7 +64,8 @@ class TestSplunk(unittest.TestCase):
         valid = {'1': 1,
                  '1.0': 1.0,
                  STATE_ON: 1,
-                 STATE_OFF: 0}
+                 STATE_OFF: 0,
+                 'foo': 'foo'}
         for in_, out in valid.items():
             state = mock.MagicMock(state=in_,
                                    domain='fake',
@@ -86,8 +87,3 @@ class TestSplunk(unittest.TestCase):
                 payload['host'], data=payload,
                 headers={'Authorization': 'Splunk secret'})
             self.mock_post.reset_mock()
-
-        for invalid in ('foo', '', object):
-            state = mock.MagicMock(state=invalid)
-            self.handler_method(mock.MagicMock(data={'new_state': state}))
-            self.assertFalse(self.mock_post.called)


### PR DESCRIPTION
I was chatting with @miniconfig while this was running CI tests to see if the change I made to remove string states from splunk reporting was right. @balloob merged it before I finished (because he's awesome). So this un-does that.

I'll just merge this trivial change when it passes. My bad for being too fast (or slow?)!
