### PR TITLE
Fix SNMP device_tracker results without MAC addresses

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -66,7 +66,8 @@ class SnmpScanner(object):
         """
 
         self._update_info()
-        return [client['mac'] for client in self.last_results]
+        return [client['mac'] for client in self.last_results
+                if client.get('mac')]
 
     # Supressing no-self-use warning
     # pylint: disable=R0201
@@ -111,6 +112,7 @@ class SnmpScanner(object):
         for resrow in restable:
             for _, val in resrow:
                 mac = binascii.hexlify(val.asOctets()).decode('utf-8')
+                _LOGGER.debug('Found mac %s', mac)
                 mac = ':'.join([mac[i:i+2] for i in range(0, len(mac), 2)])
                 devices.append({'mac': mac})
         return devices


### PR DESCRIPTION
**Description:**

@llauren reported that his router returns empty MAC addresses for things
on different subnets, which causes heartache for the HA snmp device tracker.

**Related issue (if applicable):** # (reported via gitter)

@llauren tested this already and reported in chat that this solves the problem.
