### PR TITLE
Pass format through to temper_device so that Fahrenheit works

### DIFF
--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/sensor.temper/
 """
 import logging
 
-from homeassistant.const import CONF_NAME, DEVICE_DEFAULT_NAME
+from homeassistant.const import CONF_NAME, DEVICE_DEFAULT_NAME, TEMP_FAHRENHEIT
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,7 +56,9 @@ class TemperSensor(Entity):
     def update(self):
         """Retrieve latest state."""
         try:
-            self.current_value = self.temper_device.get_temperature()
+            format_str = ('fahrenheit' if self.temp_unit == TEMP_FAHRENHEIT
+                          else 'celsius')
+            self.current_value = self.temper_device.get_temperature(format_str)
         except IOError:
             _LOGGER.error('Failed to get temperature due to insufficient '
                           'permissions. Try running with "sudo"')


### PR DESCRIPTION
**Description:**
Pass through the configured temperature unit to the temper device API so that conversion to Fahrenheit is performed if desired

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.
