### PR TITLE
Fix coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
     - $HOME/.cache/pip
 install: pip install -U tox
 language: python
-script: tox
-after_success:
+script:
+  - tox
+  - pip install coveralls
   - coveralls


### PR DESCRIPTION
Coveralls failed to run because it was only being installed in the Tox virtual environments.

The problem with this fix is that `coveralls` fails to run locally. Not the end of the world as it means nothing but it will confuse users running tests locally.

I tried to do `coveralls || true` but that doesn't work as it's not executed in a shell.

CC @sdague 
