### PR TITLE
Add GNTP notifier

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -109,6 +109,7 @@ omit =
     homeassistant/components/media_player/squeezebox.py
     homeassistant/components/notify/free_mobile.py
     homeassistant/components/notify/googlevoice.py
+    homeassistant/components/notify/gntp.py
     homeassistant/components/notify/instapush.py
     homeassistant/components/notify/message_bird.py
     homeassistant/components/notify/nma.py

--- a/homeassistant/components/notify/gntp.py
+++ b/homeassistant/components/notify/gntp.py
@@ -1,0 +1,58 @@
+"""
+GNTP (aka Growl) notification service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.gntp/
+"""
+import logging
+import os
+
+from homeassistant.components.notify import (
+    ATTR_TITLE, BaseNotificationService)
+
+REQUIREMENTS = ['gntp==1.0.3']
+
+_LOGGER = logging.getLogger(__name__)
+
+_GNTP_LOGGER = logging.getLogger('gntp')
+_GNTP_LOGGER.setLevel(logging.ERROR)
+
+
+def get_service(hass, config):
+    """Get the GNTP notification service."""
+    if config.get('app_icon') is None:
+        icon_file = os.path.join(os.path.dirname(__file__), "..", "frontend",
+                                 "www_static", "favicon-192x192.png")
+        app_icon = open(icon_file, 'rb').read()
+    else:
+        app_icon = config.get('app_icon')
+
+    return GNTPNotificationService(config.get('app_name', 'HomeAssistant'),
+                                   config.get('app_icon', app_icon),
+                                   config.get('hostname', 'localhost'),
+                                   config.get('password'),
+                                   config.get('port', 23053))
+
+
+# pylint: disable=too-few-public-methods
+class GNTPNotificationService(BaseNotificationService):
+    """Implement the notification service for GNTP."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, app_name, app_icon, hostname, password, port):
+        """Initialize the service."""
+        from gntp import notifier
+        self.gntp = notifier.GrowlNotifier(
+            applicationName=app_name,
+            notifications=["Notification"],
+            applicationIcon=app_icon,
+            hostname=hostname,
+            password=password,
+            port=port
+        )
+        self.gntp.register()
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to a user."""
+        self.gntp.notify(noteType="Notification", title=kwargs.get(ATTR_TITLE),
+                         description=message)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -54,6 +54,9 @@ freesms==0.1.0
 # homeassistant.components.conversation
 fuzzywuzzy==0.8.0
 
+# homeassistant.components.notify.gntp
+gntp==1.0.3
+
 # homeassistant.components.mqtt.server
 hbmqtt==0.6.3
 


### PR DESCRIPTION
**Description:**
This adds a GNTP notifier. GNTP is used by Growl for Mac and Windows.

**Related issue (if applicable):** balloob/home-assistant.io#331

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
notify:
  name: NOTIFER_NAME
  platform: gntp
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
