### PR TITLE
Proximity multiple zones

### DIFF
--- a/homeassistant/components/proximity_zones.py
+++ b/homeassistant/components/proximity_zones.py
@@ -3,21 +3,25 @@ custom_components.proximity_zones
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 proximity_zones:
-- zone: home
+  home:
+    zone: home
     ignored_zones:
       - twork
       - elschool
     devices:
-      - device_tracker.nwaring_nickmobile
-      - device_tracker.eleanorsiphone
-      - device_tracker.tsiphone
+      - nwaring_nickmobile
+      - eleanorsiphone
+      - tsiphone
     tolerance: 1
-- zone: work
+    name: Home
+  work:
+    zone: work
     ignored_zones:
       - home
     devices:
-      - device_tracker.nwaring_nickmobile
+      - nwaring_nickmobile
     tolerance: 10
+    name: Work Nick
 """
 
 import logging
@@ -68,7 +72,7 @@ def setup(hass, config):  # pylint: disable=too-many-locals,too-many-statements
 
         proximity_devices = []
         for variable in prox_config['devices']:
-            proximity_devices.append(variable)
+            proximity_devices.append('device_tracker.' + variable)
 
         ignored_zones = []
         if 'ignored_zones' in prox_config:
@@ -79,13 +83,13 @@ def setup(hass, config):  # pylint: disable=too-many-locals,too-many-statements
         tolerance = prox_config.get('tolerance', DEFAULT_TOLERANCE)
 
         # get the zone to monitor proximity to from configuration.yaml
-        proximity_zone = prox_config.get('zone', DEFAULT_PROXIMITY_ZONE)
+        proximity_zone = 'zone.' + prox_config.get('zone',
+                                                   DEFAULT_PROXIMITY_ZONE)
 
         friendly_name = prox_config.get(CONF_NAME, prox)
 
         entity_id = DOMAIN + '.' + prox
-        proximity_zone = 'zone.' + proximity_zone
-
+        
         state = hass.states.get(proximity_zone)
         zone_friendly_name = (state.name).lower()
 

--- a/homeassistant/components/proximity_zones.py
+++ b/homeassistant/components/proximity_zones.py
@@ -1,0 +1,409 @@
+"""
+custom_components.proximity_zones
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+proximity_zones:
+- zone: home
+    ignored_zones:
+      - twork
+      - elschool
+    devices:
+      - device_tracker.nwaring_nickmobile
+      - device_tracker.eleanorsiphone
+      - device_tracker.tsiphone
+    tolerance: 1
+- zone: work
+    ignored_zones:
+      - home
+    devices:
+      - device_tracker.nwaring_nickmobile
+    tolerance: 10
+"""
+
+import logging
+from homeassistant.helpers.event import track_state_change
+from homeassistant.helpers.entity import Entity
+from homeassistant.util.location import distance
+from homeassistant.components import zone
+from homeassistant.const import CONF_NAME
+
+DEPENDENCIES = ['zone', 'device_tracker']
+
+# domain for the component
+DOMAIN = 'proximity_zones'
+
+# default tolerance
+DEFAULT_TOLERANCE = 1
+
+# default zone
+DEFAULT_PROXIMITY_ZONE = 'home'
+
+# entity attributes
+ATTR_DIST_FROM = 'dist_to_zone'
+ATTR_DIR_OF_TRAVEL = 'dir_of_travel'
+ATTR_NEAREST = 'nearest'
+ATTR_FRIENDLY_NAME = 'friendly_name'
+
+# Shortcut for the logger
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup(hass, config):  # pylint: disable=too-many-locals,too-many-statements
+    """ get the zones and offsets from configuration.yaml"""
+
+    proximities = []
+    if config.get(DOMAIN) is None:
+        return False
+
+    for prox, prox_config in config[DOMAIN].items():
+
+        if not isinstance(prox_config, dict):
+            _LOGGER.error("Missing configuration data for proximity %s", prox)
+            continue
+
+        # get the devices from configuration.yaml
+        if 'devices' not in prox_config:
+            _LOGGER.error('devices not found in config')
+            continue
+
+        proximity_devices = []
+        for variable in prox_config['devices']:
+            proximity_devices.append(variable)
+
+        ignored_zones = []
+        if 'ignored_zones' in prox_config:
+            for variable in prox_config['ignored_zones']:
+                ignored_zones.append(variable)
+
+        # get the direction of travel tolerance from configuration.yaml
+        tolerance = prox_config.get('tolerance', DEFAULT_TOLERANCE)
+
+        # get the zone to monitor proximity to from configuration.yaml
+        proximity_zone = prox_config.get('zone', DEFAULT_PROXIMITY_ZONE)
+
+        friendly_name = prox_config.get(CONF_NAME, prox)
+
+        entity_id = DOMAIN + '.' + prox
+        proximity_zone = 'zone.' + proximity_zone
+
+        state = hass.states.get(proximity_zone)
+        zone_friendly_name = (state.name).lower()
+
+        # set the default values
+        dist_to_zone = 'not set'
+        dir_of_travel = 'not set'
+        nearest = 'not set'
+
+        proximity = Proximity(hass, zone_friendly_name, dist_to_zone,
+                              dir_of_travel, nearest, ignored_zones,
+                              proximity_devices, tolerance, proximity_zone,
+                              friendly_name)
+        proximity.entity_id = entity_id
+
+        proximity.update_ha_state()
+        proximity.check_proximity_initial_state()
+
+        proximities.append(proximity)
+        # main command to monitor proximity of devices
+        track_state_change(hass, proximity.proximity_devices,
+                           proximity.check_proximity_state_change)
+
+    if not proximities:
+        _LOGGER.error("No proximities added")
+        return False
+
+    # Tells the bootstrapper that the component was successfully initialized
+    return True
+
+
+class Proximity(Entity):  # pylint: disable=too-many-instance-attributes
+    """ Represents a Proximity in Home Assistant. """
+    def __init__(self, hass, zone_friendly_name, dist_to, dir_of_travel,
+                 nearest, ignored_zones, proximity_devices, tolerance,
+                 proximity_zone, friendly_name):
+        # pylint: disable=too-many-arguments
+        self.hass = hass
+        self.friendly_name = friendly_name
+        self.zone_friendly_name = zone_friendly_name
+        self.dist_to = dist_to
+        self.dir_of_travel = dir_of_travel
+        self.nearest = nearest
+        self.ignored_zones = ignored_zones
+        self.proximity_devices = proximity_devices
+        self.tolerance = tolerance
+        self.proximity_zone = proximity_zone
+
+    @property
+    def state(self):
+        return self.dist_to
+
+    @property
+    def unit_of_measurement(self):
+        """ Unit of measurement of this entity """
+        return "km"
+
+    @property
+    def state_attributes(self):
+        return {
+            ATTR_DIR_OF_TRAVEL: self.dir_of_travel,
+            ATTR_NEAREST: self.nearest,
+            ATTR_FRIENDLY_NAME: self.friendly_name
+        }
+
+    def check_proximity_state_change(self, entity, old_state, new_state):
+        # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+        """ Function to perform the proximity checking """
+        entity_name = new_state.name
+        devices_to_calculate = self.ignored_zones == []
+        devices_have_coordinates = False
+        devices_in_zone = ''
+
+        zone_state = self.hass.states.get(self.proximity_zone)
+        proximity_latitude = zone_state.attributes.get('latitude')
+        proximity_longitude = zone_state.attributes.get('longitude')
+
+        # check for devices in the monitored zone
+        for device in self.proximity_devices:
+            device_state = self.hass.states.get(device)
+
+            if 'latitude' not in device_state.attributes:
+                continue
+
+            devices_have_coordinates = True
+
+            device_state_lat = device_state.attributes['latitude']
+            device_state_lon = device_state.attributes['longitude']
+
+            for ignored_zone in self.ignored_zones:
+                ignored_zone_state = self.hass.states.get('zone.' +
+                                                          ignored_zone)
+                if not zone.in_zone(ignored_zone_state,
+                                    device_state_lat,
+                                    device_state_lon):
+                    devices_to_calculate = True
+
+            # check the location of all devices
+            if zone.in_zone(zone_state,
+                            device_state_lat,
+                            device_state_lon):
+                device_friendly = device_state.name
+                if devices_in_zone != '':
+                    devices_in_zone = devices_in_zone + ', '
+                devices_in_zone = devices_in_zone + device_friendly
+
+        # at least one device is in the monitored zone so update the entity
+        if devices_in_zone != '':
+            self.dist_to = 0
+            self.dir_of_travel = 'arrived'
+            self.nearest = devices_in_zone
+            self.update_ha_state()
+            return
+
+        # no-one to track so reset the entity
+        if not devices_to_calculate or not devices_have_coordinates:
+            self.dist_to = 'not set'
+            self.dir_of_travel = 'not set'
+            self.nearest = 'not set'
+            self.update_ha_state()
+            return
+
+        # we can't check proximity because latitude and longitude don't exist
+        if 'latitude' not in new_state.attributes:
+            return
+
+        # collect distances to the zone for all devices
+        distances_to_zone = {}
+        for device in self.proximity_devices:
+            # ignore devices in an ignored zone
+            device_state = self.hass.states.get(device)
+
+            # ignore devices if proximity cannot be calculated
+            if 'latitude' not in device_state.attributes:
+                continue
+
+            device_state_lat = device_state.attributes['latitude']
+            device_state_lon = device_state.attributes['longitude']
+
+            device_in_ignored_zone = False
+            for ignored_zone in self.ignored_zones:
+                ignored_zone_state = self.hass.states.get('zone.' +
+                                                          ignored_zone)
+                if zone.in_zone(ignored_zone_state,
+                                device_state_lat,
+                                device_state_lon):
+                    device_in_ignored_zone = True
+                    continue
+            if device_in_ignored_zone:
+                continue
+
+            # calculate the distance to the proximity zone
+            dist_to_zone = distance(proximity_latitude,
+                                    proximity_longitude,
+                                    device_state_lat,
+                                    device_state_lon)
+
+            # add the device and distance to a dictionary
+            distances_to_zone[device] = round(dist_to_zone / 1000, 1)
+
+        # loop through each of the distances collected and work out the closest
+        closest_device = ''
+        dist_to_zone = 1000000
+
+        for device in distances_to_zone:
+            if distances_to_zone[device] < dist_to_zone:
+                closest_device = device
+                dist_to_zone = distances_to_zone[device]
+
+        # if the closest device is one of the other devices
+        if closest_device != entity:
+            self.dist_to = round(distances_to_zone[closest_device])
+            self.dir_of_travel = 'unknown'
+            device_state = self.hass.states.get(closest_device)
+            self.nearest = device_state.name
+            self.update_ha_state()
+            return
+
+        # stop if we cannot calculate the direction of travel (i.e. we don't
+        # have a previous state and a current LAT and LONG)
+        if old_state is None or 'latitude' not in old_state.attributes:
+            self.dist_to = round(distances_to_zone[entity])
+            self.dir_of_travel = 'unknown'
+            self.nearest = entity_name
+            self.update_ha_state()
+            return
+
+        # reset the variables
+        distance_travelled = 0
+
+        # calculate the distance travelled
+        old_distance = distance(proximity_latitude, proximity_longitude,
+                                old_state.attributes['latitude'],
+                                old_state.attributes['longitude'])
+        new_distance = distance(proximity_latitude, proximity_longitude,
+                                new_state.attributes['latitude'],
+                                new_state.attributes['longitude'])
+        distance_travelled = round(new_distance - old_distance, 1)
+
+        # check for tolerance
+        if distance_travelled < self.tolerance * -1:
+            direction_of_travel = 'towards'
+        elif distance_travelled > self.tolerance:
+            direction_of_travel = 'away_from'
+        else:
+            direction_of_travel = 'stationary'
+
+        # update the proximity entity
+        self.dist_to = round(dist_to_zone)
+        self.dir_of_travel = direction_of_travel
+        self.nearest = entity_name
+        self.update_ha_state()
+        _LOGGER.debug('proximity.%s update entity: distance=%s: direction=%s: '
+                      'device=%s', self.friendly_name, round(dist_to_zone),
+                      direction_of_travel, entity_name)
+
+        _LOGGER.info('%s: proximity calculation complete', entity_name)
+
+    def check_proximity_initial_state(self):
+        # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+        """ Function to perform the proximity checking in the initial state """
+        devices_to_calculate = self.ignored_zones == []
+        devices_have_coordinates = False
+        devices_in_zone = ''
+
+        zone_state = self.hass.states.get(self.proximity_zone)
+        proximity_latitude = zone_state.attributes.get('latitude')
+        proximity_longitude = zone_state.attributes.get('longitude')
+
+        # check for devices in the monitored zone
+        for device in self.proximity_devices:
+            device_state = self.hass.states.get(device)
+
+            if 'latitude' not in device_state.attributes:
+                continue
+
+            devices_have_coordinates = True
+
+            device_state_lat = device_state.attributes['latitude']
+            device_state_lon = device_state.attributes['longitude']
+
+            for ignored_zone in self.ignored_zones:
+                ignored_zone_state = self.hass.states.get('zone.' +
+                                                          ignored_zone)
+                if not zone.in_zone(ignored_zone_state,
+                                    device_state_lat,
+                                    device_state_lon):
+                    devices_to_calculate = True
+
+            # check the location of all devices
+            if zone.in_zone(zone_state,
+                            device_state_lat,
+                            device_state_lon):
+                device_friendly = device_state.name
+                if devices_in_zone != '':
+                    devices_in_zone = devices_in_zone + ', '
+                devices_in_zone = devices_in_zone + device_friendly
+
+        # at least one device is in the monitored zone so update the entity
+        if devices_in_zone != '':
+            self.dist_to = 0
+            self.dir_of_travel = 'arrived'
+            self.nearest = devices_in_zone
+            self.update_ha_state()
+            return
+
+        # no-one to track so reset the entity
+        if not devices_to_calculate or not devices_have_coordinates:
+            self.dist_to = 'not set'
+            self.dir_of_travel = 'not set'
+            self.nearest = 'not set'
+            self.update_ha_state()
+            return
+
+        # collect distances to the zone for all devices
+        distances_to_zone = {}
+        for device in self.proximity_devices:
+            # ignore devices in an ignored zone
+            device_state = self.hass.states.get(device)
+
+            # ignore devices if proximity cannot be calculated
+            if 'latitude' not in device_state.attributes:
+                continue
+
+            device_state_lat = device_state.attributes['latitude']
+            device_state_lon = device_state.attributes['longitude']
+
+            device_in_ignored_zone = False
+            for ignored_zone in self.ignored_zones:
+                ignored_zone_state = self.hass.states.get('zone.' +
+                                                          ignored_zone)
+                if zone.in_zone(ignored_zone_state,
+                                device_state_lat,
+                                device_state_lon):
+                    device_in_ignored_zone = True
+                    continue
+            if device_in_ignored_zone:
+                continue
+
+            # calculate the distance to the proximity zone
+            dist_to_zone = distance(proximity_latitude,
+                                    proximity_longitude,
+                                    device_state_lat,
+                                    device_state_lon)
+
+            # add the device and distance to a dictionary
+            distances_to_zone[device] = round(dist_to_zone / 1000, 1)
+
+        # loop through each of the distances collected and work out the closest
+        closest_device = ''
+        dist_to_zone = 1000000
+
+        for device in distances_to_zone:
+            if distances_to_zone[device] < dist_to_zone:
+                closest_device = device
+                dist_to_zone = distances_to_zone[device]
+
+        self.dist_to = round(distances_to_zone[closest_device])
+        self.dir_of_travel = 'unknown'
+        device_state = self.hass.states.get(closest_device)
+        self.nearest = device_state.name
+        self.update_ha_state()

--- a/tests/components/test_proximity_zones.py
+++ b/tests/components/test_proximity_zones.py
@@ -5,22 +5,23 @@ tests.components.proximity_zones
 Tests proximity_zones component.
 """
 
+import homeassistant.core as ha
 import os
 from homeassistant.components import proximity_zones
 from homeassistant.components import zone
 import homeassistant.components.device_tracker as device_tracker
-from datetime import timedelta
+import homeassistant.util.dt as dt_util
+from datetime import datetime, timedelta
 from tests.common import get_test_home_assistant
-
 
 class TestProximityZones:
     """ Test the Proximity_zones component. """
 
     def setup_method(self, method):
         self.hass = get_test_home_assistant()
-
+        
         self.yaml_devices = self.hass.config.path(device_tracker.YAML_DEVICES)
-
+        
         zone.setup(self.hass, {
             'zone': [
                 {
@@ -37,23 +38,24 @@ class TestProximityZones:
                 },
             ]
         })
-
+        
         dev_id = 'test1'
+        entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
         friendly_name = 'test1'
         picture = 'http://placehold.it/200x200'
 
         device = device_tracker.Device(
-            self.hass,
-            timedelta(seconds=180),
-            0,
-            True,
-            dev_id,
+            self.hass, 
+            timedelta(seconds=180), 
+            0, 
+            True, 
+            dev_id, 
             None,
-            friendly_name,
-            picture,
+            friendly_name, 
+            picture, 
             away_hide=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
-
+        
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -61,8 +63,9 @@ class TestProximityZones:
                 'latitude': 50,
                 'longitude': 50
             })
-
+        
         dev_id = 'test2'
+        entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
         friendly_name = 'test2'
         picture = 'http://placehold.it/200x200'
 
@@ -70,7 +73,7 @@ class TestProximityZones:
             self.hass, timedelta(seconds=180), 0, True, dev_id, None,
             friendly_name, picture, away_hide=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
-
+        
         self.hass.states.set(
             'device_tracker.test2', 'not_home',
             {
@@ -78,16 +81,16 @@ class TestProximityZones:
                 'latitude': 50,
                 'longitude': 50
             })
-
+        
     def teardown_method(self, method):
         """ Stop down stuff we started. """
         self.hass.stop()
-
+        
         try:
             os.remove(self.hass.config.path(device_tracker.YAML_DEVICES))
         except FileNotFoundError:
             pass
-
+        
     def test_proximity(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -97,8 +100,8 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 },
@@ -108,8 +111,8 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
@@ -120,18 +123,18 @@ class TestProximityZones:
         assert state.state != 'not set'
         assert state.attributes.get('nearest') != 'not set'
         assert state.attributes.get('dir_of_travel') != 'not set'
-
+        
     def test_no_config(self):
         assert not proximity_zones.setup(self.hass, {
         })
-
+        
     def test_no_proximity_config(self):
         assert not proximity_zones.setup(self.hass, {
             'proximity_zones': {
                 'home': 'test'
             }
         })
-
+        
     def test_no_devices_in_config(self):
         assert not proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -151,7 +154,7 @@ class TestProximityZones:
                 }
             }
         })
-
+        
     def test_no_tolerance_in_config(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -161,8 +164,8 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     }
                 },
                 'work': {
@@ -171,35 +174,35 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     }
                 }
             }
         })
-
+        
     def test_no_ignored_zones_in_config(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
                 'home': {
                     'zone': 'home',
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 },
                 'work': {
                     'zone': 'work',
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+     
     def test_no_zone_in_config(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -208,8 +211,8 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 },
@@ -218,14 +221,14 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+    
     def test_device_tracker_test1_in_zone(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -235,7 +238,7 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1'
+                        'test1'
                     },
                     'tolerance': 1
                 },
@@ -245,14 +248,14 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+        
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -261,10 +264,10 @@ class TestProximityZones:
                 'longitude': 50
             })
         self.hass.pool.block_till_done()
-
+        
         state = self.hass.states.get('device_tracker.test1')
         assert state.state == 'not_home'
-
+        
         self.hass.states.set(
             'device_tracker.test1', 'home',
             {
@@ -273,28 +276,28 @@ class TestProximityZones:
                 'longitude': 1.1
             })
         self.hass.pool.block_till_done()
-
+        
         device_state = self.hass.states.get('device_tracker.test1')
         assert device_state.state == 'home'
         device_state_lat = device_state.attributes['latitude']
         assert device_state_lat == 2.1
         device_state_lon = device_state.attributes['longitude']
         assert device_state_lon == 1.1
-
+        
         zone_state = self.hass.states.get('zone.home')
         assert zone_state.state == 'zoning'
         proximity_latitude = zone_state.attributes.get('latitude')
         assert proximity_latitude == 2.1
         proximity_longitude = zone_state.attributes.get('longitude')
         assert proximity_longitude == 1.1
-
+        
         assert zone.in_zone(zone_state, device_state_lat, device_state_lon)
-
+        
         state = self.hass.states.get('proximity_zones.home')
         assert state.state == '0'
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'arrived'
-
+        
     def test_device_trackers_in_zone_at_start(self):
         self.hass.states.set(
             'device_tracker.test1', 'home',
@@ -320,8 +323,8 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 },
@@ -331,20 +334,20 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
-        })
-
+        })        
+        
         state = self.hass.states.get('proximity_zones.home')
         assert state.state == '0'
         assert ((state.attributes.get('nearest') == 'test1, test2') or
                 (state.attributes.get('nearest') == 'test2, test1'))
         assert state.attributes.get('dir_of_travel') == 'arrived'
-
+        
     def test_device_trackers_in_zone(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -354,8 +357,8 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 },
@@ -365,13 +368,13 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
-        })
+        })        
         self.hass.states.set(
             'device_tracker.test1', 'home',
             {
@@ -393,7 +396,7 @@ class TestProximityZones:
         assert ((state.attributes.get('nearest') == 'test1, test2') or
                 (state.attributes.get('nearest') == 'test2, test1'))
         assert state.attributes.get('dir_of_travel') == 'arrived'
-
+        
     def test_device_tracker_test1_away(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -403,7 +406,7 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1'
+                        'test1'
                     },
                     'tolerance': 1
                 },
@@ -413,14 +416,14 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+        
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -432,7 +435,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'towards'
-
+        
     def test_device_tracker_test1_awayfurther(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -442,7 +445,7 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1'
+                        'test1'
                     },
                     'tolerance': 1
                 },
@@ -452,14 +455,14 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+        
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -482,7 +485,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'away_from'
-
+        
     def test_device_tracker_test1_awaycloser(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -492,7 +495,7 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1'
+                        'test1'
                     },
                     'tolerance': 1
                 },
@@ -502,14 +505,14 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+        
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -532,7 +535,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'towards'
-
+        
     def test_all_device_trackers_in_ignored_zone(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -542,7 +545,7 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1'
+                        'test1'
                     },
                     'tolerance': 1
                 },
@@ -552,14 +555,14 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+        
         self.hass.states.set(
             'device_tracker.test1', 'work',
             {
@@ -572,7 +575,7 @@ class TestProximityZones:
         assert state.state == 'not set'
         assert state.attributes.get('nearest') == 'not set'
         assert state.attributes.get('dir_of_travel') == 'not set'
-
+        
     def test_all_device_trackers_in_ignored_zone_at_start(self):
         self.hass.states.set(
             'device_tracker.test1', 'work',
@@ -582,7 +585,7 @@ class TestProximityZones:
                 'longitude': 100
             })
         self.hass.pool.block_till_done()
-
+        
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
                 'home': {
@@ -591,8 +594,8 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 },
@@ -602,18 +605,18 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+        
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test2'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-
+        
     def test_device_tracker_test1_no_coordinates(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -623,7 +626,7 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1'
+                        'test1'
                     },
                     'tolerance': 1
                 },
@@ -633,14 +636,14 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+        
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -650,7 +653,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'not set'
         assert state.attributes.get('dir_of_travel') == 'not set'
-
+        
     def test_device_tracker_test1_no_coordinates_at_start(self):
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
@@ -658,7 +661,7 @@ class TestProximityZones:
                 'friendly_name': 'test1'
             })
         self.hass.pool.block_till_done()
-
+        
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
                 'home': {
@@ -667,7 +670,7 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1'
+                        'test1'
                     },
                     'tolerance': 1
                 },
@@ -677,18 +680,18 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+                
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'not set'
         assert state.attributes.get('dir_of_travel') == 'not set'
-
+        
     def test_device_tracker_test1_awayfurther_than_test2_first_test1(self):
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
@@ -710,8 +713,8 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 },
@@ -721,14 +724,14 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+        
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -751,7 +754,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-
+        
     def test_device_tracker_test1_awayfurther_than_test2_first_test2(self):
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
@@ -773,8 +776,8 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 },
@@ -784,14 +787,14 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+        
         self.hass.states.set(
             'device_tracker.test2', 'not_home',
             {
@@ -814,7 +817,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-
+        
     def test_device_tracker_test1_awayfurther_test2_in_ignored_zone(self):
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
@@ -838,8 +841,8 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 },
@@ -849,14 +852,14 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+        
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -868,7 +871,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-
+        
     def test_device_tracker_test1_awayfurther_test2_first(self):
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
@@ -890,8 +893,8 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 },
@@ -901,14 +904,14 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+        
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -917,7 +920,7 @@ class TestProximityZones:
                 'longitude': 5.1
             })
         self.hass.pool.block_till_done()
-
+        
         self.hass.states.set(
             'device_tracker.test2', 'not_home',
             {
@@ -953,7 +956,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test2'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-
+        
     def test_device_tracker_test1_awayfurther_a_bit(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -963,7 +966,7 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1'
+                        'test1'
                     },
                     'tolerance': 1000
                 },
@@ -973,14 +976,14 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+        
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -1003,7 +1006,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'stationary'
-
+    
     def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(self):
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
@@ -1025,8 +1028,8 @@ class TestProximityZones:
                         'work'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 },
@@ -1036,14 +1039,14 @@ class TestProximityZones:
                         'home'
                     },
                     'devices': {
-                        'device_tracker.test1',
-                        'device_tracker.test2'
+                        'test1',
+                        'test2'
                     },
                     'tolerance': 1
                 }
             }
         })
-
+        
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -1055,7 +1058,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-
+        
         self.hass.states.set(
             'device_tracker.test2', 'not_home',
             {
@@ -1067,7 +1070,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test2'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-
+        
         self.hass.states.set(
             'device_tracker.test2', 'work',
             {

--- a/tests/components/test_proximity_zones.py
+++ b/tests/components/test_proximity_zones.py
@@ -1,0 +1,1084 @@
+"""
+tests.components.proximity_zones
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests proximity_zones component.
+"""
+
+import homeassistant.core as ha
+import os
+from homeassistant.components import proximity_zones
+from homeassistant.components import zone
+import homeassistant.components.device_tracker as device_tracker
+import homeassistant.util.dt as dt_util
+from datetime import datetime, timedelta
+from tests.common import get_test_home_assistant
+
+class TestProximityZones:
+    """ Test the Proximity_zones component. """
+
+    def setup_method(self, method):
+        self.hass = get_test_home_assistant()
+        
+        self.yaml_devices = self.hass.config.path(device_tracker.YAML_DEVICES)
+        
+        zone.setup(self.hass, {
+            'zone': [
+                {
+                    'name': 'home',
+                    'latitude': 2.1,
+                    'longitude': 1.1,
+                    'radius': 10,
+                },
+                {
+                    'name': 'work',
+                    'latitude': 100,
+                    'longitude': 100,
+                    'radius': 10,
+                },
+            ]
+        })
+        
+        dev_id = 'test1'
+        entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
+        friendly_name = 'test1'
+        picture = 'http://placehold.it/200x200'
+
+        device = device_tracker.Device(
+            self.hass, 
+            timedelta(seconds=180), 
+            0, 
+            True, 
+            dev_id, 
+            None,
+            friendly_name, 
+            picture, 
+            away_hide=True)
+        device_tracker.update_config(self.yaml_devices, dev_id, device)
+        
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 50,
+                'longitude': 50
+            })
+        
+        dev_id = 'test2'
+        entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
+        friendly_name = 'test2'
+        picture = 'http://placehold.it/200x200'
+
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), 0, True, dev_id, None,
+            friendly_name, picture, away_hide=True)
+        device_tracker.update_config(self.yaml_devices, dev_id, device)
+        
+        self.hass.states.set(
+            'device_tracker.test2', 'not_home',
+            {
+                'friendly_name': 'test2',
+                'latitude': 50,
+                'longitude': 50
+            })
+        
+    def teardown_method(self, method):
+        """ Stop down stuff we started. """
+        self.hass.stop()
+        
+        try:
+            os.remove(self.hass.config.path(device_tracker.YAML_DEVICES))
+        except FileNotFoundError:
+            pass
+        
+    def test_proximity(self):
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.state != 'not set'
+        assert state.attributes.get('nearest') != 'not set'
+        assert state.attributes.get('dir_of_travel') != 'not set'
+        
+    def test_no_config(self):
+        assert not proximity_zones.setup(self.hass, {
+        })
+        
+    def test_no_proximity_config(self):
+        assert not proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': 'test'
+            }
+        })
+        
+    def test_no_devices_in_config(self):
+        assert not proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+    def test_no_tolerance_in_config(self):
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    }
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    }
+                }
+            }
+        })
+        
+    def test_no_ignored_zones_in_config(self):
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+     
+    def test_no_zone_in_config(self):
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+    
+    def test_device_tracker_test1_in_zone(self):
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 50,
+                'longitude': 50
+            })
+        self.hass.pool.block_till_done()
+        
+        state = self.hass.states.get('device_tracker.test1')
+        assert state.state == 'not_home'
+        
+        self.hass.states.set(
+            'device_tracker.test1', 'home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 2.1,
+                'longitude': 1.1
+            })
+        self.hass.pool.block_till_done()
+        
+        device_state = self.hass.states.get('device_tracker.test1')
+        assert device_state.state == 'home'
+        device_state_lat = device_state.attributes['latitude']
+        assert device_state_lat == 2.1
+        device_state_lon = device_state.attributes['longitude']
+        assert device_state_lon == 1.1
+        
+        zone_state = self.hass.states.get('zone.home')
+        assert zone_state.state == 'zoning'
+        proximity_latitude = zone_state.attributes.get('latitude')
+        assert proximity_latitude == 2.1
+        proximity_longitude = zone_state.attributes.get('longitude')
+        assert proximity_longitude == 1.1
+        
+        assert zone.in_zone(zone_state, device_state_lat, device_state_lon)
+        
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.state == '0'
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'arrived'
+        
+    def test_device_trackers_in_zone_at_start(self):
+        self.hass.states.set(
+            'device_tracker.test1', 'home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 2.1,
+                'longitude': 1.1
+            })
+        self.hass.pool.block_till_done()
+        self.hass.states.set(
+            'device_tracker.test2', 'home',
+            {
+                'friendly_name': 'test2',
+                'latitude': 2.1,
+                'longitude': 1.1
+            })
+        self.hass.pool.block_till_done()
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })        
+        
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.state == '0'
+        assert ((state.attributes.get('nearest') == 'test1, test2') or
+                (state.attributes.get('nearest') == 'test2, test1'))
+        assert state.attributes.get('dir_of_travel') == 'arrived'
+        
+    def test_device_trackers_in_zone(self):
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })        
+        self.hass.states.set(
+            'device_tracker.test1', 'home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 2.1,
+                'longitude': 1.1
+            })
+        self.hass.pool.block_till_done()
+        self.hass.states.set(
+            'device_tracker.test2', 'home',
+            {
+                'friendly_name': 'test2',
+                'latitude': 2.1,
+                'longitude': 1.1
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.state == '0'
+        assert ((state.attributes.get('nearest') == 'test1, test2') or
+                (state.attributes.get('nearest') == 'test2, test1'))
+        assert state.attributes.get('dir_of_travel') == 'arrived'
+        
+    def test_device_tracker_test1_away(self):
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 20.1,
+                'longitude': 10.1
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'towards'
+        
+    def test_device_tracker_test1_awayfurther(self):
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 20.1,
+                'longitude': 10.1
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'towards'
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 40.1,
+                'longitude': 20.1
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'away_from'
+        
+    def test_device_tracker_test1_awaycloser(self):
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 40.1,
+                'longitude': 20.1
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'towards'
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 20.1,
+                'longitude': 10.1
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'towards'
+        
+    def test_all_device_trackers_in_ignored_zone(self):
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+        self.hass.states.set(
+            'device_tracker.test1', 'work',
+            {
+                'friendly_name': 'test1',
+                'latitude': 100,
+                'longitude': 100
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.state == 'not set'
+        assert state.attributes.get('nearest') == 'not set'
+        assert state.attributes.get('dir_of_travel') == 'not set'
+        
+    def test_all_device_trackers_in_ignored_zone_at_start(self):
+        self.hass.states.set(
+            'device_tracker.test1', 'work',
+            {
+                'friendly_name': 'test1',
+                'latitude': 100,
+                'longitude': 100
+            })
+        self.hass.pool.block_till_done()
+        
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test2'
+        assert state.attributes.get('dir_of_travel') == 'unknown'
+        
+    def test_device_tracker_test1_no_coordinates(self):
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1'
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'not set'
+        assert state.attributes.get('dir_of_travel') == 'not set'
+        
+    def test_device_tracker_test1_no_coordinates_at_start(self):
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1'
+            })
+        self.hass.pool.block_till_done()
+        
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+                
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'not set'
+        assert state.attributes.get('dir_of_travel') == 'not set'
+        
+    def test_device_tracker_test1_awayfurther_than_test2_first_test1(self):
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1'
+            })
+        self.hass.pool.block_till_done()
+        self.hass.states.set(
+            'device_tracker.test2', 'not_home',
+            {
+                'friendly_name': 'test2'
+            })
+        self.hass.pool.block_till_done()
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 20.1,
+                'longitude': 10.1
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'unknown'
+        self.hass.states.set(
+            'device_tracker.test2', 'not_home',
+            {
+                'friendly_name': 'test2',
+                'latitude': 40.1,
+                'longitude': 20.1
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'unknown'
+        
+    def test_device_tracker_test1_awayfurther_than_test2_first_test2(self):
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1'
+            })
+        self.hass.pool.block_till_done()
+        self.hass.states.set(
+            'device_tracker.test2', 'not_home',
+            {
+                'friendly_name': 'test2'
+            })
+        self.hass.pool.block_till_done()
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+        self.hass.states.set(
+            'device_tracker.test2', 'not_home',
+            {
+                'friendly_name': 'test2',
+                'latitude': 40.1,
+                'longitude': 20.1
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test2'
+        assert state.attributes.get('dir_of_travel') == 'unknown'
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 20.1,
+                'longitude': 10.1
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'unknown'
+        
+    def test_device_tracker_test1_awayfurther_test2_in_ignored_zone(self):
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1'
+            })
+        self.hass.pool.block_till_done()
+        self.hass.states.set(
+            'device_tracker.test2', 'work',
+            {
+                'friendly_name': 'test2',
+                'latitude': 100,
+                'longitude': 100
+            })
+        self.hass.pool.block_till_done()
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 20.1,
+                'longitude': 10.1
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'unknown'
+        
+    def test_device_tracker_test1_awayfurther_test2_first(self):
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1'
+            })
+        self.hass.pool.block_till_done()
+        self.hass.states.set(
+            'device_tracker.test2', 'not_home',
+            {
+                'friendly_name': 'test2'
+            })
+        self.hass.pool.block_till_done()
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 10.1,
+                'longitude': 5.1
+            })
+        self.hass.pool.block_till_done()
+        
+        self.hass.states.set(
+            'device_tracker.test2', 'not_home',
+            {
+                'friendly_name': 'test2',
+                'latitude': 20.1,
+                'longitude': 10.1
+            })
+        self.hass.pool.block_till_done()
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 40.1,
+                'longitude': 20.1
+            })
+        self.hass.pool.block_till_done()
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 35.1,
+                'longitude': 15.1
+            })
+        self.hass.pool.block_till_done()
+        self.hass.states.set(
+            'device_tracker.test1', 'work',
+            {
+                'friendly_name': 'test1',
+                'latitude': 100,
+                'longitude': 100
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test2'
+        assert state.attributes.get('dir_of_travel') == 'unknown'
+        
+    def test_device_tracker_test1_awayfurther_a_bit(self):
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1'
+                    },
+                    'tolerance': 1000
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 20.1000001,
+                'longitude': 10.1000001
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'towards'
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 20.1000002,
+                'longitude': 10.1000002
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'stationary'
+    
+    def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(self):
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1'
+            })
+        self.hass.pool.block_till_done()
+        self.hass.states.set(
+            'device_tracker.test2', 'not_home',
+            {
+                'friendly_name': 'test2'
+            })
+        self.hass.pool.block_till_done()
+        assert proximity_zones.setup(self.hass, {
+            'proximity_zones': {
+                'home': {
+                    'zone': 'home',
+                    'ignored_zones': {
+                        'work'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                },
+                'work': {
+                    'zone': 'work',
+                    'ignored_zones': {
+                        'home'
+                    },
+                    'devices': {
+                        'device_tracker.test1',
+                        'device_tracker.test2'
+                    },
+                    'tolerance': 1
+                }
+            }
+        })
+        
+        self.hass.states.set(
+            'device_tracker.test1', 'not_home',
+            {
+                'friendly_name': 'test1',
+                'latitude': 20.1,
+                'longitude': 10.1
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'unknown'
+        
+        self.hass.states.set(
+            'device_tracker.test2', 'not_home',
+            {
+                'friendly_name': 'test2',
+                'latitude': 10.1,
+                'longitude': 5.1
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test2'
+        assert state.attributes.get('dir_of_travel') == 'unknown'
+        
+        self.hass.states.set(
+            'device_tracker.test2', 'work',
+            {
+                'friendly_name': 'test2',
+                'latitude': 100,
+                'longitude': 100
+            })
+        self.hass.pool.block_till_done()
+        state = self.hass.states.get('proximity_zones.home')
+        assert state.attributes.get('nearest') == 'test1'
+        assert state.attributes.get('dir_of_travel') == 'unknown'

--- a/tests/components/test_proximity_zones.py
+++ b/tests/components/test_proximity_zones.py
@@ -5,23 +5,22 @@ tests.components.proximity_zones
 Tests proximity_zones component.
 """
 
-import homeassistant.core as ha
 import os
 from homeassistant.components import proximity_zones
 from homeassistant.components import zone
 import homeassistant.components.device_tracker as device_tracker
-import homeassistant.util.dt as dt_util
-from datetime import datetime, timedelta
+from datetime import timedelta
 from tests.common import get_test_home_assistant
 
 class TestProximityZones:
     """ Test the Proximity_zones component. """
 
+
     def setup_method(self, method):
         self.hass = get_test_home_assistant()
-        
+
         self.yaml_devices = self.hass.config.path(device_tracker.YAML_DEVICES)
-        
+
         zone.setup(self.hass, {
             'zone': [
                 {
@@ -38,24 +37,23 @@ class TestProximityZones:
                 },
             ]
         })
-        
+
         dev_id = 'test1'
-        entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
         friendly_name = 'test1'
         picture = 'http://placehold.it/200x200'
 
         device = device_tracker.Device(
-            self.hass, 
-            timedelta(seconds=180), 
-            0, 
-            True, 
-            dev_id, 
+            self.hass,
+            timedelta(seconds=180),
+            0,
+            True,
+            dev_id,
             None,
-            friendly_name, 
-            picture, 
+            friendly_name,
+            picture,
             away_hide=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
-        
+
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -63,9 +61,8 @@ class TestProximityZones:
                 'latitude': 50,
                 'longitude': 50
             })
-        
+
         dev_id = 'test2'
-        entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
         friendly_name = 'test2'
         picture = 'http://placehold.it/200x200'
 
@@ -73,7 +70,7 @@ class TestProximityZones:
             self.hass, timedelta(seconds=180), 0, True, dev_id, None,
             friendly_name, picture, away_hide=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
-        
+
         self.hass.states.set(
             'device_tracker.test2', 'not_home',
             {
@@ -81,16 +78,16 @@ class TestProximityZones:
                 'latitude': 50,
                 'longitude': 50
             })
-        
+
     def teardown_method(self, method):
         """ Stop down stuff we started. """
         self.hass.stop()
-        
+
         try:
             os.remove(self.hass.config.path(device_tracker.YAML_DEVICES))
         except FileNotFoundError:
             pass
-        
+
     def test_proximity(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -123,18 +120,18 @@ class TestProximityZones:
         assert state.state != 'not set'
         assert state.attributes.get('nearest') != 'not set'
         assert state.attributes.get('dir_of_travel') != 'not set'
-        
+
     def test_no_config(self):
         assert not proximity_zones.setup(self.hass, {
         })
-        
+
     def test_no_proximity_config(self):
         assert not proximity_zones.setup(self.hass, {
             'proximity_zones': {
                 'home': 'test'
             }
         })
-        
+
     def test_no_devices_in_config(self):
         assert not proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -154,7 +151,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
     def test_no_tolerance_in_config(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -180,7 +177,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
     def test_no_ignored_zones_in_config(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -202,7 +199,7 @@ class TestProximityZones:
                 }
             }
         })
-     
+
     def test_no_zone_in_config(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -228,7 +225,7 @@ class TestProximityZones:
                 }
             }
         })
-    
+
     def test_device_tracker_test1_in_zone(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -255,7 +252,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -264,10 +261,10 @@ class TestProximityZones:
                 'longitude': 50
             })
         self.hass.pool.block_till_done()
-        
+
         state = self.hass.states.get('device_tracker.test1')
         assert state.state == 'not_home'
-        
+
         self.hass.states.set(
             'device_tracker.test1', 'home',
             {
@@ -276,28 +273,28 @@ class TestProximityZones:
                 'longitude': 1.1
             })
         self.hass.pool.block_till_done()
-        
+
         device_state = self.hass.states.get('device_tracker.test1')
         assert device_state.state == 'home'
         device_state_lat = device_state.attributes['latitude']
         assert device_state_lat == 2.1
         device_state_lon = device_state.attributes['longitude']
         assert device_state_lon == 1.1
-        
+
         zone_state = self.hass.states.get('zone.home')
         assert zone_state.state == 'zoning'
         proximity_latitude = zone_state.attributes.get('latitude')
         assert proximity_latitude == 2.1
         proximity_longitude = zone_state.attributes.get('longitude')
         assert proximity_longitude == 1.1
-        
+
         assert zone.in_zone(zone_state, device_state_lat, device_state_lon)
-        
+
         state = self.hass.states.get('proximity_zones.home')
         assert state.state == '0'
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'arrived'
-        
+
     def test_device_trackers_in_zone_at_start(self):
         self.hass.states.set(
             'device_tracker.test1', 'home',
@@ -340,14 +337,14 @@ class TestProximityZones:
                     'tolerance': 1
                 }
             }
-        })        
-        
+        })
+
         state = self.hass.states.get('proximity_zones.home')
         assert state.state == '0'
         assert ((state.attributes.get('nearest') == 'test1, test2') or
                 (state.attributes.get('nearest') == 'test2, test1'))
         assert state.attributes.get('dir_of_travel') == 'arrived'
-        
+
     def test_device_trackers_in_zone(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -374,7 +371,7 @@ class TestProximityZones:
                     'tolerance': 1
                 }
             }
-        })        
+        })
         self.hass.states.set(
             'device_tracker.test1', 'home',
             {
@@ -396,7 +393,7 @@ class TestProximityZones:
         assert ((state.attributes.get('nearest') == 'test1, test2') or
                 (state.attributes.get('nearest') == 'test2, test1'))
         assert state.attributes.get('dir_of_travel') == 'arrived'
-        
+
     def test_device_tracker_test1_away(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -423,7 +420,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -435,7 +432,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'towards'
-        
+
     def test_device_tracker_test1_awayfurther(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -462,7 +459,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -485,7 +482,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'away_from'
-        
+
     def test_device_tracker_test1_awaycloser(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -512,7 +509,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -535,7 +532,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'towards'
-        
+
     def test_all_device_trackers_in_ignored_zone(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -562,7 +559,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
         self.hass.states.set(
             'device_tracker.test1', 'work',
             {
@@ -575,7 +572,7 @@ class TestProximityZones:
         assert state.state == 'not set'
         assert state.attributes.get('nearest') == 'not set'
         assert state.attributes.get('dir_of_travel') == 'not set'
-        
+
     def test_all_device_trackers_in_ignored_zone_at_start(self):
         self.hass.states.set(
             'device_tracker.test1', 'work',
@@ -585,7 +582,7 @@ class TestProximityZones:
                 'longitude': 100
             })
         self.hass.pool.block_till_done()
-        
+
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
                 'home': {
@@ -612,11 +609,11 @@ class TestProximityZones:
                 }
             }
         })
-        
+
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test2'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-        
+
     def test_device_tracker_test1_no_coordinates(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -643,7 +640,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -653,7 +650,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'not set'
         assert state.attributes.get('dir_of_travel') == 'not set'
-        
+
     def test_device_tracker_test1_no_coordinates_at_start(self):
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
@@ -661,7 +658,7 @@ class TestProximityZones:
                 'friendly_name': 'test1'
             })
         self.hass.pool.block_till_done()
-        
+
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
                 'home': {
@@ -687,11 +684,11 @@ class TestProximityZones:
                 }
             }
         })
-                
+
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'not set'
         assert state.attributes.get('dir_of_travel') == 'not set'
-        
+
     def test_device_tracker_test1_awayfurther_than_test2_first_test1(self):
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
@@ -731,7 +728,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -754,7 +751,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-        
+
     def test_device_tracker_test1_awayfurther_than_test2_first_test2(self):
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
@@ -794,7 +791,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
         self.hass.states.set(
             'device_tracker.test2', 'not_home',
             {
@@ -817,7 +814,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-        
+
     def test_device_tracker_test1_awayfurther_test2_in_ignored_zone(self):
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
@@ -859,7 +856,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -871,7 +868,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-        
+
     def test_device_tracker_test1_awayfurther_test2_first(self):
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
@@ -911,7 +908,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -920,7 +917,7 @@ class TestProximityZones:
                 'longitude': 5.1
             })
         self.hass.pool.block_till_done()
-        
+
         self.hass.states.set(
             'device_tracker.test2', 'not_home',
             {
@@ -956,7 +953,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test2'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-        
+
     def test_device_tracker_test1_awayfurther_a_bit(self):
         assert proximity_zones.setup(self.hass, {
             'proximity_zones': {
@@ -983,7 +980,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -1006,7 +1003,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'stationary'
-    
+
     def test_device_tracker_test1_nearest_after_test2_in_ignored_zone(self):
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
@@ -1046,7 +1043,7 @@ class TestProximityZones:
                 }
             }
         })
-        
+
         self.hass.states.set(
             'device_tracker.test1', 'not_home',
             {
@@ -1058,7 +1055,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test1'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-        
+
         self.hass.states.set(
             'device_tracker.test2', 'not_home',
             {
@@ -1070,7 +1067,7 @@ class TestProximityZones:
         state = self.hass.states.get('proximity_zones.home')
         assert state.attributes.get('nearest') == 'test2'
         assert state.attributes.get('dir_of_travel') == 'unknown'
-        
+
         self.hass.states.set(
             'device_tracker.test2', 'work',
             {

--- a/tests/components/test_proximity_zones.py
+++ b/tests/components/test_proximity_zones.py
@@ -12,9 +12,9 @@ import homeassistant.components.device_tracker as device_tracker
 from datetime import timedelta
 from tests.common import get_test_home_assistant
 
+
 class TestProximityZones:
     """ Test the Proximity_zones component. """
-
 
     def setup_method(self, method):
         self.hass = get_test_home_assistant()


### PR DESCRIPTION
This PR allows you to have multiple Proximity Zones entities. This allows you to track the distance between your devices and multiple zones.
You can even create multiple entities for just one zone, but with different devices, ignored_zones and tolerance.
