### PR TITLE
Service call validation

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -87,8 +87,10 @@ LIGHT_TURN_ON_SCHEMA = vol.Schema({
     ATTR_PROFILE: str,
     ATTR_TRANSITION: VALID_TRANSITION,
     ATTR_BRIGHTNESS: vol.All(int, vol.Range(min=0, max=255)),
-    ATTR_RGB_COLOR: vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
-    ATTR_XY_COLOR: vol.ExactSequence((cv.small_float, cv.small_float)),
+    ATTR_RGB_COLOR: vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
+                            vol.Coerce(tuple)),
+    ATTR_XY_COLOR: vol.All(vol.ExactSequence((cv.small_float, cv.small_float)),
+                           vol.Coerce(tuple)),
     ATTR_COLOR_TEMP: vol.All(int, vol.Range(min=154, max=500)),
     ATTR_FLASH: [FLASH_SHORT, FLASH_LONG],
     ATTR_EFFECT: [EFFECT_COLORLOOP, EFFECT_RANDOM, EFFECT_WHITE],
@@ -222,7 +224,7 @@ def setup(hass, config):
         profile = profiles.get(params.pop(ATTR_PROFILE, None))
 
         if profile:
-            params.setdefault(ATTR_XY_COLOR, list(profile[:2]))
+            params.setdefault(ATTR_XY_COLOR, profile[:2])
             params.setdefault(ATTR_BRIGHTNESS, profile[2])
 
         for light in target_lights:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -14,6 +14,8 @@ import threading
 import time
 from types import MappingProxyType
 
+import voluptuous as vol
+
 import homeassistant.helpers.temperature as temp_helper
 import homeassistant.util as util
 import homeassistant.util.dt as dt_util
@@ -494,13 +496,14 @@ class StateMachine(object):
 class Service(object):
     """Represents a callable service."""
 
-    __slots__ = ['func', 'description', 'fields']
+    __slots__ = ['func', 'description', 'fields', 'schema']
 
-    def __init__(self, func, description, fields):
+    def __init__(self, func, description, fields, schema):
         """Initialize a service."""
         self.func = func
         self.description = description or ''
         self.fields = fields or {}
+        self.schema = schema
 
     def as_dict(self):
         """Return dictionary representation of this service."""
@@ -560,16 +563,20 @@ class ServiceRegistry(object):
         """Test if specified service exists."""
         return service in self._services.get(domain, [])
 
-    def register(self, domain, service, service_func, description=None):
+    # pylint: disable=too-many-arguments
+    def register(self, domain, service, service_func, description=None,
+                 schema=None):
         """
         Register a service.
 
         Description is a dict containing key 'description' to describe
         the service and a key 'fields' to describe the fields.
+
+        Schema is called to coerce and validate the service data.
         """
         description = description or {}
         service_obj = Service(service_func, description.get('description'),
-                              description.get('fields', {}))
+                              description.get('fields', {}), schema)
         with self._lock:
             if domain in self._services:
                 self._services[domain][service] = service_obj
@@ -635,6 +642,15 @@ class ServiceRegistry(object):
             return
 
         service_handler = self._services[domain][service]
+        service_validator = service_handler.schema
+        try:
+            if service_validator:
+                service_data = service_validator(service_data)
+        except vol.MultipleInvalid as ex:
+            _LOGGER.error('Invalid service data for %s.%s: %s',
+                          domain, service, ex)
+            return
+
         service_call = ServiceCall(domain, service, service_data, call_id)
 
         # Add a job to the pool that calls _execute_service

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -12,8 +12,8 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): str,
 }, extra=vol.ALLOW_EXTRA)
 
-byte = vol.All(int, vol.Range(min=0, max=255))
-small_float = vol.All(float, vol.Range(min=0, max=1))
+byte = vol.All(vol.Coerce(int), vol.Range(min=0, max=255))
+small_float = vol.All(vol.Coerce(float), vol.Range(min=0, max=1))
 latitude = vol.All(vol.Coerce(float), vol.Range(min=-90, max=90))
 longitude = vol.All(vol.Coerce(float), vol.Range(min=-180, max=180))
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -12,6 +12,8 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): str,
 }, extra=vol.ALLOW_EXTRA)
 
+byte = vol.All(int, vol.Range(min=0, max=255))
+small_float = vol.All(float, vol.Range(min=0, max=1))
 latitude = vol.All(vol.Coerce(float), vol.Range(min=-90, max=90))
 longitude = vol.All(vol.Coerce(float), vol.Range(min=-180, max=180))
 

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -170,8 +170,8 @@ class TestLight(unittest.TestCase):
         light.turn_on(self.hass, dev1.entity_id,
                       transition=10, brightness=20)
         light.turn_on(
-            self.hass, dev2.entity_id, rgb_color=[255, 255, 255])
-        light.turn_on(self.hass, dev3.entity_id, xy_color=[.4, .6])
+            self.hass, dev2.entity_id, rgb_color=(255, 255, 255))
+        light.turn_on(self.hass, dev3.entity_id, xy_color=(.4, .6))
 
         self.hass.pool.block_till_done()
 
@@ -182,10 +182,10 @@ class TestLight(unittest.TestCase):
             data)
 
         method, data = dev2.last_call('turn_on')
-        self.assertEquals(data[light.ATTR_RGB_COLOR], [255, 255, 255])
+        self.assertEquals(data[light.ATTR_RGB_COLOR], (255, 255, 255))
 
         method, data = dev3.last_call('turn_on')
-        self.assertEqual({light.ATTR_XY_COLOR: [.4, .6]}, data)
+        self.assertEqual({light.ATTR_XY_COLOR: (.4, .6)}, data)
 
         # One of the light profiles
         prof_name, prof_x, prof_y, prof_bri = 'relax', 0.5119, 0.4147, 144
@@ -195,20 +195,20 @@ class TestLight(unittest.TestCase):
         # Specify a profile and attributes to overwrite it
         light.turn_on(
             self.hass, dev2.entity_id,
-            profile=prof_name, brightness=100, xy_color=[.4, .6])
+            profile=prof_name, brightness=100, xy_color=(.4, .6))
 
         self.hass.pool.block_till_done()
 
         method, data = dev1.last_call('turn_on')
         self.assertEqual(
             {light.ATTR_BRIGHTNESS: prof_bri,
-             light.ATTR_XY_COLOR: [prof_x, prof_y]},
+             light.ATTR_XY_COLOR: (prof_x, prof_y)},
             data)
 
         method, data = dev2.last_call('turn_on')
         self.assertEqual(
             {light.ATTR_BRIGHTNESS: 100,
-             light.ATTR_XY_COLOR: [.4, .6]},
+             light.ATTR_XY_COLOR: (.4, .6)},
             data)
 
         # Test shitty data
@@ -278,5 +278,5 @@ class TestLight(unittest.TestCase):
         method, data = dev1.last_call('turn_on')
 
         self.assertEqual(
-            {light.ATTR_XY_COLOR: [.4, .6], light.ATTR_BRIGHTNESS: 100},
+            {light.ATTR_XY_COLOR: (.4, .6), light.ATTR_BRIGHTNESS: 100},
             data)

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -212,6 +212,7 @@ class TestLight(unittest.TestCase):
             data)
 
         # Test shitty data
+        light.turn_on(self.hass)
         light.turn_on(self.hass, dev1.entity_id, profile="nonexisting")
         light.turn_on(self.hass, dev2.entity_id, xy_color=["bla-di-bla", 5])
         light.turn_on(self.hass, dev3.entity_id, rgb_color=[255, None, 2])
@@ -227,7 +228,7 @@ class TestLight(unittest.TestCase):
         method, data = dev3.last_call('turn_on')
         self.assertEqual({}, data)
 
-        # faulty attributes should not overwrite profile data
+        # faulty attributes will not trigger a service call
         light.turn_on(
             self.hass, dev1.entity_id,
             profile=prof_name, brightness='bright', rgb_color='yellowish')
@@ -235,10 +236,7 @@ class TestLight(unittest.TestCase):
         self.hass.pool.block_till_done()
 
         method, data = dev1.last_call('turn_on')
-        self.assertEqual(
-            {light.ATTR_BRIGHTNESS: prof_bri,
-             light.ATTR_XY_COLOR: [prof_x, prof_y]},
-            data)
+        self.assertEqual({}, data)
 
     def test_broken_light_profiles(self):
         """Test light profiles."""

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -305,7 +305,7 @@ class TestLightMQTT(unittest.TestCase):
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_ON, state.state)
-        self.assertEqual([75, 75, 75], state.attributes['rgb_color'])
+        self.assertEqual((75, 75, 75), state.attributes['rgb_color'])
         self.assertEqual(50, state.attributes['brightness'])
 
     def test_show_brightness_if_only_command_topic(self):


### PR DESCRIPTION
**Description:**
Service validator for the services exposed by the light component.

There is one failing test where invalid input is sent to the service because the test does not expect that the request is blocked before it even reaches the light and so the last known request remains unchanged from the previous test.

Restricting values based on the Hue ranges, but we may have to revisit that as the Lightify RGBW bulbs have a wider color_temperature range, and as far as I know WeMo bulbs can transition over longer periods than 900 seconds.

**Related issue (if applicable):** #1657 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
