### PR TITLE
set name to hyperion assets

### DIFF
--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -19,7 +19,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup a Hyperion server remote."""
     host = config.get(CONF_HOST, None)
     port = config.get("port", 19444)
-    device = Hyperion(host, port)
+    device = Hyperion( config.get('name', host), host, port)
     if device.setup():
         add_devices_callback([device])
         return True
@@ -30,11 +30,11 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 class Hyperion(Light):
     """Representation of a Hyperion remote."""
 
-    def __init__(self, host, port):
+    def __init__(self, name, host, port):
         """Initialize the light."""
         self._host = host
         self._port = port
-        self._name = host
+        self._name = name
         self._is_available = True
         self._rgb_color = [255, 255, 255]
 
@@ -75,7 +75,8 @@ class Hyperion(Light):
         """Get the hostname of the remote."""
         response = self.json_request({"command": "serverinfo"})
         if response:
-            self._name = response["info"]["hostname"]
+            if self._name == self._host:
+                self._name = response["info"]["hostname"]
             return True
 
         return False

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -19,7 +19,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup a Hyperion server remote."""
     host = config.get(CONF_HOST, None)
     port = config.get("port", 19444)
-    device = Hyperion( config.get('name', host), host, port)
+    device = Hyperion(config.get('name', host), host, port)
     if device.setup():
         add_devices_callback([device])
         return True


### PR DESCRIPTION
**Description:**
Specifying the name in the configuration

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
light kodi_xxx:
  name: "Kodi XXX"
  platform: hyperion
  host: 192.168.1.222
  port: 19444
```

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
