### PR TITLE
Fix static configured wemo devices

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -77,7 +77,8 @@ def setup(hass, config):
     devices = [(device.host, device) for device in pywemo.discover_devices()]
 
     # Add static devices from the config file
-    devices.extend((address, None) for address in config.get('static', []))
+    devices.extend((address, None)
+                   for address in config['wemo'].get('static', []))
 
     for address, device in devices:
         port = pywemo.ouimeaux_device.probe_wemo(address)

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -58,12 +58,12 @@ def setup(hass, config):
     def discovery_dispatch(service, discovery_info):
         """Dispatcher for WeMo discovery events."""
         # name, model, location, mac
-        _, model_name, _, mac = discovery_info
+        _, model_name, url, _ = discovery_info
 
         # Only register a device once
-        if mac in KNOWN_DEVICES:
+        if url in KNOWN_DEVICES:
             return
-        KNOWN_DEVICES.append(mac)
+        KNOWN_DEVICES.append(url)
 
         service = WEMO_MODEL_DISPATCH.get(model_name) or DISCOVER_SWITCHES
         component = WEMO_SERVICE_DISPATCH.get(service)


### PR DESCRIPTION
The new wemo code was pulling 'static' from the global config instead of
the wemo component config.

Also, the wemo component was tracking devices by mac to avoid adding duplicates,
but this means we'd never be able to load more than one static wemo, since
they all have mac=None.

This changes the code to track by url, which has to be unique per wemo
anyway, and which we also have for even static wemos.

cc @jaharkes 
cc @pavoni 

@balloob If we do an 0.14.1 I think this should be in it if possible.
