### PR TITLE
Better YAML parsing error reporting

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     CONF_CUSTOMIZE, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME,
     CONF_TEMPERATURE_UNIT, CONF_TIME_ZONE, EVENT_COMPONENT_LOADED,
     TEMP_CELCIUS, TEMP_FAHRENHEIT, PLATFORM_FORMAT, __version__)
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     event_decorators, service, config_per_platform, extract_domain_configs)
 from homeassistant.helpers.entity import Entity
@@ -293,7 +294,10 @@ def from_config_file(config_path, hass=None, verbose=False, daemon=False,
 
     enable_logging(hass, verbose, daemon, log_rotate_days)
 
-    config_dict = config_util.load_yaml_config_file(config_path)
+    try:
+        config_dict = config_util.load_yaml_config_file(config_path)
+    except HomeAssistantError:
+        return None
 
     return from_config_dict(config_dict, hass, enable_log=False,
                             skip_pip=skip_pip)

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -29,9 +29,9 @@ def load_yaml(fname):
             # If configuration file is empty YAML returns None
             # We convert that to an empty dict
             return yaml.load(conf_file, Loader=SafeLineLoader) or {}
-    except yaml.YAMLError:
-        error = 'Error reading YAML configuration file {}'.format(fname)
-        _LOGGER.exception(error)
+    except yaml.YAMLError as e:
+        error = 'Error reading YAML configuration file {}: {}'.format(fname, e)
+        _LOGGER.error(error)
         raise HomeAssistantError(error)
 
 


### PR DESCRIPTION
**Description:**
When a YAML error is found (like duplicate keys), we print the exception to the console instead of a nice formatted message. This PR fixes this.

**Checklist:**

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
