### PR TITLE
Allow entry into passive zones.

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -99,14 +99,11 @@ def setup_scanner(hass, config, see):
                         _LOGGER.info("Added beacon %s", location)
                 else:
                     # Normal region
-                    if not zone.attributes.get('passive'):
-                        kwargs['location_name'] = location
-
                     regions = REGIONS_ENTERED[dev_id]
                     if location not in regions:
                         regions.append(location)
                     _LOGGER.info("Enter region %s", location)
-                    _set_gps_from_zone(kwargs, zone)
+                    _set_gps_from_zone(kwargs, location, zone)
 
                 see(**kwargs)
                 see_beacons(dev_id, kwargs)
@@ -121,9 +118,7 @@ def setup_scanner(hass, config, see):
                 if new_region:
                     # Exit to previous region
                     zone = hass.states.get("zone.{}".format(new_region))
-                    if not zone.attributes.get('passive'):
-                        kwargs['location_name'] = new_region
-                    _set_gps_from_zone(kwargs, zone)
+                    _set_gps_from_zone(kwargs, new_region, zone)
                     _LOGGER.info("Exit to %s", new_region)
                     see(**kwargs)
                     see_beacons(dev_id, kwargs)
@@ -184,11 +179,12 @@ def _parse_see_args(topic, data):
     return dev_id, kwargs
 
 
-def _set_gps_from_zone(kwargs, zone):
+def _set_gps_from_zone(kwargs, location, zone):
     """Set the see parameters from the zone parameters."""
     if zone is not None:
         kwargs['gps'] = (
             zone.attributes['latitude'],
             zone.attributes['longitude'])
         kwargs['gps_accuracy'] = zone.attributes['radius']
+        kwargs['location_name'] = location
     return kwargs

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -133,15 +133,6 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
                 'radius': 100000
             })
 
-        self.hass.states.set(
-            'zone.passive', 'zoning',
-            {
-                'name': 'zone',
-                'latitude': 3.0,
-                'longitude': 1.0,
-                'radius': 10,
-                'passive': True
-            })
         # Clear state between teste
         self.hass.states.set(DEVICE_TRACKER_STATE, None)
         owntracks.REGIONS_ENTERED = defaultdict(list)
@@ -324,43 +315,6 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         message['desc'] = "inner_2"
         self.send_message(EVENT_TOPIC, message)
         self.assert_location_state('outer')
-
-    def test_event_entry_exit_passive_zone(self):
-        """Test the event for passive zone exits."""
-        # Enter passive zone
-        message = REGION_ENTER_MESSAGE.copy()
-        message['desc'] = "passive"
-        self.send_message(EVENT_TOPIC, message)
-
-        # Should pick up gps put not zone
-        self.assert_location_state('not_home')
-        self.assert_location_latitude(3.0)
-        self.assert_location_accuracy(10.0)
-
-        # Enter inner2 zone
-        message = REGION_ENTER_MESSAGE.copy()
-        message['desc'] = "inner_2"
-        self.send_message(EVENT_TOPIC, message)
-        self.assert_location_state('inner_2')
-        self.assert_location_latitude(2.1)
-        self.assert_location_accuracy(10.0)
-
-        # Exit inner_2 - should be in 'passive'
-        # ie gps co-ords - but not zone
-        message = REGION_LEAVE_MESSAGE.copy()
-        message['desc'] = "inner_2"
-        self.send_message(EVENT_TOPIC, message)
-        self.assert_location_state('not_home')
-        self.assert_location_latitude(3.0)
-        self.assert_location_accuracy(10.0)
-
-        # Exit passive - should be in 'outer'
-        message = REGION_LEAVE_MESSAGE.copy()
-        message['desc'] = "passive"
-        self.send_message(EVENT_TOPIC, message)
-        self.assert_location_state('outer')
-        self.assert_location_latitude(2.0)
-        self.assert_location_accuracy(60.0)
 
     def test_event_entry_unknown_zone(self):
         """Test the event for unknown zone."""


### PR DESCRIPTION
**Description:**
Description:
Allow owntracks events to enter passive zones.
See discussion here https://github.com/balloob/home-assistant/pull/1527

Related issue (if applicable): #
closes #1219
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
