### PR TITLE
mysensors.py Prevent sensor name mixup

### DIFF
--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -139,7 +139,7 @@ def pf_callback_factory(map_sv_types, devices, add_devices, entity_class):
                 if key in devices:
                     devices[key].update_ha_state(True)
                     continue
-                name = '{} {}.{}'.format(
+                name = '{} {} {}'.format(
                     gateway.sensors[node_id].sketch_name, node_id, child.id)
                 if isinstance(entity_class, dict):
                     device_class = entity_class[child.type]


### PR DESCRIPTION
**Description:**
Change the sensor name schema so nodes are not mixed up. The dot that was present before was ignored by home-assistant.
Before name:  "skeatchname" "node_id""child_id"  eg. wall 107
New name   :  "skeatchname" "node_id" "child_id"  eg. wall 10 7
This will result in a Home Assistant Entity ID of: sensor.wall_10_7

Note. This will brake mysensor sensor name backwards compatibility for thaw’s that already have set up Home Assistant. Fix is to update names in yaml configuration file.

Testing: 
Tested OK on deployed platform, Home-Assistant 1.6 (raspberry pi) + MySensors 1.5 (Arduino + NRF24L01)
Not tested using `tox` 

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
