### PR TITLE
Be flexible in what we accept for script.delay configuration.

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -16,6 +16,7 @@ from homeassistant.util import slugify
 # Home Assistant types
 byte = vol.All(vol.Coerce(int), vol.Range(min=0, max=255))
 small_float = vol.All(vol.Coerce(float), vol.Range(min=0, max=1))
+positive_int = vol.All(vol.Coerce(int), vol.Range(min=0))
 latitude = vol.All(vol.Coerce(float), vol.Range(min=-90, max=90),
                    msg='invalid latitude')
 longitude = vol.All(vol.Coerce(float), vol.Range(min=-180, max=180),

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -206,6 +206,45 @@ class TestScript(unittest.TestCase):
 
         self.assertEqual(2, len(calls))
 
+    def test_alt_delay(self):
+        """Test alternative delay config format."""
+        event = 'test_event'
+        calls = []
+
+        def record_event(event):
+            """Add recorded event to set."""
+            calls.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        assert _setup_component(self.hass, 'script', {
+            'script': {
+                'test': {
+                    'sequence': [{
+                        'event': event,
+                    }, {
+                        'delay': None,
+                        'seconds': 5
+                    }, {
+                        'event': event,
+                    }]
+                }
+            }
+        })
+
+        script.turn_on(self.hass, ENTITY_ID)
+        self.hass.pool.block_till_done()
+
+        self.assertTrue(script.is_on(self.hass, ENTITY_ID))
+        self.assertEqual(1, len(calls))
+
+        future = dt_util.utcnow() + timedelta(seconds=5)
+        fire_time_changed(self.hass, future)
+        self.hass.pool.block_till_done()
+
+        self.assertFalse(script.is_on(self.hass, ENTITY_ID))
+        self.assertEqual(2, len(calls))
+
     def test_cancel_while_delay(self):
         """Test the cancelling while the delay is present."""
         event = 'test_event'


### PR DESCRIPTION
**Description:**
It seems a common error when writing scripts is to forget to indent the time values for a delay.
But there seems to be no ambiguity even in that case. So here is a PR that extends the config validation and delay handling to allow non-indented time specifications. 

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
script:
  delayed_off:
    alias: Turn light off after a 10 minute delay
    sequence:
      - delay:
        minutes: 10
      - service: light.turn_off
        data:
          entity_id: light.somewhere
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.

Accept delay configuration even when someone forgets to indent the time
specification.

Also removed 'weeks' and 'microseconds' from acceptable delay values.
There is a new homeassistant release every 2 weeks and running scripts
are not persisting across restarts. And there is still the option of
using (weeks*7) days if the long delay is really necessary.

And if someone really depends on microsecond delay precision we are
unlikely to be able to provide this accuracy, even milliseconds is
suspect for that matter but will at least allow us to specify some
subsecond delay.
