### PR TITLE
Throttle should work on a single method

### DIFF
--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -238,3 +238,20 @@ class TestUtil(unittest.TestCase):
 
         self.assertTrue(throttled())
         self.assertIsNone(throttled())
+
+    def test_throttle_on_two_method(self):
+        """ Test that throttle works when wrapping two methods. """
+
+        class Tester(object):
+            @util.Throttle(timedelta(seconds=1))
+            def hello(self):
+                return True
+
+            @util.Throttle(timedelta(seconds=1))
+            def goodbye(self):
+                return True
+
+        tester = Tester()
+
+        self.assertTrue(tester.hello())
+        self.assertTrue(tester.goodbye())


### PR DESCRIPTION
The thread lock for a method with a `@Throttle` decorator was added to the class it belonged to instead of the Throttle object itself. The effect of this was that if several methods in one class had the decorator all of those methods would share the throttle thread lock. 

This patch adds the thread lock to the Throttle object itself instead, which will be created for each decorated method.

Are my assumptions correct?
