### PR TITLE
remove the default Home Assistant notification title

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -19,7 +19,7 @@ DOMAIN = "notify"
 
 # Title of notification
 ATTR_TITLE = "title"
-ATTR_TITLE_DEFAULT = "Home Assistant"
+ATTR_TITLE_DEFAULT = ""
 
 # Target of the notification (user, device, etc)
 ATTR_TARGET = 'target'


### PR DESCRIPTION
#114634013 - Make title of messages optional (notifications)
