### PR TITLE
Fixed close connection issue with rfxtrx device and update rfxtrx lib

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -57,9 +57,6 @@ omit =
     homeassistant/components/nest.py
     homeassistant/components/*/nest.py
 
-    homeassistant/components/rfxtrx.py
-    homeassistant/components/*/rfxtrx.py
-
     homeassistant/components/rpi_gpio.py
     homeassistant/components/*/rpi_gpio.py
 

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -7,9 +7,9 @@ https://home-assistant.io/components/rfxtrx/
 import logging
 
 from homeassistant.util import slugify
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['https://github.com/Danielhiversen/pyRFXtrx/' +
-                'archive/0.5.zip#pyRFXtrx==0.5']
+REQUIREMENTS = ['pyRFXtrx==0.6.5']
 
 DOMAIN = "rfxtrx"
 
@@ -71,6 +71,10 @@ def setup(hass, config):
                            transport_protocol=rfxtrxmod.DummyTransport2)
     else:
         RFXOBJECT = rfxtrxmod.Core(device, handle_receive, debug=debug)
+
+    def _shutdown_rfxtrx(event):
+        RFXOBJECT.close_connection()
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown_rfxtrx)
 
     return True
 

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -7,9 +7,10 @@ https://home-assistant.io/components/rfxtrx/
 import logging
 
 from homeassistant.util import slugify
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 REQUIREMENTS = ['https://github.com/Danielhiversen/pyRFXtrx/' +
-                'archive/0.5.zip#pyRFXtrx==0.5']
+                'archive/0.6.5.zip#pyRFXtrx==0.6.5']
 
 DOMAIN = "rfxtrx"
 
@@ -71,6 +72,10 @@ def setup(hass, config):
                            transport_protocol=rfxtrxmod.DummyTransport2)
     else:
         RFXOBJECT = rfxtrxmod.Core(device, handle_receive, debug=debug)
+
+    def _shutdown_rfxtrx(event):
+        RFXOBJECT.close_connection()
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown_rfxtrx)
 
     return True
 

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -9,8 +9,7 @@ import logging
 from homeassistant.util import slugify
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['https://github.com/Danielhiversen/pyRFXtrx/' +
-                'archive/0.6.5.zip#pyRFXtrx==0.6.5']
+REQUIREMENTS = ['pyRFXtrx==0.6.5']
 
 DOMAIN = "rfxtrx"
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -63,9 +63,6 @@ hikvision==0.4
 # homeassistant.components.sensor.dht
 # http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
 
-# homeassistant.components.rfxtrx
-https://github.com/Danielhiversen/pyRFXtrx/archive/0.6.5.zip#pyRFXtrx==0.6.5
-
 # homeassistant.components.sensor.netatmo
 https://github.com/HydrelioxGitHub/netatmo-api-python/archive/43ff238a0122b0939a0dc4e8836b6782913fb6e2.zip#lnetatmo==0.4.0
 
@@ -153,6 +150,9 @@ pushetta==1.0.15
 
 # homeassistant.components.sensor.cpuspeed
 py-cpuinfo==0.2.3
+
+# homeassistant.components.rfxtrx
+pyRFXtrx==0.6.5
 
 # homeassistant.components.media_player.cast
 pychromecast==0.7.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -64,7 +64,7 @@ hikvision==0.4
 # http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
 
 # homeassistant.components.rfxtrx
-https://github.com/Danielhiversen/pyRFXtrx/archive/0.5.zip#pyRFXtrx==0.5
+https://github.com/Danielhiversen/pyRFXtrx/archive/0.6.5.zip#pyRFXtrx==0.6.5
 
 # homeassistant.components.sensor.netatmo
 https://github.com/HydrelioxGitHub/netatmo-api-python/archive/43ff238a0122b0939a0dc4e8836b6782913fb6e2.zip#lnetatmo==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -63,9 +63,6 @@ hikvision==0.4
 # homeassistant.components.sensor.dht
 # http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
 
-# homeassistant.components.rfxtrx
-https://github.com/Danielhiversen/pyRFXtrx/archive/0.5.zip#pyRFXtrx==0.5
-
 # homeassistant.components.sensor.netatmo
 https://github.com/HydrelioxGitHub/netatmo-api-python/archive/43ff238a0122b0939a0dc4e8836b6782913fb6e2.zip#lnetatmo==0.4.0
 
@@ -153,6 +150,9 @@ pushetta==1.0.15
 
 # homeassistant.components.sensor.cpuspeed
 py-cpuinfo==0.2.3
+
+# homeassistant.components.rfxtrx
+pyRFXtrx==0.6.5
 
 # homeassistant.components.media_player.cast
 pychromecast==0.7.2

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -11,12 +11,9 @@ from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.components.light import rfxtrx
 from unittest.mock import patch
 
-import pytest
-
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif(True, reason='Does not clean up properly, takes 100% CPU')
 class TestLightRfxtrx(unittest.TestCase):
     """ Test the Rfxtrx light. """
 
@@ -28,6 +25,8 @@ class TestLightRfxtrx(unittest.TestCase):
         """ Stop down stuff we started. """
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx_core.RFX_DEVICES = {}
+        if rfxtrx_core.RFXOBJECT:
+            rfxtrx_core.RFXOBJECT.close_connection()
         self.hass.stop()
 
     def test_default_config(self):

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -25,6 +25,8 @@ class TestLightRfxtrx(unittest.TestCase):
         """ Stop down stuff we started. """
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx_core.RFX_DEVICES = {}
+        if rfxtrx_core.RFXOBJECT:
+            rfxtrx_core.RFXOBJECT.close_connection()
         self.hass.stop()
 
     def test_default_config(self):
@@ -99,7 +101,6 @@ class TestLightRfxtrx(unittest.TestCase):
             entity.turn_on(brightness=255)
         self.assertTrue(entity.is_on)
         self.assertEqual(entity.brightness, 255)
-        rfxtrx_core.RFXOBJECT.close_connection()
 
     def test_several_lights(self):
         """ Test with 3 lights """
@@ -141,7 +142,6 @@ class TestLightRfxtrx(unittest.TestCase):
                 self.assertEqual('<Entity Test: off>', entity.__str__())
 
         self.assertEqual(3, device_num)
-        rfxtrx_core.RFXOBJECT.close_connection()
 
     def test_discover_light(self):
         """ Test with discover of light """

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -11,12 +11,9 @@ from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.components.light import rfxtrx
 from unittest.mock import patch
 
-import pytest
-
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif(True, reason='Does not clean up properly, takes 100% CPU')
 class TestLightRfxtrx(unittest.TestCase):
     """ Test the Rfxtrx light. """
 
@@ -102,6 +99,7 @@ class TestLightRfxtrx(unittest.TestCase):
             entity.turn_on(brightness=255)
         self.assertTrue(entity.is_on)
         self.assertEqual(entity.brightness, 255)
+        rfxtrx_core.RFXOBJECT.close_connection()
 
     def test_several_lights(self):
         """ Test with 3 lights """
@@ -143,6 +141,7 @@ class TestLightRfxtrx(unittest.TestCase):
                 self.assertEqual('<Entity Test: off>', entity.__str__())
 
         self.assertEqual(3, device_num)
+        rfxtrx_core.RFXOBJECT.close_connection()
 
     def test_discover_light(self):
         """ Test with discover of light """

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -25,6 +25,8 @@ class TestSwitchRfxtrx(unittest.TestCase):
         """ Stop down stuff we started. """
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx_core.RFX_DEVICES = {}
+        if rfxtrx_core.RFXOBJECT:
+            rfxtrx_core.RFXOBJECT.close_connection()
         self.hass.stop()
 
     def test_default_config(self):
@@ -79,7 +81,6 @@ class TestSwitchRfxtrx(unittest.TestCase):
                    return_value=None):
             entity.turn_off()
         self.assertFalse(entity.is_on)
-        rfxtrx_core.RFXOBJECT.close_connection()
 
     def test_several_switchs(self):
         """ Test with 3 switchs """
@@ -121,7 +122,6 @@ class TestSwitchRfxtrx(unittest.TestCase):
                 self.assertEqual('<Entity Test: off>', entity.__str__())
 
         self.assertEqual(3, device_num)
-        rfxtrx_core.RFXOBJECT.close_connection()
 
     def test_discover_switch(self):
         """ Test with discover of switch """

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -11,12 +11,9 @@ from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.components.switch import rfxtrx
 from unittest.mock import patch
 
-import pytest
-
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif(True, reason='Does not clean up properly, takes 100% CPU')
 class TestSwitchRfxtrx(unittest.TestCase):
     """ Test the Rfxtrx switch. """
 
@@ -82,6 +79,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
                    return_value=None):
             entity.turn_off()
         self.assertFalse(entity.is_on)
+        rfxtrx_core.RFXOBJECT.close_connection()
 
     def test_several_switchs(self):
         """ Test with 3 switchs """
@@ -123,6 +121,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
                 self.assertEqual('<Entity Test: off>', entity.__str__())
 
         self.assertEqual(3, device_num)
+        rfxtrx_core.RFXOBJECT.close_connection()
 
     def test_discover_switch(self):
         """ Test with discover of switch """

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -11,12 +11,9 @@ from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.components.switch import rfxtrx
 from unittest.mock import patch
 
-import pytest
-
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif(True, reason='Does not clean up properly, takes 100% CPU')
 class TestSwitchRfxtrx(unittest.TestCase):
     """ Test the Rfxtrx switch. """
 
@@ -28,6 +25,8 @@ class TestSwitchRfxtrx(unittest.TestCase):
         """ Stop down stuff we started. """
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx_core.RFX_DEVICES = {}
+        if rfxtrx_core.RFXOBJECT:
+            rfxtrx_core.RFXOBJECT.close_connection()
         self.hass.stop()
 
     def test_default_config(self):

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -11,12 +11,9 @@ import time
 from homeassistant.components import rfxtrx as rfxtrx
 from homeassistant.components.sensor import rfxtrx as rfxtrx_sensor
 
-import pytest
-
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif(True, reason='Does not clean up properly, takes 100% CPU')
 class TestRFXTRX(unittest.TestCase):
     """ Test the sun module. """
 
@@ -28,7 +25,8 @@ class TestRFXTRX(unittest.TestCase):
         """ Stop down stuff we started. """
         rfxtrx.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx.RFX_DEVICES = {}
-        rfxtrx.RFXOBJECT = None
+        if rfxtrx.RFXOBJECT:
+            rfxtrx.RFXOBJECT.close_connection()
         self.hass.stop()
 
     def test_default_config(self):
@@ -55,6 +53,7 @@ class TestRFXTRX(unittest.TestCase):
 
         self.assertEquals(len(rfxtrx.RFXOBJECT.sensors()), 2)
         self.assertEquals(len(devices), 2)
+        rfxtrx.RFXOBJECT.close_connection()
 
     def test_config_failing(self):
         """ Test config """

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -11,12 +11,9 @@ import time
 from homeassistant.components import rfxtrx as rfxtrx
 from homeassistant.components.sensor import rfxtrx as rfxtrx_sensor
 
-import pytest
-
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif(True, reason='Does not clean up properly, takes 100% CPU')
 class TestRFXTRX(unittest.TestCase):
     """ Test the sun module. """
 
@@ -28,7 +25,6 @@ class TestRFXTRX(unittest.TestCase):
         """ Stop down stuff we started. """
         rfxtrx.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx.RFX_DEVICES = {}
-        rfxtrx.RFXOBJECT = None
         self.hass.stop()
 
     def test_default_config(self):
@@ -55,6 +51,7 @@ class TestRFXTRX(unittest.TestCase):
 
         self.assertEquals(len(rfxtrx.RFXOBJECT.sensors()), 2)
         self.assertEquals(len(devices), 2)
+        rfxtrx.RFXOBJECT.close_connection()
 
     def test_config_failing(self):
         """ Test config """

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -25,6 +25,8 @@ class TestRFXTRX(unittest.TestCase):
         """ Stop down stuff we started. """
         rfxtrx.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx.RFX_DEVICES = {}
+        if rfxtrx_core.RFXOBJECT:
+            rfxtrx_core.RFXOBJECT.close_connection()
         self.hass.stop()
 
     def test_default_config(self):

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -25,8 +25,8 @@ class TestRFXTRX(unittest.TestCase):
         """ Stop down stuff we started. """
         rfxtrx.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx.RFX_DEVICES = {}
-        if rfxtrx_core.RFXOBJECT:
-            rfxtrx_core.RFXOBJECT.close_connection()
+        if rfxtrx.RFXOBJECT:
+            rfxtrx.RFXOBJECT.close_connection()
         self.hass.stop()
 
     def test_default_config(self):


### PR DESCRIPTION
**Description:**
Try to fix slow rfxtrx tests. This PR is increasing the run time for the tests with more than 2 minutes. I am not sure how I can fix that.

**Related issue (if applicable):**  #1480
Slow rfxtrx tests

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
