### PR TITLE
Add now and utcnow to template

### DIFF
--- a/homeassistant/util/template.py
+++ b/homeassistant/util/template.py
@@ -12,6 +12,7 @@ from jinja2.sandbox import ImmutableSandboxedEnvironment
 
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.exceptions import TemplateError
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 _SENTINEL = object()
@@ -45,7 +46,9 @@ def render(hass, template, variables=None, **kwargs):
         return ENV.from_string(template, {
             'states': AllStates(hass),
             'is_state': hass.states.is_state,
-            'is_state_attr': hass.states.is_state_attr
+            'is_state_attr': hass.states.is_state_attr,
+            'now': now(),
+            'utcnow': utcnow()
         }).render(kwargs).strip()
     except jinja2.TemplateError as err:
         raise TemplateError(err)
@@ -102,6 +105,16 @@ def multiply(value, amount):
     except ValueError:
         # If value can't be converted to float
         return value
+
+
+def now():
+    """ Renders the current time for the time zone. """
+    return dt_util.now()
+
+
+def utcnow():
+    """ Renders the current UTC time. """
+    return dt_util.utcnow()
 
 
 class TemplateEnvironment(ImmutableSandboxedEnvironment):

--- a/tests/util/test_template.py
+++ b/tests/util/test_template.py
@@ -8,6 +8,7 @@ Tests Home Assistant template util methods.
 import unittest
 from homeassistant.exceptions import TemplateError
 from homeassistant.util import template
+import homeassistant.util.dt as dt_util
 
 from tests.common import get_test_home_assistant
 
@@ -68,6 +69,13 @@ class TestUtilTemplate(unittest.TestCase):
                 self.hass,
                 '{{ states.sensor.temperature.state | multiply(10) | round }}'
             ))
+
+    def test_rendering_now(self):
+        self.assertEqual(
+            dt_util.datetime_to_local_str(dt_util.now()),
+            template.render(self.hass,
+                            '{{ now }}',
+                            now=dt_util.datetime_to_local_str(dt_util.now())))
 
     def test_passing_vars_as_keywords(self):
         self.assertEqual(


### PR DESCRIPTION
This Pull Reuest adds `now` and `utcnow` to templating.

``` bash
$ curl -X POST -H "x-ha-access: YOUR_PASSWORD" \
      -d '{"template": "It is {{ now }}"}' \
      http://localhost:8123/api/template
```

Fixes #1282

Pivotal story: https://www.pivotaltracker.com/story/show/114149119
