### PR TITLE
Fixed issue with Wink locks lock, and unlock methods

### DIFF
--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -57,10 +57,10 @@ class WinkLockDevice(LockDevice):
         """ True if device is locked. """
         return self.wink.state()
 
-    def lock(self):
+    def lock(self, **kwargs):
         """ Lock the device. """
         self.wink.set_state(True)
 
-    def unlock(self):
+    def unlock(self, **kwargs):
         """ Unlock the device. """
         self.wink.set_state(False)


### PR DESCRIPTION
It appears that #1136 broke the wink lock. The additional "code" parameter that can gets passed isn't expected in the wink lock components lock and unlock methods. This fixes that issue.

Can you squash your commits? 

@balloob apparently I can't lol, just opened a new PR
