### PR TITLE
Fix for the issue #1323

### DIFF
--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -15,7 +15,9 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import validate_config
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['https://github.com/deisi/fritzconnection/archive/b5c14515e1c8e2652b06b6316a7f3913df942841.zip#fritzconnection==0.4.6']
+REQUIREMENTS = ['https://github.com/deisi/fritzconnection/archive/'
+                'b5c14515e1c8e2652b06b6316a7f3913df942841.zip'
+                '#fritzconnection==0.4.6']
 
 # Return cached results if last scan was less then this time ago
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)

--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import validate_config
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['fritzconnection==0.4.6']
+REQUIREMENTS = ['https://github.com/deisi/fritzconnection/archive/b5c14515e1c8e2652b06b6316a7f3913df942841.zip#fritzconnection==0.4.6']
 
 # Return cached results if last scan was less then this time ago
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)


### PR DESCRIPTION
The Webpage will also need an updated because it seems, that the password of the fritzbox is not optional any more.

I hope in the near future, we can use the official version from pip, but this is still not compatible with python3. E.g. [here](https://bitbucket.org/kbr/fritzconnection/issues/13/unable-to-get-it-to-work-on-34) is an issue about this.
