### PR TITLE
Fix vera error that can cause problems on loading

### DIFF
--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -109,7 +109,7 @@ def setup(hass, base_config):
                                   (LIGHT, DISCOVER_LIGHTS),
                                   (SWITCH, DISCOVER_SWITCHES))):
         component = get_component(comp_name)
-        bootstrap.setup_component(hass, component.DOMAIN, config)
+        bootstrap.setup_component(hass, component.DOMAIN, base_config)
         hass.bus.fire(EVENT_PLATFORM_DISCOVERED,
                       {ATTR_SERVICE: discovery,
                        ATTR_DISCOVERED: {}})


### PR DESCRIPTION
**Description:**
I think I found the problem that was causing my components to sometimes load incorrectly.

Vera was passing a local config, rather than the global config when it was loading components.

This cause platforms not to load from their config - depending on whether the platforms were first loaded by vera or not

Thanks to @balloob for the pointers in tracking this down.

**Related issue (if applicable):** #
https://github.com/balloob/home-assistant/issues/1565

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
