### PR TITLE
SCSGATE: Actually cycle through all devices to register

### DIFF
--- a/homeassistant/components/scsgate.py
+++ b/homeassistant/components/scsgate.py
@@ -104,7 +104,6 @@ class SCSGate:
                 self._device_being_registered = device.scs_id
                 self._reactor.append_task(GetStatusTask(target=device.scs_id))
 
-
     def is_device_registered(self, device_id):
         """Check whether a device is already registered or not."""
         with self._devices_to_register_lock:

--- a/homeassistant/components/scsgate.py
+++ b/homeassistant/components/scsgate.py
@@ -98,12 +98,12 @@ class SCSGate:
         from scsgate.tasks import GetStatusTask
 
         with self._devices_to_register_lock:
-            if len(self._devices_to_register) == 0:
-                return
-            _, device = self._devices_to_register.popitem()
-            self._devices[device.scs_id] = device
-            self._device_being_registered = device.scs_id
-            self._reactor.append_task(GetStatusTask(target=device.scs_id))
+            while len(self._devices_to_register) != 0:
+                _, device = self._devices_to_register.popitem()
+                self._devices[device.scs_id] = device
+                self._device_being_registered = device.scs_id
+                self._reactor.append_task(GetStatusTask(target=device.scs_id))
+
 
     def is_device_registered(self, device_id):
         """Check whether a device is already registered or not."""


### PR DESCRIPTION
**Description:**
Modify _activate_next_device function to actually cycle through self-devices_to_register instead of simply checking whether there are any and only registering one

**Checklist:**

If code communicates with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
