### PR TITLE
mqtt: Fix logic when embedded and broker configs are present.

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -195,8 +195,7 @@ def setup(hass, config):
     # Only auto config if no server config was passed in
     if broker_config and CONF_EMBEDDED not in conf:
         broker, port, username, password, certificate, protocol = broker_config
-    elif not broker_config and (CONF_EMBEDDED in conf or
-                                CONF_BROKER not in conf):
+    elif not broker_config and CONF_BROKER not in conf:
         _LOGGER.error('Unable to start broker and auto-configure MQTT.')
         return False
 


### PR DESCRIPTION
**Description:**
Fix logic in mqtt initialization.

Unable to start broker and auto-configure MQTT.

**Example entry for `configuration.yaml` (if applicable):**
I specify a "compex" configuration for the embedded MQTT server and
a broker configuration:

``` yaml
mqtt:
  embedded:
    listeners:
        default:
            max-connections: 50
            type: tcp
            bind: 0.0.0.0:8081
            ssl: 'on'
            certfile: /home/pi/ssl/server.crt
            keyfile: /home/pi/ssl/server.key
    timeout-disconnect-delay: 2
    auth:
        plugins: ['auth_file']
        allow-anonymous: false
        password-file: /home/pi/.homeassistant/mqtt/password
  broker: mascot
  port: 8081
  client_id: home-assistant-1
  keepalive: 60
  username: <>
  password: <>
  certificate: /home/pi/ssl/server.crt
  protocol: 3.1.1
```

In the current code, because both CONF_EMBEDDED and CONF_BROKER are specified, we would fail the MQTT autoconfiguration at line 199.

Autogenerated broker_config is useful only if CONF_EMBEDDED is not present (line 196).

If CONF_EMBEDDED is not present, but CONF_BROKER is, we won't even start the mqtt server, we will not autogenerate a broker_config, so we must set the broker with CONF_BROKER data.

if CONF_EMBEDDED is present, we will start the mqtt server, but the broker autoconfig will not be generated, so we must rely on a CONF_BROKER.

In consequence, it does not matter if CONF_EMBEDDED is present or not at line 198.

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. 
- [ ] Tests have been added to verify that the new code works.

Fix test to prevent early exit of mqtt init handler when
both embedded and broker configs are present.

Signed-off-by: Gwendal Grignou gwendal@gmail.com
