### PR TITLE
Only add visible sonos devices

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -39,8 +39,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import soco
 
     if discovery_info:
-        add_devices([SonosDevice(hass, soco.SoCo(discovery_info))])
-        return True
+        player = soco.SoCo(discovery_info)
+        if player.is_visible:
+            add_devices([SonosDevice(hass, player)])
+            return True
+        return False
 
     players = None
     hosts = config.get('hosts', None)


### PR DESCRIPTION
**Description:**
A SonosDevice is now created for all discovered sonos devices, but this fails for devices that do not have a media renderer. For me it happens because of a SUB player (which is paired with a playbar), but I would think it also applies to e.g bridges.  
The soco.discover() method used further down in setup_platform handles filtering out such devices by default.
