### PR TITLE
This code never properly worked because the incorrect variable was used

### DIFF
--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -63,7 +63,7 @@ class RestNotificationService(BaseNotificationService):
             data[self._title_param_name] = kwargs.get(ATTR_TITLE)
 
         if self._target_param_name is not None:
-            data[self._title_param_name] = kwargs.get(ATTR_TARGET)
+            data[self._target_param_name] = kwargs.get(ATTR_TARGET)
 
         if self._method == 'POST':
             response = requests.post(self._resource, data=data, timeout=10)


### PR DESCRIPTION
This fixes an incorrect variable name in the REST notify platform.
