### PR TITLE
Add `for` to state automation.

### DIFF
--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -7,14 +7,21 @@ For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#state-trigger
 """
 import logging
+from datetime import timedelta
 
-from homeassistant.const import MATCH_ALL
-from homeassistant.helpers.event import track_state_change
+import homeassistant.util.dt as dt_util
+
+from homeassistant.const import (
+    EVENT_STATE_CHANGED, EVENT_TIME_CHANGED, MATCH_ALL)
+from homeassistant.components.automation.time import (
+    CONF_HOURS, CONF_MINUTES, CONF_SECONDS)
+from homeassistant.helpers.event import track_state_change, track_point_in_time
 
 CONF_ENTITY_ID = "entity_id"
 CONF_FROM = "from"
 CONF_TO = "to"
 CONF_STATE = "state"
+CONF_FOR = "for"
 
 
 def trigger(hass, config, action):
@@ -34,9 +41,60 @@ def trigger(hass, config, action):
             'Config error. Surround to/from values with quotes.')
         return False
 
+    if CONF_FOR in config:
+        hours = config[CONF_FOR].get(CONF_HOURS)
+        minutes = config[CONF_FOR].get(CONF_MINUTES)
+        seconds = config[CONF_FOR].get(CONF_SECONDS)
+
+        if hours is None and minutes is None and seconds is None:
+            logging.getLogger(__name__).error(
+                "Received invalid value for '%s': %s",
+                config[CONF_FOR], CONF_FOR)
+            return False
+
+        if config.get(CONF_TO) is None and config.get(CONF_STATE) is None:
+            logging.getLogger(__name__).error(
+                "For: requires a to: value'%s': %s",
+                config[CONF_FOR], CONF_FOR)
+            return False
+
     def state_automation_listener(entity, from_s, to_s):
         """ Listens for state changes and calls action. """
-        action()
+
+        def state_for_listener(now):
+            """ Fires on state changes after a delay and calls action. """
+            logging.getLogger(__name__).error('Listener fired')
+
+            hass.bus.remove_listener(
+                EVENT_STATE_CHANGED, for_state_listener)
+            action()
+
+        def state_for_cancel_listener(entity, inner_from_s, inner_to_s):
+            """ Fires on state changes and cancels
+                for listener if state changed. """
+            logging.getLogger(__name__).error(
+                'state_for_cancel_listener')
+            if inner_to_s == to_s:
+                return
+            logging.getLogger(__name__).error('Listeners removed')
+            hass.bus.remove_listener(EVENT_TIME_CHANGED, for_time_listener)
+            hass.bus.remove_listener(
+                EVENT_STATE_CHANGED, for_state_listener)
+
+        if CONF_FOR in config:
+            now = dt_util.now()
+            target_tm = now + timedelta(
+                hours=(hours or 0.0),
+                minutes=(minutes or 0.0),
+                seconds=(seconds or 0.0))
+            logging.getLogger(__name__).error('Listeners added')
+            for_time_listener = track_point_in_time(
+                hass, state_for_listener, target_tm)
+            for_state_listener = track_state_change(
+                hass, entity_id, state_for_cancel_listener,
+                MATCH_ALL, MATCH_ALL)
+        else:
+            action()
 
     track_state_change(
         hass, entity_id, state_automation_listener, from_state, to_state)

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -70,8 +70,6 @@ def trigger(hass, config, action):
         def state_for_cancel_listener(entity, inner_from_s, inner_to_s):
             """ Fires on state changes and cancels
                 for listener if state changed. """
-            logging.getLogger(__name__).error(
-                'state_for_cancel_listener')
             if inner_to_s == to_s:
                 return
             hass.bus.remove_listener(EVENT_TIME_CHANGED, for_time_listener)

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -63,8 +63,6 @@ def trigger(hass, config, action):
 
         def state_for_listener(now):
             """ Fires on state changes after a delay and calls action. """
-            logging.getLogger(__name__).error('Listener fired')
-
             hass.bus.remove_listener(
                 EVENT_STATE_CHANGED, for_state_listener)
             action()
@@ -76,7 +74,6 @@ def trigger(hass, config, action):
                 'state_for_cancel_listener')
             if inner_to_s == to_s:
                 return
-            logging.getLogger(__name__).error('Listeners removed')
             hass.bus.remove_listener(EVENT_TIME_CHANGED, for_time_listener)
             hass.bus.remove_listener(
                 EVENT_STATE_CHANGED, for_state_listener)
@@ -87,7 +84,6 @@ def trigger(hass, config, action):
                 hours=(hours or 0.0),
                 minutes=(minutes or 0.0),
                 seconds=(seconds or 0.0))
-            logging.getLogger(__name__).error('Listeners added')
             for_time_listener = track_point_in_time(
                 hass, state_for_listener, target_tm)
             for_state_listener = track_state_change(


### PR DESCRIPTION
A first cut of https://github.com/balloob/home-assistant/issues/1095.

This add the ability to trigger an automation after an entity has been in a state for a specified amount of time. An example:-

```
automation:
  alias: 'Test delay"'
  trigger:
    - platform: state
      entity_id: input_boolean.input
      to: 'on'
      for:
        seconds: 10
  action:
    service: input_boolean.turn_on
    entity_id: input_boolean.result
```
