### PR TITLE
Allow deeply nested configurations for automation rules

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -34,6 +34,17 @@ DEFAULT_CONDITION_TYPE = CONDITION_TYPE_AND
 _LOGGER = logging.getLogger(__name__)
 
 
+def iterate_automations(hass, config, config_key, conf):
+    """Iterate over the found automation and add it"""
+    for list_no, config_block in enumerate(conf):
+        if isinstance(conf[list_no], list):
+            iterate_automations(hass, config, config_key, conf[list_no])
+        else:
+            name = config_block.get(CONF_ALIAS, "{}, {}".format(config_key,
+                                                                list_no))
+            _setup_automation(hass, config_block, name, config)
+
+
 def setup(hass, config):
     """Setup the automation."""
     for config_key in extract_domain_configs(config, DOMAIN):
@@ -42,10 +53,7 @@ def setup(hass, config):
         if not isinstance(conf, list):
             conf = [conf]
 
-        for list_no, config_block in enumerate(conf):
-            name = config_block.get(CONF_ALIAS, "{}, {}".format(config_key,
-                                                                list_no))
-            _setup_automation(hass, config_block, name, config)
+        iterate_automations(hass, config, config_key, conf)
 
     return True
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -35,7 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def iterate_automations(hass, config, config_key, conf):
-    """Iterate over the found automation and add it"""
+    """Iterate over the found automation and add it."""
     for list_no, config_block in enumerate(conf):
         if isinstance(conf[list_no], list):
             iterate_automations(hass, config, config_key, conf[list_no])


### PR DESCRIPTION
**Description:** This PR allows users to have deeply nested list style YAML syntax for automation rules. I only implemented this for automation because I don't believe there would be a use case in other components for such heavily nested configuration.

I'm a neat freak, so I laid out my directory structure like this:

```
├── automation
│   ├── devices
│   │   ├── front_door
│   │   │   ├── open_lighting.yaml
│   │   │   └── open_notify.yaml
│   │   ├── front_door.yaml
│   ├── devices.yaml
├── automation.yaml
```

And here's the file contents, in order of inclusion:
1. automation.yaml

``` yaml
- !include automation/devices.yaml
```
1. automation/devices.yaml

``` yaml
- !include devices/front_door.yaml
```
1. automation/devices/front_door.yaml

``` yaml
- !include front_door/open_notify.yaml
- !include front_door/open_lighting.yaml
```

**Checklist:**

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
