### PR TITLE
Update unifi version

### DIFF
--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -12,7 +12,8 @@ from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.helpers import validate_config
 
 # Unifi package doesn't list urllib3 as a requirement
-REQUIREMENTS = ['urllib3', 'unifi==1.2.4']
+REQUIREMENTS = ['urllib3', 'unifi==1.2.5']
+
 _LOGGER = logging.getLogger(__name__)
 CONF_PORT = 'port'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -316,7 +316,7 @@ transmissionrpc==0.11
 uber_rides==0.2.1
 
 # homeassistant.components.device_tracker.unifi
-unifi==1.2.4
+unifi==1.2.5
 
 # homeassistant.components.device_tracker.unifi
 urllib3


### PR DESCRIPTION
**Description:**
Unifi version bump. Fixes unifi install issue.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [X] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

New unifi version has a fix that will allow it to install correctly
