### PR TITLE
Upgrade python-telegram-bot to 4.0.1

### DIFF
--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import validate_config
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['python-telegram-bot==3.4']
+REQUIREMENTS = ['python-telegram-bot==4.0.1']
 
 
 def get_service(hass, config):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -243,7 +243,7 @@ python-pushover==0.2
 python-statsd==1.7.2
 
 # homeassistant.components.notify.telegram
-python-telegram-bot==3.4
+python-telegram-bot==4.0.1
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.2.0


### PR DESCRIPTION
v4.0.1
    Implement Bot API 2.0
    Almost complete recode of Dispatcher 

Tested with the following configuration:

``` yaml
notify:
  - platform: telegram
    name: telegram
    api_key: 1234xxxxx:AAxxxxxxxg
    chat_id: 10xxxxxx
```

Message sent with "Call Service"

``` json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"
}
```
