### PR TITLE
wake on lan platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -158,6 +158,7 @@ omit =
     homeassistant/components/switch/orvibo.py
     homeassistant/components/switch/rest.py
     homeassistant/components/switch/transmission.py
+    homeassistant/components/switch/wake_on_lan.py
     homeassistant/components/thermostat/heatmiser.py
     homeassistant/components/thermostat/homematic.py
     homeassistant/components/thermostat/proliphix.py

--- a/homeassistant/components/switch/wake_on_lan.py
+++ b/homeassistant/components/switch/wake_on_lan.py
@@ -1,0 +1,79 @@
+"""
+Support for wake on lan.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.wake_on_lan/
+"""
+import logging
+import platform
+import subprocess as sp
+
+from homeassistant.components.switch import SwitchDevice
+
+_LOGGER = logging.getLogger(__name__)
+REQUIREMENTS = ['wakeonlan==0.2.2']
+
+DEFAULT_NAME = "Wake on LAN"
+DEFAULT_PING_TIMEOUT = 1
+
+
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Add wake on lan switch."""
+    if config.get('mac_address') is None:
+        _LOGGER.error("Missing required variable: mac_address")
+        return False
+
+    add_devices_callback([WOLSwitch(
+        hass,
+        config.get('name', DEFAULT_NAME),
+        config.get('host'),
+        config.get('mac_address'),
+        )])
+
+
+class WOLSwitch(SwitchDevice):
+    """Representation of a wake on lan switch."""
+
+    def __init__(self, hass, name, host, mac_address):
+        """Initialize the WOL switch."""
+        from wakeonlan import wol
+        self._hass = hass
+        self._name = name
+        self._host = host
+        self._mac_address = mac_address
+        self._state = False
+        self._wol = wol
+        self.update()
+
+    @property
+    def should_poll(self):
+        """Poll for status regularly."""
+        return True
+
+    @property
+    def is_on(self):
+        """True if switch is on."""
+        return self._state
+
+    @property
+    def name(self):
+        """The name of the switch."""
+        return self._name
+
+    def turn_on(self):
+        """Turn the device on."""
+        self._wol.send_magic_packet(self._mac_address)
+        self.update_ha_state()
+
+    def update(self):
+        """Check if device is on and update the state."""
+        if platform.system().lower() == "windows":
+            ping_cmd = "ping -n 1 -w {} {}"\
+                .format(DEFAULT_PING_TIMEOUT * 1000, self._host)
+        else:
+            ping_cmd = "ping -c 1 -W {} {}"\
+                .format(DEFAULT_PING_TIMEOUT, self._host)
+
+        status = sp.getstatusoutput(ping_cmd)[0]
+
+        self._state = not bool(status)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -283,6 +283,9 @@ uvcclient==0.8
 # homeassistant.components.verisure
 vsure==0.6.1
 
+# homeassistant.components.switch.wake_on_lan
+wakeonlan==0.2.2
+
 # homeassistant.components.zigbee
 xbee-helper==0.0.6
 


### PR DESCRIPTION
Trying this wake on lan platform again

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

```
switch:
- platform: wake_on_lan
  name: "WOL"
  host: "192.168.1.1"
  mac_address: "00-01-02-03-04-05"
```

**Checklist:**
- [ ] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [x] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
