### PR TITLE
Enable openzwave's network heal and soft reset.

### DIFF
--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -28,6 +28,8 @@ DEFAULT_ZWAVE_CONFIG_PATH = os.path.join(sys.prefix, 'share',
 
 SERVICE_ADD_NODE = "add_node"
 SERVICE_REMOVE_NODE = "remove_node"
+SERVICE_HEAL_NETWORK = "heal_network"
+SERVICE_SOFT_RESET = "soft_reset"
 
 DISCOVER_SENSORS = "zwave.sensors"
 DISCOVER_SWITCHES = "zwave.switch"
@@ -149,6 +151,7 @@ def get_config_value(node, value_index):
         return get_config_value(node, value_index)
 
 
+# pylint: disable=R0914
 def setup(hass, config):
     """Setup Z-Wave.
 
@@ -249,6 +252,14 @@ def setup(hass, config):
         """Switch into exclusion mode."""
         NETWORK.controller.begin_command_remove_device()
 
+    def heal_network(event):
+        """Heal the network."""
+        NETWORK.heal()
+
+    def soft_reset(event):
+        """Soft reset the controller."""
+        NETWORK.controller.soft_reset()
+
     def stop_zwave(event):
         """Stop Z-Wave."""
         NETWORK.stop()
@@ -268,6 +279,8 @@ def setup(hass, config):
         # hardware inclusion button
         hass.services.register(DOMAIN, SERVICE_ADD_NODE, add_node)
         hass.services.register(DOMAIN, SERVICE_REMOVE_NODE, remove_node)
+        hass.services.register(DOMAIN, SERVICE_HEAL_NETWORK, heal_network)
+        hass.services.register(DOMAIN, SERVICE_SOFT_RESET, soft_reset)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_zwave)
 


### PR DESCRIPTION
**Description:**
   Makes Zwave's network heal and the controller's soft reset
    commands available as service calls. They can be used
    in automation to help keep the zwave network healthy.

An example use in the automation section of configuration.yaml:

```
    automation:
     alias: At 2:35am, heal problematic zwave network routes
     trigger:
       platform: time
       after: '2:35:00'
     action:
       service: zwave.heal
```

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [ ] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
