### PR TITLE
Add MQTT export component

### DIFF
--- a/homeassistant/components/mqtt_export.py
+++ b/homeassistant/components/mqtt_export.py
@@ -1,0 +1,44 @@
+"""
+MQTT publisher for all Home Assistant states.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/mqtt_export/
+"""
+import json
+
+import homeassistant.loader as loader
+from homeassistant.const import (STATE_UNKNOWN, EVENT_STATE_CHANGED)
+from homeassistant.remote import JSONEncoder
+
+DOMAIN = "mqtt_export"
+DEPENDENCIES = ['mqtt']
+
+DEFAULT_TOPIC = 'home-assistant/states'
+PAYLOAD = None
+
+
+def setup(hass, config):
+    """Setup the MQTT export component."""
+    mqtt = loader.get_component('mqtt')
+    pub_topic = config[DOMAIN].get('publish_topic', DEFAULT_TOPIC)
+
+    global PAYLOAD
+    PAYLOAD = dict(states=None, details=None)
+
+    # Add the configuration
+    PAYLOAD['details'] = hass.config.as_dict()
+
+    def mqtt_event_listener(event):
+        """Listen for new messages on the bus and send data to MQTT."""
+        state = event.data.get('new_state')
+        if state is None or state.state in (STATE_UNKNOWN, ''):
+            return None
+
+        PAYLOAD['states'] = hass.states.all()
+
+        payload = json.dumps(PAYLOAD, cls=JSONEncoder)
+        mqtt.publish(hass, pub_topic, payload)
+
+    hass.bus.listen(EVENT_STATE_CHANGED, mqtt_event_listener)
+
+    return True

--- a/tests/components/test_mqtt_export.py
+++ b/tests/components/test_mqtt_export.py
@@ -1,0 +1,47 @@
+"""The tests for the MQTT export component."""
+import unittest
+from unittest.mock import patch
+
+import homeassistant.components.mqtt_export as export
+import homeassistant.util.dt as dt_util
+
+from tests.common import (
+    get_test_home_assistant,
+    mock_mqtt_component,
+    fire_time_changed
+)
+
+
+class TestMqttExport(unittest.TestCase):
+    """Test the MQTT export module."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        super(TestMqttExport, self).setUp()
+        self.hass = get_test_home_assistant()
+        self.mock_publish = mock_mqtt_component(self.hass)
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def add_export(self, pub_topic=None):
+        """Add a mqtt_export component to hass."""
+        config = {}
+        if pub_topic:
+            config['publish_topic'] = pub_topic
+        return export.setup(self.hass, {export.DOMAIN: config})
+
+    def test_setup_succeeds(self):
+        """Test if setup is successful."""
+        self.assertTrue(self.add_export())
+
+    @patch('homeassistant.components.mqtt.publish')
+    def test_time_event_does_not_send_message(self, mock_pub):
+        """"Test of not sending a new message if time event."""
+        self.assertTrue(self.add_export(pub_topic='bar'))
+        self.hass.pool.block_till_done()
+        mock_pub.reset_mock()
+
+        fire_time_changed(self.hass, dt_util.utcnow())
+        self.assertFalse(mock_pub.called)


### PR DESCRIPTION
**Description:**
This component collects and sends all states as one MQTT messages to a given topic. In addition there is the current configuration attached (as shown in the [Rest API docs](https://home-assistant.io/developers/rest_api/#get-apiconfig)).

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
mqtt_export:
  publish_topic: "home/states"
```

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
