### PR TITLE
Remove unnecessary dependency from TCP binary sensor for #1617

### DIFF
--- a/homeassistant/components/binary_sensor/tcp.py
+++ b/homeassistant/components/binary_sensor/tcp.py
@@ -9,7 +9,6 @@ import logging
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.sensor.tcp import Sensor, DOMAIN, CONF_VALUE_ON
 
-DEPENDENCIES = [DOMAIN]
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/binary_sensor/tcp.py
+++ b/homeassistant/components/binary_sensor/tcp.py
@@ -7,7 +7,8 @@ https://home-assistant.io/components/binary_sensor.tcp/
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.components.sensor.tcp import Sensor, DOMAIN, CONF_VALUE_ON
+from homeassistant.components.sensor.tcp import Sensor, CONF_VALUE_ON
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/tcp.py
+++ b/homeassistant/components/sensor/tcp.py
@@ -13,8 +13,6 @@ from homeassistant.helpers import template
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import Entity
 
-DOMAIN = "tcp"
-
 CONF_PORT = "port"
 CONF_TIMEOUT = "timeout"
 CONF_PAYLOAD = "payload"


### PR DESCRIPTION
Dependency line was left over from a refactor to remove the central TCP component and shift the shared code to the TCP sensor. I believe this is the correct fix (confirmed by @molobrakos) for #1617 but I'm not able to test it at the minute.
