### PR TITLE
Assume we only run one Logitech Media server on a host.

### DIFF
--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -42,9 +42,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
     # Only add a media server once
-    if (host, port) in KNOWN_DEVICES:
+    if host in KNOWN_DEVICES:
         return False
-    KNOWN_DEVICES.append((host, port))
+    KNOWN_DEVICES.append(host)
 
     lms = LogitechMediaServer(
         host, port,


### PR DESCRIPTION
**Description:**

@frelev reported a new error message he observed in his logs now that the logitech media server is autodetected by discovery. He run the CLI interface that home-assistant uses on a non-default port and as such already configures the host and port (and possibly login) information in `configuration.yaml`.

Because discovery uses port 3484/udp (SlimProto), we cannot be sure what port the CLI protocol uses and assume it runs on the default 9090/tcp port. Because discovery uses a well-known port we can be fairly certain only one LMS instance will run on a particular host, so we should just ignore any discovered devices with the assumed default port if the same host was already defined in the configuration.

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
