### PR TITLE
Add assumed_state to Group, MQTT Switch, MQTT Light

### DIFF
--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -134,6 +134,11 @@ class MqttLight(Light):
         """ True if device is on. """
         return self._state
 
+    @property
+    def assumed_state(self):
+        """Return True if we do optimistic updates."""
+        return self._optimistic
+
     def turn_on(self, **kwargs):
         """ Turn the device on. """
         should_update = False

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -97,6 +97,11 @@ class MqttSwitch(SwitchDevice):
         """ True if device is on. """
         return self._state
 
+    @property
+    def assumed_state(self):
+        """Return True if we do optimistic updates."""
+        return self._optimistic
+
     def turn_on(self, **kwargs):
         """ Turn the device on. """
         mqtt.publish(self.hass, self._command_topic, self._payload_on,

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -45,7 +45,7 @@ light:
 """
 import unittest
 
-from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.light as light
 from tests.common import (
   get_test_home_assistant, mock_mqtt_component, fire_mqtt_message)
@@ -115,6 +115,7 @@ class TestLightMQTT(unittest.TestCase):
         self.assertEqual(STATE_OFF, state.state)
         self.assertIsNone(state.attributes.get('rgb_color'))
         self.assertIsNone(state.attributes.get('brightness'))
+        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
 
         fire_mqtt_message(self.hass, 'test_light_rgb/status', 'on')
         self.hass.pool.block_till_done()
@@ -201,6 +202,7 @@ class TestLightMQTT(unittest.TestCase):
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
+        self.assertTrue(state.attributes.get(ATTR_ASSUMED_STATE))
 
         light.turn_on(self.hass, 'light.test')
         self.hass.pool.block_till_done()

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -6,7 +6,7 @@ Tests MQTT switch.
 """
 import unittest
 
-from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.switch as switch
 from tests.common import (
     mock_mqtt_component, fire_mqtt_message, get_test_home_assistant)
@@ -37,6 +37,7 @@ class TestSensorMQTT(unittest.TestCase):
 
         state = self.hass.states.get('switch.test')
         self.assertEqual(STATE_OFF, state.state)
+        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
 
         fire_mqtt_message(self.hass, 'state-topic', 'beer on')
         self.hass.pool.block_till_done()
@@ -64,6 +65,7 @@ class TestSensorMQTT(unittest.TestCase):
 
         state = self.hass.states.get('switch.test')
         self.assertEqual(STATE_OFF, state.state)
+        self.assertTrue(state.attributes.get(ATTR_ASSUMED_STATE))
 
         switch.turn_on(self.hass, 'switch.test')
         self.hass.pool.block_till_done()


### PR DESCRIPTION
This sets assumed_state to True for MQTT switch and light if optimistic.

Groups will have assumed_state set to True if any of the tracked states has an assumed state.

Fixes #1263 
