### PR TITLE
Do not propagate api password

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -207,6 +207,9 @@ class RequestHandler(SimpleHTTPRequestHandler):
                               self.server.api_password or
                               self.verify_session())
 
+        # we don't need to forward the password from here
+        data.pop(DATA_API_PASSWORD, None)
+
         if '_METHOD' in data:
             method = data.pop('_METHOD')
 

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     HTTP_HEADER_CONTENT_LENGTH, HTTP_HEADER_CONTENT_TYPE, HTTP_HEADER_EXPIRES,
     HTTP_HEADER_HA_AUTH, HTTP_HEADER_VARY, HTTP_METHOD_NOT_ALLOWED,
     HTTP_NOT_FOUND, HTTP_OK, HTTP_UNAUTHORIZED, HTTP_UNPROCESSABLE_ENTITY,
-    SERVER_PORT)
+    SERVER_PORT, URL_ROOT, URL_API_EVENT_FORWARD)
 
 DOMAIN = "http"
 
@@ -207,8 +207,9 @@ class RequestHandler(SimpleHTTPRequestHandler):
                               self.server.api_password or
                               self.verify_session())
 
-        # we don't need to forward the password from here
-        data.pop(DATA_API_PASSWORD, None)
+        # we really shouldn't need to forward the password from here
+        if url.path not in [URL_ROOT, URL_API_EVENT_FORWARD]:
+            data.pop(DATA_API_PASSWORD, None)
 
         if '_METHOD' in data:
             method = data.pop('_METHOD')


### PR DESCRIPTION
**Description:**
We should not forward the api_password that was used to authenticate the request to the services that are called.

There are two exceptions at the moment,
- the event forwarding/remote api uses the local api password to authenticate with the remote.
- the top index page embeds the api password the user used to authenticate.

**Related issue (if applicable):** #

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
