### PR TITLE
FIX enable volume commands for non-coordinators too

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -197,30 +197,26 @@ class SonosDevice(MediaPlayerDevice):
         """Flag of media commands that are supported."""
         return SUPPORT_SONOS
 
-    @only_if_coordinator
-    def turn_off(self):
-        """Turn off media player."""
-        self._player.pause()
-
-    @only_if_coordinator
     def volume_up(self):
         """Volume up media player."""
         self._player.volume += 1
 
-    @only_if_coordinator
     def volume_down(self):
         """Volume down media player."""
         self._player.volume -= 1
 
-    @only_if_coordinator
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
         self._player.volume = str(int(volume * 100))
 
-    @only_if_coordinator
     def mute_volume(self, mute):
         """Mute (true) or unmute (false) media player."""
         self._player.mute = mute
+
+    @only_if_coordinator
+    def turn_off(self):
+        """Turn off media player."""
+        self._player.pause()
 
     @only_if_coordinator
     def media_play(self):


### PR DESCRIPTION
**Description:**
With 124a9b7a8186c70ec175e17d6cab0df65e20c887 it has been introduced the `only_if_coordinator` decorator to avoid exceptions when commands target speakers that are grouped (not coordinators). Volume commands though are available in this case too, so the decorator should not be applied.

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
