### PR TITLE
Kodi play media

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -515,7 +515,7 @@ class MediaPlayerDevice(Entity):
 
     def play_media(self, media_type, media_id):
         """Play a piece of media."""
-        raise NotImplementedError()
+        return bool(self.supported_media_commands & SUPPORT_PLAY_MEDIA)
 
     def select_source(self, source):
         """Select input source."""

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -7,10 +7,14 @@ https://home-assistant.io/components/media_player/
 import logging
 import os
 
+import voluptuous as vol
+
 from homeassistant.components import discovery
 from homeassistant.config import load_yaml_config_file
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
+import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     STATE_OFF, STATE_UNKNOWN, STATE_PLAYING, STATE_IDLE,
     ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON,
@@ -34,6 +38,7 @@ DISCOVERY_PLATFORMS = {
 }
 
 SERVICE_PLAY_MEDIA = 'play_media'
+SERVICE_SELECT_SOURCE = 'select_source'
 
 ATTR_MEDIA_VOLUME_LEVEL = 'volume_level'
 ATTR_MEDIA_VOLUME_MUTED = 'is_volume_muted'
@@ -54,6 +59,7 @@ ATTR_MEDIA_PLAYLIST = 'media_playlist'
 ATTR_APP_ID = 'app_id'
 ATTR_APP_NAME = 'app_name'
 ATTR_SUPPORTED_MEDIA_COMMANDS = 'supported_media_commands'
+ATTR_INPUT_SOURCE = 'source'
 
 MEDIA_TYPE_MUSIC = 'music'
 MEDIA_TYPE_TVSHOW = 'tvshow'
@@ -73,7 +79,9 @@ SUPPORT_TURN_ON = 128
 SUPPORT_TURN_OFF = 256
 SUPPORT_PLAY_MEDIA = 512
 SUPPORT_VOLUME_STEP = 1024
+SUPPORT_SELECT_SOURCE = 2048
 
+# simple services that only take entity_id(s) as optional argument
 SERVICE_TO_METHOD = {
     SERVICE_TURN_ON: 'turn_on',
     SERVICE_TURN_OFF: 'turn_off',
@@ -85,7 +93,6 @@ SERVICE_TO_METHOD = {
     SERVICE_MEDIA_PAUSE: 'media_pause',
     SERVICE_MEDIA_NEXT_TRACK: 'media_next_track',
     SERVICE_MEDIA_PREVIOUS_TRACK: 'media_previous_track',
-    SERVICE_PLAY_MEDIA: 'play_media',
 }
 
 ATTR_TO_PROPERTY = [
@@ -107,7 +114,35 @@ ATTR_TO_PROPERTY = [
     ATTR_APP_ID,
     ATTR_APP_NAME,
     ATTR_SUPPORTED_MEDIA_COMMANDS,
+    ATTR_INPUT_SOURCE,
 ]
+
+# Service call validation schemas
+MEDIA_PLAYER_SCHEMA = vol.Schema({
+    ATTR_ENTITY_ID: cv.entity_ids,
+})
+
+MEDIA_PLAYER_MUTE_VOLUME_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
+    vol.Required(ATTR_MEDIA_VOLUME_MUTED): vol.Coerce(bool),
+})
+
+MEDIA_PLAYER_SET_VOLUME_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
+    vol.Required(ATTR_MEDIA_VOLUME_LEVEL): cv.small_float,
+})
+
+MEDIA_PLAYER_MEDIA_SEEK_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
+    vol.Required(ATTR_MEDIA_SEEK_POSITION):
+        vol.All(vol.Coerce(float), vol.Range(min=0)),
+})
+
+MEDIA_PLAYER_PLAY_MEDIA_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
+    vol.Required(ATTR_MEDIA_CONTENT_TYPE): cv.string,
+    vol.Required(ATTR_MEDIA_CONTENT_ID): cv.string,
+})
+
+MEDIA_PLAYER_SELECT_SOURCE_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
+    vol.Required(ATTR_INPUT_SOURCE): cv.string,
+})
 
 
 def is_on(hass, entity_id=None):
@@ -219,6 +254,16 @@ def play_media(hass, media_type, media_id, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_PLAY_MEDIA, data)
 
 
+def select_source(hass, source, entity_id=None):
+    """Send the media player the command to select input source."""
+    data = {ATTR_INPUT_SOURCE: source}
+
+    if entity_id:
+        data[ATTR_ENTITY_ID] = entity_id
+
+    hass.services.call(DOMAIN, SERVICE_SELECT_SOURCE, data)
+
+
 def setup(hass, config):
     """Track states and offer events for media_players."""
     component = EntityComponent(
@@ -242,17 +287,12 @@ def setup(hass, config):
 
     for service in SERVICE_TO_METHOD:
         hass.services.register(DOMAIN, service, media_player_service_handler,
-                               descriptions.get(service))
+                               descriptions.get(service),
+                               schema=MEDIA_PLAYER_SCHEMA)
 
     def volume_set_service(service):
         """Set specified volume on the media player."""
         volume = service.data.get(ATTR_MEDIA_VOLUME_LEVEL)
-
-        if volume is None:
-            _LOGGER.error(
-                'Received call to %s without attribute %s',
-                service.service, ATTR_MEDIA_VOLUME_LEVEL)
-            return
 
         for player in component.extract_from_service(service):
             player.set_volume_level(volume)
@@ -261,17 +301,12 @@ def setup(hass, config):
                 player.update_ha_state(True)
 
     hass.services.register(DOMAIN, SERVICE_VOLUME_SET, volume_set_service,
-                           descriptions.get(SERVICE_VOLUME_SET))
+                           descriptions.get(SERVICE_VOLUME_SET),
+                           schema=MEDIA_PLAYER_SET_VOLUME_SCHEMA)
 
     def volume_mute_service(service):
         """Mute (true) or unmute (false) the media player."""
         mute = service.data.get(ATTR_MEDIA_VOLUME_MUTED)
-
-        if mute is None:
-            _LOGGER.error(
-                'Received call to %s without attribute %s',
-                service.service, ATTR_MEDIA_VOLUME_MUTED)
-            return
 
         for player in component.extract_from_service(service):
             player.mute_volume(mute)
@@ -280,17 +315,12 @@ def setup(hass, config):
                 player.update_ha_state(True)
 
     hass.services.register(DOMAIN, SERVICE_VOLUME_MUTE, volume_mute_service,
-                           descriptions.get(SERVICE_VOLUME_MUTE))
+                           descriptions.get(SERVICE_VOLUME_MUTE),
+                           schema=MEDIA_PLAYER_MUTE_VOLUME_SCHEMA)
 
     def media_seek_service(service):
         """Seek to a position."""
         position = service.data.get(ATTR_MEDIA_SEEK_POSITION)
-
-        if position is None:
-            _LOGGER.error(
-                'Received call to %s without attribute %s',
-                service.service, ATTR_MEDIA_SEEK_POSITION)
-            return
 
         for player in component.extract_from_service(service):
             player.media_seek(position)
@@ -299,20 +329,28 @@ def setup(hass, config):
                 player.update_ha_state(True)
 
     hass.services.register(DOMAIN, SERVICE_MEDIA_SEEK, media_seek_service,
-                           descriptions.get(SERVICE_MEDIA_SEEK))
+                           descriptions.get(SERVICE_MEDIA_SEEK),
+                           schema=MEDIA_PLAYER_MEDIA_SEEK_SCHEMA)
+
+    def select_source_service(service):
+        """Change input to selected source."""
+        input_source = service.data.get(ATTR_INPUT_SOURCE)
+
+        for player in component.extract_from_service(service):
+            player.select_source(input_source)
+
+            if player.should_poll:
+                player.update_ha_state(True)
+
+    hass.services.register(DOMAIN, SERVICE_SELECT_SOURCE,
+                           select_source_service,
+                           descriptions.get(SERVICE_SELECT_SOURCE),
+                           schema=MEDIA_PLAYER_SELECT_SOURCE_SCHEMA)
 
     def play_media_service(service):
         """Play specified media_id on the media player."""
         media_type = service.data.get(ATTR_MEDIA_CONTENT_TYPE)
         media_id = service.data.get(ATTR_MEDIA_CONTENT_ID)
-
-        if media_type is None or media_id is None:
-            missing_attr = (ATTR_MEDIA_CONTENT_TYPE if media_type is None
-                            else ATTR_MEDIA_CONTENT_ID)
-            _LOGGER.error(
-                'Received call to %s without attribute %s',
-                service.service, missing_attr)
-            return
 
         for player in component.extract_from_service(service):
             player.play_media(media_type, media_id)
@@ -320,9 +358,9 @@ def setup(hass, config):
             if player.should_poll:
                 player.update_ha_state(True)
 
-    hass.services.register(
-        DOMAIN, SERVICE_PLAY_MEDIA, play_media_service,
-        descriptions.get(SERVICE_PLAY_MEDIA))
+    hass.services.register(DOMAIN, SERVICE_PLAY_MEDIA, play_media_service,
+                           descriptions.get(SERVICE_PLAY_MEDIA),
+                           schema=MEDIA_PLAYER_PLAY_MEDIA_SCHEMA)
 
     return True
 
@@ -430,6 +468,11 @@ class MediaPlayerDevice(Entity):
         return None
 
     @property
+    def source(self):
+        """Name of the current input source."""
+        return None
+
+    @property
     def supported_media_commands(self):
         """Flag media commands that are supported."""
         return 0
@@ -472,8 +515,11 @@ class MediaPlayerDevice(Entity):
 
     def play_media(self, media_type, media_id):
         """Play a piece of media."""
-        #raise NotImplementedError()
-        return bool(self.supported_media_commands & SUPPORT_PLAY_MEDIA)
+        raise NotImplementedError()
+
+    def select_source(self, source):
+        """Select input source."""
+        raise NotImplementedError()
 
     # No need to overwrite these.
     @property
@@ -510,6 +556,11 @@ class MediaPlayerDevice(Entity):
     def support_play_media(self):
         """Boolean if play media command supported."""
         return bool(self.supported_media_commands & SUPPORT_PLAY_MEDIA)
+
+    @property
+    def support_select_source(self):
+        """Boolean if select source command supported."""
+        return bool(self.supported_media_commands & SUPPORT_SELECT_SOURCE)
 
     def toggle(self):
         """Toggle the power on the media player."""

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -7,14 +7,10 @@ https://home-assistant.io/components/media_player/
 import logging
 import os
 
-import voluptuous as vol
-
 from homeassistant.components import discovery
 from homeassistant.config import load_yaml_config_file
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     STATE_OFF, STATE_UNKNOWN, STATE_PLAYING, STATE_IDLE,
     ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON,
@@ -38,7 +34,6 @@ DISCOVERY_PLATFORMS = {
 }
 
 SERVICE_PLAY_MEDIA = 'play_media'
-SERVICE_SELECT_SOURCE = 'select_source'
 
 ATTR_MEDIA_VOLUME_LEVEL = 'volume_level'
 ATTR_MEDIA_VOLUME_MUTED = 'is_volume_muted'
@@ -59,7 +54,6 @@ ATTR_MEDIA_PLAYLIST = 'media_playlist'
 ATTR_APP_ID = 'app_id'
 ATTR_APP_NAME = 'app_name'
 ATTR_SUPPORTED_MEDIA_COMMANDS = 'supported_media_commands'
-ATTR_INPUT_SOURCE = 'source'
 
 MEDIA_TYPE_MUSIC = 'music'
 MEDIA_TYPE_TVSHOW = 'tvshow'
@@ -79,9 +73,7 @@ SUPPORT_TURN_ON = 128
 SUPPORT_TURN_OFF = 256
 SUPPORT_PLAY_MEDIA = 512
 SUPPORT_VOLUME_STEP = 1024
-SUPPORT_SELECT_SOURCE = 2048
 
-# simple services that only take entity_id(s) as optional argument
 SERVICE_TO_METHOD = {
     SERVICE_TURN_ON: 'turn_on',
     SERVICE_TURN_OFF: 'turn_off',
@@ -93,6 +85,7 @@ SERVICE_TO_METHOD = {
     SERVICE_MEDIA_PAUSE: 'media_pause',
     SERVICE_MEDIA_NEXT_TRACK: 'media_next_track',
     SERVICE_MEDIA_PREVIOUS_TRACK: 'media_previous_track',
+    SERVICE_PLAY_MEDIA: 'play_media',
 }
 
 ATTR_TO_PROPERTY = [
@@ -114,35 +107,7 @@ ATTR_TO_PROPERTY = [
     ATTR_APP_ID,
     ATTR_APP_NAME,
     ATTR_SUPPORTED_MEDIA_COMMANDS,
-    ATTR_INPUT_SOURCE,
 ]
-
-# Service call validation schemas
-MEDIA_PLAYER_SCHEMA = vol.Schema({
-    ATTR_ENTITY_ID: cv.entity_ids,
-})
-
-MEDIA_PLAYER_MUTE_VOLUME_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
-    vol.Required(ATTR_MEDIA_VOLUME_MUTED): vol.Coerce(bool),
-})
-
-MEDIA_PLAYER_SET_VOLUME_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
-    vol.Required(ATTR_MEDIA_VOLUME_LEVEL): cv.small_float,
-})
-
-MEDIA_PLAYER_MEDIA_SEEK_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
-    vol.Required(ATTR_MEDIA_SEEK_POSITION):
-        vol.All(vol.Coerce(float), vol.Range(min=0)),
-})
-
-MEDIA_PLAYER_PLAY_MEDIA_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
-    vol.Required(ATTR_MEDIA_CONTENT_TYPE): cv.string,
-    vol.Required(ATTR_MEDIA_CONTENT_ID): cv.string,
-})
-
-MEDIA_PLAYER_SELECT_SOURCE_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
-    vol.Required(ATTR_INPUT_SOURCE): cv.string,
-})
 
 
 def is_on(hass, entity_id=None):
@@ -254,16 +219,6 @@ def play_media(hass, media_type, media_id, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_PLAY_MEDIA, data)
 
 
-def select_source(hass, source, entity_id=None):
-    """Send the media player the command to select input source."""
-    data = {ATTR_INPUT_SOURCE: source}
-
-    if entity_id:
-        data[ATTR_ENTITY_ID] = entity_id
-
-    hass.services.call(DOMAIN, SERVICE_SELECT_SOURCE, data)
-
-
 def setup(hass, config):
     """Track states and offer events for media_players."""
     component = EntityComponent(
@@ -287,12 +242,17 @@ def setup(hass, config):
 
     for service in SERVICE_TO_METHOD:
         hass.services.register(DOMAIN, service, media_player_service_handler,
-                               descriptions.get(service),
-                               schema=MEDIA_PLAYER_SCHEMA)
+                               descriptions.get(service))
 
     def volume_set_service(service):
         """Set specified volume on the media player."""
         volume = service.data.get(ATTR_MEDIA_VOLUME_LEVEL)
+
+        if volume is None:
+            _LOGGER.error(
+                'Received call to %s without attribute %s',
+                service.service, ATTR_MEDIA_VOLUME_LEVEL)
+            return
 
         for player in component.extract_from_service(service):
             player.set_volume_level(volume)
@@ -301,12 +261,17 @@ def setup(hass, config):
                 player.update_ha_state(True)
 
     hass.services.register(DOMAIN, SERVICE_VOLUME_SET, volume_set_service,
-                           descriptions.get(SERVICE_VOLUME_SET),
-                           schema=MEDIA_PLAYER_SET_VOLUME_SCHEMA)
+                           descriptions.get(SERVICE_VOLUME_SET))
 
     def volume_mute_service(service):
         """Mute (true) or unmute (false) the media player."""
         mute = service.data.get(ATTR_MEDIA_VOLUME_MUTED)
+
+        if mute is None:
+            _LOGGER.error(
+                'Received call to %s without attribute %s',
+                service.service, ATTR_MEDIA_VOLUME_MUTED)
+            return
 
         for player in component.extract_from_service(service):
             player.mute_volume(mute)
@@ -315,12 +280,17 @@ def setup(hass, config):
                 player.update_ha_state(True)
 
     hass.services.register(DOMAIN, SERVICE_VOLUME_MUTE, volume_mute_service,
-                           descriptions.get(SERVICE_VOLUME_MUTE),
-                           schema=MEDIA_PLAYER_MUTE_VOLUME_SCHEMA)
+                           descriptions.get(SERVICE_VOLUME_MUTE))
 
     def media_seek_service(service):
         """Seek to a position."""
         position = service.data.get(ATTR_MEDIA_SEEK_POSITION)
+
+        if position is None:
+            _LOGGER.error(
+                'Received call to %s without attribute %s',
+                service.service, ATTR_MEDIA_SEEK_POSITION)
+            return
 
         for player in component.extract_from_service(service):
             player.media_seek(position)
@@ -329,28 +299,20 @@ def setup(hass, config):
                 player.update_ha_state(True)
 
     hass.services.register(DOMAIN, SERVICE_MEDIA_SEEK, media_seek_service,
-                           descriptions.get(SERVICE_MEDIA_SEEK),
-                           schema=MEDIA_PLAYER_MEDIA_SEEK_SCHEMA)
-
-    def select_source_service(service):
-        """Change input to selected source."""
-        input_source = service.data.get(ATTR_INPUT_SOURCE)
-
-        for player in component.extract_from_service(service):
-            player.select_source(input_source)
-
-            if player.should_poll:
-                player.update_ha_state(True)
-
-    hass.services.register(DOMAIN, SERVICE_SELECT_SOURCE,
-                           select_source_service,
-                           descriptions.get(SERVICE_SELECT_SOURCE),
-                           schema=MEDIA_PLAYER_SELECT_SOURCE_SCHEMA)
+                           descriptions.get(SERVICE_MEDIA_SEEK))
 
     def play_media_service(service):
         """Play specified media_id on the media player."""
         media_type = service.data.get(ATTR_MEDIA_CONTENT_TYPE)
         media_id = service.data.get(ATTR_MEDIA_CONTENT_ID)
+
+        if media_type is None or media_id is None:
+            missing_attr = (ATTR_MEDIA_CONTENT_TYPE if media_type is None
+                            else ATTR_MEDIA_CONTENT_ID)
+            _LOGGER.error(
+                'Received call to %s without attribute %s',
+                service.service, missing_attr)
+            return
 
         for player in component.extract_from_service(service):
             player.play_media(media_type, media_id)
@@ -358,9 +320,9 @@ def setup(hass, config):
             if player.should_poll:
                 player.update_ha_state(True)
 
-    hass.services.register(DOMAIN, SERVICE_PLAY_MEDIA, play_media_service,
-                           descriptions.get(SERVICE_PLAY_MEDIA),
-                           schema=MEDIA_PLAYER_PLAY_MEDIA_SCHEMA)
+    hass.services.register(
+        DOMAIN, SERVICE_PLAY_MEDIA, play_media_service,
+        descriptions.get(SERVICE_PLAY_MEDIA))
 
     return True
 
@@ -468,11 +430,6 @@ class MediaPlayerDevice(Entity):
         return None
 
     @property
-    def source(self):
-        """Name of the current input source."""
-        return None
-
-    @property
     def supported_media_commands(self):
         """Flag media commands that are supported."""
         return 0
@@ -515,11 +472,8 @@ class MediaPlayerDevice(Entity):
 
     def play_media(self, media_type, media_id):
         """Play a piece of media."""
-        raise NotImplementedError()
-
-    def select_source(self, source):
-        """Select input source."""
-        raise NotImplementedError()
+        #raise NotImplementedError()
+        return bool(self.supported_media_commands & SUPPORT_PLAY_MEDIA)
 
     # No need to overwrite these.
     @property
@@ -556,11 +510,6 @@ class MediaPlayerDevice(Entity):
     def support_play_media(self):
         """Boolean if play media command supported."""
         return bool(self.supported_media_commands & SUPPORT_PLAY_MEDIA)
-
-    @property
-    def support_select_source(self):
-        """Boolean if select source command supported."""
-        return bool(self.supported_media_commands & SUPPORT_SELECT_SOURCE)
 
     def toggle(self):
         """Toggle the power on the media player."""

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -515,7 +515,7 @@ class MediaPlayerDevice(Entity):
 
     def play_media(self, media_type, media_id):
         """Play a piece of media."""
-        return bool(self.supported_media_commands & SUPPORT_PLAY_MEDIA)
+        raise NotImplementedError()
 
     def select_source(self, source):
         """Select input source."""

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -9,7 +9,9 @@ import urllib
 
 from homeassistant.components.media_player import (
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK, SUPPORT_SEEK,
-    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, MediaPlayerDevice)
+    SUPPORT_PLAY_MEDIA,
+    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, 
+    MediaPlayerDevice)
 from homeassistant.const import (
     STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING)
 
@@ -17,7 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = ['jsonrpc-requests==0.1']
 
 SUPPORT_KODI = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
-    SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK | SUPPORT_SEEK
+    SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK | SUPPORT_SEEK | \
+    SUPPORT_PLAY_MEDIA
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -268,3 +271,10 @@ class KodiDevice(MediaPlayerDevice):
             self._server.Player.Seek(players[0]['playerid'], time)
 
         self.update_ha_state()
+
+    def play_media(self, media_type, media_id):
+        """Send the play_media command to the media player."""
+
+        _LOGGER.warning(media_id)
+        self._server.Player.Open({media_type:media_id},{})
+

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -9,8 +9,7 @@ import urllib
 
 from homeassistant.components.media_player import (
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK, SUPPORT_SEEK,
-    SUPPORT_PLAY_MEDIA,
-    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, 
+    SUPPORT_PLAY_MEDIA, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     MediaPlayerDevice)
 from homeassistant.const import (
     STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING)
@@ -275,6 +274,4 @@ class KodiDevice(MediaPlayerDevice):
     def play_media(self, media_type, media_id):
         """Send the play_media command to the media player."""
 
-        _LOGGER.warning(media_id)
-        self._server.Player.Open({media_type:media_id},{})
-
+        self._server.Player.Open({media_type: media_id}, {})

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -273,5 +273,4 @@ class KodiDevice(MediaPlayerDevice):
 
     def play_media(self, media_type, media_id):
         """Send the play_media command to the media player."""
-
         self._server.Player.Open({media_type: media_id}, {})


### PR DESCRIPTION
**Description:**
Added media_player/play_media service to Kodi

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
automation:
- alias: 'Play Rain Lullaby'
  trigger:
    platform: state
    entity_id: input_select.lullaby
    to: "Rain"
  action:
    service: media_player.play_media
    data:
      entity_id: media_player.kodi_test
      media_content_id: "Downloads/"
      media_content_type: "directory"
```

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
