### PR TITLE
Handle Share off for events in OwnTracks app

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -80,6 +80,11 @@ def setup_scanner(hass, config, see):
         if not isinstance(data, dict) or data.get('_type') != 'transition':
             return
 
+        if data.get('desc') is None:
+            _LOGGER.error(
+                "Location missing from `enter/exit` message - "
+                "please turn `Share` on in OwnTracks app")
+            return
         # OwnTracks uses - at the start of a beacon zone
         # to switch on 'hold mode' - ignore this
         location = data['desc'].lstrip("-")


### PR DESCRIPTION
**Description:**
Fix exception if share is turned off in OwnTracks app

Trace error message

**Related issue (if applicable):** #
Raised in gitter

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
