### PR TITLE
Nuimo component first draft

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -66,6 +66,8 @@ omit =
     homeassistant/components/scsgate.py
     homeassistant/components/*/scsgate.py
 
+    homeassistant/components/nuimo.py
+
     homeassistant/components/binary_sensor/arest.py
     homeassistant/components/binary_sensor/rest.py
     homeassistant/components/browser.py

--- a/homeassistant/components/nuimo.py
+++ b/homeassistant/components/nuimo.py
@@ -1,0 +1,157 @@
+"""
+Component that connects to a Bluetooth reachable Nuimo device.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/nuimo/
+"""
+from logging import getLogger
+import threading
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.helpers import validate_config
+
+REQUIREMENTS = [
+    'https://github.com/shaftoe/nuimo-raspberrypi-demo/archive/'
+    'pip.zip#nuimocore==0.0.1',
+    'https://github.com/IanHarvey/bluepy/archive/master.zip#bluepy==1.0.3']
+
+_LOGGER = getLogger(__name__)
+
+DOMAIN = "nuimo"
+ENTITY_ID = "{}.nuimo_battery".format(DOMAIN)
+EVENT_NUIMO = "nuimo_action"
+
+
+class NuimoDelegate(object):  # pylint: disable=too-few-public-methods
+    """Translate Nuimo bluetooth messages into HASS events."""
+
+    def __init__(self, hass, nuimo):
+        """Initialize nuimo delegate object."""
+        self._nuimo = nuimo
+        self._hass = hass
+
+    # pylint: disable=invalid-name
+    def handleNotification(self, c_handle, data):
+        """Listen for notifications and send them into bus or states."""
+        if int(c_handle) == self._nuimo.characteristicValueHandles['BATTERY']:
+            self._hass.states.set(ENTITY_ID, data[0])
+        elif int(c_handle) == self._nuimo.characteristicValueHandles['FLY']:
+            self._hass.bus.fire(EVENT_NUIMO, {
+                'action': 'FLY',
+                'value0': data[0],
+                'value1': data[1],
+            })
+        elif int(c_handle) == self._nuimo.characteristicValueHandles['SWIPE']:
+            self._hass.bus.fire(EVENT_NUIMO,
+                                {'action': 'SWIPE', 'value': data[0]})
+        elif int(c_handle) == \
+                self._nuimo.characteristicValueHandles['ROTATION']:
+            _LOGGER.warning('ROTATION not implemented in Python v3')
+        elif int(c_handle) == self._nuimo.characteristicValueHandles['BUTTON']:
+            self._hass.bus.fire(EVENT_NUIMO,
+                                {'action': 'BUTTON', 'value': data[0]})
+
+
+class NuimoManager(threading.Thread):
+    """Manage Nuimo process."""
+
+    def __init__(self, hass, mac):
+        """Initialize Nuimo manager object."""
+        super(NuimoManager, self).__init__()
+        self._hass = hass
+        self._mac = mac
+        self._hass_is_running = True
+        self._listener = None
+
+        from nuimocore import Nuimo
+        self._nuimo = Nuimo(mac)
+        self._nuimo.set_delegate(NuimoDelegate(self._hass, self._nuimo))
+
+    def connect(self):
+        """Try to connect to Nuimo, return False if connection failed."""
+        from nuimocore import BTLEException
+        try:
+            _LOGGER.info('Trying to connect to Nuimo (MAC %s)...', self._mac)
+            self._nuimo.connect()
+        except BTLEException:
+            _LOGGER.error("""Failed to connect to Nuimo (MAC %s). Make sure to:
+1. Disable the Bluetooth device: hciconfig hci0 down
+2. Enable the Bluetooth device: hciconfig hci0 up
+3. Enable BLE: btmgmt le on
+4. Pass the right MAC address: hcitool lescan | grep Nuimo""", self._mac)
+            return False
+        _LOGGER.info('Nuimo (MAC %s) connected!', self._mac)
+        self.display_hass_logo()
+        return True
+
+    def _reconnect(self, retries=5):
+        """Try a `retries` number of reconnects."""
+        for retry in range(1, retries+1):
+            _LOGGER.warning('Connection with Nuimo (MAC %s) lost, '
+                            'reconnection attempt %s of %s',
+                            self._mac,
+                            retry,
+                            retries)
+            success = self.connect()
+            if success:
+                return True
+        return False
+
+    def run(self):
+        """Start the thread."""
+        from nuimocore import BTLEException
+        self._listener = self._hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP,
+                                                    self.stop)
+        while self._hass_is_running:
+            try:
+                self._nuimo.waitForNotifications()
+            except BTLEException as btle_exception:
+                # Try to reconnect when disconnection exception is
+                # thrown. Ignore any other Bluetooth exception for now
+                if btle_exception.code == BTLEException.DISCONNECTED:
+                    if not self._reconnect():
+                        self.stop(None)
+            except ValueError:
+                # This caches an open bug with nuimocore and Python v3
+                # when KeyboardException is risen
+                # https://github.com/getsenic/nuimo-raspberrypi-demo/issues/8
+                pass
+
+    def stop(self, event):  # pylint: disable=unused-argument
+        """Set _hass_is_running as false, stopping the Nuimo polling."""
+        _LOGGER.info('Stopping Nuimo (MAC %s) background process', self._mac)
+        self._hass_is_running = False
+        self._hass.bus.remove_listener(EVENT_HOMEASSISTANT_STOP,
+                                       self._listener)
+
+    def display_hass_logo(self):
+        """Display HASS logo on Nuimo for 4 seconds."""
+        self._nuimo.displayLedMatrix(
+            "    *    " +
+            "   * * * " +
+            "  *   ** " +
+            " *     * " +
+            "*********" +
+            " *     * " +
+            " *     * " +
+            " *     * " +
+            " ******* ", 4.0)
+
+
+def setup(hass, config):
+    """Setup the Nuimo component."""
+    if not validate_config(config, {DOMAIN: ['mac']}, _LOGGER):
+        _LOGGER.error("You must define the MAC address "
+                      "for your Nuimo in the config file. "
+                      "Setup aborted")
+        return False
+    mac = config.get(DOMAIN)['mac']
+
+    # Setup nuimo
+    manager = NuimoManager(hass, mac)
+    # NOTE: connect() will block the main thread for a few seconds
+    # if Nuimo device is not available
+    success = manager.connect()
+    if not success:
+        return False
+    manager.start()
+    return True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -69,6 +69,9 @@ https://github.com/Danielhiversen/pyRFXtrx/archive/0.5.zip#pyRFXtrx==0.5
 # homeassistant.components.sensor.netatmo
 https://github.com/HydrelioxGitHub/netatmo-api-python/archive/43ff238a0122b0939a0dc4e8836b6782913fb6e2.zip#lnetatmo==0.4.0
 
+# homeassistant.components.nuimo
+https://github.com/IanHarvey/bluepy/archive/master.zip#bluepy==1.0.3
+
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.1.1.zip#pyW215==0.1.1
 
@@ -92,6 +95,9 @@ https://github.com/rkabadi/temper-python/archive/3dbdaf2d87b8db9a3cd6e5585fc7045
 
 # homeassistant.components.scene.hunterdouglas_powerview
 https://github.com/sander76/powerviewApi/archive/master.zip#powerviewApi==0.2
+
+# homeassistant.components.nuimo
+https://github.com/shaftoe/nuimo-raspberrypi-demo/archive/pip.zip#nuimocore==0.0.1
 
 # homeassistant.components.mysensors
 https://github.com/theolind/pymysensors/archive/f0c928532167fb24823efa793ec21ca646fd37a6.zip#pymysensors==0.5


### PR DESCRIPTION
This is my first attempt to integrate [Senic Nuimo hardware](https://www.senic.com) into Home Assistant

Unfortunately so far there's no SDK available but just a demo Python script to be used to do some testing on a Raspberry Pi, I had to do some modifications to make it available via Pip and I am currently providing pull requests to have them available from upstream, developers says there'll be soon a proper SDK and at that point everything should be easier/cleaner.

Also, for some reason with Python v3 one of the actions (ROTATE) is not mapped properly so it's not implemented here yet, I'm waiting for [this issue](https://github.com/getsenic/nuimo-raspberrypi-demo/issues/8) to be solved

**Example entry for `configuration.yaml`:**

``` yaml
nuimo:
  mac: 08:00:27:9f:9f:6c
```

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [x] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
