### PR TITLE
0.16.1: Revert pyicloud upgrade

### DIFF
--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.event import track_utc_time_change
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyicloud==0.8.1']
+REQUIREMENTS = ['pyicloud==0.7.2']
 
 CONF_INTERVAL = 'interval'
 DEFAULT_INTERVAL = 8

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """Constants used by Home Assistant components."""
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"
 REQUIRED_PYTHON_VER = (3, 4)
 
 # Can be used to specify a catch all when registering state or event listeners.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -176,7 +176,7 @@ pydispatcher==2.0.5
 pyfttt==0.3
 
 # homeassistant.components.device_tracker.icloud
-pyicloud==0.8.1
+pyicloud==0.7.2
 
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.3.2


### PR DESCRIPTION
**Description:**
Users have reported in #1625 that iCloud no longer functions after the upgrade. On top of that there seems to be no instructions in how to avoid this / clean this up.

I'm reverting this change until there is a clear upgrade path without interference for users.

**Related issue (if applicable):** #1625 

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
