### PR TITLE
Add dweet export component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,6 +14,9 @@ omit =
     homeassistant/components/bloomsky.py
     homeassistant/components/*/bloomsky.py
 
+    homeassistant/components/dweet.py
+    homeassistant/components/*/dweet.py
+
     homeassistant/components/ecobee.py
     homeassistant/components/*/ecobee.py
 
@@ -143,7 +146,6 @@ omit =
     homeassistant/components/sensor/cpuspeed.py
     homeassistant/components/sensor/deutsche_bahn.py
     homeassistant/components/sensor/dht.py
-    homeassistant/components/sensor/dweet.py
     homeassistant/components/sensor/efergy.py
     homeassistant/components/sensor/eliqonline.py
     homeassistant/components/sensor/forecast.py

--- a/homeassistant/components/dweet.py
+++ b/homeassistant/components/dweet.py
@@ -1,0 +1,73 @@
+"""
+A component which allows you to send data to Dweet.io.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/dweet/
+"""
+import logging
+from datetime import timedelta
+import voluptuous as vol
+
+from homeassistant.const import EVENT_STATE_CHANGED, STATE_UNKNOWN
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import state as state_helper
+from homeassistant.util import Throttle
+
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "dweet"
+DEPENDENCIES = []
+
+REQUIREMENTS = ['dweepy==0.2.0']
+
+CONF_NAME = 'name'
+CONF_WHITELIST = 'whitelist'
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=1)
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_WHITELIST): cv.string,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+# pylint: disable=too-many-locals
+def setup(hass, config):
+    """Setup the Dweet.io component."""
+    conf = config[DOMAIN]
+    name = conf[CONF_NAME]
+    whitelist = conf.get(CONF_WHITELIST, [])
+    json_body = {}
+
+    def dweet_event_listener(event):
+        """Listen for new messages on the bus and sends them to Dweet.io."""
+        state = event.data.get('new_state')
+        if state is None or state.state in (STATE_UNKNOWN, '') \
+                or state.entity_id not in whitelist:
+            return
+
+        try:
+            _state = state_helper.state_as_number(state)
+        except ValueError:
+            _state = state.state
+
+        json_body[state.attributes.get('friendly_name')] = _state
+
+        send_data(name, json_body)
+
+    hass.bus.listen(EVENT_STATE_CHANGED, dweet_event_listener)
+
+    return True
+
+
+@Throttle(MIN_TIME_BETWEEN_UPDATES)
+def send_data(name, msg):
+    """Send the collected data to Dweet.io."""
+    import dweepy
+    try:
+        dweepy.dweet_for(name, msg)
+    except dweepy.DweepyError:
+        _LOGGER.error("Error saving data '%s' to Dweet.io", msg)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -40,6 +40,7 @@ blockchain==1.3.1
 # homeassistant.components.notify.xmpp
 dnspython3==1.12.0
 
+# homeassistant.components.dweet
 # homeassistant.components.sensor.dweet
 dweepy==0.2.0
 


### PR DESCRIPTION
**Description:**
The export component pushes states from your local HA instance to [Dweet.io](https://dweet.io). The states of those "dweets" can then be visualized with [Dweet.io](https://dweet.io) itself but also with [Freeboard](https://freeboard.io). 

Instead of a backlist approach it would be more comfortable to me if we go with a whitelist. The reason is that all data on [Dweet.io](https://dweet.io) are public accessible as long not [locks](https://dweet.io/locks) are used. "Locks" are not supported at the moment.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
dweet:
  name: HAExport
  whitelist:
    - input_slider.brightness
    - input_boolean.notify_home
    - sensor.weather_temperature
    - sensor.cpu
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
