### PR TITLE
Exclude venv directories from linting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 1
 testpaths = tests
 
 [flake8]
-exclude = .venv,.git,.tox,docs,www_static,tests
+exclude = .venv,.git,.tox,docs,www_static,tests,venv,bin,lib
 
 [pep257]
 ignore = D203,D105


### PR DESCRIPTION
I would wager that the #1 most common venv name is "venv" and we should exclude it :)
