### PR TITLE
Fixed the z-wave sensor workarounds for empty manufacturer ids

### DIFF
--- a/homeassistant/components/binary_sensor/zwave.py
+++ b/homeassistant/components/binary_sensor/zwave.py
@@ -39,22 +39,26 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     node = NETWORK.nodes[discovery_info[ATTR_NODE_ID]]
     value = node.values[discovery_info[ATTR_VALUE_ID]]
-
-    specific_sensor_key = (int(value.node.manufacturer_id, 16),
-                           int(value.node.product_id, 16),
-                           value.index)
-
     value.set_change_verified(False)
-    if specific_sensor_key in DEVICE_MAPPINGS:
-        if DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_NO_OFF_EVENT:
-            # Default the multiplier to 4
-            re_arm_multiplier = (get_config_value(value.node, 9) or 4)
-            add_devices([
-                ZWaveTriggerSensor(value, "motion",
-                                   hass, re_arm_multiplier * 8)
-            ])
 
-    elif value.command_class == COMMAND_CLASS_SENSOR_BINARY:
+    # Make sure that we have values for the key before converting to int
+    if (value.node.manufacturer_id.strip() and
+            value.node.product_id.strip()):
+        specific_sensor_key = (int(value.node.manufacturer_id, 16),
+                               int(value.node.product_id, 16),
+                               value.index)
+
+        if specific_sensor_key in DEVICE_MAPPINGS:
+            if DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_NO_OFF_EVENT:
+                # Default the multiplier to 4
+                re_arm_multiplier = (get_config_value(value.node, 9) or 4)
+                add_devices([
+                    ZWaveTriggerSensor(value, "motion",
+                                       hass, re_arm_multiplier * 8)
+                ])
+                return
+
+    if value.command_class == COMMAND_CLASS_SENSOR_BINARY:
         add_devices([ZWaveBinarySensor(value, None)])
 
 

--- a/homeassistant/components/sensor/zwave.py
+++ b/homeassistant/components/sensor/zwave.py
@@ -50,17 +50,20 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     #                     groups[1].associations):
     #     node.groups[1].add_association(NETWORK.controller.node_id)
 
-    specific_sensor_key = (int(value.node.manufacturer_id, 16),
-                           int(value.node.product_id, 16),
-                           value.index)
+    # Make sure that we have values for the key before converting to int
+    if (value.node.manufacturer_id.strip() and
+            value.node.product_id.strip()):
+        specific_sensor_key = (int(value.node.manufacturer_id, 16),
+                               int(value.node.product_id, 16),
+                               value.index)
 
-    # Check workaround mappings for specific devices.
-    if specific_sensor_key in DEVICE_MAPPINGS:
-        if DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_IGNORE:
-            return
+        # Check workaround mappings for specific devices.
+        if specific_sensor_key in DEVICE_MAPPINGS:
+            if DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_IGNORE:
+                return
 
     # Generic Device mappings
-    elif value.command_class == COMMAND_CLASS_SENSOR_MULTILEVEL:
+    if value.command_class == COMMAND_CLASS_SENSOR_MULTILEVEL:
         add_devices([ZWaveMultilevelSensor(value)])
 
     elif (value.command_class == COMMAND_CLASS_METER and


### PR DESCRIPTION
**Description:**

Fixed issues for devices not reporting any manufacturer id.

**Related issues:** 
#1439
#1424

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
