### PR TITLE
Add custom volume increment support to sonos platform

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -94,6 +94,7 @@ class SonosDevice(MediaPlayerDevice):
     def __init__(self, hass, player):
         """Initialize the Sonos device."""
         self.hass = hass
+        self.volume_increment = 5
         super(SonosDevice, self).__init__()
         self._player = player
         self.update()
@@ -199,11 +200,11 @@ class SonosDevice(MediaPlayerDevice):
 
     def volume_up(self):
         """Volume up media player."""
-        self._player.volume += 1
+        self._player.volume += self.volume_increment
 
     def volume_down(self):
         """Volume down media player."""
-        self._player.volume -= 1
+        self._player.volume -= self.volume_increment
 
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""


### PR DESCRIPTION
**Description:**
For some Sonos user a volume increase/decrease of 1 might be too small, would be nice to have a way to change the default increase value from configuration

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
media_player:
  platform: sonos
  volume_increment: 5
```

**Checklist:**
- [x] Local tests with `tox` run successfully.
