### PR TITLE
Wink spotter support

### DIFF
--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.garage_door import GarageDoorDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.1']
+REQUIREMENTS = ['python-wink==0.6.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.light import ATTR_BRIGHTNESS, Light
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.1']
+REQUIREMENTS = ['python-wink==0.6.2']
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.1']
+REQUIREMENTS = ['python-wink==0.6.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -38,34 +38,24 @@ class WinkSensorDevice(Entity):
 
     def __init__(self, wink):
         self.wink = wink
-        capability = self.wink.capability()
-        if capability == "humidity":
-            self._unit_of_measurement = "%"
-        elif capability == "temperature":
-            self._unit_of_measurement = "°C"
-        elif capability == "brightness":
-            self._unit_of_measurement = "%"
-        else:
-            self._unit_of_measurement = None
+        self._unit_of_measurement = self.wink.UNIT
 
     @property
     def state(self):
         """ Returns the state. """
         capability = self.wink.capability()
-        if capability == "opened":
-            state = STATE_OPEN if self.is_open else STATE_CLOSED
-        elif capability == "humidity":
+        if capability == "humidity":
             state = self.wink.humidity_percentage()
         elif capability == "temperature":
             state = self.wink.temperature_float()
-        elif capability == "brightness":
-            state = self.wink.brightness_percentage()
         elif capability == "loudness":
-            state = self.wink.loudness_boolean()
+            state = STATE_OPEN if self.wink.loudness_boolean() else STATE_CLOSED
         elif capability == "vibration":
-            state = self.wink.vibration_boolean()
+            state = STATE_OPEN if self.wink.vibration_boolean() else STATE_CLOSED
+        elif capability == "brightness":
+            state = STATE_OPEN if self.wink.brightness_boolean() else STATE_CLOSED
         else:
-           state = STATE_OPEN
+            state = STATE_OPEN if self.is_open else STATE_CLOSED
         return state
 
     @property

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -49,11 +49,20 @@ class WinkSensorDevice(Entity):
         elif capability == "temperature":
             state = self.wink.temperature_float()
         elif capability == "loudness":
-            state = STATE_OPEN if self.wink.loudness_boolean() else STATE_CLOSED
+            if self.wink.loudness_boolean():
+                state = STATE_OPEN
+            else:
+                state = STATE_CLOSED
         elif capability == "vibration":
-            state = STATE_OPEN if self.wink.vibration_boolean() else STATE_CLOSED
+            if self.wink.vibration_boolean():
+                state = STATE_OPEN
+            else:
+                state = STATE_CLOSED
         elif capability == "brightness":
-            state = STATE_OPEN if self.wink.brightness_boolean() else STATE_CLOSED
+            if self.wink.brightness_boolean():
+                state = STATE_OPEN
+            else:
+                state = STATE_CLOSED
         else:
             state = STATE_OPEN if self.is_open else STATE_CLOSED
         return state

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -38,11 +38,40 @@ class WinkSensorDevice(Entity):
 
     def __init__(self, wink):
         self.wink = wink
+        capability = self.wink.capability()
+        if capability == "humidity":
+            self._unit_of_measurement = "%"
+        elif capability == "temperature":
+            self._unit_of_measurement = "°C"
+        elif capability == "brightness":
+            self._unit_of_measurement = "%"
+        else:
+            self._unit_of_measurement = None
 
     @property
     def state(self):
         """ Returns the state. """
-        return STATE_OPEN if self.is_open else STATE_CLOSED
+        capability = self.wink.capability()
+        if capability == "opened":
+            state = STATE_OPEN if self.is_open else STATE_CLOSED
+        elif capability == "humidity":
+            state = self.wink.humidity_percentage()
+        elif capability == "temperature":
+            state = self.wink.temperature_float()
+        elif capability == "brightness":
+            state = self.wink.brightness_percentage()
+        elif capability == "loudness":
+            state = self.wink.loudness_boolean()
+        elif capability == "vibration":
+            state = self.wink.vibration_boolean()
+        else:
+           state = STATE_OPEN
+        return state
+
+    @property
+    def unit_of_measurement(self):
+        """ Unit of measurement of this entity, if any. """
+        return self._unit_of_measurement
 
     @property
     def unique_id(self):

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.const import CONF_ACCESS_TOKEN, STATE_CLOSED, STATE_OPEN
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-wink==0.6.1']
+REQUIREMENTS = ['python-wink==0.6.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.wink import WinkToggleDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.1']
+REQUIREMENTS = ['python-wink==0.6.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.loader import get_component
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.6.1']
+REQUIREMENTS = ['python-wink==0.6.2']
 
 DISCOVER_LIGHTS = "wink.lights"
 DISCOVER_SWITCHES = "wink.switches"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -206,7 +206,7 @@ python-twitch==1.2.0
 # homeassistant.components.lock.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.6.1
+python-wink==0.6.2
 
 # homeassistant.components.keyboard
 pyuserinput==0.1.9


### PR DESCRIPTION
Support for the Wink Quirky Spotter Multipurpose Sensor. These sensors are currently reported into Home Assistant, but they are all reported as open/closed. This will present these sensors with their appropriate sensor values and units.  There was a minor update in python-wink to report brightness as a boolean, therefore the python-wink version was incremented.

Temperature = Degrees Celsius
Humidity = %
Brightness = Boolean, so still reported as open or closed. Open means a change in light was detected
Loudness = Boolean, so still reported as open or closed. Open means a loud sound was detected
Vibration = Boolean, so still reported as open or closed. Open means motion/vibration was detected.

@TDWhbp Can you please test this? 
