### PR TITLE
Rfxtrx: Simplified configuration

### DIFF
--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -57,7 +57,6 @@ def _valid_device(value):
     for key, device in value.items():
         # Still accept old configuration
         if 'packetid' in device.keys():
-            print(key, device.keys(), device, config)
             msg = 'You are using an outdated configuration of the rfxtrx ' +\
                   'devuce, {}. Your new config should be:\n{}: \n\t name:{}\n'\
                   .format(key, device.get('packetid'),

--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -42,7 +42,6 @@ def _valid_sensor(value):
     for key, device in value.items():
         # Still accept old configuration
         if 'packetid' in device.keys():
-            print(key, device.keys(), device, config)
             msg = 'You are using an outdated configuration of the rfxtrx ' +\
                   'sensor, {}. Your new config should be:\n{}: \n\t name:{}\n'\
                   .format(key, device.get('packetid'),

--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -5,87 +5,52 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.rfxtrx/
 """
 import logging
-from collections import OrderedDict
 import voluptuous as vol
 
 import homeassistant.components.rfxtrx as rfxtrx
-from homeassistant.const import TEMP_CELSIUS
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 from homeassistant.components.rfxtrx import (
     ATTR_AUTOMATIC_ADD, ATTR_NAME,
-    CONF_DEVICES, ATTR_DATA_TYPE)
+    CONF_DEVICES, ATTR_DATA_TYPE, DATA_TYPES)
 
 DEPENDENCIES = ['rfxtrx']
 
-DATA_TYPES = OrderedDict([
-    ('Temperature', TEMP_CELSIUS),
-    ('Humidity', '%'),
-    ('Barometer', ''),
-    ('Wind direction', ''),
-    ('Rain rate', ''),
-    ('Energy usage', 'W'),
-    ('Total usage', 'W')])
 _LOGGER = logging.getLogger(__name__)
-
-DEVICE_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_NAME, default=None): cv.string,
-    vol.Optional(ATTR_DATA_TYPE, default=[]):
-        vol.All(cv.ensure_list, [vol.In(DATA_TYPES.keys())]),
-})
-
-
-def _valid_sensor(value):
-    """Validate a dictionary of devices definitions."""
-    config = OrderedDict()
-    for key, device in value.items():
-        # Still accept old configuration
-        if 'packetid' in device.keys():
-            msg = 'You are using an outdated configuration of the rfxtrx ' +\
-                  'sensor, {}. Your new config should be:\n{}: \n\t name:{}\n'\
-                  .format(key, device.get('packetid'),
-                          device.get(ATTR_NAME, 'sensor_name'))
-            _LOGGER.warning(msg)
-            key = device.get('packetid')
-            device.pop('packetid')
-        try:
-            key = rfxtrx.validate_packetid(key)
-            config[key] = DEVICE_SCHEMA(device)
-            if not config[key][ATTR_NAME]:
-                config[key][ATTR_NAME] = key
-        except vol.MultipleInvalid as ex:
-            raise vol.Invalid('Rfxtrx sensor {} is invalid: {}'
-                              .format(key, ex))
-    return config
-
 
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required("platform"): rfxtrx.DOMAIN,
-    vol.Required(CONF_DEVICES): vol.All(dict, _valid_sensor),
+    vol.Optional(CONF_DEVICES, default={}): vol.All(dict, rfxtrx.valid_sensor),
     vol.Optional(ATTR_AUTOMATIC_ADD, default=False):  cv.boolean,
 }, extra=vol.ALLOW_EXTRA)
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the RFXtrx platform."""
+    # pylint: disable=too-many-locals
     from RFXtrx import SensorEvent
-
     sensors = []
     for packet_id, entity_info in config['devices'].items():
         event = rfxtrx.get_rfx_object(packet_id)
         device_id = "sensor_" + slugify(event.device.id_string.lower())
-
         if device_id in rfxtrx.RFX_DEVICES:
             continue
         _LOGGER.info("Add %s rfxtrx.sensor", entity_info[ATTR_NAME])
+
         sub_sensors = {}
-        for _data_type in cv.ensure_list(entity_info[ATTR_DATA_TYPE]):
+        data_types = entity_info[ATTR_DATA_TYPE]
+        if len(data_types) == 0:
+            for data_type in DATA_TYPES:
+                if data_type in event.values:
+                    data_types = [data_type]
+                    break
+        for _data_type in data_types:
             new_sensor = RfxtrxSensor(event, entity_info[ATTR_NAME],
                                       _data_type)
             sensors.append(new_sensor)
             sub_sensors[_data_type] = new_sensor
-        rfxtrx.RFX_DEVICES[slugify(device_id)] = sub_sensors
+        rfxtrx.RFX_DEVICES[device_id] = sub_sensors
 
     add_devices_callback(sensors)
 
@@ -103,19 +68,21 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             return
 
         # Add entity if not exist and the automatic_add is True
-        if config[ATTR_AUTOMATIC_ADD]:
-            pkt_id = "".join("{0:02x}".format(x) for x in event.data)
-            entity_name = "%s : %s" % (device_id, pkt_id)
-            _LOGGER.info(
-                "Automatic add rfxtrx.sensor: (%s : %s)",
-                device_id,
-                pkt_id)
+        if not config[ATTR_AUTOMATIC_ADD]:
+            return
 
-            new_sensor = RfxtrxSensor(event, entity_name)
-            sub_sensors = {}
-            sub_sensors[new_sensor.data_type] = new_sensor
-            rfxtrx.RFX_DEVICES[device_id] = sub_sensors
-            add_devices_callback([new_sensor])
+        pkt_id = "".join("{0:02x}".format(x) for x in event.data)
+        _LOGGER.info("Automatic add rfxtrx.sensor: %s",
+                     device_id)
+
+        for data_type in DATA_TYPES:
+            if data_type in event.values:
+                new_sensor = RfxtrxSensor(event, pkt_id, data_type)
+                break
+        sub_sensors = {}
+        sub_sensors[new_sensor.data_type] = new_sensor
+        rfxtrx.RFX_DEVICES[device_id] = sub_sensors
+        add_devices_callback([new_sensor])
 
     if sensor_update not in rfxtrx.RECEIVED_EVT_SUBSCRIBERS:
         rfxtrx.RECEIVED_EVT_SUBSCRIBERS.append(sensor_update)
@@ -124,7 +91,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 class RfxtrxSensor(Entity):
     """Representation of a RFXtrx sensor."""
 
-    def __init__(self, event, name, data_type=None):
+    def __init__(self, event, name, data_type):
         """Initialize the sensor."""
         self.event = event
         self._unit_of_measurement = None
@@ -133,12 +100,6 @@ class RfxtrxSensor(Entity):
         if data_type:
             self.data_type = data_type
             self._unit_of_measurement = DATA_TYPES[data_type]
-            return
-        for data_type in DATA_TYPES:
-            if data_type in self.event.values:
-                self._unit_of_measurement = DATA_TYPES[data_type]
-                self.data_type = data_type
-                break
 
     def __str__(self):
         """Return the name of the sensor."""

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -194,7 +194,7 @@ class TestLightRfxtrx(unittest.TestCase):
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         entity = rfxtrx_core.RFX_DEVICES['0e611622']
         self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual('<Entity 0e611622 : 0b11009e00e6116202020070: on>',
+        self.assertEqual('<Entity 0b11009e00e6116202020070: on>',
                          entity.__str__())
 
         event = rfxtrx_core.get_rfx_object('0b11009e00e6116201010070')
@@ -210,7 +210,7 @@ class TestLightRfxtrx(unittest.TestCase):
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         entity = rfxtrx_core.RFX_DEVICES['118cdea2']
         self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual('<Entity 118cdea2 : 0b1100120118cdea02020070: on>',
+        self.assertEqual('<Entity 0b1100120118cdea02020070: on>',
                          entity.__str__())
 
         # trying to add a sensor

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -29,9 +29,8 @@ class TestLightRfxtrx(unittest.TestCase):
             'light': {'platform': 'rfxtrx',
                       'automatic_add': True,
                       'devices':
-                      {'213c7f216': {
+                      {'0b1100cd0213c7f210010f51': {
                                'name': 'Test',
-                               'packetid': '0b1100cd0213c7f210010f51',
                                rfxtrx_core.ATTR_FIREEVENT: True}}}}))
 
         self.assertTrue(_setup_component(self.hass, 'light', {
@@ -62,7 +61,7 @@ class TestLightRfxtrx(unittest.TestCase):
                       'devices': {}}}))
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
 
-    def test_one_light(self):
+    def test_old_config(self):
         """Test with 1 light."""
         self.assertTrue(_setup_component(self.hass, 'light', {
             'light': {'platform': 'rfxtrx',
@@ -76,7 +75,50 @@ class TestLightRfxtrx(unittest.TestCase):
             rfxtrxmod.Core("", transport_protocol=rfxtrxmod.DummyTransport)
 
         self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
-        entity = rfxtrx_core.RFX_DEVICES['123efab1']
+        entity = rfxtrx_core.RFX_DEVICES['213c7f216']
+        self.assertEqual('Test', entity.name)
+        self.assertEqual('off', entity.state)
+        self.assertTrue(entity.assumed_state)
+        self.assertEqual(entity.signal_repetitions, 1)
+        self.assertFalse(entity.should_fire_event)
+        self.assertFalse(entity.should_poll)
+
+        self.assertFalse(entity.is_on)
+
+        entity.turn_on()
+        self.assertTrue(entity.is_on)
+        self.assertEqual(entity.brightness, 255)
+
+        entity.turn_off()
+        self.assertFalse(entity.is_on)
+        self.assertEqual(entity.brightness, 0)
+
+        entity.turn_on(brightness=100)
+        self.assertTrue(entity.is_on)
+        self.assertEqual(entity.brightness, 100)
+
+        entity.turn_on(brightness=10)
+        self.assertTrue(entity.is_on)
+        self.assertEqual(entity.brightness, 10)
+
+        entity.turn_on(brightness=255)
+        self.assertTrue(entity.is_on)
+        self.assertEqual(entity.brightness, 255)
+
+    def test_one_light(self):
+        """Test with 1 light."""
+        self.assertTrue(_setup_component(self.hass, 'light', {
+            'light': {'platform': 'rfxtrx',
+                      'devices':
+                      {'0b1100cd0213c7f210010f51': {
+                               'name': 'Test'}}}}))
+
+        import RFXtrx as rfxtrxmod
+        rfxtrx_core.RFXOBJECT =\
+            rfxtrxmod.Core("", transport_protocol=rfxtrxmod.DummyTransport)
+
+        self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
+        entity = rfxtrx_core.RFX_DEVICES['213c7f216']
         self.assertEqual('Test', entity.name)
         self.assertEqual('off', entity.state)
         self.assertTrue(entity.assumed_state)
@@ -112,15 +154,12 @@ class TestLightRfxtrx(unittest.TestCase):
             'light': {'platform': 'rfxtrx',
                       'signal_repetitions': 3,
                       'devices':
-                      {'123efab1': {
-                               'name': 'Test',
-                               'packetid': '0b1100cd0213c7f230010f71'},
-                        '118cdea2': {
-                            'name': 'Bath',
-                            'packetid': '0b1100100118cdea02010f70'},
-                        '213c7f216': {
-                            'name': 'Living',
-                            'packetid': '0b1100100118cdea02010f70'}}}}))
+                      {'0b1100cd0213c7f230010f71': {
+                               'name': 'Test'},
+                        '0b1100100118cdea02010f70': {
+                            'name': 'Bath'},
+                        '0b1100101118cdea02010f70': {
+                            'name': 'Living'}}}}))
 
         self.assertEqual(3, len(rfxtrx_core.RFX_DEVICES))
         device_num = 0

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -30,7 +30,7 @@ class TestSensorRfxtrx(unittest.TestCase):
                            {}}}))
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
 
-    def test_one_sensor(self):
+    def test_old_config_sensor(self):
         """Test with 1 sensor."""
         self.assertTrue(_setup_component(self.hass, 'sensor', {
             'sensor': {'platform': 'rfxtrx',
@@ -41,8 +41,27 @@ class TestSensorRfxtrx(unittest.TestCase):
                                'data_type': 'Temperature'}}}}))
 
         self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
-        print(rfxtrx_core.RFX_DEVICES)
-        entity = rfxtrx_core.RFX_DEVICES['sensor_0502']
+        entity = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']
+        self.assertEqual('Test', entity.name)
+        self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
+        self.assertEqual(14.9, entity.state)
+        self.assertEqual({'Humidity status': 'normal', 'Temperature': 14.9,
+                          'Rssi numeric': 6, 'Humidity': 34,
+                          'Battery numeric': 9,
+                          'Humidity status numeric': 2},
+                         entity.device_state_attributes)
+
+    def test_one_sensor(self):
+        """Test with 1 sensor."""
+        self.assertTrue(_setup_component(self.hass, 'sensor', {
+            'sensor': {'platform': 'rfxtrx',
+                       'devices':
+                           {'0a52080705020095220269': {
+                               'name': 'Test',
+                               'data_type': 'Temperature'}}}}))
+
+        self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
+        entity = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']
         self.assertEqual('Test', entity.name)
         self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
         self.assertEqual(14.9, entity.state)
@@ -57,44 +76,44 @@ class TestSensorRfxtrx(unittest.TestCase):
         self.assertTrue(_setup_component(self.hass, 'sensor', {
                 'sensor': {'platform': 'rfxtrx',
                            'devices':
-                               {'sensor_0502': {
+                               {'0a52080705020095220269': {
                                    'name': 'Test',
-                                   'packetid': '0a52080705020095220269',
                                    'data_type': 'Temperature'},
-                                   'sensor_0601': {
-                                   'name': 'Bath_Humidity',
-                                   'packetid': '0a520802060100ff0e0269',
-                                   'data_type': 'Humidity'},
-                                   'sensor_0601 2': {
+                                   '0a520802060100ff0e0269': {
                                    'name': 'Bath',
-                                   'packetid': '0a520802060100ff0e0269'}}}}))
+                                   'data_type': ['Temperature', 'Humidity']
+                                   }}}}))
 
-        self.assertEqual(3, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
         device_num = 0
         for id in rfxtrx_core.RFX_DEVICES:
-            entity = rfxtrx_core.RFX_DEVICES[id]
-            if entity.name == 'Bath_Humidity':
+            if id == 'sensor_0601':
                 device_num = device_num + 1
-                self.assertEqual('%', entity.unit_of_measurement)
-                self.assertEqual(14, entity.state)
+                self.assertEqual(len(rfxtrx_core.RFX_DEVICES[id]), 2)
+                _entity_temp = rfxtrx_core.RFX_DEVICES[id]['Temperature']
+                _entity_hum = rfxtrx_core.RFX_DEVICES[id]['Humidity']
+                self.assertEqual('%', _entity_hum.unit_of_measurement)
+                self.assertEqual(14, _entity_hum.state)
                 self.assertEqual({'Battery numeric': 9, 'Temperature': 25.5,
                                   'Humidity': 14, 'Humidity status': 'normal',
                                   'Humidity status numeric': 2,
                                   'Rssi numeric': 6},
-                                 entity.device_state_attributes)
-                self.assertEqual('Bath_Humidity', entity.__str__())
-            elif entity.name == 'Bath':
-                device_num = device_num + 1
-                self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
-                self.assertEqual(25.5, entity.state)
+                                 _entity_hum.device_state_attributes)
+                self.assertEqual('Bath', _entity_hum.__str__())
+
+                self.assertEqual(TEMP_CELSIUS,
+                                 _entity_temp.unit_of_measurement)
+                self.assertEqual(25.5, _entity_temp.state)
                 self.assertEqual({'Battery numeric': 9, 'Temperature': 25.5,
                                   'Humidity': 14, 'Humidity status': 'normal',
                                   'Humidity status numeric': 2,
                                   'Rssi numeric': 6},
-                                 entity.device_state_attributes)
-                self.assertEqual('Bath', entity.__str__())
-            elif entity.name == 'Test':
+                                 _entity_temp.device_state_attributes)
+                self.assertEqual('Bath', _entity_temp.__str__())
+            elif id == 'sensor_0502':
                 device_num = device_num + 1
+                entity = rfxtrx_core.RFX_DEVICES[id]['Temperature']
+
                 self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
                 self.assertEqual(14.9, entity.state)
                 self.assertEqual({'Humidity status': 'normal',
@@ -105,7 +124,7 @@ class TestSensorRfxtrx(unittest.TestCase):
                                  entity.device_state_attributes)
                 self.assertEqual('Test', entity.__str__())
 
-        self.assertEqual(3, device_num)
+        self.assertEqual(2, device_num)
 
     def test_discover_sensor(self):
         """Test with discovery of sensor."""
@@ -118,7 +137,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         event.data = bytearray(b'\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y')
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
 
-        entity = rfxtrx_core.RFX_DEVICES['sensor_0701']
+        entity = rfxtrx_core.RFX_DEVICES['sensor_0701']['Temperature']
         self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
         self.assertEqual({'Humidity status': 'normal',
                           'Temperature': 18.4,
@@ -135,7 +154,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         event = rfxtrx_core.get_rfx_object('0a52080405020095240279')
         event.data = bytearray(b'\nR\x08\x04\x05\x02\x00\x95$\x02y')
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES['sensor_0502']
+        entity = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']
         self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
         self.assertEqual({'Humidity status': 'normal',
                           'Temperature': 14.9,
@@ -149,7 +168,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         event = rfxtrx_core.get_rfx_object('0a52085e070100b31b0279')
         event.data = bytearray(b'\nR\x08^\x07\x01\x00\xb3\x1b\x02y')
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES['sensor_0701']
+        entity = rfxtrx_core.RFX_DEVICES['sensor_0701']['Temperature']
         self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
         self.assertEqual({'Humidity status': 'normal',
                           'Temperature': 17.9,
@@ -197,45 +216,44 @@ class TestSensorRfxtrx(unittest.TestCase):
         self.assertTrue(_setup_component(self.hass, 'sensor', {
                 'sensor': {'platform': 'rfxtrx',
                            'devices':
-                               {'sensor_0502': {
+                               {'0a52080705020095220269': {
                                    'name': 'Test',
-                                   'packetid': '0a52080705020095220269',
                                    'data_type': 'Temperature'},
-                                   'sensor_0601': {
-                                   'name': 'Bath_Humidity',
-                                   'packetid': '0a520802060100ff0e0269',
-                                   'data_type': 'Humidity'},
-                                   'sensor_0601 2': {
+                                   '0a520802060100ff0e0269': {
                                    'name': 'Bath',
-                                   'packetid': '0a520802060100ff0e0269'}}}}))
+                                   'data_type': ['Temperature', 'Humidity']
+                                   }}}}))
 
-        self.assertEqual(3, len(rfxtrx_core.RFX_DEVICES))
-
+        self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
         device_num = 0
         for id in rfxtrx_core.RFX_DEVICES:
-            entity = rfxtrx_core.RFX_DEVICES[id]
-            if entity.name == 'Bath_Humidity':
+            if id == 'sensor_0601':
                 device_num = device_num + 1
-                self.assertEqual('%', entity.unit_of_measurement)
-                self.assertEqual(14, entity.state)
+                self.assertEqual(len(rfxtrx_core.RFX_DEVICES[id]), 2)
+                _entity_temp = rfxtrx_core.RFX_DEVICES[id]['Temperature']
+                _entity_hum = rfxtrx_core.RFX_DEVICES[id]['Humidity']
+                self.assertEqual('%', _entity_hum.unit_of_measurement)
+                self.assertEqual(14, _entity_hum.state)
                 self.assertEqual({'Battery numeric': 9, 'Temperature': 25.5,
                                   'Humidity': 14, 'Humidity status': 'normal',
                                   'Humidity status numeric': 2,
                                   'Rssi numeric': 6},
-                                 entity.device_state_attributes)
-                self.assertEqual('Bath_Humidity', entity.__str__())
-            elif entity.name == 'Bath':
-                device_num = device_num + 1
-                self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
-                self.assertEqual(25.5, entity.state)
+                                 _entity_hum.device_state_attributes)
+                self.assertEqual('Bath', _entity_hum.__str__())
+
+                self.assertEqual(TEMP_CELSIUS,
+                                 _entity_temp.unit_of_measurement)
+                self.assertEqual(25.5, _entity_temp.state)
                 self.assertEqual({'Battery numeric': 9, 'Temperature': 25.5,
                                   'Humidity': 14, 'Humidity status': 'normal',
                                   'Humidity status numeric': 2,
                                   'Rssi numeric': 6},
-                                 entity.device_state_attributes)
-                self.assertEqual('Bath', entity.__str__())
-            elif entity.name == 'Test':
+                                 _entity_temp.device_state_attributes)
+                self.assertEqual('Bath', _entity_temp.__str__())
+            elif id == 'sensor_0502':
                 device_num = device_num + 1
+                entity = rfxtrx_core.RFX_DEVICES[id]['Temperature']
+
                 self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
                 self.assertEqual(14.9, entity.state)
                 self.assertEqual({'Humidity status': 'normal',
@@ -246,7 +264,7 @@ class TestSensorRfxtrx(unittest.TestCase):
                                  entity.device_state_attributes)
                 self.assertEqual('Test', entity.__str__())
 
-        self.assertEqual(3, device_num)
+        self.assertEqual(2, device_num)
 
         event = rfxtrx_core.get_rfx_object('0a520802060101ff0f0269')
         event.data = bytearray(b'\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y')
@@ -257,33 +275,36 @@ class TestSensorRfxtrx(unittest.TestCase):
         event.data = bytearray(b'\nR\x08\x04\x05\x02\x00\x95$\x02y')
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
 
-        self.assertEqual(3, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
 
         device_num = 0
         for id in rfxtrx_core.RFX_DEVICES:
-            entity = rfxtrx_core.RFX_DEVICES[id]
-            if entity.name == 'Bath_Humidity':
+            if id == 'sensor_0601':
                 device_num = device_num + 1
-                self.assertEqual('%', entity.unit_of_measurement)
-                self.assertEqual(15, entity.state)
+                self.assertEqual(len(rfxtrx_core.RFX_DEVICES[id]), 2)
+                _entity_temp = rfxtrx_core.RFX_DEVICES[id]['Temperature']
+                _entity_hum = rfxtrx_core.RFX_DEVICES[id]['Humidity']
+                self.assertEqual('%', _entity_hum.unit_of_measurement)
+                self.assertEqual(15, _entity_hum.state)
                 self.assertEqual({'Battery numeric': 9, 'Temperature': 51.1,
                                   'Humidity': 15, 'Humidity status': 'normal',
                                   'Humidity status numeric': 2,
                                   'Rssi numeric': 6},
-                                 entity.device_state_attributes)
-                self.assertEqual('Bath_Humidity', entity.__str__())
-            elif entity.name == 'Bath':
-                device_num = device_num + 1
-                self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
-                self.assertEqual(51.1, entity.state)
+                                 _entity_hum.device_state_attributes)
+                self.assertEqual('Bath', _entity_hum.__str__())
+
+                self.assertEqual(TEMP_CELSIUS,
+                                 _entity_temp.unit_of_measurement)
+                self.assertEqual(51.1, _entity_temp.state)
                 self.assertEqual({'Battery numeric': 9, 'Temperature': 51.1,
                                   'Humidity': 15, 'Humidity status': 'normal',
                                   'Humidity status numeric': 2,
                                   'Rssi numeric': 6},
-                                 entity.device_state_attributes)
-                self.assertEqual('Bath', entity.__str__())
-            elif entity.name == 'Test':
+                                 _entity_temp.device_state_attributes)
+                self.assertEqual('Bath', _entity_temp.__str__())
+            elif id == 'sensor_0502':
                 device_num = device_num + 1
+                entity = rfxtrx_core.RFX_DEVICES[id]['Temperature']
                 self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
                 self.assertEqual(13.3, entity.state)
                 self.assertEqual({'Humidity status': 'normal',
@@ -294,6 +315,5 @@ class TestSensorRfxtrx(unittest.TestCase):
                                  entity.device_state_attributes)
                 self.assertEqual('Test', entity.__str__())
 
-        self.assertEqual(3, device_num)
-
-        self.assertEqual(3, len(rfxtrx_core.RFX_DEVICES))
+        self.assertEqual(2, device_num)
+        self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -71,6 +71,25 @@ class TestSensorRfxtrx(unittest.TestCase):
                           'Humidity status numeric': 2},
                          entity.device_state_attributes)
 
+    def test_one_sensor_no_datatype(self):
+        """Test with 1 sensor."""
+        self.assertTrue(_setup_component(self.hass, 'sensor', {
+            'sensor': {'platform': 'rfxtrx',
+                       'devices':
+                           {'0a52080705020095220269': {
+                               'name': 'Test'}}}}))
+
+        self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
+        entity = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']
+        self.assertEqual('Test', entity.name)
+        self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
+        self.assertEqual(14.9, entity.state)
+        self.assertEqual({'Humidity status': 'normal', 'Temperature': 14.9,
+                          'Rssi numeric': 6, 'Humidity': 34,
+                          'Battery numeric': 9,
+                          'Humidity status numeric': 2},
+                         entity.device_state_attributes)
+
     def test_several_sensors(self):
         """Test with 3 sensors."""
         self.assertTrue(_setup_component(self.hass, 'sensor', {
@@ -145,7 +164,7 @@ class TestSensorRfxtrx(unittest.TestCase):
                           'Battery numeric': 9,
                           'Humidity status numeric': 2},
                          entity.device_state_attributes)
-        self.assertEqual('sensor_0701 : 0a520801070100b81b0279',
+        self.assertEqual('0a520801070100b81b0279',
                          entity.__str__())
 
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
@@ -162,7 +181,7 @@ class TestSensorRfxtrx(unittest.TestCase):
                           'Battery numeric': 9,
                           'Humidity status numeric': 2},
                          entity.device_state_attributes)
-        self.assertEqual('sensor_0502 : 0a52080405020095240279',
+        self.assertEqual('0a52080405020095240279',
                          entity.__str__())
 
         event = rfxtrx_core.get_rfx_object('0a52085e070100b31b0279')
@@ -176,7 +195,7 @@ class TestSensorRfxtrx(unittest.TestCase):
                           'Battery numeric': 9,
                           'Humidity status numeric': 2},
                          entity.device_state_attributes)
-        self.assertEqual('sensor_0701 : 0a520801070100b81b0279',
+        self.assertEqual('0a520801070100b81b0279',
                          entity.__str__())
 
         # trying to add a switch

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -29,9 +29,8 @@ class TestSwitchRfxtrx(unittest.TestCase):
             'switch': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'devices':
-                           {'213c7f216': {
+                           {'0b1100cd0213c7f210010f51': {
                                'name': 'Test',
-                               'packetid': '0b1100cd0213c7f210010f51',
                                rfxtrx_core.ATTR_FIREEVENT: True}
                             }}}))
 
@@ -71,17 +70,6 @@ class TestSwitchRfxtrx(unittest.TestCase):
                             }}}))
 
     def test_invalid_config4(self):
-        self.assertFalse(_setup_component(self.hass, 'switch', {
-            'switch': {'platform': 'rfxtrx',
-                       'automatic_add': True,
-                       'devices':
-                           {'AA3c7f216': {
-                               'name': 'Test',
-                               'packetid': '0b1100cd0213c7f210010f51',
-                               rfxtrx_core.ATTR_FIREEVENT: True}
-                            }}}))
-
-    def test_invalid_config5(self):
         """Test configuration."""
         self.assertFalse(_setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
@@ -100,7 +88,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
                            {}}}))
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
 
-    def test_one_switch(self):
+    def test_old_config(self):
         """Test with 1 switch."""
         self.assertTrue(_setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
@@ -114,7 +102,34 @@ class TestSwitchRfxtrx(unittest.TestCase):
             rfxtrxmod.Core("", transport_protocol=rfxtrxmod.DummyTransport)
 
         self.assertEqual(1,  len(rfxtrx_core.RFX_DEVICES))
-        entity = rfxtrx_core.RFX_DEVICES['123efab1']
+        entity = rfxtrx_core.RFX_DEVICES['213c7f216']
+        self.assertEqual('Test', entity.name)
+        self.assertEqual('off', entity.state)
+        self.assertTrue(entity.assumed_state)
+        self.assertEqual(entity.signal_repetitions, 1)
+        self.assertFalse(entity.should_fire_event)
+        self.assertFalse(entity.should_poll)
+
+        self.assertFalse(entity.is_on)
+        entity.turn_on()
+        self.assertTrue(entity.is_on)
+        entity.turn_off()
+        self.assertFalse(entity.is_on)
+
+    def test_one_switch(self):
+        """Test with 1 switch."""
+        self.assertTrue(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'devices':
+                           {'0b1100cd0213c7f210010f51': {
+                               'name': 'Test'}}}}))
+
+        import RFXtrx as rfxtrxmod
+        rfxtrx_core.RFXOBJECT =\
+            rfxtrxmod.Core("", transport_protocol=rfxtrxmod.DummyTransport)
+
+        self.assertEqual(1,  len(rfxtrx_core.RFX_DEVICES))
+        entity = rfxtrx_core.RFX_DEVICES['213c7f216']
         self.assertEqual('Test', entity.name)
         self.assertEqual('off', entity.state)
         self.assertTrue(entity.assumed_state)
@@ -134,15 +149,12 @@ class TestSwitchRfxtrx(unittest.TestCase):
             'switch': {'platform': 'rfxtrx',
                        'signal_repetitions': 3,
                        'devices':
-                           {'123efab1': {
-                               'name': 'Test',
-                               'packetid': '0b1100cd0213c7f230010f71'},
-                            '118cdea2': {
-                            'name': 'Bath',
-                            'packetid': '0b1100100118cdea02010f70'},
-                            '213c7f216': {
-                            'name': 'Living',
-                            'packetid': '0b1100100118cdea02010f70'}}}}))
+                           {'0b1100cd0213c7f230010f71': {
+                               'name': 'Test'},
+                            '0b1100100118cdea02010f70': {
+                            'name': 'Bath'},
+                            '0b1100101118cdea02010f70': {
+                            'name': 'Living'}}}}))
 
         self.assertEqual(3, len(rfxtrx_core.RFX_DEVICES))
         device_num = 0

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -190,7 +190,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         entity = rfxtrx_core.RFX_DEVICES['118cdea2']
         self.assertEqual(1, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual('<Entity 118cdea2 : 0b1100100118cdea01010f70: on>',
+        self.assertEqual('<Entity 0b1100100118cdea01010f70: on>',
                          entity.__str__())
 
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
@@ -203,7 +203,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
         entity = rfxtrx_core.RFX_DEVICES['118cdeb2']
         self.assertEqual(2, len(rfxtrx_core.RFX_DEVICES))
-        self.assertEqual('<Entity 118cdeb2 : 0b1100120118cdea02000070: on>',
+        self.assertEqual('<Entity 0b1100120118cdea02000070: on>',
                          entity.__str__())
 
         # Trying to add a sensor

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -82,9 +82,8 @@ class TestRFXTRX(unittest.TestCase):
             'switch': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'devices':
-                           {'213c7f216': {
+                           {'0b1100cd0213c7f210010f51': {
                                'name': 'Test',
-                               'packetid': '0b1100cd0213c7f210010f51',
                                rfxtrx.ATTR_FIREEVENT: True}
                             }}}))
 

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -37,10 +37,10 @@ class TestRFXTRX(unittest.TestCase):
                        'automatic_add': True,
                        'devices': {}}}))
 
-        while len(rfxtrx.RFX_DEVICES) < 2:
+        while len(rfxtrx.RFX_DEVICES) < 1:
             time.sleep(0.1)
 
-        self.assertEqual(len(rfxtrx.RFXOBJECT.sensors()), 2)
+        self.assertEqual(len(rfxtrx.RFXOBJECT.sensors()), 1)
 
     def test_valid_config(self):
         """Test configuration."""


### PR DESCRIPTION
**Description:**
Several people have had problems setting up the rfxtrx device. So this simplifies the procedures.

Before the configuration looked like:

```
  devices:
    123efab1:
      name: My DI.0 light device
      packetid: 1b2200000890efab1213f60
```

The new configuration is:

```
  devices:
    1b2200000890efab1213f60:
      name: My DI.0 light device
```

And it should be much easier to find the new  packet id, since it will be the name of an auto added device.

The old configuration still works, but you get a warning and are explained how you should update your configuration.

Only if you have more than one data type for one sensor displayed, you have to update your configuration:

Before:

```
   sensor_0601:
     name: Bath_Humidity
     packetid: 0a520802060100ff0e0269
     data_type: Humidity
   sensor_0601 2:
     name: Bath
     packetid: 0a520802060100ff0e0269

```

Now:

```
    0a520802060100ff0e0269: 
        name: Bad
        data_type: 
         - Humidity
         - Temperature

```

I will also update the documentation at https://home-assistant.io/components/rfxtrx/

@turbokongen @emil-e
Do you have any comments on this?

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
