### PR TITLE
WIP Purge old data from sqlite db on hass start-up

### DIFF
--- a/homeassistant/components/recorder.py
+++ b/homeassistant/components/recorder.py
@@ -13,8 +13,8 @@ import logging
 import queue
 import sqlite3
 import threading
-import voluptuous as vol
 from datetime import date, datetime, timedelta
+import voluptuous as vol
 
 import homeassistant.util.dt as dt_util
 from homeassistant.const import (

--- a/tests/components/test_recorder.py
+++ b/tests/components/test_recorder.py
@@ -1,6 +1,8 @@
 """The tests for the Recorder component."""
 # pylint: disable=too-many-public-methods,protected-access
 import unittest
+import time
+import json
 from unittest.mock import patch
 
 from homeassistant.const import MATCH_ALL
@@ -10,7 +12,7 @@ from tests.common import get_test_home_assistant
 
 
 class TestRecorder(unittest.TestCase):
-    """Test the chromecast module."""
+    """Test the recorder module."""
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
@@ -24,6 +26,66 @@ class TestRecorder(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
         recorder._INSTANCE.block_till_done()
+
+    def _add_test_states(self):
+        """Adds multiple states to the db for testing."""
+        now = int(time.time())
+        five_days_ago = now - (60*60*24*5)
+        attributes = {'test_attr': 5, 'test_attr_10': 'nice'}
+
+        test_states = """
+        INSERT INTO states (
+        entity_id, domain, state, attributes, last_changed, last_updated,
+        created, utc_offset, event_id)
+        VALUES
+        ('test.recorder2', 'sensor', 'purgeme', '{attr}', {five_days_ago},
+            {five_days_ago}, {five_days_ago}, -18000, 1001),
+        ('test.recorder2', 'sensor', 'purgeme', '{attr}', {five_days_ago},
+            {five_days_ago}, {five_days_ago}, -18000, 1002),
+        ('test.recorder2', 'sensor', 'purgeme', '{attr}', {five_days_ago},
+            {five_days_ago}, {five_days_ago}, -18000, 1002),
+        ('test.recorder2', 'sensor', 'dontpurgeme', '{attr}', {now},
+            {now}, {now}, -18000, 1003),
+        ('test.recorder2', 'sensor', 'dontpurgeme', '{attr}', {now},
+            {now}, {now}, -18000, 1004);
+        """.format(
+            attr=json.dumps(attributes),
+            five_days_ago=five_days_ago,
+            now=now,
+        )
+
+        # insert test states
+        self.hass.pool.block_till_done()
+        recorder._INSTANCE.block_till_done()
+        recorder.query(test_states)
+
+    def _add_test_events(self):
+        """Adds a few events for testing."""
+        now = int(time.time())
+        five_days_ago = now - (60*60*24*5)
+        event_data = {'test_attr': 5, 'test_attr_10': 'nice'}
+
+        test_events = """
+        INSERT INTO events (
+        event_type, event_data, origin, created, time_fired, utc_offset
+        ) VALUES
+        ('EVENT_TEST_PURGE', '{event_data}', 'LOCAL', {five_days_ago},
+            {five_days_ago}, -18000),
+        ('EVENT_TEST_PURGE', '{event_data}', 'LOCAL', {five_days_ago},
+            {five_days_ago}, -18000),
+        ('EVENT_TEST', '{event_data}', 'LOCAL', {now}, {five_days_ago}, -18000),
+        ('EVENT_TEST', '{event_data}', 'LOCAL', {now}, {five_days_ago}, -18000),
+        ('EVENT_TEST', '{event_data}', 'LOCAL', {now}, {five_days_ago}, -18000);
+        """.format(
+            event_data=json.dumps(event_data),
+            now=now,
+            five_days_ago=five_days_ago
+        )
+
+        # insert test events
+        self.hass.pool.block_till_done()
+        recorder._INSTANCE.block_till_done()
+        recorder.query(test_events)
 
     def test_saving_state(self):
         """Test saving and restoring a state."""
@@ -64,3 +126,58 @@ class TestRecorder(unittest.TestCase):
             'SELECT * FROM events WHERE event_type = ?', (event_type, ))
 
         self.assertEqual(events, db_events)
+
+    def test_purge_old_states(self):
+        """Tests deleting old states."""
+        self._add_test_states()
+        # make sure we start with 5 states
+        states = recorder.query_states('SELECT * FROM states')
+        self.assertEqual(len(states), 5)
+
+        # run purge_old_data()
+        recorder._INSTANCE.purge_days = 4
+        recorder._INSTANCE._purge_old_data()
+
+        # we should only have 2 states left after purging
+        states = recorder.query_states('SELECT * FROM states')
+        self.assertEqual(len(states), 2)
+
+    def test_purge_old_events(self):
+        """Tests deleting old events."""
+        self._add_test_events()
+        events = recorder.query_events('SELECT * FROM events WHERE '
+                                       'event_type LIKE "EVENT_TEST%"')
+        self.assertEqual(len(events), 5)
+
+        # run purge_old_data()
+        recorder._INSTANCE.purge_days = 4
+        recorder._INSTANCE._purge_old_data()
+
+        # now we should only have 3 events left
+        events = recorder.query_events('SELECT * FROM events WHERE '
+                                       'event_type LIKE "EVENT_TEST%"')
+        self.assertEqual(len(events), 3)
+
+
+    def test_purge_disabled(self):
+        """Tests leaving purge_days disabled."""
+        self._add_test_states()
+        self._add_test_events()
+        # make sure we start with 5 states and events
+        states = recorder.query_states('SELECT * FROM states')
+        events = recorder.query_events('SELECT * FROM events WHERE '
+                                       'event_type LIKE "EVENT_TEST%"')
+        self.assertEqual(len(states), 5)
+        self.assertEqual(len(events), 5)
+
+
+        # run purge_old_data()
+        recorder._INSTANCE.purge_days = None
+        recorder._INSTANCE._purge_old_data()
+
+        # we should have all of our states still
+        states = recorder.query_states('SELECT * FROM states')
+        events = recorder.query_events('SELECT * FROM events WHERE '
+                                       'event_type LIKE "EVENT_TEST%"')
+        self.assertEqual(len(states), 5)
+        self.assertEqual(len(events), 5)


### PR DESCRIPTION
**Description:**

Each time HASS starts, the recorder component will run _purge_old_data() before going into the event loop.   _purge_old_data() will delete records from the `events` and `states` tables older than X days.  After deleting those records, `VACUUM` is run on the database to free up disk space taken by the deleted records.

This also adds a `purge_days` config option to the history component.  By default it is set to `-1` which means no old records will be deleted.

Let me know if `purge_days` should be changed to something else.  I considered `purge_after` and a few other similar names, but figured purge_days would be obvious that it's expecting days.

**Related issue (if applicable):** #1337 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
# Enables support for tracking state changes over time.
recorder:
  # Delete events and states older than 2 weeks
  purge_days: 14
```

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
