### PR TITLE
Bump pywemo version.

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components import discovery
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.3.14']
+REQUIREMENTS = ['pywemo==0.3.16']
 
 DOMAIN = 'wemo'
 DISCOVER_LIGHTS = 'wemo.light'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -222,7 +222,7 @@ pyuserinput==0.1.9
 pyvera==0.2.8
 
 # homeassistant.components.wemo
-pywemo==0.3.14
+pywemo==0.3.16
 
 # homeassistant.components.thermostat.radiotherm
 radiotherm==1.2


### PR DESCRIPTION
**Description:**
This contains @kk7ds's better fix for the wemo probe timeout problem (wemo's can get into a state where they accept a connection on a port - but hang when you try to talk to them).

This copes with the timeout if it's a hang - but gives up quickly if the connection isn't accepted.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
