### PR TITLE
Refactor vera into a platform.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -32,6 +32,7 @@ omit =
     homeassistant/components/tellduslive.py
     homeassistant/components/*/tellduslive.py
 
+    homeassistant/components/vera.py
     homeassistant/components/*/vera.py
 
     homeassistant/components/ecobee.py

--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -9,7 +9,8 @@ import logging
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (STATE_ON, STATE_OFF)
-from homeassistant.components import (bloomsky, mysensors, zwave, wemo, wink)
+from homeassistant.components import (
+    bloomsky, mysensors, zwave, vera, wemo, wink)
 
 DOMAIN = 'binary_sensor'
 SCAN_INTERVAL = 30
@@ -37,6 +38,7 @@ DISCOVERY_PLATFORMS = {
     bloomsky.DISCOVER_BINARY_SENSORS: 'bloomsky',
     mysensors.DISCOVER_BINARY_SENSORS: 'mysensors',
     zwave.DISCOVER_BINARY_SENSORS: 'zwave',
+    vera.DISCOVER_BINARY_SENSORS: 'vera',
     wemo.DISCOVER_BINARY_SENSORS: 'wemo',
     wink.DISCOVER_BINARY_SENSORS: 'wink'
 }

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -10,7 +10,7 @@ import csv
 
 from homeassistant.components import (
     group, discovery, wemo, wink, isy994,
-    zwave, insteon_hub, mysensors, tellstick)
+    zwave, insteon_hub, mysensors, tellstick, vera)
 from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (
     STATE_ON, SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE,
@@ -66,6 +66,7 @@ DISCOVERY_PLATFORMS = {
     zwave.DISCOVER_LIGHTS: 'zwave',
     mysensors.DISCOVER_LIGHTS: 'mysensors',
     tellstick.DISCOVER_LIGHTS: 'tellstick',
+    vera.DISCOVER_LIGHTS: 'vera',
 }
 
 PROP_TO_ATTR = {

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -6,15 +6,15 @@ https://home-assistant.io/components/light.vera/
 """
 import logging
 
-from requests.exceptions import RequestException
-
 import homeassistant.util.dt as dt_util
 from homeassistant.components.light import ATTR_BRIGHTNESS, Light
 from homeassistant.const import (
     ATTR_ARMED, ATTR_BATTERY_LEVEL, ATTR_LAST_TRIP_TIME, ATTR_TRIPPED,
-    EVENT_HOMEASSISTANT_STOP, STATE_OFF, STATE_ON)
+    STATE_OFF, STATE_ON)
+from homeassistant.components.vera import (
+    VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
 
-REQUIREMENTS = ['pyvera==0.2.8']
+DEPENDENCIES = ['vera']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,74 +22,17 @@ _LOGGER = logging.getLogger(__name__)
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup Vera lights."""
-    import pyvera as veraApi
-
-    base_url = config.get('vera_controller_url')
-    if not base_url:
-        _LOGGER.error(
-            "The required parameter 'vera_controller_url'"
-            " was not found in config"
-        )
-        return False
-
-    device_data = config.get('device_data', {})
-
-    vera_controller, created = veraApi.init_controller(base_url)
-
-    if created:
-        def stop_subscription(event):
-            """Shutdown Vera subscriptions and subscription thread on exit."""
-            _LOGGER.info("Shutting down subscriptions.")
-            vera_controller.stop()
-
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_subscription)
-
-    devices = []
-    try:
-        devices = vera_controller.get_devices([
-            'Switch',
-            'On/Off Switch',
-            'Dimmable Switch'])
-    except RequestException:
-        # There was a network related error connecting to the vera controller.
-        _LOGGER.exception("Error communicating with Vera API")
-        return False
-
-    lights = []
-    for device in devices:
-        extra_data = device_data.get(device.device_id, {})
-        exclude = extra_data.get('exclude', False)
-
-        if exclude is not True:
-            lights.append(VeraLight(device, vera_controller, extra_data))
-
-    add_devices_callback(lights)
+    add_devices_callback(
+        VeraLight(device, VERA_CONTROLLER) for device in VERA_DEVICES['light'])
 
 
-class VeraLight(Light):
+class VeraLight(VeraDevice, Light):
     """Representation of a Vera Light, including dimmable."""
 
-    def __init__(self, vera_device, controller, extra_data=None):
+    def __init__(self, vera_device, controller):
         """Initialize the light."""
-        self.vera_device = vera_device
-        self.extra_data = extra_data
-        self.controller = controller
-        if self.extra_data and self.extra_data.get('name'):
-            self._name = self.extra_data.get('name')
-        else:
-            self._name = self.vera_device.name
-        self._state = STATE_OFF
-
-        self.controller.register(vera_device, self._update_callback)
-        self.update()
-
-    def _update_callback(self, _device):
-        self.update_ha_state(True)
-
-    @property
-    def name(self):
-        """Return the name of the light."""
-        return self._name
+        self._state = False
+        VeraDevice.__init__(self, vera_device, controller)
 
     @property
     def brightness(self):
@@ -137,20 +80,13 @@ class VeraLight(Light):
             attr[ATTR_TRIPPED] = 'True' if tripped else 'False'
 
         attr['Vera Device Id'] = self.vera_device.vera_device_id
-
-    @property
-    def should_poll(self):
-        """No polling needed."""
-        return False
+        return attr
 
     @property
     def is_on(self):
         """Return true if device is on."""
-        return self._state == STATE_ON
+        return self._state
 
     def update(self):
         """Called by the vera device callback to update state."""
-        if self.vera_device.is_switched_on():
-            self._state = STATE_ON
-        else:
-            self._state = STATE_OFF
+        self._state = self.vera_device.is_switched_on()

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -8,7 +8,8 @@ import logging
 
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.components import (
-    wink, zwave, isy994, verisure, ecobee, tellduslive, mysensors, bloomsky)
+    wink, zwave, isy994, verisure, ecobee, tellduslive, mysensors,
+    bloomsky, vera)
 
 DOMAIN = 'sensor'
 SCAN_INTERVAL = 30
@@ -25,6 +26,7 @@ DISCOVERY_PLATFORMS = {
     ecobee.DISCOVER_SENSORS: 'ecobee',
     tellduslive.DISCOVER_SENSORS: 'tellduslive',
     mysensors.DISCOVER_SENSORS: 'mysensors',
+    vera.DISCOVER_SENSORS: 'vera',
 }
 
 

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -6,108 +6,39 @@ https://home-assistant.io/components/sensor.vera/
 """
 import logging
 
-from requests.exceptions import RequestException
-
 import homeassistant.util.dt as dt_util
 from homeassistant.const import (
     ATTR_ARMED, ATTR_BATTERY_LEVEL, ATTR_LAST_TRIP_TIME, ATTR_TRIPPED,
-    EVENT_HOMEASSISTANT_STOP, TEMP_CELCIUS, TEMP_FAHRENHEIT)
+    TEMP_CELCIUS, TEMP_FAHRENHEIT)
 from homeassistant.helpers.entity import Entity
+from homeassistant.components.vera import (
+    VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
 
-REQUIREMENTS = ['pyvera==0.2.8']
+DEPENDENCIES = ['vera']
 
 _LOGGER = logging.getLogger(__name__)
 
 
-# pylint: disable=unused-argument
-def get_devices(hass, config):
-    """Setup the Vera Sensors."""
-    import pyvera as veraApi
-
-    base_url = config.get('vera_controller_url')
-    if not base_url:
-        _LOGGER.error(
-            "The required parameter 'vera_controller_url'"
-            " was not found in config"
-        )
-        return False
-
-    device_data = config.get('device_data', {})
-
-    vera_controller, created = veraApi.init_controller(base_url)
-
-    if created:
-        def stop_subscription(event):
-            """Shutdown Vera subscriptions and subscription thread on exit."""
-            _LOGGER.info("Shutting down subscriptions.")
-            vera_controller.stop()
-
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_subscription)
-
-    categories = ['Temperature Sensor',
-                  'Light Sensor',
-                  'Humidity Sensor',
-                  'Sensor']
-    devices = []
-    try:
-        devices = vera_controller.get_devices(categories)
-    except RequestException:
-        # There was a network related error connecting to the vera controller.
-        _LOGGER.exception("Error communicating with Vera API")
-        return False
-
-    vera_sensors = []
-    for device in devices:
-        extra_data = device_data.get(device.device_id, {})
-        exclude = extra_data.get('exclude', False)
-
-        if exclude is not True:
-            vera_sensors.append(
-                VeraSensor(device, vera_controller, extra_data))
-
-    return vera_sensors
-
-
-def setup_platform(hass, config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Perform the setup for Vera controller devices."""
-    add_devices(get_devices(hass, config))
+    add_devices_callback(
+        VeraSensor(device, VERA_CONTROLLER)
+        for device in VERA_DEVICES['sensor'])
 
 
-class VeraSensor(Entity):
+class VeraSensor(VeraDevice, Entity):
     """Representation of a Vera Sensor."""
 
-    def __init__(self, vera_device, controller, extra_data=None):
+    def __init__(self, vera_device, controller):
         """Initialize the sensor."""
-        self.vera_device = vera_device
-        self.controller = controller
-        self.extra_data = extra_data
-        if self.extra_data and self.extra_data.get('name'):
-            self._name = self.extra_data.get('name')
-        else:
-            self._name = self.vera_device.name
-        self.current_value = ''
+        self.current_value = None
         self._temperature_units = None
-
-        self.controller.register(vera_device, self._update_callback)
-        self.update()
-
-    def _update_callback(self, _device):
-        """Called by the vera device callback to update state."""
-        self.update_ha_state(True)
-
-    def __str__(self):
-        """String representation of sensor."""
-        return "%s %s %s" % (self.name, self.vera_device.device_id, self.state)
+        VeraDevice.__init__(self, vera_device, controller)
 
     @property
     def state(self):
         """Return the name of the sensor."""
         return self.current_value
-
-    @property
-    def name(self):
-        """Return the mame of the sensor."""
-        return self._name
 
     @property
     def unit_of_measurement(self):
@@ -143,11 +74,6 @@ class VeraSensor(Entity):
 
         attr['Vera Device Id'] = self.vera_device.vera_device_id
         return attr
-
-    @property
-    def should_poll(self):
-        """No polling needed."""
-        return False
 
     def update(self):
         """Update the state."""

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID)
 from homeassistant.components import (
     group, wemo, wink, isy994, verisure,
-    zwave, tellduslive, tellstick, mysensors)
+    zwave, tellduslive, tellstick, mysensors, vera)
 
 DOMAIN = 'switch'
 SCAN_INTERVAL = 30
@@ -42,6 +42,7 @@ DISCOVERY_PLATFORMS = {
     tellduslive.DISCOVER_SWITCHES: 'tellduslive',
     mysensors.DISCOVER_SWITCHES: 'mysensors',
     tellstick.DISCOVER_SWITCHES: 'tellstick',
+    vera.DISCOVER_SWITCHES: 'vera',
 }
 
 PROP_TO_ATTR = {

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -1,0 +1,142 @@
+"""
+Support for Vera devices.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/vera/
+"""
+import logging
+
+from collections import defaultdict
+from requests.exceptions import RequestException
+
+from homeassistant import bootstrap
+from homeassistant.const import (
+    ATTR_SERVICE, ATTR_DISCOVERED,
+    EVENT_HOMEASSISTANT_STOP, EVENT_PLATFORM_DISCOVERED)
+from homeassistant.helpers.entity import Entity
+from homeassistant.loader import get_component
+
+REQUIREMENTS = ['pyvera==0.2.8']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'vera'
+
+VERA_CONTROLLER = None
+
+CONF_EXCLUDE = 'exclude'
+CONF_LIGHTS = 'lights'
+
+BINARY_SENSOR = 'binary_sensor'
+SENSOR = 'sensor'
+LIGHT = 'light'
+SWITCH = 'switch'
+
+DEVICE_CATEGORIES = {
+    'Sensor': BINARY_SENSOR,
+    'Temperature Sensor': SENSOR,
+    'Light Sensor': SENSOR,
+    'Humidity Sensor': SENSOR,
+    'Dimmable Switch': LIGHT,
+    'Switch': SWITCH,
+    'Armable Sensor': SWITCH,
+    'On/Off Switch': SWITCH,
+    # 'Window Covering': NOT SUPPORTED YET
+}
+
+DISCOVER_BINARY_SENSORS = 'vera.binary_sensors'
+DISCOVER_SENSORS = 'vera.sensors'
+DISCOVER_LIGHTS = 'vera.lights'
+DISCOVER_SWITCHES = 'vera.switchs'
+
+VERA_DEVICES = defaultdict(list)
+
+
+# pylint: disable=unused-argument, too-many-function-args
+def setup(hass, base_config):
+    """Common setup for Vera devices."""
+    global VERA_CONTROLLER
+    import pyvera as veraApi
+
+    config = base_config.get(DOMAIN)
+    base_url = config.get('vera_controller_url')
+    if not base_url:
+        _LOGGER.error(
+            "The required parameter 'vera_controller_url'"
+            " was not found in config"
+        )
+        return False
+
+    VERA_CONTROLLER, _ = veraApi.init_controller(base_url)
+
+    def stop_subscription(event):
+        """Shutdown Vera subscriptions and subscription thread on exit."""
+        _LOGGER.info("Shutting down subscriptions.")
+        VERA_CONTROLLER.stop()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_subscription)
+
+    try:
+        all_devices = VERA_CONTROLLER.get_devices(
+            list(DEVICE_CATEGORIES.keys()))
+    except RequestException:
+        # There was a network related error connecting to the vera controller.
+        _LOGGER.exception("Error communicating with Vera API")
+        return False
+
+    exclude = config.get(CONF_EXCLUDE, [])
+    if not isinstance(exclude, list):
+        _LOGGER.error("'exclude' must be a list of device_ids")
+        return False
+
+    lights_ids = config.get(CONF_LIGHTS, [])
+    if not isinstance(lights_ids, list):
+        _LOGGER.error("'lights' must be a list of device_ids")
+        return False
+
+    for device in all_devices:
+        if device.device_id in exclude:
+            continue
+        dev_type = DEVICE_CATEGORIES.get(device.category)
+        if dev_type is None:
+            continue
+        if dev_type == SWITCH and device.device_id in lights_ids:
+            dev_type = LIGHT
+        VERA_DEVICES[dev_type].append(device)
+
+    for comp_name, discovery in (((BINARY_SENSOR, DISCOVER_BINARY_SENSORS),
+                                  (SENSOR, DISCOVER_SENSORS),
+                                  (LIGHT, DISCOVER_LIGHTS),
+                                  (SWITCH, DISCOVER_SWITCHES))):
+        component = get_component(comp_name)
+        bootstrap.setup_component(hass, component.DOMAIN, config)
+        hass.bus.fire(EVENT_PLATFORM_DISCOVERED,
+                      {ATTR_SERVICE: discovery,
+                       ATTR_DISCOVERED: {}})
+    return True
+
+
+class VeraDevice(Entity):
+    """Representation of a Vera devicetity."""
+
+    def __init__(self, vera_device, controller):
+        """Initialize the device."""
+        self.vera_device = vera_device
+        self.controller = controller
+        self._name = self.vera_device.name
+
+        self.controller.register(vera_device, self._update_callback)
+        self.update()
+
+    def _update_callback(self, _device):
+        self.update_ha_state(True)
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -218,9 +218,7 @@ python-wink==0.6.2
 # homeassistant.components.keyboard
 pyuserinput==0.1.9
 
-# homeassistant.components.light.vera
-# homeassistant.components.sensor.vera
-# homeassistant.components.switch.vera
+# homeassistant.components.vera
 pyvera==0.2.8
 
 # homeassistant.components.wemo


### PR DESCRIPTION
**Description:**
This PR will restructure the Vera code into a platform - and add support for binary sensors

It's a breaking change - and since the configuration.yaml will change anyway - I've simplified the customisation.

Because the previous code was loaded per component type - it's likely that people are expecting some of their switches to be created as lights - so I've include a facility to force switches to be created as lights.

Vera creates a lot of devices which aren't used - so I've continued the ability of the old code to exclude devices - but simplified how this is specified.
**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
vera:
  vera_controller_url: http://192.168.1.161:3480/
  # Optional to exclude devices - this is a list of vera device ids
  exclude: [ 13, 14, 16, 20, 23, 27, 28, 30, 31, 35, 36, 44, 45, 56, 57, 66, 67, 71, 72, 73, 74, 75, 76, 77, 78, 88, 89, 99]
  # Optional to import switches as lights - this is a list of vera device ids
  lights: [15, 17, 19, 21, 22, 24, 26, 43, 64, 70, 87]
```

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [x] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
