### PR TITLE
Filter out AirCam models in UVC camera platform

### DIFF
--- a/homeassistant/components/camera/uvc.py
+++ b/homeassistant/components/camera/uvc.py
@@ -47,6 +47,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error('Unable to connect to NVR: %s', str(ex))
         return False
 
+    # Filter out airCam models, which are not supported in the latest
+    # version of UnifiVideo and which are EOL by Ubiquiti
+    cameras = [camera for camera in cameras
+               if 'airCam' not in nvrconn.get_camera(camera['uuid'])['model']]
+
     add_devices([UnifiVideoCamera(nvrconn,
                                   camera['uuid'],
                                   camera['name'])

--- a/tests/components/camera/test_uvc.py
+++ b/tests/components/camera/test_uvc.py
@@ -27,10 +27,19 @@ class TestUVCSetup(unittest.TestCase):
         fake_cameras = [
             {'uuid': 'one', 'name': 'Front'},
             {'uuid': 'two', 'name': 'Back'},
+            {'uuid': 'three', 'name': 'Old AirCam'},
         ]
+
+        def fake_get_camera(uuid):
+            if uuid == 'three':
+                return {'model': 'airCam'}
+            else:
+                return {'model': 'UVC'}
+
         hass = mock.MagicMock()
         add_devices = mock.MagicMock()
         mock_remote.return_value.index.return_value = fake_cameras
+        mock_remote.return_value.get_camera.side_effect = fake_get_camera
         self.assertTrue(uvc.setup_platform(hass, config, add_devices))
         mock_remote.assert_called_once_with('foo', 123, 'secret')
         add_devices.assert_called_once_with([
@@ -54,6 +63,7 @@ class TestUVCSetup(unittest.TestCase):
         hass = mock.MagicMock()
         add_devices = mock.MagicMock()
         mock_remote.return_value.index.return_value = fake_cameras
+        mock_remote.return_value.get_camera.return_value = {'model': 'UVC'}
         self.assertTrue(uvc.setup_platform(hass, config, add_devices))
         mock_remote.assert_called_once_with('foo', 7080, 'secret')
         add_devices.assert_called_once_with([


### PR DESCRIPTION
The older (unsupported AirCam) models behave differently and also apparently
suffer some under the last release of the NVR that supported them. Since they
are EOL and not supported by current software, filter them out so we don't
break while trying to extract an image from them.
