### PR TITLE
systemd unit fixes

### DIFF
--- a/script/home-assistant@.service
+++ b/script/home-assistant@.service
@@ -7,8 +7,9 @@ After=network.target
 [Service]
 Type=simple
 User=%i
-WorkingDirectory=%h
-ExecStart=/usr/bin/hass --config %h/.homeassistant/
+# Enable the following line if you get network-related HA errors during boot
+#ExecStartPre=/usr/bin/sleep 60
+ExecStart=/usr/bin/hass
 SendSIGKILL=no
 
 [Install]


### PR DESCRIPTION
**Description:**
- Removed the %h argument. 
  %h points to the home directory of the user running  systemd, not the user running the service. 
  In most cases (i'm using ArchLinux), systemd is ran by root, so %h will default to /root, and therefore fail to locate the user's config path.
  It's easier to omit this entire config location argument, since HA will pick it up from the User parameter.
- Added an optional step to sleep for one minute before starting HA during boot.
  In my system, the After=network.target is not enough of a condition, because network interfaces could be up, but resolv.conf may not be ready to serve yet, and as a result network discovery will fail at boot.
  The UI will only show the statically defined components, until HA is restarted.
  "network-online.target" does not help either. 
  The easiest, and most generic solution, for all different systems and behaviours would just be to wait a while until all targets are up, and then start HA, at the cost of a small startup delay. 
  I have therefore added an optional sleep statement, for systems that may need it, to be enabled and configured where appropriate.

**Related issue (if applicable):** #
A forum example also experiencing network discovery issues during boot:
https://automic.us/forum/viewtopic.php?f=4&t=197&p=563&hilit=systemd#p563

**Sample network discovery error log:**

```
Mar 24 23:48:34 fire hass[382]: ERROR:homeassistant.components.device_tracker:Error setting up platform asuswrt
Mar 24 23:48:34 fire hass[382]: Traceback (most recent call last):
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/homeassistant/components/device_tracker/__init__.py", line 118, in setup_platform
Mar 24 23:48:34 fire hass[382]:     scanner = platform.get_scanner(hass, {DOMAIN: p_config})
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/homeassistant/components/device_tracker/asuswrt.py", line 45, in get_scanner
Mar 24 23:48:34 fire hass[382]:     scanner = AsusWrtDeviceScanner(config[DOMAIN])
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/homeassistant/components/device_tracker/asuswrt.py", line 64, in __init__
Mar 24 23:48:34 fire hass[382]:     data = self.get_asuswrt_data()
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/homeassistant/components/device_tracker/asuswrt.py", line 106, in get_asuswrt_data
Mar 24 23:48:34 fire hass[382]:     telnet = telnetlib.Telnet(self.host)
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/telnetlib.py", line 218, in __init__
Mar 24 23:48:34 fire hass[382]:     self.open(host, port, timeout)
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/telnetlib.py", line 234, in open
Mar 24 23:48:34 fire hass[382]:     self.sock = socket.create_connection((host, port), timeout)
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/socket.py", line 711, in create_connection
Mar 24 23:48:34 fire hass[382]:     raise err
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/socket.py", line 702, in create_connection
Mar 24 23:48:34 fire hass[382]:     sock.connect(sa)
Mar 24 23:48:34 fire hass[382]: OSError: [Errno 101] Network is unreachable
Mar 24 23:48:34 fire hass[382]: INFO:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=group.all_devices, old_state=None, new_state=<state group.all_devices=not_home; entity_id=('device_tracker.485ab6940679', 'device_tracker.542aa219f46e', 'device_tracker.android49c0807bc6003f94', 'device_tracker.001ec015e9a5'), order=0, hidden=True, auto=True, friendly_name=all devices @ 23:48:34 24-03-2016>>
Mar 24 23:48:34 fire hass[382]: INFO:homeassistant.core:Bus:Handling <Event service_registered[L]: service=see, domain=device_tracker>
Mar 24 23:48:34 fire hass[382]: INFO:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=device_tracker>
Mar 24 23:48:34 fire hass[382]: INFO:homeassistant.core:Bus:Handling <Event service_registered[L]: service=trigger, domain=ifttt>
Mar 24 23:48:34 fire hass[382]: INFO:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=ifttt>
Mar 24 23:48:34 fire hass[382]: INFO:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=discovery>
Mar 24 23:48:34 fire hass[382]: INFO:requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): pypi.python.org
Mar 24 23:48:34 fire hass[382]: ERROR:homeassistant.components.updater:Could not contact PyPI to check for updates
Mar 24 23:48:34 fire hass[382]: Traceback (most recent call last):
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/urllib3/connection.py", line 137, in _new_conn
Mar 24 23:48:34 fire hass[382]:     (self.host, self.port), self.timeout, **extra_kw)
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/urllib3/util/connection.py", line 67, in create_connection
Mar 24 23:48:34 fire hass[382]:     for res in socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM):
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/socket.py", line 732, in getaddrinfo
Mar 24 23:48:34 fire hass[382]:     for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
Mar 24 23:48:34 fire hass[382]: socket.gaierror: [Errno -2] Name or service not known
Mar 24 23:48:34 fire hass[382]: During handling of the above exception, another exception occurred:
Mar 24 23:48:34 fire hass[382]: Traceback (most recent call last):
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/urllib3/connectionpool.py", line 558, in urlopen
Mar 24 23:48:34 fire hass[382]:     body=body, headers=headers)
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/urllib3/connectionpool.py", line 345, in _make_request
Mar 24 23:48:34 fire hass[382]:     self._validate_conn(conn)
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/urllib3/connectionpool.py", line 783, in _validate_conn
Mar 24 23:48:34 fire hass[382]:     conn.connect()
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/urllib3/connection.py", line 217, in connect
Mar 24 23:48:34 fire hass[382]:     conn = self._new_conn()
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/urllib3/connection.py", line 146, in _new_conn
Mar 24 23:48:34 fire hass[382]:     self, "Failed to establish a new connection: %s" % e)
Mar 24 23:48:34 fire hass[382]: requests.packages.urllib3.exceptions.NewConnectionError: <requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7fd0ec1ceac8>: Failed to establish a new connection: [Errno -2] Name or service not known
Mar 24 23:48:34 fire hass[382]: During handling of the above exception, another exception occurred:
Mar 24 23:48:34 fire hass[382]: Traceback (most recent call last):
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/requests/adapters.py", line 376, in send
Mar 24 23:48:34 fire hass[382]:     timeout=timeout
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/urllib3/connectionpool.py", line 608, in urlopen
Mar 24 23:48:34 fire hass[382]:     _stacktrace=sys.exc_info()[2])
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/urllib3/util/retry.py", line 273, in increment
Mar 24 23:48:34 fire hass[382]:     raise MaxRetryError(_pool, url, error or ResponseError(cause))
Mar 24 23:48:34 fire hass[382]: requests.packages.urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='pypi.python.org', port=443): Max retries exceeded with url: /pypi/homeassistant/json (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7fd0ec1ceac8>: Failed to establish a new connection: [Errno -2] Name or service not known',))
Mar 24 23:48:34 fire hass[382]: During handling of the above exception, another exception occurred:
Mar 24 23:48:34 fire hass[382]: Traceback (most recent call last):
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/homeassistant/components/updater.py", line 42, in get_newest_version
Mar 24 23:48:34 fire hass[382]:     req = requests.get(PYPI_URL)
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/requests/api.py", line 67, in get
Mar 24 23:48:34 fire hass[382]:     return request('get', url, params=params, **kwargs)
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/requests/api.py", line 53, in request
Mar 24 23:48:34 fire hass[382]:     return session.request(method=method, url=url, **kwargs)
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/requests/sessions.py", line 468, in request
Mar 24 23:48:34 fire hass[382]:     resp = self.send(prep, **send_kwargs)
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/requests/sessions.py", line 576, in send
Mar 24 23:48:34 fire hass[382]:     r = adapter.send(request, **kwargs)
Mar 24 23:48:34 fire hass[382]:   File "/usr/lib/python3.5/site-packages/requests/adapters.py", line 437, in send
Mar 24 23:48:34 fire hass[382]:     raise ConnectionError(e, request=request)
Mar 24 23:48:34 fire hass[382]: requests.exceptions.ConnectionError: HTTPSConnectionPool(host='pypi.python.org', port=443): Max retries exceeded with url: /pypi/homeassistant/json (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7fd0ec1ceac8>: Failed to establish a new connection: [Errno -2] Name or service not known',))
```
