### PR TITLE
Improve Nest target temp display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ config/custom_components/*
 !config/custom_components/hello_world.py
 !config/custom_components/mqtt_example.py
 
+tests/config/deps
 tests/config/home-assistant.log
 
 # Hide sublime text stuff

--- a/homeassistant/components/thermostat/nest.py
+++ b/homeassistant/components/thermostat/nest.py
@@ -88,8 +88,10 @@ class NestThermostat(ThermostatDevice):
             elif self.operation == STATE_HEAT:
                 temp = low
             else:
-                range_average = (low + high)/2
-                if self.current_temperature < range_average:
+                # If the outside temp is lower than the current temp, consider
+                # the 'low' temp to the target, otherwise use the high temp
+                if (self.device.structure.weather.current.temperature <
+                        self.current_temperature):
                     temp = low
                 elif self.current_temperature >= range_average:
                     temp = high

--- a/homeassistant/components/thermostat/nest.py
+++ b/homeassistant/components/thermostat/nest.py
@@ -93,7 +93,7 @@ class NestThermostat(ThermostatDevice):
                 if (self.device.structure.weather.current.temperature <
                         self.current_temperature):
                     temp = low
-                elif self.current_temperature >= range_average:
+                else:
                     temp = high
         else:
             if self.is_away_mode_on:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,5 +4,5 @@ coveralls>=1.1
 pytest>=2.8.0
 pytest-cov>=2.2.0
 pytest-timeout>=1.0.0
-betamax>=0.5.1
+betamax==0.5.1
 pydocstyle>=1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ universal = 1
 testpaths = tests
 
 [flake8]
-exclude = .venv,.git,.tox,docs,www_static,venv,bin,lib
+exclude = .venv,.git,.tox,docs,www_static,venv,bin,lib,deps


### PR DESCRIPTION
The Nest target temperature methods were not taking the 'away' status into account, leading to misleading target temps being reported.

When picking which of the high/low temperatures to display as the "target", it makes more sense to take the outside temperature into consideration, rather than the current temperature of the thermostat.

If the temperature outside is less than the temperature of the thermostat, we are far more likely to end up in "heating" mode eventually, and vice versa, regardless of where the current inside temp falls in the range between high and low.
