### PR TITLE
Add discoverable component

### DIFF
--- a/homeassistant/components/discoverable.py
+++ b/homeassistant/components/discoverable.py
@@ -1,0 +1,121 @@
+"""Component to allow discovering Home Assistant on local network."""
+import json
+import logging
+import select
+import socket
+import threading
+from urllib.parse import urlsplit
+
+from homeassistant.const import (
+    __version__, EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+from homeassistant import remote
+
+DOMAIN = 'discoverable'
+DEPENDENCIES = ['api']
+
+MCAST_IP = "224.0.0.123"
+MCAST_PORT = 38123
+BIND_IP = "0.0.0.0"
+
+POLL_TIMEOUT = 5
+
+DISCOVER_TIMEOUT = 5
+DISCOVERY_QUERY = 'Home Assistants Assemble!'.encode('utf-8')
+
+CONF_EXPOSE_PASSWORD = 'expose_password'
+DEFAULT_EXPOSE_PASSWORD = False
+
+_LOGGING = logging.getLogger(__name__)
+
+
+def setup(hass, config):
+    """Set up the server to become discoverable when started."""
+    expose_password = config.get(DOMAIN, {}).get(CONF_EXPOSE_PASSWORD,
+                                                 DEFAULT_EXPOSE_PASSWORD)
+    listener = AssemblyListener(hass, expose_password)
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, lambda _: listener.start())
+
+    return True
+
+
+def get_instance(api_password=None):
+    """Discover and instantiate remote HA."""
+    info = scan()
+
+    if info is None:
+        return None
+
+    parts = urlsplit(info.get('host'))
+    api = remote.API(parts.hostname, info.get('api_password', api_password),
+                     parts.port, parts.scheme == 'https')
+    return remote.HomeAssistant(api)
+
+
+def scan():
+    """Scan the network for Home Assistant instances."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(DISCOVER_TIMEOUT)
+    addrs = socket.getaddrinfo(MCAST_IP, MCAST_PORT, socket.AF_INET,
+                               socket.SOCK_DGRAM)
+    sock.sendto(DISCOVERY_QUERY, addrs[0][4])
+    try:
+        data = sock.recv(1024)
+        return json.loads(data.decode('utf-8'))
+    except (socket.timeout, ValueError):
+        return None
+
+
+class AssemblyListener(threading.Thread):
+    """Listener for Home Assistant discovery requests."""
+
+    def __init__(self, hass, expose_password):
+        """Initialize discovery thread."""
+        super().__init__()
+        self.hass = hass
+        self.expose_password = expose_password
+        self.daemon = True
+
+    def run(self):
+        """Run discovery thread."""
+        should_stop = threading.Event()
+
+        self.hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP,
+                                  lambda _: should_stop.set())
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        addr = socket.getaddrinfo(BIND_IP, MCAST_PORT, socket.AF_INET,
+                                  socket.SOCK_DGRAM)[0][4]
+        sock.bind(addr)
+        sock.setsockopt(
+            socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
+            socket.inet_aton(MCAST_IP) + socket.inet_aton(BIND_IP))
+
+        while not should_stop.is_set():
+            ready = select.select([sock], [], [], POLL_TIMEOUT)[0]
+
+            if not ready:
+                continue
+
+            data, addr = sock.recvfrom(1024)
+
+            if data != DISCOVERY_QUERY:
+                _LOGGING.warning('Unexpected data encountered: %s', data)
+                continue
+
+            _LOGGING.info('Discovered by %s', addr)
+            sock.sendto(json.dumps(self.response()).encode('utf-8'), addr)
+
+    def response(self):
+        """Generate discovery response."""
+        api = self.hass.config.api
+        resp = {
+            'content-type': 'home-assistant/server',
+            'host': api.base_url,
+            'version': __version__,
+        }
+
+        if api.api_password is None or self.expose_password:
+            resp['api_password'] = api.api_password
+
+        return resp

--- a/tests/components/test_discoverable.py
+++ b/tests/components/test_discoverable.py
@@ -1,0 +1,81 @@
+"""Test discoverable component."""
+import time
+from unittest.mock import MagicMock, patch
+
+from homeassistant import bootstrap
+from homeassistant.components import discoverable, http
+from homeassistant.const import __version__
+
+from tests.common import get_test_instance_port, get_test_home_assistant
+
+
+class TestDiscoverableMethods(object):
+    @patch('homeassistant.components.discoverable.AssemblyListener')
+    def test_exposing_password_defaults_false(self, mock_listener):
+        hass = MagicMock()
+
+        assert discoverable.setup(hass, {})
+
+        assert mock_listener.mock_calls[0][1] == (hass, False)
+
+    def test_exposing_password(self):
+        base_url = 'http://very-fancy-host.com:8123'
+        api_password = 'secret'
+
+        hass = MagicMock()
+        hass.config.api.base_url = base_url
+        hass.config.api.api_password = None
+
+        assert discoverable.AssemblyListener(hass, False).response() == {
+            'content-type': 'home-assistant/server',
+            'host': base_url,
+            'version': __version__,
+            'api_password': None,
+        }
+
+        hass.config.api.api_password = api_password
+
+        assert discoverable.AssemblyListener(hass, False).response() == {
+            'content-type': 'home-assistant/server',
+            'host': base_url,
+            'version': __version__,
+        }
+
+        hass.config.api.api_password = api_password
+
+        assert discoverable.AssemblyListener(hass, True).response() == {
+            'content-type': 'home-assistant/server',
+            'host': base_url,
+            'version': __version__,
+            'api_password': api_password,
+        }
+
+
+class TestDiscoverableFlow(object):
+    def setup_method(self, method):
+        self.hass = get_test_home_assistant()
+        bootstrap.setup_component(
+            self.hass, http.DOMAIN,
+            {http.DOMAIN: {http.CONF_API_PASSWORD: 'SuperSecret',
+             http.CONF_SERVER_PORT: get_test_instance_port()}})
+
+    def teardown_method(self, method):
+        self.hass.stop()
+
+    def test_broadcast_and_get_instance(self):
+        self.hass.states.set('test.hello', 'world')
+
+        discoverable.setup(self.hass, {
+            discoverable.DOMAIN: {
+                discoverable.CONF_EXPOSE_PASSWORD: True
+            }
+        })
+
+        self.hass.start()
+
+        time.sleep(0.1)
+
+        remote = discoverable.get_instance()
+
+        assert remote is not None
+        assert remote.states.is_state('test.hello', 'world')


### PR DESCRIPTION
**Description:**
Introduces support for Home Assistant servers to be discoverable. This will allow micropython instances to get started without any required config (example from micropython home assistant [docs](https://github.com/balloob/micropython-home-assistant#discovery)):

``` python
from homeassistant.discovery import get_instance()

hass = get_instance()

for state in hass.states():
    print(state)
```

It is up to the user to expose the password in the discovery response (Default: off). If password not exposed, uHA instances will have to provide it (`get_instance('my password')`).

I decided to roll a new Home Assistant discovery protocol as all other protocols seemed way too overkill.

[Example client to get data.](https://github.com/balloob/micropython-home-assistant/blob/master/homeassistant/discovery.py#L20-L32)

Would love to get feedback.

**Related issue (if applicable):** #1153 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
discoverable:
  expose_password: yes
```

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- [x] Tests have been added to verify that the new code works.
