### PR TITLE
Upgrade astral

### DIFF
--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.event import (
 from homeassistant.util import dt as dt_util
 from homeassistant.util import location as location_util
 
-REQUIREMENTS = ['astral==0.9']
+REQUIREMENTS = ['astral==1.0']
 DOMAIN = "sun"
 ENTITY_ID = "sun.sun"
 

--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -113,8 +113,8 @@ def setup(hass, config):
 
     from astral import Location
 
-    location = Location(('', '', latitude, longitude, hass.config.time_zone,
-                         elevation))
+    location = Location(('', '', latitude, longitude,
+                         hass.config.time_zone.zone, elevation))
 
     sun = Sun(hass, location)
     sun.point_in_time_listener(dt_util.utcnow())

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -26,7 +26,7 @@ TwitterAPI==2.3.6
 apcaccess==0.0.4
 
 # homeassistant.components.sun
-astral==0.9
+astral==1.0
 
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.7


### PR DESCRIPTION
**Description**
astral-1.0 uses a stricter exception handler, which revealed that we are passing the wrong value for the timezone argument.

**Related issue (if applicable):** #1751

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
