### PR TITLE
Add value_on and value_off to MQTT switches.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Home Assistant
 
-Everybody is invited and welcome to contribute to Home Assistant. There is a lot to do...if you are not a developer perhaps you would like to help with the documentation on [home-assistant.io](https://home-assistant.io/)? If you are a developer and have devices in your home which aren't working with Home Assistant yet, why not spent a couple of hours and help to integrate them? 
+Everybody is invited and welcome to contribute to Home Assistant. There is a lot to do...if you are not a developer perhaps you would like to help with the documentation on [home-assistant.io](https://home-assistant.io/)? If you are a developer and have devices in your home which aren't working with Home Assistant yet, why not spent a couple of hours and help to integrate them?
 
 The process is straight-forward.
 
@@ -9,7 +9,7 @@ The process is straight-forward.
  - Ensure tests work.
  - Create a Pull Request against the [**dev**](https://github.com/balloob/home-assistant/tree/dev) branch of Home Assistant.
 
-Still interested? Then you should read the next sections and get more details. 
+Still interested? Then you should read the next sections and get more details.
 
 ## Adding support for a new device
 
@@ -50,7 +50,7 @@ These attributes are defined in [homeassistant.components](https://github.com/ba
 
 ### Proper Visibility Handling
 
-Generally, when creating a new entity for Home Assistant you will want it to be a class that inherits the [homeassistant.helpers.entity.Entity](https://github.com/balloob/home-assistant/blob/master/homeassistant/helpers/entity.py) class. If this is done, visibility will be handled for you. 
+Generally, when creating a new entity for Home Assistant you will want it to be a class that inherits the [homeassistant.helpers.entity.Entity](https://github.com/balloob/home-assistant/blob/master/homeassistant/helpers/entity.py) class. If this is done, visibility will be handled for you.
 You can set a suggestion for your entity's visibility by setting the hidden property by doing something similar to the following.
 
 ```python

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -33,8 +33,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         _LOGGER.error("Missing required variable: command_topic")
         return False
 
-    payload_on = convert(config.get('payload_on'), str, DEFAULT_PAYLOAD_ON),
-    payload_off = convert(config.get('payload_off'), str, DEFAULT_PAYLOAD_OFF),
+    payload_on = convert(config.get('payload_on'), str, DEFAULT_PAYLOAD_ON)
+    payload_off = convert(config.get('payload_off'), str, DEFAULT_PAYLOAD_OFF)
     add_devices_callback([MqttSwitch(
         hass,
         convert(config.get('name'), str, DEFAULT_NAME),

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -33,6 +33,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         _LOGGER.error("Missing required variable: command_topic")
         return False
 
+    payload_on = convert(config.get('payload_on'), str, DEFAULT_PAYLOAD_ON),
+    payload_off = convert(config.get('payload_off'), str, DEFAULT_PAYLOAD_OFF),
     add_devices_callback([MqttSwitch(
         hass,
         convert(config.get('name'), str, DEFAULT_NAME),
@@ -40,10 +42,10 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         config.get('command_topic'),
         convert(config.get('qos'), int, DEFAULT_QOS),
         convert(config.get('retain'), bool, DEFAULT_RETAIN),
-        convert(config.get('payload_on'), str, DEFAULT_PAYLOAD_ON),
-        convert(config.get('payload_off'), str, DEFAULT_PAYLOAD_OFF),
-        convert(config.get('value_on'), str, DEFAULT_VALUE_ON),
-        convert(config.get('value_off'), str, DEFAULT_VALUE_OFF),
+        payload_on,
+        payload_off,
+        convert(config.get('value_on'), str, payload_on),
+        convert(config.get('value_off'), str, payload_off),
         convert(config.get('optimistic'), bool, DEFAULT_OPTIMISTIC),
         config.get(CONF_VALUE_TEMPLATE))])
 

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -18,6 +18,8 @@ DEFAULT_NAME = "MQTT Switch"
 DEFAULT_QOS = 0
 DEFAULT_PAYLOAD_ON = "ON"
 DEFAULT_PAYLOAD_OFF = "OFF"
+DEFAULT_VALUE_ON = DEFAULT_PAYLOAD_ON
+DEFAULT_VALUE_OFF = DEFAULT_PAYLOAD_OFF
 DEFAULT_OPTIMISTIC = False
 DEFAULT_RETAIN = False
 
@@ -40,6 +42,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         convert(config.get('retain'), bool, DEFAULT_RETAIN),
         convert(config.get('payload_on'), str, DEFAULT_PAYLOAD_ON),
         convert(config.get('payload_off'), str, DEFAULT_PAYLOAD_OFF),
+        convert(config.get('value_on'), str, DEFAULT_VALUE_ON),
+        convert(config.get('value_off'), str, DEFAULT_VALUE_OFF),
         convert(config.get('optimistic'), bool, DEFAULT_OPTIMISTIC),
         config.get(CONF_VALUE_TEMPLATE))])
 
@@ -49,7 +53,8 @@ class MqttSwitch(SwitchDevice):
     """Representation of a switch that can be toggled using MQTT."""
 
     def __init__(self, hass, name, state_topic, command_topic, qos, retain,
-                 payload_on, payload_off, optimistic, value_template):
+                 payload_on, payload_off, value_on, value_off, optimistic,
+                 value_template):
         """Initialize the MQTT switch."""
         self._state = False
         self._hass = hass
@@ -60,6 +65,8 @@ class MqttSwitch(SwitchDevice):
         self._retain = retain
         self._payload_on = payload_on
         self._payload_off = payload_off
+        self._value_on = value_on
+        self._value_off = value_off
         self._optimistic = optimistic
 
         def message_received(topic, payload, qos):
@@ -67,10 +74,10 @@ class MqttSwitch(SwitchDevice):
             if value_template is not None:
                 payload = template.render_with_possible_json_value(
                     hass, value_template, payload)
-            if payload == self._payload_on:
+            if payload == self._value_on:
                 self._state = True
                 self.update_ha_state()
-            elif payload == self._payload_off:
+            elif payload == self._value_off:
                 self._state = False
                 self.update_ha_state()
 


### PR DESCRIPTION
This adds the `value_on` and `value_off` parameters to the mqtt switch. The default value is the same as `payload_on`, so it's backwards-compatible (old installations will continue working as usual).

My switch publishes a very long and convoluted string of timings to get switched on, but then simply returns a "1" in its state, so I needed something that would sense this properly. I added the `value_on` parameter as it would be nice to be more explicit about what the state needs to be to consider the switch on.
