### PR TITLE
Added assumed state to command_line switch

### DIFF
--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -33,6 +33,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     add_devices_callback(devices)
 
 
+# pylint: disable=too-many-instance-attributes
 class CommandSwitch(SwitchDevice):
     """Representation a switch that can be toggled using shell commands."""
 
@@ -91,6 +92,11 @@ class CommandSwitch(SwitchDevice):
     def is_on(self):
         """Return true if device is on."""
         return self._state
+
+    @property
+    def assumed_state(self):
+        """Return true if we do optimistic updates."""
+        return self._command_state is False
 
     def _query_state(self):
         """Query for state."""

--- a/tests/components/switch/test_command_line.py
+++ b/tests/components/switch/test_command_line.py
@@ -6,6 +6,7 @@ import unittest
 
 from homeassistant.const import STATE_ON, STATE_OFF
 import homeassistant.components.switch as switch
+import homeassistant.components.switch.command_line as command_line
 
 from tests.common import get_test_home_assistant
 
@@ -155,3 +156,21 @@ class TestCommandSwitch(unittest.TestCase):
 
             state = self.hass.states.get('switch.test')
             self.assertEqual(STATE_ON, state.state)
+
+    def test_assumed_state_should_be_true_if_command_state_is_false(self):
+        """Test with state value."""
+        self.hass = get_test_home_assistant()
+
+        # Set state command to false
+        statecmd = False
+
+        no_state_device = command_line.CommandSwitch(self.hass, "Test", "echo",
+                                                     "echo", statecmd, None)
+        self.assertTrue(no_state_device.assumed_state)
+
+        # Set state command
+        statecmd = 'cat {}'
+
+        state_device = command_line.CommandSwitch(self.hass, "Test", "echo",
+                                                  "echo", statecmd, None)
+        self.assertFalse(state_device.assumed_state)


### PR DESCRIPTION
**Description:**
This PR adds the assumed state functionality to the command_line switch component. Switches will default to assumed state if no statecmd is provided. 

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
  - platform: command_line
    switches:        
          Test:
              oncmd: switch_command on
              offcmd: switch_command off
```

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
