### PR TITLE
Add `explicit` attribute to zones.

### DIFF
--- a/tests/components/test_zone.py
+++ b/tests/components/test_zone.py
@@ -24,7 +24,8 @@ class TestComponentZone(unittest.TestCase):
             'latitude': 32.880837,
             'longitude': -117.237561,
             'radius': 250,
-            'passive': True
+            'passive': True,
+            'explicit': True
         }
         assert zone.setup(self.hass, {
             'zone': info
@@ -35,7 +36,7 @@ class TestComponentZone(unittest.TestCase):
         assert info['latitude'] == state.attributes['latitude']
         assert info['longitude'] == state.attributes['longitude']
         assert info['radius'] == state.attributes['radius']
-        assert info['passive'] == state.attributes['passive']
+        assert info['explicit'] == state.attributes['explicit']
 
     def test_active_zone_skips_passive_zones(self):
         """Test active and passive zones."""
@@ -47,6 +48,37 @@ class TestComponentZone(unittest.TestCase):
                     'longitude': -117.237561,
                     'radius': 250,
                     'passive': True
+                },
+            ]
+        })
+
+        active = zone.active_zone(self.hass, 32.880600, -117.237561)
+        assert active is None
+
+        assert zone.setup(self.hass, {
+            'zone': [
+                {
+                    'name': 'Active Zone',
+                    'latitude': 32.880800,
+                    'longitude': -117.237561,
+                    'radius': 500,
+                },
+            ]
+        })
+
+        active = zone.active_zone(self.hass, 32.880700, -117.237561)
+        assert 'zone.active_zone' == active.entity_id
+
+    def test_active_zone_skips_explicit_zones(self):
+        """Test active and passive zones."""
+        assert zone.setup(self.hass, {
+            'zone': [
+                {
+                    'name': 'Explicit Zone',
+                    'latitude': 32.880600,
+                    'longitude': -117.237561,
+                    'radius': 250,
+                    'explicit': True
                 },
             ]
         })


### PR DESCRIPTION
**Description:**
This PR solves an issue with using iBeacons with HA

There are cases when using beacons where you want to create zones which HA cannot reliably distinguish using gps. However these zones are useful when using iBeacons. 

A good example would be distinguishing between rooms in a house. You can't use gps for this because:-
- It's not accurate enough to reliably distinguish been the locations.
- In a multi-floored house the rooms have the same location.

This PR adds a new `explicit` attribute to mark a zone that can only be entered with an `enter` event, but is otherwise like a `passive` zone.

@balloob I know you weren't convinced by the need for this - but the more I use iBeacons - the more convinced I am that we need this, so keen to discuss more.

The code needed to implement this was already in HA with passive zones, so this is more about tests than code!

**Related issue (if applicable):** #
closes https://github.com/balloob/home-assistant/issues/1219

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
zone:
  name: Home
  latitude: 32.8773367
  longitude: -117.2494053
  radius: 100

zone 2:
  name: Bedroom
  latitude: 32.8773367
  longitude: -117.2494053
  radius: 3
  explicit: True

zone 3:
  name: Kitchen
  latitude: 32.879
  longitude: -117.2494053
  radius: 3
  explicit: True

```

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
