### PR TITLE
Remove usage of ATTR_FRIENDLY_NAME within components/platforms

### DIFF
--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -16,8 +16,7 @@ from homeassistant.helpers import validate_config
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.const import (
     CONF_HOST, CONF_USERNAME, CONF_PASSWORD, EVENT_PLATFORM_DISCOVERED,
-    EVENT_HOMEASSISTANT_STOP, ATTR_SERVICE, ATTR_DISCOVERED,
-    ATTR_FRIENDLY_NAME)
+    EVENT_HOMEASSISTANT_STOP, ATTR_SERVICE, ATTR_DISCOVERED)
 
 DOMAIN = "isy994"
 REQUIREMENTS = ['PyISY==1.0.5']
@@ -147,7 +146,7 @@ class ISYDeviceABC(ToggleEntity):
     @property
     def state_attributes(self):
         """ Returns the state attributes for the node. """
-        attr = {ATTR_FRIENDLY_NAME: self.name}
+        attr = {}
         for name, prop in self._attrs.items():
             attr[name] = getattr(self, prop)
             attr = self._attr_filter(attr)

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -7,8 +7,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.tellstick/
 """
 from homeassistant.components.light import Light, ATTR_BRIGHTNESS
-from homeassistant.const import (EVENT_HOMEASSISTANT_STOP,
-                                 ATTR_FRIENDLY_NAME)
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 REQUIREMENTS = ['tellcore-py==1.1.2']
 SIGNAL_REPETITIONS = 1
 
@@ -58,7 +57,6 @@ class TellstickLight(Light):
         import tellcore.constants as tellcore_constants
 
         self.tellstick_device = tellstick_device
-        self.state_attr = {ATTR_FRIENDLY_NAME: tellstick_device.name}
         self.signal_repetitions = signal_repetitions
         self._brightness = 0
 

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -26,7 +26,6 @@ DEFAULT_PROXIMITY_ZONE = 'home'
 ATTR_DIST_FROM = 'dist_to_zone'
 ATTR_DIR_OF_TRAVEL = 'dir_of_travel'
 ATTR_NEAREST = 'nearest'
-ATTR_FRIENDLY_NAME = 'friendly_name'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -95,6 +94,11 @@ class Proximity(Entity):  # pylint: disable=too-many-instance-attributes
         self.proximity_zone = proximity_zone
 
     @property
+    def name(self):
+        """Return the name of the entity."""
+        return self.friendly_name
+
+    @property
     def state(self):
         """ Returns the state. """
         return self.dist_to
@@ -110,7 +114,6 @@ class Proximity(Entity):  # pylint: disable=too-many-instance-attributes
         return {
             ATTR_DIR_OF_TRAVEL: self.dir_of_travel,
             ATTR_NEAREST: self.nearest,
-            ATTR_FRIENDLY_NAME: self.friendly_name
         }
 
     def check_proximity_state_change(self, entity, old_state, new_state):

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -24,7 +24,7 @@ ENTITY_ID_PATTERN = re.compile(r"^(\w+)\.(\w+)$")
 
 def generate_entity_id(entity_id_format, name, current_ids=None, hass=None):
     """Generate a unique entity ID based on given entity IDs or used ids."""
-    name = name.lower() or DEVICE_DEFAULT_NAME.lower()
+    name = (name or DEVICE_DEFAULT_NAME).lower()
     if current_ids is None:
         if hass is None:
             raise RuntimeError("Missing required parameter currentids or hass")
@@ -71,7 +71,7 @@ class Entity(object):
     @property
     def name(self):
         """Return the name of the entity."""
-        return DEVICE_DEFAULT_NAME
+        return None
 
     @property
     def state(self):
@@ -161,7 +161,7 @@ class Entity(object):
             state = STATE_UNAVAILABLE
             attr = {}
 
-        if ATTR_FRIENDLY_NAME not in attr and self.name is not None:
+        if self.name is not None:
             attr[ATTR_FRIENDLY_NAME] = str(self.name)
 
         if ATTR_ICON not in attr and self.icon is not None:


### PR DESCRIPTION
This removes the usage of ATTR_FRIENDLY_NAME within components/platforms. The only way to set the name is to overwrite the `name` property.

Also fixes a bug where we would always set `friendly_name` to `DEVICE_DEFAULT_NAME` if `name` property not implemented by entity. Now the attribute will not be added to the attributes.
