### PR TITLE
Don't setup a previously loaded hue bridge

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -57,6 +57,11 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     if discovery_info is not None:
         host = urlparse(discovery_info[1]).hostname
+        configured_host = _find_host_from_config(hass, filename)
+        if configured_host is not None:
+            if host != configured_host and \
+                    host == socket.gethostbyname(configured_host):
+                return
     else:
         host = config.get(CONF_HOST, None)
 


### PR DESCRIPTION
**Description:**

Compare the IP of the hue bridge specified in the config against the IP of a discovered bridge. Skip setup if a bridge resolving to the IP is already configured.

**Related issue (if applicable):** #1825

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [N/A] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [N/A] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [N/A] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [N/A] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [N/A] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [N/A] Tests have been added to verify that the new code works.

Fix for  #1825, check if a hue bridge is setup using a
hostname that resolves to the discovered IP.
