### PR TITLE
Nest sensor - remove broken sensor types

### DIFF
--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -32,10 +32,7 @@ JSON_VARIABLE_NAMES = {'weather_humidity': 'humidity',
 SENSOR_UNITS = {'humidity': '%', 'battery_level': 'V',
                 'kph': 'kph', 'temperature': '°C'}
 
-SENSOR_TEMP_TYPES = ['temperature',
-                     'target',
-                     'away_temperature[0]',
-                     'away_temperature[1]']
+SENSOR_TEMP_TYPES = ['temperature', 'target']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):


### PR DESCRIPTION
**Description:**
Disable broken Nest sensor types.

CC @joshughes

**Related issue (if applicable):** Fixes #1584 

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
