### PR TITLE
Reconnect loopenergy

### DIFF
--- a/homeassistant/components/sensor/loopenergy.py
+++ b/homeassistant/components/sensor/loopenergy.py
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "loopenergy"
 
-REQUIREMENTS = ['pyloopenergy==0.0.6']
+REQUIREMENTS = ['pyloopenergy==0.0.7']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/loopenergy.py
+++ b/homeassistant/components/sensor/loopenergy.py
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "loopenergy"
 
-REQUIREMENTS = ['pyloopenergy==0.0.5']
+REQUIREMENTS = ['pyloopenergy==0.0.6']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -110,7 +110,7 @@ class LoopEnergyElec(LoopEnergyDevice):
 
     def update(self):
         """Get the cached Loop energy."""
-        self._state = self._controller.electricity_useage
+        self._state = round(self._controller.electricity_useage, 2)
 
 
 # pylint: disable=too-many-instance-attributes
@@ -126,4 +126,4 @@ class LoopEnergyGas(LoopEnergyDevice):
 
     def update(self):
         """Get the cached Loop energy."""
-        self._state = self._controller.gas_useage
+        self._state = round(self._controller.gas_useage, 2)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -183,7 +183,7 @@ pyfttt==0.3
 pyicloud==0.7.2
 
 # homeassistant.components.sensor.loopenergy
-pyloopenergy==0.0.6
+pyloopenergy==0.0.7
 
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.3.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -183,7 +183,7 @@ pyfttt==0.3
 pyicloud==0.7.2
 
 # homeassistant.components.sensor.loopenergy
-pyloopenergy==0.0.5
+pyloopenergy==0.0.6
 
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.3.2


### PR DESCRIPTION
**Description:**
This bumps the pyloopenergy library.

The new ones re-connects after errors.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
