### PR TITLE
Don't set Bitcoin wallet if not setup in configuration

### DIFF
--- a/homeassistant/components/sensor/bitcoin.py
+++ b/homeassistant/components/sensor/bitcoin.py
@@ -59,12 +59,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error('Currency "%s" is not available. Using "USD".', currency)
         currency = 'USD'
 
-    wallet = Wallet(wallet_id, password)
-
-    try:
-        wallet.get_balance()
-    except exceptions.APIException as error:
-        _LOGGER.error(error)
+    if wallet_id is not None and password is not None:
+        wallet = Wallet(wallet_id, password)
+        try:
+            wallet.get_balance()
+        except exceptions.APIException as error:
+            _LOGGER.error(error)
+            wallet = None
+    else:
         wallet = None
 
     data = BitcoinData()


### PR DESCRIPTION
Because of problems with the Wallet part of python blockchain library (see #1242 ) , the entire Bitcoin module isn't working currently.
This change does not fix those problems but at least makes the sensor work again for people who don't need Wallet-related functionality.

It also just seems better practice to not set a wallet and call "wallet.get_balance()" when no wallet is set in configuration.
