### PR TITLE
Fix mysensors sensor types

### DIFF
--- a/homeassistant/components/sensor/mysensors.py
+++ b/homeassistant/components/sensor/mysensors.py
@@ -61,8 +61,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 pres.S_MULTIMETER: [set_req.V_VOLTAGE,
                                     set_req.V_CURRENT,
                                     set_req.V_IMPEDANCE],
-                pres.S_SPRINKLER: [set_req.V_TRIPPED],
-                pres.S_WATER_LEAK: [set_req.V_TRIPPED],
                 pres.S_SOUND: [set_req.V_LEVEL],
                 pres.S_VIBRATION: [set_req.V_LEVEL],
                 pres.S_MOISTURE: [set_req.V_LEVEL],


### PR DESCRIPTION
**Description:**
- Remove sprinkler and water leak from sensor types. These two are
  supported by binary sensor.

**Checklist:**
- [x] Local tests with `tox` ran successfully.
- [x] No CI failures. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- If code communicates with devices:
  - [ ] 3rd party library/libraries for communication is/are added as dependencies via the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] 3rd party dependencies are imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] `requirements_all.txt` is up-to-date, `script/gen_requirements_all.py` ran and the updated file is included in the PR.
  - [ ] New files were added to `.coveragerc`.
- If the code does not depend on external Python module:
  - [ ] Tests to verify that the code works are included.
- [x] [Commits will be squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) when the PR is ready to be merged.
