### PR TITLE
Upgrade pushbullet.py to 0.10.0

### DIFF
--- a/homeassistant/components/notify/pushbullet.py
+++ b/homeassistant/components/notify/pushbullet.py
@@ -11,7 +11,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_API_KEY
 
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ['pushbullet.py==0.9.0']
+REQUIREMENTS = ['pushbullet.py==0.10.0']
 
 
 # pylint: disable=unused-argument

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -176,7 +176,7 @@ proliphix==0.1.0
 psutil==4.1.0
 
 # homeassistant.components.notify.pushbullet
-pushbullet.py==0.9.0
+pushbullet.py==0.10.0
 
 # homeassistant.components.notify.pushetta
 pushetta==1.0.15


### PR DESCRIPTION
 0.10.0
- Version bump

0.9.1
- Fix edit_device method to keep nickname

Tested with the following configuration:

``` yaml
  - platform: pushbullet
    name: pushbullet
    api_key: v1...k
```

and "Call Service"

``` json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"
}
```
