### PR TITLE
Test function for mqtt topic validators and IsFile() linting fix

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -88,7 +88,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
         vol.Optional(CONF_USERNAME): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_CERTIFICATE): vol.IsFile(),
+        vol.Optional(CONF_CERTIFICATE): cv.isfile,
         vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL):
             [PROTOCOL_31, PROTOCOL_311],
         vol.Optional(CONF_EMBEDDED): _HBMQTT_CONFIG_SCHEMA,

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -34,6 +34,11 @@ def boolean(value):
     return bool(value)
 
 
+def isfile(value):
+    """Validate that the value is an existing file."""
+    return vol.IsFile('not a file')(value)
+
+
 def ensure_list(value):
     """Wrap value in list if it is not one."""
     return value if isinstance(value, list) else [value]

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -4,6 +4,8 @@ import unittest
 from unittest import mock
 import socket
 
+import voluptuous as vol
+
 from homeassistant.bootstrap import _setup_component
 import homeassistant.components.mqtt as mqtt
 from homeassistant.const import (
@@ -306,3 +308,7 @@ class TestMQTTCallbacks(unittest.TestCase):
 
         self.assertEqual({'test/topic': 1}, mqtt.MQTT_CLIENT.topics)
         self.assertEqual({}, mqtt.MQTT_CLIENT.progress)
+
+    def test_invalid_mqtt_topics(self):
+        self.assertRaises(vol.Invalid, mqtt.valid_publish_topic, 'bad+topic')
+        self.assertRaises(vol.Invalid, mqtt.valid_subscribe_topic, 'bad\0one')


### PR DESCRIPTION
**Description:**
Tests if we correctly raise voluptuous.Invalid when given an invalid mqtt topic.

*\* Checklist:**
If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
