### PR TITLE
Added available method to all wink components

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-wink==0.6.3']
+REQUIREMENTS = ['python-wink==0.6.4']
 
 # These are the available sensors mapped to binary_sensor class
 SENSOR_TYPES = {
@@ -76,6 +76,11 @@ class WinkBinarySensorDevice(BinarySensorDevice, Entity):
     def name(self):
         """Return the name of the sensor if any."""
         return self.wink.name()
+
+    @property
+    def available(self):
+        """True if connection == True."""
+        return self.wink.available
 
     def update(self):
         """Update state of the sensor."""

--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.garage_door import GarageDoorDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.3']
+REQUIREMENTS = ['python-wink==0.6.4']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -56,6 +56,11 @@ class WinkGarageDoorDevice(GarageDoorDevice):
     def is_closed(self):
         """Return true if door is closed."""
         return self.wink.state() == 0
+
+    @property
+    def available(self):
+        """True if connection == True."""
+        return self.wink.available
 
     def close_door(self):
         """Close the door."""

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.light import ATTR_BRIGHTNESS, Light
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.3']
+REQUIREMENTS = ['python-wink==0.6.4']
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
@@ -57,6 +57,11 @@ class WinkLight(Light):
     def brightness(self):
         """Return the brightness of the light."""
         return int(self.wink.brightness() * 255)
+
+    @property
+    def available(self):
+        """True if connection == True."""
+        return self.wink.available
 
     # pylint: disable=too-few-public-methods
     def turn_on(self, **kwargs):

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.3']
+REQUIREMENTS = ['python-wink==0.6.4']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -55,6 +55,11 @@ class WinkLockDevice(LockDevice):
     def is_locked(self):
         """Return true if device is locked."""
         return self.wink.state()
+
+    @property
+    def available(self):
+        """True if connection == True."""
+        return self.wink.available
 
     def lock(self, **kwargs):
         """Lock the device."""

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -10,7 +10,7 @@ from homeassistant.const import (CONF_ACCESS_TOKEN, STATE_CLOSED,
                                  STATE_OPEN, TEMP_CELCIUS)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-wink==0.6.3']
+REQUIREMENTS = ['python-wink==0.6.4']
 
 SENSOR_TYPES = ['temperature', 'humidity']
 
@@ -73,6 +73,11 @@ class WinkSensorDevice(Entity):
     def name(self):
         """Return the name of the sensor if any."""
         return self.wink.name()
+
+    @property
+    def available(self):
+        """True if connection == True."""
+        return self.wink.available
 
     def update(self):
         """Update state of the sensor."""

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.wink import WinkToggleDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.6.3']
+REQUIREMENTS = ['python-wink==0.6.4']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.loader import get_component
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.6.3']
+REQUIREMENTS = ['python-wink==0.6.4']
 
 DISCOVER_LIGHTS = "wink.lights"
 DISCOVER_SWITCHES = "wink.switches"
@@ -83,6 +83,11 @@ class WinkToggleDevice(ToggleEntity):
     def is_on(self):
         """Return true if device is on."""
         return self.wink.state()
+
+    @property
+    def available(self):
+        """True if connection == True."""
+        return self.wink.available
 
     def turn_on(self, **kwargs):
         """Turn the device on."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -213,7 +213,7 @@ python-twitch==1.2.0
 # homeassistant.components.lock.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.6.3
+python-wink==0.6.4
 
 # homeassistant.components.keyboard
 pyuserinput==0.1.9


### PR DESCRIPTION
**Description:**
This is the final requirement to fix issue #861 with this PR any Wink device that reports as "Offline" in the Wink iOS or Android Apps will now be disabled in the front-end with a grey icon and the text "unavailable" in place of the switch or sensor status.

**Related issue (if applicable):** #861 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**
- [X] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [X] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [X] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
