### PR TITLE
actually set HTTP version 1.1

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -166,7 +166,6 @@ class RequestHandler(SimpleHTTPRequestHandler):
         # Track if this was an authenticated request
         self.authenticated = False
         SimpleHTTPRequestHandler.__init__(self, req, client_addr, server)
-        self.protocol_version = 'HTTP/1.1'
 
     def log_message(self, fmt, *arguments):
         """Redirect built-in log to HA logging."""
@@ -177,12 +176,15 @@ class RequestHandler(SimpleHTTPRequestHandler):
                 fmt, *(arg.replace(self.server.api_password, '*******')
                        if isinstance(arg, str) else arg for arg in arguments))
 
-    def _handle_request(self, method):  # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches,too-many-statements
+    def _handle_request(self, method):
         """Perform some common checks and call appropriate method."""
         url = urlparse(self.path)
 
         # Read query input. parse_qs gives a list for each value, we want last
         data = {key: data[-1] for key, data in parse_qs(url.query).items()}
+
+        self.protocol_version = 'HTTP/1.1'
 
         # Did we get post input ?
         content_length = int(self.headers.get(HTTP_HEADER_CONTENT_LENGTH, 0))

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -58,6 +58,12 @@ class TestAPI(unittest.TestCase):
         """Stop everything that was started."""
         hass.pool.block_till_done()
 
+    def test_http_version(self):
+        """Test HTTP version."""
+        HTTP_1_1 = 11
+        self.assertEqual(HTTP_1_1,
+                         requests.get(_url(const.URL_API)).raw.version)
+
     # TODO move back to http component and test with use_auth.
     def test_access_denied_without_password(self):
         """Test access without password."""

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -55,6 +55,11 @@ class TestFrontend(unittest.TestCase):
         """Stop everything that was started."""
         hass.pool.block_till_done()
 
+    def test_http_version(self):
+        """Test HTTP version."""
+        HTTP_1_1 = 11
+        self.assertEqual(HTTP_1_1, requests.get(HTTP_BASE_URL).raw.version)
+
     def test_frontend_and_static(self):
         """Test if we can get the frontend."""
         req = requests.get(_url(""))


### PR DESCRIPTION
**Description:**
use HTTP version 1.1

**Related issue (if applicable):** #1619 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
