### PR TITLE
Upgrade TwitterAPI to 2.4.1

### DIFF
--- a/homeassistant/components/notify/twitter.py
+++ b/homeassistant/components/notify/twitter.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers import validate_config
 
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ['TwitterAPI==2.3.6']
+REQUIREMENTS = ['TwitterAPI==2.4.1']
 
 CONF_CONSUMER_KEY = "consumer_key"
 CONF_CONSUMER_SECRET = "consumer_secret"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -20,7 +20,7 @@ PyMata==2.07a
 SoCo==0.11.1
 
 # homeassistant.components.notify.twitter
-TwitterAPI==2.3.6
+TwitterAPI==2.4.1
 
 # homeassistant.components.apcupsd
 apcaccess==0.0.4


### PR DESCRIPTION
No changelog  for 2.4.1 available

Tested with the following configuration:

``` yaml
notify:
  - platform: twitter
    name: twitter
    consumer_key: kxxxxxxxxxxxxxxxxxxxxx
    consumer_secret: oxxxxxxxxxxxxxxxxxxxxxxx
    access_token: 1xxxxxxxxxxxxxxxxxxxxxxxx
    access_token_secret: s7xxxxxxxxxxxxxxxxxxxxx
```

Message sent with "Call Service"

``` json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"
}
```
