### PR TITLE
Fix bloomsky component importing

### DIFF
--- a/homeassistant/components/camera/bloomsky.py
+++ b/homeassistant/components/camera/bloomsky.py
@@ -8,7 +8,7 @@ https://home-assistant.io/components/camera.bloomsky/
 """
 import logging
 import requests
-import homeassistant.components.bloomsky as bloomsky
+from homeassistant.loader import get_component
 from homeassistant.components.camera import Camera
 
 DEPENDENCIES = ["bloomsky"]
@@ -17,6 +17,7 @@ DEPENDENCIES = ["bloomsky"]
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """ set up access to BloomSky cameras """
+    bloomsky = get_component('bloomsky')
     for device in bloomsky.BLOOMSKY.devices.values():
         add_devices_callback([BloomSkyCamera(bloomsky.BLOOMSKY, device)])
 

--- a/homeassistant/components/sensor/bloomsky.py
+++ b/homeassistant/components/sensor/bloomsky.py
@@ -7,7 +7,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/sensor.bloomsky/
 """
 import logging
-import homeassistant.components.bloomsky as bloomsky
+from homeassistant.loader import get_component
 from homeassistant.helpers.entity import Entity
 
 DEPENDENCIES = ["bloomsky"]
@@ -36,6 +36,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """ Set up the available BloomSky weather sensors. """
 
     logger = logging.getLogger(__name__)
+    bloomsky = get_component('bloomsky')
 
     for device_key in bloomsky.BLOOMSKY.devices:
         device = bloomsky.BLOOMSKY.devices[device_key]


### PR DESCRIPTION
This tweaks bloomsky to use `get_component` instead of importing the component directly. By doing so it will honor when the main bloomsky component is overwritten by a custom component.

I have been neglecting to enforce this for a while but this is the proper way we should be referencing other components to not bypass custom components.
