### PR TITLE
ZWave binary sensor support

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -12,7 +12,7 @@ import logging
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (STATE_ON, STATE_OFF)
-from homeassistant.components import (bloomsky, mysensors)
+from homeassistant.components import (bloomsky, mysensors, zwave)
 
 DOMAIN = 'binary_sensor'
 SCAN_INTERVAL = 30
@@ -34,6 +34,7 @@ SENSOR_CLASSES = [
 DISCOVERY_PLATFORMS = {
     bloomsky.DISCOVER_BINARY_SENSORS: 'bloomsky',
     mysensors.DISCOVER_BINARY_SENSORS: 'mysensors',
+    zwave.DISCOVER_BINARY_SENSORS: 'zwave',
 }
 
 

--- a/homeassistant/components/binary_sensor/zwave.py
+++ b/homeassistant/components/binary_sensor/zwave.py
@@ -1,0 +1,69 @@
+"""
+homeassistant.components.binary_sensor.zwave
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Interfaces with Z-Wave sensors.
+
+For more details about this platform, please refer to the documentation
+at https://home-assistant.io/components/zwave/
+"""
+
+
+import logging
+
+from homeassistant.components.zwave import (
+    ATTR_NODE_ID, ATTR_VALUE_ID,
+    COMMAND_CLASS_SENSOR_BINARY, NETWORK,
+    ZWaveDeviceEntity)
+from homeassistant.components.binary_sensor import (
+    DOMAIN,
+    BinarySensorDevice)
+
+_LOGGER = logging.getLogger(__name__)
+DEPENDENCIES = []
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the mysensors platform for sensors."""
+
+    if discovery_info is None or NETWORK is None:
+        return
+
+    node = NETWORK.nodes[discovery_info[ATTR_NODE_ID]]
+    value = node.values[discovery_info[ATTR_VALUE_ID]]
+
+    value.set_change_verified(False)
+    if value.command_class == COMMAND_CLASS_SENSOR_BINARY:
+        add_devices([ZWaveBinarySensor(value, "opening")])
+
+
+class ZWaveBinarySensor(BinarySensorDevice, ZWaveDeviceEntity):
+    """ Represents a binary sensor within Z-Wave. """
+
+    def __init__(self, value, sensor_class):
+        self._sensor_type = sensor_class
+        from openzwave.network import ZWaveNetwork
+        from pydispatch import dispatcher
+
+        ZWaveDeviceEntity.__init__(self, value, DOMAIN)
+
+        dispatcher.connect(
+            self.value_changed, ZWaveNetwork.SIGNAL_VALUE_CHANGED)
+
+    @property
+    def is_on(self):
+        """Return True if the binary sensor is on."""
+        return self._value.data
+
+    @property
+    def sensor_class(self):
+        """Return the class of this sensor, from SENSOR_CLASSES."""
+        return self._sensor_type
+
+    @property
+    def should_poll(self):
+        return False
+
+    def value_changed(self, value):
+        """ Called when a value has changed on the network. """
+        if self._value.value_id == value.value_id:
+            self.update_ha_state()

--- a/homeassistant/components/binary_sensor/zwave.py
+++ b/homeassistant/components/binary_sensor/zwave.py
@@ -41,6 +41,7 @@ class ZWaveBinarySensor(BinarySensorDevice, ZWaveDeviceEntity):
 
     def __init__(self, value, sensor_class):
         self._sensor_type = sensor_class
+        # pylint: disable=import-error
         from openzwave.network import ZWaveNetwork
         from pydispatch import dispatcher
 

--- a/homeassistant/components/sensor/zwave.py
+++ b/homeassistant/components/sensor/zwave.py
@@ -14,7 +14,7 @@ import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import DOMAIN
 from homeassistant.components.zwave import (
     ATTR_NODE_ID, ATTR_VALUE_ID, COMMAND_CLASS_ALARM, COMMAND_CLASS_METER,
-    COMMAND_CLASS_SENSOR_BINARY, COMMAND_CLASS_SENSOR_MULTILEVEL, NETWORK,
+    COMMAND_CLASS_SENSOR_MULTILEVEL, NETWORK,
     TYPE_DECIMAL, ZWaveDeviceEntity, get_config_value)
 from homeassistant.const import (
     STATE_OFF, STATE_ON, TEMP_CELCIUS, TEMP_FAHRENHEIT)
@@ -79,9 +79,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             return
 
     # generic Device mappings
-    elif value.command_class == COMMAND_CLASS_SENSOR_BINARY:
-        add_devices([ZWaveBinarySensor(value)])
-
     elif value.command_class == COMMAND_CLASS_SENSOR_MULTILEVEL:
         add_devices([ZWaveMultilevelSensor(value)])
 
@@ -118,16 +115,6 @@ class ZWaveSensor(ZWaveDeviceEntity, Entity):
         """ Called when a value has changed on the network. """
         if self._value.value_id == value.value_id:
             self.update_ha_state()
-
-
-# pylint: disable=too-few-public-methods
-class ZWaveBinarySensor(ZWaveSensor):
-    """ Represents a binary sensor within Z-Wave. """
-
-    @property
-    def state(self):
-        """ Returns the state of the sensor. """
-        return STATE_ON if self._value.data else STATE_OFF
 
 
 class ZWaveTriggerSensor(ZWaveSensor):

--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -34,6 +34,7 @@ SERVICE_REMOVE_NODE = "remove_node"
 DISCOVER_SENSORS = "zwave.sensors"
 DISCOVER_SWITCHES = "zwave.switch"
 DISCOVER_LIGHTS = "zwave.light"
+DISCOVER_BINARY_SENSORS = 'zwave.binary_sensor'
 
 EVENT_SCENE_ACTIVATED = "zwave.scene_activated"
 
@@ -54,13 +55,13 @@ TYPE_BYTE = "Byte"
 TYPE_BOOL = "Bool"
 TYPE_DECIMAL = "Decimal"
 
+
 # list of tuple (DOMAIN, discovered service, supported command
 # classes, value type)
 DISCOVERY_COMPONENTS = [
     ('sensor',
      DISCOVER_SENSORS,
-     [COMMAND_CLASS_SENSOR_BINARY,
-      COMMAND_CLASS_SENSOR_MULTILEVEL,
+     [COMMAND_CLASS_SENSOR_MULTILEVEL,
       COMMAND_CLASS_METER,
       COMMAND_CLASS_ALARM],
      TYPE_WHATEVER,
@@ -75,7 +76,13 @@ DISCOVERY_COMPONENTS = [
      [COMMAND_CLASS_SWITCH_BINARY],
      TYPE_BOOL,
      GENRE_USER),
+    ('binary_sensor',
+     DISCOVER_BINARY_SENSORS,
+     [COMMAND_CLASS_SENSOR_BINARY],
+     TYPE_BOOL,
+     GENRE_USER)
 ]
+
 
 ATTR_NODE_ID = "node_id"
 ATTR_VALUE_ID = "value_id"


### PR DESCRIPTION
Treat ZWave binary sensors as binary_sensor components instead of
regular sensors.
