### PR TITLE
Return early from setup_platform when zwave NETWORK is not configured

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -19,7 +19,7 @@ from homeassistant.components.zwave import (
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """ Find and add Z-Wave lights. """
-    if discovery_info is None:
+    if discovery_info is None or NETWORK is None:
         return
 
     node = NETWORK.nodes[discovery_info[ATTR_NODE_ID]]

--- a/homeassistant/components/sensor/zwave.py
+++ b/homeassistant/components/sensor/zwave.py
@@ -52,7 +52,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     #   platform: zwave
     #
     # `setup_platform` will be called without `discovery_info`.
-    if discovery_info is None:
+    if discovery_info is None or NETWORK is None:
         return
 
     node = NETWORK.nodes[discovery_info[ATTR_NODE_ID]]

--- a/homeassistant/components/switch/zwave.py
+++ b/homeassistant/components/switch/zwave.py
@@ -15,7 +15,7 @@ from homeassistant.components.zwave import (
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """ Find and return demo switches. """
-    if discovery_info is None:
+    if discovery_info is None or NETWORK is None:
         return
 
     node = NETWORK.nodes[discovery_info[ATTR_NODE_ID]]


### PR DESCRIPTION
This is to fix an issue I brought up in https://github.com/balloob/home-assistant/issues/1307 where forwarding zwave events to a master HA would cause errors if it wasn't configured for zwave.
