### PR TITLE
Added throttle to turn_on/off methods

### DIFF
--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -6,11 +6,14 @@ Support for Tellstick lights.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.tellstick/
 """
+from datetime import timedelta
 from homeassistant.components.light import ATTR_BRIGHTNESS, Light
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.util import Throttle
 
 REQUIREMENTS = ['tellcore-py==1.1.2']
 SIGNAL_REPETITIONS = 1
+MIN_TIME_BETWEEN_CALLS = timedelta(seconds=0.5)
 
 
 # pylint: disable=unused-argument
@@ -83,6 +86,7 @@ class TellstickLight(Light):
         """ Brightness of this light between 0..255. """
         return self._brightness
 
+    @Throttle(MIN_TIME_BETWEEN_CALLS)
     def turn_off(self, **kwargs):
         """ Turns the switch off. """
         for _ in range(self.signal_repetitions):
@@ -90,6 +94,7 @@ class TellstickLight(Light):
         self._brightness = 0
         self.update_ha_state()
 
+    @Throttle(MIN_TIME_BETWEEN_CALLS)
     def turn_on(self, **kwargs):
         """ Turns the switch on. """
         brightness = kwargs.get(ATTR_BRIGHTNESS)

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -8,10 +8,14 @@ https://home-assistant.io/components/switch.tellstick/
 """
 import logging
 
+from datetime import timedelta
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.util import Throttle
+
 
 SIGNAL_REPETITIONS = 1
+MIN_TIME_BETWEEN_CALLS = timedelta(seconds=0.5)
 REQUIREMENTS = ['tellcore-py==1.1.2']
 _LOGGER = logging.getLogger(__name__)
 
@@ -92,12 +96,14 @@ class TellstickSwitchDevice(ToggleEntity):
 
         return last_command == tellcore_constants.TELLSTICK_TURNON
 
+    @Throttle(MIN_TIME_BETWEEN_CALLS)
     def turn_on(self, **kwargs):
         """ Turns the switch on. """
         for _ in range(self.signal_repetitions):
             self.tellstick_device.turn_on()
         self.update_ha_state()
 
+    @Throttle(MIN_TIME_BETWEEN_CALLS)
     def turn_off(self, **kwargs):
         """ Turns the switch off. """
         for _ in range(self.signal_repetitions):


### PR DESCRIPTION
**Description:**
When calling the backend lib/device too fast I got an error (-6) that the device was unavailable. 
By throttling the calls everything works as expected.
- [x] Local tests with `tox` run successfully.
- [ ] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
