### PR TITLE
Add support for sensor classes

### DIFF
--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -6,7 +6,8 @@ https://home-assistant.io/components/binary_sensor.rest/
 """
 import logging
 
-from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.binary_sensor import (BinarySensorDevice,
+                                                    SENSOR_CLASSES)
 from homeassistant.components.sensor.rest import RestData
 from homeassistant.const import CONF_VALUE_TEMPLATE
 from homeassistant.helpers import template
@@ -19,11 +20,16 @@ DEFAULT_METHOD = 'GET'
 
 # pylint: disable=unused-variable
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup REST binary sensors."""
+    """Setup the REST binary sensor."""
     resource = config.get('resource', None)
     method = config.get('method', DEFAULT_METHOD)
     payload = config.get('payload', None)
     verify_ssl = config.get('verify_ssl', True)
+
+    sensor_class = config.get('sensor_class')
+    if sensor_class not in SENSOR_CLASSES:
+        _LOGGER.warning('Unknown sensor class: %s', sensor_class)
+        sensor_class = None
 
     rest = RestData(method, resource, payload, verify_ssl)
     rest.update()
@@ -33,19 +39,23 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
     add_devices([RestBinarySensor(
-        hass, rest, config.get('name', DEFAULT_NAME),
+        hass,
+        rest,
+        config.get('name', DEFAULT_NAME),
+        sensor_class,
         config.get(CONF_VALUE_TEMPLATE))])
 
 
 # pylint: disable=too-many-arguments
 class RestBinarySensor(BinarySensorDevice):
-    """A REST binary sensor."""
+    """Representation of a REST binary sensor."""
 
-    def __init__(self, hass, rest, name, value_template):
+    def __init__(self, hass, rest, name, sensor_class, value_template):
         """Initialize a REST binary sensor."""
         self._hass = hass
         self.rest = rest
         self._name = name
+        self._sensor_class = sensor_class
         self._state = False
         self._value_template = value_template
         self.update()
@@ -54,6 +64,11 @@ class RestBinarySensor(BinarySensorDevice):
     def name(self):
         """Return the name of the binary sensor."""
         return self._name
+
+    @property
+    def sensor_class(self):
+        """Return the class of this sensor."""
+        return self._sensor_class
 
     @property
     def is_on(self):


### PR DESCRIPTION
**Description:**
The REST sensor didn't support the setting of the sensor class so far. 

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
  - platform: rest
    name: Binary REST Test
    resource: http://localhost:5000/test/binary_sensor2
    value_template: '{{ value_json.state }}'
    sensor_class: motion
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
