### PR TITLE
Show error message frontend if can't find server

### DIFF
--- a/homeassistant/components/frontend/index.html.template
+++ b/homeassistant/components/frontend/index.html.template
@@ -28,20 +28,55 @@
         left: 0;
         right: 0;
         bottom: 0;
-        margin-bottom: 123px;
+        margin-bottom: 97px;
+        font-family: Roboto, sans-serif;
+        font-size: 0pt;
+        transition: font-size 2s;
+      }
+
+      #ha-init-skeleton paper-spinner {
+        height: 28px;
+      }
+
+      #ha-init-skeleton a {
+        color: #03A9F4;
+        text-decoration: none;
+        font-weight: bold;
+      }
+
+      #ha-init-skeleton.error {
+        font-size: 16px;
+      }
+
+      #ha-init-skeleton.error img,
+      #ha-init-skeleton.error paper-spinner {
+        display: none;
       }
     </style>
-    <link rel='import' href='/static/{{ app_url }}' async>
+    <script>
+      function initError() {
+        document
+          .getElementById('ha-init-skeleton')
+          .classList.add('error');
+      }
+    </script>
+    <link rel='import' href='/static/{{ app_url }}' onerror='initError()' async>
   </head>
   <body fullbleed>
-    <div id='ha-init-skeleton'><img src='/static/favicon-192x192.png' height='192'></div>
+    <div id='ha-init-skeleton'>
+      <img src='/static/favicon-192x192.png' height='192'>
+      <paper-spinner active></paper-spinner>
+      Home Assistant had trouble<br>connecting to the server.<br><br><a href='/'>TRY AGAIN</a>
+    </div>
     <script>
-      var webComponentsSupported = ('registerElement' in document &&
-                                    'import' in document.createElement('link') &&
-                                    'content' in document.createElement('template'))
+      var webComponentsSupported = (
+        'registerElement' in document &&
+        'import' in document.createElement('link') &&
+        'content' in document.createElement('template'));
       if (!webComponentsSupported) {
         var script = document.createElement('script')
         script.async = true
+        script.onerror = initError;
         script.src = '/static/webcomponents-lite.min.js'
         document.head.appendChild(script)
       }


### PR DESCRIPTION
**Description:**
Show an error message on the frontend if we have been unable to fetch the frontend files. Should prevent people from being 'stuck' on a logo only screen.

**Related issue (if applicable):** #

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
