### PR TITLE
Execute all lint tests even if flake8 reports errors.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
 
 [testenv:lint]
 basepython = python3
+ignore_errors = True
 commands =
      flake8
      pylint homeassistant


### PR DESCRIPTION
Still fails the tox environment if `flake8` has errors, but will execute both `flake8` and `pylint` so you can see the output from both.
