### PR TITLE
Add MQTT server component

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -74,7 +74,8 @@ def setup(hass, config):
     hass.bus.listen_once(
         ha.EVENT_HOMEASSISTANT_START,
         lambda event:
-        threading.Thread(target=server.start, daemon=True).start())
+        threading.Thread(target=server.start, daemon=True,
+                         name='HTTP-server').start())
 
     hass.http = server
     hass.config.api = rem.API(util.get_local_ip(), api_password, server_port,

--- a/homeassistant/components/mqtt/server.py
+++ b/homeassistant/components/mqtt/server.py
@@ -1,0 +1,114 @@
+"""MQTT server."""
+import asyncio
+import logging
+import tempfile
+import threading
+
+from homeassistant.components.mqtt import PROTOCOL_311
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+
+REQUIREMENTS = ['hbmqtt==0.6.3']
+DEPENDENCIES = ['http']
+
+
+@asyncio.coroutine
+def broker_coro(loop, config):
+    """Start broker coroutine."""
+    from hbmqtt.broker import Broker
+    broker = Broker(config, loop)
+    yield from broker.start()
+    return broker
+
+
+def loop_run(loop, broker, shutdown_complete):
+    """Run broker and clean up when done."""
+    loop.run_forever()
+    # run_forever ends when stop is called because we're shutting down
+    loop.run_until_complete(broker.shutdown())
+    loop.close()
+    shutdown_complete.set()
+
+
+def start(hass, server_config):
+    """Initialize MQTT Server."""
+    from hbmqtt.broker import BrokerException
+
+    loop = asyncio.new_event_loop()
+
+    try:
+        passwd = tempfile.NamedTemporaryFile()
+
+        if server_config is None:
+            server_config, client_config = generate_config(hass, passwd)
+        else:
+            client_config = None
+
+        start_server = asyncio.gather(broker_coro(loop, server_config),
+                                      loop=loop)
+        loop.run_until_complete(start_server)
+        # Result raises exception if one was raised during startup
+        broker = start_server.result()[0]
+    except BrokerException:
+        logging.getLogger(__name__).exception('Error initializing MQTT server')
+        loop.close()
+        return False, None
+    finally:
+        passwd.close()
+
+    shutdown_complete = threading.Event()
+
+    def shutdown(event):
+        """Gracefully shutdown MQTT broker."""
+        loop.call_soon_threadsafe(loop.stop)
+        shutdown_complete.wait()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, shutdown)
+
+    threading.Thread(target=loop_run, args=(loop, broker, shutdown_complete),
+                     name="MQTT-server").start()
+
+    return True, client_config
+
+
+def generate_config(hass, passwd):
+    """Generate a configuration based on current Home Assistant instance."""
+    config = {
+        'listeners': {
+            'default': {
+                'max-connections': 50000,
+                'bind': '0.0.0.0:1883',
+                'type': 'tcp',
+            },
+            'ws-1': {
+                'bind': '0.0.0.0:8080',
+                'type': 'ws',
+            },
+        },
+        'auth': {
+            'allow-anonymous': hass.config.api.api_password is None
+        },
+        'plugins': ['auth_anonymous'],
+    }
+
+    if hass.config.api.api_password:
+        username = 'homeassistant'
+        password = hass.config.api.api_password
+
+        # Encrypt with what hbmqtt uses to verify
+        from passlib.apps import custom_app_context
+
+        passwd.write(
+            'homeassistant:{}\n'.format(
+                custom_app_context.encrypt(
+                    hass.config.api.api_password)).encode('utf-8'))
+        passwd.flush()
+
+        config['auth']['password-file'] = passwd.name
+        config['plugins'].append('auth_file')
+    else:
+        username = None
+        password = None
+
+    client_config = ('localhost', 1883, username, password, None, PROTOCOL_311)
+
+    return config, client_config

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -775,7 +775,7 @@ def create_timer(hass, interval=TIMER_INTERVAL):
 
     def start_timer(event):
         """Start the timer."""
-        thread = threading.Thread(target=timer)
+        thread = threading.Thread(target=timer, name='Timer')
         thread.daemon = True
         thread.start()
 

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -331,7 +331,9 @@ class ThreadPool(object):
             if not self.running:
                 raise RuntimeError("ThreadPool not running")
 
-            worker = threading.Thread(target=self._worker)
+            worker = threading.Thread(
+                target=self._worker,
+                name='ThreadPool Worker {}'.format(self.worker_count))
             worker.daemon = True
             worker.start()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -54,6 +54,9 @@ freesms==0.1.0
 # homeassistant.components.conversation
 fuzzywuzzy==0.8.0
 
+# homeassistant.components.mqtt.server
+hbmqtt==0.6.3
+
 # homeassistant.components.thermostat.heatmiser
 heatmiserV3==0.9.1
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -44,10 +44,6 @@ class TestMQTT(unittest.TestCase):
         self.hass.pool.block_till_done()
         self.assertTrue(mqtt.MQTT_CLIENT.stop.called)
 
-    def test_setup_fails_if_no_broker_config(self):
-        """Test for setup failure if broker configuration is missing."""
-        self.assertFalse(mqtt.setup(self.hass, {mqtt.DOMAIN: {}}))
-
     def test_setup_fails_if_no_connect_broker(self):
         """Test for setup failure if connection to broker is missing."""
         with mock.patch('homeassistant.components.mqtt.MQTT',

--- a/tests/components/mqtt/test_server.py
+++ b/tests/components/mqtt/test_server.py
@@ -1,0 +1,55 @@
+"""The tests for the MQTT component embedded server."""
+from unittest.mock import MagicMock, patch
+
+import homeassistant.components.mqtt as mqtt
+
+from tests.common import get_test_home_assistant
+
+
+class TestMQTT:
+    """Test the MQTT component."""
+
+    def setup_method(self, method):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @patch('homeassistant.components.mqtt.MQTT')
+    @patch('asyncio.gather')
+    @patch('asyncio.new_event_loop')
+    def test_creating_config_with_http_pass(self, mock_new_loop, mock_gather,
+                                            mock_mqtt):
+        """Test if the MQTT server gets started and subscribe/publish msg."""
+        self.hass.config.components.append('http')
+        password = 'super_secret'
+
+        self.hass.config.api = MagicMock(api_password=password)
+        assert mqtt.setup(self.hass, {})
+        assert mock_mqtt.called
+        assert mock_mqtt.mock_calls[0][1][5] == 'homeassistant'
+        assert mock_mqtt.mock_calls[0][1][6] == password
+
+        mock_mqtt.reset_mock()
+
+        self.hass.config.api = MagicMock(api_password=None)
+        assert mqtt.setup(self.hass, {})
+        assert mock_mqtt.called
+        assert mock_mqtt.mock_calls[0][1][5] is None
+        assert mock_mqtt.mock_calls[0][1][6] is None
+
+    @patch('asyncio.gather')
+    @patch('asyncio.new_event_loop')
+    def test_broker_config_fails(self, mock_new_loop, mock_gather):
+        """Test if the MQTT component fails if server fails."""
+        self.hass.config.components.append('http')
+        from hbmqtt.broker import BrokerException
+
+        mock_gather.side_effect = BrokerException
+
+        self.hass.config.api = MagicMock(api_password=None)
+        assert not mqtt.setup(self.hass, {
+            'mqtt': {'embedded': {}}
+        })


### PR DESCRIPTION
**Description:**
This PR will update the MQTT component. It will now automatically start an embedded broker if no broker config is given and connect to it. It is using the [HBMQTT broker](https://pypi.python.org/pypi/hbmqtt).

It will significantly lower the barrier for people that are trying out MQTT.

The default config for the broker is to allow access using user/pass h`omeassistant` / `<your api password>`

Test with:

```
# First run HASS with mqtt component activated without any config
# In terminal 1
mosquitto_sub -V mqttv311 -t # -v
# In terminal 2
mosquitto_pub -V mqttv311 -t hello -m world
```

You can provide config for the embedded server using the embedded config key (see example YAML below).

To do:
- [x] If no config given, automatically generate one based on your current HTTP configuration
- [x] Tests
- [x] HA Shutdown hook to properly shutdown broker

**Related issue (if applicable):** Fixes #1178 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
mqtt:

# or

mqtt:
  embedded:
    # Your HBMQTT config here. Example at:
    # http://hbmqtt.readthedocs.org/en/latest/references/broker.html#broker-configuration
```

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
