### PR TITLE
Add assumed_state to mysensors switch and light

### DIFF
--- a/homeassistant/components/light/mysensors.py
+++ b/homeassistant/components/light/mysensors.py
@@ -117,6 +117,11 @@ class MySensorsLight(Light):
         return self.value_type in self._values
 
     @property
+    def assumed_state(self):
+        """Return True if unable to access real state of entity."""
+        return self.gateway.optimistic
+
+    @property
     def is_on(self):
         """True if device is on."""
         return self._state

--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -1,9 +1,5 @@
 """
-homeassistant.components.mysensors.
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-MySensors component that connects to a MySensors gateway via pymysensors
-API.
+Connect to a MySensors gateway via pymysensors API.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.mysensors/

--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -149,6 +149,11 @@ class MySensorsSwitch(SwitchDevice):
         """Return True if entity is available."""
         return self.value_type in self._values
 
+    @property
+    def assumed_state(self):
+        """Return True if unable to access real state of entity."""
+        return self.gateway.optimistic
+
     def update(self):
         """Update the controller with the latest value from a sensor."""
         node = self.gateway.sensors[self.node_id]


### PR DESCRIPTION
**Description:**
- Return true for assumed_state if optimistic config setting is true.
- Fix PEP257

**Related issue (if applicable):** #
See https://github.com/balloob/home-assistant/issues/1263

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
