### PR TITLE
Fixed bug in rfxtrx sensor

### DIFF
--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -39,7 +39,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         event = rfxtrx.get_rfx_object(entity_info[ATTR_PACKETID])
         new_sensor = RfxtrxSensor(event, entity_info[ATTR_NAME],
                                   entity_info.get(ATTR_DATA_TYPE, None))
-        rfxtrx.RFX_DEVICES[device_id] = new_sensor
+        rfxtrx.RFX_DEVICES[slugify(device_id)] = new_sensor
         sensors.append(new_sensor)
 
     add_devices_callback(sensors)
@@ -53,6 +53,12 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
         if device_id in rfxtrx.RFX_DEVICES:
             rfxtrx.RFX_DEVICES[device_id].event = event
+            k = 2
+            _device_id = device_id + "_" + str(k)
+            while _device_id in rfxtrx.RFX_DEVICES:
+                rfxtrx.RFX_DEVICES[_device_id].event = event
+                k = k + 1
+                _device_id = device_id + "_" + str(k)
             return
 
         # Add entity if not exist and the automatic_add is True


### PR DESCRIPTION
**Description:**
Fixed a bug in rfxtrx sensor when adding multiple values from one sensor

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
