### PR TITLE
Tests rfxtrx device

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -51,10 +51,6 @@ omit =
     homeassistant/components/zwave.py
     homeassistant/components/*/zwave.py
 
-    homeassistant/components/rfxtrx.py
-    homeassistant/components/switch/rfxtrx.py
-    homeassistant/components/light/rfxtrx.py
-
     homeassistant/components/mysensors.py
     homeassistant/components/*/mysensors.py
 

--- a/homeassistant/components/light/rfxtrx.py
+++ b/homeassistant/components/light/rfxtrx.py
@@ -164,18 +164,16 @@ class RfxtrxLight(Light):
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         if not self._event:
             return
-
         if brightness is None:
-            self._brightness = 100
+            self._brightness = 255
             for _ in range(self.signal_repetitions):
                 self._event.device.send_on(rfxtrx.RFXOBJECT.transport)
         else:
-            self._brightness = ((brightness + 4) * 100 // 255 - 1)
+            self._brightness = brightness
+            _brightness = (brightness * 100 // 255)
             for _ in range(self.signal_repetitions):
                 self._event.device.send_dim(rfxtrx.RFXOBJECT.transport,
-                                            self._brightness)
-
-        self._brightness = (self._brightness * 255 // 100)
+                                            _brightness)
         self._state = True
         self.update_ha_state()
 

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -11,8 +11,7 @@ import logging
 from homeassistant.util import slugify
 
 REQUIREMENTS = ['https://github.com/Danielhiversen/pyRFXtrx/' +
-                'archive/master.zip' +
-                '#pyRFXtrx==0.5']
+                'archive/0.5.zip#pyRFXtrx==0.5']
 
 DOMAIN = "rfxtrx"
 

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -10,8 +10,9 @@ import logging
 
 from homeassistant.util import slugify
 
-REQUIREMENTS = ['https://github.com/Danielhiversen/pyRFXtrx/archive/0.4.zip' +
-                '#pyRFXtrx==0.4']
+REQUIREMENTS = ['https://github.com/Danielhiversen/pyRFXtrx/' +
+                'archive/master.zip' +
+                '#pyRFXtrx==0.5']
 
 DOMAIN = "rfxtrx"
 
@@ -22,6 +23,7 @@ ATTR_NAME = 'name'
 ATTR_PACKETID = 'packetid'
 ATTR_FIREEVENT = 'fire_event'
 ATTR_DATA_TYPE = 'data_type'
+ATTR_DUMMY = "dummy"
 
 EVENT_BUTTON_PRESSED = 'button_pressed'
 
@@ -37,7 +39,6 @@ def setup(hass, config):
     # Declare the Handle event
     def handle_receive(event):
         """ Callback all subscribers for RFXtrx gateway. """
-
         # Log RFXCOM event
         if not event.device.id_string:
             return
@@ -58,16 +59,22 @@ def setup(hass, config):
     global RFXOBJECT
 
     if ATTR_DEVICE not in config[DOMAIN]:
-        _LOGGER.exception(
-            "can found device parameter in %s YAML configuration section",
+        _LOGGER.error(
+            "can not find device parameter in %s YAML configuration section",
             DOMAIN
         )
         return False
 
     device = config[DOMAIN][ATTR_DEVICE]
     debug = config[DOMAIN].get(ATTR_DEBUG, False)
+    dummy_connection = config[DOMAIN].get(ATTR_DUMMY, False)
 
-    RFXOBJECT = rfxtrxmod.Core(device, handle_receive, debug=debug)
+    if dummy_connection:
+        RFXOBJECT =\
+            rfxtrxmod.Core(device, handle_receive, debug=debug,
+                           transport_protocol=rfxtrxmod.DummyTransport2)
+    else:
+        RFXOBJECT = rfxtrxmod.Core(device, handle_receive, debug=debug)
 
     return True
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -64,7 +64,7 @@ hikvision==0.4
 # http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
 
 # homeassistant.components.rfxtrx
-https://github.com/Danielhiversen/pyRFXtrx/archive/0.4.zip#pyRFXtrx==0.4
+https://github.com/Danielhiversen/pyRFXtrx/archive/master.zip#pyRFXtrx==0.5
 
 # homeassistant.components.sensor.netatmo
 https://github.com/HydrelioxGitHub/netatmo-api-python/archive/43ff238a0122b0939a0dc4e8836b6782913fb6e2.zip#lnetatmo==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -64,7 +64,7 @@ hikvision==0.4
 # http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
 
 # homeassistant.components.rfxtrx
-https://github.com/Danielhiversen/pyRFXtrx/archive/master.zip#pyRFXtrx==0.5
+https://github.com/Danielhiversen/pyRFXtrx/archive/0.5.zip#pyRFXtrx==0.5
 
 # homeassistant.components.sensor.netatmo
 https://github.com/HydrelioxGitHub/netatmo-api-python/archive/43ff238a0122b0939a0dc4e8836b6782913fb6e2.zip#lnetatmo==0.4.0

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -1,0 +1,266 @@
+"""
+tests.components.light.test_rfxtrx
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests Rfxtrx light.
+"""
+
+import unittest
+
+from homeassistant.components import rfxtrx as rfxtrx_core
+from homeassistant.components.light import rfxtrx
+from unittest.mock import patch
+
+from tests.common import get_test_home_assistant
+
+
+class TestLightRfxtrx(unittest.TestCase):
+    """ Test the Rfxtrx light. """
+
+    def setUp(self):
+        """ setup hass """
+        self.hass = get_test_home_assistant(0)
+
+    def tearDown(self):
+        """ Stop down stuff we started. """
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
+        rfxtrx_core.RFX_DEVICES = {}
+        self.hass.stop()
+
+    def test_default_config(self):
+        """ Test with 0 lights """
+        config = {'devices': {}}
+        devices = []
+
+        def add_dev_callback(devs):
+            """ callback to add device """
+            for dev in devs:
+                devices.append(dev)
+
+        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+        self.assertEqual(0, len(devices))
+
+    def test_one_sensor(self):
+        """ Test with 1 light """
+        config = {'devices':
+                  {'123efab1': {
+                      'name': 'Test',
+                      'packetid': '0b1100cd0213c7f210010f51'}}}
+        import RFXtrx as rfxtrxmod
+        rfxtrx_core.RFXOBJECT =\
+            rfxtrxmod.Core("", transport_protocol=rfxtrxmod.DummyTransport)
+
+        devices = []
+
+        def add_dev_callback(devs):
+            """ callback to add device """
+            for dev in devs:
+                devices.append(dev)
+
+        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+
+        self.assertEqual(1, len(devices))
+        entity = devices[0]
+        self.assertEqual('Test', entity.name)
+        self.assertEqual('off', entity.state)
+        self.assertTrue(entity.assumed_state)
+        self.assertEqual(entity.signal_repetitions, 1)
+        self.assertFalse(entity.should_fire_event)
+        self.assertFalse(entity.should_poll)
+
+        self.assertFalse(entity.is_on)
+        with patch('homeassistant.components.light.' +
+                   'rfxtrx.RfxtrxLight.update_ha_state',
+                   return_value=None):
+            entity.turn_on()
+        self.assertTrue(entity.is_on)
+        self.assertEqual(entity.brightness, 255)
+        with patch('homeassistant.components.light.' +
+                   'rfxtrx.RfxtrxLight.update_ha_state',
+                   return_value=None):
+            entity.turn_off()
+        self.assertFalse(entity.is_on)
+        self.assertEqual(entity.brightness, 0)
+        with patch('homeassistant.components.light.' +
+                   'rfxtrx.RfxtrxLight.update_ha_state',
+                   return_value=None):
+            entity.turn_on(brightness=100)
+        self.assertTrue(entity.is_on)
+        self.assertEqual(entity.brightness, 100)
+        with patch('homeassistant.components.light.' +
+                   'rfxtrx.RfxtrxLight.update_ha_state',
+                   return_value=None):
+            entity.turn_on(brightness=10)
+        self.assertTrue(entity.is_on)
+        self.assertEqual(entity.brightness, 10)
+        with patch('homeassistant.components.light.' +
+                   'rfxtrx.RfxtrxLight.update_ha_state',
+                   return_value=None):
+            entity.turn_on(brightness=255)
+        self.assertTrue(entity.is_on)
+        self.assertEqual(entity.brightness, 255)
+
+    def test_several_lights(self):
+        """ Test with 3 lights """
+        config = {'signal_repetitions': 3,
+                  'devices':
+                  {'123efab1': {
+                      'name': 'Test',
+                      'packetid': '0b1100cd0213c7f230010f71'},
+                   '118cdea2': {
+                       'name': 'Bath',
+                       'packetid': '0b1100100118cdea02010f70'},
+                   '213c7f216': {
+                       'name': 'Living',
+                       'packetid': '2b1121cd1213c7f211111f71'}}}
+        devices = []
+
+        def add_dev_callback(devs):
+            """ callback to add device """
+            for dev in devs:
+                devices.append(dev)
+
+        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+
+        self.assertEqual(3, len(devices))
+        device_num = 0
+        for entity in devices:
+            self.assertEqual(entity.signal_repetitions, 3)
+            if entity.name == 'Living':
+                device_num = device_num + 1
+                self.assertEqual('off', entity.state)
+                self.assertEqual('<Entity Living: off>', entity.__str__())
+            elif entity.name == 'Bath':
+                device_num = device_num + 1
+                self.assertEqual('off', entity.state)
+                self.assertEqual('<Entity Bath: off>', entity.__str__())
+            elif entity.name == 'Test':
+                device_num = device_num + 1
+                self.assertEqual('off', entity.state)
+                self.assertEqual('<Entity Test: off>', entity.__str__())
+
+        self.assertEqual(3, device_num)
+
+    def test_discover_light(self):
+        """ Test with discover of light """
+        config = {'automatic_add': True, 'devices': {}}
+        devices = []
+
+        def add_dev_callback(devs):
+            """ callback to add device """
+            for dev in devs:
+                devices.append(dev)
+
+        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+
+        event = rfxtrx_core.get_rfx_object('0b11009e00e6116202020070')
+        event.data = bytearray(b'\x0b\x11\x00\x9e\x00\xe6\x11b\x02\x02\x00p')
+        with patch('homeassistant.components.light.' +
+                   'rfxtrx.RfxtrxLight.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        entity = devices[0]
+        self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(1, len(devices))
+        self.assertEqual('<Entity 0e611622 : 0b11009e00e6116202020070: on>',
+                         entity.__str__())
+
+        event = rfxtrx_core.get_rfx_object('0b11009e00e6116201010070')
+        event.data = bytearray(b'\x0b\x11\x00\x9e\x00\xe6\x11b\x01\x01\x00p')
+        with patch('homeassistant.components.light.' +
+                   'rfxtrx.RfxtrxLight.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(1, len(devices))
+
+        event = rfxtrx_core.get_rfx_object('0b1100120118cdea02020070')
+        event.data = bytearray([0x0b, 0x11, 0x00, 0x12, 0x01, 0x18,
+                                0xcd, 0xea, 0x02, 0x02, 0x00, 0x70])
+        with patch('homeassistant.components.light.' +
+                   'rfxtrx.RfxtrxLight.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        entity = devices[1]
+        self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(2, len(devices))
+        self.assertEqual('<Entity 118cdea2 : 0b1100120118cdea02020070: on>',
+                         entity.__str__())
+
+        # trying to add a sensor
+        event = rfxtrx_core.get_rfx_object('0a52085e070100b31b0279')
+        event.data = bytearray(b'\nR\x08^\x07\x01\x00\xb3\x1b\x02y')
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(2, len(devices))
+
+        # trying to add a swicth
+        event = rfxtrx_core.get_rfx_object('0b1100100118cdea02010f70')
+        event.data = bytearray([0x0b, 0x11, 0x00, 0x10, 0x01, 0x18,
+                                0xcd, 0xea, 0x01, 0x01, 0x0f, 0x70])
+        with patch('homeassistant.components.light.' +
+                   'rfxtrx.RfxtrxLight.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(2, len(devices))
+
+    def test_discover_light_noautoadd(self):
+        """ Test with discover of light when auto add is False """
+        config = {'automatic_add': False, 'devices': {}}
+        devices = []
+
+        def add_dev_callback(devs):
+            """ callback to add device """
+            for dev in devs:
+                devices.append(dev)
+
+        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+
+        event = rfxtrx_core.get_rfx_object('0b1100120118cdea02020070')
+        event.data = bytearray([0x0b, 0x11, 0x00, 0x12, 0x01, 0x18,
+                                0xcd, 0xea, 0x02, 0x02, 0x00, 0x70])
+        with patch('homeassistant.components.light.' +
+                   'rfxtrx.RfxtrxLight.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(0, len(devices))
+
+        event = rfxtrx_core.get_rfx_object('0b1100120118cdea02010070')
+        event.data = bytearray([0x0b, 0x11, 0x00, 0x12, 0x01, 0x18,
+                                0xcd, 0xea, 0x02, 0x01, 0x00, 0x70])
+        with patch('homeassistant.components.light.' +
+                   'rfxtrx.RfxtrxLight.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(0, len(devices))
+
+        event = rfxtrx_core.get_rfx_object('0b1100120118cdea02020070')
+        event.data = bytearray([0x0b, 0x11, 0x00, 0x12, 0x01, 0x18,
+                                0xcd, 0xea, 0x02, 0x02, 0x00, 0x70])
+        with patch('homeassistant.components.light.' +
+                   'rfxtrx.RfxtrxLight.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(0, len(devices))
+
+        # trying to add a sensor
+        event = rfxtrx_core.get_rfx_object('0a52085e070100b31b0279')
+        event.data = bytearray(b'\nR\x08^\x07\x01\x00\xb3\x1b\x02y')
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(0, len(devices))
+
+        # trying to add a switch
+        event = rfxtrx_core.get_rfx_object('0b1100100118cdea02010f70')
+        event.data = bytearray([0x0b, 0x11, 0x00, 0x10, 0x01, 0x18,
+                                0xcd, 0xea, 0x01, 0x01, 0x0f, 0x70])
+        with patch('homeassistant.components.light.' +
+                   'rfxtrx.RfxtrxLight.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(0, len(devices))

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -1,0 +1,242 @@
+"""
+tests.components.switch.test_rfxtrx
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests Rfxtrx switch.
+"""
+
+import unittest
+
+from homeassistant.components import rfxtrx as rfxtrx_core
+from homeassistant.components.switch import rfxtrx
+from unittest.mock import patch
+
+from tests.common import get_test_home_assistant
+
+
+class TestSwitchRfxtrx(unittest.TestCase):
+    """ Test the Rfxtrx switch. """
+
+    def setUp(self):
+        """ setup hass """
+        self.hass = get_test_home_assistant(0)
+
+    def tearDown(self):
+        """ Stop down stuff we started. """
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
+        rfxtrx_core.RFX_DEVICES = {}
+        self.hass.stop()
+
+    def test_default_config(self):
+        """ Test with 0 switchs """
+        config = {'devices': {}}
+        devices = []
+
+        def add_dev_callback(devs):
+            """ callback to add device """
+            for dev in devs:
+                devices.append(dev)
+
+        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+        self.assertEqual(0, len(devices))
+
+    def test_one_sensor(self):
+        """ Test with 1 switch """
+        config = {'devices':
+                  {'123efab1': {
+                      'name': 'Test',
+                      'packetid': '0b1100cd0213c7f210010f51'}}}
+        import RFXtrx as rfxtrxmod
+        rfxtrx_core.RFXOBJECT =\
+            rfxtrxmod.Core("", transport_protocol=rfxtrxmod.DummyTransport)
+
+        devices = []
+
+        def add_dev_callback(devs):
+            """ callback to add device """
+            for dev in devs:
+                devices.append(dev)
+
+        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+
+        self.assertEqual(1, len(devices))
+        entity = devices[0]
+        self.assertEqual('Test', entity.name)
+        self.assertEqual('off', entity.state)
+        self.assertTrue(entity.assumed_state)
+        self.assertEqual(entity.signal_repetitions, 1)
+        self.assertFalse(entity.should_fire_event)
+        self.assertFalse(entity.should_poll)
+
+        self.assertFalse(entity.is_on)
+        with patch('homeassistant.components.switch.' +
+                   'rfxtrx.RfxtrxSwitch.update_ha_state',
+                   return_value=None):
+            entity.turn_on()
+        self.assertTrue(entity.is_on)
+        with patch('homeassistant.components.switch.' +
+                   'rfxtrx.RfxtrxSwitch.update_ha_state',
+                   return_value=None):
+            entity.turn_off()
+        self.assertFalse(entity.is_on)
+
+    def test_several_switchs(self):
+        """ Test with 3 switchs """
+        config = {'signal_repetitions': 3,
+                  'devices':
+                  {'123efab1': {
+                      'name': 'Test',
+                      'packetid': '0b1100cd0213c7f230010f71'},
+                   '118cdea2': {
+                       'name': 'Bath',
+                       'packetid': '0b1100100118cdea02010f70'},
+                   '213c7f216': {
+                       'name': 'Living',
+                       'packetid': '2b1121cd1213c7f211111f71'}}}
+        devices = []
+
+        def add_dev_callback(devs):
+            """ callback to add device """
+            for dev in devs:
+                devices.append(dev)
+
+        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+
+        self.assertEqual(3, len(devices))
+        device_num = 0
+        for entity in devices:
+            self.assertEqual(entity.signal_repetitions, 3)
+            if entity.name == 'Living':
+                device_num = device_num + 1
+                self.assertEqual('off', entity.state)
+                self.assertEqual('<Entity Living: off>', entity.__str__())
+            elif entity.name == 'Bath':
+                device_num = device_num + 1
+                self.assertEqual('off', entity.state)
+                self.assertEqual('<Entity Bath: off>', entity.__str__())
+            elif entity.name == 'Test':
+                device_num = device_num + 1
+                self.assertEqual('off', entity.state)
+                self.assertEqual('<Entity Test: off>', entity.__str__())
+
+        self.assertEqual(3, device_num)
+
+    def test_discover_switch(self):
+        """ Test with discover of switch """
+        config = {'automatic_add': True, 'devices': {}}
+        devices = []
+
+        def add_dev_callback(devs):
+            """ callback to add device """
+            for dev in devs:
+                devices.append(dev)
+
+        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+
+        event = rfxtrx_core.get_rfx_object('0b1100100118cdea02010f70')
+        event.data = bytearray([0x0b, 0x11, 0x00, 0x10, 0x01, 0x18,
+                                0xcd, 0xea, 0x01, 0x01, 0x0f, 0x70])
+        with patch('homeassistant.components.switch.' +
+                   'rfxtrx.RfxtrxSwitch.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        entity = devices[0]
+        self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(1, len(devices))
+        self.assertEqual('<Entity 118cdea2 : 0b1100100118cdea01010f70: on>',
+                         entity.__str__())
+
+        with patch('homeassistant.components.switch.' +
+                   'rfxtrx.RfxtrxSwitch.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(1, len(devices))
+
+        event = rfxtrx_core.get_rfx_object('0b1100100118cdeb02010f70')
+        event.data = bytearray([0x0b, 0x11, 0x00, 0x12, 0x01, 0x18,
+                                0xcd, 0xea, 0x02, 0x00, 0x00, 0x70])
+        with patch('homeassistant.components.switch.' +
+                   'rfxtrx.RfxtrxSwitch.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        entity = devices[1]
+        self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(2, len(devices))
+        self.assertEqual('<Entity 118cdeb2 : 0b1100120118cdea02000070: on>',
+                         entity.__str__())
+
+        # trying to add a sensor
+        event = rfxtrx_core.get_rfx_object('0a52085e070100b31b0279')
+        event.data = bytearray(b'\nR\x08^\x07\x01\x00\xb3\x1b\x02y')
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(2, len(devices))
+
+        # trying to add a light
+        event = rfxtrx_core.get_rfx_object('0b1100100118cdea02010f70')
+        event.data = bytearray([0x0b, 0x11, 0x11, 0x10, 0x01, 0x18,
+                                0xcd, 0xea, 0x01, 0x02, 0x0f, 0x70])
+        with patch('homeassistant.components.switch.' +
+                   'rfxtrx.RfxtrxSwitch.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(2, len(devices))
+
+    def test_discover_switch_noautoadd(self):
+        """ Test with discover of switch when auto add is False """
+        config = {'automatic_add': False, 'devices': {}}
+        devices = []
+
+        def add_dev_callback(devs):
+            """ callback to add device """
+            for dev in devs:
+                devices.append(dev)
+
+        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+
+        event = rfxtrx_core.get_rfx_object('0b1100100118cdea02010f70')
+        event.data = bytearray([0x0b, 0x11, 0x00, 0x10, 0x01, 0x18,
+                                0xcd, 0xea, 0x01, 0x01, 0x0f, 0x70])
+        with patch('homeassistant.components.switch.' +
+                   'rfxtrx.RfxtrxSwitch.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(0, len(devices))
+
+        with patch('homeassistant.components.switch.' +
+                   'rfxtrx.RfxtrxSwitch.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(0, len(devices))
+
+        event = rfxtrx_core.get_rfx_object('0b1100100118cdeb02010f70')
+        event.data = bytearray([0x0b, 0x11, 0x00, 0x12, 0x01, 0x18,
+                                0xcd, 0xea, 0x02, 0x00, 0x00, 0x70])
+        with patch('homeassistant.components.switch.' +
+                   'rfxtrx.RfxtrxSwitch.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(0, len(devices))
+
+        # trying to add a sensor
+        event = rfxtrx_core.get_rfx_object('0a52085e070100b31b0279')
+        event.data = bytearray(b'\nR\x08^\x07\x01\x00\xb3\x1b\x02y')
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(0, len(devices))
+
+        # trying to add a light
+        event = rfxtrx_core.get_rfx_object('0b1100100118cdea02010f70')
+        event.data = bytearray([0x0b, 0x11, 0x11, 0x10, 0x01,
+                                0x18, 0xcd, 0xea, 0x01, 0x02, 0x0f, 0x70])
+        with patch('homeassistant.components.switch.' +
+                   'rfxtrx.RfxtrxSwitch.update_ha_state',
+                   return_value=None):
+            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(0, len(devices))

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -1,0 +1,60 @@
+"""
+tests.components.test_rfxtrx
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests Rfxtrx component.
+"""
+# pylint: disable=too-many-public-methods,protected-access
+import unittest
+import time
+
+from homeassistant.components import rfxtrx as rfxtrx
+from homeassistant.components.sensor import rfxtrx as rfxtrx_sensor
+
+from tests.common import get_test_home_assistant
+
+
+class TestSun(unittest.TestCase):
+    """ Test the sun module. """
+
+    def setUp(self):
+        """ setup hass """
+        self.hass = get_test_home_assistant(0)
+
+    def tearDown(self):
+        """ Stop down stuff we started. """
+        rfxtrx.RECEIVED_EVT_SUBSCRIBERS = []
+        rfxtrx.RFX_DEVICES = {}
+        rfxtrx.RFXOBJECT = None
+        self.hass.stop()
+
+    def test_default_config(self):
+        """ Test config """
+        self.assertTrue(rfxtrx.setup(self.hass, {
+            'rfxtrx': {
+                'device': '/dev/serial/by-id/usb' +
+                          '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
+                'dummy': True}
+        }))
+
+        config = {'devices': {}}
+        devices = []
+
+        def add_dev_callback(devs):
+            """ callback to add device """
+            for dev in devs:
+                devices.append(dev)
+
+        rfxtrx_sensor.setup_platform(self.hass, config, add_dev_callback)
+
+        while len(rfxtrx.RFX_DEVICES) < 2:
+            time.sleep(0.1)
+
+        self.assertEquals(len(rfxtrx.RFXOBJECT.sensors()), 2)
+        self.assertEquals(len(devices), 2)
+
+    def test_config_failing(self):
+        """ Test config """
+        self.assertFalse(rfxtrx.setup(self.hass, {
+            'rfxtrx': {}
+        }))


### PR DESCRIPTION
**Description:**
- Adding tests for the rfxtrx component, light and switch
- Fixed a bug in setting the brightness
- Update to latest version of the rfxtrx library. 

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [x] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
