### PR TITLE
Moved Wink binary sensors to a binary sensor class

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -10,25 +10,27 @@ import logging
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (STATE_ON, STATE_OFF)
-from homeassistant.components import (bloomsky, mysensors, zwave)
+from homeassistant.components import (bloomsky, mysensors, zwave, wink)
 
 DOMAIN = 'binary_sensor'
 SCAN_INTERVAL = 30
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 SENSOR_CLASSES = [
-    None,        # Generic on/off
-    'opening',   # Door, window, etc
-    'motion',    # Motion sensor
-    'gas',       # CO, CO2, etc
-    'smoke',     # Smoke detector
-    'moisture',  # Specifically a wetness sensor
-    'light',     # Lightness threshold
-    'power',     # Power, over-current, etc
-    'safety',    # Generic on=unsafe, off=safe
-    'heat',      # On means hot (or too hot)
-    'cold',      # On means cold (or too cold)
-    'moving',    # On means moving, Off means stopped
+    None,         # Generic on/off
+    'opening',    # Door, window, etc
+    'motion',     # Motion sensor
+    'gas',        # CO, CO2, etc
+    'smoke',      # Smoke detector
+    'moisture',   # Specifically a wetness sensor
+    'light',      # Lightness threshold
+    'power',      # Power, over-current, etc
+    'safety',     # Generic on=unsafe, off=safe
+    'heat',       # On means hot (or too hot)
+    'cold',       # On means cold (or too cold)
+    'moving',     # On means moving, Off means stopped
+    'sound',      # On means sound detected, Off means no sound
+    'vibration',  # On means vibration detected, Off means no vibration
 ]
 
 # Maps discovered services to their platforms
@@ -36,6 +38,7 @@ DISCOVERY_PLATFORMS = {
     bloomsky.DISCOVER_BINARY_SENSORS: 'bloomsky',
     mysensors.DISCOVER_BINARY_SENSORS: 'mysensors',
     zwave.DISCOVER_BINARY_SENSORS: 'zwave',
+    wink.DISCOVER_BINARY_SENSORS: 'wink'
 }
 
 

--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -1,0 +1,81 @@
+"""
+Support for Wink sensors.
+
+For more details about this platform, please refer to the documentation at
+at https://home-assistant.io/components/sensor.wink/
+"""
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['python-wink==0.6.2']
+
+# These are the available sensors mapped to binary_sensor class
+SENSOR_TYPES = {
+    "opened": "opening",
+    "brightness": "light",
+    "vibration": "vibration",
+    "loudness": "sound"
+}
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Sets up the Wink platform."""
+    import pywink
+
+    if discovery_info is None:
+        token = config.get(CONF_ACCESS_TOKEN)
+
+        if token is None:
+            logging.getLogger(__name__).error(
+                "Missing wink access_token. "
+                "Get one at https://winkbearertoken.appspot.com/")
+            return
+
+        pywink.set_bearer_token(token)
+
+    for sensor in pywink.get_sensors():
+        if sensor.capability() in SENSOR_TYPES:
+            add_devices([WinkBinarySensorDevice(sensor)])
+
+
+class WinkBinarySensorDevice(BinarySensorDevice, Entity):
+    """Represents a Wink sensor."""
+
+    def __init__(self, wink):
+        self.wink = wink
+        self._unit_of_measurement = self.wink.UNIT
+        self.capability = self.wink.capability()
+
+    @property
+    def is_on(self):
+        """Return True if the binary sensor is on."""
+        if self.capability == "loudness":
+            return self.wink.loudness_boolean()
+        elif self.capability == "vibration":
+            return self.wink.vibration_boolean()
+        elif self.capability == "brightness":
+            return self.wink.brightness_boolean()
+        else:
+            return self.wink.state()
+
+    @property
+    def sensor_class(self):
+        """Return the class of this sensor, from SENSOR_CLASSES."""
+        return SENSOR_TYPES.get(self.capability)
+
+    @property
+    def unique_id(self):
+        """ Returns the id of this wink sensor """
+        return "{}.{}".format(self.__class__, self.wink.device_id())
+
+    @property
+    def name(self):
+        """ Returns the name of the sensor if any. """
+        return self.wink.name()
+
+    def update(self):
+        """ Update state of the sensor. """
+        self.wink.update_state()

--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.garage_door import GarageDoorDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.1']
+REQUIREMENTS = ['python-wink==0.6.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.light import ATTR_BRIGHTNESS, Light
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.1']
+REQUIREMENTS = ['python-wink==0.6.2']
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.1']
+REQUIREMENTS = ['python-wink==0.6.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -11,7 +11,7 @@ import logging
 from homeassistant.components.wink import WinkToggleDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.1']
+REQUIREMENTS = ['python-wink==0.6.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -16,11 +16,12 @@ from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.loader import get_component
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.6.1']
+REQUIREMENTS = ['python-wink==0.6.2']
 
 DISCOVER_LIGHTS = "wink.lights"
 DISCOVER_SWITCHES = "wink.switches"
 DISCOVER_SENSORS = "wink.sensors"
+DISCOVER_BINARY_SENSORS = "wink.binary_sensors"
 DISCOVER_LOCKS = "wink.locks"
 DISCOVER_GARAGE_DOORS = "wink.garage_doors"
 
@@ -41,6 +42,7 @@ def setup(hass, config):
             ('switch', lambda: pywink.get_switches or
              pywink.get_sirens or
              pywink.get_powerstrip_outlets, DISCOVER_SWITCHES),
+            ('binary_sensor', pywink.get_sensors, DISCOVER_BINARY_SENSORS),
             ('sensor', lambda: pywink.get_sensors or
              pywink.get_eggtrays, DISCOVER_SENSORS),
             ('lock', pywink.get_locks, DISCOVER_LOCKS),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -201,12 +201,13 @@ python-telegram-bot==3.2.0
 python-twitch==1.2.0
 
 # homeassistant.components.wink
+# homeassistant.components.binary_sensor.wink
 # homeassistant.components.garage_door.wink
 # homeassistant.components.light.wink
 # homeassistant.components.lock.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.6.1
+python-wink==0.6.2
 
 # homeassistant.components.keyboard
 pyuserinput==0.1.9


### PR DESCRIPTION
This is my first attempt at moving all Wink binary sensors into a binary sensor class. Currently all wink sensors binary or not are handled by /sensors/wink.py. This change will move window/door, spotter, motion, and maybe more? sensors into the binary sensor class. 

Not sure if there is an easier way to validate if a sensor is binary or not? Currently python-wink doesn't have a get_binary_sensors() method so my current approach is to check the sensors capability to decide if it is binary. 

**note this also includes the changes for https://github.com/balloob/home-assistant/pull/1377 mostly to make sure I am doing this correctly and don't break things.
