### PR TITLE
Add test for fire event in rfxtrx component

### DIFF
--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -178,8 +178,6 @@ def apply_received_command(event):
             is_on = RFX_DEVICES[device_id]._brightness > 0
             RFX_DEVICES[device_id]._state = is_on
             RFX_DEVICES[device_id].update_ha_state()
-        else:
-            return
 
         # Fire event
         if RFX_DEVICES[device_id].should_fire_event:

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -3,9 +3,9 @@
 import unittest
 import time
 
+from homeassistant.bootstrap import _setup_component
 from homeassistant.components import rfxtrx as rfxtrx
 from homeassistant.components.sensor import rfxtrx as rfxtrx_sensor
-
 from tests.common import get_test_home_assistant
 
 
@@ -46,11 +46,56 @@ class TestRFXTRX(unittest.TestCase):
         while len(rfxtrx.RFX_DEVICES) < 2:
             time.sleep(0.1)
 
-        self.assertEquals(len(rfxtrx.RFXOBJECT.sensors()), 2)
-        self.assertEquals(len(devices), 2)
+        self.assertEqual(len(rfxtrx.RFXOBJECT.sensors()), 2)
+        self.assertEqual(len(devices), 2)
 
     def test_config_failing(self):
         """Test configuration."""
         self.assertFalse(rfxtrx.setup(self.hass, {
             'rfxtrx': {}
         }))
+
+    def test_fire_event(self):
+        """Test fire event."""
+
+        self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
+            'rfxtrx': {
+                'device': '/dev/serial/by-id/usb' +
+                          '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
+                'dummy': True}
+        }))
+        self.assertTrue(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'automatic_add': True,
+                       'devices':
+                           {'213c7f216': {
+                               'name': 'Test',
+                               'packetid': '0b1100cd0213c7f210010f51',
+                               rfxtrx.ATTR_FIREEVENT: True}
+                            }}}))
+
+        calls = []
+
+        def record_event(event):
+            """Add recorded event to set."""
+            calls.append(event)
+
+        self.hass.bus.listen(rfxtrx.EVENT_BUTTON_PRESSED, record_event)
+
+        entity = rfxtrx.RFX_DEVICES['213c7f216']
+        self.assertEqual('Test', entity.name)
+        self.assertEqual('off', entity.state)
+        self.assertTrue(entity.should_fire_event)
+
+        event = rfxtrx.get_rfx_object('0b1100cd0213c7f210010f51')
+        event.data = bytearray([0x0b, 0x11, 0x00, 0x10, 0x01, 0x18,
+                                0xcd, 0xea, 0x01, 0x01, 0x0f, 0x70])
+        rfxtrx.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.hass.pool.block_till_done()
+
+        self.assertEqual(event.values['Command'], "On")
+        self.assertEqual('on', entity.state)
+        self.assertEqual(1, len(rfxtrx.RFX_DEVICES))
+        self.assertEqual(1, len(calls))
+        self.assertEqual(calls[0].data,
+                         {'entity_id': 'switch.test', 'state': 'on'})


### PR DESCRIPTION
**Description:**
Add test for fire event in rfxtrx component

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
