### PR TITLE
Give mFi options to control TLS usage

### DIFF
--- a/homeassistant/components/sensor/mfi.py
+++ b/homeassistant/components/sensor/mfi.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, TEMP_CELCIUS
 from homeassistant.helpers import validate_config
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['mficlient==0.2.2']
+REQUIREMENTS = ['mficlient==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +32,8 @@ SENSOR_MODELS = [
     'Input Analog',
     'Input Digital',
 ]
+CONF_TLS = 'use_tls'
+CONF_VERIFY_TLS = 'verify_tls'
 
 
 # pylint: disable=unused-variable
@@ -46,14 +48,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
     host = config.get('host')
-    port = int(config.get('port', 6443))
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
+    use_tls = bool(config.get(CONF_TLS, True))
+    verify_tls = bool(config.get(CONF_VERIFY_TLS, True))
+    default_port = use_tls and 6443 or 6080
+    port = int(config.get('port', default_port))
 
     from mficlient.client import FailedToLogin, MFiClient
 
     try:
-        client = MFiClient(host, username, password, port=port)
+        client = MFiClient(host, username, password, port=port,
+                           use_tls=use_tls, verify=verify_tls)
     except (FailedToLogin, requests.exceptions.ConnectionError) as ex:
         _LOGGER.error('Unable to connect to mFi: %s', str(ex))
         return False

--- a/homeassistant/components/switch/mfi.py
+++ b/homeassistant/components/switch/mfi.py
@@ -14,7 +14,7 @@ from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import validate_config
 
-REQUIREMENTS = ['mficlient==0.2.2']
+REQUIREMENTS = ['mficlient==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,6 +24,8 @@ SWITCH_MODELS = [
     'Output 12v',
     'Output 24v',
 ]
+CONF_TLS = 'use_tls'
+CONF_VERIFY_TLS = 'verify_tls'
 
 
 # pylint: disable=unused-variable
@@ -39,14 +41,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
     host = config.get('host')
-    port = int(config.get('port', 6443))
     username = config.get('username')
     password = config.get('password')
+    use_tls = bool(config.get(CONF_TLS, True))
+    verify_tls = bool(config.get(CONF_VERIFY_TLS, True))
+    default_port = use_tls and 6443 or 6080
+    port = int(config.get('port', default_port))
 
     from mficlient.client import FailedToLogin, MFiClient
 
     try:
-        client = MFiClient(host, username, password, port=port)
+        client = MFiClient(host, username, password, port=port,
+                           use_tls=use_tls, verify=verify_tls)
     except (FailedToLogin, requests.exceptions.ConnectionError) as ex:
         _LOGGER.error('Unable to connect to mFi: %s', str(ex))
         return False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -113,7 +113,7 @@ limitlessled==1.0.0
 
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi
-mficlient==0.2.2
+mficlient==0.3.0
 
 # homeassistant.components.discovery
 netdisco==0.5.3

--- a/tests/components/sensor/test_mfi.py
+++ b/tests/components/sensor/test_mfi.py
@@ -27,6 +27,8 @@ class TestMfiSensorSetup(unittest.TestCase):
             'port': 6123,
             'username': 'user',
             'password': 'pass',
+            'use_tls': True,
+            'verify_tls': True,
         }
     }
 
@@ -71,7 +73,8 @@ class TestMfiSensorSetup(unittest.TestCase):
         del config[self.THING]['port']
         assert self.COMPONENT.setup(self.hass, config)
         mock_client.assert_called_once_with('foo', 'user', 'pass',
-                                            port=6443)
+                                            port=6443, use_tls=True,
+                                            verify=True)
 
     @mock.patch('mficlient.client.MFiClient')
     def test_setup_with_port(self, mock_client):
@@ -79,7 +82,19 @@ class TestMfiSensorSetup(unittest.TestCase):
         config[self.THING]['port'] = 6123
         assert self.COMPONENT.setup(self.hass, config)
         mock_client.assert_called_once_with('foo', 'user', 'pass',
-                                            port=6123)
+                                            port=6123, use_tls=True,
+                                            verify=True)
+
+    @mock.patch('mficlient.client.MFiClient')
+    def test_setup_with_tls_disabled(self, mock_client):
+        config = dict(self.GOOD_CONFIG)
+        del config[self.THING]['port']
+        config[self.THING]['use_tls'] = False
+        config[self.THING]['verify_tls'] = False
+        assert self.COMPONENT.setup(self.hass, config)
+        mock_client.assert_called_once_with('foo', 'user', 'pass',
+                                            port=6080, use_tls=False,
+                                            verify=False)
 
     @mock.patch('mficlient.client.MFiClient')
     @mock.patch('homeassistant.components.sensor.mfi.MfiSensor')


### PR DESCRIPTION
The default configuration of the mFi controller generates self-signed
certificates which are valid for short periods of time, and which are
regnerated on start or as needed. This makes requests mad. Since most
people will be using the self-signed certificates anyway, add options
to let them choose non-TLS, or unverified connections if they want/need.

This bumps the mficlient requirement to 0.3.0 for proper handling of
verify=False.
