### PR TITLE
Allow toggling service for an Input Boolean

### DIFF
--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -9,7 +9,8 @@ at https://home-assistant.io/components/input_boolean/
 import logging
 
 from homeassistant.const import (
-    ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_ON)
+    ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON,
+    SERVICE_TOGGLE, STATE_ON)
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.util import slugify
@@ -74,11 +75,14 @@ def setup(hass, config):
         for input_b in target_inputs:
             if service.service == SERVICE_TURN_ON:
                 input_b.turn_on()
+            elif service.service == SERVICE_TOGGLE:
+                input_b.toggle()
             else:
                 input_b.turn_off()
 
     hass.services.register(DOMAIN, SERVICE_TURN_OFF, toggle_service)
     hass.services.register(DOMAIN, SERVICE_TURN_ON, toggle_service)
+    hass.services.register(DOMAIN, SERVICE_TOGGLE, toggle_service)
 
     component.add_entities(entities)
 


### PR DESCRIPTION
**Description:**

**Related issue (if applicable):** #
**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**
- [ ] Local tests with `tox` ran successfully.
- [ ] No CI failures. **Your PR cannot be merged unless CI is green!**
- [ ] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- If code communicates with devices:
  - [ ] 3rd party library/libraries for communication is/are added as dependencies via the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] 3rd party dependencies are imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] `requirements_all.txt` is up-to-date, `script/gen_requirements_all.py` ran and the updated file is included in the PR.
  - [ ] New files were added to `.coveragerc`.
- If the code does not depend on external Python module:
  - [ ] Tests to verify that the code works are included.
- [ ] [Commits will be squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) when the PR is ready to be merged.
