### PR TITLE
MQTT Light: fix brightness issues

### DIFF
--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -26,7 +26,6 @@ DEPENDENCIES = ['mqtt']
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Add MQTT Light."""
-
     if config.get('command_topic') is None:
         _LOGGER.error("Missing required variable: command_topic")
         return False
@@ -51,12 +50,12 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
 
 class MqttLight(Light):
-    """Provides a MQTT light."""
+    """MQTT light."""
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(self, hass, name, topic, templates, qos, payload, optimistic,
                  brightness_scale):
-
+        """Initialize MQTT light."""
         self._hass = hass
         self._name = name
         self._topic = topic
@@ -98,6 +97,8 @@ class MqttLight(Light):
             mqtt.subscribe(self._hass, self._topic["brightness_state_topic"],
                            brightness_received, self._qos)
             self._brightness = 255
+        elif self._topic["brightness_command_topic"] is not None:
+            self._brightness = 255
         else:
             self._brightness = None
 
@@ -110,6 +111,8 @@ class MqttLight(Light):
         if self._topic["rgb_state_topic"] is not None:
             mqtt.subscribe(self._hass, self._topic["rgb_state_topic"],
                            rgb_received, self._qos)
+            self._rgb = [255, 255, 255]
+        if self._topic["rgb_command_topic"] is not None:
             self._rgb = [255, 255, 255]
         else:
             self._rgb = None
@@ -131,7 +134,7 @@ class MqttLight(Light):
 
     @property
     def name(self):
-        """Returns the name of the device if any."""
+        """Name of the device if any."""
         return self._name
 
     @property

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -305,3 +305,25 @@ class TestLightMQTT(unittest.TestCase):
         self.assertEqual(STATE_ON, state.state)
         self.assertEqual([75, 75, 75], state.attributes['rgb_color'])
         self.assertEqual(50, state.attributes['brightness'])
+
+    def test_show_brightness_if_only_command_topic(self):
+        self.assertTrue(light.setup(self.hass, {
+            'light': {
+                'platform': 'mqtt',
+                'name': 'test',
+                'brightness_command_topic': 'test_light_rgb/brightness/set',
+                'command_topic': 'test_light_rgb/set',
+                'state_topic': 'test_light_rgb/status',
+            }
+        }))
+
+        state = self.hass.states.get('light.test')
+        self.assertEqual(STATE_OFF, state.state)
+        self.assertIsNone(state.attributes.get('brightness'))
+
+        fire_mqtt_message(self.hass, 'test_light_rgb/status', 'ON')
+        self.hass.pool.block_till_done()
+
+        state = self.hass.states.get('light.test')
+        self.assertEqual(STATE_ON, state.state)
+        self.assertEqual(255, state.attributes.get('brightness'))


### PR DESCRIPTION
**Description:**
There are 2 issues related to MQTT lights that are fixed by this PR and a new feature:
- MQTT lights with no brightness state topic would not allow changing the brightness from the UI. (because brightness would always be `None` and thus not show).
- Same as above but for RGB color
- ~~Setting brightness to zero turns light off and to non-zero turns light on. (#1494)~~ (not fixed, see comments, [fix here](https://gist.github.com/balloob/ff6d3d57800fafe00c43))

**Related issue (if applicable):** 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
light:
  platform: mqtt
  brightness_command_topic: home/kitchen/ceiling/brightness
```

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
