### PR TITLE
Fixed the workaround for philio slim multi sensor.

### DIFF
--- a/homeassistant/components/binary_sensor/zwave.py
+++ b/homeassistant/components/binary_sensor/zwave.py
@@ -5,17 +5,30 @@ For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/binary_sensor.zwave/
 """
 import logging
+import datetime
+import homeassistant.util.dt as dt_util
+from homeassistant.helpers.event import track_point_in_time
 
 from homeassistant.components.zwave import (
     ATTR_NODE_ID, ATTR_VALUE_ID,
     COMMAND_CLASS_SENSOR_BINARY, NETWORK,
-    ZWaveDeviceEntity)
+    ZWaveDeviceEntity, get_config_value)
 from homeassistant.components.binary_sensor import (
     DOMAIN,
     BinarySensorDevice)
 
 _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = []
+
+PHILIO = 0x013c
+PHILIO_SLIM_SENSOR = 0x0002
+PHILIO_SLIM_SENSOR_MOTION = (PHILIO, PHILIO_SLIM_SENSOR, 0)
+
+WORKAROUND_NO_OFF_EVENT = 'trigger_no_off_event'
+
+DEVICE_MAPPINGS = {
+    PHILIO_SLIM_SENSOR_MOTION: WORKAROUND_NO_OFF_EVENT,
+}
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -27,8 +40,21 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     node = NETWORK.nodes[discovery_info[ATTR_NODE_ID]]
     value = node.values[discovery_info[ATTR_VALUE_ID]]
 
+    specific_sensor_key = (int(value.node.manufacturer_id, 16),
+                           int(value.node.product_id, 16),
+                           value.index)
+
     value.set_change_verified(False)
-    if value.command_class == COMMAND_CLASS_SENSOR_BINARY:
+    if specific_sensor_key in DEVICE_MAPPINGS:
+        if DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_NO_OFF_EVENT:
+            # Default the multiplier to 4
+            re_arm_multiplier = (get_config_value(value.node, 9) or 4)
+            add_devices([
+                ZWaveTriggerSensor(value, "motion",
+                                   hass, re_arm_multiplier * 8)
+            ])
+
+    elif value.command_class == COMMAND_CLASS_SENSOR_BINARY:
         add_devices([ZWaveBinarySensor(value, "opening")])
 
 
@@ -65,3 +91,43 @@ class ZWaveBinarySensor(BinarySensorDevice, ZWaveDeviceEntity):
         """Called when a value has changed on the network."""
         if self._value.value_id == value.value_id:
             self.update_ha_state()
+
+
+class ZWaveTriggerSensor(ZWaveBinarySensor):
+    """
+    Represents a stateless sensor which triggers events just 'On'
+    within Z-Wave.
+    """
+
+    def __init__(self, sensor_value, sensor_class, hass, re_arm_sec=60):
+        super(ZWaveTriggerSensor, self).__init__(sensor_value, sensor_class)
+        self._hass = hass
+        self.invalidate_after = dt_util.utcnow()
+        self.re_arm_sec = re_arm_sec
+
+    def value_changed(self, value):
+        """Called when a value has changed on the network."""
+        if self._value.value_id == value.value_id:
+            self.update_ha_state()
+            if value.data:
+                # only allow this value to be true for 60 secs
+                self.invalidate_after = dt_util.utcnow() + datetime.timedelta(
+                    seconds=self.re_arm_sec)
+                track_point_in_time(
+                    self._hass, self.update_ha_state,
+                    self.invalidate_after)
+
+    @property
+    def state(self):
+        """Returns the state of the sensor."""
+        if not self._value.data or \
+                (self.invalidate_after is not None and
+                 self.invalidate_after <= dt_util.utcnow()):
+            return False
+
+        return True
+
+    @property
+    def is_on(self):
+        """Return True if the binary sensor is on."""
+        return self.state


### PR DESCRIPTION
Moved the workaround into the binary_sensor platform.

Changed the key matching to utilize integer values. 
It does not report always return the hex marker '0x' in the identifier strings. 
This PR closes issue #1349
