### PR TITLE
Upgrading to python-wink 0.7.5.

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-wink==0.7.4']
+REQUIREMENTS = ['python-wink==0.7.5']
 
 # These are the available sensors mapped to binary_sensor class
 SENSOR_TYPES = {

--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.garage_door import GarageDoorDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.4']
+REQUIREMENTS = ['python-wink==0.7.5']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -13,7 +13,7 @@ from homeassistant.util import color as color_util
 from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
 
-REQUIREMENTS = ['python-wink==0.7.4']
+REQUIREMENTS = ['python-wink==0.7.5']
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.4']
+REQUIREMENTS = ['python-wink==0.7.5']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -10,7 +10,7 @@ from homeassistant.const import (CONF_ACCESS_TOKEN, STATE_CLOSED,
                                  STATE_OPEN, TEMP_CELSIUS)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-wink==0.7.4']
+REQUIREMENTS = ['python-wink==0.7.5']
 
 SENSOR_TYPES = ['temperature', 'humidity']
 

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.wink import WinkToggleDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.4']
+REQUIREMENTS = ['python-wink==0.7.5']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.loader import get_component
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.7.4']
+REQUIREMENTS = ['python-wink==0.7.5']
 
 DISCOVER_LIGHTS = "wink.lights"
 DISCOVER_SWITCHES = "wink.switches"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -255,7 +255,7 @@ python-twitch==1.2.0
 # homeassistant.components.lock.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.7.4
+python-wink==0.7.5
 
 # homeassistant.components.keyboard
 pyuserinput==0.1.9


### PR DESCRIPTION
**Description:**

This fixes a bug where light bulb statuses were failing to update on the HA polling update call.

**Related issue (if applicable):** https://github.com/bradsk88/python-wink/issues/35

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L5])).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
-     ~~New files were added to `.coveragerc`.~~
