### PR TITLE
Enable zwave test_network command.

### DIFF
--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -35,6 +35,7 @@ SERVICE_ADD_NODE = "add_node"
 SERVICE_REMOVE_NODE = "remove_node"
 SERVICE_HEAL_NETWORK = "heal_network"
 SERVICE_SOFT_RESET = "soft_reset"
+SERVICE_TEST_NETWORK = "test_network"
 
 DISCOVER_SENSORS = "zwave.sensors"
 DISCOVER_SWITCHES = "zwave.switch"
@@ -269,6 +270,10 @@ def setup(hass, config):
         """Soft reset the controller."""
         NETWORK.controller.soft_reset()
 
+    def test_network(event):
+        """Test the network by sending commands to all the nodes."""
+        NETWORK.test()
+
     def stop_zwave(event):
         """Stop Z-Wave."""
         NETWORK.stop()
@@ -310,6 +315,7 @@ def setup(hass, config):
         hass.services.register(DOMAIN, SERVICE_REMOVE_NODE, remove_node)
         hass.services.register(DOMAIN, SERVICE_HEAL_NETWORK, heal_network)
         hass.services.register(DOMAIN, SERVICE_SOFT_RESET, soft_reset)
+        hass.services.register(DOMAIN, SERVICE_TEST_NETWORK, test_network)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_zwave)
 


### PR DESCRIPTION
**Description:**
Enable the openzwave test_network command.

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Allows for testing the zwave network by sending
a no-op command to all the nodes. In theory,
this will also bring back nodes which have been
put in the "presumed dead" state.
