### PR TITLE
fix ecobee sensor unique id.

### DIFF
--- a/homeassistant/components/sensor/ecobee.py
+++ b/homeassistant/components/sensor/ecobee.py
@@ -66,7 +66,7 @@ class EcobeeSensor(Entity):
     @property
     def unique_id(self):
         """Unique id of this sensor."""
-        return "sensor_ecobee_{}_{}".format(self.type, self.index)
+        return "sensor_ecobee_{}_{}".format(self._name, self.index)
 
     @property
     def unit_of_measurement(self):


### PR DESCRIPTION
The unique id added in 4840dd297a84369eed6a609193c3d781d86476b2 caused my some of my sensors to go missing.  This fixes it by using a truly unique id.
