### PR TITLE
UPnP port mapping component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -65,6 +65,8 @@ omit =
     homeassistant/components/scsgate.py
     homeassistant/components/*/scsgate.py
 
+    homeassistant/components/upnp.py
+
     homeassistant/components/binary_sensor/arest.py
     homeassistant/components/binary_sensor/rest.py
     homeassistant/components/browser.py

--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -19,8 +19,7 @@ def setup(hass, config):
     """Register a port mapping for Home Assistant via UPnP."""
     import miniupnpc
 
-    # Miniupnpc dynamically includes UPnP
-    # pylint: disable=no-name-in-module, no-member
+    # pylint: disable=no-member
     upnp = miniupnpc.UPnP()
 
     upnp.discoverdelay = 200

--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -1,0 +1,45 @@
+"""
+This module will attempt to open a port in your router for Home Assistant.
+
+For more details about UPnP, please refer to the documentation at
+https://home-assistant.io/components/upnp/
+"""
+import logging
+
+from homeassistant.const import (EVENT_HOMEASSISTANT_STOP)
+
+DEPENDENCIES = ["api"]
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "upnp"
+
+
+def setup(hass, config):
+    """Register a port mapping for Home Assistant via UPnP."""
+    import miniupnpc
+
+    # Miniupnpc dynamically includes UPnP
+    # pylint: disable=no-name-in-module, no-member
+    upnp = miniupnpc.UPnP()
+
+    upnp.discoverdelay = 200
+    upnp.discover()
+    try:
+        upnp.selectigd()
+    # pylint: disable=broad-except
+    except Exception:
+        _LOGGER.exception("Error when attempting to discover a UPnP IGD")
+        return False
+
+    upnp.addportmapping(hass.config.api.port, "TCP",
+                        hass.config.api.host, hass.config.api.port,
+                        "Home Assistant", "")
+
+    def deregister_port(event):
+        """De-register the UPnP port mapping."""
+        upnp.deleteportmapping(hass.config.api.port, "TCP")
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, deregister_port)
+
+    return True

--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -17,6 +17,7 @@ DOMAIN = "upnp"
 
 def setup(hass, config):
     """Register a port mapping for Home Assistant via UPnP."""
+    # pylint: disable=import-error
     import miniupnpc
 
     # pylint: disable=no-member


### PR DESCRIPTION
**Description:** This adds a new UPnP component which will automagically port map your Home Assistant instance. It requires [miniupnpc](https://github.com/miniupnp/miniupnp/tree/master/miniupnpc) to be installed.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
upnp:
```

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
