### PR TITLE
Change to freegeoip.io and add a second service as fall-back

### DIFF
--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -17,16 +17,35 @@ LocationInfo = collections.namedtuple(
      'city', 'zip_code', 'time_zone', 'latitude', 'longitude',
      'use_fahrenheit'])
 
+DATA_SOURCE = ['https://freegeoip.io/json/', 'http://ip-api.com/json']
+
 
 def detect_location_info():
     """Detect location information."""
-    try:
-        raw_info = requests.get(
-            'https://freegeoip.net/json/', timeout=5).json()
-    except (requests.RequestException, ValueError):
-        return None
+    success = None
 
-    data = {key: raw_info.get(key) for key in LocationInfo._fields}
+    for source in DATA_SOURCE:
+        try:
+            raw_info = requests.get(source, timeout=5).json()
+            success = source
+            break
+        except (requests.RequestException, ValueError):
+            success = False
+
+    if success is False:
+        return None
+    else:
+        data = {key: raw_info.get(key) for key in LocationInfo._fields}
+        if success is DATA_SOURCE[1]:
+            data['ip'] = raw_info.get('query')
+            data['country_code'] = raw_info.get('countryCode')
+            data['country_name'] = raw_info.get('country')
+            data['region_code'] = raw_info.get('region')
+            data['region_name'] = raw_info.get('regionName')
+            data['zip_code'] = raw_info.get('zip')
+            data['time_zone'] = raw_info.get('timezone')
+            data['latitude'] = raw_info.get('lat')
+            data['longitude'] = raw_info.get('lon')
 
     # From Wikipedia: Fahrenheit is used in the Bahamas, Belize,
     # the Cayman Islands, Palau, and the United States and associated


### PR DESCRIPTION
**Description:**
https://freegeoip.net/json/ is no longer available. This PR switches to https://freegeoip.io/json/ and add http://ip-api.com/json as a fall-back.

**Related issue (if applicable):** #1679 (Story: https://www.pivotaltracker.com/story/show/116857495)

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
