### PR TITLE
Eq3btsmart

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -172,12 +172,12 @@ omit =
     homeassistant/components/switch/rest.py
     homeassistant/components/switch/transmission.py
     homeassistant/components/switch/wake_on_lan.py
+    homeassistant/components/thermostat/eq3btsmart.py
     homeassistant/components/thermostat/heatmiser.py
     homeassistant/components/thermostat/homematic.py
     homeassistant/components/thermostat/proliphix.py
     homeassistant/components/thermostat/radiotherm.py
     homeassistant/components/*/thinkingcleaner.py
-    homeassistant/components/thermostat/eq3btsmart.py
 
 
 [report]

--- a/.coveragerc
+++ b/.coveragerc
@@ -177,6 +177,7 @@ omit =
     homeassistant/components/thermostat/proliphix.py
     homeassistant/components/thermostat/radiotherm.py
     homeassistant/components/*/thinkingcleaner.py
+    homeassistant/components/thermostat/eq3btsmart.py
 
 
 [report]

--- a/homeassistant/components/thermostat/eq3btsmart.py
+++ b/homeassistant/components/thermostat/eq3btsmart.py
@@ -1,0 +1,207 @@
+"""
+Support for eq3 Bluetooth Smart thermostats.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/thermostat.max/
+"""
+import logging
+
+from homeassistant.components.thermostat import ThermostatDevice
+from homeassistant.const import TEMP_CELCIUS
+from homeassistant.helpers.temperature import convert
+
+import struct
+from datetime import datetime
+
+REQUIREMENTS = ['bluepy>=1.0.0']
+
+CONF_MAC = 'mac'
+CONF_DEVICES = 'devices'
+CONF_ID = 'id'
+
+PROPERTY_WRITE_HANDLE = 0x411
+PROPERTY_NTFY_HANDLE = 0x421
+PROPERTY_ID_VALUE_PACKED = struct.pack('B', 0)
+PROPERTY_GETINFO_VALUE_PACKED = struct.pack('B', 3)
+PROPERTY_TEMPERATURE_VALUE = 0x41
+PROPERTY_TEMPERATURE_VALUE_PACKED = struct.pack(
+    'B', PROPERTY_TEMPERATURE_VALUE)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the eq3 BLE thermostats."""
+    devices = []
+
+    for name, device_cfg in config[CONF_DEVICES].items():
+        mac = device_cfg[CONF_MAC]
+        devices.append(eq3BTSmartThermostat(mac, name))
+
+    add_devices(devices)
+    return True
+
+
+# pylint: disable=too-many-instance-attributes
+class EQ3BTSmartThermostat(ThermostatDevice):
+    """Representation of a Homematic thermostat."""
+
+    def __init__(self, _mac, _name):
+        """Initialize the thermostat."""
+        from bluepy import btle
+
+        self._mac = _mac
+        self._name = _name
+        self._target_temperature = -1
+        self._mode = -1
+        self._mode_readable = ''
+        self._requestValue = -1
+        self._requestHandle = -1
+        
+        self._delegate = self.getDelegate()
+
+        self._conn = btle.Peripheral()
+        self._connect()
+        self.update()
+
+    def getDelegate():
+        """Return the notification handler."""
+        from bluepy import btle
+                
+        class EQ3BTSmartDelegate(btle.DefaultDelegate):
+            """Class for Callback handling."""
+
+            def __init__(self, _thermostat):
+                """Initialize the Callback handler."""
+
+                btle.DefaultDelegate.__init__(self)
+                self._thermostat = thermostat
+
+            def handleNotification(self, cHandle, data):
+                """Handle Callback from a Bluetooth (GATT) request."""
+                if cHandle == PROPERTY_NTFY_HANDLE:
+                    if self._thermostat._requestValue == PROPERTY_GETINFO_VALUE_PACKED:
+                        self._thermostat._mode = data[2] & 1
+                        self._thermostat._mode_readable = self.decodeMode(data[2])
+                        self._thermostat._target_temperature = data[5] / 2.0
+        
+        return EQ3BTSmartDelegate(self)
+
+    def _connect(self):
+        """Connect to the Bluetooth thermostat."""
+        _LOGGER.info("EQ3 Smart BLE: connecting to " + self._name +
+                     " " + self._mac)
+        self._conn.connect(self._mac)
+        self._conn.withDelegate(self._delegate)
+        self._setTime()
+
+    def _setTime(self):
+        """Set the correct time into the thermostat."""
+        time = datetime.now()
+        value = struct.pack('BBBBBB', int(time.strftime("%y")),
+                            time.month, time.day, time.hour,
+                            time.minute, time.second)
+        self.writeCommandRaw(PROPERTY_WRITE_HANDLE, value)
+
+    def _disconnect(self):
+        """Close the Bluetooth connection."""
+        self._conn.disconnect()
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement that is used."""
+        return TEMP_CELCIUS
+
+    @property
+    def current_temperature(self):
+        """This thermostat can not report the current temperature.
+           So return the target temperature.
+        """
+        return self.target_temperature
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self._target_temperature
+
+    def set_temperature(self, temperature):
+        """Set new target temperature."""
+        value = struct.pack('BB', PROPERTY_TEMPERATURE_VALUE,
+                            int(temperature*2))
+        self.writeRequestRaw(PROPERTY_WRITE_HANDLE, value)
+        self._target_temperature = temperature
+
+    @property
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
+        return {"mode": self._mode, "mode_readable": self._mode_readable}
+
+    @property
+    def min_temp(self):
+        """Return the minimum temperature."""
+        return round(convert(4.5, TEMP_CELCIUS, self.unit_of_measurement))
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature."""
+        return round(convert(30.5, TEMP_CELCIUS, self.unit_of_measurement))
+
+    def decodeMode(self, mode):
+        """Convert the numerical mode to a human-readable description."""
+        ret = ""
+        if mode & 1:
+            ret = "manual"
+        else:
+            ret = "auto"
+
+        if mode & 2:
+            ret = ret + " holiday"
+        if mode & 4:
+            ret = ret + " boost"
+        if mode & 8:
+            ret = ret + " dst"
+        if mode & 16:
+            ret = ret + " window"
+
+        return ret
+
+    def writeRequest(self, handle, value):
+        """Write a GATT Command with callback."""
+        self.writeCommand(handle, value, True)
+
+    def writeRequestRaw(self, handle, value):
+        """Write a GATT Command with callback
+           without utf-8 converting the input.
+        """
+        self.writeCommandRaw(handle, value, True)
+
+    def writeCommand(self, handle, value, waitForIt=False):
+        """Write a GATT Command without callback."""
+        self.writeCommand(handle, value.encode('utf-8'), waitForIt)
+
+    def writeCommandRaw(self, handle, value, waitForIt=False, exception=False):
+        """Write a GATT Command without callback
+           without utf-8 converting the input.
+        """
+        try:
+            self._requestHandle = handle
+            self._requestValue = value
+            self._conn.writeCharacteristic(handle, value, waitForIt)
+            if waitForIt:
+                while self._conn.waitForNotifications(0.1):
+                    continue
+        except btle.BTLEException:
+            if exception is False:
+                self._disconnect()
+                self._connect()
+                self.writeCommandRaw(handle, value, waitForIt, True)
+
+    def update(self, exception=False):
+        """Update the data from the thermostat."""
+        self.writeRequestRaw(PROPERTY_WRITE_HANDLE,
+                             PROPERTY_GETINFO_VALUE_PACKED)

--- a/homeassistant/components/thermostat/eq3btsmart.py
+++ b/homeassistant/components/thermostat/eq3btsmart.py
@@ -1,6 +1,9 @@
 """
 Support for eq3 Bluetooth Smart thermostats.
+
+Uses bluepy_devices library.
 """
+
 import logging
 
 from homeassistant.components.thermostat import ThermostatDevice

--- a/homeassistant/components/thermostat/eq3btsmart.py
+++ b/homeassistant/components/thermostat/eq3btsmart.py
@@ -1,30 +1,17 @@
 """
 Support for eq3 Bluetooth Smart thermostats.
-
-For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/thermostat.max/
 """
 import logging
-import struct
-from datetime import datetime
 
 from homeassistant.components.thermostat import ThermostatDevice
 from homeassistant.const import TEMP_CELCIUS
 from homeassistant.helpers.temperature import convert
 
-REQUIREMENTS = ['bluepy>=1.0.0']
+REQUIREMENTS = ['bluepy_devices>=0.2.0']
 
 CONF_MAC = 'mac'
 CONF_DEVICES = 'devices'
 CONF_ID = 'id'
-
-PROP_WRITE_HANDLE = 0x411
-PROP_NTFY_HANDLE = 0x421
-PROP_ID_VALUE_PACKED = struct.pack('B', 0)
-PROP_GETINFO_VALUE_PACKED = struct.pack('B', 3)
-PROP_TEMPERATURE_VALUE = 0x41
-PROP_TEMPERATURE_VALUE_PACKED = struct.pack(
-    'B', PROP_TEMPERATURE_VALUE)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,70 +30,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 # pylint: disable=too-many-instance-attributes
 class EQ3BTSmartThermostat(ThermostatDevice):
-    """Representation of a Homematic thermostat."""
+    """Representation of a EQ3 Bluetooth Smart thermostat."""
 
     def __init__(self, _mac, _name):
         """Initialize the thermostat."""
-        from bluepy import btle
+        from bluepy_devices.devices import eq3btsmart
 
-        self._mac = _mac
         self._name = _name
-        self._target_temperature = -1
-        self._mode = -1
-        self._mode_readable = ''
-        self._request_value = -1
-        self._request_handle = -1
 
-        self._conn = btle.Peripheral()
-        self._connect()
-        self.update()
-
-    def get_delegate(self):
-        """Return the notification handler."""
-        from bluepy import btle
-
-        class EQ3BTSmartDelegate(btle.DefaultDelegate):
-            """Class for Callback handling."""
-
-            def __init__(self, _thermostat):
-                """Initialize the Callback handler."""
-                btle.DefaultDelegate.__init__(self)
-                self._thermostat = _thermostat
-
-            def handleNotification(self, handle, data):
-                """Handle Callback from a Bluetooth (GATT) request."""
-                self._thermostat.handle_notification(handle, data)
-
-        return EQ3BTSmartDelegate(self)
-
-    def handle_notification(self, handle, data):
-        """Handle Callback from a Bluetooth (GATT) request."""
-        if handle == PROP_NTFY_HANDLE:
-            if self._request_value == PROP_GETINFO_VALUE_PACKED:
-                self._mode = data[2] & 1
-                self._mode_readable = self.decode_mode(data[2])
-                self._target_temperature = data[5] / 2.0
-
-    def _connect(self):
-        """Connect to the Bluetooth thermostat."""
-        _LOGGER.info("EQ3 Smart BLE: connecting to " + self._name +
-                     " " + self._mac)
-        self._conn.connect(self._mac)
-        delegate = self.get_delegate()
-        self._conn.withDelegate(delegate)
-        self._set_time()
-
-    def _set_time(self):
-        """Set the correct time into the thermostat."""
-        time = datetime.now()
-        value = struct.pack('BBBBBB', int(time.strftime("%y")),
-                            time.month, time.day, time.hour,
-                            time.minute, time.second)
-        self.write_command_raw(PROP_WRITE_HANDLE, value)
-
-    def _disconnect(self):
-        """Close the Bluetooth connection."""
-        self._conn.disconnect()
+        self._thermostat = eq3btsmart.EQ3BTSmartThermostat(_mac)
 
     @property
     def name(self):
@@ -126,81 +58,30 @@ class EQ3BTSmartThermostat(ThermostatDevice):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self._target_temperature
+        return self._thermostat.target_temperature
 
     def set_temperature(self, temperature):
         """Set new target temperature."""
-        value = struct.pack('BB', PROP_TEMPERATURE_VALUE,
-                            int(temperature*2))
-        self.write_request_raw(PROP_WRITE_HANDLE, value)
-        self._target_temperature = temperature
+        self._thermostat.target_temperature = temperature
 
     @property
     def device_state_attributes(self):
         """Return the device specific state attributes."""
-        return {"mode": self._mode, "mode_readable": self._mode_readable}
+        return {"mode": self._thermostat.mode,
+                "mode_readable": self._thermostat.mode_readable}
 
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        return round(convert(4.5, TEMP_CELCIUS, self.unit_of_measurement))
+        return convert(self._thermostat.min_temp, TEMP_CELCIUS,
+                       self.unit_of_measurement)
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        return round(convert(30.5, TEMP_CELCIUS, self.unit_of_measurement))
-
-    @staticmethod
-    def decode_mode(mode):
-        """Convert the numerical mode to a human-readable description."""
-        ret = ""
-        if mode & 1:
-            ret = "manual"
-        else:
-            ret = "auto"
-
-        if mode & 2:
-            ret = ret + " holiday"
-        if mode & 4:
-            ret = ret + " boost"
-        if mode & 8:
-            ret = ret + " dst"
-        if mode & 16:
-            ret = ret + " window"
-
-        return ret
-
-    def write_request(self, handle, value):
-        """Write a GATT Command with callback."""
-        self.write_command(handle, value, True)
-
-    def write_request_raw(self, handle, value):
-        """Write a GATT Command with callback - no utf-8."""
-        self.write_command_raw(handle, value, True)
-
-    def write_command(self, handle, value, wait_for_it=False):
-        """Write a GATT Command without callback."""
-        self.write_command(handle, value.encode('utf-8'), wait_for_it)
-
-    def write_command_raw(self, handle, value,
-                          wait_for_it=False, exception=False):
-        """Write a GATT Command without callback - not utf-8."""
-        from bluepy import btle
-
-        try:
-            self._request_handle = handle
-            self._request_value = value
-            self._conn.writeCharacteristic(handle, value, wait_for_it)
-            if wait_for_it:
-                while self._conn.waitForNotifications(1):
-                    continue
-        except btle.BTLEException:
-            if exception is False:
-                self._disconnect()
-                self._connect()
-                self.write_command_raw(handle, value, wait_for_it, True)
+        return convert(self._thermostat.max_temp, TEMP_CELCIUS,
+                       self.unit_of_measurement)
 
     def update(self):
         """Update the data from the thermostat."""
-        self.write_request_raw(PROP_WRITE_HANDLE,
-                               PROP_GETINFO_VALUE_PACKED)
+        self._thermostat.update()

--- a/homeassistant/components/thermostat/eq3btsmart.py
+++ b/homeassistant/components/thermostat/eq3btsmart.py
@@ -5,13 +5,12 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/thermostat.max/
 """
 import logging
+import struct
+from datetime import datetime
 
 from homeassistant.components.thermostat import ThermostatDevice
 from homeassistant.const import TEMP_CELCIUS
 from homeassistant.helpers.temperature import convert
-
-import struct
-from datetime import datetime
 
 REQUIREMENTS = ['bluepy>=1.0.0']
 
@@ -19,13 +18,13 @@ CONF_MAC = 'mac'
 CONF_DEVICES = 'devices'
 CONF_ID = 'id'
 
-PROPERTY_WRITE_HANDLE = 0x411
-PROPERTY_NTFY_HANDLE = 0x421
-PROPERTY_ID_VALUE_PACKED = struct.pack('B', 0)
-PROPERTY_GETINFO_VALUE_PACKED = struct.pack('B', 3)
-PROPERTY_TEMPERATURE_VALUE = 0x41
-PROPERTY_TEMPERATURE_VALUE_PACKED = struct.pack(
-    'B', PROPERTY_TEMPERATURE_VALUE)
+PROP_WRITE_HANDLE = 0x411
+PROP_NTFY_HANDLE = 0x421
+PROP_ID_VALUE_PACKED = struct.pack('B', 0)
+PROP_GETINFO_VALUE_PACKED = struct.pack('B', 3)
+PROP_TEMPERATURE_VALUE = 0x41
+PROP_TEMPERATURE_VALUE_PACKED = struct.pack(
+    'B', PROP_TEMPERATURE_VALUE)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +35,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for name, device_cfg in config[CONF_DEVICES].items():
         mac = device_cfg[CONF_MAC]
-        devices.append(eq3BTSmartThermostat(mac, name))
+        devices.append(EQ3BTSmartThermostat(mac, name))
 
     add_devices(devices)
     return True
@@ -55,53 +54,55 @@ class EQ3BTSmartThermostat(ThermostatDevice):
         self._target_temperature = -1
         self._mode = -1
         self._mode_readable = ''
-        self._requestValue = -1
-        self._requestHandle = -1
-        
-        self._delegate = self.getDelegate()
+        self._request_value = -1
+        self._request_handle = -1
 
         self._conn = btle.Peripheral()
         self._connect()
         self.update()
 
-    def getDelegate():
+    def get_delegate(self):
         """Return the notification handler."""
         from bluepy import btle
-                
+
         class EQ3BTSmartDelegate(btle.DefaultDelegate):
             """Class for Callback handling."""
 
             def __init__(self, _thermostat):
                 """Initialize the Callback handler."""
-
                 btle.DefaultDelegate.__init__(self)
-                self._thermostat = thermostat
+                self._thermostat = _thermostat
 
-            def handleNotification(self, cHandle, data):
+            def handleNotification(self, handle, data):
                 """Handle Callback from a Bluetooth (GATT) request."""
-                if cHandle == PROPERTY_NTFY_HANDLE:
-                    if self._thermostat._requestValue == PROPERTY_GETINFO_VALUE_PACKED:
-                        self._thermostat._mode = data[2] & 1
-                        self._thermostat._mode_readable = self.decodeMode(data[2])
-                        self._thermostat._target_temperature = data[5] / 2.0
-        
+                self._thermostat.handle_notification(handle, data)
+
         return EQ3BTSmartDelegate(self)
+
+    def handle_notification(self, handle, data):
+        """Handle Callback from a Bluetooth (GATT) request."""
+        if handle == PROP_NTFY_HANDLE:
+            if self._request_value == PROP_GETINFO_VALUE_PACKED:
+                self._mode = data[2] & 1
+                self._mode_readable = self.decode_mode(data[2])
+                self._target_temperature = data[5] / 2.0
 
     def _connect(self):
         """Connect to the Bluetooth thermostat."""
         _LOGGER.info("EQ3 Smart BLE: connecting to " + self._name +
                      " " + self._mac)
         self._conn.connect(self._mac)
-        self._conn.withDelegate(self._delegate)
-        self._setTime()
+        delegate = self.get_delegate()
+        self._conn.withDelegate(delegate)
+        self._set_time()
 
-    def _setTime(self):
+    def _set_time(self):
         """Set the correct time into the thermostat."""
         time = datetime.now()
         value = struct.pack('BBBBBB', int(time.strftime("%y")),
                             time.month, time.day, time.hour,
                             time.minute, time.second)
-        self.writeCommandRaw(PROPERTY_WRITE_HANDLE, value)
+        self.write_command_raw(PROP_WRITE_HANDLE, value)
 
     def _disconnect(self):
         """Close the Bluetooth connection."""
@@ -119,9 +120,7 @@ class EQ3BTSmartThermostat(ThermostatDevice):
 
     @property
     def current_temperature(self):
-        """This thermostat can not report the current temperature.
-           So return the target temperature.
-        """
+        """Can not report temperature, so return target_temperature."""
         return self.target_temperature
 
     @property
@@ -131,9 +130,9 @@ class EQ3BTSmartThermostat(ThermostatDevice):
 
     def set_temperature(self, temperature):
         """Set new target temperature."""
-        value = struct.pack('BB', PROPERTY_TEMPERATURE_VALUE,
+        value = struct.pack('BB', PROP_TEMPERATURE_VALUE,
                             int(temperature*2))
-        self.writeRequestRaw(PROPERTY_WRITE_HANDLE, value)
+        self.write_request_raw(PROP_WRITE_HANDLE, value)
         self._target_temperature = temperature
 
     @property
@@ -151,7 +150,8 @@ class EQ3BTSmartThermostat(ThermostatDevice):
         """Return the maximum temperature."""
         return round(convert(30.5, TEMP_CELCIUS, self.unit_of_measurement))
 
-    def decodeMode(self, mode):
+    @staticmethod
+    def decode_mode(mode):
         """Convert the numerical mode to a human-readable description."""
         ret = ""
         if mode & 1:
@@ -170,38 +170,37 @@ class EQ3BTSmartThermostat(ThermostatDevice):
 
         return ret
 
-    def writeRequest(self, handle, value):
+    def write_request(self, handle, value):
         """Write a GATT Command with callback."""
-        self.writeCommand(handle, value, True)
+        self.write_command(handle, value, True)
 
-    def writeRequestRaw(self, handle, value):
-        """Write a GATT Command with callback
-           without utf-8 converting the input.
-        """
-        self.writeCommandRaw(handle, value, True)
+    def write_request_raw(self, handle, value):
+        """Write a GATT Command with callback - no utf-8."""
+        self.write_command_raw(handle, value, True)
 
-    def writeCommand(self, handle, value, waitForIt=False):
+    def write_command(self, handle, value, wait_for_it=False):
         """Write a GATT Command without callback."""
-        self.writeCommand(handle, value.encode('utf-8'), waitForIt)
+        self.write_command(handle, value.encode('utf-8'), wait_for_it)
 
-    def writeCommandRaw(self, handle, value, waitForIt=False, exception=False):
-        """Write a GATT Command without callback
-           without utf-8 converting the input.
-        """
+    def write_command_raw(self, handle, value,
+                          wait_for_it=False, exception=False):
+        """Write a GATT Command without callback - not utf-8."""
+        from bluepy import btle
+
         try:
-            self._requestHandle = handle
-            self._requestValue = value
-            self._conn.writeCharacteristic(handle, value, waitForIt)
-            if waitForIt:
-                while self._conn.waitForNotifications(0.1):
+            self._request_handle = handle
+            self._request_value = value
+            self._conn.writeCharacteristic(handle, value, wait_for_it)
+            if wait_for_it:
+                while self._conn.waitForNotifications(1):
                     continue
         except btle.BTLEException:
             if exception is False:
                 self._disconnect()
                 self._connect()
-                self.writeCommandRaw(handle, value, waitForIt, True)
+                self.write_command_raw(handle, value, wait_for_it, True)
 
-    def update(self, exception=False):
+    def update(self):
         """Update the data from the thermostat."""
-        self.writeRequestRaw(PROPERTY_WRITE_HANDLE,
-                             PROPERTY_GETINFO_VALUE_PACKED)
+        self.write_request_raw(PROP_WRITE_HANDLE,
+                               PROP_GETINFO_VALUE_PACKED)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -34,6 +34,9 @@ blinkstick==1.1.7
 # homeassistant.components.sensor.bitcoin
 blockchain==1.3.1
 
+# homeassistant.components.thermostat.eq3btsmart
+bluepy>=1.0.0
+
 # homeassistant.components.notify.xmpp
 dnspython3==1.12.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -35,7 +35,7 @@ blinkstick==1.1.7
 blockchain==1.3.1
 
 # homeassistant.components.thermostat.eq3btsmart
-bluepy>=1.0.0
+bluepy_devices>=0.2.0
 
 # homeassistant.components.notify.xmpp
 dnspython3==1.12.0


### PR DESCRIPTION
**Description:**

Support for EQ3 Bluetooth Smart Thermostats.
The only functionality is to set the temperature, there doesn't seem to be any way to query the temperature sensor or battery level (see https://forum.fhem.de/index.php/topic,39308.15.html).

Setup is a bit more cumbersome than for most other thermostats. It has to be paired first:

```
bluetoothctl
scan on
<Wait for the thermostat to be found, which looks like this: [NEW] Device 00:11:22:33:44:55 CC-RT-BLE>
scan off
<Set the thermostat to pairing mode.>
pair <MAC>
trust <MAC>
disconnect <MAC>
exit
```

Then check with gatttool if the connection works as expected:

```
gatttool -b 00:11:22:33:44:55 -I
[00:11:22:33:44:55][LE]> connect
Attempting to connect to 00:11:22:33:44:55
Connection successful
[00:11:22:33:44:55][LE]> char-write-req 0x0411 03
Characteristic value was written successfully
Notification handle = 0x0421 value: 02 01 09 14 04 2d
[00:11:22:33:44:55][LE]> disconnect
[00:11:22:33:44:55][LE]> exit
```

Important: For gatttool or homeassistant to work, the thermostat needs to be disconnected from bluetoothd, so I found it best to modify the hass-daemon startscript by adding:

```
  /usr/bin/bt-device -d CC-RT-BLE
```

to the start function of /etc/init.d/hass-daemon.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
thermostat:
  platform: eq3btsmart
    devices:
      room1:
        mac: '00:11:22:33:44:55'
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
