### PR TITLE
Upgrade blinkstick to 1.1.8

### DIFF
--- a/homeassistant/components/light/blinksticklight.py
+++ b/homeassistant/components/light/blinksticklight.py
@@ -11,7 +11,7 @@ from homeassistant.components.light import ATTR_RGB_COLOR, Light
 _LOGGER = logging.getLogger(__name__)
 
 
-REQUIREMENTS = ["blinkstick==1.1.7"]
+REQUIREMENTS = ["blinkstick==1.1.8"]
 
 
 # pylint: disable=unused-argument

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -29,7 +29,7 @@ apcaccess==0.0.4
 astral==1.0
 
 # homeassistant.components.light.blinksticklight
-blinkstick==1.1.7
+blinkstick==1.1.8
 
 # homeassistant.components.sensor.bitcoin
 blockchain==1.3.1


### PR DESCRIPTION
v1.1.8
- Get and set number of LEDs for BlinkStick Flex
- Mode description update
- Display LED count with --info parameter
- Option to set LED count with --set-led-count for BlinkStick Flex
