### PR TITLE
Catch platform setup error

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -79,6 +79,9 @@ class EntityComponent(object):
         platform = prepare_setup_platform(
             self.hass, self.config, self.domain, platform_type)
 
+        if platform is None:
+            return
+
         # Config > Platform > Component
         scan_interval = platform_config.get(
             CONF_SCAN_INTERVAL,


### PR DESCRIPTION
When a platform fails to setup, it used to be caught by the broad Exception catch in line 91. That spams the logs with a message that confuses the user. Now it will just have bootstrap print out the message and return afterwards.

There was already a test for this and the behavior also doesn't change, just the error message is nicer.
