### PR TITLE
upgrade pyicloud version

### DIFF
--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.event import track_utc_time_change
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyicloud==0.7.2']
+REQUIREMENTS = ['pyicloud==0.8.1']
 
 CONF_INTERVAL = 'interval'
 DEFAULT_INTERVAL = 8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -170,7 +170,7 @@ pydispatcher==2.0.5
 pyfttt==0.3
 
 # homeassistant.components.device_tracker.icloud
-pyicloud==0.7.2
+pyicloud==0.8.1
 
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.3.2


### PR DESCRIPTION
**Description:** upgrades pyicloud version for bugfixes and later updates to the icloud platform

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
