### PR TITLE
History: update significant states

### DIFF
--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -19,6 +19,7 @@ DOMAIN = 'history'
 DEPENDENCIES = ['recorder', 'http']
 
 SIGNIFICANT_DOMAINS = ('thermostat',)
+IGNORE_DOMAINS = ('zone', 'scene',)
 
 URL_HISTORY_PERIOD = re.compile(
     r'/api/history/period(?:/(?P<date>\d{4}-\d{1,2}-\d{1,2})|)')
@@ -46,9 +47,10 @@ def get_significant_states(start_time, end_time=None, entity_id=None):
 
     """
     where = """
-        (domain in ({}) or last_changed=last_updated)
-        AND last_updated > ?
-    """.format(",".join(["'%s'" % x for x in SIGNIFICANT_DOMAINS]))
+        (domain IN ({}) OR last_changed=last_updated)
+        AND domain NOT IN ({}) AND last_updated > ?
+    """.format(",".join("'%s'" % x for x in SIGNIFICANT_DOMAINS),
+               ",".join("'%s'" % x for x in IGNORE_DOMAINS))
 
     data = [start_time]
 

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -148,7 +148,7 @@ class TestComponentHistory(unittest.TestCase):
         """test that only significant states are returned with
         get_significant_states.
 
-        We inject a bunch of state updates from media player and
+        We inject a bunch of state updates from media player, zone and
         thermostat. We should get back every thermostat change that
         includes an attribute change, but only the state updates for
         media player (attribute changes are not significant and not returned).
@@ -157,6 +157,7 @@ class TestComponentHistory(unittest.TestCase):
         self.init_recorder()
         mp = 'media_player.test'
         therm = 'thermostat.test'
+        zone = 'zone.home'
 
         def set_state(entity_id, state, **kwargs):
             self.hass.states.set(entity_id, state, **kwargs)
@@ -186,6 +187,8 @@ class TestComponentHistory(unittest.TestCase):
             # this state will be skipped only different in time
             set_state(mp, 'YouTube',
                       attributes={'media_title': str(sentinel.mt3)})
+            # this state will be skipped because domain blacklisted
+            set_state(zone, 'zoning')
             states[therm].append(
                 set_state(therm, 21, attributes={'current_temperature': 19.8}))
 
@@ -199,4 +202,4 @@ class TestComponentHistory(unittest.TestCase):
                 set_state(therm, 21, attributes={'current_temperature': 20}))
 
         hist = history.get_significant_states(zero, four)
-        self.assertEqual(states, hist)
+        assert states == hist

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -158,6 +158,8 @@ class TestComponentHistory(unittest.TestCase):
         mp = 'media_player.test'
         therm = 'thermostat.test'
         zone = 'zone.home'
+        script_nc = 'script.cannot_cancel_this_one'
+        script_c = 'script.can_cancel_this_one'
 
         def set_state(entity_id, state, **kwargs):
             self.hass.states.set(entity_id, state, **kwargs)
@@ -170,7 +172,7 @@ class TestComponentHistory(unittest.TestCase):
         three = two + timedelta(seconds=1)
         four = three + timedelta(seconds=1)
 
-        states = {therm: [], mp: []}
+        states = {therm: [], mp: [], script_c: []}
         with patch('homeassistant.components.recorder.dt_util.utcnow',
                    return_value=one):
             states[mp].append(
@@ -189,6 +191,9 @@ class TestComponentHistory(unittest.TestCase):
                       attributes={'media_title': str(sentinel.mt3)})
             # this state will be skipped because domain blacklisted
             set_state(zone, 'zoning')
+            set_state(script_nc, 'off')
+            states[script_c].append(
+                set_state(script_c, 'off', attributes={'can_cancel': True}))
             states[therm].append(
                 set_state(therm, 21, attributes={'current_temperature': 19.8}))
 


### PR DESCRIPTION
**Description:**
Our history tab is returning states for entities that are never changing (scenes, zones). These will now be hidden if querying for significant states.

Then there are scripts that _sometimes_ never change (if they cannot be cancelled). As we currently cannot filter states in the DB based on attributes, we will filter those in memory.

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
