### PR TITLE
Expose HTTP Port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,6 @@ RUN pip3 install --no-cache-dir -r requirements_all.txt
 # Copy source
 COPY . .
 
+EXPOSE 8123
+
 CMD [ "python", "-m", "homeassistant", "--config", "/config" ]


### PR DESCRIPTION
This allows for this image to be used with the automated nginx-proxy image. Additionally, it informs users what port the container runs on.
