### PR TITLE
Nest binary sensor fixes

### DIFF
--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -13,7 +13,7 @@ import homeassistant.components.nest as nest
 from homeassistant.components.sensor.nest import NestSensor
 from homeassistant.components.binary_sensor import BinarySensorDevice
 
-
+DEPENDENCIES = ['nest']
 BINARY_TYPES = ['fan',
                 'hvac_ac_state',
                 'hvac_aux_heater_state',

--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -17,6 +17,7 @@ from homeassistant.components.binary_sensor import BinarySensorDevice
 BINARY_TYPES = ['fan',
                 'hvac_ac_state',
                 'hvac_aux_heater_state',
+                'hvac_heater_state',
                 'hvac_heat_x2_state',
                 'hvac_heat_x3_state',
                 'hvac_alt_heat_state',


### PR DESCRIPTION
Make sure the Nest binary sensors wait with initialization until the component has been set up.
Also add hvac_heater_state as a sensor type so that we can see when the heating system is active.
