### PR TITLE
Make debugging of invalid config easier when duplicated key is found

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -39,7 +39,7 @@ def _ordered_dict(loader, node):
     dups = [k for k, v in Counter(k for k, _ in nodes).items() if v > 1]
     if dups:
         msg = ""
-        for (key, value) in nodes:
+        for key in nodes:
             msg = msg + str(key) + "=..., "
         raise yaml.YAMLError("ERROR: duplicate keys:"
                              " {} in configuration of: {}"

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -38,9 +38,7 @@ def _ordered_dict(loader, node):
     nodes = loader.construct_pairs(node)
     dups = [k for k, v in Counter(k for k, _ in nodes).items() if v > 1]
     if dups:
-        msg = ""
-        for (key, _) in nodes:
-            msg = msg + str(key) + "=..., "
+        msg = ', '.join('{}=…'.format(item[0]) for item in nodes)
         raise yaml.YAMLError("ERROR: duplicate keys:"
                              " {} in configuration of: {}"
                              .format(dups, msg))

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -41,7 +41,7 @@ def _ordered_dict(loader, node):
     if dups:
         msg = repr_helper(nodes)
         raise yaml.YAMLError("ERROR: duplicate keys:"
-                             " {} in configuration of: \n{}"
+                             " {} in configuration of: {}"
                              .format(dups, msg))
     return OrderedDict(nodes)
 

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -39,7 +39,9 @@ def _ordered_dict(loader, node):
     nodes = loader.construct_pairs(node)
     dups = [k for k, v in Counter(k for k, _ in nodes).items() if v > 1]
     if dups:
-        msg = repr_helper(nodes)
+        msg = ""
+        for (key, value) in nodes:
+            msg = msg + str(key) + "=..., "
         raise yaml.YAMLError("ERROR: duplicate keys:"
                              " {} in configuration of: {}"
                              .format(dups, msg))

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -39,7 +39,7 @@ def _ordered_dict(loader, node):
     dups = [k for k, v in Counter(k for k, _ in nodes).items() if v > 1]
     if dups:
         msg = ""
-        for key in nodes:
+        for (key, _) in nodes:
             msg = msg + str(key) + "=..., "
         raise yaml.YAMLError("ERROR: duplicate keys:"
                              " {} in configuration of: {}"

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -39,7 +39,12 @@ def _ordered_dict(loader, node):
     nodes = loader.construct_pairs(node)
     dups = [k for k, v in Counter(k for k, _ in nodes).items() if v > 1]
     if dups:
-        raise yaml.YAMLError("ERROR: duplicate keys: {}".format(dups))
+        msg = ""
+        for (key, value) in nodes:
+            msg = msg + str(key) + ": " + str(value) + "\n"
+        raise yaml.YAMLError("ERROR: duplicate keys:"
+                             " {} in configuration of: \n{}"
+                             .format(dups, msg))
     return OrderedDict(nodes)
 
 

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -2,7 +2,7 @@
 import logging
 import os
 from collections import Counter, OrderedDict
-
+from homeassistant.util import repr_helper
 import yaml
 
 from homeassistant.exceptions import HomeAssistantError
@@ -39,9 +39,7 @@ def _ordered_dict(loader, node):
     nodes = loader.construct_pairs(node)
     dups = [k for k, v in Counter(k for k, _ in nodes).items() if v > 1]
     if dups:
-        msg = ""
-        for (key, value) in nodes:
-            msg = msg + str(key) + ": " + str(value) + "\n"
+        msg = repr_helper(nodes)
         raise yaml.YAMLError("ERROR: duplicate keys:"
                              " {} in configuration of: \n{}"
                              .format(dups, msg))

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -5,7 +5,6 @@ from collections import Counter, OrderedDict
 import yaml
 
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.util import repr_helper
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -2,10 +2,10 @@
 import logging
 import os
 from collections import Counter, OrderedDict
-from homeassistant.util import repr_helper
 import yaml
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util import repr_helper
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
**Description:**
Print more info when a duplicated key in the config is found.
Ideally the line number in the configuration file should also be printed, but I am not sure if that is available?

yaml.error.YAMLError: ERROR: duplicate keys: ['platform'] in configuration of: 
platform: template
platform: numeric_state
entity_id: sun.sun
value_template: {{ state.attributes.elevation }}
below: -2
