### PR TITLE
Enable Pep257 checking on CI

### DIFF
--- a/homeassistant/components/binary_sensor/mysensors.py
+++ b/homeassistant/components/binary_sensor/mysensors.py
@@ -90,7 +90,7 @@ class MySensorsBinarySensor(BinarySensorDevice):
 
     @property
     def should_poll(self):
-        """MySensor gateway pushes its state to HA."""
+        """Mysensor gateway pushes its state to HA."""
         return False
 
     @property

--- a/homeassistant/components/sensor/cpuspeed.py
+++ b/homeassistant/components/sensor/cpuspeed.py
@@ -47,7 +47,7 @@ class CpuSpeedSensor(Entity):
 
     @property
     def unit_of_measurement(self):
-        """return the unit the value is expressed in."""
+        """Return the unit the value is expressed in."""
         return self._unit_of_measurement
 
     @property

--- a/homeassistant/components/sensor/torque.py
+++ b/homeassistant/components/sensor/torque.py
@@ -101,7 +101,7 @@ class TorqueSensor(Entity):
 
     @property
     def state(self):
-        """return the state of the sensor."""
+        """Return the state of the sensor."""
         return self._state
 
     @property

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -96,6 +96,7 @@ class VeraSensor(Entity):
         self.update_ha_state(True)
 
     def __str__(self):
+        """String representation of sensor."""
         return "%s %s %s" % (self.name, self.vera_device.device_id, self.state)
 
     @property

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -56,6 +56,7 @@ class ModbusSwitch(ToggleEntity):
         self.register_value = None
 
     def __str__(self):
+        """String representation of Modbus switch."""
         return "%s: %s" % (self.name, self.state)
 
     @property

--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -88,7 +88,7 @@ class MySensorsSwitch(SwitchDevice):
 
     @property
     def should_poll(self):
-        """MySensor gateway pushes its state to HA."""
+        """Mysensor gateway pushes its state to HA."""
         return False
 
     @property

--- a/homeassistant/components/switch/rest.py
+++ b/homeassistant/components/switch/rest.py
@@ -64,7 +64,7 @@ class RestSwitch(SwitchDevice):
 
     @property
     def is_on(self):
-        """return true if device is on."""
+        """Return true if device is on."""
         return self._state
 
     def turn_on(self, **kwargs):

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -179,7 +179,7 @@ class OrderedSet(collections.MutableSet):
             curr = curr[2]
 
     def __reversed__(self):
-        """reverse the ordering."""
+        """Reverse the ordering."""
         end = self.end
         curr = end[1]
         while curr is not end:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,3 +5,4 @@ pytest>=2.8.0
 pytest-cov>=2.2.0
 pytest-timeout>=1.0.0
 betamax>=0.5.1
+pydocstyle>=1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,3 @@ testpaths = tests
 
 [flake8]
 exclude = .venv,.git,.tox,docs,www_static,venv,bin,lib
-
-[pep257]
-ignore = D203,D105

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ ignore_errors = True
 commands =
      flake8
      pylint homeassistant
+     pydocstyle homeassistant tests
 
 [testenv:requirements]
 basepython = python3


### PR DESCRIPTION
This will enable pep257 checking on CI.

I am using `pydocstyle` instead of `pep257` as the tool has been [renamed](https://github.com/PyCQA/pydocstyle#pydocstyle---docstring-style-checker).

Full credit for PEP257 compatibility goes to @fabaff who did an amazing job fixing it all :bow: 
