### PR TITLE
Rfxtrx config validating

### DIFF
--- a/homeassistant/components/light/rfxtrx.py
+++ b/homeassistant/components/light/rfxtrx.py
@@ -15,6 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = rfxtrx.DEFAULT_SCHEMA
 
+
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the RFXtrx platform."""
     import RFXtrx as rfxtrxmod

--- a/homeassistant/components/light/rfxtrx.py
+++ b/homeassistant/components/light/rfxtrx.py
@@ -13,6 +13,7 @@ DEPENDENCIES = ['rfxtrx']
 
 _LOGGER = logging.getLogger(__name__)
 
+PLATFORM_SCHEMA = rfxtrx.DEFAULT_SCHEMA
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the RFXtrx platform."""

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -14,6 +14,7 @@ REQUIREMENTS = ['pyRFXtrx==0.6.5']
 
 DOMAIN = "rfxtrx"
 
+ATTR_AUTOMATIC_ADD = 'automatic_add'
 ATTR_DEVICE = 'device'
 ATTR_DEBUG = 'debug'
 ATTR_STATE = 'state'
@@ -127,7 +128,7 @@ def get_new_device(event, config, device):
     """Add entity if not exist and the automatic_add is True."""
     device_id = slugify(event.device.id_string.lower())
     if device_id not in RFX_DEVICES:
-        automatic_add = config.get('automatic_add', False)
+        automatic_add = config.get(ATTR_AUTOMATIC_ADD, False)
         if not automatic_add:
             return
 

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -139,7 +139,6 @@ def get_devices_from_config(config, device):
     signal_repetitions = config[CONF_SIGNAL_REPETITIONS]
 
     devices = []
-    print("____________----",config)
     for device_id, entity_info in config[CONF_DEVICES].items():
         if device_id in RFX_DEVICES:
             continue

--- a/homeassistant/components/switch/rfxtrx.py
+++ b/homeassistant/components/switch/rfxtrx.py
@@ -6,9 +6,7 @@ https://home-assistant.io/components/switch.rfxtrx/
 """
 import logging
 
-import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 import homeassistant.components.rfxtrx as rfxtrx
 from homeassistant.components.switch import SwitchDevice
 
@@ -16,14 +14,7 @@ DEPENDENCIES = ['rfxtrx']
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_DEVICE, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_DEBUG, default=DEFAULT_PAYLOAD_ON): cv.boolean,
-    vol.Optional(ATTR_NAME, default=DEFAULT_PAYLOAD_OFF): cv.string,
-    vol.Optional(ATTR_FIREEVENT, default=DEFAULT_OPTIMISTIC): cv.boolean,
-    vol.Optional(ATTR_FIREEVENT, default=DEFAULT_OPTIMISTIC): cv.boolean,
-    vol.Optional(ATTR_FIREEVENT, default=DEFAULT_OPTIMISTIC): cv.boolean,
-})
+PLATFORM_SCHEMA = rfxtrx.DEFAULT_SCHEMA
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the RFXtrx platform."""

--- a/homeassistant/components/switch/rfxtrx.py
+++ b/homeassistant/components/switch/rfxtrx.py
@@ -6,6 +6,9 @@ https://home-assistant.io/components/switch.rfxtrx/
 """
 import logging
 
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
 import homeassistant.components.rfxtrx as rfxtrx
 from homeassistant.components.switch import SwitchDevice
 
@@ -13,6 +16,14 @@ DEPENDENCIES = ['rfxtrx']
 
 _LOGGER = logging.getLogger(__name__)
 
+PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICE, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_DEBUG, default=DEFAULT_PAYLOAD_ON): cv.boolean,
+    vol.Optional(ATTR_NAME, default=DEFAULT_PAYLOAD_OFF): cv.string,
+    vol.Optional(ATTR_FIREEVENT, default=DEFAULT_OPTIMISTIC): cv.boolean,
+    vol.Optional(ATTR_FIREEVENT, default=DEFAULT_OPTIMISTIC): cv.boolean,
+    vol.Optional(ATTR_FIREEVENT, default=DEFAULT_OPTIMISTIC): cv.boolean,
+})
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the RFXtrx platform."""

--- a/homeassistant/components/switch/rfxtrx.py
+++ b/homeassistant/components/switch/rfxtrx.py
@@ -16,6 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = rfxtrx.DEFAULT_SCHEMA
 
+
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the RFXtrx platform."""
     import RFXtrx as rfxtrxmod

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -120,7 +120,7 @@ class TestLightRfxtrx(unittest.TestCase):
                             'packetid': '0b1100100118cdea02010f70'},
                         '213c7f216': {
                             'name': 'Living',
-                            'packetid': '2b1121cd1213c7f211111f71'}}}}))
+                            'packetid': '0b1100100118cdea02010f70'}}}}))
 
         self.assertEqual(3, len(rfxtrx_core.RFX_DEVICES))
         device_num = 0

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -1,9 +1,8 @@
 """The tests for the Rfxtrx light platform."""
 import unittest
 
+from homeassistant.bootstrap import _setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
-from homeassistant.components.light import rfxtrx
-from unittest.mock import patch
 
 from tests.common import get_test_home_assistant
 
@@ -14,6 +13,7 @@ class TestLightRfxtrx(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant(0)
+        self.hass.config.components = ['rfxtrx']
 
     def tearDown(self):
         """Stop everything that was started."""
@@ -23,40 +23,60 @@ class TestLightRfxtrx(unittest.TestCase):
             rfxtrx_core.RFXOBJECT.close_connection()
         self.hass.stop()
 
+    def test_valid_config(self):
+        """Test configuration."""
+        self.assertTrue(_setup_component(self.hass, 'light', {
+            'light': {'platform': 'rfxtrx',
+                      'automatic_add': True,
+                      'devices':
+                      {'213c7f216': {
+                               'name': 'Test',
+                               'packetid': '0b1100cd0213c7f210010f51',
+                               rfxtrx_core.ATTR_FIREEVENT: True}}}}))
+
+        self.assertTrue(_setup_component(self.hass, 'light', {
+            'light': {'platform': 'rfxtrx',
+                      'automatic_add': True,
+                      'devices':
+                      {'213c7f216': {
+                               'name': 'Test',
+                               'packetid': '0b1100cd0213c7f210010f51',
+                               'signal_repetitions': 3}}}}))
+
+    def test_invalid_config(self):
+        """Test configuration."""
+        self.assertFalse(_setup_component(self.hass, 'light', {
+            'light': {'platform': 'rfxtrx',
+                      'automatic_add': True,
+                      'invalid_key': 'afda',
+                      'devices':
+                      {'213c7f216': {
+                               'name': 'Test',
+                               'packetid': '0b1100cd0213c7f210010f51',
+                               rfxtrx_core.ATTR_FIREEVENT: True}}}}))
+
     def test_default_config(self):
-        """Test with 0 lights."""
-        config = {'devices': {}}
-        devices = []
+        """Test with 0 switches."""
+        self.assertTrue(_setup_component(self.hass, 'light', {
+            'light': {'platform': 'rfxtrx',
+                      'devices': {}}}))
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
 
-        def add_dev_callback(devs):
-            """Add a callback to add devices."""
-            for dev in devs:
-                devices.append(dev)
-
-        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
-        self.assertEqual(0, len(devices))
-
-    def test_one_sensor(self):
+    def test_one_light(self):
         """Test with 1 light."""
-        config = {'devices':
-                  {'123efab1': {
-                      'name': 'Test',
-                      'packetid': '0b1100cd0213c7f210010f51'}}}
+        self.assertTrue(_setup_component(self.hass, 'light', {
+            'light': {'platform': 'rfxtrx',
+                      'devices':
+                      {'123efab1': {
+                               'name': 'Test',
+                               'packetid': '0b1100cd0213c7f210010f51'}}}}))
+
         import RFXtrx as rfxtrxmod
         rfxtrx_core.RFXOBJECT =\
             rfxtrxmod.Core("", transport_protocol=rfxtrxmod.DummyTransport)
 
-        devices = []
-
-        def add_dev_callback(devs):
-            """Add a callback to add devices."""
-            for dev in devs:
-                devices.append(dev)
-
-        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
-
-        self.assertEqual(1, len(devices))
-        entity = devices[0]
+        self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
+        entity = rfxtrx_core.RFX_DEVICES['123efab1']
         self.assertEqual('Test', entity.name)
         self.assertEqual('off', entity.state)
         self.assertTrue(entity.assumed_state)
@@ -65,62 +85,47 @@ class TestLightRfxtrx(unittest.TestCase):
         self.assertFalse(entity.should_poll)
 
         self.assertFalse(entity.is_on)
-        with patch('homeassistant.components.light.' +
-                   'rfxtrx.RfxtrxLight.update_ha_state',
-                   return_value=None):
-            entity.turn_on()
+
+        entity.turn_on()
         self.assertTrue(entity.is_on)
         self.assertEqual(entity.brightness, 255)
-        with patch('homeassistant.components.light.' +
-                   'rfxtrx.RfxtrxLight.update_ha_state',
-                   return_value=None):
-            entity.turn_off()
+
+        entity.turn_off()
         self.assertFalse(entity.is_on)
         self.assertEqual(entity.brightness, 0)
-        with patch('homeassistant.components.light.' +
-                   'rfxtrx.RfxtrxLight.update_ha_state',
-                   return_value=None):
-            entity.turn_on(brightness=100)
+
+        entity.turn_on(brightness=100)
         self.assertTrue(entity.is_on)
         self.assertEqual(entity.brightness, 100)
-        with patch('homeassistant.components.light.' +
-                   'rfxtrx.RfxtrxLight.update_ha_state',
-                   return_value=None):
-            entity.turn_on(brightness=10)
+
+        entity.turn_on(brightness=10)
         self.assertTrue(entity.is_on)
         self.assertEqual(entity.brightness, 10)
-        with patch('homeassistant.components.light.' +
-                   'rfxtrx.RfxtrxLight.update_ha_state',
-                   return_value=None):
-            entity.turn_on(brightness=255)
+
+        entity.turn_on(brightness=255)
         self.assertTrue(entity.is_on)
         self.assertEqual(entity.brightness, 255)
 
     def test_several_lights(self):
         """Test with 3 lights."""
-        config = {'signal_repetitions': 3,
-                  'devices':
-                  {'123efab1': {
-                      'name': 'Test',
-                      'packetid': '0b1100cd0213c7f230010f71'},
-                   '118cdea2': {
-                       'name': 'Bath',
-                       'packetid': '0b1100100118cdea02010f70'},
-                   '213c7f216': {
-                       'name': 'Living',
-                       'packetid': '2b1121cd1213c7f211111f71'}}}
-        devices = []
+        self.assertTrue(_setup_component(self.hass, 'light', {
+            'light': {'platform': 'rfxtrx',
+                      'signal_repetitions': 3,
+                      'devices':
+                      {'123efab1': {
+                               'name': 'Test',
+                               'packetid': '0b1100cd0213c7f230010f71'},
+                        '118cdea2': {
+                            'name': 'Bath',
+                            'packetid': '0b1100100118cdea02010f70'},
+                        '213c7f216': {
+                            'name': 'Living',
+                            'packetid': '2b1121cd1213c7f211111f71'}}}}))
 
-        def add_dev_callback(devs):
-            """Add a callback to add devices."""
-            for dev in devs:
-                devices.append(dev)
-
-        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
-
-        self.assertEqual(3, len(devices))
+        self.assertEqual(3, len(rfxtrx_core.RFX_DEVICES))
         device_num = 0
-        for entity in devices:
+        for id in rfxtrx_core.RFX_DEVICES:
+            entity = rfxtrx_core.RFX_DEVICES[id]
             self.assertEqual(entity.signal_repetitions, 3)
             if entity.name == 'Living':
                 device_num = device_num + 1
@@ -139,47 +144,33 @@ class TestLightRfxtrx(unittest.TestCase):
 
     def test_discover_light(self):
         """Test with discovery of lights."""
-        config = {'automatic_add': True, 'devices': {}}
-        devices = []
-
-        def add_dev_callback(devs):
-            """Add a callback to add devices."""
-            for dev in devs:
-                devices.append(dev)
-
-        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+        self.assertTrue(_setup_component(self.hass, 'light', {
+            'light': {'platform': 'rfxtrx',
+                      'automatic_add': True,
+                      'devices': {}}}))
 
         event = rfxtrx_core.get_rfx_object('0b11009e00e6116202020070')
         event.data = bytearray(b'\x0b\x11\x00\x9e\x00\xe6\x11b\x02\x02\x00p')
-        with patch('homeassistant.components.light.' +
-                   'rfxtrx.RfxtrxLight.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = devices[0]
+
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        entity = rfxtrx_core.RFX_DEVICES['0e611622']
         self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(1, len(devices))
         self.assertEqual('<Entity 0e611622 : 0b11009e00e6116202020070: on>',
                          entity.__str__())
 
         event = rfxtrx_core.get_rfx_object('0b11009e00e6116201010070')
         event.data = bytearray(b'\x0b\x11\x00\x9e\x00\xe6\x11b\x01\x01\x00p')
-        with patch('homeassistant.components.light.' +
-                   'rfxtrx.RfxtrxLight.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(1, len(devices))
 
         event = rfxtrx_core.get_rfx_object('0b1100120118cdea02020070')
         event.data = bytearray([0x0b, 0x11, 0x00, 0x12, 0x01, 0x18,
                                 0xcd, 0xea, 0x02, 0x02, 0x00, 0x70])
-        with patch('homeassistant.components.light.' +
-                   'rfxtrx.RfxtrxLight.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = devices[1]
+
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        entity = rfxtrx_core.RFX_DEVICES['118cdea2']
         self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(2, len(devices))
         self.assertEqual('<Entity 118cdea2 : 0b1100120118cdea02020070: on>',
                          entity.__str__())
 
@@ -188,75 +179,53 @@ class TestLightRfxtrx(unittest.TestCase):
         event.data = bytearray(b'\nR\x08^\x07\x01\x00\xb3\x1b\x02y')
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(2, len(devices))
 
         # trying to add a swicth
         event = rfxtrx_core.get_rfx_object('0b1100100118cdea02010f70')
         event.data = bytearray([0x0b, 0x11, 0x00, 0x10, 0x01, 0x18,
                                 0xcd, 0xea, 0x01, 0x01, 0x0f, 0x70])
-        with patch('homeassistant.components.light.' +
-                   'rfxtrx.RfxtrxLight.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(2, len(devices))
 
     def test_discover_light_noautoadd(self):
         """Test with discover of light when auto add is False."""
-        config = {'automatic_add': False, 'devices': {}}
-        devices = []
-
-        def add_dev_callback(devs):
-            """Add a callback to add devices."""
-            for dev in devs:
-                devices.append(dev)
-
-        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+        self.assertTrue(_setup_component(self.hass, 'light', {
+            'light': {'platform': 'rfxtrx',
+                      'automatic_add': False,
+                      'devices': {}}}))
 
         event = rfxtrx_core.get_rfx_object('0b1100120118cdea02020070')
         event.data = bytearray([0x0b, 0x11, 0x00, 0x12, 0x01, 0x18,
                                 0xcd, 0xea, 0x02, 0x02, 0x00, 0x70])
-        with patch('homeassistant.components.light.' +
-                   'rfxtrx.RfxtrxLight.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(0, len(devices))
 
         event = rfxtrx_core.get_rfx_object('0b1100120118cdea02010070')
         event.data = bytearray([0x0b, 0x11, 0x00, 0x12, 0x01, 0x18,
                                 0xcd, 0xea, 0x02, 0x01, 0x00, 0x70])
-        with patch('homeassistant.components.light.' +
-                   'rfxtrx.RfxtrxLight.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(0, len(devices))
 
         event = rfxtrx_core.get_rfx_object('0b1100120118cdea02020070')
         event.data = bytearray([0x0b, 0x11, 0x00, 0x12, 0x01, 0x18,
                                 0xcd, 0xea, 0x02, 0x02, 0x00, 0x70])
-        with patch('homeassistant.components.light.' +
-                   'rfxtrx.RfxtrxLight.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(0, len(devices))
 
         # Trying to add a sensor
         event = rfxtrx_core.get_rfx_object('0a52085e070100b31b0279')
         event.data = bytearray(b'\nR\x08^\x07\x01\x00\xb3\x1b\x02y')
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(0, len(devices))
 
         # Trying to add a switch
         event = rfxtrx_core.get_rfx_object('0b1100100118cdea02010f70')
         event.data = bytearray([0x0b, 0x11, 0x00, 0x10, 0x01, 0x18,
                                 0xcd, 0xea, 0x01, 0x01, 0x0f, 0x70])
-        with patch('homeassistant.components.light.' +
-                   'rfxtrx.RfxtrxLight.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(0, len(devices))

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -128,7 +128,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
         entity.turn_off()
         self.assertFalse(entity.is_on)
 
-    def test_several_switchs(self):
+    def test_several_switches(self):
         """Test with 3 switches."""
         self.assertTrue(_setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
@@ -142,7 +142,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
                             'packetid': '0b1100100118cdea02010f70'},
                             '213c7f216': {
                             'name': 'Living',
-                            'packetid': '2b1121cd1213c7f211111f71'}}}}))
+                            'packetid': '0b1100100118cdea02010f70'}}}}))
 
         self.assertEqual(3, len(rfxtrx_core.RFX_DEVICES))
         device_num = 0

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -1,9 +1,8 @@
 """The tests for the Rfxtrx switch platform."""
 import unittest
 
+from homeassistant.bootstrap import _setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
-from homeassistant.components.switch import rfxtrx
-from unittest.mock import patch
 
 from tests.common import get_test_home_assistant
 
@@ -14,6 +13,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant(0)
+        self.hass.config.components = ['rfxtrx']
 
     def tearDown(self):
         """Stop everything that was started."""
@@ -23,40 +23,66 @@ class TestSwitchRfxtrx(unittest.TestCase):
             rfxtrx_core.RFXOBJECT.close_connection()
         self.hass.stop()
 
+    def test_valid_config(self):
+        """Test configuration."""
+        self.assertTrue(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'automatic_add': True,
+                       'devices':
+                           {'213c7f216': {
+                               'name': 'Test',
+                               'packetid': '0b1100cd0213c7f210010f51',
+                               rfxtrx_core.ATTR_FIREEVENT: True}
+                            }}}))
+
+        self.assertTrue(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'automatic_add': True,
+                       'devices':
+                           {'213c7f216': {
+                               'name': 'Test',
+                               'packetid': '0b1100cd0213c7f210010f51',
+                               'signal_repetitions': 3}
+                            }}}))
+
+    def test_invalid_config(self):
+        """Test configuration."""
+        self.assertFalse(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'automatic_add': True,
+                       'invalid_key': 'afda',
+                       'devices':
+                           {'213c7f216': {
+                               'name': 'Test',
+                               'packetid': '0b1100cd0213c7f210010f51',
+                               rfxtrx_core.ATTR_FIREEVENT: True}
+                            }}}))
+
     def test_default_config(self):
         """Test with 0 switches."""
-        config = {'devices': {}}
-        devices = []
+        self.assertTrue(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'devices':
+                           {}}}))
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
 
-        def add_dev_callback(devs):
-            """Add a callback to add devices."""
-            for dev in devs:
-                devices.append(dev)
-
-        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
-        self.assertEqual(0, len(devices))
-
-    def test_one_sensor(self):
+    def test_one_switch(self):
         """Test with 1 switch."""
-        config = {'devices':
-                  {'123efab1': {
-                      'name': 'Test',
-                      'packetid': '0b1100cd0213c7f210010f51'}}}
+
+        self.assertTrue(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'devices':
+                           {'123efab1': {
+                               'name': 'Test',
+                               'packetid': '0b1100cd0213c7f210010f51'}}}}))
+
         import RFXtrx as rfxtrxmod
         rfxtrx_core.RFXOBJECT =\
             rfxtrxmod.Core("", transport_protocol=rfxtrxmod.DummyTransport)
+        self.hass.pool.block_till_done()
 
-        devices = []
-
-        def add_dev_callback(devs):
-            """Add a callback to add devices."""
-            for dev in devs:
-                devices.append(dev)
-
-        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
-
-        self.assertEqual(1, len(devices))
-        entity = devices[0]
+        self.assertEqual(1,  len(rfxtrx_core.RFX_DEVICES))
+        entity = rfxtrx_core.RFX_DEVICES['123efab1']
         self.assertEqual('Test', entity.name)
         self.assertEqual('off', entity.state)
         self.assertTrue(entity.assumed_state)
@@ -65,42 +91,31 @@ class TestSwitchRfxtrx(unittest.TestCase):
         self.assertFalse(entity.should_poll)
 
         self.assertFalse(entity.is_on)
-        with patch('homeassistant.components.switch.' +
-                   'rfxtrx.RfxtrxSwitch.update_ha_state',
-                   return_value=None):
-            entity.turn_on()
+        entity.turn_on()
         self.assertTrue(entity.is_on)
-        with patch('homeassistant.components.switch.' +
-                   'rfxtrx.RfxtrxSwitch.update_ha_state',
-                   return_value=None):
-            entity.turn_off()
+        entity.turn_off()
         self.assertFalse(entity.is_on)
 
     def test_several_switchs(self):
         """Test with 3 switches."""
-        config = {'signal_repetitions': 3,
-                  'devices':
-                  {'123efab1': {
-                      'name': 'Test',
-                      'packetid': '0b1100cd0213c7f230010f71'},
-                   '118cdea2': {
-                       'name': 'Bath',
-                       'packetid': '0b1100100118cdea02010f70'},
-                   '213c7f216': {
-                       'name': 'Living',
-                       'packetid': '2b1121cd1213c7f211111f71'}}}
-        devices = []
+        self.assertTrue(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'signal_repetitions': 3,
+                       'devices':
+                           {'123efab1': {
+                               'name': 'Test',
+                               'packetid': '0b1100cd0213c7f230010f71'},
+                            '118cdea2': {
+                            'name': 'Bath',
+                            'packetid': '0b1100100118cdea02010f70'},
+                            '213c7f216': {
+                            'name': 'Living',
+                            'packetid': '2b1121cd1213c7f211111f71'}}}}))
 
-        def add_dev_callback(devs):
-            """Add a callback to add devices."""
-            for dev in devs:
-                devices.append(dev)
-
-        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
-
-        self.assertEqual(3, len(devices))
+        self.assertEqual(3, len(rfxtrx_core.RFX_DEVICES))
         device_num = 0
-        for entity in devices:
+        for id in rfxtrx_core.RFX_DEVICES:
+            entity = rfxtrx_core.RFX_DEVICES[id]
             self.assertEqual(entity.signal_repetitions, 3)
             if entity.name == 'Living':
                 device_num = device_num + 1
@@ -119,46 +134,31 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def test_discover_switch(self):
         """Test with discovery of switches."""
-        config = {'automatic_add': True, 'devices': {}}
-        devices = []
-
-        def add_dev_callback(devs):
-            """Add a callback to add devices."""
-            for dev in devs:
-                devices.append(dev)
-
-        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+        self.assertTrue(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'automatic_add': True,
+                       'devices': {}}}))
 
         event = rfxtrx_core.get_rfx_object('0b1100100118cdea02010f70')
         event.data = bytearray([0x0b, 0x11, 0x00, 0x10, 0x01, 0x18,
                                 0xcd, 0xea, 0x01, 0x01, 0x0f, 0x70])
-        with patch('homeassistant.components.switch.' +
-                   'rfxtrx.RfxtrxSwitch.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = devices[0]
+
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        entity = rfxtrx_core.RFX_DEVICES['118cdea2']
         self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(1, len(devices))
         self.assertEqual('<Entity 118cdea2 : 0b1100100118cdea01010f70: on>',
                          entity.__str__())
 
-        with patch('homeassistant.components.switch.' +
-                   'rfxtrx.RfxtrxSwitch.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(1, len(devices))
 
         event = rfxtrx_core.get_rfx_object('0b1100100118cdeb02010f70')
         event.data = bytearray([0x0b, 0x11, 0x00, 0x12, 0x01, 0x18,
                                 0xcd, 0xea, 0x02, 0x00, 0x00, 0x70])
-        with patch('homeassistant.components.switch.' +
-                   'rfxtrx.RfxtrxSwitch.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = devices[1]
+
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        entity = rfxtrx_core.RFX_DEVICES['118cdeb2']
         self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(2, len(devices))
         self.assertEqual('<Entity 118cdeb2 : 0b1100120118cdea02000070: on>',
                          entity.__str__())
 
@@ -167,72 +167,47 @@ class TestSwitchRfxtrx(unittest.TestCase):
         event.data = bytearray(b'\nR\x08^\x07\x01\x00\xb3\x1b\x02y')
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(2, len(devices))
 
         # Trying to add a light
         event = rfxtrx_core.get_rfx_object('0b1100100118cdea02010f70')
         event.data = bytearray([0x0b, 0x11, 0x11, 0x10, 0x01, 0x18,
                                 0xcd, 0xea, 0x01, 0x02, 0x0f, 0x70])
-        with patch('homeassistant.components.switch.' +
-                   'rfxtrx.RfxtrxSwitch.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(2, len(devices))
 
     def test_discover_switch_noautoadd(self):
         """Test with discovery of switch when auto add is False."""
-        config = {'automatic_add': False, 'devices': {}}
-        devices = []
-
-        def add_dev_callback(devs):
-            """Add a callback to add devices."""
-            for dev in devs:
-                devices.append(dev)
-
-        rfxtrx.setup_platform(self.hass, config, add_dev_callback)
+        self.assertTrue(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'automatic_add': False,
+                       'devices': {}}}))
 
         event = rfxtrx_core.get_rfx_object('0b1100100118cdea02010f70')
         event.data = bytearray([0x0b, 0x11, 0x00, 0x10, 0x01, 0x18,
                                 0xcd, 0xea, 0x01, 0x01, 0x0f, 0x70])
-        with patch('homeassistant.components.switch.' +
-                   'rfxtrx.RfxtrxSwitch.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(0, len(devices))
 
-        with patch('homeassistant.components.switch.' +
-                   'rfxtrx.RfxtrxSwitch.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(0, len(devices))
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
+
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
 
         event = rfxtrx_core.get_rfx_object('0b1100100118cdeb02010f70')
         event.data = bytearray([0x0b, 0x11, 0x00, 0x12, 0x01, 0x18,
                                 0xcd, 0xea, 0x02, 0x00, 0x00, 0x70])
-        with patch('homeassistant.components.switch.' +
-                   'rfxtrx.RfxtrxSwitch.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(0, len(devices))
 
         # Trying to add a sensor
         event = rfxtrx_core.get_rfx_object('0a52085e070100b31b0279')
         event.data = bytearray(b'\nR\x08^\x07\x01\x00\xb3\x1b\x02y')
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(0, len(devices))
 
         # Trying to add a light
         event = rfxtrx_core.get_rfx_object('0b1100100118cdea02010f70')
         event.data = bytearray([0x0b, 0x11, 0x11, 0x10, 0x01,
                                 0x18, 0xcd, 0xea, 0x01, 0x02, 0x0f, 0x70])
-        with patch('homeassistant.components.switch.' +
-                   'rfxtrx.RfxtrxSwitch.update_ha_state',
-                   return_value=None):
-            rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual(0, len(devices))

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -35,17 +35,18 @@ class TestSwitchRfxtrx(unittest.TestCase):
                                rfxtrx_core.ATTR_FIREEVENT: True}
                             }}}))
 
-        self.assertTrue(_setup_component(self.hass, 'switch', {
+    def test_invalid_config1(self):
+        self.assertFalse(_setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'devices':
-                           {'213c7f216': {
+                           {'2FF7f216': {
                                'name': 'Test',
                                'packetid': '0b1100cd0213c7f210010f51',
                                'signal_repetitions': 3}
                             }}}))
 
-    def test_invalid_config(self):
+    def test_invalid_config2(self):
         """Test configuration."""
         self.assertFalse(_setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
@@ -55,6 +56,39 @@ class TestSwitchRfxtrx(unittest.TestCase):
                            {'213c7f216': {
                                'name': 'Test',
                                'packetid': '0b1100cd0213c7f210010f51',
+                               rfxtrx_core.ATTR_FIREEVENT: True}
+                            }}}))
+
+    def test_invalid_config3(self):
+        self.assertFalse(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'automatic_add': True,
+                       'devices':
+                           {'213c7f216': {
+                               'name': 'Test',
+                               'packetid': 'AA1100cd0213c7f210010f51',
+                               rfxtrx_core.ATTR_FIREEVENT: True}
+                            }}}))
+
+    def test_invalid_config4(self):
+        self.assertFalse(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'automatic_add': True,
+                       'devices':
+                           {'AA3c7f216': {
+                               'name': 'Test',
+                               'packetid': '0b1100cd0213c7f210010f51',
+                               rfxtrx_core.ATTR_FIREEVENT: True}
+                            }}}))
+
+    def test_invalid_config5(self):
+        """Test configuration."""
+        self.assertFalse(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'automatic_add': True,
+                       'devices':
+                           {'213c7f216': {
+                               'name': 'Test',
                                rfxtrx_core.ATTR_FIREEVENT: True}
                             }}}))
 

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -68,7 +68,6 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def test_one_switch(self):
         """Test with 1 switch."""
-
         self.assertTrue(_setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'devices':
@@ -79,7 +78,6 @@ class TestSwitchRfxtrx(unittest.TestCase):
         import RFXtrx as rfxtrxmod
         rfxtrx_core.RFXOBJECT =\
             rfxtrxmod.Core("", transport_protocol=rfxtrxmod.DummyTransport)
-        self.hass.pool.block_till_done()
 
         self.assertEqual(1,  len(rfxtrx_core.RFX_DEVICES))
         entity = rfxtrx_core.RFX_DEVICES['123efab1']

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -26,7 +26,7 @@ class TestRFXTRX(unittest.TestCase):
 
     def test_default_config(self):
         """Test configuration."""
-        self.assertTrue(rfxtrx.setup(self.hass, {
+        self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
                 'device': '/dev/serial/by-id/usb' +
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
@@ -49,11 +49,36 @@ class TestRFXTRX(unittest.TestCase):
         self.assertEqual(len(rfxtrx.RFXOBJECT.sensors()), 2)
         self.assertEqual(len(devices), 2)
 
-    def test_config_failing(self):
+    def test_valid_config(self):
         """Test configuration."""
-        self.assertFalse(rfxtrx.setup(self.hass, {
+        self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
+            'rfxtrx': {
+                'device': '/dev/serial/by-id/usb' +
+                          '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
+                'dummy': True,
+        }}))
+
+        self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
+            'rfxtrx': {
+                'device': '/dev/serial/by-id/usb' +
+                          '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
+                'dummy': True,
+                'debug': True,
+        }}))
+
+
+    def test_invalid_config(self):
+        """Test configuration."""
+        self.assertFalse(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {}
         }))
+        
+        self.assertFalse(_setup_component(self.hass, 'rfxtrx', {
+            'rfxtrx': {
+                'device': '/dev/serial/by-id/usb' +
+                          '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
+                'invalid_key': True
+        }}))
 
     def test_fire_event(self):
         """Test fire event."""

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -55,30 +55,26 @@ class TestRFXTRX(unittest.TestCase):
             'rfxtrx': {
                 'device': '/dev/serial/by-id/usb' +
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
-                'dummy': True,
-        }}))
+                'dummy': True}}))
 
         self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
                 'device': '/dev/serial/by-id/usb' +
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
                 'dummy': True,
-                'debug': True,
-        }}))
-
+                'debug': True}}))
 
     def test_invalid_config(self):
         """Test configuration."""
         self.assertFalse(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {}
         }))
-        
+
         self.assertFalse(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
                 'device': '/dev/serial/by-id/usb' +
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
-                'invalid_key': True
-        }}))
+                'invalid_key': True}}))
 
     def test_fire_event(self):
         """Test fire event."""


### PR DESCRIPTION
**Description:**
Config validation of the rfxtrx device

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
