### PR TITLE
add a dockerfile for raspberry pi 2

### DIFF
--- a/Dockerfile-rpi2
+++ b/Dockerfile-rpi2
@@ -1,0 +1,27 @@
+FROM resin/raspberrypi2-python:3.4
+MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
+
+VOLUME /config
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# For the nmap tracker
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends nmap net-tools && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY script/build_python_openzwave script/build_python_openzwave
+RUN apt-get update && \
+   apt-get install -y cython3 libudev-dev && \
+   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+   pip3 install "cython<0.23" && \
+   script/build_python_openzwave
+
+COPY requirements_all.txt requirements_all.txt
+RUN pip3 install --no-cache-dir -r requirements_all.txt
+
+# Copy source
+COPY . .
+
+CMD [ "python", "-m", "homeassistant", "--config", "/config" ]


### PR DESCRIPTION
**Description:**
This is to add the capability for users to build their own docker image for the raspberry pi 2. It would be nice to also build this automatically and host it on the docker hub.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**
- [ ] Local tests with `tox` run successfully.
- [ ] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [ ] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [ ] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
