### PR TITLE
Hue Lights - Allow Unreachable Lights

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -74,7 +74,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     setup_bridge(host, hass, add_devices_callback, filename, allow_unreachable)
 
 
-def setup_bridge(host, hass, add_devices_callback, filename, allow_unreachable):
+def setup_bridge(host, hass, add_devices_callback, filename,
+                 allow_unreachable):
     """Setup a phue bridge based on host parameter."""
     import phue
 

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -174,7 +174,7 @@ class HueLight(Light):
 
     # pylint: disable=too-many-arguments
     def __init__(self, light_id, info, bridge, update_lights,
-                 bridge_type='hue', allow_unreachable=False):
+                 bridge_type, allow_unreachable):
         """Initialize the light."""
         self.light_id = light_id
         self.info = info

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -213,7 +213,11 @@ class HueLight(Light):
     def is_on(self):
         """Return true if device is on."""
         self.update_lights()
-        return self.info['state']['reachable'] and self.info['state']['on']
+
+        if self.allow_unreachable:
+            return self.info['state']['on']
+        else:
+            return self.info['state']['reachable'] and self.info['state']['on']
 
     def turn_on(self, **kwargs):
         """Turn the specified or all lights on."""

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -71,10 +71,10 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     if host in _CONFIGURING:
         return
 
-    setup_bridge(host, hass, add_devices_callback, filename)
+    setup_bridge(host, hass, add_devices_callback, filename, allow_unreachable)
 
 
-def setup_bridge(host, hass, add_devices_callback, filename):
+def setup_bridge(host, hass, add_devices_callback, filename, allow_unreachable):
     """Setup a phue bridge based on host parameter."""
     import phue
 
@@ -132,7 +132,7 @@ def setup_bridge(host, hass, add_devices_callback, filename):
             if light_id not in lights:
                 lights[light_id] = HueLight(int(light_id), info,
                                             bridge, update_lights,
-                                            bridge_type=bridge_type)
+                                            bridge_type, allow_unreachable)
                 new_lights.append(lights[light_id])
             else:
                 lights[light_id].info = info
@@ -173,13 +173,15 @@ class HueLight(Light):
 
     # pylint: disable=too-many-arguments
     def __init__(self, light_id, info, bridge, update_lights,
-                 bridge_type='hue'):
+                 bridge_type='hue', allow_unreachable=False):
         """Initialize the light."""
         self.light_id = light_id
         self.info = info
         self.bridge = bridge
         self.update_lights = update_lights
         self.bridge_type = bridge_type
+
+        self.allow_unreachable = allow_unreachable
 
     @property
     def unique_id(self):

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -53,6 +53,8 @@ def _find_host_from_config(hass, filename=PHUE_CONFIG_FILE):
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the Hue lights."""
     filename = config.get(CONF_FILENAME, PHUE_CONFIG_FILE)
+    allow_unreachable = config.get('allow_unreachable', False)
+
     if discovery_info is not None:
         host = urlparse(discovery_info[1]).hostname
     else:

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -91,7 +91,8 @@ def setup_bridge(host, hass, add_devices_callback, filename,
     except phue.PhueRegistrationException:
         _LOGGER.warning("Connected to Hue at %s but not registered.", host)
 
-        request_configuration(host, hass, add_devices_callback, filename)
+        request_configuration(host, hass, add_devices_callback, filename,
+                              allow_unreachable)
 
         return
 
@@ -144,7 +145,8 @@ def setup_bridge(host, hass, add_devices_callback, filename,
     update_lights()
 
 
-def request_configuration(host, hass, add_devices_callback, filename):
+def request_configuration(host, hass, add_devices_callback, filename,
+                          allow_unreachable):
     """Request configuration steps from the user."""
     configurator = get_component('configurator')
 
@@ -158,7 +160,8 @@ def request_configuration(host, hass, add_devices_callback, filename):
     # pylint: disable=unused-argument
     def hue_configuration_callback(data):
         """The actions to do when our configuration callback is called."""
-        setup_bridge(host, hass, add_devices_callback, filename)
+        setup_bridge(host, hass, add_devices_callback, filename,
+                     allow_unreachable)
 
     _CONFIGURING[host] = configurator.request_config(
         hass, "Philips Hue", hue_configuration_callback,


### PR DESCRIPTION
This adds a config for Hue lights to allow unreachable lights to still work.

GE Link bulbs routinely become `unreachable` from the Hue Bridge. But...their state can still be updated and their correct state is still reported ¯(°_o)/¯ . 

Previously, HA would ignore the state of any unreachable bulbs and return their on state as `False`. This will give you the option to still return the actual state.

This fixes #1058 
### New Config

``` yaml
light:
  platform: hue
  allow_unreachable: true

```
### Checklist
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
