### PR TITLE
Add assumed_state property to entity

### DIFF
--- a/homeassistant/components/switch/demo.py
+++ b/homeassistant/components/switch/demo.py
@@ -12,17 +12,18 @@ from homeassistant.const import DEVICE_DEFAULT_NAME
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """ Find and return demo switches. """
     add_devices_callback([
-        DemoSwitch('Decorative Lights', True, None),
-        DemoSwitch('AC', False, 'mdi:air-conditioner')
+        DemoSwitch('Decorative Lights', True, None, True),
+        DemoSwitch('AC', False, 'mdi:air-conditioner', False)
     ])
 
 
 class DemoSwitch(SwitchDevice):
     """ Provides a demo switch. """
-    def __init__(self, name, state, icon):
+    def __init__(self, name, state, icon, assumed):
         self._name = name or DEVICE_DEFAULT_NAME
         self._state = state
         self._icon = icon
+        self._assumed = assumed
 
     @property
     def should_poll(self):
@@ -38,6 +39,11 @@ class DemoSwitch(SwitchDevice):
     def icon(self):
         """ Returns the icon to use for device if any. """
         return self._icon
+
+    @property
+    def assumed_state(self):
+        """Return if the state is based on assumptions."""
+        return self._assumed
 
     @property
     def current_power_mwh(self):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -124,6 +124,9 @@ ATTR_LONGITUDE = "longitude"
 # Accuracy of location in meters
 ATTR_GPS_ACCURACY = 'gps_accuracy'
 
+# If state is assumed
+ATTR_ASSUMED_STATE = 'assumed_state'
+
 # #### SERVICES ####
 SERVICE_HOMEASSISTANT_STOP = "stop"
 SERVICE_HOMEASSISTANT_RESTART = "restart"

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -13,7 +13,7 @@ from homeassistant.util import ensure_unique_string, slugify
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, ATTR_HIDDEN, ATTR_UNIT_OF_MEASUREMENT, ATTR_ICON,
     DEVICE_DEFAULT_NAME, STATE_ON, STATE_OFF, STATE_UNKNOWN, STATE_UNAVAILABLE,
-    TEMP_CELCIUS, TEMP_FAHRENHEIT)
+    TEMP_CELCIUS, TEMP_FAHRENHEIT, ATTR_ASSUMED_STATE)
 
 # Dict mapping entity_id to a boolean that overwrites the hidden property
 _OVERWRITE = defaultdict(dict)
@@ -116,6 +116,11 @@ class Entity(object):
         """Return True if entity is available."""
         return True
 
+    @property
+    def assumed_state(self):
+        """Return True if unable to access real state of entity."""
+        return False
+
     def update(self):
         """Retrieve latest state."""
         pass
@@ -164,11 +169,14 @@ class Entity(object):
         if ATTR_FRIENDLY_NAME not in attr and self.name is not None:
             attr[ATTR_FRIENDLY_NAME] = str(self.name)
 
-        if ATTR_ICON not in attr and self.icon is not None:
+        if self.icon is not None:
             attr[ATTR_ICON] = str(self.icon)
 
         if self.hidden:
             attr[ATTR_HIDDEN] = bool(self.hidden)
+
+        if self.assumed_state:
+            attr[ATTR_ASSUMED_STATE] = bool(self.assumed_state)
 
         # overwrite properties that have been set in the config file
         attr.update(_OVERWRITE.get(self.entity_id, {}))


### PR DESCRIPTION
This will add a new boolean property to the entity class: assumed_state. ([background story](https://home-assistant.io/blog/2016/02/12/classifying-the-internet-of-things/))

On itself it will not do anything. It will be used to indicate that we are unable to poll the real state and that this state is based on assumptions that our commands are successful.

The frontend will show entities with an assumed state differently. For example, for a switch with an assumed state we will show two buttons (`turn off`, `turn on`) instead of a switch. (Added in bca3207e0ce2ad905278fd5579175547e462acb7)
