### PR TITLE
Fix error in update method for V_STATUS

### DIFF
--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -153,7 +153,6 @@ class MySensorsSwitch(SwitchDevice):
             _LOGGER.info(
                 "%s: value_type %s, value = %s", self._name, value_type, value)
             if value_type == self.gateway.const.SetReq.V_ARMED or \
-               value_type == self.gateway.const.SetReq.V_STATUS or \
                value_type == self.gateway.const.SetReq.V_LIGHT or \
                value_type == self.gateway.const.SetReq.V_LOCK_STATUS:
                 self._values[value_type] = (


### PR DESCRIPTION
- Remove check against V_STATUS to avoid error when using version 1.4
  of mysensors. V_LIGHT has the same integer value so V_STATUS is not
  needed.
