### PR TITLE
Disable updater.updater on dev versions

### DIFF
--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -20,6 +20,11 @@ ENTITY_ID = 'updater.updater'
 
 def setup(hass, config):
     """Setup the updater component."""
+    if 'dev' in CURRENT_VERSION:
+        # This component only makes sense in release versions
+        _LOGGER.warning('Updater not supported in development version')
+        return False
+
     def check_newest_version(_=None):
         """Check if a new version is available and report if one is."""
         newest = get_newest_version()

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -4,13 +4,14 @@ from unittest.mock import patch
 
 import requests
 
-from homeassistant.const import __version__ as CURRENT_VERSION
 from homeassistant.components import updater
 import homeassistant.util.dt as dt_util
 from tests.common import fire_time_changed, get_test_home_assistant
 
 NEW_VERSION = '10000.0'
 
+# We need to use a 'real' looking version number to load the updater component
+MOCK_CURRENT_VERSION = '10.0'
 
 class TestUpdater(unittest.TestCase):
     """Test the Updater component."""
@@ -27,6 +28,7 @@ class TestUpdater(unittest.TestCase):
     def test_new_version_shows_entity_on_start(self, mock_get_newest_version):
         """Test if new entity is created if new version is available."""
         mock_get_newest_version.return_value = NEW_VERSION
+        updater.CURRENT_VERSION = MOCK_CURRENT_VERSION
 
         self.assertTrue(updater.setup(self.hass, {
             'updater': None
@@ -38,7 +40,8 @@ class TestUpdater(unittest.TestCase):
     @patch('homeassistant.components.updater.get_newest_version')
     def test_no_entity_on_same_version(self, mock_get_newest_version):
         """Test if no entity is created if same version."""
-        mock_get_newest_version.return_value = CURRENT_VERSION
+        mock_get_newest_version.return_value = MOCK_CURRENT_VERSION
+        updater.CURRENT_VERSION = MOCK_CURRENT_VERSION
 
         self.assertTrue(updater.setup(self.hass, {
             'updater': None
@@ -67,3 +70,12 @@ class TestUpdater(unittest.TestCase):
 
         mock_get.side_effect = KeyError
         self.assertIsNone(updater.get_newest_version())
+
+    def test_updater_disabled_on_dev(self):
+        """Test if the updater component is disabled on dev."""
+        updater.CURRENT_VERSION = MOCK_CURRENT_VERSION + 'dev'
+
+        self.assertFalse(updater.setup(self.hass, {
+            'updater': None
+        }))
+

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -13,6 +13,7 @@ NEW_VERSION = '10000.0'
 # We need to use a 'real' looking version number to load the updater component
 MOCK_CURRENT_VERSION = '10.0'
 
+
 class TestUpdater(unittest.TestCase):
     """Test the Updater component."""
 


### PR DESCRIPTION
The Updater component doesn't make much sense on dev versions. If you
want to run a production config with the updater enabled, you end up
with an 'Update Available' badge pointing you to the last release
version. This change disables the Updater component on dev and updates
the tests to use a faked version number.

A warning is emitted if the Updater component is disabled to ensure there is no confusion.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
