### PR TITLE
This commit will allow mpd to handle the play_media service.  Even th…

### DIFF
--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -10,14 +10,16 @@ import socket
 from homeassistant.components.media_player import (
     MEDIA_TYPE_MUSIC, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE,
     SUPPORT_PREVIOUS_TRACK, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_SET, MediaPlayerDevice)
+    SUPPORT_VOLUME_SET, SUPPORT_PLAY_MEDIA, MEDIA_TYPE_PLAYLIST,
+    MediaPlayerDevice)
 from homeassistant.const import STATE_OFF, STATE_PAUSED, STATE_PLAYING
 
 _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = ['python-mpd2==0.5.5']
 
 SUPPORT_MPD = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_TURN_OFF | \
-    SUPPORT_TURN_ON | SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK
+    SUPPORT_TURN_ON | SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK | \
+    SUPPORT_PLAY_MEDIA
 
 
 # pylint: disable=unused-argument
@@ -64,7 +66,7 @@ class MpdDevice(MediaPlayerDevice):
     """Representation of a MPD server."""
 
     # MPD confuses pylint
-    # pylint: disable=no-member, abstract-method
+    # pylint: disable=no-member, too-many-public-methods, abstract-method
     def __init__(self, server, port, location, password):
         """Initialize the MPD device."""
         import mpd
@@ -203,3 +205,14 @@ class MpdDevice(MediaPlayerDevice):
     def media_previous_track(self):
         """Service to send the MPD the command for previous track."""
         self.client.previous()
+
+    def play_media(self, media_type, media_id):
+        """Send the media player the command for playing a playlist."""
+        _LOGGER.info(str.format("Playing playlist: {0}", media_id))
+        if media_type == MEDIA_TYPE_PLAYLIST:
+            self.client.clear()
+            self.client.load(media_id)
+            self.client.play()
+        else:
+            _LOGGER.error(str.format("Invalid media type. Expected: {0}",
+                                     MEDIA_TYPE_PLAYLIST))


### PR DESCRIPTION
**Description:**
This change add the ability for the mpd component to load an existing playlist, via the play_media service.  The intent is that this would be used during a script/scene.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
script:
  relaxing_music:
    sequence:
    - service: media_player.play_media
      data:
        entity_id: media_player.main
        media_content_type: playlist
        media_content_id: relaxing_playlist
```

**Checklist:**

If code communicates with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

…ough there's not really a place in the UI for it, it will now be possible to set a playlist as part of a script, and ultimately a scene.
