### PR TITLE
Exclude locally built python-openzwave from tox.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ universal = 1
 testpaths = tests
 
 [flake8]
-exclude = .venv,.git,.tox,docs,www_static,venv,bin,lib,deps
+exclude = .venv,.git,.tox,docs,www_static,venv,bin,lib,deps,build


### PR DESCRIPTION
**Description:**
Excludes locally built python-openzwave from tox testing
