### PR TITLE
Add assumed state for Tellstick devices.

### DIFF
--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -125,3 +125,8 @@ class TellstickLight(Light):
     def should_poll(self):
         """ Tells Home Assistant not to poll this entity. """
         return False
+
+    @property
+    def assumed_state(self):
+        """  Tellstick devices are always assumed state """
+        return True

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -73,6 +73,11 @@ class TellstickSwitchDevice(ToggleEntity):
         return False
 
     @property
+    def assumed_state(self):
+        """  Tellstick devices are always assumed state """
+        return True
+
+    @property
     def name(self):
         """ Returns the name of the switch if any. """
         return self.tellstick_device.name


### PR DESCRIPTION
**Description:**
Adde assumed state to the tellstick platform

**Related issue (if applicable):** 
#1263

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).

Tellstick device states are always assumed so this should be set to true.
