### PR TITLE
Uber: Dont load price sensors for metered (read: taxi/cabs) products

### DIFF
--- a/homeassistant/components/sensor/uber.py
+++ b/homeassistant/components/sensor/uber.py
@@ -47,8 +47,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
            (product_id not in wanted_product_ids):
             continue
         dev.append(UberSensor('time', timeandpriceest, product_id, product))
-        isMetered = (product['price_details']['estimate'] == "Metered")
-        if 'price_details' in product and isMetered is False:
+        is_metered = (product['price_details']['estimate'] == "Metered")
+        if 'price_details' in product and is_metered is False:
             dev.append(UberSensor('price', timeandpriceest,
                                   product_id, product))
     add_devices(dev)

--- a/homeassistant/components/sensor/uber.py
+++ b/homeassistant/components/sensor/uber.py
@@ -47,7 +47,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
            (product_id not in wanted_product_ids):
             continue
         dev.append(UberSensor('time', timeandpriceest, product_id, product))
-        if 'price_details' in product:
+        isMetered = (product['price_details']['estimate'] == "Metered")
+        if 'price_details' in product and isMetered is False:
             dev.append(UberSensor('price', timeandpriceest,
                                   product_id, product))
     add_devices(dev)


### PR DESCRIPTION
Quick little fix for a user reported issue with using the Uber sensor. UberTAXI/UberCAB will return price details but without estimates. This fix blocks out any metered products from having a price sensor loaded.
