### PR TITLE
Add Wemo Motion device as a binary sensor.

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -10,7 +10,7 @@ import logging
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (STATE_ON, STATE_OFF)
-from homeassistant.components import (bloomsky, mysensors, zwave, wink)
+from homeassistant.components import (bloomsky, mysensors, zwave, wemo, wink)
 
 DOMAIN = 'binary_sensor'
 SCAN_INTERVAL = 30
@@ -38,6 +38,7 @@ DISCOVERY_PLATFORMS = {
     bloomsky.DISCOVER_BINARY_SENSORS: 'bloomsky',
     mysensors.DISCOVER_BINARY_SENSORS: 'mysensors',
     zwave.DISCOVER_BINARY_SENSORS: 'zwave',
+    wemo.DISCOVER_BINARY_SENSORS: 'wemo',
     wink.DISCOVER_BINARY_SENSORS: 'wink'
 }
 

--- a/homeassistant/components/binary_sensor/wemo.py
+++ b/homeassistant/components/binary_sensor/wemo.py
@@ -1,0 +1,75 @@
+"""
+Support for WeMo sensors.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.wemo/
+"""
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.loader import get_component
+
+DEPENDENCIES = ['wemo']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=unused-argument, too-many-function-args
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Register discovered WeMo binary sensors."""
+    import pywemo.discovery as discovery
+
+    if discovery_info is not None:
+        location = discovery_info[2]
+        mac = discovery_info[3]
+        device = discovery.device_from_description(location, mac)
+
+        if device:
+            add_devices_callback([WemoBinarySensor(device)])
+
+
+class WemoBinarySensor(BinarySensorDevice):
+    """Represents a WeMo binary sensor."""
+
+    def __init__(self, device):
+        """Initialize the WeMo sensor."""
+        self.wemo = device
+        self._state = None
+
+        wemo = get_component('wemo')
+        wemo.SUBSCRIPTION_REGISTRY.register(self.wemo)
+        wemo.SUBSCRIPTION_REGISTRY.on(self.wemo, None, self._update_callback)
+
+    def _update_callback(self, _device, _params):
+        """Called by the wemo device callback to update state."""
+        _LOGGER.info(
+            'Subscription update for  %s',
+            _device)
+        self.update_ha_state(True)
+
+    @property
+    def should_poll(self):
+        """No polling needed with subscriptions."""
+        return False
+
+    @property
+    def unique_id(self):
+        """Return the id of this WeMo device."""
+        return "{}.{}".format(self.__class__, self.wemo.serialnumber)
+
+    @property
+    def name(self):
+        """Return the name of the sevice if any."""
+        return self.wemo.name
+
+    @property
+    def is_on(self):
+        """True if sensor is on."""
+        return self._state
+
+    def update(self):
+        """Update WeMo state."""
+        try:
+            self._state = self.wemo.get_state(True)
+        except AttributeError:
+            _LOGGER.warning('Could not update status for %s', self.name)

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -15,7 +15,7 @@ REQUIREMENTS = ['pywemo==0.3.12']
 
 DOMAIN = 'wemo'
 DISCOVER_LIGHTS = 'wemo.light'
-DISCOVER_MOTION = 'wemo.motion'
+DISCOVER_BINARY_SENSORS = 'wemo.binary_sensor'
 DISCOVER_SWITCHES = 'wemo.switch'
 
 # mapping from Wemo model_name to service
@@ -23,13 +23,13 @@ WEMO_MODEL_DISPATCH = {
     'Bridge':  DISCOVER_LIGHTS,
     'Insight': DISCOVER_SWITCHES,
     'Maker':   DISCOVER_SWITCHES,
-    'Motion':  DISCOVER_MOTION,
+    'Sensor':  DISCOVER_BINARY_SENSORS,
     'Socket':  DISCOVER_SWITCHES,
     'LightSwitch': DISCOVER_SWITCHES
 }
 WEMO_SERVICE_DISPATCH = {
     DISCOVER_LIGHTS: 'light',
-    DISCOVER_MOTION: 'binary_sensor',
+    DISCOVER_BINARY_SENSORS: 'binary_sensor',
     DISCOVER_SWITCHES: 'switch',
 }
 


### PR DESCRIPTION
This PR add the Wemo Motion device, as a HA binary sensor.

No changes to `configuration.yaml` - can be discovered using `discovery` or statically as with other wemo components.

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - No new requirements
  - [x] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
