### PR TITLE
Add mysensors binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -12,6 +12,7 @@ import logging
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (STATE_ON, STATE_OFF)
+from homeassistant.components import (mysensors, )
 
 DOMAIN = 'binary_sensor'
 SCAN_INTERVAL = 30
@@ -27,13 +28,19 @@ SENSOR_CLASSES = [
     'light',     # Lightness threshold
     'power',     # Power, over-current, etc
     'safety',    # Generic on=unsafe, off=safe
-    ]
+]
+
+# Maps discovered services to their platforms
+DISCOVERY_PLATFORMS = {
+    mysensors.DISCOVER_BINARY_SENSORS: 'mysensors',
+}
 
 
 def setup(hass, config):
-    """ Track states and offer events for binary sensors. """
+    """Track states and offer events for binary sensors."""
     component = EntityComponent(
-        logging.getLogger(__name__), DOMAIN, hass, SCAN_INTERVAL)
+        logging.getLogger(__name__), DOMAIN, hass, SCAN_INTERVAL,
+        DISCOVERY_PLATFORMS)
 
     component.setup(config)
 
@@ -42,30 +49,31 @@ def setup(hass, config):
 
 # pylint: disable=no-self-use
 class BinarySensorDevice(Entity):
-    """ Represents a binary sensor. """
+    """Represent a binary sensor."""
 
     @property
     def is_on(self):
-        """ True if the binary sensor is on. """
+        """Return True if the binary sensor is on."""
         return None
 
     @property
     def state(self):
-        """ Returns the state of the binary sensor. """
+        """Return the state of the binary sensor."""
         return STATE_ON if self.is_on else STATE_OFF
 
     @property
     def friendly_state(self):
-        """ Returns the friendly state of the binary sensor. """
+        """Return the friendly state of the binary sensor."""
         return None
 
     @property
     def sensor_class(self):
-        """ Returns the class of this sensor, from SENSOR_CASSES. """
+        """Return the class of this sensor, from SENSOR_CASSES."""
         return None
 
     @property
-    def device_state_attributes(self):
+    def state_attributes(self):
+        """Return device specific state attributes."""
         return {
             'sensor_class': self.sensor_class,
         }

--- a/homeassistant/components/light/mysensors.py
+++ b/homeassistant/components/light/mysensors.py
@@ -58,7 +58,8 @@ class MySensorsLight(Light):
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes
 
-    def __init__(self, gateway, node_id, child_id, name, value_type):
+    def __init__(
+            self, gateway, node_id, child_id, name, value_type, child_type):
         """Setup instance attributes."""
         self.gateway = gateway
         self.node_id = node_id

--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -42,12 +42,14 @@ GATEWAYS = None
 DISCOVER_SENSORS = 'mysensors.sensors'
 DISCOVER_SWITCHES = 'mysensors.switches'
 DISCOVER_LIGHTS = 'mysensors.lights'
+DISCOVER_BINARY_SENSORS = 'mysensors.binary_sensor'
 
 # Maps discovered services to their platforms
 DISCOVERY_COMPONENTS = [
     ('sensor', DISCOVER_SENSORS),
     ('switch', DISCOVER_SWITCHES),
     ('light', DISCOVER_LIGHTS),
+    ('binary_sensor', DISCOVER_BINARY_SENSORS),
 ]
 
 
@@ -148,7 +150,7 @@ def pf_callback_factory(map_sv_types, devices, add_devices, entity_class):
                 else:
                     device_class = entity_class
                 devices[key] = device_class(
-                    gateway, node_id, child.id, name, value_type)
+                    gateway, node_id, child.id, name, value_type, child.type)
 
                 _LOGGER.info('Adding new devices: %s', devices[key])
                 add_devices([devices[key]])

--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -52,7 +52,8 @@ class MySensorsSwitch(SwitchDevice):
 
     # pylint: disable=too-many-arguments
 
-    def __init__(self, gateway, node_id, child_id, name, value_type):
+    def __init__(
+            self, gateway, node_id, child_id, name, value_type, child_type):
         """Setup class attributes on instantiation.
 
         Args:
@@ -61,6 +62,7 @@ class MySensorsSwitch(SwitchDevice):
         child_id (str): Id of child.
         name (str): Entity name.
         value_type (str): Value type of child. Value is entity state.
+        child_type (str): Child type of child.
 
         Attributes:
         gateway (GatewayWrapper): Gateway object

--- a/tests/components/binary_sensor/test_binary_sensor.py
+++ b/tests/components/binary_sensor/test_binary_sensor.py
@@ -11,7 +11,10 @@ from homeassistant.const import STATE_ON, STATE_OFF
 
 
 class TestBinarySensor(unittest.TestCase):
+    """Test the binary_sensor base class."""
+
     def test_state(self):
+        """Test binary sensor state."""
         sensor = binary_sensor.BinarySensorDevice()
         self.assertEqual(STATE_OFF, sensor.state)
         with mock.patch('homeassistant.components.binary_sensor.'
@@ -26,11 +29,12 @@ class TestBinarySensor(unittest.TestCase):
                              binary_sensor.BinarySensorDevice().state)
 
     def test_attributes(self):
+        """Test binary sensor attributes."""
         sensor = binary_sensor.BinarySensorDevice()
         self.assertEqual({'sensor_class': None},
-                         sensor.device_state_attributes)
+                         sensor.state_attributes)
         with mock.patch('homeassistant.components.binary_sensor.'
                         'BinarySensorDevice.sensor_class',
                         new='motion'):
             self.assertEqual({'sensor_class': 'motion'},
-                             sensor.device_state_attributes)
+                             sensor.state_attributes)


### PR DESCRIPTION
- Add mysensors binary sensor.
- Add discovery platforms to binary_sensor base component.
- Replace device_state_attributes with state_attributes in
  binary_sensor base class.
- Fix docstrings.
- Add discovery of binary sensor to mysensors component.
- Add child.type as argument to mysensors device_class.
- Move binary sensor types from sensor to binary_sensor module.
- Fix binary_sensor attribute tests. Use state_attributes instead of
  device_state_attributes.
