### PR TITLE
Allow use of pynetgear 3.3 port parameter.

### DIFF
--- a/homeassistant/components/device_tracker/netgear.py
+++ b/homeassistant/components/device_tracker/netgear.py
@@ -9,7 +9,8 @@ import threading
 from datetime import timedelta
 
 from homeassistant.components.device_tracker import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, \
+ CONF_PORT
 from homeassistant.util import Throttle
 
 # Return cached results if last scan was less then this time ago.

--- a/homeassistant/components/device_tracker/netgear.py
+++ b/homeassistant/components/device_tracker/netgear.py
@@ -9,14 +9,14 @@ import threading
 from datetime import timedelta
 
 from homeassistant.components.device_tracker import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT
 from homeassistant.util import Throttle
 
 # Return cached results if last scan was less then this time ago.
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ['pynetgear==0.3.2']
+REQUIREMENTS = ['pynetgear==0.3.3']
 
 
 def get_scanner(hass, config):
@@ -25,12 +25,13 @@ def get_scanner(hass, config):
     host = info.get(CONF_HOST)
     username = info.get(CONF_USERNAME)
     password = info.get(CONF_PASSWORD)
+    port = info.get(CONF_PORT)
 
     if password is not None and host is None:
         _LOGGER.warning('Found username or password but no host')
         return None
 
-    scanner = NetgearDeviceScanner(host, username, password)
+    scanner = NetgearDeviceScanner(host, username, password, port)
 
     return scanner if scanner.success_init else None
 
@@ -38,7 +39,7 @@ def get_scanner(hass, config):
 class NetgearDeviceScanner(object):
     """Queries a Netgear wireless router using the SOAP-API."""
 
-    def __init__(self, host, username, password):
+    def __init__(self, host, username, password, port):
         """Initialize the scanner."""
         import pynetgear
 
@@ -49,8 +50,10 @@ class NetgearDeviceScanner(object):
             self._api = pynetgear.Netgear()
         elif username is None:
             self._api = pynetgear.Netgear(password, host)
-        else:
+        elif port is None:
             self._api = pynetgear.Netgear(password, host, username)
+        else:
+            self._api = pynetgear.Netgear(password, host, username, port)
 
         _LOGGER.info("Logging in")
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -23,6 +23,7 @@ CONF_CUSTOMIZE = "customize"
 
 CONF_PLATFORM = "platform"
 CONF_HOST = "host"
+CONF_PORT = "port"
 CONF_HOSTS = "hosts"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -189,7 +189,7 @@ pyicloud==0.7.2
 pyloopenergy==0.0.7
 
 # homeassistant.components.device_tracker.netgear
-pynetgear==0.3.2
+pynetgear==0.3.3
 
 # homeassistant.components.alarm_control_panel.nx584
 # homeassistant.components.binary_sensor.nx584


### PR DESCRIPTION
**Description:**
Upgrade to pynetgear version 3.3. Introduce "port" to configuration and pass it to pynetgear when available. I believe I have fixed the requirements file and tox now runs.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
device_tracker:
  platform: netgear
  host: YOUR_ROUTER_IP
  username: YOUR_ADMIN_USERNAME
  password: YOUR_ADMIN_PASSWORD
  port: YOUR_ROUTER_PORT
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
