### PR TITLE
Add abilitiy to display errors

### DIFF
--- a/homeassistant/components/persistent_notification.py
+++ b/homeassistant/components/persistent_notification.py
@@ -1,0 +1,18 @@
+"""
+A component which is collecting configuration errors.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/persistent_notification/
+"""
+
+DOMAIN = "persistent_notification"
+
+
+def create(hass, entity, msg):
+    """Create a state for an error."""
+    hass.states.set('{}.{}'.format(DOMAIN, entity), msg)
+
+
+def setup(hass, config):
+    """Setup the persistent notification component."""
+    return True


### PR DESCRIPTION
**Description:**
The error log is available in the "Developer tools". The `error` component will display errors directly in the frontend. This should make errors in the configuration more accessible for user especially with the on-going effort for the validation.

The current state should show how it could work. It's pretty simple but would require that the `error` component is loaded right after the initialization of HA. The bus is used to push the errors to the frontend.

I guess that there are more elegant ways to do this. So, I'm looking for feedback before proceeding.

![ha-errors](https://cloud.githubusercontent.com/assets/116184/14589361/416d52d2-04e0-11e6-82cf-183c78b33018.png)

**Related issue (if applicable):** https://www.pivotaltracker.com/story/show/116917427

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
error:
```

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
