### PR TITLE
Ontime and delay attribute are allways present in deutsche_bahn sensor

### DIFF
--- a/homeassistant/components/sensor/deutsche_bahn.py
+++ b/homeassistant/components/sensor/deutsche_bahn.py
@@ -69,11 +69,10 @@ class DeutscheBahnSensor(Entity):
         """Get the latest delay from bahn.de and updates the state."""
         self.data.update()
         self._state = self.data.connections[0].get('departure', 'Unknown')
-        delay = self.data.connections[0].get('delay',
-                                             {'delay_departure': 0,
-                                              'delay_arrival': 0})
-        if delay['delay_departure'] != 0:
-            self._state += " + {}".format(delay['delay_departure'])
+        if self.data.connections[0]['delay'] != 0:
+            self._state += " + {}".format(
+                self.data.connections[0]['delay']
+            )
 
 
 # pylint: disable=too-few-public-methods
@@ -95,6 +94,14 @@ class SchieneData(object):
                                                     self.goal,
                                                     datetime.now())
         for con in self.connections:
-            # Details info are not useful.
+            # Details info is not useful.
+            # Having a more consistent interface simplifies
+            # usage of Template sensors later on
             if 'details' in con:
                 con.pop('details')
+                delay = con.get('delay',
+                                {'delay_departure': 0,
+                                 'delay_arrival': 0})
+                # IMHO only delay_departure is usefull
+                con['delay'] = delay['delay_departure']
+                con['ontime'] = con.get('ontime', False)


### PR DESCRIPTION
**Description:**
Attributes of the deutsche_bahn sensor were a mess. I permanently added an `ontime` and `delay` attribute. This simplifies usage of Templates for a deutsche_bahn sensor a lot.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
- platform: deutsche_bahn
  from: Berlin
  to: Frankfurt
```

and a template sensor can easily be set up with:

``` yaml
- platform: template
  sensors:
    delay_to_frankfurt:
      friendly_name: 'Delay to Frankfurt'
      value_template: '{{ states.sensor.berlin_to_frankfurt.attributes.delay }}'
      unit_of_measurement: 'min'
```

since before there was no guarantee that  `states.sensor.berlin_to_frankfurt.attributes.delay` existed and it was a `dict` obj, witch wasn't useful in any case.
**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
