### PR TITLE
Add entity_picture property

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -15,7 +15,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.components import bloomsky
 from homeassistant.const import (
-    ATTR_ENTITY_PICTURE,
     HTTP_NOT_FOUND,
     ATTR_ENTITY_ID,
     )
@@ -133,6 +132,11 @@ class Camera(Entity):
         return False
 
     @property
+    def entity_picture(self):
+        """Return a link to the camera feed as entity picture."""
+        return ENTITY_IMAGE_URL.format(self.entity_id)
+
+    @property
     # pylint: disable=no-self-use
     def is_recording(self):
         """Return true if the device is recording."""
@@ -195,9 +199,7 @@ class Camera(Entity):
     @property
     def state_attributes(self):
         """Camera state attributes."""
-        attr = {
-            ATTR_ENTITY_PICTURE: ENTITY_IMAGE_URL.format(self.entity_id),
-        }
+        attr = {}
 
         if self.model:
             attr['model_name'] = self.model

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -25,7 +25,7 @@ import homeassistant.util.dt as dt_util
 
 from homeassistant.helpers.event import track_utc_time_change
 from homeassistant.const import (
-    ATTR_ENTITY_PICTURE, ATTR_GPS_ACCURACY, ATTR_LATITUDE, ATTR_LONGITUDE,
+    ATTR_GPS_ACCURACY, ATTR_LATITUDE, ATTR_LONGITUDE,
     DEVICE_DEFAULT_NAME, STATE_HOME, STATE_NOT_HOME)
 
 DOMAIN = "device_tracker"
@@ -298,12 +298,14 @@ class Device(Entity):
         return self._state
 
     @property
+    def entity_picture(self):
+        """Picture of the device."""
+        return self.config_picture
+
+    @property
     def state_attributes(self):
         """ Device state attributes. """
         attr = {}
-
-        if self.config_picture:
-            attr[ATTR_ENTITY_PICTURE] = self.config_picture
 
         if self.gps:
             attr[ATTR_LATITUDE] = self.gps[0]

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.const import (
     STATE_OFF, STATE_UNKNOWN, STATE_PLAYING, STATE_IDLE,
-    ATTR_ENTITY_ID, ATTR_ENTITY_PICTURE, SERVICE_TURN_OFF, SERVICE_TURN_ON,
+    ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON,
     SERVICE_VOLUME_UP, SERVICE_VOLUME_DOWN, SERVICE_VOLUME_SET,
     SERVICE_VOLUME_MUTE, SERVICE_TOGGLE,
     SERVICE_MEDIA_PLAY_PAUSE, SERVICE_MEDIA_PLAY, SERVICE_MEDIA_PAUSE,
@@ -526,6 +526,11 @@ class MediaPlayerDevice(Entity):
             self.media_play()
 
     @property
+    def entity_picture(self):
+        """Return image of the media playing."""
+        return None if self.state == STATE_OFF else self.media_image_url
+
+    @property
     def state_attributes(self):
         """ Return the state attributes. """
         if self.state == STATE_OFF:
@@ -537,8 +542,5 @@ class MediaPlayerDevice(Entity):
                 attr: getattr(self, attr) for attr
                 in ATTR_TO_PROPERTY if getattr(self, attr) is not None
             }
-
-            if self.media_image_url:
-                state_attr[ATTR_ENTITY_PICTURE] = self.media_image_url
 
         return state_attr

--- a/homeassistant/components/sensor/steam_online.py
+++ b/homeassistant/components/sensor/steam_online.py
@@ -7,7 +7,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.steam_online/
 """
 from homeassistant.helpers.entity import Entity
-from homeassistant.const import (ATTR_ENTITY_PICTURE, CONF_API_KEY)
+from homeassistant.const import CONF_API_KEY
 
 ICON = 'mdi:steam'
 
@@ -62,11 +62,9 @@ class SteamSensor(Entity):
         }.get(self._profile.status, 'Offline')
 
     @property
-    def device_state_attributes(self):
-        """ Returns the state attributes. """
-        return {
-            ATTR_ENTITY_PICTURE: self._profile.avatar_medium
-        }
+    def entity_picture(self):
+        """Avatar of the account."""
+        return self._profile.avatar_medium
 
     @property
     def icon(self):

--- a/homeassistant/components/sensor/twitch.py
+++ b/homeassistant/components/sensor/twitch.py
@@ -4,7 +4,6 @@ Support for the Twitch stream status.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.twitch/
 """
-from homeassistant.const import ATTR_ENTITY_PICTURE
 from homeassistant.helpers.entity import Entity
 
 STATE_STREAMING = 'streaming'
@@ -51,6 +50,11 @@ class TwitchSensor(Entity):
         """State of the sensor."""
         return self._state
 
+    @property
+    def entity_picture(self):
+        """Preview of current game."""
+        return self._preview
+
     # pylint: disable=no-member
     def update(self):
         """Update device state."""
@@ -62,6 +66,7 @@ class TwitchSensor(Entity):
             self._preview = stream.get('preview').get('small')
             self._state = STATE_STREAMING
         else:
+            self._preview = None
             self._state = STATE_OFFLINE
 
     @property
@@ -71,7 +76,6 @@ class TwitchSensor(Entity):
             return {
                 ATTR_GAME: self._game,
                 ATTR_TITLE: self._title,
-                ATTR_ENTITY_PICTURE: self._preview
             }
 
     @property

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -8,8 +8,7 @@ import logging
 
 import requests
 
-from homeassistant.const import (
-    ATTR_ENTITY_PICTURE, CONF_LATITUDE, CONF_LONGITUDE)
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import dt as dt_util
 from homeassistant.util import location
@@ -98,19 +97,20 @@ class YrSensor(Entity):
         return self._state
 
     @property
+    def entity_picture(self):
+        """Weather symbol if type is symbol."""
+        if self.type != 'symbol':
+            return None
+        return "http://api.met.no/weatherapi/weathericon/1.1/" \
+               "?symbol={0};content_type=image/png".format(self._state)
+
+    @property
     def device_state_attributes(self):
         """Returns state attributes. """
-        data = {
+        return {
             'about': "Weather forecast from yr.no, delivered by the"
                      " Norwegian Meteorological Institute and the NRK"
         }
-        if self.type == 'symbol':
-            symbol_nr = self._state
-            data[ATTR_ENTITY_PICTURE] = \
-                "http://api.met.no/weatherapi/weathericon/1.1/" \
-                "?symbol={0};content_type=image/png".format(symbol_nr)
-
-        return data
 
     @property
     def unit_of_measurement(self):


### PR DESCRIPTION
We have a few attributes that if set on the statemachine, affect how the entity is represented. As these are standardized we have been moving them to properties on the Entity class to clarify that they are 'official' properties.

This PR will replace adding your own `ATTR_ENTITY_PICTURE` to the attributes and convert it to the property `entity_picture`.
