### PR TITLE
Fix GPS Accuracy Issue

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -28,6 +28,8 @@ _LOGGER = logging.getLogger(__name__)
 
 LOCK = threading.Lock()
 
+CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
+DEFAULT_MAX_GPS_ACCURACY = 500
 
 def setup_scanner(hass, config, see):
     """ Set up an OwnTracks tracker. """
@@ -47,6 +49,16 @@ def setup_scanner(hass, config, see):
 
         if not isinstance(data, dict) or data.get('_type') != 'location':
             return
+
+        #Check for GPS accuracy
+        if CONF_MAX_GPS_ACCURACY in config:
+            max_gps_accuracy = config[CONF_MAX_GPS_ACCURACY]
+        else:
+            max_gps_accuracy = DEFAULT_MAX_GPS_ACCURACY
+        if 'acc' in data:
+            if data['acc'] > max_gps_accuracy:
+                _LOGGER.info("Inaccurate GPS reported")
+                return
 
         dev_id, kwargs = _parse_see_args(topic, data)
 
@@ -77,6 +89,16 @@ def setup_scanner(hass, config, see):
 
         if not isinstance(data, dict) or data.get('_type') != 'transition':
             return
+
+        #Check for GPS accuracy
+        if CONF_MAX_GPS_ACCURACY in config:
+            max_gps_accuracy = config[CONF_MAX_GPS_ACCURACY]
+        else:
+            max_gps_accuracy = DEFAULT_MAX_GPS_ACCURACY
+        if 'acc' in data:
+            if data['acc'] > max_gps_accuracy:
+                _LOGGER.info("Inaccurate GPS reported")
+                return
 
         # OwnTracks uses - at the start of a beacon zone
         # to switch on 'hold mode' - ignore this

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -31,6 +31,7 @@ LOCK = threading.Lock()
 CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
 DEFAULT_MAX_GPS_ACCURACY = 500
 
+
 def setup_scanner(hass, config, see):
     """ Set up an OwnTracks tracker. """
 

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -28,6 +28,8 @@ _LOGGER = logging.getLogger(__name__)
 
 LOCK = threading.Lock()
 
+CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
+DEFAULT_MAX_GPS_ACCURACY = 500
 
 def setup_scanner(hass, config, see):
     """ Set up an OwnTracks tracker. """
@@ -47,6 +49,16 @@ def setup_scanner(hass, config, see):
 
         if not isinstance(data, dict) or data.get('_type') != 'location':
             return
+
+        # Check for GPS accuracy
+        if CONF_MAX_GPS_ACCURACY in config:
+            max_gps_accuracy = config[CONF_MAX_GPS_ACCURACY]
+        else:
+            max_gps_accuracy = DEFAULT_MAX_GPS_ACCURACY
+        if 'acc' in data:
+            if data['acc'] > max_gps_accuracy:
+                _LOGGER.info("Inaccurate GPS reported")
+                return
 
         dev_id, kwargs = _parse_see_args(topic, data)
 
@@ -77,6 +89,16 @@ def setup_scanner(hass, config, see):
 
         if not isinstance(data, dict) or data.get('_type') != 'transition':
             return
+
+        # Check for GPS accuracy
+        if CONF_MAX_GPS_ACCURACY in config:
+            max_gps_accuracy = config[CONF_MAX_GPS_ACCURACY]
+        else:
+            max_gps_accuracy = DEFAULT_MAX_GPS_ACCURACY
+        if 'acc' in data:
+            if data['acc'] > max_gps_accuracy:
+                _LOGGER.info("Inaccurate GPS reported")
+                return
 
         # OwnTracks uses - at the start of a beacon zone
         # to switch on 'hold mode' - ignore this


### PR DESCRIPTION
**Description:**
Dismiss a GPS report if this one is not accurate enough

**Related issue (if applicable):** #1270 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

device_tracker:
  platform: owntracks
  max_gps_accuracy: 200

```

**Checklist:**
- [ ] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

Dismiss a GPS report if is GPS is not accurate enough
