### PR TITLE
external dependency evohomeclient 0.2.4 gave a json decode error.

### DIFF
--- a/homeassistant/components/thermostat/honeywell.py
+++ b/homeassistant/components/thermostat/honeywell.py
@@ -11,7 +11,7 @@ from homeassistant.components.thermostat import ThermostatDevice
 from homeassistant.const import (
     CONF_PASSWORD, CONF_USERNAME, TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
-REQUIREMENTS = ['evohomeclient==0.2.4',
+REQUIREMENTS = ['evohomeclient==0.2.5',
                 'somecomfort==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -47,7 +47,7 @@ dweepy==0.2.0
 eliqonline==1.0.11
 
 # homeassistant.components.thermostat.honeywell
-evohomeclient==0.2.4
+evohomeclient==0.2.5
 
 # homeassistant.components.feedreader
 feedparser==5.2.1


### PR DESCRIPTION
**Description:**
Changed the external dependency.

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

upped to 0.2.5
