### PR TITLE
Change Uber requirements to point to master repo

### DIFF
--- a/homeassistant/components/sensor/uber.py
+++ b/homeassistant/components/sensor/uber.py
@@ -11,9 +11,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ['https://github.com/denismakogon/rides-python-sdk/archive/'
-                'py3-support.zip#'
-                'uber_rides==0.1.2-dev']
+REQUIREMENTS = ['uber_rides==0.2.1']
 
 ICON = 'mdi:taxi'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -81,9 +81,6 @@ https://github.com/Xorso/pyalarmdotcom/archive/0.1.1.zip#pyalarmdotcom==0.1.1
 # homeassistant.components.modbus
 https://github.com/bashwork/pymodbus/archive/d7fc4f1cc975631e0a9011390e8017f64b612661.zip#pymodbus==1.2.0
 
-# homeassistant.components.sensor.uber
-https://github.com/denismakogon/rides-python-sdk/archive/py3-support.zip#uber_rides==0.1.2-dev
-
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
 
@@ -282,6 +279,9 @@ tellive-py==0.5.2
 # homeassistant.components.sensor.transmission
 # homeassistant.components.switch.transmission
 transmissionrpc==0.11
+
+# homeassistant.components.sensor.uber
+uber_rides==0.2.1
 
 # homeassistant.components.device_tracker.unifi
 unifi==1.2.4


### PR DESCRIPTION
Uber Rides SDK has been updated upstream to support Python3. I've changed the requirements to point to the official repository instead of the fork.
