### PR TITLE
Make tox run faster by using in-memory sqlite db.

### DIFF
--- a/homeassistant/components/recorder.py
+++ b/homeassistant/components/recorder.py
@@ -168,6 +168,7 @@ class RecorderRun(object):
 class Recorder(threading.Thread):
     """A threaded recorder class."""
 
+    # pylint: disable=too-many-instance-attributes
     def __init__(self, hass):
         """Initialize the recorder."""
         threading.Thread.__init__(self)
@@ -179,6 +180,7 @@ class Recorder(threading.Thread):
         self.lock = threading.Lock()
         self.recording_start = dt_util.utcnow()
         self.utc_offset = dt_util.now().utcoffset().total_seconds()
+        self.db_path = self.hass.config.path(DB_FILE)
 
         def start_recording(event):
             """Start recording."""
@@ -302,8 +304,7 @@ class Recorder(threading.Thread):
 
     def _setup_connection(self):
         """Ensure database is ready to fly."""
-        db_path = self.hass.config.path(DB_FILE)
-        self.conn = sqlite3.connect(db_path, check_same_thread=False)
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self.conn.row_factory = sqlite3.Row
 
         # Make sure the database is closed whenever Python exits

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -1,7 +1,6 @@
 """The tests the History component."""
 # pylint: disable=protected-access,too-many-public-methods
 from datetime import timedelta
-import os
 import unittest
 from unittest.mock import patch, sentinel
 
@@ -24,13 +23,10 @@ class TestComponentHistory(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-        db_path = self.hass.config.path(recorder.DB_FILE)
-        if os.path.isfile(db_path):
-            os.remove(db_path)
-
     def init_recorder(self):
         """Initialize the recorder."""
-        recorder.setup(self.hass, {})
+        with patch('homeassistant.core.Config.path', return_value=':memory:'):
+            recorder.setup(self.hass, {})
         self.hass.start()
         self.wait_recording_done()
 

--- a/tests/components/test_recorder.py
+++ b/tests/components/test_recorder.py
@@ -1,7 +1,7 @@
 """The tests for the Recorder component."""
 # pylint: disable=too-many-public-methods,protected-access
 import unittest
-import os
+from unittest.mock import patch
 
 from homeassistant.const import MATCH_ALL
 from homeassistant.components import recorder
@@ -15,7 +15,8 @@ class TestRecorder(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        recorder.setup(self.hass, {})
+        with patch('homeassistant.core.Config.path', return_value=':memory:'):
+            recorder.setup(self.hass, {})
         self.hass.start()
         recorder._INSTANCE.block_till_done()
 
@@ -23,7 +24,6 @@ class TestRecorder(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
         recorder._INSTANCE.block_till_done()
-        os.remove(self.hass.config.path(recorder.DB_FILE))
 
     def test_saving_state(self):
         """Test saving and restoring a state."""


### PR DESCRIPTION
**Description:**
Use in-memory sqlite db while running pytest on the recorder and history components.

My system was spending a lot of time on disk-io, seemingly migrating an empty home-assistant.db repeatedly while the recorder and history components were tested. This change drops the time to run all tests from a little over 50 seconds to under 20 seconds.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
