### PR TITLE
New version of betamax broke the yr.no sensor test.

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,5 +4,5 @@ coveralls>=1.1
 pytest>=2.8.0
 pytest-cov>=2.2.0
 pytest-timeout>=1.0.0
-betamax>=0.5.1
+betamax==0.5.1
 pydocstyle>=1.0.0


### PR DESCRIPTION
**Description:**
A new betamax release (0.6.0) seems to have broken the yr.no unit tests.

This patch pins betamax to 0.5.1 in the tox test environment.

**Related issue (if applicable):** various recent travis-ci build failures
