### PR TITLE
Bump rxv to 0.1.11.

### DIFF
--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -10,7 +10,7 @@ from homeassistant.components.media_player import (
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     MediaPlayerDevice)
 from homeassistant.const import STATE_OFF, STATE_ON
-REQUIREMENTS = ['rxv==0.1.9']
+REQUIREMENTS = ['rxv==0.1.11']
 _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_YAMAHA = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -244,7 +244,7 @@ pywemo==0.3.24
 radiotherm==1.2
 
 # homeassistant.components.media_player.yamaha
-rxv==0.1.9
+rxv==0.1.11
 
 # homeassistant.components.media_player.samsungtv
 samsungctl==0.5.1


### PR DESCRIPTION
**Description:**
Update yamaha component to the rxv release that no longer uses socket.setdefaulttimeout().

**Related issue (if applicable):** #1686

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Fixes socket read/write timeout issues.
