### PR TITLE
New template helpers now, utcnow, distance, closest

### DIFF
--- a/homeassistant/helpers/location.py
+++ b/homeassistant/helpers/location.py
@@ -1,0 +1,27 @@
+"""Location helpers for Home Assistant."""
+
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.core import State
+from homeassistant.util import location as loc_util
+
+
+def has_location(state):
+    """Test if state contains a valid location."""
+    return (isinstance(state, State) and
+            isinstance(state.attributes.get(ATTR_LATITUDE), float) and
+            isinstance(state.attributes.get(ATTR_LONGITUDE), float))
+
+
+def closest(latitude, longitude, states):
+    """Return closest state to point."""
+    with_location = [state for state in states if has_location(state)]
+
+    if not with_location:
+        return None
+
+    return min(
+        with_location,
+        key=lambda state: loc_util.distance(
+            latitude, longitude, state.attributes.get(ATTR_LATITUDE),
+            state.attributes.get(ATTR_LONGITUDE))
+    )

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -57,7 +57,7 @@ def convert(value, to_type, default=None):
     """ Converts value to to_type, returns default if fails. """
     try:
         return default if value is None else to_type(value)
-    except ValueError:
+    except (ValueError, TypeError):
         # If value could not be converted
         return default
 

--- a/homeassistant/util/template.py
+++ b/homeassistant/util/template.py
@@ -162,7 +162,7 @@ def multiply(value, amount):
     """Filter to convert value to float and multiply it."""
     try:
         return float(value) * amount
-    except ValueError:
+    except (ValueError, TypeError):
         # If value can't be converted to float
         return value
 

--- a/homeassistant/util/template.py
+++ b/homeassistant/util/template.py
@@ -148,17 +148,17 @@ class LocationHelpers(object):
 
 
 def forgiving_round(value, precision=0):
-    """ Rounding method that accepts strings. """
+    """Rounding filter that accepts strings."""
     try:
         value = round(float(value), precision)
         return int(value) if precision == 0 else value
-    except ValueError:
+    except (ValueError, TypeError):
         # If value can't be converted to float
         return value
 
 
 def multiply(value, amount):
-    """ Converts to float and multiplies value. """
+    """Filter to convert value to float and multiply it."""
     try:
         return float(value) * amount
     except ValueError:
@@ -167,9 +167,10 @@ def multiply(value, amount):
 
 
 class TemplateEnvironment(ImmutableSandboxedEnvironment):
-    """ Home Assistant template environment. """
+    """Home Assistant template environment."""
 
     def is_safe_callable(self, obj):
+        """Test if callback is safe."""
         return isinstance(obj, AllStates) or super().is_safe_callable(obj)
 
 ENV = TemplateEnvironment()

--- a/homeassistant/util/template.py
+++ b/homeassistant/util/template.py
@@ -44,6 +44,7 @@ def render(hass, template, variables=None, **kwargs):
         kwargs.update(variables)
 
     location_helper = LocationHelpers(hass)
+    utcnow = dt_util.utcnow()
 
     try:
         return ENV.from_string(template, {
@@ -51,8 +52,8 @@ def render(hass, template, variables=None, **kwargs):
             'is_state': hass.states.is_state,
             'is_state_attr': hass.states.is_state_attr,
             'states': AllStates(hass),
-            'now': dt_util.now,
-            'utcnow': dt_util.utcnow,
+            'now': dt_util.as_local(utcnow),
+            'utcnow': utcnow,
         }).render(kwargs).strip()
     except jinja2.TemplateError as err:
         raise TemplateError(err)

--- a/homeassistant/util/template.py
+++ b/homeassistant/util/template.py
@@ -12,6 +12,7 @@ from jinja2.sandbox import ImmutableSandboxedEnvironment
 
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.exceptions import TemplateError
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 _SENTINEL = object()
@@ -45,7 +46,9 @@ def render(hass, template, variables=None, **kwargs):
         return ENV.from_string(template, {
             'states': AllStates(hass),
             'is_state': hass.states.is_state,
-            'is_state_attr': hass.states.is_state_attr
+            'is_state_attr': hass.states.is_state_attr,
+            'now': dt_util.now,
+            'utcnow': dt_util.utcnow,
         }).render(kwargs).strip()
     except jinja2.TemplateError as err:
         raise TemplateError(err)

--- a/homeassistant/util/template.py
+++ b/homeassistant/util/template.py
@@ -156,12 +156,12 @@ class LocationMethods(object):
             states = list(entities)
         else:
             if isinstance(entities, State):
-                entity_id = entities.entity_id
+                gr_entity_id = entities.entity_id
             else:
-                entity_id = str(entities)
+                gr_entity_id = str(entities)
 
             states = [self._hass.states.get(entity_id) for entity_id
-                      in group.expand_entity_ids(self._hass, [entity_id])]
+                      in group.expand_entity_ids(self._hass, [gr_entity_id])]
 
         return loc_helper.closest(latitude, longitude, states)
 

--- a/tests/helpers/test_location.py
+++ b/tests/helpers/test_location.py
@@ -1,0 +1,53 @@
+"""Tests Home Assistant location helpers."""
+# pylint: disable=too-many-public-methods
+import unittest
+
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.core import State
+from homeassistant.helpers import location
+
+
+class TestHelpersLocation(unittest.TestCase):
+    def test_has_location_with_invalid_states(self):
+        for state in (None, 1, "hello", object):
+            self.assertFalse(location.has_location(state))
+
+    def test_has_location_with_states_with_invalid_locations(self):
+        state = State('hello.world', 'invalid', {
+            ATTR_LATITUDE: 'no number',
+            ATTR_LONGITUDE: 123.12
+        })
+        self.assertFalse(location.has_location(state))
+
+    def test_has_location_with_states_with_valid_location(self):
+        state = State('hello.world', 'invalid', {
+            ATTR_LATITUDE: 123.12,
+            ATTR_LONGITUDE: 123.12
+        })
+        self.assertTrue(location.has_location(state))
+
+    def test_closest_with_no_states_with_location(self):
+        state = State('light.test', 'on')
+        state2 = State('light.test', 'on', {
+            ATTR_LATITUDE: 'invalid',
+            ATTR_LONGITUDE: 123.45,
+        })
+        state3 = State('light.test', 'on', {
+            ATTR_LONGITUDE: 123.45,
+        })
+
+        self.assertIsNone(
+            location.closest(123.45, 123.45, [state, state2, state3]))
+
+    def test_closest_returns_closest(self):
+        state = State('light.test', 'on', {
+            ATTR_LATITUDE: 124.45,
+            ATTR_LONGITUDE: 124.45,
+        })
+        state2 = State('light.test', 'on', {
+            ATTR_LATITUDE: 125.45,
+            ATTR_LONGITUDE: 125.45,
+        })
+
+        self.assertEqual(
+            state, location.closest(123.45, 123.45, [state, state2]))

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -53,6 +53,7 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(True, util.convert("True", bool))
         self.assertEqual(1, util.convert("NOT A NUMBER", int, 1))
         self.assertEqual(1, util.convert(None, int, 1))
+        self.assertEqual(1, util.convert(object, int, 1))
 
     def test_ensure_unique_string(self):
         """ Test ensure_unique_string. """

--- a/tests/util/test_template.py
+++ b/tests/util/test_template.py
@@ -84,6 +84,19 @@ class TestUtilTemplate(unittest.TestCase):
                 '{{ "no_number" | round }}'
             ))
 
+    def test_multiply(self):
+        tests = {
+            None: 'None',
+            10: '100',
+            '"abcd"': 'abcd'
+        }
+
+        for inp, out in tests.items():
+            self.assertEqual(
+                out,
+                template.render(self.hass,
+                                '{{ %s | multiply(10) | round }}' % inp))
+
     def test_passing_vars_as_keywords(self):
         self.assertEqual(
             '127', template.render(self.hass, '{{ hello }}', hello=127))

--- a/tests/util/test_template.py
+++ b/tests/util/test_template.py
@@ -62,14 +62,26 @@ class TestUtilTemplate(unittest.TestCase):
                 self.hass,
                 '{{ states.sensor.temperature.state | round(1) }}'))
 
-    def test_rounding_value2(self):
-        self.hass.states.set('sensor.temperature', 12.78)
-
         self.assertEqual(
             '128',
             template.render(
                 self.hass,
                 '{{ states.sensor.temperature.state | multiply(10) | round }}'
+            ))
+
+    def test_rounding_value_get_original_value_on_error(self):
+        self.assertEqual(
+            'None',
+            template.render(
+                self.hass,
+                '{{ None | round }}'
+            ))
+
+        self.assertEqual(
+            'no_number',
+            template.render(
+                self.hass,
+                '{{ "no_number" | round }}'
             ))
 
     def test_passing_vars_as_keywords(self):

--- a/tests/util/test_template.py
+++ b/tests/util/test_template.py
@@ -162,3 +162,84 @@ class TestUtilTemplate(unittest.TestCase):
         self.assertEqual(
             dt_util.utcnow().isoformat(),
             template.render(self.hass, '{{ utcnow().isoformat() }}'))
+
+    def test_distance_function_with_1_state(self):
+        self.hass.states.set('test.object', 'happy', {
+            'latitude': 32.87336,
+            'longitude': -117.22943,
+        })
+
+        self.assertEqual(
+            '187',
+            template.render(
+                self.hass, '{{ distance(states.test.object) | round }}'))
+
+    def test_distance_function_with_2_states(self):
+        self.hass.states.set('test.object', 'happy', {
+            'latitude': 32.87336,
+            'longitude': -117.22943,
+        })
+
+        self.hass.states.set('test.object_2', 'happy', {
+            'latitude': self.hass.config.latitude,
+            'longitude': self.hass.config.longitude,
+        })
+
+        self.assertEqual(
+            '187',
+            template.render(
+                self.hass,
+                '{{ distance(states.test.object, states.test.object_2)'
+                '| round }}'))
+
+    def test_distance_function_with_1_coord(self):
+        self.assertEqual(
+            '187',
+            template.render(
+                self.hass, '{{ distance("32.87336", "-117.22943") | round }}'))
+
+    def test_distance_function_with_2_coords(self):
+        self.assertEqual(
+            '187',
+            template.render(
+                self.hass,
+                '{{ distance("32.87336", "-117.22943", %s, %s) | round }}'
+                % (self.hass.config.latitude, self.hass.config.longitude)))
+
+    def test_distance_function_with_1_state_1_coord(self):
+        self.hass.states.set('test.object_2', 'happy', {
+            'latitude': self.hass.config.latitude,
+            'longitude': self.hass.config.longitude,
+        })
+
+        self.assertEqual(
+            '187',
+            template.render(
+                self.hass,
+                '{{ distance("32.87336", "-117.22943", states.test.object_2) '
+                '| round }}'))
+
+        self.assertEqual(
+            '187',
+            template.render(
+                self.hass,
+                '{{ distance(states.test.object_2, "32.87336", "-117.22943") '
+                '| round }}'))
+
+    def test_distance_function_return_None_if_invalid_state(self):
+        self.hass.states.set('test.object_2', 'happy', {
+            'latitude': 10,
+        })
+
+        self.assertEqual(
+            'None',
+            template.render(
+                self.hass,
+                '{{ distance(states.test.object_2) | round }}'))
+
+    def test_distance_function_return_None_if_invalid_coord(self):
+        self.assertEqual(
+            'None',
+            template.render(
+                self.hass,
+                '{{ distance("123", "abc") | round }}'))

--- a/tests/util/test_template.py
+++ b/tests/util/test_template.py
@@ -6,8 +6,11 @@ Tests Home Assistant template util methods.
 """
 # pylint: disable=too-many-public-methods
 import unittest
+from unittest.mock import patch
+
 from homeassistant.exceptions import TemplateError
 from homeassistant.util import template
+import homeassistant.util.dt as dt_util
 
 from tests.common import get_test_home_assistant
 
@@ -143,3 +146,19 @@ class TestUtilTemplate(unittest.TestCase):
         self.assertEqual(
             'unknown',
             template.render(self.hass, '{{ states("test.object2") }}'))
+
+    @patch('homeassistant.core.dt_util.now', return_value=dt_util.now())
+    @patch('homeassistant.util.template.TemplateEnvironment.is_safe_callable',
+           return_value=True)
+    def test_now_function(self, mock_is_safe, mock_now):
+        self.assertEqual(
+            dt_util.now().isoformat(),
+            template.render(self.hass, '{{ now().isoformat() }}'))
+
+    @patch('homeassistant.core.dt_util.utcnow', return_value=dt_util.utcnow())
+    @patch('homeassistant.util.template.TemplateEnvironment.is_safe_callable',
+           return_value=True)
+    def test_utcnow_function(self, mock_is_safe, mock_utcnow):
+        self.assertEqual(
+            dt_util.utcnow().isoformat(),
+            template.render(self.hass, '{{ utcnow().isoformat() }}'))

--- a/tests/util/test_template.py
+++ b/tests/util/test_template.py
@@ -292,7 +292,6 @@ class TestUtilTemplate(unittest.TestCase):
                 self.hass,
                 '{{ distance("123", states.test_object_2) }}'))
 
-
     def test_closest_function_home_vs_domain(self):
         self.hass.states.set('test_domain.object', 'happy', {
             'latitude': self.hass.config.latitude + 0.1,

--- a/tests/util/test_template.py
+++ b/tests/util/test_template.py
@@ -159,21 +159,26 @@ class TestUtilTemplate(unittest.TestCase):
             'unknown',
             template.render(self.hass, '{{ states("test.object2") }}'))
 
-    @patch('homeassistant.core.dt_util.now', return_value=dt_util.now())
+    @patch('homeassistant.core.dt_util.utcnow', return_value=dt_util.utcnow())
     @patch('homeassistant.util.template.TemplateEnvironment.is_safe_callable',
            return_value=True)
-    def test_now_function(self, mock_is_safe, mock_now):
+    def test_now(self, mock_is_safe, mock_utcnow):
         self.assertEqual(
-            dt_util.now().isoformat(),
-            template.render(self.hass, '{{ now().isoformat() }}'))
+            dt_util.utcnow().isoformat(),
+            template.render(self.hass, '{{ now.isoformat() }}'))
 
     @patch('homeassistant.core.dt_util.utcnow', return_value=dt_util.utcnow())
     @patch('homeassistant.util.template.TemplateEnvironment.is_safe_callable',
            return_value=True)
-    def test_utcnow_function(self, mock_is_safe, mock_utcnow):
+    def test_utcnow(self, mock_is_safe, mock_utcnow):
         self.assertEqual(
             dt_util.utcnow().isoformat(),
-            template.render(self.hass, '{{ utcnow().isoformat() }}'))
+            template.render(self.hass, '{{ utcnow.isoformat() }}'))
+
+    def test_utcnow_is_exactly_now(self):
+        self.assertEqual(
+            'True',
+            template.render(self.hass, '{{ utcnow == now }}'))
 
     def test_distance_function_with_1_state(self):
         self.hass.states.set('test.object', 'happy', {


### PR DESCRIPTION
This will add 4 new variables/methods available in templates:
- `now` - the current local time
- `utcnow` - the current utc time
- `distance()` - measure the distance in meters between home, entity, coordinates
- `closest()` - find the closest entity
### Distance examples

If only 1 location is passed in will measure the distance from home.

``` jinja2
Using Lat Lng coordinates: {{ distance(123.45, 123.45) }}

Using State: {{ distance(device_tracker.paulus) }}

These can also be combined in any combination:
{{ distance(123.45, 123.45, device_tracker.paulus) }}
{{ distance(device_tracker.anne_therese, device_tracker.paulus) }}
```
### Closest examples

Find entities closest to the Home Assistant location:

``` jinja2
Query all entities: {{ closest(states) }}
Query all entities of a specific domain: {{ closest(states.device_tracker) }}
Query all entities in group.children: {{ closest('group.children') }}
Query all entities in group.children: {{ closest(states.group.children) }}
```

Find entities closest to a coordinate or another entity. All previous arguments still apply for 2nd argument.

``` jinja2
Closest to a coordinate: {{ closest(23.456, 23.456, 'group.children') }}
Closest to an entity: {{ closest('zone.school', 'group.children') }}
Closest to an entity: {{ closest(states.zone.school, 'group.children') }}
```
### Combined

Since closest returns a state, we can combine it with distance too

``` jinja2
{{ closest(states).name }} is {{ distance(closest(states)) }} meters away.
```
