### PR TITLE
Type checks for MQTT config

### DIFF
--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -11,6 +11,7 @@ import homeassistant.components.mqtt as mqtt
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_RGB_COLOR, Light)
 from homeassistant.helpers.template import render_with_possible_json_value
+from homeassistant.util import convert
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,20 +33,20 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     add_devices_callback([MqttLight(
         hass,
-        config.get('name', DEFAULT_NAME),
-        {key: config.get(key) for key in
+        convert(config.get('name'), str, DEFAULT_NAME),
+        {key: convert(config.get(key), str) for key in
          (typ + topic
           for typ in ('', 'brightness_', 'rgb_')
           for topic in ('state_topic', 'command_topic'))},
-        {key: config.get(key + '_value_template')
+        {key: convert(config.get(key + '_value_template'), str)
          for key in ('state', 'brightness', 'rgb')},
-        config.get('qos', DEFAULT_QOS),
+        convert(config.get('qos'), int, DEFAULT_QOS),
         {
-            'on': config.get('payload_on', DEFAULT_PAYLOAD_ON),
-            'off': config.get('payload_off', DEFAULT_PAYLOAD_OFF)
+            'on': convert(config.get('payload_on'), str, DEFAULT_PAYLOAD_ON),
+            'off': convert(config.get('payload_off'), str, DEFAULT_PAYLOAD_OFF)
         },
-        config.get('optimistic', DEFAULT_OPTIMISTIC),
-        config.get('brightness_scale', DEFAULT_BRIGHTNESS_SCALE)
+        convert(config.get('optimistic'), bool, DEFAULT_OPTIMISTIC),
+        convert(config.get('brightness_scale'), int, DEFAULT_BRIGHTNESS_SCALE)
     )])
 
 

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -10,6 +10,7 @@ import homeassistant.components.mqtt as mqtt
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import CONF_VALUE_TEMPLATE
 from homeassistant.helpers import template
+from homeassistant.util import convert
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,14 +33,14 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     add_devices_callback([MqttSwitch(
         hass,
-        config.get('name', DEFAULT_NAME),
+        convert(config.get('name'), str, DEFAULT_NAME),
         config.get('state_topic'),
         config.get('command_topic'),
-        config.get('qos', DEFAULT_QOS),
-        config.get('retain', DEFAULT_RETAIN),
-        config.get('payload_on', DEFAULT_PAYLOAD_ON),
-        config.get('payload_off', DEFAULT_PAYLOAD_OFF),
-        config.get('optimistic', DEFAULT_OPTIMISTIC),
+        convert(config.get('qos'), int, DEFAULT_QOS),
+        convert(config.get('retain'), bool, DEFAULT_RETAIN),
+        convert(config.get('payload_on'), str, DEFAULT_PAYLOAD_ON),
+        convert(config.get('payload_off'), str, DEFAULT_PAYLOAD_OFF),
+        convert(config.get('optimistic'), bool, DEFAULT_OPTIMISTIC),
         config.get(CONF_VALUE_TEMPLATE))])
 
 

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -122,9 +122,9 @@ class TestLightMQTT(unittest.TestCase):
                 'brightness_command_topic': 'test_light_rgb/brightness/set',
                 'rgb_state_topic': 'test_light_rgb/rgb/status',
                 'rgb_command_topic': 'test_light_rgb/rgb/set',
-                'qos': 0,
-                'payload_on': 'on',
-                'payload_off': 'off'
+                'qos': '0',
+                'payload_on': 1,
+                'payload_off': 0
             }
         }))
 
@@ -134,7 +134,7 @@ class TestLightMQTT(unittest.TestCase):
         self.assertIsNone(state.attributes.get('brightness'))
         self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
 
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', 'on')
+        fire_mqtt_message(self.hass, 'test_light_rgb/status', '1')
         self.hass.pool.block_till_done()
 
         state = self.hass.states.get('light.test')
@@ -142,13 +142,13 @@ class TestLightMQTT(unittest.TestCase):
         self.assertEqual([255, 255, 255], state.attributes.get('rgb_color'))
         self.assertEqual(255, state.attributes.get('brightness'))
 
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', 'off')
+        fire_mqtt_message(self.hass, 'test_light_rgb/status', '0')
         self.hass.pool.block_till_done()
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
 
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', 'on')
+        fire_mqtt_message(self.hass, 'test_light_rgb/status', '1')
         self.hass.pool.block_till_done()
 
         fire_mqtt_message(self.hass, 'test_light_rgb/brightness/status', '100')
@@ -159,7 +159,7 @@ class TestLightMQTT(unittest.TestCase):
         self.assertEqual(100,
                          light_state.attributes['brightness'])
 
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', 'on')
+        fire_mqtt_message(self.hass, 'test_light_rgb/status', '1')
         self.hass.pool.block_till_done()
 
         fire_mqtt_message(self.hass, 'test_light_rgb/rgb/status',

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -27,8 +27,8 @@ class TestSensorMQTT(unittest.TestCase):
                 'name': 'test',
                 'state_topic': 'state-topic',
                 'command_topic': 'command-topic',
-                'payload_on': 'beer on',
-                'payload_off': 'beer off'
+                'payload_on': 1,
+                'payload_off': 0
             }
         }))
 
@@ -36,13 +36,13 @@ class TestSensorMQTT(unittest.TestCase):
         self.assertEqual(STATE_OFF, state.state)
         self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
 
-        fire_mqtt_message(self.hass, 'state-topic', 'beer on')
+        fire_mqtt_message(self.hass, 'state-topic', '1')
         self.hass.pool.block_till_done()
 
         state = self.hass.states.get('switch.test')
         self.assertEqual(STATE_ON, state.state)
 
-        fire_mqtt_message(self.hass, 'state-topic', 'beer off')
+        fire_mqtt_message(self.hass, 'state-topic', '0')
         self.hass.pool.block_till_done()
 
         state = self.hass.states.get('switch.test')
@@ -57,7 +57,7 @@ class TestSensorMQTT(unittest.TestCase):
                 'command_topic': 'command-topic',
                 'payload_on': 'beer on',
                 'payload_off': 'beer off',
-                'qos': 2
+                'qos': '2'
             }
         }))
 


### PR DESCRIPTION
**Description:**
YAML likes to be as helpful as possible and will convert any number to a number type in Python. This is not always what we expect. This PR converts MQTT configuration to expected type.

**Related issue (if applicable):** Fixes #1500 

**Checklist:**
- [ ] Local tests with `tox` run successfully.
- [ ] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [ ] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [ ] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
