### PR TITLE
added mapping and exclude lists

### DIFF
--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -66,10 +66,8 @@ class YamahaDevice(MediaPlayerDevice):
             self.build_source_list()
 
         current_source = self._receiver.input
-        if current_source in self._source_names:
-            self._current_source = self._source_names[current_source]
-        else:
-            self._current_source = current_source
+        self._current_source = self._source_names.get(current_source,
+                                                      current_source)
 
     def build_source_list(self):
         """Build the source list."""
@@ -137,7 +135,5 @@ class YamahaDevice(MediaPlayerDevice):
 
     def select_source(self, source):
         """Select input source."""
-        if source in self._reverse_mapping:
-            self._receiver.input = self._reverse_mapping[source]
-        else:
-            self._receiver.input = source
+        self._receiver.input = self._reverse_mapping.get(source,
+                                                         source)


### PR DESCRIPTION
**Description:**

**Related issue (if applicable):** #
https://github.com/home-assistant/home-assistant/issues/1874

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
media_player:
  - platform: yamaha
    name: "Livingroom"
    mapping:
      HDMI1: "XBOX"
      HDMI2: "PS4"
      HDMI3: "Wii U"
      HDMI4: "PS3"
      HDMI5: "PC"
      AV1: "TV"
    excludes:
      - "AV2"
      - "AV3"
      - "AV4"
      - "AV5"
      - "AV6"
      - "AirPlay"
      - "HDMI6"
      - "JUKE"
      - "SERVER"
      - "TUNER"
      - "Spotify"
      - "NET RADIO"
```

**Checklist:**

If code communicates with devices:
- [x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
