### PR TITLE
add gps_accuracy and battery information to the see function

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -57,7 +57,6 @@ ATTR_DEV_ID = 'dev_id'
 ATTR_HOST_NAME = 'host_name'
 ATTR_LOCATION_NAME = 'location_name'
 ATTR_GPS = 'gps'
-ATTR_GPS_ACCURACY = 'gps_accuracy'
 ATTR_BATTERY = 'battery'
 
 DISCOVERY_PLATFORMS = {

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -57,6 +57,7 @@ ATTR_DEV_ID = 'dev_id'
 ATTR_HOST_NAME = 'host_name'
 ATTR_LOCATION_NAME = 'location_name'
 ATTR_GPS = 'gps'
+ATTR_GPS_ACCURACY = 'gps_accuracy'
 ATTR_BATTERY = 'battery'
 
 DISCOVERY_PLATFORMS = {
@@ -82,7 +83,9 @@ def see(hass, mac=None, dev_id=None, host_name=None, location_name=None,
              (ATTR_DEV_ID, dev_id),
              (ATTR_HOST_NAME, host_name),
              (ATTR_LOCATION_NAME, location_name),
-             (ATTR_GPS, gps)) if value is not None}
+             (ATTR_GPS, gps),
+             (ATTR_GPS_ACCURACY, gps_accuracy),
+             (ATTR_BATTERY, battery)) if value is not None}
     hass.services.call(DOMAIN, SERVICE_SEE, data)
 
 


### PR DESCRIPTION
**Description:**
The gps_accuracy and battery information get lost when calling the see function of the device_tracker platform instead of using the service

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**
- [ ] Local tests with `tox` run successfully.
- [ ] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [ ] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [ ] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

the see function from device_tracker doesn't pass the gps_accuracy and the battery information to the see service, so this information gets lost.
