### PR TITLE
Ignore .venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ nosetests.xml
 pyvenv.cfg
 pip-selfcheck.json
 venv
+.venv
 
 # vimmy stuff
 *.swp


### PR DESCRIPTION
When using virtualfish ('virtualenvwrapper' for the fish shell), you
can create a .venv file in a directory that contains the name of a
virtualenv that will be activated automatically when you cd into that
directory. This is a good and useful thing, but since folks will have
different names for their virtualenvs, we should ignore this file.

That... and I'm probably the only one using fish/virtualfish...
