### PR TITLE
Add assumed_state for rfxtrx switch and light.

### DIFF
--- a/homeassistant/components/light/rfxtrx.py
+++ b/homeassistant/components/light/rfxtrx.py
@@ -152,6 +152,12 @@ class RfxtrxLight(Light):
         """ Brightness of this light between 0..255. """
         return self._brightness
 
+    @property
+    def assumed_state(self):
+        """Return True if unable to access real state of entity."""
+        return True
+
+
     def turn_on(self, **kwargs):
         """ Turn the light on. """
         brightness = kwargs.get(ATTR_BRIGHTNESS)

--- a/homeassistant/components/light/rfxtrx.py
+++ b/homeassistant/components/light/rfxtrx.py
@@ -157,7 +157,6 @@ class RfxtrxLight(Light):
         """Return True if unable to access real state of entity."""
         return True
 
-
     def turn_on(self, **kwargs):
         """ Turn the light on. """
         brightness = kwargs.get(ATTR_BRIGHTNESS)

--- a/homeassistant/components/switch/rfxtrx.py
+++ b/homeassistant/components/switch/rfxtrx.py
@@ -132,6 +132,11 @@ class RfxtrxSwitch(SwitchDevice):
         """ True if light is on. """
         return self._state
 
+    @property
+    def assumed_state(self):
+        """Return True if unable to access real state of entity."""
+        return True
+
     def turn_on(self, **kwargs):
         """ Turn the device on. """
         if self._event:


### PR DESCRIPTION
@Danielhiversen @badele @jacobtomlinson
Is this correct to implement, based on the rfxtrx never can know the actual state of a device?
It will actually be better for automation, because it will allow to turn on something that might not be on and reported as on by HA.
It will also allow for using switches for adjusting dim level for lights.
Do not merge until discussion finished please :)
