### PR TITLE
ZwaveDimmer turn_on brightness changed from float to integer

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -101,7 +101,7 @@ class ZwaveDimmer(ZWaveDeviceEntity, Light):
 
         # Zwave multilevel switches use a range of [0, 99] to control
         # brightness.
-        brightness = (self._brightness / 255) * 99
+        brightness = int((self._brightness / 255) * 99)
 
         if self._value.node.set_dimmer(self._value.value_id, brightness):
             self._state = STATE_ON


### PR DESCRIPTION
**Description:**
Fixes issue with setting brightness for Fibaro FGD-212 Dimmer

**Related issue (if applicable):** #
#1537

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**
- [ ] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
- If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
