### PR TITLE
Allow for restart without using parent/child processes.

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -2,12 +2,12 @@
 from __future__ import print_function
 
 import argparse
+from multiprocessing.spawn import get_executable
 import os
 import signal
 import sys
 import threading
 import time
-from multiprocessing import Process
 
 from homeassistant.const import (
     __version__,
@@ -87,8 +87,7 @@ def get_arguments():
     parser.add_argument(
         '--debug',
         action='store_true',
-        help='Start Home Assistant in debug mode. Runs in single process to '
-        'enable use of interactive debuggers.')
+        help='Start Home Assistant in debug mode')
     parser.add_argument(
         '--open-ui',
         action='store_true',
@@ -123,14 +122,14 @@ def get_arguments():
         '--restart-osx',
         action='store_true',
         help='Restarts on OS X.')
-    if os.name != "nt":
+    if os.name == "posix":
         parser.add_argument(
             '--daemon',
             action='store_true',
             help='Run Home Assistant as daemon')
 
     arguments = parser.parse_args()
-    if os.name == "nt":
+    if os.name != "posix" or arguments.debug:
         arguments.daemon = False
     return arguments
 
@@ -144,7 +143,6 @@ def daemonize():
 
     # Decouple fork
     os.setsid()
-    os.umask(0)
 
     # Create second fork
     pid = os.fork()
@@ -220,12 +218,8 @@ def uninstall_osx():
     print("Home Assistant has been uninstalled.")
 
 
-def setup_and_run_hass(config_dir, args, top_process=False):
-    """Setup HASS and run.
-
-    Block until stopped. Will assume it is running in a subprocess unless
-    top_process is set to true.
-    """
+def setup_and_run_hass(config_dir, args):
+    """Setup HASS and run."""
     from homeassistant import bootstrap
 
     if args.demo_mode:
@@ -256,42 +250,61 @@ def setup_and_run_hass(config_dir, args, top_process=False):
 
         hass.bus.listen_once(EVENT_HOMEASSISTANT_START, open_browser)
 
+    print('Starting Home-Assistant')
     hass.start()
     exit_code = int(hass.block_till_stopped())
 
-    if not top_process:
-        sys.exit(exit_code)
     return exit_code
 
 
-def run_hass_process(hass_proc):
-    """Run a child hass process. Returns True if it should be restarted."""
-    requested_stop = threading.Event()
-    hass_proc.daemon = True
+def try_to_restart():
+    """Attempt to clean up state and start a new homeassistant instance."""
+    # Things should be mostly shut down already at this point, now just try
+    # to clean up things that may have been left behind.
+    sys.stderr.write('Home Assistant attempting to restart.\n')
 
-    def request_stop(*args):
-        """Request hass stop, *args is for signal handler callback."""
-        requested_stop.set()
-        hass_proc.terminate()
+    # Count remaining threads, ideally there should only be one non-daemonized
+    # thread left (which is us). Nothing we really do with it, but it might be
+    # useful when debugging shutdown/restart issues.
+    nthreads = sum(thread.isAlive() and not thread.isDaemon()
+                   for thread in threading.enumerate())
+    if nthreads > 1:
+        sys.stderr.write("Found {} non-daemonic threads.\n".format(nthreads))
 
-    try:
-        signal.signal(signal.SIGTERM, request_stop)
-    except ValueError:
-        print('Could not bind to SIGTERM. Are you running in a thread?')
+    # Send terminate signal to all processes in our process group which
+    # should be any children that have not themselves changed the process
+    # group id. Don't bother if couldn't even call setpgid.
+    if hasattr(os, 'setpgid'):
+        sys.stderr.write("Signalling child processes to terminate...\n")
+        os.kill(0, signal.SIGTERM)
 
-    hass_proc.start()
-    try:
-        hass_proc.join()
-    except KeyboardInterrupt:
-        request_stop()
+        # wait for child processes to terminate
         try:
-            hass_proc.join()
-        except KeyboardInterrupt:
-            return False
+            while True:
+                time.sleep(1)
+                if os.waitpid(0, os.WNOHANG) == (0, 0):
+                    break
+        except OSError:
+            pass
 
-    return (not requested_stop.isSet() and
-            hass_proc.exitcode == RESTART_EXIT_CODE,
-            hass_proc.exitcode)
+    elif os.name == 'nt':
+        # Maybe one of the following will work, but how do we indicate which
+        # processes are our children if there is no process group?
+        # os.kill(0, signal.CTRL_C_EVENT)
+        # os.kill(0, signal.CTRL_BREAK_EVENT)
+        pass
+
+    # Try to not leave behind open filedescriptors with the emphasis on try.
+    os.closerange(3, 1024)
+
+    # Now launch into a new instance of Home-Assistant. If this fails we
+    # fall through and exit with error 100 (RESTART_EXIT_CODE) in which case
+    # systemd will restart us when RestartForceExitStatus=100 is set in the
+    # systemd.service file.
+    sys.stderr.write("Restarting Home-Assistant\n")
+    exe = get_executable()
+    args = [exe] + [arg for arg in sys.argv if arg != '--daemon']
+    os.execv(exe, args)
 
 
 def main():
@@ -325,21 +338,14 @@ def main():
     if args.pid_file:
         write_pid(args.pid_file)
 
-    # Run hass in debug mode if requested
-    if args.debug:
-        sys.stderr.write('Running in debug mode. '
-                         'Home Assistant will not be able to restart.\n')
-        exit_code = setup_and_run_hass(config_dir, args, top_process=True)
-        if exit_code == RESTART_EXIT_CODE:
-            sys.stderr.write('Home Assistant requested a '
-                             'restart in debug mode.\n')
-        return exit_code
+    # Create new process group if we can
+    if hasattr(os, 'setpgid'):
+        os.setpgid(0, 0)
 
-    # Run hass as child process. Restart if necessary.
-    keep_running = True
-    while keep_running:
-        hass_proc = Process(target=setup_and_run_hass, args=(config_dir, args))
-        keep_running, exit_code = run_hass_process(hass_proc)
+    exit_code = setup_and_run_hass(config_dir, args)
+    if exit_code == RESTART_EXIT_CODE:
+        try_to_restart()
+
     return exit_code
 
 

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import argparse
 import os
+import platform
 import signal
 import sys
 import threading
@@ -294,7 +295,12 @@ def try_to_restart():
         pass
 
     # Try to not leave behind open filedescriptors with the emphasis on try.
-    os.closerange(3, 1024)
+    if platform.system() != 'Darwin':
+        try:
+            max_fd = os.sysconf("SC_OPEN_MAX")
+        except ValueError:
+            max_fd = 256
+        os.closerange(3, max_fd)
 
     # Now launch into a new instance of Home-Assistant. If this fails we
     # fall through and exit with error 100 (RESTART_EXIT_CODE) in which case

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 
 import argparse
-from multiprocessing.spawn import get_executable
 import os
 import signal
 import sys
@@ -302,9 +301,8 @@ def try_to_restart():
     # systemd will restart us when RestartForceExitStatus=100 is set in the
     # systemd.service file.
     sys.stderr.write("Restarting Home-Assistant\n")
-    exe = get_executable()
-    args = [exe] + [arg for arg in sys.argv if arg != '--daemon']
-    os.execv(exe, args)
+    args = [sys.executable] + [arg for arg in sys.argv if arg != '--daemon']
+    os.execv(sys.executable, args)
 
 
 def main():

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -79,6 +79,7 @@ class HomeAssistant(object):
 
         def restart_homeassistant(*args):
             """Reset Home Assistant."""
+            _LOGGER.warning('Home Assistant requested a restart.')
             request_restart.set()
             request_shutdown.set()
 
@@ -92,14 +93,19 @@ class HomeAssistant(object):
         except ValueError:
             _LOGGER.warning(
                 'Could not bind to SIGTERM. Are you running in a thread?')
-
-        while not request_shutdown.isSet():
-            try:
+        try:
+            signal.signal(signal.SIGHUP, restart_homeassistant)
+        except ValueError:
+            _LOGGER.warning(
+                'Could not bind to SIGHUP. Are you running in a thread?')
+        try:
+            while not request_shutdown.isSet():
                 time.sleep(1)
-            except KeyboardInterrupt:
-                break
+        except KeyboardInterrupt:
+            pass
+        finally:
+            self.stop()
 
-        self.stop()
         return RESTART_EXIT_CODE if request_restart.isSet() else 0
 
     def stop(self):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -98,6 +98,8 @@ class HomeAssistant(object):
         except ValueError:
             _LOGGER.warning(
                 'Could not bind to SIGHUP. Are you running in a thread?')
+        except AttributeError:
+            pass
         try:
             while not request_shutdown.isSet():
                 time.sleep(1)


### PR DESCRIPTION
**Description:**
Simplify restarts using just the 'exec' part of fork and exec.

Assuming that we normally correctly shut down running threads and release resources, we just do some minimal scrubbing of open file descriptors and child processes which would normally stay around across an exec() boundary.

In case exec fails we return 100, which means that systemd could be set up to handle the restart automatically if we set `RestartForceExitStatus=100` in the systemd.service file.

Only tested on Linux, should work on MacOS X and aside for not cleaning up stray child processes "should" work on Windows.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
