### PR TITLE
Fix for MQTT config validation on the protocol field.

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -90,7 +90,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_CERTIFICATE): cv.isfile,
         vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL):
-            [PROTOCOL_31, PROTOCOL_311],
+            vol.All(cv.string, vol.In([PROTOCOL_31, PROTOCOL_311])),
         vol.Optional(CONF_EMBEDDED): _HBMQTT_CONFIG_SCHEMA,
     }),
 }, extra=vol.ALLOW_EXTRA)

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -58,6 +58,17 @@ class TestMQTT(unittest.TestCase):
                 }
             })
 
+    def test_setup_protocol_validation(self):
+        """Test for setup failure if connection to broker is missing."""
+        with mock.patch('paho.mqtt.client.Client'):
+            self.hass.config.components = []
+            assert _setup_component(self.hass, mqtt.DOMAIN, {
+                mqtt.DOMAIN: {
+                    mqtt.CONF_BROKER: 'test-broker',
+                    mqtt.CONF_PROTOCOL: 3.1,
+                }
+            })
+
     def test_publish_calls_service(self):
         """Test the publishing of call to services."""
         self.hass.bus.listen_once(EVENT_CALL_SERVICE, self.record_calls)


### PR DESCRIPTION
**Description:**
We should be testing if a string is one of several options, instead we were validating the user provided a list of all options.

**Related issue (if applicable):** #1762 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
