### PR TITLE
Fix own tracks mobile beacon race condition

### DIFF
--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -379,3 +379,35 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         message['lat'] = "4.0"
         self.send_message(LOCATION_TOPIC, LOCATION_MESSAGE)
         self.assert_tracker_latitude(3.0)
+
+    def test_mobile_multiple_async_enter_exit(self):
+        # Test race condition
+        enter_message = REGION_ENTER_MESSAGE.copy()
+        enter_message['desc'] = IBEACON_DEVICE
+        exit_message = REGION_LEAVE_MESSAGE.copy()
+        exit_message['desc'] = IBEACON_DEVICE
+
+        fire_mqtt_message(
+            self.hass, EVENT_TOPIC, json.dumps(enter_message))
+        fire_mqtt_message(
+            self.hass, EVENT_TOPIC, json.dumps(exit_message))
+        fire_mqtt_message(
+            self.hass, EVENT_TOPIC, json.dumps(enter_message))
+        fire_mqtt_message(
+            self.hass, EVENT_TOPIC, json.dumps(exit_message))
+
+        self.hass.pool.block_till_done()
+        self.assertEqual(owntracks.MOBILE_BEACONS_ACTIVE['greg_phone'], [])
+
+    def test_mobile_multiple_enter_exit(self):
+        # Should only happen if the iphone dies
+        enter_message = REGION_ENTER_MESSAGE.copy()
+        enter_message['desc'] = IBEACON_DEVICE
+        exit_message = REGION_LEAVE_MESSAGE.copy()
+        exit_message['desc'] = IBEACON_DEVICE
+
+        self.send_message(EVENT_TOPIC, enter_message)
+        self.send_message(EVENT_TOPIC, enter_message)
+        self.send_message(EVENT_TOPIC, exit_message)
+
+        self.assertEqual(owntracks.MOBILE_BEACONS_ACTIVE['greg_phone'], [])

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -387,16 +387,17 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         exit_message = REGION_LEAVE_MESSAGE.copy()
         exit_message['desc'] = IBEACON_DEVICE
 
+        for i in range(0, 20):
+            fire_mqtt_message(
+                self.hass, EVENT_TOPIC, json.dumps(enter_message))
+            fire_mqtt_message(
+                self.hass, EVENT_TOPIC, json.dumps(exit_message))
+
         fire_mqtt_message(
             self.hass, EVENT_TOPIC, json.dumps(enter_message))
-        fire_mqtt_message(
-            self.hass, EVENT_TOPIC, json.dumps(exit_message))
-        fire_mqtt_message(
-            self.hass, EVENT_TOPIC, json.dumps(enter_message))
-        fire_mqtt_message(
-            self.hass, EVENT_TOPIC, json.dumps(exit_message))
 
         self.hass.pool.block_till_done()
+        self.send_message(EVENT_TOPIC, exit_message)
         self.assertEqual(owntracks.MOBILE_BEACONS_ACTIVE['greg_phone'], [])
 
     def test_mobile_multiple_enter_exit(self):


### PR DESCRIPTION
Closes https://github.com/balloob/home-assistant/issues/1273

This PR fixes two issues in ibeacons.

There was a missing lock that could cause region entry and exit to update incorrectly, and there was also an issue that wouldn't handle multiple entries (which shouldn't generally happen unless device connections are lost - but should be handless).
