### PR TITLE
Add yr weather component to default config

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -31,14 +31,15 @@ DEFAULT_CONFIG = (
      'pedia.org/wiki/List_of_tz_database_time_zones'),
 )
 DEFAULT_COMPONENTS = {
-    'introduction': 'Show links to resources in log and frontend',
-    'frontend': 'Enables the frontend',
-    'updater': 'Checks for available updates',
-    'discovery': 'Discover some devices automatically',
-    'conversation': 'Allows you to issue voice commands from the frontend',
-    'history': 'Enables support for tracking state changes over time.',
-    'logbook': 'View all events in a logbook',
-    'sun': 'Track the sun',
+    'introduction:': 'Show links to resources in log and frontend',
+    'frontend:': 'Enables the frontend',
+    'updater:': 'Checks for available updates',
+    'discovery:': 'Discover some devices automatically',
+    'conversation:': 'Allows you to issue voice commands from the frontend',
+    'history:': 'Enables support for tracking state changes over time.',
+    'logbook:': 'View all events in a logbook',
+    'sun:': 'Track the sun',
+    'sensor:\n   platform: yr': 'Prediction of weather',
 }
 
 
@@ -127,7 +128,7 @@ def create_default_config(config_dir, detect_location=True):
 
             for component, description in DEFAULT_COMPONENTS.items():
                 config_file.write("# {}\n".format(description))
-                config_file.write("{}:\n\n".format(component))
+                config_file.write("{}\n\n".format(component))
 
         return config_path
 


### PR DESCRIPTION
**Description:**
Added the yr weather component to the default config.

I had to remove auto adding of colon to the end of each component, since "platform: yr" should not end with a colon.

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
