### PR TITLE
Update light component mqtt.py for improvement with espeasy brightness control over mqtt

### DIFF
--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -194,8 +194,8 @@ class MqttLight(Light):
 
         if not self._state:
             mqtt.publish(self._hass, self._topic["command_topic"],
-            self._payload["on"], self._qos, self._retain)
-            
+                         self._payload["on"], self._qos, self._retain)
+
         if ATTR_RGB_COLOR in kwargs and \
            self._topic["rgb_command_topic"] is not None:
 

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -192,6 +192,10 @@ class MqttLight(Light):
         """Turn the device on."""
         should_update = False
 
+        if not self._state:
+            mqtt.publish(self._hass, self._topic["command_topic"],
+            self._payload["on"], self._qos, self._retain)
+            
         if ATTR_RGB_COLOR in kwargs and \
            self._topic["rgb_command_topic"] is not None:
 
@@ -213,9 +217,6 @@ class MqttLight(Light):
             if self._optimistic_brightness:
                 self._brightness = kwargs[ATTR_BRIGHTNESS]
                 should_update = True
-
-        mqtt.publish(self._hass, self._topic["command_topic"],
-                     self._payload["on"], self._qos, self._retain)
 
         if self._optimistic:
             # Optimistically assume that switch has changed state.


### PR DESCRIPTION
**Description:**
Added a check to prevent sending payload on when light is already on
This is helpful when using ESP8266 with espeasy firmware as you are just sending pwm value via mqtt directly to IO pin. It was conflicting with a change of brightness.
My command topic is the same as the brightness topic. When there was a brightness change, HA was always sending a ''payload on'' AFTER the brightness value.
I'm still having issue with tracking the brightness value after on off but this is a start

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
light:
  platform: mqtt
  name: "Office light"
  brightness_command_topic: "/espeasy1/pwm/13"
  command_topic: "/espeasy1/pwm/13"
  brightness_scale: 1024
  qos: 0
  payload_on: "1024"
  payload_off: "0"
  optimistic: true
```

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
