### PR TITLE
Track wemos by serial

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     EVENT_PLATFORM_DISCOVERED)
 
 DOMAIN = "discovery"
-REQUIREMENTS = ['netdisco==0.5.3']
+REQUIREMENTS = ['netdisco==0.5.4']
 
 SCAN_INTERVAL = 300  # seconds
 

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -58,12 +58,13 @@ def setup(hass, config):
     def discovery_dispatch(service, discovery_info):
         """Dispatcher for WeMo discovery events."""
         # name, model, location, mac
-        _, model_name, url, _ = discovery_info
+        _, model_name, _, _, serial = discovery_info
 
         # Only register a device once
-        if url in KNOWN_DEVICES:
+        if serial in KNOWN_DEVICES:
             return
-        KNOWN_DEVICES.append(url)
+        _LOGGER.debug('Discovered unique device %s', serial)
+        KNOWN_DEVICES.append(serial)
 
         service = WEMO_MODEL_DISPATCH.get(model_name) or DISCOVER_SWITCHES
         component = WEMO_SERVICE_DISPATCH.get(service)
@@ -91,6 +92,7 @@ def setup(hass, config):
         if device is None:
             device = pywemo.discovery.device_from_description(url, None)
 
-        discovery_info = (device.name, device.model_name, url, device.mac)
+        discovery_info = (device.name, device.model_name, url, device.mac,
+                          device.serialnumber)
         discovery.discover(hass, discovery.SERVICE_WEMO, discovery_info)
     return True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -116,7 +116,7 @@ limitlessled==1.0.0
 mficlient==0.3.0
 
 # homeassistant.components.discovery
-netdisco==0.5.3
+netdisco==0.5.4
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.2.10


### PR DESCRIPTION
**Description:**

Builds upon balloob/home-assistant#1453 by adding a dependency on a newer version of netdisco that includes the serial number of a discovered WeMo device.

depends on balloob/netdisco#14
