### PR TITLE
by default, don't start in runlevel 2

### DIFF
--- a/script/hass-daemon
+++ b/script/hass-daemon
@@ -3,8 +3,8 @@
 # Provides:          hass
 # Required-Start:    $local_fs $network $named $time $syslog
 # Required-Stop:     $local_fs $network $named $time $syslog
-# Default-Start:     2 3 4 5
-# Default-Stop:      0 1 6
+# Default-Start:     3 4 5
+# Default-Stop:      0 1 2 6
 # Description:       Home\ Assistant
 ### END INIT INFO
 


### PR DESCRIPTION
Some components don't like networking not being available on daemon start. For example, unifi dev tracking throws an exception and won't load at all rendering device tracking inoperable until daemon restart. I doubt very many people are using hass in runlevel 2, disabling it by default will prevent the race condition and might prevent a few headaches.
