### PR TITLE
Case insensitive test for boolean string values in config validation

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -23,6 +23,7 @@ longitude = vol.All(vol.Coerce(float), vol.Range(min=-180, max=180),
 def boolean(value):
     """Validate and coerce a boolean value."""
     if isinstance(value, str):
+        value = value.lower()
         if value in ('1', 'true', 'yes', 'on', 'enable'):
             return True
         if value in ('0', 'false', 'no', 'off', 'disable'):

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -4,6 +4,21 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
 
+def test_boolean():
+    """Test boolean validation."""
+    schema = vol.Schema(cv.boolean)
+
+    for value in ('T', 'negative', 'lock'):
+        with pytest.raises(vol.MultipleInvalid):
+            schema(value)
+
+    for value in ('true', 'On', '1', 'YES', 'enable', 1, True):
+        assert schema(value)
+
+    for value in ('false', 'Off', '0', 'NO', 'disable', 0, False):
+        assert not schema(value)
+
+
 def test_latitude():
     """Test latitude validation."""
     schema = vol.Schema(cv.latitude)


### PR DESCRIPTION
**Description:**
Be more flexible in what is accepted as boolean string values.

**Related issue (if applicable):** #

**Checklist:**

If the code does not interact with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] Tests have been added to verify that the new code works.
