### PR TITLE
Fix crash of Rfxtrx component when using config option fire_event

### DIFF
--- a/homeassistant/components/light/rfxtrx.py
+++ b/homeassistant/components/light/rfxtrx.py
@@ -107,7 +107,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                 rfxtrx.RFX_DEVICES[device_id].hass.bus.fire(
                     EVENT_BUTTON_PRESSED, {
                         ATTR_ENTITY_ID:
-                            rfxtrx.RFX_DEVICES[device_id].device_id,
+                            rfxtrx.RFX_DEVICES[device_id].entity_id,
                         ATTR_STATE: event.values['Command'].lower()
                     }
                 )

--- a/homeassistant/components/switch/rfxtrx.py
+++ b/homeassistant/components/switch/rfxtrx.py
@@ -94,7 +94,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                     rfxtrx.RFX_DEVICES[device_id].hass.bus.fire(
                         EVENT_BUTTON_PRESSED, {
                             ATTR_ENTITY_ID:
-                                rfxtrx.RFX_DEVICES[device_id].device_id,
+                                rfxtrx.RFX_DEVICES[device_id].entity_id,
                             ATTR_STATE: event.values['Command'].lower()
                         }
                     )


### PR DESCRIPTION
**Description:**
This fixes a bug that crashed the rfxtrx component when using config option **fire_event: True**
The config flag enables a user to use the rfxtrx event in automations with repeating signals.

**Related issue (if applicable):** #
#1640

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
fire_event: True
```
