### PR TITLE
Use updater to show devel version information

### DIFF
--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -31,10 +31,13 @@ def setup(hass, config):
             hass.states.set(
                 ENTITY_ID, newest, {ATTR_FRIENDLY_NAME: 'Update Available'})
 
-    event.track_time_change(hass, check_newest_version,
-                            hour=[0, 12], minute=0, second=0)
-
-    check_newest_version()
+    if 'dev' in CURRENT_VERSION:
+        hass.states.set(
+            ENTITY_ID, CURRENT_VERSION, {ATTR_FRIENDLY_NAME: 'devel'})
+    else:
+        event.track_time_change(hass, check_newest_version,
+                                hour=[0, 12], minute=0, second=0)
+        check_newest_version()
 
     return True
 


### PR DESCRIPTION
Having updater notifications in devel mode doesn't help much,
but we can still make use of it for showing information about
the development version currently used
