### PR TITLE
Synchronized tellcore calls

### DIFF
--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -7,13 +7,15 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.tellstick/
 """
 from datetime import timedelta
+import logging
 from homeassistant.components.light import ATTR_BRIGHTNESS, Light
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
-from homeassistant.util import Throttle
+from homeassistant.util import Synchronized
 
 REQUIREMENTS = ['tellcore-py==1.1.2']
 SIGNAL_REPETITIONS = 1
 MIN_TIME_BETWEEN_CALLS = timedelta(seconds=0.5)
+_LOGGER = logging.getLogger(__name__)
 
 
 # pylint: disable=unused-argument
@@ -38,8 +40,9 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         """ Called from the TelldusCore library to update one device """
         for light_device in lights:
             if light_device.tellstick_device.id == id_:
-                # Execute the update in another thread
-                light_device.update_ha_state(True)
+                # We got the current values so set state directly.
+                light_device.set_state(method, data)
+                light_device.update_ha_state()
                 break
 
     callback_id = core.register_device_event(_device_event_callback)
@@ -66,9 +69,7 @@ class TellstickLight(Light):
 
         self.last_sent_command_mask = (tellcore_constants.TELLSTICK_TURNON |
                                        tellcore_constants.TELLSTICK_TURNOFF |
-                                       tellcore_constants.TELLSTICK_DIM |
-                                       tellcore_constants.TELLSTICK_UP |
-                                       tellcore_constants.TELLSTICK_DOWN)
+                                       tellcore_constants.TELLSTICK_DIM)
         self.update()
 
     @property
@@ -86,15 +87,10 @@ class TellstickLight(Light):
         """ Brightness of this light between 0..255. """
         return self._brightness
 
-    @Throttle(MIN_TIME_BETWEEN_CALLS)
     def turn_off(self, **kwargs):
         """ Turns the switch off. """
-        for _ in range(self.signal_repetitions):
-            self.tellstick_device.turn_off()
-        self._brightness = 0
-        self.update_ha_state()
+        self._call_light(0)
 
-    @Throttle(MIN_TIME_BETWEEN_CALLS)
     def turn_on(self, **kwargs):
         """ Turns the switch on. """
         brightness = kwargs.get(ATTR_BRIGHTNESS)
@@ -104,27 +100,53 @@ class TellstickLight(Light):
         else:
             self._brightness = brightness
 
-        for _ in range(self.signal_repetitions):
-            self.tellstick_device.dim(self._brightness)
-        self.update_ha_state()
+        self._call_light(self._brightness)
 
+    @Synchronized(True)
+    def _call_light(self, brightness):
+        from tellcore.library import TelldusError
+        try:
+            for _ in range(self.signal_repetitions):
+                if brightness == 0:
+                    self.tellstick_device.turn_off()
+                else:
+                    self.tellstick_device.dim(brightness)
+            self._brightness = brightness
+            self.update_ha_state()
+        except TelldusError:
+            _LOGGER.error(TelldusError)
+
+    @Synchronized(True)
     def update(self):
         """ Update state of the light. """
         import tellcore.constants as tellcore_constants
+        from tellcore.library import TelldusError
 
-        last_command = self.tellstick_device.last_sent_command(
-            self.last_sent_command_mask)
+        try:
+            last_command = self.tellstick_device.last_sent_command(
+                self.last_sent_command_mask)
+            last_sent_value = (None if last_command !=
+                               tellcore_constants.TELLSTICK_DIM else
+                               self.tellstick_device.last_sent_value())
+            self.set_state(last_command, last_sent_value)
+        except TelldusError:
+            _LOGGER.error(TelldusError)
 
+    def set_state(self, last_command, last_sent_value):
+        """
+        Sets the state depending on last command sent
+        :param last_command:
+        :param last_sent_value:
+        :return:
+        """
+        import tellcore.constants as tellcore_constants
         if last_command == tellcore_constants.TELLSTICK_TURNON:
             self._brightness = 255
         elif last_command == tellcore_constants.TELLSTICK_TURNOFF:
             self._brightness = 0
-        elif (last_command == tellcore_constants.TELLSTICK_DIM or
-              last_command == tellcore_constants.TELLSTICK_UP or
-              last_command == tellcore_constants.TELLSTICK_DOWN):
-            last_sent_value = self.tellstick_device.last_sent_value()
-            if last_sent_value is not None:
-                self._brightness = last_sent_value
+        elif (last_sent_value is not None and
+              last_command == tellcore_constants.TELLSTICK_DIM):
+            self._brightness = last_sent_value
 
     @property
     def should_poll(self):

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -6,11 +6,14 @@ Support for Tellstick lights.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.tellstick/
 """
+from datetime import timedelta
 from homeassistant.components.light import ATTR_BRIGHTNESS, Light
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.util import Throttle
 
 REQUIREMENTS = ['tellcore-py==1.1.2']
 SIGNAL_REPETITIONS = 1
+MIN_TIME_BETWEEN_CALLS = timedelta(seconds=0.5)
 
 
 # pylint: disable=unused-argument
@@ -83,6 +86,7 @@ class TellstickLight(Light):
         """ Brightness of this light between 0..255. """
         return self._brightness
 
+    @Throttle(MIN_TIME_BETWEEN_CALLS)
     def turn_off(self, **kwargs):
         """ Turns the switch off. """
         for _ in range(self.signal_repetitions):
@@ -90,6 +94,7 @@ class TellstickLight(Light):
         self._brightness = 0
         self.update_ha_state()
 
+    @Throttle(MIN_TIME_BETWEEN_CALLS)
     def turn_on(self, **kwargs):
         """ Turns the switch on. """
         brightness = kwargs.get(ATTR_BRIGHTNESS)

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -8,10 +8,14 @@ https://home-assistant.io/components/switch.tellstick/
 """
 import logging
 
+from datetime import timedelta
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.util import Throttle
+
 
 SIGNAL_REPETITIONS = 1
+MIN_TIME_BETWEEN_CALLS = timedelta(seconds=0.5)
 REQUIREMENTS = ['tellcore-py==1.1.2']
 _LOGGER = logging.getLogger(__name__)
 
@@ -92,12 +96,14 @@ class TellstickSwitchDevice(ToggleEntity):
 
         return last_command == tellcore_constants.TELLSTICK_TURNON
 
+    @Throttle(MIN_TIME_BETWEEN_CALLS)
     def turn_on(self, **kwargs):
         """ Turns the switch on. """
         for _ in range(self.signal_repetitions):
             self.tellstick_device.turn_on()
         self.update_ha_state()
 
+    @Throttle(MIN_TIME_BETWEEN_CALLS)
     def turn_off(self, **kwargs):
         """ Turns the switch off. """
         for _ in range(self.signal_repetitions):

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -11,8 +11,7 @@ import logging
 from datetime import timedelta
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.entity import ToggleEntity
-from homeassistant.util import Throttle
-
+from homeassistant.util import Synchronized
 
 SIGNAL_REPETITIONS = 1
 MIN_TIME_BETWEEN_CALLS = timedelta(seconds=0.5)
@@ -42,9 +41,14 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     def _device_event_callback(id_, method, data, cid):
         """ Called from the TelldusCore library to update one device """
+
         for switch_device in switches:
             if switch_device.tellstick_device.id == id_:
-                switch_device.update_ha_state()
+                # Set state directly,
+                # Don't want to call update to prevent deadlocks
+                switch_device.set_switch_state(
+                    method == tellcore_constants.TELLSTICK_TURNON
+                )
                 break
 
     callback_id = core.register_device_event(_device_event_callback)
@@ -67,9 +71,12 @@ class TellstickSwitchDevice(ToggleEntity):
 
         self.tellstick_device = tellstick_device
         self.signal_repetitions = signal_repetitions
-
         self.last_sent_command_mask = (tellcore_constants.TELLSTICK_TURNON |
                                        tellcore_constants.TELLSTICK_TURNOFF)
+
+        self._state = False
+        # Query tellcore for the current state
+        self.update()
 
     @property
     def should_poll(self):
@@ -88,24 +95,42 @@ class TellstickSwitchDevice(ToggleEntity):
 
     @property
     def is_on(self):
-        """ True if switch is on. """
-        import tellcore.constants as tellcore_constants
+        return self._state
 
-        last_command = self.tellstick_device.last_sent_command(
-            self.last_sent_command_mask)
-
-        return last_command == tellcore_constants.TELLSTICK_TURNON
-
-    @Throttle(MIN_TIME_BETWEEN_CALLS)
     def turn_on(self, **kwargs):
         """ Turns the switch on. """
-        for _ in range(self.signal_repetitions):
-            self.tellstick_device.turn_on()
-        self.update_ha_state()
+        self._call_switch(True)
 
-    @Throttle(MIN_TIME_BETWEEN_CALLS)
     def turn_off(self, **kwargs):
         """ Turns the switch off. """
-        for _ in range(self.signal_repetitions):
-            self.tellstick_device.turn_off()
+        self._call_switch(False)
+
+    def set_switch_state(self, is_on):
+        """ Sets the private switch state """
+        self._state = is_on
         self.update_ha_state()
+
+    @Synchronized(True)
+    def _call_switch(self, turn_on):
+        from tellcore.library import TelldusError
+        try:
+            for _ in range(self.signal_repetitions):
+                if turn_on:
+                    self.tellstick_device.turn_on()
+                else:
+                    self.tellstick_device.turn_off()
+            self.set_switch_state(turn_on)
+        except TelldusError:
+            _LOGGER.error(TelldusError)
+
+    @Synchronized(True)
+    def update(self):
+        """ Update state of the switch. """
+        import tellcore.constants as tellcore_constants
+        from tellcore.library import TelldusError
+        try:
+            last_command = self.tellstick_device.last_sent_command(
+                self.last_sent_command_mask)
+            self._state = last_command == tellcore_constants.TELLSTICK_TURNON
+        except TelldusError:
+            _LOGGER.error(TelldusError)


### PR DESCRIPTION
**Description:**
Added the Synchronized decorator to all tellcore calls
This fixes a problem with lights/switches not receiving an update when calling multiple devices too fast.
There is still a problem, that I suspect already existed.
When externally changing just the brightness, the off to on state is not updated, cant figure out why this is not working. Calling turn_on/turn_off works as expected.

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [ ] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
