### PR TITLE
Add support for NetAtmo rain gauge

### DIFF
--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -26,7 +26,10 @@ SENSOR_TYPES = {
     'co2':         ['CO2', 'ppm', 'mdi:cloud'],
     'pressure':    ['Pressure', 'mbar', 'mdi:gauge'],
     'noise':       ['Noise', 'dB', 'mdi:volume-high'],
-    'humidity':    ['Humidity', '%', 'mdi:water-percent']
+    'humidity':    ['Humidity', '%', 'mdi:water-percent'],
+    'rain':        ['Rain', 'mm', 'mdi:weather-rainy'],
+    'sum_rain_1':  ['sum_rain_1', 'mm', 'mdi:weather-rainy'],
+    'sum_rain_24': ['sum_rain_24', 'mm', 'mdi:weather-rainy'],
 }
 
 CONF_SECRET_KEY = 'secret_key'
@@ -128,6 +131,12 @@ class NetAtmoSensor(Entity):
             self._state = round(data['Temperature'], 1)
         elif self.type == 'humidity':
             self._state = data['Humidity']
+        elif self.type == 'rain':
+            self._state = data['Rain']
+        elif self.type == 'sum_rain_1':
+            self._state = data['sum_rain_1']
+        elif self.type == 'sum_rain_24':
+            self._state = data['sum_rain_24']
         elif self.type == 'noise':
             self._state = data['Noise']
         elif self.type == 'co2':


### PR DESCRIPTION
**Description:**
I added a few new Sensor_types to support the NetAtmo rain gauge.

**Example entry for `configuration.yaml` (if applicable):**

```
sensor: !include devices/sensor.yaml
group:
    outside: sensor.netatmo_outside_temperature, sensor.netatmo_garten_rain, sensor.netatmo_garten_sum_rain_1, sensor.netatmo_garten_sum_rain_24, sun.sun
```

Example Config from my devices/sensor.yaml:

``` ỳaml
 platform: netatmo
  api_key: XXXXX
  secret_key: XXXXX
  username: XXXXX
  password: XXXXXXX
modules:
    Bedroom:
      - temperature
    LivingRoom:
      - temperature
    Outside:
      - temperature
    Garden:
      - rain
      - sum_rain_1
      - sum_rain_24
```

The three new parameters stand for:
- rain # Estimated rainfall for today in "mm"
- sum_rain_1 # Rainfall in the last hour in "mm"
- sum_rain_24 # Rainfall in "mm" from 00:00am - 23:59pm
