### PR TITLE
Forecast.io: Added minutely, hourly, and daily summary

### DIFF
--- a/homeassistant/components/sensor/forecast.py
+++ b/homeassistant/components/sensor/forecast.py
@@ -137,10 +137,10 @@ class ForeCastSensor(Entity):
         import forecastio
 
         self.forecast_client.update()
-        data = self.forecast_client.data
-        data_minutely = self.forecast_client.data_minutely
-        data_hourly = self.forecast_client.data_hourly
-        data_daily = self.forecast_client.data_daily
+        data = self.forecast_client.data.currently()
+        data_minutely = self.forecast_client.data.minutely()
+        data_hourly = self.forecast_client.data.hourly()
+        data_daily = self.forecast_client.data.daily()
 
         try:
             if self.type == 'summary':
@@ -197,9 +197,6 @@ class ForeCastData(object):
         self.latitude = latitude
         self.longitude = longitude
         self.data = None
-        self.data_minutely = None
-        self.data_hourly = None
-        self.data_daily = None
         self.unit_system = None
         self.units = units
         self.update()
@@ -213,8 +210,5 @@ class ForeCastData(object):
                                             self.latitude,
                                             self.longitude,
                                             units=self.units)
-        self.data = forecast.currently()
-        self.data_minutely = forecast.minutely()
-        self.data_hourly = forecast.hourly()
-        self.data_daily = forecast.daily()
+        self.data = forecast
         self.unit_system = forecast.json['flags']['units']

--- a/homeassistant/components/sensor/forecast.py
+++ b/homeassistant/components/sensor/forecast.py
@@ -18,6 +18,9 @@ _LOGGER = logging.getLogger(__name__)
 # Name, si unit, us unit, ca unit, uk unit, uk2 unit
 SENSOR_TYPES = {
     'summary': ['Summary', None, None, None, None, None],
+    'minutely_summary': ['Minutely Summary', None, None, None, None, None],
+    'hourly_summary': ['Hourly Summary', None, None, None, None, None],
+    'daily_summary': ['Daily Summary', None, None, None, None, None],
     'icon': ['Icon', None, None, None, None, None],
     'nearest_storm_distance': ['Nearest Storm Distance',
                                'km', 'm', 'km', 'km', 'm'],
@@ -135,10 +138,19 @@ class ForeCastSensor(Entity):
 
         self.forecast_client.update()
         data = self.forecast_client.data
+        data_minutely = self.forecast_client.data_minutely
+        data_hourly = self.forecast_client.data_hourly
+        data_daily = self.forecast_client.data_daily
 
         try:
             if self.type == 'summary':
                 self._state = data.summary
+            elif self.type == 'minutely_summary':
+                self._state = data_minutely.summary
+            elif self.type == 'hourly_summary':
+                self._state = data_hourly.summary
+            elif self.type == 'daily_summary':
+                self._state = data_daily.summary
             elif self.type == 'icon':
                 self._state = data.icon
             elif self.type == 'nearest_storm_distance':
@@ -185,6 +197,9 @@ class ForeCastData(object):
         self.latitude = latitude
         self.longitude = longitude
         self.data = None
+        self.data_minutely = None
+        self.data_hourly = None
+        self.data_daily = None
         self.unit_system = None
         self.units = units
         self.update()
@@ -199,4 +214,7 @@ class ForeCastData(object):
                                             self.longitude,
                                             units=self.units)
         self.data = forecast.currently()
+        self.data_minutely = forecast.minutely()
+        self.data_hourly = forecast.hourly()
+        self.data_daily = forecast.daily()
         self.unit_system = forecast.json['flags']['units']


### PR DESCRIPTION
**Description:**
Additional summary types, shown on Forecast.io as "next hour", "next 24 hours" and "next 7 days".

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: forecast
  api_key: YOUR_APP_KEY
  monitored_conditions:
    - minutely_summary
    - hourly_summary
    - daily_summary
```

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
