### PR TITLE
Trying to fix failing sun component tests.

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -6,10 +6,11 @@ from unittest import mock
 from homeassistant import core as ha, loader
 from homeassistant.bootstrap import _setup_component
 from homeassistant.helpers.entity import ToggleEntity
+import homeassistant.util.dt as date_util
 from homeassistant.const import (
     STATE_ON, STATE_OFF, DEVICE_DEFAULT_NAME, EVENT_TIME_CHANGED,
     EVENT_STATE_CHANGED, EVENT_PLATFORM_DISCOVERED, ATTR_SERVICE,
-    ATTR_DISCOVERED, SERVER_PORT)
+    ATTR_DISCOVERED, SERVER_PORT, TEMP_CELCIUS)
 from homeassistant.components import sun, mqtt
 
 _TEST_INSTANCE_PORT = SERVER_PORT
@@ -34,6 +35,8 @@ def get_test_home_assistant(num_threads=None):
     hass.config.config_dir = get_test_config_dir()
     hass.config.latitude = 32.87336
     hass.config.longitude = -117.22743
+    hass.config.time_zone = date_util.get_time_zone('US/Pacific')
+    hass.config.temperature_unit = TEMP_CELCIUS
 
     if 'custom_components.test' not in loader.AVAILABLE_COMPONENTS:
         loader.prepare(hass)

--- a/tests/components/test_sun.py
+++ b/tests/components/test_sun.py
@@ -32,16 +32,13 @@ class TestSun(unittest.TestCase):
 
     def test_setting_rising(self):
         """Test retrieving sun setting and rising."""
-        latitude = 32.87336
-        longitude = 117.22743
-
-        # Compare it with the real data
-        self.hass.config.latitude = latitude
-        self.hass.config.longitude = longitude
         sun.setup(self.hass, {sun.DOMAIN: {sun.CONF_ELEVATION: 0}})
 
         astral = Astral()
         utc_now = dt_util.utcnow()
+
+        latitude = self.hass.config.latitude
+        longitude = self.hass.config.longitude
 
         mod = -1
         while True:
@@ -73,8 +70,6 @@ class TestSun(unittest.TestCase):
 
     def test_state_change(self):
         """Test if the state changes at next setting/rising."""
-        self.hass.config.latitude = '32.87336'
-        self.hass.config.longitude = '117.22743'
         sun.setup(self.hass, {sun.DOMAIN: {sun.CONF_ELEVATION: 0}})
 
         if sun.is_on(self.hass):


### PR DESCRIPTION
**Description:**
Trying to figure out why the sun component tests were failing. Haven't found an obvious cause but these changes should reduce some of the variables.
- Set a timezone to go along with the location of the home-assistant test instance.
- Don't replace the lat/long values of the hass component when running the sun test, as location was moved from US west coast to a place in China.

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Make sure we set a timezone to make UTC calculations predictable
and don't override the location of the test_home_assistant config.
