### PR TITLE
Fix noisy error on template component startup.

### DIFF
--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -90,6 +90,8 @@ class BinarySensorTemplate(BinarySensorDevice):
         hass.bus.listen(EVENT_STATE_CHANGED, self._event_listener)
 
     def _event_listener(self, event):
+        if not hasattr(self, 'hass'):
+            return
         self.update_ha_state(True)
 
     @property

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -86,12 +86,13 @@ class SensorTemplate(Entity):
         self._unit_of_measurement = unit_of_measurement
         self._template = state_template
         self.update()
+        self.hass.bus.listen(EVENT_STATE_CHANGED, self._event_listener)
 
-        def _update_callback(_event):
-            """ Called when the target device changes state. """
-            self.update_ha_state(True)
-
-        self.hass.bus.listen(EVENT_STATE_CHANGED, _update_callback)
+    def _event_listener(self, event):
+        """ Called when the target device changes state. """
+        if not hasattr(self, 'hass'):
+            return
+        self.update_ha_state(True)
 
     @property
     def name(self):

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -100,12 +100,13 @@ class SwitchTemplate(SwitchDevice):
         self._on_action = on_action
         self._off_action = off_action
         self.update()
+        self.hass.bus.listen(EVENT_STATE_CHANGED, self._event_listener)
 
-        def _update_callback(_event):
-            """Called when the target device changes state."""
-            self.update_ha_state(True)
-
-        self.hass.bus.listen(EVENT_STATE_CHANGED, _update_callback)
+    def _event_listener(self, event):
+        """ Called when the target device changes state. """
+        if not hasattr(self, 'hass'):
+            return
+        self.update_ha_state(True)
 
     @property
     def name(self):


### PR DESCRIPTION
**Description:**
Fix noisy error on component startup.
Make event callback code consistent.

**Related issue (if applicable):** #
Closes https://github.com/balloob/home-assistant/issues/1478
**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
