### PR TITLE
Fix #1287 for honeywell US systems with no fan

### DIFF
--- a/homeassistant/components/thermostat/honeywell.py
+++ b/homeassistant/components/thermostat/honeywell.py
@@ -14,7 +14,7 @@ from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD, TEMP_CELCIUS,
                                  TEMP_FAHRENHEIT)
 
 REQUIREMENTS = ['evohomeclient==0.2.4',
-                'somecomfort==0.2.0']
+                'somecomfort==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -235,7 +235,7 @@ sleekxmpp==1.3.1
 snapcast==1.1.1
 
 # homeassistant.components.thermostat.honeywell
-somecomfort==0.2.0
+somecomfort==0.2.1
 
 # homeassistant.components.sensor.speedtest
 speedtest-cli==0.3.4

--- a/tests/components/thermostat/test_honeywell.py
+++ b/tests/components/thermostat/test_honeywell.py
@@ -307,3 +307,13 @@ class TestHoneywellUS(unittest.TestCase):
         expected['fan'] = 'idle'
         self.device.fan_running = False
         self.assertEqual(expected, self.honeywell.device_state_attributes)
+
+    def test_with_no_fan(self):
+        self.device.fan_running = False
+        self.device.fan_mode = None
+        expected = {
+            'fan': 'idle',
+            'fanmode': None,
+            'system_mode': 'heat',
+        }
+        self.assertEqual(expected, self.honeywell.device_state_attributes)


### PR DESCRIPTION
This bumps the somecomfort requirement to 0.2.1 to pull in a change
that makes handling no-fan systems graceful. Adds a test that should
prove it gives us what we want.

If no fan, then fan is always idle and fanmode is None.
