### PR TITLE
Don't round values in Thermostat internal state

### DIFF
--- a/homeassistant/components/thermostat/__init__.py
+++ b/homeassistant/components/thermostat/__init__.py
@@ -270,12 +270,12 @@ class ThermostatDevice(Entity):
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        return round(convert(7, TEMP_CELCIUS, self.unit_of_measurement))
+        return convert(7, TEMP_CELCIUS, self.unit_of_measurement)
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        return round(convert(35, TEMP_CELCIUS, self.unit_of_measurement))
+        return convert(35, TEMP_CELCIUS, self.unit_of_measurement)
 
     def _convert_for_display(self, temp):
         """Convert temperature into preferred units for display purposes."""

--- a/homeassistant/components/thermostat/nest.py
+++ b/homeassistant/components/thermostat/nest.py
@@ -70,7 +70,7 @@ class NestThermostat(ThermostatDevice):
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        return round(self.device.temperature, 1)
+        return self.device.temperature
 
     @property
     def operation(self):
@@ -102,21 +102,21 @@ class NestThermostat(ThermostatDevice):
         else:
             temp = target
 
-        return round(temp, 1)
+        return temp
 
     @property
     def target_temperature_low(self):
         """Return the lower bound temperature we try to reach."""
         if self.device.mode == 'range':
-            return round(self.device.target[0], 1)
-        return round(self.target_temperature, 1)
+            return self.device.target[0]
+        return self.target_temperature
 
     @property
     def target_temperature_high(self):
         """Return the upper bound temperature we try to reach."""
         if self.device.mode == 'range':
-            return round(self.device.target[1], 1)
-        return round(self.target_temperature, 1)
+            return self.device.target[1]
+        return self.target_temperature
 
     @property
     def is_away_mode_on(self):

--- a/homeassistant/components/thermostat/radiotherm.py
+++ b/homeassistant/components/thermostat/radiotherm.py
@@ -80,7 +80,7 @@ class RadioThermostat(ThermostatDevice):
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        return round(self._current_temperature, 1)
+        return self._current_temperature
 
     @property
     def operation(self):
@@ -90,7 +90,7 @@ class RadioThermostat(ThermostatDevice):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return round(self._target_temperature, 1)
+        return self._target_temperature
 
     def update(self):
         """Update the data from the thermostat."""


### PR DESCRIPTION
Since all values coming out of the Thermostat component pass though the
_convert_for_display() method (which handles any necessary rounding),
there is no need to round values that only exist in the internal state
of the thermostat device. It serves no purpose and risks rounding
errors/precision loss.
