### PR TITLE
Fixed intermittent error during setup

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -404,8 +404,9 @@ class StateMachine(object):
 
         domain_filter = domain_filter.lower()
 
-        return [state.entity_id for state in self._states.values()
-                if state.domain == domain_filter]
+        with self._lock:
+            return [state.entity_id for state in self._states.values()
+                    if state.domain == domain_filter]
 
     def all(self):
         """Create a list of all states."""


### PR DESCRIPTION
Got this exception

```
ERROR:homeassistant.bootstrap:Error during setup of component group
Traceback (most recent call last):
  File "/home/per/home-assistant/homeassistant/bootstrap.py", line 99, in _setup_component
    if not component.setup(hass, config):
  File "/home/per/home-assistant/homeassistant/components/group.py", line 124, in setup
    object_id=object_id)
  File "/home/per/home-assistant/homeassistant/components/group.py", line 139, in __init__
    self._order = len(hass.states.entity_ids(DOMAIN))
  File "/home/per/home-assistant/homeassistant/core.py", line 456, in entity_ids
    return [state.entity_id for state in self._states.values()
  File "/home/per/home-assistant/homeassistant/core.py", line 456, in <listcomp>
    return [state.entity_id for state in self._states.values()
RuntimeError: dictionary changed size during iteration
```

Seems to be quite uncommon that this intermittent error occur. 

This small change should fix it... 
