### PR TITLE
Add support for imperial gas meter and user specified gas calorific value.

### DIFF
--- a/homeassistant/components/sensor/loopenergy.py
+++ b/homeassistant/components/sensor/loopenergy.py
@@ -8,12 +8,13 @@ import logging
 
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.util import convert
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "loopenergy"
 
-REQUIREMENTS = ['pyloopenergy==0.0.7']
+REQUIREMENTS = ['pyloopenergy==0.0.10']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -24,6 +25,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     elec_secret = config.get('electricity_secret')
     gas_serial = config.get('gas_serial')
     gas_secret = config.get('gas_secret')
+    gas_type = config.get('gas_type', 'metric')
+    gas_calorific = convert(config.get('gas_calorific'), float, 39.11)
 
     if not (elec_serial and elec_secret):
         _LOGGER.error(
@@ -39,11 +42,20 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             "serial and secret tokens")
         return None
 
+    if gas_type not in ['imperial', 'metric']:
+        _LOGGER.error(
+            "Configuration Error, 'gas_type' "
+            "can only be 'imperial' or 'metric' ")
+        return None
+
+    # pylint: disable=too-many-function-args
     controller = pyloopenergy.LoopEnergy(
         elec_serial,
         elec_secret,
         gas_serial,
-        gas_secret
+        gas_secret,
+        gas_type,
+        gas_calorific
         )
 
     def stop_loopenergy(event):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -196,7 +196,7 @@ pyfttt==0.3
 pyicloud==0.7.2
 
 # homeassistant.components.sensor.loopenergy
-pyloopenergy==0.0.7
+pyloopenergy==0.0.10
 
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.3.3


### PR DESCRIPTION
**Description:**
This PR upgrades the version of pyloopenergy, and adds support for imperial gas meters and choosing your own gas supplier's calorific value.

Sadly neither of these parameters is currently available from the loop energy (undocumented) API.

Both the new parameters are optional.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: loopenergy
    electricity_serial: 'XXX'
    electricity_secret: 'XXX'
    gas_serial: 'XXX'
    gas_secret: 'XXX'
    gas_type: imperial # optional default is metric
    gas_calorific: 38.2 # optional default is 39.11
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
