### PR TITLE
Use HTTP 1.1

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -14,10 +14,7 @@ import requests
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.components import bloomsky
-from homeassistant.const import (
-    HTTP_NOT_FOUND,
-    ATTR_ENTITY_ID,
-    )
+from homeassistant.const import HTTP_OK, HTTP_NOT_FOUND, ATTR_ENTITY_ID
 
 
 DOMAIN = 'camera'
@@ -36,7 +33,7 @@ STATE_IDLE = 'idle'
 
 ENTITY_IMAGE_URL = '/api/camera_proxy/{0}'
 
-MULTIPART_BOUNDARY = '--jpegboundary'
+MULTIPART_BOUNDARY = '--jpgboundary'
 MJPEG_START_HEADER = 'Content-type: {0}\r\n\r\n'
 
 
@@ -49,17 +46,6 @@ def setup(hass, config):
 
     component.setup(config)
 
-    # -------------------------------------------------------------------------
-    # CAMERA COMPONENT ENDPOINTS
-    # -------------------------------------------------------------------------
-    # The following defines the endpoints for serving images from the camera
-    # via the HA http server.  This is means that you can access images from
-    # your camera outside of your LAN without the need for port forwards etc.
-
-    # Because the authentication header can't be added in image requests these
-    # endpoints are secured with session based security.
-
-    # pylint: disable=unused-argument
     def _proxy_camera_image(handler, path_match, data):
         """Serve the camera image via the HA server."""
         entity_id = path_match.group(ATTR_ENTITY_ID)
@@ -77,22 +63,16 @@ def setup(hass, config):
             handler.end_headers()
             return
 
-        handler.wfile.write(response)
+        handler.send_response(HTTP_OK)
+        handler.write_content(response)
 
     hass.http.register_path(
         'GET',
         re.compile(r'/api/camera_proxy/(?P<entity_id>[a-zA-Z\._0-9]+)'),
         _proxy_camera_image)
 
-    # pylint: disable=unused-argument
     def _proxy_camera_mjpeg_stream(handler, path_match, data):
-        """
-        Proxy the camera image as an mjpeg stream via the HA server.
-
-        This function takes still images from the IP camera and turns them
-        into an MJPEG stream.  This means that HA can return a live video
-        stream even with only a still image URL available.
-        """
+        """Proxy the camera image as an mjpeg stream via the HA server."""
         entity_id = path_match.group(ATTR_ENTITY_ID)
         camera = component.entities.get(entity_id)
 
@@ -112,8 +92,7 @@ def setup(hass, config):
 
     hass.http.register_path(
         'GET',
-        re.compile(
-            r'/api/camera_proxy_stream/(?P<entity_id>[a-zA-Z\._0-9]+)'),
+        re.compile(r'/api/camera_proxy_stream/(?P<entity_id>[a-zA-Z\._0-9]+)'),
         _proxy_camera_mjpeg_stream)
 
     return True
@@ -137,19 +116,16 @@ class Camera(Entity):
         return ENTITY_IMAGE_URL.format(self.entity_id)
 
     @property
-    # pylint: disable=no-self-use
     def is_recording(self):
         """Return true if the device is recording."""
         return False
 
     @property
-    # pylint: disable=no-self-use
     def brand(self):
         """Camera brand."""
         return None
 
     @property
-    # pylint: disable=no-self-use
     def model(self):
         """Camera model."""
         return None
@@ -160,29 +136,28 @@ class Camera(Entity):
 
     def mjpeg_stream(self, handler):
         """Generate an HTTP MJPEG stream from camera images."""
-        handler.request.sendall(bytes('HTTP/1.1 200 OK\r\n', 'utf-8'))
-        handler.request.sendall(bytes(
-            'Content-type: multipart/x-mixed-replace; \
-                boundary=--jpgboundary\r\n\r\n', 'utf-8'))
-        handler.request.sendall(bytes('--jpgboundary\r\n', 'utf-8'))
+        def write_string(text):
+            """Helper method to write a string to the stream."""
+            handler.request.sendall(bytes(text + '\r\n', 'utf-8'))
 
-        # MJPEG_START_HEADER.format()
+        write_string('HTTP/1.1 200 OK')
+        write_string('Content-type: multipart/x-mixed-replace; '
+                     'boundary={}'.format(MULTIPART_BOUNDARY))
+        write_string('')
+        write_string(MULTIPART_BOUNDARY)
+
         while True:
             img_bytes = self.camera_image()
+
             if img_bytes is None:
                 continue
-            headers_str = '\r\n'.join((
-                'Content-length: {}'.format(len(img_bytes)),
-                'Content-type: image/jpeg',
-            )) + '\r\n\r\n'
 
-            handler.request.sendall(
-                bytes(headers_str, 'utf-8') +
-                img_bytes +
-                bytes('\r\n', 'utf-8'))
-
-            handler.request.sendall(
-                bytes('--jpgboundary\r\n', 'utf-8'))
+            write_string('Content-length: {}'.format(len(img_bytes)))
+            write_string('Content-type: image/jpeg')
+            write_string('')
+            handler.request.sendall(img_bytes)
+            write_string('')
+            write_string(MULTIPART_BOUNDARY)
 
             time.sleep(0.5)
 

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -66,10 +66,6 @@ def _handle_get_api_bootstrap(handler, path_match, data):
 
 def _handle_get_root(handler, path_match, data):
     """Render the frontend."""
-    handler.send_response(HTTP_OK)
-    handler.send_header('Content-type', 'text/html; charset=utf-8')
-    handler.end_headers()
-
     if handler.server.development:
         app_url = "home-assistant-polymer/src/home-assistant.html"
     else:
@@ -86,7 +82,9 @@ def _handle_get_root(handler, path_match, data):
     template_html = template_html.replace('{{ auth }}', auth)
     template_html = template_html.replace('{{ icons }}', mdi_version.VERSION)
 
-    handler.wfile.write(template_html.encode("UTF-8"))
+    handler.send_response(HTTP_OK)
+    handler.write_content(template_html.encode("UTF-8"),
+                          'text/html; charset=utf-8')
 
 
 def _handle_get_service_worker(handler, path_match, data):

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -164,6 +164,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
         # Track if this was an authenticated request
         self.authenticated = False
         SimpleHTTPRequestHandler.__init__(self, req, client_addr, server)
+        self.protocol_version = 'HTTP/1.1'
 
     def log_message(self, fmt, *arguments):
         """Redirect built-in log to HA logging."""

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -104,8 +104,6 @@ class TestAPI(unittest.TestCase):
             _url(const.URL_API_STATES_ENTITY.format("test.test")),
             headers=HA_HEADERS)
 
-        self.assertEqual(req.headers['content-length'], str(len(req.content)))
-
         data = ha.State.from_dict(req.json())
 
         state = hass.states.get("test.test")


### PR DESCRIPTION
**Description:**
This PR will upgrade HTTP Server to use HTTP 1.1.

The risk with using HTTP 1.1 is that all handlers should properly sent content-length headers. If not, stuff will break. Since we expose this functionality to any component, this might be a very bad idea.

This PR should include an extra helper method to help sending data to the client that will handle gzip/content length header.

To do:
- [x] Frontend.get_root does not send `content-length` header
- [ ] Extract a method for sending data so we can always ensure content length header / gzip

**Related issue (if applicable):** #1619 

**Checklist:**

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
