### PR TITLE
Fix for #1843

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -32,6 +32,9 @@ PHUE_CONFIG_FILE = "phue.conf"
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)
 
+# Track previously setup bridges
+_CONFIGURED_BRIDGES = {}
+
 
 def _find_host_from_config(hass, filename=PHUE_CONFIG_FILE):
     """Attempt to detect host based on existing configuration."""
@@ -68,7 +71,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             return False
 
     # Only act if we are not already configuring this host
-    if host in _CONFIGURING:
+    if host in _CONFIGURING or \
+            socket.gethostbyname(host) in _CONFIGURED_BRIDGES:
         return
 
     setup_bridge(host, hass, add_devices_callback, filename, allow_unreachable)
@@ -142,6 +146,7 @@ def setup_bridge(host, hass, add_devices_callback, filename,
         if new_lights:
             add_devices_callback(new_lights)
 
+    _CONFIGURED_BRIDGES[socket.gethostbyname(host)] = True
     update_lights()
 
 


### PR DESCRIPTION
**Description:**
Fixes #1843 by tracking previously configured bridges.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [X] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Tracks previously configured bridges by IP and prevents duplicates
from being configured
