### PR TITLE
Force zone params to be float

### DIFF
--- a/homeassistant/components/zone.py
+++ b/homeassistant/components/zone.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
 from homeassistant.helpers import extract_domain_configs
 from homeassistant.helpers.entity import Entity, generate_entity_id
 from homeassistant.util.location import distance
+from homeassistant.util import convert
 
 DOMAIN = "zone"
 ENTITY_ID_FORMAT = 'zone.{}'
@@ -80,9 +81,9 @@ def setup(hass, config):
 
         for entry in entries:
             name = entry.get(CONF_NAME, DEFAULT_NAME)
-            latitude = entry.get(ATTR_LATITUDE)
-            longitude = entry.get(ATTR_LONGITUDE)
-            radius = entry.get(ATTR_RADIUS, DEFAULT_RADIUS)
+            latitude = convert(entry.get(ATTR_LATITUDE), float)
+            longitude = convert(entry.get(ATTR_LONGITUDE), float)
+            radius = convert(entry.get(ATTR_RADIUS, DEFAULT_RADIUS), float)
             icon = entry.get(ATTR_ICON)
             passive = entry.get(ATTR_PASSIVE, DEFAULT_PASSIVE)
 


### PR DESCRIPTION
**Description:**
Force zone long, late and radius to be float

**Related issue (if applicable):** #
Closes https://github.com/balloob/home-assistant/issues/1479
**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
