### PR TITLE
Fix mFi error handling in setup_platform

### DIFF
--- a/homeassistant/components/sensor/mfi.py
+++ b/homeassistant/components/sensor/mfi.py
@@ -6,6 +6,8 @@ https://home-assistant.io/components/sensor.mfi/
 """
 import logging
 
+import requests
+
 from homeassistant.components.sensor import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, TEMP_CELCIUS
 from homeassistant.helpers import validate_config
@@ -48,11 +50,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    from mficlient.client import MFiClient
+    from mficlient.client import FailedToLogin, MFiClient
 
     try:
         client = MFiClient(host, username, password, port=port)
-    except client.FailedToLogin as ex:
+    except (FailedToLogin, requests.exceptions.ConnectionError) as ex:
         _LOGGER.error('Unable to connect to mFi: %s', str(ex))
         return False
 

--- a/homeassistant/components/switch/mfi.py
+++ b/homeassistant/components/switch/mfi.py
@@ -8,6 +8,8 @@ https://home-assistant.io/components/switch.mfi/
 """
 import logging
 
+import requests
+
 from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import validate_config
@@ -41,11 +43,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     username = config.get('username')
     password = config.get('password')
 
-    from mficlient.client import MFiClient
+    from mficlient.client import FailedToLogin, MFiClient
 
     try:
         client = MFiClient(host, username, password, port=port)
-    except client.FailedToLogin as ex:
+    except (FailedToLogin, requests.exceptions.ConnectionError) as ex:
         _LOGGER.error('Unable to connect to mFi: %s', str(ex))
         return False
 

--- a/tests/components/sensor/test_mfi.py
+++ b/tests/components/sensor/test_mfi.py
@@ -7,6 +7,8 @@ Tests mFi sensor.
 import unittest
 import unittest.mock as mock
 
+import requests
+
 import homeassistant.components.sensor as sensor
 import homeassistant.components.sensor.mfi as mfi
 from homeassistant.const import TEMP_CELCIUS
@@ -49,6 +51,15 @@ class TestMfiSensorSetup(unittest.TestCase):
     def test_setup_failed_login(self, mock_client):
         mock_client.FailedToLogin = Exception()
         mock_client.MFiClient.side_effect = mock_client.FailedToLogin
+        self.assertFalse(
+            self.PLATFORM.setup_platform(self.hass,
+                                         dict(self.GOOD_CONFIG),
+                                         None))
+
+    @mock.patch('mficlient.client')
+    def test_setup_failed_connect(self, mock_client):
+        mock_client.FailedToLogin = Exception()
+        mock_client.MFiClient.side_effect = requests.exceptions.ConnectionError
         self.assertFalse(
             self.PLATFORM.setup_platform(self.hass,
                                          dict(self.GOOD_CONFIG),


### PR DESCRIPTION
The exception we were catching incorrectly referenced the client variable
in local scope instead of the module. Also, if we fail to connect we can
get a requests exception, so catch and handle that as well.
