### PR TITLE
Disable updater.updater on dev versions

### DIFF
--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -20,6 +20,11 @@ ENTITY_ID = 'updater.updater'
 
 def setup(hass, config):
     """Setup the updater component."""
+    if 'dev' in CURRENT_VERSION:
+        # This component only makes sense in release versions
+        _LOGGER.warning('Updater not supported in development version')
+        return False
+
     def check_newest_version(_=None):
         """Check if a new version is available and report if one is."""
         newest = get_newest_version()


### PR DESCRIPTION
The Updater component doesn't make much sense on dev versions. If you
want to run a production config with the updater enabled, you end up
with an 'Update Available' badge pointing you to the last release
version. This change disables the Updater component on dev and updates
the tests to use a faked version number.

A warning is emitted if the Updater component is disabled to ensure
there is no confusion.

**Checklist:**
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
