### PR TITLE
Use whole degrees fahrenheit for thermostats

### DIFF
--- a/homeassistant/components/thermostat/__init__.py
+++ b/homeassistant/components/thermostat/__init__.py
@@ -182,14 +182,15 @@ class ThermostatDevice(Entity):
         """Return the optional state attributes."""
         data = {
             ATTR_CURRENT_TEMPERATURE:
-            self._convert(self.current_temperature, 1),
-            ATTR_MIN_TEMP: self._convert(self.min_temp, 1),
-            ATTR_MAX_TEMP: self._convert(self.max_temp, 1),
-            ATTR_TEMPERATURE: self._convert(self.target_temperature, 1),
+            self._convert_for_display(self.current_temperature),
+            ATTR_MIN_TEMP: self._convert_for_display(self.min_temp),
+            ATTR_MAX_TEMP: self._convert_for_display(self.max_temp),
+            ATTR_TEMPERATURE:
+            self._convert_for_display(self.target_temperature),
             ATTR_TEMPERATURE_LOW:
-            self._convert(self.target_temperature_low, 1),
+            self._convert_for_display(self.target_temperature_low),
             ATTR_TEMPERATURE_HIGH:
-            self._convert(self.target_temperature_high, 1),
+            self._convert_for_display(self.target_temperature_high),
         }
 
         operation = self.operation
@@ -276,12 +277,18 @@ class ThermostatDevice(Entity):
         """Return the maximum temperature."""
         return round(convert(35, TEMP_CELCIUS, self.unit_of_measurement))
 
-    def _convert(self, temp, round_dec=None):
-        """Convert temperature into user preferred temperature."""
+    def _convert_for_display(self, temp):
+        """Convert temperature into preferred units for display purposes."""
         if temp is None:
             return None
 
         value = convert(temp, self.unit_of_measurement,
                         self.hass.config.temperature_unit)
 
-        return value if round_dec is None else round(value, round_dec)
+        if self.hass.config.temperature_unit is TEMP_CELCIUS:
+            decimal_count = 1
+        else:
+            # Users of fahrenheit generally expect integer units.
+            decimal_count = 0
+
+        return round(value, decimal_count)


### PR DESCRIPTION
Users of fahrenheit generally expect to see whole degrees. The fahrenheit
scale is sufficiently precise that decimals aren't really useful in terms
of temperatures humans care about.

This change rounds fahrenheit values to whole degrees and celsius values
to one decimal place. It also renames the ThermostatDevice._convert()
method to _convert_for_display(), making its purpose more clear. It is
not useful for the min_temp() and max_temp() methods, as those relate to
the internal state of the ThermostatDevice object, and may use different
units. Adding optional source and target units to _convert() would have
added needless complexity, it's cleaner to just use convert() in those
methods.

**Checklist:**
If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
