### PR TITLE
New notification platform "command line"

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -103,6 +103,7 @@ omit =
     homeassistant/components/notify/free_mobile.py
     homeassistant/components/notify/instapush.py
     homeassistant/components/notify/nma.py
+    homeassistant/components/notify/command_line.py
     homeassistant/components/notify/pushbullet.py
     homeassistant/components/notify/pushetta.py
     homeassistant/components/notify/pushover.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -103,7 +103,6 @@ omit =
     homeassistant/components/notify/free_mobile.py
     homeassistant/components/notify/instapush.py
     homeassistant/components/notify/nma.py
-    homeassistant/components/notify/command_line.py
     homeassistant/components/notify/pushbullet.py
     homeassistant/components/notify/pushetta.py
     homeassistant/components/notify/pushover.py

--- a/homeassistant/components/notify/command_line.py
+++ b/homeassistant/components/notify/command_line.py
@@ -39,8 +39,9 @@ class CommandLineNotificationService(BaseNotificationService):
     def send_message(self, message="", **kwargs):
         """ Send a message to a command_line. """
         try:
-            subprocess.call("{} \"{}\"".format(self.command,
-                                               shlex.quote(message)),
-                            shell=True)
+            subprocess.check_call(
+                "{} {}".format(self.command,
+                               shlex.quote(message)),
+                shell=True)
         except subprocess.CalledProcessError:
             _LOGGER.error('Command failed: %s', self.command)

--- a/homeassistant/components/notify/command_line.py
+++ b/homeassistant/components/notify/command_line.py
@@ -1,0 +1,46 @@
+"""
+homeassistant.components.notify.command_line
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+command_line notification service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.command_line/
+"""
+import logging
+import subprocess
+import shlex
+from homeassistant.helpers import validate_config
+from homeassistant.components.notify import (
+    DOMAIN, BaseNotificationService)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_service(hass, config):
+    """ Get the Command Line notification service. """
+
+    if not validate_config({DOMAIN: config},
+                           {DOMAIN: ['command']},
+                           _LOGGER):
+        return None
+
+    command = config['command']
+
+    return CommandLineNotificationService(command)
+
+
+# pylint: disable=too-few-public-methods
+class CommandLineNotificationService(BaseNotificationService):
+    """ Implements notification service for the Command Line service. """
+
+    def __init__(self, command):
+        self.command = command
+
+    def send_message(self, message="", **kwargs):
+        """ Send a message to a command_line. """
+        try:
+            subprocess.call("{} \"{}\"".format(self.command,
+                                               shlex.quote(message)),
+                            shell=True)
+        except subprocess.CalledProcessError:
+            _LOGGER.error('Command failed: %s', self.command)

--- a/tests/components/notify/test_command_line.py
+++ b/tests/components/notify/test_command_line.py
@@ -1,0 +1,58 @@
+"""
+tests.components.notify.test_command_line
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests command line notification.
+"""
+import os
+import tempfile
+import unittest
+
+from homeassistant import core
+import homeassistant.components.notify as notify
+from unittest.mock import patch
+
+
+class TestCommandLine(unittest.TestCase):
+    """ Test the command line. """
+
+    def setUp(self):  # pylint: disable=invalid-name
+        self.hass = core.HomeAssistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """ Stop down stuff we started. """
+        self.hass.stop()
+
+    def test_command_line_output(self):
+        with tempfile.TemporaryDirectory() as tempdirname:
+            filename = os.path.join(tempdirname, 'message.txt')
+            message = 'one, two, testing, testing'
+            self.assertTrue(notify.setup(self.hass, {
+                'notify': {
+                    'name': 'test',
+                    'platform': 'command_line',
+                    'command': 'echo $(cat) > {}'.format(filename)
+                }
+            }))
+
+            self.hass.services.call('notify', 'test', {'message': message},
+                                    blocking=True)
+
+            result = open(filename).read()
+            # the echo command adds a line break
+            self.assertEqual(result, "{}\n".format(message))
+
+    @patch('homeassistant.components.notify.command_line._LOGGER.error')
+    def test_error_for_none_zero_exit_code(self, mock_error):
+        """ Test if an error if logged for non zero exit codes. """
+        self.assertTrue(notify.setup(self.hass, {
+            'notify': {
+                'name': 'test',
+                'platform': 'command_line',
+                'command': 'echo $(cat); exit 1'
+            }
+        }))
+
+        self.hass.services.call('notify', 'test', {'message': 'error'},
+                                blocking=True)
+        self.assertEqual(1, mock_error.call_count)


### PR DESCRIPTION
Don't know if I missed some other way of doing this but I think this is a great platform for all kind of notifications, I use it for TTS with espeak. 

Here is an example

``` yaml
notify:
  - platform: command_line
    name: voice
    command: "espeak -vmb/mb-us1"
```

The message will be appended after the command. 
