### PR TITLE
Updated wink version for binary switch fix

### DIFF
--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.garage_door import GarageDoorDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.0']
+REQUIREMENTS = ['python-wink==0.6.1']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.light import ATTR_BRIGHTNESS, Light
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.0']
+REQUIREMENTS = ['python-wink==0.6.1']
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.0']
+REQUIREMENTS = ['python-wink==0.6.1']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.const import CONF_ACCESS_TOKEN, STATE_CLOSED, STATE_OPEN
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-wink==0.6.0']
+REQUIREMENTS = ['python-wink==0.6.1']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.wink import WinkToggleDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.0']
+REQUIREMENTS = ['python-wink==0.6.1']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.loader import get_component
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.6.0']
+REQUIREMENTS = ['python-wink==0.6.1']
 
 DISCOVER_LIGHTS = "wink.lights"
 DISCOVER_SWITCHES = "wink.switches"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -206,7 +206,7 @@ python-twitch==1.2.0
 # homeassistant.components.lock.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.6.0
+python-wink==0.6.1
 
 # homeassistant.components.keyboard
 pyuserinput==0.1.9


### PR DESCRIPTION
This updates the version of python-wink to 0.6.1. This version fixes an issue discovered by @TDWhbp where generic z-wave switches wouldn't responded to state changes. 

This version also includes adding the sensor type (Temp, humidity, ect.) to the name of each Wink Spotter sensor. This should make it easier to identify the sensors, before they were labeled sensor.spotter, sensor.spotter_1, ... now they should be displayed as sensor.spotter_temperature, sensor.spotter_humidity, ... 
