### PR TITLE
Fix for the issue #1323

### DIFF
--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -12,7 +12,9 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import validate_config
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['fritzconnection==0.4.6']
+REQUIREMENTS = ['https://github.com/deisi/fritzconnection/archive/'
+                'b5c14515e1c8e2652b06b6316a7f3913df942841.zip'
+                '#fritzconnection==0.4.6']
 
 # Return cached results if last scan was less then this time ago.
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -49,9 +49,6 @@ evohomeclient==0.2.4
 # homeassistant.components.notify.free_mobile
 freesms==0.1.0
 
-# homeassistant.components.device_tracker.fritz
-# fritzconnection==0.4.6
-
 # homeassistant.components.conversation
 fuzzywuzzy==0.8.0
 
@@ -88,6 +85,9 @@ https://github.com/bashwork/pymodbus/archive/d7fc4f1cc975631e0a9011390e8017f64b6
 
 # homeassistant.components.media_player.onkyo
 https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.2
+
+# homeassistant.components.device_tracker.fritz
+# https://github.com/deisi/fritzconnection/archive/b5c14515e1c8e2652b06b6316a7f3913df942841.zip#fritzconnection==0.4.6
 
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1


### PR DESCRIPTION
**Description:**
Use patched version of fritzconnection so it works with python3.

**Related issue (if applicable):** Fixes #1323

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
    device_tracker:
      - platform: fritz
        host: 192.168.178.1
        username: admin
        password: 1234
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
