### PR TITLE
Gracefully handle having no wemo config section

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -78,7 +78,7 @@ def setup(hass, config):
 
     # Add static devices from the config file
     devices.extend((address, None)
-                   for address in config['wemo'].get('static', []))
+                   for address in config.get(DOMAIN, {}).get('static', []))
 
     for address, device in devices:
         port = pywemo.ouimeaux_device.probe_wemo(address)


### PR DESCRIPTION
I broke this with my fix, where I assumed that we'd always have a wemo
config section if we're running the wemo code. However, if we're fully
auto-detected, we might not.
