### PR TITLE
Handle Wemo startup race condition.

### DIFF
--- a/homeassistant/components/binary_sensor/wemo.py
+++ b/homeassistant/components/binary_sensor/wemo.py
@@ -45,6 +45,9 @@ class WemoBinarySensor(BinarySensorDevice):
         _LOGGER.info(
             'Subscription update for  %s',
             _device)
+        if not hasattr(self, 'hass'):
+            self.update()
+            return
         self.update_ha_state(True)
 
     @property

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -63,6 +63,9 @@ class WemoSwitch(SwitchDevice):
         _LOGGER.info(
             'Subscription update for  %s',
             _device)
+        if not hasattr(self, 'hass'):
+            self.update()
+            return
         self.update_ha_state(True)
 
     @property


### PR DESCRIPTION
**Description:**
I've just started to see some errors on startup of WeMo switches.

This can result in not setting initial state - and the devices being unavailable.

Suspect this is a race condition where the callback from the wemo comes back before the HA component is initialized. I guess this could be because of other HA changes have changed the timing on startup.

This PR copes with getting initial state correct - even if the HA component isn't initialized. 

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
  `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
