### PR TITLE
changed powerview version requirement to solve error in installing

### DIFF
--- a/homeassistant/components/scene/hunterdouglas_powerview.py
+++ b/homeassistant/components/scene/hunterdouglas_powerview.py
@@ -11,7 +11,7 @@ from homeassistant.components.scene import Scene
 _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = [
     'https://github.com/sander76/powerviewApi/'
-    'archive/master.zip#powerview_api==0.2']
+    'archive/master.zip#powerviewApi==0.2']
 
 HUB_ADDRESS = 'address'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -91,7 +91,7 @@ https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f
 https://github.com/rkabadi/temper-python/archive/3dbdaf2d87b8db9a3cd6e5585fc704537dd2d09b.zip#temperusb==1.2.3
 
 # homeassistant.components.scene.hunterdouglas_powerview
-https://github.com/sander76/powerviewApi/archive/master.zip#powerview_api==0.2
+https://github.com/sander76/powerviewApi/archive/master.zip#powerviewApi==0.2
 
 # homeassistant.components.mysensors
 https://github.com/theolind/pymysensors/archive/f0c928532167fb24823efa793ec21ca646fd37a6.zip#pymysensors==0.5


### PR DESCRIPTION
**Description:**
Solving a stupid mistake. powerview version requirement changed to correct text.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**
- [ ] Local tests with `tox` run successfully.
- [ ] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [ ] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [ ] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
