### PR TITLE
0.13.1 / Fix: state_as_number always return float

### DIFF
--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.garage_door import GarageDoorDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.5.0']
+REQUIREMENTS = ['python-wink==0.6.0']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.light import ATTR_BRIGHTNESS, Light
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.5.0']
+REQUIREMENTS = ['python-wink==0.6.0']
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.5.0']
+REQUIREMENTS = ['python-wink==0.6.0']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import CONF_ACCESS_TOKEN, STATE_OPEN, STATE_CLOSED
 
-REQUIREMENTS = ['python-wink==0.5.0']
+REQUIREMENTS = ['python-wink==0.6.0']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.wink import WinkToggleDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.5.0']
+REQUIREMENTS = ['python-wink==0.6.0']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     ATTR_SERVICE, ATTR_DISCOVERED)
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.5.0']
+REQUIREMENTS = ['python-wink==0.6.0']
 
 DISCOVER_LIGHTS = "wink.lights"
 DISCOVER_SWITCHES = "wink.switches"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """Constants used by Home Assistant components."""
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 # Can be used to specify a catch all when registering state or event listeners.
 MATCH_ALL = '*'

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -309,7 +309,7 @@ class State(object):
                 "Format should be <domain>.<object_id>").format(entity_id))
 
         self.entity_id = entity_id.lower()
-        self.state = state
+        self.state = str(state)
         self.attributes = MappingProxyType(attributes or {})
         self.last_updated = dt_util.strip_microseconds(
             last_updated or dt_util.utcnow())

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -109,16 +109,5 @@ def state_as_number(state):
     elif state.state in (STATE_OFF, STATE_UNLOCKED, STATE_UNKNOWN,
                          STATE_BELOW_HORIZON, STATE_CLOSED):
         return 0
-    else:
-        try:
-            # This distinction is probably not important,
-            # but in case something downstream cares about
-            # int vs. float, try to be helpful here.
-            if '.' in state.state:
-                return float(state.state)
-            else:
-                return int(state.state)
-        except (ValueError, TypeError):
-            pass
 
-    raise ValueError('State is not a number')
+    return float(state.state)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -199,7 +199,7 @@ python-twitch==1.2.0
 # homeassistant.components.lock.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.5.0
+python-wink==0.6.0
 
 # homeassistant.components.keyboard
 pyuserinput==0.1.9

--- a/tests/components/test_graphite.py
+++ b/tests/components/test_graphite.py
@@ -89,6 +89,7 @@ class TestGraphite(unittest.TestCase):
                  'bat': 'NaN',
                  }
         expected = [
+            'ha.entity.state 0.000000 12345',
             'ha.entity.foo 1.000000 12345',
             'ha.entity.bar 2.000000 12345',
             'ha.entity.baz 1.000000 12345',

--- a/tests/components/test_statsd.py
+++ b/tests/components/test_statsd.py
@@ -7,6 +7,7 @@ Tests statsd feeder.
 import unittest
 from unittest import mock
 
+import homeassistant.core as ha
 import homeassistant.components.statsd as statsd
 from homeassistant.const import STATE_ON, STATE_OFF, EVENT_STATE_CHANGED
 
@@ -78,6 +79,6 @@ class TestStatsd(unittest.TestCase):
             mock_gauge.return_value.send.reset_mock()
 
         for invalid in ('foo', '', object):
-            state = mock.MagicMock(state=invalid)
-            handler_method(mock.MagicMock(data={'new_state': state}))
+            handler_method(mock.MagicMock(data={
+                'new_state': ha.State('domain.test', invalid, {})}))
             self.assertFalse(mock_gauge.return_value.send.called)

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -165,24 +165,18 @@ class TestStateHelpers(unittest.TestCase):
                 ha.State('domain.test', _state, {})))
 
     def test_as_number_coercion(self):
-        for _state in ('0', '0.0'):
+        for _state in ('0', '0.0', 0, 0.0):
             self.assertEqual(
-                0.0, float(state.state_as_number(
-                ha.State('domain.test', _state, {}))))
-        for _state in ('1', '1.0'):
+                0.0, state.state_as_number(
+                    ha.State('domain.test', _state, {})))
+        for _state in ('1', '1.0', 1, 1.0):
             self.assertEqual(
-                1.0, float(state.state_as_number(
-                    ha.State('domain.test', _state, {}))))
-
-    def test_as_number_tries_to_keep_types(self):
-        result = state.state_as_number(ha.State('domain.test', '1', {}))
-        self.assertTrue(isinstance(result, int))
-        result = state.state_as_number(ha.State('domain.test', '1.0', {}))
-        self.assertTrue(isinstance(result, float))
+                1.0, state.state_as_number(
+                    ha.State('domain.test', _state, {})))
 
     def test_as_number_invalid_cases(self):
-        for _state in ('', 'foo', 'foo.bar', None, False, True, None,
-                       object, object()):
+        for _state in ('', 'foo', 'foo.bar', None, False, True, object,
+                       object()):
             self.assertRaises(ValueError,
                               state.state_as_number,
                               ha.State('domain.test', _state, {}))


### PR DESCRIPTION
Two users reported issues with their InfluxDB instances with release 0.13: InfluxDB will set a type of a field based on the type of the first reported value. It raises an error instead of coercing the value if we try to save an integer into a float field.

Home Assistant is not consistent in the type of number that we return. We try to return an integer if possible, else a float.

This PR will update `state_as_number` to always return the number as a float. The alternative would be to cast all numbers to a float before passing it down to Influx. We should verify that the behavior does not break the other stats components.

This PR will also apply a constraint to `State` that was previously only applied at the `StateMachine` level: all states have to be strings.

I plan to release 0.13.1 when this issue is resolved.

CC @kk7ds 
