### PR TITLE
Use pynetgear3.3

### DIFF
--- a/homeassistant/components/device_tracker/netgear.py
+++ b/homeassistant/components/device_tracker/netgear.py
@@ -9,14 +9,14 @@ import threading
 from datetime import timedelta
 
 from homeassistant.components.device_tracker import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT
 from homeassistant.util import Throttle
 
 # Return cached results if last scan was less then this time ago.
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ['pynetgear==0.3.2']
+REQUIREMENTS = ['pynetgear==0.3.3']
 
 
 def get_scanner(hass, config):
@@ -25,12 +25,13 @@ def get_scanner(hass, config):
     host = info.get(CONF_HOST)
     username = info.get(CONF_USERNAME)
     password = info.get(CONF_PASSWORD)
+    port = info.get(CONF_PORT)
 
     if password is not None and host is None:
         _LOGGER.warning('Found username or password but no host')
         return None
 
-    scanner = NetgearDeviceScanner(host, username, password)
+    scanner = NetgearDeviceScanner(host, username, password, port)
 
     return scanner if scanner.success_init else None
 
@@ -38,7 +39,7 @@ def get_scanner(hass, config):
 class NetgearDeviceScanner(object):
     """Queries a Netgear wireless router using the SOAP-API."""
 
-    def __init__(self, host, username, password):
+    def __init__(self, host, username, password, port):
         """Initialize the scanner."""
         import pynetgear
 
@@ -49,8 +50,10 @@ class NetgearDeviceScanner(object):
             self._api = pynetgear.Netgear()
         elif username is None:
             self._api = pynetgear.Netgear(password, host)
-        else:
+        elif port is None:
             self._api = pynetgear.Netgear(password, host, username)
+        else:
+            self._api = pynetgear.Netgear(password, host, username, port)
 
         _LOGGER.info("Logging in")
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """Constants used by Home Assistant components."""
 
-__version__ = "0.17.0.dev0"
+__version__ = "0.16.1"
 REQUIRED_PYTHON_VER = (3, 4)
 
 # Can be used to specify a catch all when registering state or event listeners.
@@ -21,6 +21,7 @@ CONF_CUSTOMIZE = "customize"
 
 CONF_PLATFORM = "platform"
 CONF_HOST = "host"
+CONF_PORT = "port"
 CONF_HOSTS = "hosts"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """Constants used by Home Assistant components."""
 
-__version__ = "0.16.1"
+__version__ = "0.17.0.dev0"
 REQUIRED_PYTHON_VER = (3, 4)
 
 # Can be used to specify a catch all when registering state or event listeners.


### PR DESCRIPTION
**Description:**
Upgrade to pynetgear version 3.3. Introduce "port" to configuration and pass it to pynetgear when available. I do not have the python dev environment fully running so I could not run tox or even successfully get a hass env started. Sorry.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
device_tracker:
  platform: netgear
  host: YOUR_ROUTER_IP
  username: YOUR_ADMIN_USERNAME
  password: YOUR_ADMIN_PASSWORD
  port: YOUR_ROUTER_PORT
```
