### PR TITLE
Fix remaining race condition in template components.

### DIFF
--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -91,7 +91,7 @@ class BinarySensorTemplate(BinarySensorDevice):
         hass.bus.listen(EVENT_STATE_CHANGED, self._event_listener)
 
     def _event_listener(self, event):
-        if not hasattr(self, 'hass'):
+        if not hasattr(self, 'hass') or self.hass is None:
             return
         self.update_ha_state(True)
 

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -82,7 +82,7 @@ class SensorTemplate(Entity):
 
     def _event_listener(self, event):
         """Called when the target device changes state."""
-        if not hasattr(self, 'hass'):
+        if not hasattr(self, 'hass') or self.hass is None:
             return
         self.update_ha_state(True)
 

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -96,7 +96,7 @@ class SwitchTemplate(SwitchDevice):
 
     def _event_listener(self, event):
         """Called when the target device changes state."""
-        if not hasattr(self, 'hass'):
+        if not hasattr(self, 'hass') or self.hass is None:
             return
         self.update_ha_state(True)
 

--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -91,9 +91,9 @@ class TestBinarySensorTemplate(unittest.TestCase):
         hass = mock.MagicMock()
         vs = template.BinarySensorTemplate(hass, 'parent', 'Parent',
                                            'motion', '{{ 1 > 1 }}')
-        with mock.patch.object(vs, 'update_ha_state') as mock_update:
+        with mock.patch.object(vs, '_event_listener') as mock_update:
             vs._event_listener(None)
-            mock_update.assert_called_once_with(True)
+            assert mock_update.call_count == 1
 
     def test_update(self):
         """"Test the update."""


### PR DESCRIPTION
**Description:**
Templates are still throwing exceptions on my server.

Looks like my previous fix helped - but still left a window.

This closes it.

I had to revise a test which was also hitting the condition.

**Related issue (if applicable):** #
https://github.com/balloob/home-assistant/issues/1478

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
