### PR TITLE
Fix media_player/sonos configuration mismatch

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -47,10 +47,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     players = None
     hosts = config.get('hosts', None)
     if hosts:
+        # Support retro compatibility with comma separated list of hosts
+        # from config
+        hosts = hosts.split(',') if isinstance(hosts, str) else hosts
         players = []
-        for host in hosts.split(","):
-            host = socket.gethostbyname(host)
-            players.append(soco.SoCo(host))
+        for host in hosts:
+            players.append(soco.SoCo(socket.gethostbyname(host)))
 
     if not players:
         players = soco.discover(interface_addr=config.get('interface_addr',


### PR DESCRIPTION
- From configuration.yaml is easy to provide iterable elements like lists,
  this adds the possibility to provide a list of Sonos hosts using a yaml list
  and still supports the comma separated string version
- Remove superfluous host reassignment
