### PR TITLE
Add mysensors tcp ethernet gateway

### DIFF
--- a/homeassistant/components/binary_sensor/mysensors.py
+++ b/homeassistant/components/binary_sensor/mysensors.py
@@ -101,8 +101,16 @@ class MySensorsBinarySensor(BinarySensorDevice):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
+        try:
+            ip_address, tcp_port = self.gateway.server_address
+            device = '{}:{}'.format(ip_address, tcp_port)
+        except AttributeError:
+            try:
+                device = self.gateway.port
+            except AttributeError:
+                device = ''
         attr = {
-            self.mysensors.ATTR_PORT: self.gateway.port,
+            self.mysensors.ATTR_DEVICE: device,
             self.mysensors.ATTR_NODE_ID: self.node_id,
             self.mysensors.ATTR_CHILD_ID: self.child_id,
             ATTR_BATTERY_LEVEL: self.battery_level,

--- a/homeassistant/components/binary_sensor/mysensors.py
+++ b/homeassistant/components/binary_sensor/mysensors.py
@@ -6,10 +6,9 @@ https://home-assistant.io/components/binary_sensor.mysensors/
 """
 import logging
 
-from homeassistant.const import (
-    ATTR_BATTERY_LEVEL, STATE_OFF, STATE_ON)
-from homeassistant.components.binary_sensor import (
-    BinarySensorDevice, SENSOR_CLASSES)
+from homeassistant.components.binary_sensor import (SENSOR_CLASSES,
+                                                    BinarySensorDevice)
+from homeassistant.const import ATTR_BATTERY_LEVEL, STATE_OFF, STATE_ON
 from homeassistant.loader import get_component
 
 _LOGGER = logging.getLogger(__name__)
@@ -101,14 +100,11 @@ class MySensorsBinarySensor(BinarySensorDevice):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        try:
-            ip_address, tcp_port = self.gateway.server_address
-            device = '{}:{}'.format(ip_address, tcp_port)
-        except AttributeError:
-            try:
-                device = self.gateway.port
-            except AttributeError:
-                device = ''
+        address = getattr(self.gateway, 'server_address', None)
+        if address:
+            device = '{}:{}'.format(address[0], address[1])
+        else:
+            device = self.gateway.port
         attr = {
             self.mysensors.ATTR_DEVICE: device,
             self.mysensors.ATTR_NODE_ID: self.node_id,

--- a/homeassistant/components/light/mysensors.py
+++ b/homeassistant/components/light/mysensors.py
@@ -100,15 +100,23 @@ class MySensorsLight(Light):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        device_attr = {
-            self.mysensors.ATTR_PORT: self.gateway.port,
+        try:
+            ip_address, tcp_port = self.gateway.server_address
+            device = '{}:{}'.format(ip_address, tcp_port)
+        except AttributeError:
+            try:
+                device = self.gateway.port
+            except AttributeError:
+                device = ''
+        attr = {
+            self.mysensors.ATTR_DEVICE: device,
             self.mysensors.ATTR_NODE_ID: self.node_id,
             self.mysensors.ATTR_CHILD_ID: self.child_id,
             ATTR_BATTERY_LEVEL: self.battery_level,
         }
         for value_type, value in self._values.items():
-            device_attr[self.gateway.const.SetReq(value_type).name] = value
-        return device_attr
+            attr[self.gateway.const.SetReq(value_type).name] = value
+        return attr
 
     @property
     def available(self):

--- a/homeassistant/components/light/mysensors.py
+++ b/homeassistant/components/light/mysensors.py
@@ -6,8 +6,8 @@ https://home-assistant.io/components/light.mysensors/
 """
 import logging
 
-from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_RGB_COLOR, Light)
+from homeassistant.components.light import (ATTR_BRIGHTNESS, ATTR_RGB_COLOR,
+                                            Light)
 from homeassistant.const import ATTR_BATTERY_LEVEL, STATE_OFF, STATE_ON
 from homeassistant.loader import get_component
 from homeassistant.util.color import rgb_hex_to_rgb_list
@@ -100,14 +100,11 @@ class MySensorsLight(Light):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        try:
-            ip_address, tcp_port = self.gateway.server_address
-            device = '{}:{}'.format(ip_address, tcp_port)
-        except AttributeError:
-            try:
-                device = self.gateway.port
-            except AttributeError:
-                device = ''
+        address = getattr(self.gateway, 'server_address', None)
+        if address:
+            device = '{}:{}'.format(address[0], address[1])
+        else:
+            device = self.gateway.port
         attr = {
             self.mysensors.ATTR_DEVICE: device,
             self.mysensors.ATTR_NODE_ID: self.node_id,

--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -5,33 +5,36 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.mysensors/
 """
 import logging
+import socket
 
 import homeassistant.bootstrap as bootstrap
-from homeassistant.const import (
-    ATTR_DISCOVERED, ATTR_SERVICE, EVENT_HOMEASSISTANT_START,
-    EVENT_HOMEASSISTANT_STOP, EVENT_PLATFORM_DISCOVERED, TEMP_CELCIUS,
-    CONF_OPTIMISTIC)
+from homeassistant.const import (ATTR_DISCOVERED, ATTR_SERVICE,
+                                 CONF_OPTIMISTIC, EVENT_HOMEASSISTANT_START,
+                                 EVENT_HOMEASSISTANT_STOP,
+                                 EVENT_PLATFORM_DISCOVERED, TEMP_CELCIUS)
 from homeassistant.helpers import validate_config
 
 CONF_GATEWAYS = 'gateways'
-CONF_PORT = 'port'
+CONF_DEVICE = 'device'
 CONF_DEBUG = 'debug'
 CONF_PERSISTENCE = 'persistence'
 CONF_PERSISTENCE_FILE = 'persistence_file'
 CONF_VERSION = 'version'
 CONF_BAUD_RATE = 'baud_rate'
+CONF_TCP_PORT = 'tcp_port'
 DEFAULT_VERSION = '1.4'
 DEFAULT_BAUD_RATE = 115200
+DEFAULT_TCP_PORT = 5003
 
 DOMAIN = 'mysensors'
 DEPENDENCIES = []
 REQUIREMENTS = [
     'https://github.com/theolind/pymysensors/archive/'
-    'f0c928532167fb24823efa793ec21ca646fd37a6.zip#pymysensors==0.5']
+    'cc5d0b325e13c2b623fa934f69eea7cd4555f110.zip#pymysensors==0.6']
 _LOGGER = logging.getLogger(__name__)
 ATTR_NODE_ID = 'node_id'
 ATTR_CHILD_ID = 'child_id'
-ATTR_PORT = 'port'
+ATTR_DEVICE = 'device'
 
 GATEWAYS = None
 
@@ -49,30 +52,39 @@ DISCOVERY_COMPONENTS = [
 ]
 
 
-def setup(hass, config):
+def setup(hass, config):  # pylint: disable=too-many-locals
     """Setup the MySensors component."""
     if not validate_config(config,
                            {DOMAIN: [CONF_GATEWAYS]},
                            _LOGGER):
         return False
-    if not all(CONF_PORT in gateway
+    if not all(CONF_DEVICE in gateway
                for gateway in config[DOMAIN][CONF_GATEWAYS]):
         _LOGGER.error('Missing required configuration items '
-                      'in %s: %s', DOMAIN, CONF_PORT)
+                      'in %s: %s', DOMAIN, CONF_DEVICE)
         return False
 
     import mysensors.mysensors as mysensors
 
     version = str(config[DOMAIN].get(CONF_VERSION, DEFAULT_VERSION))
     is_metric = (hass.config.temperature_unit == TEMP_CELCIUS)
+    persistence = config[DOMAIN].get(CONF_PERSISTENCE, True)
 
-    def setup_gateway(port, persistence, persistence_file, version, baud_rate):
+    def setup_gateway(device, persistence_file, baud_rate, tcp_port):
         """Return gateway after setup of the gateway."""
-        gateway = mysensors.SerialGateway(port, event_callback=None,
-                                          persistence=persistence,
-                                          persistence_file=persistence_file,
-                                          protocol_version=version,
-                                          baud=baud_rate)
+        try:
+            socket.inet_aton(device)
+            # valid ip address
+            gateway = mysensors.TCPGateway(
+                device, event_callback=None, persistence=persistence,
+                persistence_file=persistence_file, protocol_version=version,
+                port=tcp_port)
+        except OSError:
+            # invalid ip address
+            gateway = mysensors.SerialGateway(
+                device, event_callback=None, persistence=persistence,
+                persistence_file=persistence_file, protocol_version=version,
+                baud=baud_rate)
         gateway.metric = is_metric
         gateway.debug = config[DOMAIN].get(CONF_DEBUG, False)
         optimistic = config[DOMAIN].get(CONF_OPTIMISTIC, False)
@@ -93,22 +105,22 @@ def setup(hass, config):
 
         return gateway
 
-    # Setup all ports from config
+    # Setup all devices from config
     global GATEWAYS
     GATEWAYS = {}
     conf_gateways = config[DOMAIN][CONF_GATEWAYS]
     if isinstance(conf_gateways, dict):
         conf_gateways = [conf_gateways]
-    persistence = config[DOMAIN].get(CONF_PERSISTENCE, True)
 
     for index, gway in enumerate(conf_gateways):
-        port = gway[CONF_PORT]
+        device = gway[CONF_DEVICE]
         persistence_file = gway.get(
             CONF_PERSISTENCE_FILE,
             hass.config.path('mysensors{}.pickle'.format(index + 1)))
         baud_rate = gway.get(CONF_BAUD_RATE, DEFAULT_BAUD_RATE)
-        GATEWAYS[port] = setup_gateway(
-            port, persistence, persistence_file, version, baud_rate)
+        tcp_port = gway.get(CONF_TCP_PORT, DEFAULT_TCP_PORT)
+        GATEWAYS[device] = setup_gateway(
+            device, persistence_file, baud_rate, tcp_port)
 
     for (component, discovery_service) in DISCOVERY_COMPONENTS:
         # Ensure component is loaded

--- a/homeassistant/components/sensor/mysensors.py
+++ b/homeassistant/components/sensor/mysensors.py
@@ -6,8 +6,8 @@ https://home-assistant.io/components/sensor.mysensors/
 """
 import logging
 
-from homeassistant.const import (
-    ATTR_BATTERY_LEVEL, STATE_OFF, STATE_ON, TEMP_CELCIUS, TEMP_FAHRENHEIT)
+from homeassistant.const import (ATTR_BATTERY_LEVEL, STATE_OFF, STATE_ON,
+                                 TEMP_CELCIUS, TEMP_FAHRENHEIT)
 from homeassistant.helpers.entity import Entity
 from homeassistant.loader import get_component
 
@@ -157,14 +157,11 @@ class MySensorsSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        try:
-            ip_address, tcp_port = self.gateway.server_address
-            device = '{}:{}'.format(ip_address, tcp_port)
-        except AttributeError:
-            try:
-                device = self.gateway.port
-            except AttributeError:
-                device = ''
+        address = getattr(self.gateway, 'server_address', None)
+        if address:
+            device = '{}:{}'.format(address[0], address[1])
+        else:
+            device = self.gateway.port
         attr = {
             self.mysensors.ATTR_DEVICE: device,
             self.mysensors.ATTR_NODE_ID: self.node_id,

--- a/homeassistant/components/sensor/mysensors.py
+++ b/homeassistant/components/sensor/mysensors.py
@@ -157,8 +157,16 @@ class MySensorsSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
+        try:
+            ip_address, tcp_port = self.gateway.server_address
+            device = '{}:{}'.format(ip_address, tcp_port)
+        except AttributeError:
+            try:
+                device = self.gateway.port
+            except AttributeError:
+                device = ''
         attr = {
-            self.mysensors.ATTR_PORT: self.gateway.port,
+            self.mysensors.ATTR_DEVICE: device,
             self.mysensors.ATTR_NODE_ID: self.node_id,
             self.mysensors.ATTR_CHILD_ID: self.child_id,
             ATTR_BATTERY_LEVEL: self.battery_level,

--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -99,14 +99,11 @@ class MySensorsSwitch(SwitchDevice):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        try:
-            ip_address, tcp_port = self.gateway.server_address
-            device = '{}:{}'.format(ip_address, tcp_port)
-        except AttributeError:
-            try:
-                device = self.gateway.port
-            except AttributeError:
-                device = ''
+        address = getattr(self.gateway, 'server_address', None)
+        if address:
+            device = '{}:{}'.format(address[0], address[1])
+        else:
+            device = self.gateway.port
         attr = {
             self.mysensors.ATTR_DEVICE: device,
             self.mysensors.ATTR_NODE_ID: self.node_id,

--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -99,8 +99,16 @@ class MySensorsSwitch(SwitchDevice):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
+        try:
+            ip_address, tcp_port = self.gateway.server_address
+            device = '{}:{}'.format(ip_address, tcp_port)
+        except AttributeError:
+            try:
+                device = self.gateway.port
+            except AttributeError:
+                device = ''
         attr = {
-            self.mysensors.ATTR_PORT: self.gateway.port,
+            self.mysensors.ATTR_DEVICE: device,
             self.mysensors.ATTR_NODE_ID: self.node_id,
             self.mysensors.ATTR_CHILD_ID: self.child_id,
             ATTR_BATTERY_LEVEL: self.battery_level,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -35,7 +35,7 @@ blinkstick==1.1.7
 blockchain==1.3.1
 
 # homeassistant.components.thermostat.eq3btsmart
-bluepy_devices>=0.2.0
+# bluepy_devices>=0.2.0
 
 # homeassistant.components.notify.xmpp
 dnspython3==1.12.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -117,7 +117,7 @@ https://github.com/robbiet480/pygtfs/archive/432414b720c580fb2667a0a48f539118a2d
 https://github.com/sander76/powerviewApi/archive/master.zip#powerviewApi==0.2
 
 # homeassistant.components.mysensors
-https://github.com/theolind/pymysensors/archive/f0c928532167fb24823efa793ec21ca646fd37a6.zip#pymysensors==0.5
+https://github.com/theolind/pymysensors/archive/cc5d0b325e13c2b623fa934f69eea7cd4555f110.zip#pymysensors==0.6
 
 # homeassistant.components.notify.googlevoice
 https://github.com/w1ll1am23/pygooglevoice-sms/archive/7c5ee9969b97a7992fc86a753fe9f20e3ffa3f7c.zip#pygooglevoice-sms==0.0.1

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -11,6 +11,7 @@ COMMENT_REQUIREMENTS = [
     'Adafruit_Python_DHT',
     'fritzconnection',
     'pybluez',
+    'bluepy',
 ]
 
 


### PR DESCRIPTION
**Description:**

**This will BREAK existing configs for mysensors.** Change "- port:" under "gateways" to "- device:". See below for new example config.
- Bump version of pymysensors to 0.6, which includes the tcp gateway.
- Update requirements_all.txt.
- Replace CONF_PORT with CONF_DEVICE and ATTR_PORT with ATTR_DEVICE.
- Add tcp_port in config.
- Try to guess if tcp or serial gateway is configured, by validating
  device name as an ip address. If successful setup tcp gateway, if it
  fails, setup serial gateway.
- Update device_state_attributes to show correct device, ethernet or
  serial.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
mysensors:
  gateways:
    - device: '/dev/ttyUSB0'
      persistence_file: 'path/mysensors.json'
      baud_rate: 38400
    - device: '/dev/ttyACM0'
      persistence_file: 'path/mysensors2.json'
      baud_rate: 115200
    - device: '192.168.1.18'
      persistence_file: 'path/mysensors3.json'
      tcp_port: 5003
  debug: true
  persistence: true
  version: '1.5'
  optimistic: false
```

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
