### PR TITLE
Fixed close connection issue with rfxtrx device and update rfxtrx lib

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -58,9 +58,6 @@ omit =
     homeassistant/components/nest.py
     homeassistant/components/*/nest.py
 
-    homeassistant/components/rfxtrx.py
-    homeassistant/components/*/rfxtrx.py
-
     homeassistant/components/rpi_gpio.py
     homeassistant/components/*/rpi_gpio.py
 

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -7,9 +7,9 @@ https://home-assistant.io/components/rfxtrx/
 import logging
 
 from homeassistant.util import slugify
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['https://github.com/Danielhiversen/pyRFXtrx/' +
-                'archive/0.5.zip#pyRFXtrx==0.5']
+REQUIREMENTS = ['pyRFXtrx==0.6.5']
 
 DOMAIN = "rfxtrx"
 
@@ -71,6 +71,10 @@ def setup(hass, config):
                            transport_protocol=rfxtrxmod.DummyTransport2)
     else:
         RFXOBJECT = rfxtrxmod.Core(device, handle_receive, debug=debug)
+
+    def _shutdown_rfxtrx(event):
+        RFXOBJECT.close_connection()
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown_rfxtrx)
 
     return True
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -66,9 +66,6 @@ hikvision==0.4
 # homeassistant.components.sensor.dht
 # http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
 
-# homeassistant.components.rfxtrx
-https://github.com/Danielhiversen/pyRFXtrx/archive/0.5.zip#pyRFXtrx==0.5
-
 # homeassistant.components.sensor.netatmo
 https://github.com/HydrelioxGitHub/netatmo-api-python/archive/43ff238a0122b0939a0dc4e8836b6782913fb6e2.zip#lnetatmo==0.4.0
 
@@ -156,6 +153,9 @@ pushetta==1.0.15
 
 # homeassistant.components.sensor.cpuspeed
 py-cpuinfo==0.2.3
+
+# homeassistant.components.rfxtrx
+pyRFXtrx==0.6.5
 
 # homeassistant.components.media_player.cast
 pychromecast==0.7.2

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -5,12 +5,9 @@ from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.components.light import rfxtrx
 from unittest.mock import patch
 
-import pytest
-
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif(True, reason='Does not clean up properly, takes 100% CPU')
 class TestLightRfxtrx(unittest.TestCase):
     """Test the Rfxtrx light platform."""
 
@@ -22,6 +19,8 @@ class TestLightRfxtrx(unittest.TestCase):
         """Stop everything that was started."""
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx_core.RFX_DEVICES = {}
+        if rfxtrx_core.RFXOBJECT:
+            rfxtrx_core.RFXOBJECT.close_connection()
         self.hass.stop()
 
     def test_default_config(self):

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -5,12 +5,9 @@ from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.components.switch import rfxtrx
 from unittest.mock import patch
 
-import pytest
-
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif(True, reason='Does not clean up properly, takes 100% CPU')
 class TestSwitchRfxtrx(unittest.TestCase):
     """Test the Rfxtrx switch platform."""
 
@@ -22,6 +19,8 @@ class TestSwitchRfxtrx(unittest.TestCase):
         """Stop everything that was started."""
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx_core.RFX_DEVICES = {}
+        if rfxtrx_core.RFXOBJECT:
+            rfxtrx_core.RFXOBJECT.close_connection()
         self.hass.stop()
 
     def test_default_config(self):

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -6,12 +6,9 @@ import time
 from homeassistant.components import rfxtrx as rfxtrx
 from homeassistant.components.sensor import rfxtrx as rfxtrx_sensor
 
-import pytest
-
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif(True, reason='Does not clean up properly, takes 100% CPU')
 class TestRFXTRX(unittest.TestCase):
     """Test the Rfxtrx component."""
 
@@ -23,7 +20,8 @@ class TestRFXTRX(unittest.TestCase):
         """Stop everything that was started."""
         rfxtrx.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx.RFX_DEVICES = {}
-        rfxtrx.RFXOBJECT = None
+        if rfxtrx.RFXOBJECT:
+            rfxtrx.RFXOBJECT.close_connection()
         self.hass.stop()
 
     def test_default_config(self):


### PR DESCRIPTION
**Description:**
Fix slow rfxtrx tests. 

**Related issue (if applicable):**  #1480
Slow rfxtrx tests

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [x] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
