### PR TITLE
Remove support for old deprecated script call service config

### DIFF
--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -92,35 +92,6 @@ class TestScript(unittest.TestCase):
         self.assertIsNone(
             self.hass.states.get(ENTITY_ID).attributes.get('can_cancel'))
 
-    def test_calling_service_old(self):
-        """Test the calling of an old service."""
-        calls = []
-
-        def record_call(service):
-            """Add recorded event to set."""
-            calls.append(service)
-
-        self.hass.services.register('test', 'script', record_call)
-
-        self.assertTrue(script.setup(self.hass, {
-            'script': {
-                'test': {
-                    'sequence': [{
-                        'execute_service': 'test.script',
-                        'service_data': {
-                            'hello': 'world'
-                        }
-                    }]
-                }
-            }
-        }))
-
-        script.turn_on(self.hass, ENTITY_ID)
-        self.hass.pool.block_till_done()
-
-        self.assertEqual(1, len(calls))
-        self.assertEqual('world', calls[0].data.get('hello'))
-
     def test_calling_service(self):
         """Test the calling of a service."""
         calls = []
@@ -136,8 +107,48 @@ class TestScript(unittest.TestCase):
                 'test': {
                     'sequence': [{
                         'service': 'test.script',
-                        'service_data': {
+                        'data': {
                             'hello': 'world'
+                        }
+                    }]
+                }
+            }
+        }))
+
+        script.turn_on(self.hass, ENTITY_ID)
+        self.hass.pool.block_till_done()
+
+        self.assertEqual(1, len(calls))
+        self.assertEqual('world', calls[0].data.get('hello'))
+
+    def test_calling_service_template(self):
+        """Test the calling of a service."""
+        calls = []
+
+        def record_call(service):
+            """Add recorded event to set."""
+            calls.append(service)
+
+        self.hass.services.register('test', 'script', record_call)
+
+        self.assertTrue(script.setup(self.hass, {
+            'script': {
+                'test': {
+                    'sequence': [{
+                        'service_template': """
+                            {% if True %}
+                                test.script
+                            {% else %}
+                                test.not_script
+                            {% endif %}""",
+                        'data_template': {
+                            'hello': """
+                                {% if True %}
+                                    world
+                                {% else %}
+                                    Not world
+                                {% endif %}
+                            """
                         }
                     }]
                 }


### PR DESCRIPTION
**Description:**
We changed the script config for calling services since [0.7.6](https://home-assistant.io/blog/2015/10/26/firetv-and-radiotherm-now-supported/) (released Oct 26). The old config is preventing us from easily upgrading to support calling services using templates.

This PR removes support for the deprecated config and adds support for calling services using templates.

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- [x] Tests have been added to verify that the new code works.
