### PR TITLE
0.17.3

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     HTTP_HEADER_CONTENT_LENGTH, HTTP_HEADER_CONTENT_TYPE, HTTP_HEADER_EXPIRES,
     HTTP_HEADER_HA_AUTH, HTTP_HEADER_VARY, HTTP_METHOD_NOT_ALLOWED,
     HTTP_NOT_FOUND, HTTP_OK, HTTP_UNAUTHORIZED, HTTP_UNPROCESSABLE_ENTITY,
-    SERVER_PORT)
+    SERVER_PORT, URL_ROOT, URL_API_EVENT_FORWARD)
 
 DOMAIN = "http"
 
@@ -206,6 +206,10 @@ class RequestHandler(SimpleHTTPRequestHandler):
                               data.get(DATA_API_PASSWORD) ==
                               self.server.api_password or
                               self.verify_session())
+
+        # we really shouldn't need to forward the password from here
+        if url.path not in [URL_ROOT, URL_API_EVENT_FORWARD]:
+            data.pop(DATA_API_PASSWORD, None)
 
         if '_METHOD' in data:
             method = data.pop('_METHOD')

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """Constants used by Home Assistant components."""
 
-__version__ = "0.17.2"
+__version__ = "0.17.3"
 REQUIRED_PYTHON_VER = (3, 4)
 
 PLATFORM_FORMAT = '{}.{}'


### PR DESCRIPTION
One more hot fix to help people with validation issues.

We allow people passing in the API password as a GET/POST parameter. If the REST API would be used to call a service, the password would be forwarded to the service. If the service contained validation, it would fail because of an unexpected key.

Thanks to @jaharkes for squashing this bug.
