### PR TITLE
Use constant time comparison for http authentication

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -5,6 +5,7 @@ For more details about the RESTful API, please refer to the documentation at
 https://home-assistant.io/developers/api/
 """
 import gzip
+import hmac
 import json
 import logging
 import ssl
@@ -200,12 +201,22 @@ class RequestHandler(SimpleHTTPRequestHandler):
                     "Error parsing JSON", HTTP_UNPROCESSABLE_ENTITY)
                 return
 
-        self.authenticated = (self.server.api_password is None or
-                              self.headers.get(HTTP_HEADER_HA_AUTH) ==
-                              self.server.api_password or
-                              data.get(DATA_API_PASSWORD) ==
-                              self.server.api_password or
-                              self.verify_session())
+        if self.verify_session():
+            # The user has a valid session already
+            self.authenticated = True
+        elif self.server.api_password is None:
+            # No password is set, so everyone is authenticated
+            self.authenticated = True
+        elif hmac.compare_digest(self.headers.get(HTTP_HEADER_HA_AUTH, ''),
+                                 self.server.api_password):
+            # A valid auth header has been set
+            self.authenticated = True
+        elif hmac.compare_digest(data.get(DATA_API_PASSWORD, ''),
+                                 self.server.api_password):
+            # A valid password has been specified
+            self.authenticated = True
+        else:
+            self.authenticated = False
 
         if '_METHOD' in data:
             method = data.pop('_METHOD')


### PR DESCRIPTION
In order to prevent a potential timing attack, it's important to make
sure the password check takes the same amount of time, regardless of
how many characters in the candidate password match the real password.

This commit does increase the verbosity of the authentication check.
Generally it is a good idea for authentication logic to be very clear,
even if that requires some extra verbosity.

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works. (This is pretty much impossible to test without implementing a timing attack in the test suite, and ain't nobody got time for that).
