### PR TITLE
Trigger variables in automation actions

### DIFF
--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -91,7 +91,7 @@ def _handle_alexa(handler, path_match, data):
                           card['content'])
 
     if action is not None:
-        call_from_config(handler.server.hass, action, True)
+        call_from_config(handler.server.hass, action, True, response.variables)
 
     handler.write_json(response.as_dict())
 

--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -26,7 +26,14 @@ CONF_ACTION = 'action'
 
 def setup(hass, config):
     """Activate Alexa component."""
-    _CONFIG.update(config[DOMAIN].get(CONF_INTENTS, {}))
+    intents = config[DOMAIN].get(CONF_INTENTS, {})
+
+    for name, intent in intents.items():
+        if CONF_ACTION in intent:
+            intent[CONF_ACTION] = script.Script(hass, intent[CONF_ACTION],
+                                                "Alexa intent {}".format(name))
+
+    _CONFIG.update(intents)
 
     hass.http.register_path('POST', API_ENDPOINT, _handle_alexa, True)
 
@@ -90,8 +97,7 @@ def _handle_alexa(handler, path_match, data):
                           card['content'])
 
     if action is not None:
-        script.call_from_config(handler.server.hass, action,
-                                response.variables)
+        action.run(response.variables)
 
     handler.write_json(response.as_dict())
 

--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -8,8 +8,7 @@ import enum
 import logging
 
 from homeassistant.const import HTTP_OK, HTTP_UNPROCESSABLE_ENTITY
-from homeassistant.helpers.service import call_from_config
-from homeassistant.helpers import template
+from homeassistant.helpers import template, script
 
 DOMAIN = 'alexa'
 DEPENDENCIES = ['http']
@@ -91,7 +90,8 @@ def _handle_alexa(handler, path_match, data):
                           card['content'])
 
     if action is not None:
-        call_from_config(handler.server.hass, action, True, response.variables)
+        script.call_from_config(handler.server.hass, action,
+                                response.variables)
 
     handler.write_json(response.as_dict())
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -122,12 +122,11 @@ def _setup_automation(hass, config_block, name, config):
 
 def _get_action(hass, config, name):
     """Return an action based on a configuration."""
-    def action():
+    def action(variables=None):
         """Action to be executed."""
         _LOGGER.info('Executing %s', name)
         logbook.log_entry(hass, name, 'has been triggered', DOMAIN)
-
-        call_from_config(hass, config)
+        call_from_config(hass, config, variables=variables)
 
     return action
 
@@ -159,24 +158,21 @@ def _process_if(hass, config, p_config, action):
         checks.append(check)
 
     if cond_type == CONDITION_TYPE_AND:
-        def if_action():
+        def if_action(variables=None):
             """AND all conditions."""
-            if all(check() for check in checks):
-                action()
+            if all(check(variables) for check in checks):
+                action(variables)
     else:
-        def if_action():
+        def if_action(variables=None):
             """OR all conditions."""
-            if any(check() for check in checks):
-                action()
+            if any(check(variables) for check in checks):
+                action(variables)
 
     return if_action
 
 
 def _process_trigger(hass, config, trigger_configs, name, action):
     """Setup the triggers."""
-    if isinstance(trigger_configs, dict):
-        trigger_configs = [trigger_configs]
-
     for conf in trigger_configs:
         platform = _resolve_platform(METHOD_TRIGGER, hass, config,
                                      conf.get(CONF_PLATFORM))

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -11,8 +11,7 @@ import voluptuous as vol
 from homeassistant.bootstrap import prepare_setup_platform
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.components import logbook
-from homeassistant.helpers import extract_domain_configs
-from homeassistant.helpers.service import call_from_config
+from homeassistant.helpers import extract_domain_configs, script
 from homeassistant.loader import get_platform
 import homeassistant.helpers.config_validation as cv
 
@@ -88,7 +87,7 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_CONDITION_TYPE, default=DEFAULT_CONDITION_TYPE):
         vol.All(vol.Lower, vol.Any(CONDITION_TYPE_AND, CONDITION_TYPE_OR)),
     CONF_CONDITION: _CONDITION_SCHEMA,
-    vol.Required(CONF_ACTION): cv.SERVICE_SCHEMA,
+    vol.Required(CONF_ACTION): cv.SCRIPT_SCHEMA,
 })
 
 
@@ -122,11 +121,13 @@ def _setup_automation(hass, config_block, name, config):
 
 def _get_action(hass, config, name):
     """Return an action based on a configuration."""
+    script_obj = script.Script(hass, config, name)
+
     def action(variables=None):
         """Action to be executed."""
         _LOGGER.info('Executing %s', name)
         logbook.log_entry(hass, name, 'has been triggered', DOMAIN)
-        call_from_config(hass, config, variables=variables)
+        script_obj.run(variables)
 
     return action
 

--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -26,7 +26,12 @@ def trigger(hass, config, action):
         """Listen for events and calls the action when data matches."""
         if not event_data or all(val == event.data.get(key) for key, val
                                  in event_data.items()):
-            action()
+            action({
+                'trigger': {
+                    'platform': 'event',
+                    'event': event,
+                },
+            })
 
     hass.bus.listen(event_type, handle_event)
     return True

--- a/homeassistant/components/automation/mqtt.py
+++ b/homeassistant/components/automation/mqtt.py
@@ -30,7 +30,14 @@ def trigger(hass, config, action):
     def mqtt_automation_listener(msg_topic, msg_payload, qos):
         """Listen for MQTT messages."""
         if payload is None or payload == msg_payload:
-            action()
+            action({
+                'trigger': {
+                    'platform': 'mqtt',
+                    'topic': msg_topic,
+                    'payload': msg_payload,
+                    'qos': qos,
+                }
+            })
 
     mqtt.subscribe(hass, topic, mqtt_automation_listener)
 

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -92,7 +92,7 @@ def trigger(hass, config, action):
         def state_for_listener(now):
             """Fire on state changes after a delay and calls action."""
             hass.bus.remove_listener(
-                EVENT_STATE_CHANGED, attached_state_for_cancel_listener)
+                EVENT_STATE_CHANGED, attached_state_for_cancel)
             call_action()
 
         def state_for_cancel_listener(entity, inner_from_s, inner_to_s):
@@ -102,12 +102,12 @@ def trigger(hass, config, action):
             hass.bus.remove_listener(EVENT_TIME_CHANGED,
                                      attached_state_for_listener)
             hass.bus.remove_listener(EVENT_STATE_CHANGED,
-                                     attached_state_for_cancel_listener)
+                                     attached_state_for_cancel)
 
         attached_state_for_listener = track_point_in_time(
             hass, state_for_listener, dt_util.utcnow() + time_delta)
 
-        attached_state_for_cancel_listener = track_state_change(
+        attached_state_for_cancel = track_state_change(
             hass, entity_id, state_for_cancel_listener)
 
     track_state_change(

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -73,29 +73,42 @@ def trigger(hass, config, action):
 
     def state_automation_listener(entity, from_s, to_s):
         """Listen for state changes and calls action."""
+        def call_action():
+            """Call action with right context."""
+            action({
+                'trigger': {
+                    'platform': 'state',
+                    'entity_id': entity,
+                    'from_state': from_s,
+                    'to_state': to_s,
+                    'for': time_delta,
+                }
+            })
+
+        if time_delta is None:
+            call_action()
+            return
+
         def state_for_listener(now):
             """Fire on state changes after a delay and calls action."""
             hass.bus.remove_listener(
-                EVENT_STATE_CHANGED, for_state_listener)
-            action()
+                EVENT_STATE_CHANGED, attached_state_for_cancel_listener)
+            call_action()
 
         def state_for_cancel_listener(entity, inner_from_s, inner_to_s):
             """Fire on changes and cancel for listener if changed."""
             if inner_to_s == to_s:
                 return
-            hass.bus.remove_listener(EVENT_TIME_CHANGED, for_time_listener)
-            hass.bus.remove_listener(
-                EVENT_STATE_CHANGED, for_state_listener)
+            hass.bus.remove_listener(EVENT_TIME_CHANGED,
+                                     attached_state_for_listener)
+            hass.bus.remove_listener(EVENT_STATE_CHANGED,
+                                     attached_state_for_cancel_listener)
 
-        if time_delta is not None:
-            target_tm = dt_util.utcnow() + time_delta
-            for_time_listener = track_point_in_time(
-                hass, state_for_listener, target_tm)
-            for_state_listener = track_state_change(
-                hass, entity_id, state_for_cancel_listener,
-                MATCH_ALL, MATCH_ALL)
-        else:
-            action()
+        attached_state_for_listener = track_point_in_time(
+            hass, state_for_listener, dt_util.utcnow() + time_delta)
+
+        attached_state_for_cancel_listener = track_state_change(
+            hass, entity_id, state_for_cancel_listener)
 
     track_state_change(
         hass, entity_id, state_automation_listener, from_state, to_state)
@@ -109,7 +122,7 @@ def if_action(hass, config):
     state = config.get(CONF_STATE)
     time_delta = get_time_config(config)
 
-    def if_state():
+    def if_state(variables):
         """Test if condition."""
         is_state = hass.states.is_state(entity_id, state)
         return (time_delta is None and is_state or

--- a/homeassistant/components/automation/sun.py
+++ b/homeassistant/components/automation/sun.py
@@ -35,7 +35,7 @@ _SUN_EVENT = vol.All(vol.Lower, vol.Any(EVENT_SUNRISE, EVENT_SUNSET))
 TRIGGER_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'sun',
     vol.Required(CONF_EVENT): _SUN_EVENT,
-    vol.Required(CONF_OFFSET, default=timedelta(0)): cv.time_offset,
+    vol.Required(CONF_OFFSET, default=timedelta(0)): cv.time_period,
 })
 
 IF_ACTION_SCHEMA = vol.All(
@@ -43,8 +43,8 @@ IF_ACTION_SCHEMA = vol.All(
         vol.Required(CONF_PLATFORM): 'sun',
         CONF_BEFORE: _SUN_EVENT,
         CONF_AFTER: _SUN_EVENT,
-        vol.Required(CONF_BEFORE_OFFSET, default=timedelta(0)): cv.time_offset,
-        vol.Required(CONF_AFTER_OFFSET, default=timedelta(0)): cv.time_offset,
+        vol.Required(CONF_BEFORE_OFFSET, default=timedelta(0)): cv.time_period,
+        vol.Required(CONF_AFTER_OFFSET, default=timedelta(0)): cv.time_period,
     }),
     cv.has_at_least_one_key(CONF_BEFORE, CONF_AFTER),
 )

--- a/homeassistant/components/automation/sun.py
+++ b/homeassistant/components/automation/sun.py
@@ -55,11 +55,21 @@ def trigger(hass, config, action):
     event = config.get(CONF_EVENT)
     offset = config.get(CONF_OFFSET)
 
+    def call_action():
+        """Call action with right context."""
+        action({
+            'trigger': {
+                'platform': 'sun',
+                'event': event,
+                'offset': offset,
+            },
+        })
+
     # Do something to call action
     if event == EVENT_SUNRISE:
-        track_sunrise(hass, action, offset)
+        track_sunrise(hass, call_action, offset)
     else:
-        track_sunset(hass, action, offset)
+        track_sunset(hass, call_action, offset)
 
     return True
 
@@ -97,7 +107,7 @@ def if_action(hass, config):
             """Return time after sunset."""
             return sun.next_setting(hass) + after_offset
 
-    def time_if():
+    def time_if(variables):
         """Validate time based if-condition."""
         now = dt_util.now()
         before = before_func()

--- a/homeassistant/components/automation/time.py
+++ b/homeassistant/components/automation/time.py
@@ -41,7 +41,12 @@ def trigger(hass, config, action):
 
     def time_automation_listener(now):
         """Listen for time changes and calls action."""
-        action()
+        action({
+            'trigger': {
+                'platform': 'time',
+                'now': now,
+            },
+        })
 
     track_time_change(hass, time_automation_listener,
                       hour=hours, minute=minutes, second=seconds)
@@ -73,7 +78,7 @@ def if_action(hass, config):
             _error_time(after, CONF_AFTER)
             return None
 
-    def time_if():
+    def time_if(variables):
         """Validate time based if-condition."""
         now = dt_util.now()
         if before is not None and now > now.replace(hour=before.hour,

--- a/homeassistant/components/script.py
+++ b/homeassistant/components/script.py
@@ -8,101 +8,33 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/script/
 """
 import logging
-import threading
-from datetime import timedelta
-from itertools import islice
 
 import voluptuous as vol
 
-import homeassistant.util.dt as date_util
 from homeassistant.const import (
-    ATTR_ENTITY_ID, EVENT_TIME_CHANGED, SERVICE_TURN_OFF, SERVICE_TURN_ON,
-    SERVICE_TOGGLE, STATE_ON)
+    ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON,
+    SERVICE_TOGGLE, STATE_ON, CONF_ALIAS)
 from homeassistant.helpers.entity import ToggleEntity, split_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.event import track_point_in_utc_time
-from homeassistant.helpers.service import (call_from_config,
-                                           validate_service_call)
 import homeassistant.helpers.config_validation as cv
+
+from homeassistant.helpers.script import Script
 
 DOMAIN = "script"
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 DEPENDENCIES = ["group"]
 
-STATE_NOT_RUNNING = 'Not Running'
-
-CONF_ALIAS = "alias"
-CONF_SERVICE = "service"
-CONF_SERVICE_DATA = "data"
 CONF_SEQUENCE = "sequence"
-CONF_EVENT = "event"
-CONF_EVENT_DATA = "event_data"
-CONF_DELAY = "delay"
 
 ATTR_LAST_ACTION = 'last_action'
 ATTR_CAN_CANCEL = 'can_cancel'
 
 _LOGGER = logging.getLogger(__name__)
 
-_ALIAS_VALIDATOR = vol.Schema(cv.string)
-
-
-def _alias_stripper(validator):
-    """Strip alias from object for validation."""
-    def validate(value):
-        """Validate without alias value."""
-        value = value.copy()
-        alias = value.pop(CONF_ALIAS, None)
-
-        if alias is not None:
-            alias = _ALIAS_VALIDATOR(alias)
-
-        value = validator(value)
-
-        if alias is not None:
-            value[CONF_ALIAS] = alias
-
-        return value
-
-    return validate
-
-
-_TIMESPEC = vol.Schema({
-    'days': cv.positive_int,
-    'hours': cv.positive_int,
-    'minutes': cv.positive_int,
-    'seconds': cv.positive_int,
-    'milliseconds': cv.positive_int,
-})
-_TIMESPEC_REQ = cv.has_at_least_one_key(
-    'days', 'hours', 'minutes', 'seconds', 'milliseconds',
-)
-
-_DELAY_SCHEMA = vol.Any(
-    vol.Schema({
-        vol.Required(CONF_DELAY): vol.All(_TIMESPEC.extend({
-            vol.Optional(CONF_ALIAS): cv.string
-        }), _TIMESPEC_REQ)
-    }),
-    # Alternative format in case people forgot to indent after 'delay:'
-    vol.All(_TIMESPEC.extend({
-        vol.Required(CONF_DELAY): None,
-        vol.Optional(CONF_ALIAS): cv.string,
-    }), _TIMESPEC_REQ)
-)
-
-_EVENT_SCHEMA = cv.EVENT_SCHEMA.extend({
-    CONF_ALIAS: cv.string,
-})
 
 _SCRIPT_ENTRY_SCHEMA = vol.Schema({
     CONF_ALIAS: cv.string,
-    vol.Required(CONF_SEQUENCE): vol.All(vol.Length(min=1), [vol.Any(
-        _EVENT_SCHEMA,
-        _DELAY_SCHEMA,
-        # Can't extend SERVICE_SCHEMA because it is an vol.All
-        _alias_stripper(cv.SERVICE_SCHEMA),
-    )]),
+    vol.Required(CONF_SEQUENCE): cv.SCRIPT_SCHEMA,
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -152,7 +84,7 @@ def setup(hass, config):
 
     for object_id, cfg in config[DOMAIN].items():
         alias = cfg.get(CONF_ALIAS, object_id)
-        script = Script(object_id, alias, cfg[CONF_SEQUENCE])
+        script = ScriptEntity(hass, object_id, alias, cfg[CONF_SEQUENCE])
         component.add_entities((script,))
         hass.services.register(DOMAIN, object_id, service_handler,
                                schema=SCRIPT_SERVICE_SCHEMA)
@@ -183,21 +115,14 @@ def setup(hass, config):
     return True
 
 
-class Script(ToggleEntity):
-    """Representation of a script."""
+class ScriptEntity(ToggleEntity):
+    """Representation of a script entity."""
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, object_id, name, sequence):
+    def __init__(self, hass, object_id, name, sequence):
         """Initialize the script."""
         self.entity_id = ENTITY_ID_FORMAT.format(object_id)
-        self._name = name
-        self.sequence = sequence
-        self._lock = threading.Lock()
-        self._cur = -1
-        self._last_action = None
-        self._listener = None
-        self._can_cancel = any(CONF_DELAY in action for action
-                               in self.sequence)
+        self.script = Script(hass, sequence, name, self.update_ha_state)
 
     @property
     def should_poll(self):
@@ -207,91 +132,27 @@ class Script(ToggleEntity):
     @property
     def name(self):
         """Return the name of the entity."""
-        return self._name
+        return self.script.name
 
     @property
     def state_attributes(self):
         """Return the state attributes."""
         attrs = {}
-        if self._can_cancel:
-            attrs[ATTR_CAN_CANCEL] = self._can_cancel
-        if self._last_action:
-            attrs[ATTR_LAST_ACTION] = self._last_action
+        if self.script.can_cancel:
+            attrs[ATTR_CAN_CANCEL] = self.script.can_cancel
+        if self.script.last_action:
+            attrs[ATTR_LAST_ACTION] = self.script.last_action
         return attrs
 
     @property
     def is_on(self):
         """Return true if script is on."""
-        return self._cur != -1
+        return self.script.is_running
 
     def turn_on(self, **kwargs):
         """Turn the entity on."""
-        _LOGGER.info("Executing script %s", self._name)
-        with self._lock:
-            if self._cur == -1:
-                self._cur = 0
-
-            # Unregister callback if we were in a delay but turn on is called
-            # again. In that case we just continue execution.
-            self._remove_listener()
-
-            for cur, action in islice(enumerate(self.sequence), self._cur,
-                                      None):
-
-                if validate_service_call(action) is None:
-                    self._call_service(action)
-
-                elif CONF_EVENT in action:
-                    self._fire_event(action)
-
-                elif CONF_DELAY in action:
-                    # Call ourselves in the future to continue work
-                    def script_delay(now):
-                        """Called after delay is done."""
-                        self._listener = None
-                        self.turn_on()
-
-                    timespec = action[CONF_DELAY] or action.copy()
-                    timespec.pop(CONF_DELAY, None)
-                    delay = timedelta(**timespec)
-                    self._listener = track_point_in_utc_time(
-                        self.hass, script_delay, date_util.utcnow() + delay)
-                    self._cur = cur + 1
-                    self.update_ha_state()
-                    return
-
-            self._cur = -1
-            self._last_action = None
-            self.update_ha_state()
+        self.script.run()
 
     def turn_off(self, **kwargs):
         """Turn script off."""
-        _LOGGER.info("Cancelled script %s", self._name)
-        with self._lock:
-            if self._cur == -1:
-                return
-
-            self._cur = -1
-            self.update_ha_state()
-            self._remove_listener()
-
-    def _call_service(self, action):
-        """Call the service specified in the action."""
-        self._last_action = action.get(CONF_ALIAS, 'call service')
-        _LOGGER.info("Executing script %s step %s", self._name,
-                     self._last_action)
-        call_from_config(self.hass, action, True)
-
-    def _fire_event(self, action):
-        """Fire an event."""
-        self._last_action = action.get(CONF_ALIAS, action[CONF_EVENT])
-        _LOGGER.info("Executing script %s step %s", self._name,
-                     self._last_action)
-        self.hass.bus.fire(action[CONF_EVENT], action.get(CONF_EVENT_DATA))
-
-    def _remove_listener(self):
-        """Remove point in time listener, if any."""
-        if self._listener:
-            self.hass.bus.remove_listener(EVENT_TIME_CHANGED,
-                                          self._listener)
-            self._listener = None
+        self.script.stop()

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -13,6 +13,7 @@ MATCH_ALL = '*'
 DEVICE_DEFAULT_NAME = "Unnamed Device"
 
 # #### CONFIG ####
+CONF_ALIAS = "alias"
 CONF_ICON = "icon"
 CONF_LATITUDE = "latitude"
 CONF_LONGITUDE = "longitude"

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -231,8 +231,8 @@ EVENT_SCHEMA = vol.Schema({
 
 SERVICE_SCHEMA = vol.All(vol.Schema({
     vol.Exclusive('service', 'service name'): service,
-    vol.Exclusive('service_template', 'service name'): string,
-    vol.Exclusive('data', 'service data'): dict,
-    vol.Exclusive('data_template', 'service data'): {match_all: template},
-    'entity_id': entity_ids,
+    vol.Exclusive('service_template', 'service name'): template,
+    vol.Optional('data'): dict,
+    vol.Optional('data_template'): {match_all: template},
+    vol.Optional('entity_id'): entity_ids,
 }), has_at_least_one_key('service', 'service_template'))

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -6,7 +6,8 @@ import voluptuous as vol
 
 from homeassistant.loader import get_platform
 from homeassistant.const import (
-    CONF_PLATFORM, CONF_SCAN_INTERVAL, TEMP_CELSIUS, TEMP_FAHRENHEIT)
+    CONF_PLATFORM, CONF_SCAN_INTERVAL, TEMP_CELSIUS, TEMP_FAHRENHEIT,
+    CONF_ALIAS)
 from homeassistant.helpers.entity import valid_entity_id
 import homeassistant.util.dt as dt_util
 from homeassistant.util import slugify
@@ -21,6 +22,23 @@ latitude = vol.All(vol.Coerce(float), vol.Range(min=-90, max=90),
                    msg='invalid latitude')
 longitude = vol.All(vol.Coerce(float), vol.Range(min=-180, max=180),
                     msg='invalid longitude')
+
+
+# Adapted from:
+# https://github.com/alecthomas/voluptuous/issues/115#issuecomment-144464666
+def has_at_least_one_key(*keys):
+    """Validator that at least one key exists."""
+    def validate(obj):
+        """Test keys exist in dict."""
+        if not isinstance(obj, dict):
+            raise vol.Invalid('expected dictionary')
+
+        for k in obj.keys():
+            if k in keys:
+                return obj
+        raise vol.Invalid('must contain one of {}.'.format(', '.join(keys)))
+
+    return validate
 
 
 def boolean(value):
@@ -72,10 +90,24 @@ def icon(value):
     raise vol.Invalid('Icons should start with prefix "mdi:"')
 
 
-def time_offset(value):
+time_period_dict = vol.All(
+    dict, vol.Schema({
+        'days': vol.Coerce(int),
+        'hours': vol.Coerce(int),
+        'minutes': vol.Coerce(int),
+        'seconds': vol.Coerce(int),
+        'milliseconds': vol.Coerce(int),
+    }),
+    has_at_least_one_key('days', 'hours', 'minutes',
+                         'seconds', 'milliseconds'),
+    lambda value: timedelta(**value))
+
+
+def time_period_str(value):
     """Validate and transform time offset."""
     if not isinstance(value, str):
-        raise vol.Invalid('offset should be a string')
+        raise vol.Invalid(
+            'offset {} should be format HH:MM or HH:MM:SS'.format(value))
 
     negative_offset = False
     if value.startswith('-'):
@@ -107,6 +139,9 @@ def time_offset(value):
     return offset
 
 
+time_period = vol.Any(time_period_str, timedelta, time_period_dict)
+
+
 def match_all(value):
     """Validator that matches all values."""
     return value
@@ -123,6 +158,13 @@ def platform_validator(domain):
         raise vol.Invalid(
             'platform {} does not exist for {}'.format(value, domain))
     return validator
+
+
+def positive_timedelta(value):
+    """Validate timedelta is positive."""
+    if value < timedelta(0):
+        raise vol.Invalid('Time period should be positive')
+    return value
 
 
 def service(value):
@@ -200,23 +242,6 @@ def key_dependency(key, dependency):
     return validator
 
 
-# Adapted from:
-# https://github.com/alecthomas/voluptuous/issues/115#issuecomment-144464666
-def has_at_least_one_key(*keys):
-    """Validator that at least one key exists."""
-    def validate(obj):
-        """Test keys exist in dict."""
-        if not isinstance(obj, dict):
-            raise vol.Invalid('expected dictionary')
-
-        for k in obj.keys():
-            if k in keys:
-                return obj
-        raise vol.Invalid('must contain one of {}.'.format(', '.join(keys)))
-
-    return validate
-
-
 # Schemas
 
 PLATFORM_SCHEMA = vol.Schema({
@@ -225,14 +250,28 @@ PLATFORM_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 EVENT_SCHEMA = vol.Schema({
+    vol.Optional(CONF_ALIAS): string,
     vol.Required('event'): string,
-    'event_data': dict
+    vol.Optional('event_data'): dict,
 })
 
 SERVICE_SCHEMA = vol.All(vol.Schema({
+    vol.Optional(CONF_ALIAS): string,
     vol.Exclusive('service', 'service name'): service,
     vol.Exclusive('service_template', 'service name'): template,
     vol.Optional('data'): dict,
     vol.Optional('data_template'): {match_all: template},
     vol.Optional('entity_id'): entity_ids,
 }), has_at_least_one_key('service', 'service_template'))
+
+# ----- SCRIPT
+
+_DELAY_SCHEMA = vol.Schema({
+    vol.Optional(CONF_ALIAS): string,
+    vol.Required("delay"): vol.All(time_period, positive_timedelta)
+})
+
+SCRIPT_SCHEMA = vol.All(
+    ensure_list,
+    [vol.Any(SERVICE_SCHEMA, _DELAY_SCHEMA, EVENT_SCHEMA)],
+)

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -264,14 +264,12 @@ SERVICE_SCHEMA = vol.All(vol.Schema({
     vol.Optional('entity_id'): entity_ids,
 }), has_at_least_one_key('service', 'service_template'))
 
-# ----- SCRIPT
-
-_DELAY_SCHEMA = vol.Schema({
+_SCRIPT_DELAY_SCHEMA = vol.Schema({
     vol.Optional(CONF_ALIAS): string,
     vol.Required("delay"): vol.All(time_period, positive_timedelta)
 })
 
 SCRIPT_SCHEMA = vol.All(
     ensure_list,
-    [vol.Any(SERVICE_SCHEMA, _DELAY_SCHEMA, EVENT_SCHEMA)],
+    [vol.Any(SERVICE_SCHEMA, _SCRIPT_DELAY_SCHEMA, EVENT_SCHEMA)],
 )

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -21,7 +21,9 @@ def track_state_change(hass, entity_ids, action, from_state=None,
     to_state = _process_match_param(to_state)
 
     # Ensure it is a lowercase list with entity ids we want to match on
-    if isinstance(entity_ids, str):
+    if entity_ids == MATCH_ALL:
+        pass
+    elif isinstance(entity_ids, str):
         entity_ids = (entity_ids.lower(),)
     else:
         entity_ids = tuple(entity_id.lower() for entity_id in entity_ids)
@@ -29,7 +31,8 @@ def track_state_change(hass, entity_ids, action, from_state=None,
     @ft.wraps(action)
     def state_change_listener(event):
         """The listener that listens for specific state changes."""
-        if event.data['entity_id'] not in entity_ids:
+        if entity_ids != MATCH_ALL and \
+           event.data['entity_id'] not in entity_ids:
             return
 
         if event.data['old_state'] is None:

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1,0 +1,125 @@
+"""Helpers to execute scripts."""
+import logging
+import threading
+from itertools import islice
+
+import homeassistant.util.dt as date_util
+from homeassistant.const import EVENT_TIME_CHANGED
+from homeassistant.helpers.event import track_point_in_utc_time
+from homeassistant.helpers import service
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ALIAS = "alias"
+CONF_SERVICE = "service"
+CONF_SERVICE_DATA = "data"
+CONF_SEQUENCE = "sequence"
+CONF_EVENT = "event"
+CONF_EVENT_DATA = "event_data"
+CONF_DELAY = "delay"
+
+
+def call_from_config(hass, config):
+    """Call a script based on a config entry."""
+    Script(hass, config).run()
+
+
+class Script():
+    """Representation of a script."""
+
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self, hass, sequence, name=None, change_listener=None):
+        """Initialize the script."""
+        self.hass = hass
+        self.sequence = cv.SCRIPT_SCHEMA(sequence)
+        self.name = name
+        self._change_listener = change_listener
+        self._cur = -1
+        self.last_action = None
+        self.can_cancel = any(CONF_DELAY in action for action
+                              in self.sequence)
+        self._lock = threading.Lock()
+        self._delay_listener = None
+
+    @property
+    def is_running(self):
+        """Return true if script is on."""
+        return self._cur != -1
+
+    def run(self):
+        """Run script."""
+        with self._lock:
+            if self._cur == -1:
+                self._log('Running script')
+                self._cur = 0
+
+            # Unregister callback if we were in a delay but turn on is called
+            # again. In that case we just continue execution.
+            self._remove_listener()
+
+            for cur, action in islice(enumerate(self.sequence), self._cur,
+                                      None):
+
+                if CONF_DELAY in action:
+                    # Call ourselves in the future to continue work
+                    def script_delay(now):
+                        """Called after delay is done."""
+                        self._delay_listener = None
+                        self.run()
+
+                    self._delay_listener = track_point_in_utc_time(
+                        self.hass, script_delay,
+                        date_util.utcnow() + action[CONF_DELAY])
+                    self._cur = cur + 1
+                    if self._change_listener:
+                        self._change_listener()
+                    return
+
+                elif service.validate_service_call(action) is None:
+                    self._call_service(action)
+
+                elif CONF_EVENT in action:
+                    self._fire_event(action)
+
+            self._cur = -1
+            self.last_action = None
+            if self._change_listener:
+                self._change_listener()
+
+    def stop(self):
+        """Stop running script."""
+        with self._lock:
+            if self._cur == -1:
+                return
+
+            self._cur = -1
+            self._remove_listener()
+            if self._change_listener:
+                self._change_listener()
+
+    def _call_service(self, action):
+        """Call the service specified in the action."""
+        self.last_action = action.get(CONF_ALIAS, 'call service')
+        self._log("Executing step %s", self.last_action)
+        service.call_from_config(self.hass, action, True)
+
+    def _fire_event(self, action):
+        """Fire an event."""
+        self.last_action = action.get(CONF_ALIAS, action[CONF_EVENT])
+        self._log("Executing step %s", self.last_action)
+        self.hass.bus.fire(action[CONF_EVENT], action.get(CONF_EVENT_DATA))
+
+    def _remove_listener(self):
+        """Remove point in time listener, if any."""
+        if self._delay_listener:
+            self.hass.bus.remove_listener(EVENT_TIME_CHANGED,
+                                          self._delay_listener)
+            self._delay_listener = None
+
+    def _log(self, msg, *substitutes):
+        """Logger helper."""
+        if self.name is not None:
+            msg = "Script {}: {}".format(self.name, msg, *substitutes)
+
+        _LOGGER.info(msg)

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -20,9 +20,9 @@ CONF_EVENT_DATA = "event_data"
 CONF_DELAY = "delay"
 
 
-def call_from_config(hass, config):
+def call_from_config(hass, config, variables=None):
     """Call a script based on a config entry."""
-    Script(hass, config).run()
+    Script(hass, config).run(variables)
 
 
 class Script():

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -76,11 +76,11 @@ class Script():
                         self._change_listener()
                     return
 
-                elif service.validate_service_call(action) is None:
-                    self._call_service(action, variables)
-
                 elif CONF_EVENT in action:
                     self._fire_event(action)
+
+                else:
+                    self._call_service(action, variables)
 
             self._cur = -1
             self.last_action = None
@@ -102,7 +102,8 @@ class Script():
         """Call the service specified in the action."""
         self.last_action = action.get(CONF_ALIAS, 'call service')
         self._log("Executing step %s", self.last_action)
-        service.call_from_config(self.hass, action, True, variables)
+        service.call_from_config(self.hass, action, True, variables,
+                                 validate_config=False)
 
     def _fire_event(self, action):
         """Fire an event."""

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -47,7 +47,7 @@ class Script():
         """Return true if script is on."""
         return self._cur != -1
 
-    def run(self):
+    def run(self, variables=None):
         """Run script."""
         with self._lock:
             if self._cur == -1:
@@ -66,7 +66,7 @@ class Script():
                     def script_delay(now):
                         """Called after delay is done."""
                         self._delay_listener = None
-                        self.run()
+                        self.run(variables)
 
                     self._delay_listener = track_point_in_utc_time(
                         self.hass, script_delay,
@@ -77,7 +77,7 @@ class Script():
                     return
 
                 elif service.validate_service_call(action) is None:
-                    self._call_service(action)
+                    self._call_service(action, variables)
 
                 elif CONF_EVENT in action:
                     self._fire_event(action)
@@ -98,11 +98,11 @@ class Script():
             if self._change_listener:
                 self._change_listener()
 
-    def _call_service(self, action):
+    def _call_service(self, action, variables):
         """Call the service specified in the action."""
         self.last_action = action.get(CONF_ALIAS, 'call service')
         self._log("Executing step %s", self.last_action)
-        service.call_from_config(self.hass, action, True)
+        service.call_from_config(self.hass, action, True, variables)
 
     def _fire_event(self, action):
         """Fire an event."""

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -32,13 +32,15 @@ def service(domain, service_name):
     return register_service_decorator
 
 
-def call_from_config(hass, config, blocking=False, variables=None):
+def call_from_config(hass, config, blocking=False, variables=None,
+                     validate_config=True):
     """Call a service based on a config hash."""
-    try:
-        config = cv.SERVICE_SCHEMA(config)
-    except vol.Invalid as ex:
-        _LOGGER.error("Invalid config for calling service: %s", ex)
-        return
+    if validate_config:
+        try:
+            config = cv.SERVICE_SCHEMA(config)
+        except vol.Invalid as ex:
+            _LOGGER.error("Invalid config for calling service: %s", ex)
+            return
 
     if CONF_SERVICE in config:
         domain_service = config[CONF_SERVICE]
@@ -85,16 +87,3 @@ def extract_entity_ids(hass, service_call):
         return group.expand_entity_ids(hass, [service_ent_id])
 
     return [ent_id for ent_id in group.expand_entity_ids(hass, service_ent_id)]
-
-
-def validate_service_call(config):
-    """Validate service call configuration.
-
-    Helper method to validate that a configuration is a valid service call.
-    Returns None if validation succeeds, else an error description
-    """
-    try:
-        cv.SERVICE_SCHEMA(config)
-        return None
-    except vol.Invalid as ex:
-        return str(ex)

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -2,9 +2,13 @@
 import functools
 import logging
 
+import voluptuous as vol
+
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template
 from homeassistant.loader import get_component
+import homeassistant.helpers.config_validation as cv
 
 HASS = None
 
@@ -28,47 +32,38 @@ def service(domain, service_name):
     return register_service_decorator
 
 
-def call_from_config(hass, config, blocking=False):
+def call_from_config(hass, config, blocking=False, variables=None):
     """Call a service based on a config hash."""
-    validation_error = validate_service_call(config)
-    if validation_error:
-        _LOGGER.error(validation_error)
-        return
-
-    domain_service = (
-        config[CONF_SERVICE]
-        if CONF_SERVICE in config
-        else template.render(hass, config[CONF_SERVICE_TEMPLATE]))
-
     try:
-        domain, service_name = domain_service.split('.', 1)
-    except ValueError:
-        _LOGGER.error('Invalid service specified: %s', domain_service)
+        config = cv.SERVICE_SCHEMA(config)
+    except vol.Invalid as ex:
+        _LOGGER.error("Invalid config for calling service: %s", ex)
         return
 
-    service_data = config.get(CONF_SERVICE_DATA)
-
-    if service_data is None:
-        service_data = {}
-    elif isinstance(service_data, dict):
-        service_data = dict(service_data)
+    if CONF_SERVICE in config:
+        domain_service = config[CONF_SERVICE]
     else:
-        _LOGGER.error("%s should be a dictionary", CONF_SERVICE_DATA)
-        service_data = {}
+        try:
+            domain_service = template.render(
+                hass, config[CONF_SERVICE_TEMPLATE], variables)
+            domain_service = cv.service(domain_service)
+        except TemplateError as ex:
+            _LOGGER.error('Error rendering service name template: %s', ex)
+            return
+        except vol.Invalid as ex:
+            _LOGGER.error('Template rendered invalid service: %s',
+                          domain_service)
+            return
 
-    service_data_template = config.get(CONF_SERVICE_DATA_TEMPLATE)
-    if service_data_template and isinstance(service_data_template, dict):
-        for key, value in service_data_template.items():
-            service_data[key] = template.render(hass, value)
-    elif service_data_template:
-        _LOGGER.error("%s should be a dictionary", CONF_SERVICE_DATA)
+    domain, service_name = domain_service.split('.', 1)
+    service_data = dict(config.get(CONF_SERVICE_DATA, {}))
 
-    entity_id = config.get(CONF_SERVICE_ENTITY_ID)
-    if isinstance(entity_id, str):
-        service_data[ATTR_ENTITY_ID] = [ent.strip() for ent in
-                                        entity_id.split(",")]
-    elif entity_id is not None:
-        service_data[ATTR_ENTITY_ID] = entity_id
+    if CONF_SERVICE_DATA_TEMPLATE in config:
+        for key, value in config[CONF_SERVICE_DATA_TEMPLATE].items():
+            service_data[key] = template.render(hass, value, variables)
+
+    if CONF_SERVICE_ENTITY_ID in config:
+        service_data[ATTR_ENTITY_ID] = config[CONF_SERVICE_ENTITY_ID]
 
     hass.services.call(domain, service_name, service_data, blocking)
 
@@ -98,11 +93,8 @@ def validate_service_call(config):
     Helper method to validate that a configuration is a valid service call.
     Returns None if validation succeeds, else an error description
     """
-    if not isinstance(config, dict):
-        return 'Invalid configuration {}'.format(config)
-    if CONF_SERVICE not in config and CONF_SERVICE_TEMPLATE not in config:
-        return 'Missing key {} or {}: {}'.format(
-            CONF_SERVICE,
-            CONF_SERVICE_TEMPLATE,
-            config)
-    return None
+    try:
+        cv.SERVICE_SCHEMA(config)
+        return None
+    except vol.Invalid as ex:
+        return str(ex)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -316,3 +316,29 @@ class TestAutomation(unittest.TestCase):
         self.hass.bus.fire('test_event_2')
         self.hass.pool.block_till_done()
         self.assertEqual(2, len(self.calls))
+
+    def test_automation_calling_two_actions(self):
+        """Test if we can call two actions from automation definition."""
+        self.assertTrue(_setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'event',
+                    'event_type': 'test_event',
+                },
+
+                'action': [{
+                    'service': 'test.automation',
+                    'data': {'position': 0},
+                }, {
+                    'service': 'test.automation',
+                    'data': {'position': 1},
+                }],
+            }
+        }))
+
+        self.hass.bus.fire('test_event')
+        self.hass.pool.block_till_done()
+
+        assert len(self.calls) == 2
+        assert self.calls[0].data['position'] == 0
+        assert self.calls[1].data['position'] == 1

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -51,7 +51,10 @@ class TestAutomation(unittest.TestCase):
                 },
                 'action': {
                     'service': 'test.automation',
-                    'data': {'some': 'data'}
+                    'data_template': {
+                        'some': '{{ trigger.platform }} - '
+                                '{{ trigger.event.event_type }}'
+                    },
                 }
             }
         })
@@ -59,7 +62,7 @@ class TestAutomation(unittest.TestCase):
         self.hass.bus.fire('test_event')
         self.hass.pool.block_till_done()
         self.assertEqual(1, len(self.calls))
-        self.assertEqual('data', self.calls[0].data['some'])
+        self.assertEqual('event - test_event', self.calls[0].data['some'])
 
     def test_service_specify_entity_id(self):
         """Test service data."""

--- a/tests/components/automation/test_mqtt.py
+++ b/tests/components/automation/test_mqtt.py
@@ -35,14 +35,20 @@ class TestAutomationMQTT(unittest.TestCase):
                     'topic': 'test-topic'
                 },
                 'action': {
-                    'service': 'test.automation'
+                    'service': 'test.automation',
+                    'data_template': {
+                        'some': '{{ trigger.platform }} - {{ trigger.topic }}'
+                                ' - {{ trigger.payload }}'
+                    },
                 }
             }
         })
 
-        fire_mqtt_message(self.hass, 'test-topic', '')
+        fire_mqtt_message(self.hass, 'test-topic', 'test_payload')
         self.hass.pool.block_till_done()
         self.assertEqual(1, len(self.calls))
+        self.assertEqual('mqtt - test-topic - test_payload',
+                         self.calls[0].data['some'])
 
     def test_if_fires_on_topic_and_payload_match(self):
         """Test if message is fired on topic and payload match."""

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -437,15 +437,28 @@ class TestAutomationNumericState(unittest.TestCase):
                     'below': 10,
                 },
                 'action': {
-                    'service': 'test.automation'
+                    'service': 'test.automation',
+                    'data_template': {
+                        'some': '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
+                                    'platform', 'entity_id', 'below', 'above',
+                                    'from_state.state', 'from_value',
+                                    'to_state.state', 'to_value'))
+                    },
                 }
             }
         })
         # 9 is below 10
-        self.hass.states.set('test.entity', 'entity',
+        self.hass.states.set('test.entity', 'test state 1',
+                             {'test_attribute': '1.2'})
+        self.hass.pool.block_till_done()
+        self.hass.states.set('test.entity', 'test state 2',
                              {'test_attribute': '0.9'})
         self.hass.pool.block_till_done()
         self.assertEqual(1, len(self.calls))
+        self.assertEqual(
+            'numeric_state - test.entity - 10 - None - test state 1 - 12.0 - '
+            'test state 2 - 9.0',
+            self.calls[0].data['some'])
 
     def test_not_fires_on_attr_change_with_attr_not_below_multiple_attr(self):
         """"Test if not fired changed attributes."""

--- a/tests/components/automation/test_sun.py
+++ b/tests/components/automation/test_sun.py
@@ -105,6 +105,11 @@ class TestAutomationSun(unittest.TestCase):
                     },
                     'action': {
                         'service': 'test.automation',
+                        'data_template': {
+                            'some':
+                            '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
+                                'platform', 'event', 'offset'))
+                        },
                     }
                 }
             })
@@ -112,6 +117,7 @@ class TestAutomationSun(unittest.TestCase):
         fire_time_changed(self.hass, trigger_time)
         self.hass.pool.block_till_done()
         self.assertEqual(1, len(self.calls))
+        self.assertEqual('sun - sunset - 0:30:00', self.calls[0].data['some'])
 
     def test_sunrise_trigger_with_offset(self):
         """Test the runrise trigger with offset."""

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -1,4 +1,4 @@
-"""The tests fr the Template automation."""
+"""The tests for the Template automation."""
 import unittest
 
 from homeassistant.bootstrap import _setup_component
@@ -226,7 +226,13 @@ class TestAutomationTemplate(unittest.TestCase):
                                          {%- endif -%}''',
                 },
                 'action': {
-                    'service': 'test.automation'
+                    'service': 'test.automation',
+                    'data_template': {
+                        'some':
+                        '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
+                            'platform', 'entity_id', 'from_state.state',
+                            'to_state.state'))
+                    },
                 }
             }
         })
@@ -234,6 +240,9 @@ class TestAutomationTemplate(unittest.TestCase):
         self.hass.states.set('test.entity', 'world')
         self.hass.pool.block_till_done()
         self.assertEqual(1, len(self.calls))
+        self.assertEqual(
+            'template - test.entity - hello - world',
+            self.calls[0].data['some'])
 
     def test_if_fires_on_no_change_with_template_advanced(self):
         """Test for firing on no change with template advanced."""

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -176,7 +176,11 @@ class TestAutomationTime(unittest.TestCase):
                     'after': '5:00:00',
                 },
                 'action': {
-                    'service': 'test.automation'
+                    'service': 'test.automation',
+                    'data_template': {
+                        'some': '{{ trigger.platform }} - '
+                                '{{ trigger.now.hour }}'
+                    },
                 }
             }
         })
@@ -186,6 +190,7 @@ class TestAutomationTime(unittest.TestCase):
 
         self.hass.pool.block_till_done()
         self.assertEqual(1, len(self.calls))
+        self.assertEqual('time - 5', self.calls[0].data['some'])
 
     def test_if_not_working_if_no_values_in_conf_provided(self):
         """Test for failure if no configuration."""

--- a/tests/components/automation/test_zone.py
+++ b/tests/components/automation/test_zone.py
@@ -52,6 +52,13 @@ class TestAutomationZone(unittest.TestCase):
                 },
                 'action': {
                     'service': 'test.automation',
+                    'data_template': {
+                        'some': '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
+                                    'platform', 'entity_id',
+                                    'from_state.state', 'to_state.state',
+                                    'zone.name'))
+                    },
+
                 }
             }
         })
@@ -63,6 +70,9 @@ class TestAutomationZone(unittest.TestCase):
         self.hass.pool.block_till_done()
 
         self.assertEqual(1, len(self.calls))
+        self.assertEqual(
+            'zone - test.entity - hello - hello - test',
+            self.calls[0].data['some'])
 
     def test_if_not_fires_for_enter_on_zone_leave(self):
         """Test for not firing on zone leave."""

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -71,8 +71,8 @@ def setUpModule():   # pylint: disable=invalid-name
                     },
                     'action': {
                         'service': 'test.alexa',
-                        'data': {
-                            'hello': 1
+                        'data_template': {
+                            'hello': '{{ ZodiacSign }}'
                         },
                         'entity_id': 'switch.test',
                     }
@@ -278,6 +278,12 @@ class TestAlexa(unittest.TestCase):
                 'timestamp': '2015-05-13T12:34:56Z',
                 'intent': {
                     'name': 'CallServiceIntent',
+                    'slots': {
+                        'ZodiacSign': {
+                            'name': 'ZodiacSign',
+                            'value': 'virgo',
+                        }
+                    }
                 }
             }
         }
@@ -289,7 +295,7 @@ class TestAlexa(unittest.TestCase):
         self.assertEqual('test', call.domain)
         self.assertEqual('alexa', call.service)
         self.assertEqual(['switch.test'], call.data.get('entity_id'))
-        self.assertEqual(1, call.data.get('hello'))
+        self.assertEqual('virgo', call.data.get('hello'))
 
     def test_session_ended_request(self):
         """Test the request for ending the session."""

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -1,19 +1,17 @@
 """The tests for the Script component."""
 # pylint: disable=too-many-public-methods,protected-access
-from datetime import timedelta
 import unittest
 
 from homeassistant.bootstrap import _setup_component
 from homeassistant.components import script
-import homeassistant.util.dt as dt_util
 
-from tests.common import fire_time_changed, get_test_home_assistant
+from tests.common import get_test_home_assistant
 
 
 ENTITY_ID = 'script.test'
 
 
-class TestScript(unittest.TestCase):
+class TestScriptComponent(unittest.TestCase):
     """Test the Script component."""
 
     def setUp(self):  # pylint: disable=invalid-name
@@ -48,199 +46,6 @@ class TestScript(unittest.TestCase):
             }), 'Script loaded with wrong config {}'.format(value)
 
             self.assertEqual(0, len(self.hass.states.entity_ids('script')))
-
-    def test_firing_event(self):
-        """Test the firing of events."""
-        event = 'test_event'
-        calls = []
-
-        def record_event(event):
-            """Add recorded event to set."""
-            calls.append(event)
-
-        self.hass.bus.listen(event, record_event)
-
-        assert _setup_component(self.hass, 'script', {
-            'script': {
-                'test': {
-                    'alias': 'Test Script',
-                    'sequence': [{
-                        'event': event,
-                        'event_data': {
-                            'hello': 'world'
-                        }
-                    }]
-                }
-            }
-        })
-
-        script.turn_on(self.hass, ENTITY_ID)
-        self.hass.pool.block_till_done()
-
-        self.assertEqual(1, len(calls))
-        self.assertEqual('world', calls[0].data.get('hello'))
-        self.assertIsNone(
-            self.hass.states.get(ENTITY_ID).attributes.get('can_cancel'))
-
-    def test_calling_service(self):
-        """Test the calling of a service."""
-        calls = []
-
-        def record_call(service):
-            """Add recorded event to set."""
-            calls.append(service)
-
-        self.hass.services.register('test', 'script', record_call)
-
-        assert _setup_component(self.hass, 'script', {
-            'script': {
-                'test': {
-                    'sequence': [{
-                        'service': 'test.script',
-                        'data': {
-                            'hello': 'world'
-                        }
-                    }]
-                }
-            }
-        })
-
-        script.turn_on(self.hass, ENTITY_ID)
-        self.hass.pool.block_till_done()
-
-        self.assertEqual(1, len(calls))
-        self.assertEqual('world', calls[0].data.get('hello'))
-
-    def test_calling_service_template(self):
-        """Test the calling of a service."""
-        calls = []
-
-        def record_call(service):
-            """Add recorded event to set."""
-            calls.append(service)
-
-        self.hass.services.register('test', 'script', record_call)
-
-        assert _setup_component(self.hass, 'script', {
-            'script': {
-                'test': {
-                    'sequence': [{
-                        'service_template': """
-                            {% if True %}
-                                test.script
-                            {% else %}
-                                test.not_script
-                            {% endif %}""",
-                        'data_template': {
-                            'hello': """
-                                {% if True %}
-                                    world
-                                {% else %}
-                                    Not world
-                                {% endif %}
-                            """
-                        }
-                    }]
-                }
-            }
-        })
-
-        script.turn_on(self.hass, ENTITY_ID)
-        self.hass.pool.block_till_done()
-
-        self.assertEqual(1, len(calls))
-        self.assertEqual('world', calls[0].data.get('hello'))
-
-    def test_delay(self):
-        """Test the delay."""
-        event = 'test_event'
-        calls = []
-
-        def record_event(event):
-            """Add recorded event to set."""
-            calls.append(event)
-
-        self.hass.bus.listen(event, record_event)
-
-        assert _setup_component(self.hass, 'script', {
-            'script': {
-                'test': {
-                    'sequence': [{
-                        'event': event
-                    }, {
-                        'delay': {
-                            'seconds': 5
-                        }
-                    }, {
-                        'event': event,
-                    }]
-                }
-            }
-        })
-
-        script.turn_on(self.hass, ENTITY_ID)
-        self.hass.pool.block_till_done()
-
-        self.assertTrue(script.is_on(self.hass, ENTITY_ID))
-        self.assertTrue(
-            self.hass.states.get(ENTITY_ID).attributes.get('can_cancel'))
-
-        self.assertEqual(
-            event,
-            self.hass.states.get(ENTITY_ID).attributes.get('last_action'))
-        self.assertEqual(1, len(calls))
-
-        future = dt_util.utcnow() + timedelta(seconds=5)
-        fire_time_changed(self.hass, future)
-        self.hass.pool.block_till_done()
-
-        self.assertFalse(script.is_on(self.hass, ENTITY_ID))
-
-        self.assertEqual(2, len(calls))
-
-    def test_cancel_while_delay(self):
-        """Test the cancelling while the delay is present."""
-        event = 'test_event'
-        calls = []
-
-        def record_event(event):
-            """Add recorded event to set."""
-            calls.append(event)
-
-        self.hass.bus.listen(event, record_event)
-
-        assert _setup_component(self.hass, 'script', {
-            'script': {
-                'test': {
-                    'sequence': [{
-                        'delay': {
-                            'seconds': 5
-                        }
-                    }, {
-                        'event': event,
-                    }]
-                }
-            }
-        })
-
-        script.turn_on(self.hass, ENTITY_ID)
-        self.hass.pool.block_till_done()
-
-        self.assertTrue(script.is_on(self.hass, ENTITY_ID))
-
-        self.assertEqual(0, len(calls))
-
-        script.turn_off(self.hass, ENTITY_ID)
-        self.hass.pool.block_till_done()
-        self.assertFalse(script.is_on(self.hass, ENTITY_ID))
-
-        future = dt_util.utcnow() + timedelta(seconds=5)
-        fire_time_changed(self.hass, future)
-        self.hass.pool.block_till_done()
-
-        self.assertFalse(script.is_on(self.hass, ENTITY_ID))
-
-        self.assertEqual(0, len(calls))
 
     def test_turn_on_service(self):
         """Verify that the turn_on service."""

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -37,19 +37,11 @@ class TestScript(unittest.TestCase):
             {
                 'test': {
                     'sequence': {
-                        'event': 'test_event'
-                    }
-                }
-            },
-            {
-                'test': {
-                    'sequence': {
                         'event': 'test_event',
                         'service': 'homeassistant.turn_on',
                     }
                 }
             },
-
         ):
             assert not _setup_component(self.hass, 'script', {
                 'script': value
@@ -204,45 +196,6 @@ class TestScript(unittest.TestCase):
 
         self.assertFalse(script.is_on(self.hass, ENTITY_ID))
 
-        self.assertEqual(2, len(calls))
-
-    def test_alt_delay(self):
-        """Test alternative delay config format."""
-        event = 'test_event'
-        calls = []
-
-        def record_event(event):
-            """Add recorded event to set."""
-            calls.append(event)
-
-        self.hass.bus.listen(event, record_event)
-
-        assert _setup_component(self.hass, 'script', {
-            'script': {
-                'test': {
-                    'sequence': [{
-                        'event': event,
-                    }, {
-                        'delay': None,
-                        'seconds': 5
-                    }, {
-                        'event': event,
-                    }]
-                }
-            }
-        })
-
-        script.turn_on(self.hass, ENTITY_ID)
-        self.hass.pool.block_till_done()
-
-        self.assertTrue(script.is_on(self.hass, ENTITY_ID))
-        self.assertEqual(1, len(calls))
-
-        future = dt_util.utcnow() + timedelta(seconds=5)
-        fire_time_changed(self.hass, future)
-        self.hass.pool.block_till_done()
-
-        self.assertFalse(script.is_on(self.hass, ENTITY_ID))
         self.assertEqual(2, len(calls))
 
     def test_cancel_while_delay(self):

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -145,18 +145,19 @@ def test_icon():
     schema('mdi:work')
 
 
-def test_time_offset():
-    """Test time_offset validation."""
-    schema = vol.Schema(cv.time_offset)
+def test_time_period():
+    """Test time_period validation."""
+    schema = vol.Schema(cv.time_period)
 
     for value in (
-        None, '', 1234, 'hello:world', '12:', '12:34:56:78'
+        None, '', 1234, 'hello:world', '12:', '12:34:56:78',
+        {}, {'wrong_key': -10}
     ):
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
 
     for value in (
-        '8:20', '23:59', '-8:20', '-23:59:59', '-48:00'
+        '8:20', '23:59', '-8:20', '-23:59:59', '-48:00', {'minutes': 5}
     ):
         schema(value)
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -3,7 +3,6 @@
 from datetime import timedelta
 import unittest
 
-from homeassistant.bootstrap import _setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.helpers import script
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1,0 +1,175 @@
+"""The tests for the Script component."""
+# pylint: disable=too-many-public-methods,protected-access
+from datetime import timedelta
+import unittest
+
+from homeassistant.bootstrap import _setup_component
+import homeassistant.util.dt as dt_util
+from homeassistant.helpers import script
+
+from tests.common import fire_time_changed, get_test_home_assistant
+
+
+ENTITY_ID = 'script.test'
+
+
+class TestScriptHelper(unittest.TestCase):
+    """Test the Script component."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_firing_event(self):
+        """Test the firing of events."""
+        event = 'test_event'
+        calls = []
+
+        def record_event(event):
+            """Add recorded event to set."""
+            calls.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        script_obj = script.Script(self.hass, {
+            'event': event,
+            'event_data': {
+                'hello': 'world'
+            }
+        })
+
+        script_obj.run()
+
+        self.hass.pool.block_till_done()
+
+        assert len(calls) == 1
+        assert calls[0].data.get('hello') == 'world'
+        assert not script_obj.can_cancel
+
+    def test_calling_service(self):
+        """Test the calling of a service."""
+        calls = []
+
+        def record_call(service):
+            """Add recorded event to set."""
+            calls.append(service)
+
+        self.hass.services.register('test', 'script', record_call)
+
+        script_obj = script.Script(self.hass, {
+            'service': 'test.script',
+            'data': {
+                'hello': 'world'
+            }
+        })
+
+        script_obj.run()
+        self.hass.pool.block_till_done()
+
+        assert len(calls) == 1
+        assert calls[0].data.get('hello') == 'world'
+
+    def test_calling_service_template(self):
+        """Test the calling of a service."""
+        calls = []
+
+        def record_call(service):
+            """Add recorded event to set."""
+            calls.append(service)
+
+        self.hass.services.register('test', 'script', record_call)
+
+        script_obj = script.Script(self.hass, {
+            'service_template': """
+                {% if True %}
+                    test.script
+                {% else %}
+                    test.not_script
+                {% endif %}""",
+            'data_template': {
+                'hello': """
+                    {% if True %}
+                        world
+                    {% else %}
+                        Not world
+                    {% endif %}
+                """
+            }
+        })
+
+        script_obj.run()
+
+        self.hass.pool.block_till_done()
+
+        assert len(calls) == 1
+        assert calls[0].data.get('hello') == 'world'
+
+    def test_delay(self):
+        """Test the delay."""
+        event = 'test_event'
+        events = []
+
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        script_obj = script.Script(self.hass, [
+            {'event': event},
+            {'delay': {'seconds': 5}},
+            {'event': event}])
+
+        script_obj.run()
+
+        self.hass.pool.block_till_done()
+
+        assert script_obj.is_running
+        assert script_obj.can_cancel
+        assert script_obj.last_action == event
+        assert len(events) == 1
+
+        future = dt_util.utcnow() + timedelta(seconds=5)
+        fire_time_changed(self.hass, future)
+        self.hass.pool.block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 2
+
+    def test_cancel_while_delay(self):
+        """Test the cancelling while the delay is present."""
+        event = 'test_event'
+        events = []
+
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        script_obj = script.Script(self.hass, [
+            {'delay': {'seconds': 5}},
+            {'event': event}])
+
+        script_obj.run()
+
+        self.hass.pool.block_till_done()
+
+        assert script_obj.is_running
+        assert len(events) == 0
+
+        script_obj.stop()
+
+        assert not script_obj.is_running
+
+        # Make sure the script is really stopped.
+        future = dt_util.utcnow() + timedelta(seconds=5)
+        fire_time_changed(self.hass, future)
+        self.hass.pool.block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 0

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -37,7 +37,7 @@ class TestServiceHelpers(unittest.TestCase):
         self.assertEqual(1, len(runs))
 
     def test_template_service_call(self):
-        """ Test service call with tempating. """
+        """Test service call with tempating."""
         config = {
             'service_template': '{{ \'test_domain.test_service\' }}',
             'entity_id': 'hello.world',
@@ -56,6 +56,7 @@ class TestServiceHelpers(unittest.TestCase):
         self.assertEqual('goodbye', runs[0].data['hello'])
 
     def test_passing_variables_to_templates(self):
+        """Test passing variables to templates."""
         config = {
             'service_template': '{{ var_service }}',
             'entity_id': 'hello.world',
@@ -141,7 +142,7 @@ class TestServiceHelpers(unittest.TestCase):
                          service.extract_entity_ids(self.hass, call))
 
     def test_validate_service_call(self):
-        """Test is_valid_service_call method"""
+        """Test is_valid_service_call method."""
         self.assertNotEqual(
             service.validate_service_call(
                 {}),

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -2,7 +2,8 @@
 import unittest
 from unittest.mock import patch
 
-import homeassistant.components  # noqa - to prevent circular import
+# To prevent circular import when running just this file
+import homeassistant.components  # noqa
 from homeassistant import core as ha, loader
 from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ENTITY_ID
 from homeassistant.helpers import service

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -140,21 +140,3 @@ class TestServiceHelpers(unittest.TestCase):
 
         self.assertEqual(['light.ceiling', 'light.kitchen'],
                          service.extract_entity_ids(self.hass, call))
-
-    def test_validate_service_call(self):
-        """Test is_valid_service_call method."""
-        self.assertNotEqual(
-            service.validate_service_call(
-                {}),
-            None
-            )
-        self.assertEqual(
-            service.validate_service_call(
-                {'service': 'test_domain.test_service'}),
-            None
-            )
-        self.assertEqual(
-            service.validate_service_call(
-                {'service_template': 'test_domain.{{ \'test_service\' }}'}),
-            None
-            )


### PR DESCRIPTION
Just cooked this up on the flight San Diego - Toronto ;-)
- Extracts scripts logic into a script helper
- Scripts now accept variables to be passed in when turned on via service.
- Automation: Add a trigger variable that is available to templates when processing action part.
- Automation: Allow using script sequence syntax for action
- Alexa: allow script syntax for action and expose intent slots as variables
- Script - Breaking: no longer allow config delay workaround by @jaharkes because it confused the code. (now using config validation to convert all to timedeltas)

``` yaml
automation:
  trigger:
    platform: mqtt
    topic: some/notify/topic
  action:
    service: notify.notify
    data_template:
      message: {{ trigger.payload }}

automation 2:
  trigger:
    platform: state
    entity_id: light.hue
  action:
    service: notify.notify
    data_template:
      message: {{ trigger.to_state.name }} is now {{ trigger.to_state.state }}
```

Available trigger data per platform:

``` python
'trigger': {
    'platform': 'event',
    'event': event,
}

'trigger': {
    'platform': 'mqtt',
    'topic': msg_topic,
    'payload': msg_payload,
    'qos': qos,
}

'trigger': {
    'platform': 'numeric_state',
    'entity_id': entity_id,
    'below': below,
    'above': above,
    'from_state': from_state,
    'from_value': from_value,
    'to_state': to_state,
    'to_value': to_value,
}

'trigger': {
    'platform': 'state',
    'entity_id': entity,
    'from_state': from_s,
    'to_state': to_s,
    'for': time_delta,
}

'trigger': {
    'platform': 'sun',
    'event': event,
    'offset': offset,
}

'trigger': {
    'platform': 'template',
    'entity_id': entity_id,
    'from_state': from_s,
    'to_state': to_s,
}

'trigger': {
    'platform': 'time',
    'now': now,
}

'trigger': {
    'platform': 'zone',
    'entity_id': entity,
    'from_state': from_s,
    'to_state': to_s,
    'zone': zone_state,
}
```
