### PR TITLE
log "unable to fetch kodi data" only once

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -50,7 +50,7 @@ class KodiDevice(MediaPlayerDevice):
         self._server = jsonrpc_requests.Server(
             '{}/jsonrpc'.format(self._url),
             auth=auth)
-        self._players = None
+        self._players = list()
         self._properties = None
         self._item = None
         self._app_properties = None
@@ -67,8 +67,9 @@ class KodiDevice(MediaPlayerDevice):
         try:
             return self._server.Player.GetActivePlayers()
         except jsonrpc_requests.jsonrpc.TransportError:
-            _LOGGER.warning('Unable to fetch kodi data')
-            _LOGGER.debug('Unable to fetch kodi data', exc_info=True)
+            if self._players is not None:
+                _LOGGER.warning('Unable to fetch kodi data')
+                _LOGGER.debug('Unable to fetch kodi data', exc_info=True)
             return None
 
     @property


### PR DESCRIPTION
Log "unable to fetch kodi data" only once.

**Related issue (if applicable):** #1468 

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
