### PR TITLE
Allow firing the time_changed event in the web developer tools

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.state import TrackStates
 from homeassistant.helpers import template
+from homeassistant.util import dt as dt_util
 
 DOMAIN = 'api'
 DEPENDENCIES = ['http']
@@ -269,6 +270,9 @@ def _handle_api_post_events_event(handler, path_match, event_data):
 
             if state:
                 event_data[key] = state
+    elif event_type == ha.EVENT_TIME_CHANGED and event_data:
+        if 'now' in event_data:
+            event_data['now'] = dt_util.str_to_datetime(event_data['now'])
 
     handler.server.hass.bus.fire(event_type, event_data, event_origin)
 


### PR DESCRIPTION
(if there is some easier way to test things like this, please point me at it)

This makes the event api module parse a time string into a datetime
object before firing it on the bus. With this, you can simulate time
change events by passing something like this in the "fire event" developer
tool:

  type: time_changed
  data: {"now":"14:46:23 01-03-2016"}

This is extremely useful for testing sunrise/sunset events.
