### PR TITLE
Update pyicloud version

### DIFF
--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.event import track_utc_time_change
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyicloud==0.7.2']
+REQUIREMENTS = ['pyicloud==0.8.3']
 
 CONF_INTERVAL = 'interval'
 DEFAULT_INTERVAL = 8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -193,7 +193,7 @@ pydispatcher==2.0.5
 pyfttt==0.3
 
 # homeassistant.components.device_tracker.icloud
-pyicloud==0.7.2
+pyicloud==0.8.3
 
 # homeassistant.components.sensor.loopenergy
 pyloopenergy==0.0.7


### PR DESCRIPTION
**Description:**
Updates the pyicloud version to the latest version. This is needed for the new icloud platform.
In this version, the upgrade issue is fixed when the cookie folder was corrupted so everyone can safely upgrade now.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [X] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
