### PR TITLE
Fix broken protobuf==3.0.0b2.post1 requirement for cast

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -18,7 +18,8 @@ from homeassistant.const import (
     CONF_HOST, STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING,
     STATE_UNKNOWN)
 
-REQUIREMENTS = ['pychromecast==0.7.1']
+REQUIREMENTS = ['pychromecast==0.7.1',
+                'protobuf==3.0.0b2']  # 3.0.0b2post1 is broken
 CONF_IGNORE_CEC = 'ignore_cec'
 CAST_SPLASH = 'https://home-assistant.io/images/cast/splash.png'
 SUPPORT_CAST = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -139,6 +139,9 @@ plexapi==1.1.0
 # homeassistant.components.thermostat.proliphix
 proliphix==0.1.0
 
+# homeassistant.components.media_player.cast
+protobuf==3.0.0b2
+
 # homeassistant.components.sensor.systemmonitor
 psutil==4.0.0
 


### PR DESCRIPTION
**Description:**
Protobuf package is breaking us.

**Related issue (if applicable):** #1469

The protobuf==3.0.0b2.post1 package apparently breaks us, so this
pins the version (which is pulled in from pychromecast to the version
that was working for us before.
