### PR TITLE
Fix incorrectly setting can_cancel on scripts

### DIFF
--- a/homeassistant/components/script.py
+++ b/homeassistant/components/script.py
@@ -131,8 +131,8 @@ class Script(ToggleEntity):
         self._cur = -1
         self._last_action = None
         self._listener = None
-        self._can_cancel = not any(CONF_DELAY in action for action
-                                   in self.sequence)
+        self._can_cancel = any(CONF_DELAY in action for action
+                               in self.sequence)
 
     @property
     def should_poll(self):
@@ -146,13 +146,11 @@ class Script(ToggleEntity):
     @property
     def state_attributes(self):
         """ Returns the state attributes. """
-        attrs = {
-            ATTR_CAN_CANCEL: self._can_cancel
-        }
-
+        attrs = {}
+        if self._can_cancel:
+            attrs[ATTR_CAN_CANCEL] = self._can_cancel
         if self._last_action:
             attrs[ATTR_LAST_ACTION] = self._last_action
-
         return attrs
 
     @property

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -88,8 +88,8 @@ class TestScript(unittest.TestCase):
 
         self.assertEqual(1, len(calls))
         self.assertEqual('world', calls[0].data.get('hello'))
-        self.assertEqual(
-            True, self.hass.states.get(ENTITY_ID).attributes.get('can_cancel'))
+        self.assertIsNone(
+            self.hass.states.get(ENTITY_ID).attributes.get('can_cancel'))
 
     def test_calling_service_old(self):
         calls = []
@@ -174,8 +174,7 @@ class TestScript(unittest.TestCase):
         self.hass.pool.block_till_done()
 
         self.assertTrue(script.is_on(self.hass, ENTITY_ID))
-        self.assertEqual(
-            False,
+        self.assertTrue(
             self.hass.states.get(ENTITY_ID).attributes.get('can_cancel'))
 
         self.assertEqual(


### PR DESCRIPTION
It looks like the `can_cancel` attribute on script entities has been the inverse of what it should have been. This went unnoticed as it wasn't used yet for the frontend.
