### PR TITLE
Expanded homematic component with MAX! support via homegear

### DIFF
--- a/homeassistant/components/thermostat/homematic.py
+++ b/homeassistant/components/thermostat/homematic.py
@@ -10,6 +10,7 @@ from xmlrpc.client import ServerProxy
 
 from homeassistant.components.thermostat import ThermostatDevice
 from homeassistant.const import TEMP_CELCIUS
+from homeassistant.helpers.temperature import convert
 
 REQUIREMENTS = []
 
@@ -20,7 +21,11 @@ PROPERTY_SET_TEMPERATURE = 'SET_TEMPERATURE'
 PROPERTY_VALVE_STATE = 'VALVE_STATE'
 PROPERTY_ACTUAL_TEMPERATURE = 'ACTUAL_TEMPERATURE'
 PROPERTY_BATTERY_STATE = 'BATTERY_STATE'
+PROPERTY_LOWBAT = 'LOWBAT'
 PROPERTY_CONTROL_MODE = 'CONTROL_MODE'
+PROPERTY_BURST_MODE = 'BURST_RX'
+PLATFORM_TYPE_HOMEMATIC = 'HOMEMATIC'
+PLATFORM_TYPE_MAX = 'MAX'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,20 +34,29 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Homematic thermostat."""
     devices = []
     try:
-        homegear = ServerProxy(config[CONF_ADDRESS])
         for name, device_cfg in config[CONF_DEVICES].items():
+            address = config[CONF_ADDRESS]
+            homegear = ServerProxy(address)
             # get device description to detect the type
             device_type = homegear.getDeviceDescription(
                 device_cfg[CONF_ID] + ':-1')['TYPE']
 
             if device_type in ['HM-CC-RT-DN', 'HM-CC-RT-DN-BoM']:
-                devices.append(HomematicThermostat(homegear,
+                devices.append(HomematicThermostat(PLATFORM_TYPE_HOMEMATIC,
+                                                   address,
                                                    device_cfg[CONF_ID],
-                                                   name, 4))
+                                                   name, 4, 4))
+            elif device_type in ['BC-RT-TRX-CyG', 'BC-RT-TRX-CyG-2',
+                                 'BC-RT-TRX-CyG-3']:
+                devices.append(HomematicThermostat(PLATFORM_TYPE_MAX,
+                                                   address,
+                                                   device_cfg[CONF_ID],
+                                                   name, 1, 0))
             elif device_type == 'HM-TC-IT-WM-W-EU':
-                devices.append(HomematicThermostat(homegear,
+                devices.append(HomematicThermostat(PLATFORM_TYPE_HOMEMATIC,
+                                                   address,
                                                    device_cfg[CONF_ID],
-                                                   name, 2))
+                                                   name, 2, 2))
             else:
                 raise ValueError(
                     "Device Type '{}' currently not supported".format(
@@ -60,13 +74,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class HomematicThermostat(ThermostatDevice):
     """Representation of a Homematic thermostat."""
 
-    def __init__(self, device, _id, name, channel):
+    def __init__(self, platform_type, address, _id, name, channel,
+                 maint_channel):
         """Initialize the thermostat."""
-        self.device = device
+        self._platform_type = platform_type
+        self.address = address
         self._id = _id
         self._channel = channel
+        self._maint_channel = maint_channel
         self._name = name
         self._full_device_name = '{}:{}'.format(self._id, self._channel)
+        self._maint_device_name = '{}:{}'.format(self._id, self._maint_channel)
 
         self._current_temperature = None
         self._target_temperature = None
@@ -74,6 +92,11 @@ class HomematicThermostat(ThermostatDevice):
         self._battery = None
         self._mode = None
         self.update()
+
+    @property
+    def should_poll(self):
+        """Homematic has to be polled."""
+        return True
 
     @property
     def name(self):
@@ -97,9 +120,10 @@ class HomematicThermostat(ThermostatDevice):
 
     def set_temperature(self, temperature):
         """Set new target temperature."""
-        self.device.setValue(self._full_device_name,
-                             PROPERTY_SET_TEMPERATURE,
-                             temperature)
+        device = ServerProxy(self.address)
+        device.setValue(self._full_device_name,
+                        PROPERTY_SET_TEMPERATURE,
+                        temperature)
 
     @property
     def device_state_attributes(self):
@@ -108,21 +132,47 @@ class HomematicThermostat(ThermostatDevice):
                 "battery": self._battery,
                 "mode": self._mode}
 
+    @property
+    def min_temp(self):
+        """Return the minimum temperature - 4.5 means off."""
+        return convert(4.5, TEMP_CELCIUS, self.unit_of_measurement)
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature - 30.5 means on."""
+        return convert(30.5, TEMP_CELCIUS, self.unit_of_measurement)
+
     def update(self):
         """Update the data from the thermostat."""
         try:
-            self._current_temperature = self.device.getValue(
+            device = ServerProxy(self.address)
+            self._current_temperature = device.getValue(
                 self._full_device_name,
                 PROPERTY_ACTUAL_TEMPERATURE)
-            self._target_temperature = self.device.getValue(
+            self._target_temperature = device.getValue(
                 self._full_device_name,
                 PROPERTY_SET_TEMPERATURE)
-            self._valve = self.device.getValue(self._full_device_name,
-                                               PROPERTY_VALVE_STATE)
-            self._battery = self.device.getValue(self._full_device_name,
-                                                 PROPERTY_BATTERY_STATE)
-            self._mode = self.device.getValue(self._full_device_name,
-                                              PROPERTY_CONTROL_MODE)
-        except socket.error:
+
+            self._valve = device.getValue(self._full_device_name,
+                                          PROPERTY_VALVE_STATE)
+
+            if self._platform_type == PLATFORM_TYPE_HOMEMATIC:
+                self._battery = device.getValue(self._maint_device_name,
+                                                PROPERTY_BATTERY_STATE)
+            elif self._platform_type == PLATFORM_TYPE_MAX:
+                # emulate homematic battery voltage,
+                # max reports lowbat if voltage < 2.2V
+                # while homematic battery_state should
+                # be between 1.5V and 4.6V
+                lowbat = device.getValue(self._maint_device_name,
+                                         PROPERTY_LOWBAT)
+                if lowbat:
+                    self._battery = 1.5
+                else:
+                    self._battery = 4.6
+
+            self._mode = device.getValue(self._full_device_name,
+                                         PROPERTY_CONTROL_MODE)
+        except:
             _LOGGER.exception("Did not receive any temperature data from the "
                               "homematic API.")

--- a/homeassistant/components/thermostat/homematic.py
+++ b/homeassistant/components/thermostat/homematic.py
@@ -34,9 +34,9 @@ TYPE_MAX_THERMOSTAT = 'MAX_THERMOSTAT'
 
 HomematicConfig = namedtuple('HomematicConfig',
                              ['device_type',
-                             'platform_type',
-                             'channel',
-                             'maint_channel'])
+                              'platform_type',
+                              'channel',
+                              'maint_channel'])
 
 HM_TYPE_MAPPING = {
     'HM-CC-RT-DN': HomematicConfig('HM-CC-RT-DN',

--- a/homeassistant/components/thermostat/homematic.py
+++ b/homeassistant/components/thermostat/homematic.py
@@ -8,6 +8,7 @@ import logging
 import socket
 from xmlrpc.client import ServerProxy
 from xmlrpc.client import Error
+from collections import namedtuple
 
 from homeassistant.components.thermostat import ThermostatDevice
 from homeassistant.const import TEMP_CELCIUS
@@ -31,37 +32,11 @@ TYPE_HM_THERMOSTAT = 'HOMEMATIC_THERMOSTAT'
 TYPE_HM_WALLTHERMOSTAT = 'HOMEMATIC_WALLTHERMOSTAT'
 TYPE_MAX_THERMOSTAT = 'MAX_THERMOSTAT'
 
-
-class HomematicConfig():
-    """Encapsulates the individual Parameters needed to access a HM device."""
-
-    def __init__(self, device_type, platform_type, channel, maint_channel):
-        """Initialize the Config."""
-        self._device_type = device_type
-        self._platform_type = platform_type
-        self._channel = channel
-        self._maint_channel = maint_channel
-
-    @property
-    def device_type(self):
-        """Return the device type."""
-        return self._device_type
-
-    @property
-    def platform_type(self):
-        """Return the platform type."""
-        return self._platform_type
-
-    @property
-    def channel(self):
-        """Return the channel."""
-        return self._channel
-
-    @property
-    def maint_channel(self):
-        """Return the maintenance channel."""
-        return self._maint_channel
-
+HomematicConfig = namedtuple('HomematicConfig',
+                             ['device_type',
+                             'platform_type',
+                             'channel',
+                             'maint_channel'])
 
 HM_TYPE_MAPPING = {
     'HM-CC-RT-DN': HomematicConfig('HM-CC-RT-DN',


### PR DESCRIPTION
**Description:**

Expanded homematic component with MAX! support via homegear
Also multithreading fixes in homematic component

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
