### PR TITLE
Bump pywemo to 0.4.1 - fix non native light issue.

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components import discovery
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.3.24']
+REQUIREMENTS = ['pywemo==0.4.1']
 
 DOMAIN = 'wemo'
 DISCOVER_LIGHTS = 'wemo.light'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -241,7 +241,7 @@ pyuserinput==0.1.9
 pyvera==0.2.10
 
 # homeassistant.components.wemo
-pywemo==0.3.24
+pywemo==0.4.1
 
 # homeassistant.components.thermostat.radiotherm
 radiotherm==1.2


### PR DESCRIPTION
**Description:**
Fix by @jaharkes to issues raised in gitter by @cryovat

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
