### PR TITLE
Use sane defaults for zwave

### DIFF
--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/zwave/
 """
 import logging
 import os.path
-import sys
 import time
 from pprint import pprint
 
@@ -25,8 +24,6 @@ DEFAULT_CONF_USB_STICK_PATH = "/zwaveusbstick"
 CONF_DEBUG = "debug"
 CONF_POLLING_INTERVAL = "polling_interval"
 CONF_POLLING_INTENSITY = "polling_intensity"
-DEFAULT_ZWAVE_CONFIG_PATH = os.path.join(sys.prefix, 'share',
-                                         'python-openzwave', 'config')
 
 # How long to wait for the zwave network to be ready.
 NETWORK_READY_WAIT_SECS = 30
@@ -175,9 +172,19 @@ def setup(hass, config):
     # pylint: disable=global-statement, import-error
     global NETWORK
 
+    try:
+        import libopenzwave
+    except ImportError:
+        _LOGGER.error("You are missing required dependency Python Open "
+                      "Z-Wave. Please follow instructions at: "
+                      "https://home-assistant.io/components/zwave/")
+        return False
     from pydispatch import dispatcher
     from openzwave.option import ZWaveOption
     from openzwave.network import ZWaveNetwork
+
+    default_zwave_config_path = os.path.join(os.path.dirname(
+        libopenzwave.__file__), 'config')
 
     # Load configuration
     use_debug = str(config[DOMAIN].get(CONF_DEBUG)) == '1'
@@ -188,7 +195,7 @@ def setup(hass, config):
         config[DOMAIN].get(CONF_USB_STICK_PATH, DEFAULT_CONF_USB_STICK_PATH),
         user_path=hass.config.config_dir,
         config_path=config[DOMAIN].get('config_path',
-                                       DEFAULT_ZWAVE_CONFIG_PATH),)
+                                       default_zwave_config_path),)
 
     options.set_console_output(use_debug)
     options.lock()


### PR DESCRIPTION
**Description:**

Use sane default if libopenzwave is installed. In most cases this will mean that the zwave config path will not need to e manually specified.

Verify write access to the usb device before opening. If write access is missing, print an error indicating the current user, and path of usb device.

**Related issue (if applicable):** #1884, verifies https://github.com/home-assistant/home-assistant.io/pull/414 with readable error message.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [X] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [n/a] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [n/a] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Use sane default if libopenzwave is installed.

Verify write access to the usb device before opening.
