### PR TITLE
Enable certificate verification and allow non-encrypted communication

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -173,6 +173,12 @@ py-cpuinfo==0.2.3
 # homeassistant.components.rfxtrx
 pyRFXtrx==0.6.5
 
+# homeassistant.components.notify.xmpp
+pyasn1-modules==0.0.8
+
+# homeassistant.components.notify.xmpp
+pyasn1==0.1.9
+
 # homeassistant.components.media_player.cast
 pychromecast==0.7.2
 


### PR DESCRIPTION
**Description:**
This PR allows one to use the XMPP notification platform with servers which don't not support encrypted communication and for encrypted connections the verification of the certificates is enabled now.

**Related issue (if applicable):** https://community.home-assistant.io/t/how-to-disable-tls-ssl-in-jabber-xmpp-notification/488

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
  - platform: xmpp
    name: jabber
    sender: sender@jabber-server.tld
    password: sender-password
    recipient: recipient@jabber-server.tld
    tls: False
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
