### PR TITLE
Initial support for generic 433Mhz GPIO adapters on a Raspberry Pi

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -172,6 +172,7 @@ omit =
     homeassistant/components/switch/orvibo.py
     homeassistant/components/switch/pulseaudio_loopback.py
     homeassistant/components/switch/rest.py
+    homeassistant/components/switch/rpi_rf.py
     homeassistant/components/switch/transmission.py
     homeassistant/components/switch/wake_on_lan.py
     homeassistant/components/thermostat/eq3btsmart.py

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_VALUE_TEMPLATE
 
 DEFAULT_PULSELENGTH = 350
 
-REQUIREMENTS = ['RPi.GPIO==0.6.2', 'rpi-rf==0.9.3']
+REQUIREMENTS = ['RPi.GPIO==0.6.2', 'rpi-rf==0.9.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -20,12 +20,23 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Find and return switches controlled by a generic RF device via GPIO."""
     import rpi_rf
 
-    gpio = config.get('gpio', 17)
+    gpio = config.get('gpio')
+    if not gpio:
+        _LOGGER.error("No GPIO specified")
+        return False
+
     rfdevice = rpi_rf.RFDevice(gpio)
 
     switches = config.get('switches', {})
     devices = []
     for dev_name, properties in switches.items():
+        if not properties.get('code_on'):
+            _LOGGER.error("%s: code_on not specified", dev_name)
+            continue
+        if not properties.get('code_off'):
+            _LOGGER.error("%s: code_off not specified", dev_name)
+            continue
+
         devices.append(
             RPiRFSwitch(
                 hass,
@@ -33,8 +44,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                 rfdevice,
                 properties.get('protocol', None),
                 properties.get('pulselength', None),
-                properties.get('code_on', 0),
-                properties.get('code_off', 0),
+                properties.get('code_on'),
+                properties.get('code_off'),
                 properties.get(CONF_VALUE_TEMPLATE, False)))
     add_devices_callback(devices)
 

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -8,7 +8,6 @@ https://home-assistant.io/components/switch.rpi_rf/
 import logging
 
 from homeassistant.components.switch import SwitchDevice
-from homeassistant.const import CONF_VALUE_TEMPLATE
 
 REQUIREMENTS = ['rpi-rf==0.9.5']
 
@@ -45,8 +44,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                 properties.get('protocol', None),
                 properties.get('pulselength', None),
                 properties.get('code_on'),
-                properties.get('code_off'),
-                properties.get(CONF_VALUE_TEMPLATE, False)))
+                properties.get('code_off')))
     add_devices_callback(devices)
 
 
@@ -55,7 +53,7 @@ class RPiRFSwitch(SwitchDevice):
 
     # pylint: disable=too-many-arguments, too-many-instance-attributes
     def __init__(self, hass, name, rfdevice, protocol, pulselength,
-                 code_on, code_off, value_template):
+                 code_on, code_off):
         """Initialize the switch."""
         self._hass = hass
         self._name = name
@@ -65,7 +63,6 @@ class RPiRFSwitch(SwitchDevice):
         self._pulselength = pulselength
         self._code_on = code_on
         self._code_off = code_off
-        self._value_template = value_template
 
         rfdevice.enable_tx()
 

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -1,0 +1,95 @@
+"""
+Allows to configure a switch using a 433MHz module via GPIO on a Raspberry Pi.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.rpi_rf/
+"""
+
+import logging
+
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.const import CONF_VALUE_TEMPLATE
+
+DEFAULT_PULSELENGTH = 350
+
+REQUIREMENTS = ['RPi.GPIO==0.6.2', 'rpi-rf==0.9.3']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Find and return switches controlled by a generic RF device via GPIO."""
+    import rpi_rf
+
+    gpio = config.get('gpio', 17)
+    rfdevice = rpi_rf.RFDevice(gpio)
+
+    switches = config.get('switches', {})
+    devices = []
+    for dev_name, properties in switches.items():
+        devices.append(
+            RPiRFSwitch(
+                hass,
+                properties.get('name', dev_name),
+                rfdevice,
+                properties.get('pulselength', DEFAULT_PULSELENGTH),
+                properties.get('onid', 0),
+                properties.get('offid', 0),
+                properties.get(CONF_VALUE_TEMPLATE, False)))
+    add_devices_callback(devices)
+
+
+class RPiRFSwitch(SwitchDevice):
+    """Representation of a GPIO RF switch."""
+
+    # pylint: disable=too-many-arguments, too-many-instance-attributes
+    def __init__(self, hass, name, rfdevice, pulselength, id_on, id_off,
+                 value_template):
+        """Initialize the switch."""
+        self._hass = hass
+        self._name = name
+        self._state = False
+        self._rfdevice = rfdevice
+        self._pulselength = pulselength
+        self._id_on = id_on
+        self._id_off = id_off
+        self._value_template = value_template
+
+        rfdevice.enable_tx()
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    def _send_code(self, code, pulselength):
+        """Send the code with a specified pulselength."""
+        _LOGGER.info('Sending code: %s (%s)', code, pulselength)
+        self._rfdevice.tx_pulselength = pulselength
+        res = self._rfdevice.tx_code(code)
+        if not res:
+            _LOGGER.error('Sending code %s failed', code)
+        return res
+
+    def turn_on(self):
+        """Turn the switch on."""
+        if self._send_code(self._id_on, self._pulselength):
+            self._state = True
+            self.update_ha_state()
+
+    def turn_off(self):
+        """Turn the switch off."""
+        if self._send_code(self._id_off, self._pulselength):
+            self._state = False
+            self.update_ha_state()

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -34,8 +34,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                 properties.get('name', dev_name),
                 rfdevice,
                 properties.get('pulselength', DEFAULT_PULSELENGTH),
-                properties.get('onid', 0),
-                properties.get('offid', 0),
+                properties.get('code_on', 0),
+                properties.get('code_off', 0),
                 properties.get(CONF_VALUE_TEMPLATE, False)))
     add_devices_callback(devices)
 
@@ -44,7 +44,7 @@ class RPiRFSwitch(SwitchDevice):
     """Representation of a GPIO RF switch."""
 
     # pylint: disable=too-many-arguments, too-many-instance-attributes
-    def __init__(self, hass, name, rfdevice, pulselength, id_on, id_off,
+    def __init__(self, hass, name, rfdevice, pulselength, code_on, code_off,
                  value_template):
         """Initialize the switch."""
         self._hass = hass
@@ -52,8 +52,8 @@ class RPiRFSwitch(SwitchDevice):
         self._state = False
         self._rfdevice = rfdevice
         self._pulselength = pulselength
-        self._id_on = id_on
-        self._id_off = id_off
+        self._code_on = code_on
+        self._code_off = code_off
         self._value_template = value_template
 
         rfdevice.enable_tx()
@@ -84,12 +84,12 @@ class RPiRFSwitch(SwitchDevice):
 
     def turn_on(self):
         """Turn the switch on."""
-        if self._send_code(self._id_on, self._pulselength):
+        if self._send_code(self._code_on, self._pulselength):
             self._state = True
             self.update_ha_state()
 
     def turn_off(self):
         """Turn the switch off."""
-        if self._send_code(self._id_off, self._pulselength):
+        if self._send_code(self._code_off, self._pulselength):
             self._state = False
             self.update_ha_state()

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -10,7 +10,7 @@ import logging
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import CONF_VALUE_TEMPLATE
 
-REQUIREMENTS = ['RPi.GPIO==0.6.2', 'rpi-rf==0.9.5']
+REQUIREMENTS = ['rpi-rf==0.9.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -45,6 +45,9 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                 properties.get('pulselength', None),
                 properties.get('code_on'),
                 properties.get('code_off')))
+    if devices:
+        rfdevice.enable_tx()
+
     add_devices_callback(devices)
 
 
@@ -63,8 +66,6 @@ class RPiRFSwitch(SwitchDevice):
         self._pulselength = pulselength
         self._code_on = code_on
         self._code_off = code_off
-
-        rfdevice.enable_tx()
 
     @property
     def should_poll(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -272,7 +272,7 @@ pywemo==0.4.2
 radiotherm==1.2
 
 # homeassistant.components.switch.rpi_rf
-rpi-rf==0.9.3
+rpi-rf==0.9.4
 
 # homeassistant.components.media_player.yamaha
 rxv==0.1.11

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -272,7 +272,7 @@ pywemo==0.4.2
 radiotherm==1.2
 
 # homeassistant.components.switch.rpi_rf
-rpi-rf==0.9.4
+rpi-rf==0.9.5
 
 # homeassistant.components.media_player.yamaha
 rxv==0.1.11

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -16,9 +16,6 @@ PyMata==2.07a
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.6.1
 
-# homeassistant.components.switch.rpi_rf
-# RPi.GPIO==0.6.2
-
 # homeassistant.components.media_player.sonos
 SoCo==0.11.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -16,6 +16,9 @@ PyMata==2.07a
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.6.1
 
+# homeassistant.components.switch.rpi_rf
+# RPi.GPIO==0.6.2
+
 # homeassistant.components.media_player.sonos
 SoCo==0.11.1
 
@@ -267,6 +270,9 @@ pywemo==0.4.2
 
 # homeassistant.components.thermostat.radiotherm
 radiotherm==1.2
+
+# homeassistant.components.switch.rpi_rf
+rpi-rf==0.9.3
 
 # homeassistant.components.media_player.yamaha
 rxv==0.1.11


### PR DESCRIPTION
**Description:**
Support for creating a switch with generic, low-cost 433MHz GPIO adapters on a Raspberry Pi utilising PyPi module [rpi-rf](https://pypi.python.org/pypi/rpi-rf).

Platform/driver code was tucked away into mentioned module (see [here](https://github.com/milaq/rpi-rf))
Compatible with codes sniffed via [rc-switch](https://github.com/sui77/rc-switch) and [433Utils](https://github.com/ninjablocks/433Utils) (RF logic was taken from there).
Codes can also be sniffed via [receive.py](https://github.com/milaq/rpi-rf/blob/master/examples/receive.py) and sent via [send.py](https://github.com/milaq/rpi-rf/blob/master/examples/send.py) for testing.

Should be a cleaner solution than using the Commandline module in conjunction with 433Utils (No wiringPi dependency, a tad faster and Python only).

Tested and checked locally (pylint, pep8, tox) and running fine on my own instance of Home Assistant with both 0.17, 0.18 and the dev branch.

Rem.: Documentation link in rpi_rf.py lines 4f (https://home-assistant.io/components/switch.rpi_rf/) does not yet exist. Though I thought I could add it in nevertheless.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
  - platform: rpi_rf
    gpio: 17
    switches:
      bedroom_light:
        code_on: 1234567
        code_off: 1234568
      ambilight:
        pulselength: 200
        code_on: 987654
        code_off: 133742
      living_room_light:
        protocol: 5
        code_on: 654321
        code_off: 654320
      kitchen_lights:
        protocol: 3
        pulselength: 150
        code_on: 9990921
        code_off: 9920933

```

**Checklist:**
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
