### PR TITLE
verisure configuration value typo fix

### DIFF
--- a/homeassistant/components/sensor/verisure.py
+++ b/homeassistant/components/sensor/verisure.py
@@ -18,7 +18,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     sensors = []
 
-    if int(hub.config.get('temperature', '1')):
+    if int(hub.config.get('thermometers', '1')):
         hub.update_climate()
         sensors.extend([
             VerisureThermometer(value.id)


### PR DESCRIPTION
**Description:**
the configuration parameter should be 'thermometers' not 'temperature'

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date][fork] and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed][squash].
