### PR TITLE
Update Orvibo platform to the switch component, add 'mac' option

### DIFF
--- a/homeassistant/components/switch/orvibo.py
+++ b/homeassistant/components/switch/orvibo.py
@@ -26,9 +26,10 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             _LOGGER.error("Missing required variable: host")
             continue
         host = switch.get('host')
+        mac = switch.get('mac')
         try:
             switches.append(S20Switch(switch.get('name', DEFAULT_NAME),
-                                      S20(host)))
+                                      S20(host, mac=mac)))
             _LOGGER.info("Initialized S20 at %s", host)
         except S20Exception:
             _LOGGER.exception("S20 at %s couldn't be initialized",


### PR DESCRIPTION
**Description:**

This adds an optional 'mac' configuration option to the platform which
is passed to the underlying Orvibo library. The 'mac' option is required
when the switch is connected to a different subnet to the Home Assistant
host

**Related issue (if applicable):** Fixes #1716 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
  platform: orvibo
  host: IP_ADDRESS
  mac: MA:CA:DD:RE:SS:00
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
