### PR TITLE
Bump pywemo to new version.

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components import discovery
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.3.17']
+REQUIREMENTS = ['pywemo==0.3.19']
 
 DOMAIN = 'wemo'
 DISCOVER_LIGHTS = 'wemo.light'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -225,7 +225,7 @@ pyuserinput==0.1.9
 pyvera==0.2.8
 
 # homeassistant.components.wemo
-pywemo==0.3.17
+pywemo==0.3.19
 
 # homeassistant.components.thermostat.radiotherm
 radiotherm==1.2


### PR DESCRIPTION
**Description:**

pywemo has some updates that avoid light flickering on/off when up-to-date status is
not received back from the bulb but we are still able to talk to them. It also reduces the
number of requests sent to a bulb when we update both brightness and color values.

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] TravisCI does not fail. **Your PR cannot be merged unless CI is green!**
- [x] [Fork is up to date](http://stackoverflow.com/a/7244456) and was rebased on the `dev` branch before creating the PR.
- [x] Commits have been [squashed](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit).
- If code communicates with devices:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
