### PR TITLE
Fix thread termination on exit for Loopenergy, Vera and Wemo

### DIFF
--- a/homeassistant/components/sensor/loopenergy.py
+++ b/homeassistant/components/sensor/loopenergy.py
@@ -7,12 +7,13 @@ https://home-assistant.io/components/sensor.loop_energy/
 import logging
 
 from homeassistant.helpers.entity import Entity
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "loopenergy"
 
-REQUIREMENTS = ['pyloopenergy==0.0.4']
+REQUIREMENTS = ['pyloopenergy==0.0.5']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -44,6 +45,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         gas_serial,
         gas_secret
         )
+
+    def stop_loopenergy(event):
+        """Shutdown loopenergy thread on exit."""
+        _LOGGER.info("Shutting down loopenergy.")
+        controller.terminate()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_loopenergy)
 
     sensors = [LoopEnergyElec(controller)]
 

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.loader import get_component
 
-REQUIREMENTS = ['pyvera==0.2.8']
+REQUIREMENTS = ['pyvera==0.2.10']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components import discovery
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.3.23']
+REQUIREMENTS = ['pywemo==0.3.24']
 
 DOMAIN = 'wemo'
 DISCOVER_LIGHTS = 'wemo.light'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -183,7 +183,7 @@ pyfttt==0.3
 pyicloud==0.7.2
 
 # homeassistant.components.sensor.loopenergy
-pyloopenergy==0.0.4
+pyloopenergy==0.0.5
 
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.3.2
@@ -235,10 +235,10 @@ python-wink==0.6.4
 pyuserinput==0.1.9
 
 # homeassistant.components.vera
-pyvera==0.2.8
+pyvera==0.2.10
 
 # homeassistant.components.wemo
-pywemo==0.3.23
+pywemo==0.3.24
 
 # homeassistant.components.thermostat.radiotherm
 radiotherm==1.2


### PR DESCRIPTION
**Description:**
I planned to just add the thread shutdown that I missed for the new loopenergy sensor.

But as I was debugging I found that the shutdown code wasn't right for the pyvera and pywemo libraries either.

So this fixes all three.

The pywemo update also includes discovery fixes from @jaharkes.

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
