### PR TITLE
Mqtt client key auth

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -200,7 +200,7 @@ def setup(hass, config):
     broker_config = _setup_server(hass, config)
 
     broker_in_conf = True if CONF_BROKER in conf else False
-    
+
     # Only auto config if no server config was passed in
     if broker_config and CONF_EMBEDDED not in conf:
         broker, port, username, password, certificate, protocol = broker_config
@@ -228,13 +228,13 @@ def setup(hass, config):
 
     global MQTT_CLIENT
     try:
-        #Embedded broker doesn't have some ssl variables
+        # Embedded broker doesn't have some ssl variables
         if broker_in_conf:
-            MQTT_CLIENT = MQTT(hass, broker, port, client_id, keepalive, 
+            MQTT_CLIENT = MQTT(hass, broker, port, client_id, keepalive,
                                username, password, certificate, client_key,
                                client_cert, tls_insecure, protocol)
         else:
-            MQTT_CLIENT = MQTT(hass, broker, port, client_id, keepalive, 
+            MQTT_CLIENT = MQTT(hass, broker, port, client_id, keepalive,
                                username, password, certificate, protocol)
     except socket.error:
         _LOGGER.exception("Can't connect to the broker. "
@@ -286,7 +286,8 @@ class MQTT(object):
     """Home Assistant MQTT client."""
 
     def __init__(self, hass, broker, port, client_id, keepalive, username,
-                 password, certificate, client_key, client_cert, tls_insecure, protocol):
+                 password, certificate, protocol, client_key=None,
+                 client_cert=None, tls_insecure=None):
         """Initialize Home Assistant MQTT client."""
         import paho.mqtt.client as mqtt
 
@@ -309,7 +310,7 @@ class MQTT(object):
 
         if certificate is not None:
             if (client_key is not None) and (client_cert is not None):
-                self._mqttc.tls_set(certificate, certfile=client_cert, 
+                self._mqttc.tls_set(certificate, certfile=client_cert,
                                     keyfile=client_key)
             elif (client_key is not None) or (client_cert is not None):
                 _LOGGER.warning(
@@ -318,7 +319,7 @@ class MQTT(object):
             else:
                 self._mqttc.tls_set(certificate)
 
-            if  tls_insecure is not None:
+            if tls_insecure is not None:
                 self._mqttc.tls_insecure_set(tls_insecure)
 
         self._mqttc.on_subscribe = self._mqtt_on_subscribe

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -199,16 +199,17 @@ def setup(hass, config):
 
     broker_config = _setup_server(hass, config)
 
+    broker_in_conf = True if CONF_BROKER in conf else False
+    
     # Only auto config if no server config was passed in
     if broker_config and CONF_EMBEDDED not in conf:
-        broker, port, username, password, certificate, client_key, 
-        client_cert, tls_insecure, protocol = broker_config
+        broker, port, username, password, certificate, protocol = broker_config
     elif not broker_config and (CONF_EMBEDDED in conf or
                                 CONF_BROKER not in conf):
         _LOGGER.error('Unable to start broker and auto-configure MQTT.')
         return False
 
-    if CONF_BROKER in conf:
+    if broker_in_conf:
         broker = conf[CONF_BROKER]
         port = conf[CONF_PORT]
         username = conf.get(CONF_USERNAME)
@@ -227,9 +228,14 @@ def setup(hass, config):
 
     global MQTT_CLIENT
     try:
-        MQTT_CLIENT = MQTT(hass, broker, port, client_id, keepalive, username,
-                           password, certificate, client_key, client_cert, 
-                           tls_insecure, protocol)
+        #Embedded broker doesn't have some ssl variables
+        if broker_in_conf:
+            MQTT_CLIENT = MQTT(hass, broker, port, client_id, keepalive, 
+                               username, password, certificate, client_key,
+                               client_cert, tls_insecure, protocol)
+        else:
+            MQTT_CLIENT = MQTT(hass, broker, port, client_id, keepalive, 
+                               username, password, certificate, protocol)
     except socket.error:
         _LOGGER.exception("Can't connect to the broker. "
                           "Please check your settings and the broker "


### PR DESCRIPTION
**Description:**

This code allows client key authentication for mqtt servers. The variables `client_key`, `client_cert` and `tls_insecure` have been added as optional configs for external mqtt brokers. 'tls_insecure` had to added so that self signed certificates could be used.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
mqtt:
  broker: blah.blah.com
  port: 8883
  client_id: home-assistant-1
  keepalive: 60
  username: user
  password: #######
  certificate: '/homeuser/owntracks/ca.crt'
  client_key: '/home/user/owntracks/cookie.key'
  client_cert: '/home/user/owntracks/cookie.crt'
  tls_insecure: 'True'
  protocol: 3.1

```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  - no new dependancies 
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
  - no new files

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
  - _There were no previous pieces of code which tested external mqtt providers as far as I can tell so no new ones have been added. If there are could you provide a little guidance and I could add these._
