### PR TITLE
Prevent device tracker from creating invalid YAML

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -204,6 +204,7 @@ class DeviceTracker(object):
                 return
 
             # If no device can be found, create it
+            dev_id = util.ensure_unique_string(dev_id, self.devices.keys())
             device = Device(
                 self.hass, self.consider_home, self.home_range, self.track_new,
                 dev_id, mac, (host_name or dev_id).replace('_', ' '))

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -197,3 +197,16 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         mock_see.assert_called_once_with(
             mac=mac, dev_id=dev_id, host_name=host_name,
             location_name=location_name, gps=gps)
+
+    def test_not_write_duplicate_yaml_keys(self):
+        """Test that the device tracker will not generate invalid YAML."""
+        self.assertTrue(device_tracker.setup(self.hass, {}))
+
+        device_tracker.see(self.hass, 'mac_1', host_name='hello')
+        device_tracker.see(self.hass, 'mac_2', host_name='hello')
+
+        self.hass.pool.block_till_done()
+
+        config = device_tracker.load_config(self.yaml_devices, self.hass,
+                                            timedelta(seconds=0), 0)
+        assert len(config) == 2


### PR DESCRIPTION
**Description:**
With the introduction of 0.17 we are no longer silently failing if your YAML contains duplicate keys. The device tracker however was a bit sloppy and would actually create duplicate keys. This will prevent the device tracker creating duplicate keys.

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
