### PR TITLE
Add discovery for squeezebox (logitech media) servers.

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -25,6 +25,7 @@ SERVICE_CAST = 'google_cast'
 SERVICE_NETGEAR = 'netgear_router'
 SERVICE_SONOS = 'sonos'
 SERVICE_PLEX = 'plex_mediaserver'
+SERVICE_SQUEEZEBOX = 'logitech_mediaserver'
 
 SERVICE_HANDLERS = {
     SERVICE_WEMO: "wemo",
@@ -33,6 +34,7 @@ SERVICE_HANDLERS = {
     SERVICE_NETGEAR: 'device_tracker',
     SERVICE_SONOS: 'media_player',
     SERVICE_PLEX: 'media_player',
+    SERVICE_SQUEEZEBOX: 'media_player',
 }
 
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -28,6 +28,7 @@ DISCOVERY_PLATFORMS = {
     discovery.SERVICE_CAST: 'cast',
     discovery.SERVICE_SONOS: 'sonos',
     discovery.SERVICE_PLEX: 'plex',
+    discovery.SERVICE_SQUEEZEBOX: 'squeezebox',
 }
 
 SERVICE_PLAY_MEDIA = 'play_media'

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -22,19 +22,32 @@ SUPPORT_SQUEEZEBOX = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | \
     SUPPORT_VOLUME_MUTE | SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK | \
     SUPPORT_SEEK | SUPPORT_TURN_ON | SUPPORT_TURN_OFF
 
+KNOWN_DEVICES = []
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the squeezebox platform."""
-    if not config.get(CONF_HOST):
+    if discovery_info is not None:
+        host = discovery_info[0]
+        port = 9090
+    else:
+        host = config.get(CONF_HOST)
+        port = int(config.get('port', 9090))
+
+    if not host:
         _LOGGER.error(
             "Missing required configuration items in %s: %s",
             DOMAIN,
             CONF_HOST)
         return False
 
+    # Only add a media server once
+    if (host, port) in KNOWN_DEVICES:
+        return False
+    KNOWN_DEVICES.append((host, port))
+
     lms = LogitechMediaServer(
-        config.get(CONF_HOST),
-        config.get('port', '9090'),
+        host, port,
         config.get(CONF_USERNAME),
         config.get(CONF_PASSWORD))
 


### PR DESCRIPTION
**Description:**
Add the home-assistant changes needed for automatic discovery of logitech media servers.

**Related issue (if applicable):** balloob/netdisco#15 and #1561

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
discovery:
```

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
