### PR TITLE
Add reconnect retry and longer timeouts for verisure

### DIFF
--- a/homeassistant/components/alarm_control_panel/verisure.py
+++ b/homeassistant/components/alarm_control_panel/verisure.py
@@ -49,6 +49,11 @@ class VerisureAlarm(alarm.AlarmControlPanel):
         return self._state
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return hub.available
+
+    @property
     def code_format(self):
         """The code format as regex."""
         return '^\\d{%s}$' % self._digits

--- a/homeassistant/components/lock/verisure.py
+++ b/homeassistant/components/lock/verisure.py
@@ -47,6 +47,11 @@ class VerisureDoorlock(LockDevice):
         return self._state
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return hub.available
+
+    @property
     def code_format(self):
         """Return the required six digit code."""
         return '^\\d{%s}$' % self._digits

--- a/homeassistant/components/sensor/verisure.py
+++ b/homeassistant/components/sensor/verisure.py
@@ -66,6 +66,11 @@ class VerisureThermometer(Entity):
         return hub.climate_status[self._id].temperature[:-1]
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return hub.available
+
+    @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity."""
         return TEMP_CELSIUS
@@ -96,6 +101,11 @@ class VerisureHygrometer(Entity):
         return hub.climate_status[self._id].humidity[:-1]
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return hub.available
+
+    @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this sensor."""
         return "%"
@@ -123,6 +133,11 @@ class VerisureMouseDetection(Entity):
     def state(self):
         """Return the state of the sensor."""
         return hub.mouse_status[self._id].count
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return hub.available
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/switch/verisure.py
+++ b/homeassistant/components/switch/verisure.py
@@ -42,6 +42,11 @@ class VerisureSmartplug(SwitchDevice):
         """Return true if on."""
         return hub.smartplug_status[self._id].status == 'on'
 
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return hub.available
+
     def turn_on(self):
         """Set smartplug status on."""
         hub.my_pages.smartplug.set(self._id, 'on')

--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -77,7 +77,7 @@ class VerisureHub(object):
         # "wrong password" message. We will continue to retry after maintenance
         # regardless of that error.
         self._disable_wrong_password_error = False
-        self._wrong_password_given = False
+        self._password_retries = 1
         self._reconnect_timeout = time.time()
 
         self.my_pages = verisure.MyPages(
@@ -128,11 +128,13 @@ class VerisureHub(object):
             self.my_pages.smartplug.get,
             self.smartplug_status)
 
+    @property
+    def available(self):
+        """Return True if hub is available."""
+        return self._password_retries >= 0
+
     def update_component(self, get_function, status):
         """Update the status of Verisure components."""
-        if self._wrong_password_given:
-            _LOGGER.error('Wrong password for Verisure, update config')
-            return
         try:
             for overview in get_function():
                 try:
@@ -145,25 +147,26 @@ class VerisureHub(object):
 
     def reconnect(self):
         """Reconnect to Verisure MyPages."""
-        if self._reconnect_timeout > time.time():
-            return
-        if not self._lock.acquire(blocking=False):
+        if (self._reconnect_timeout > time.time() or
+                not self._lock.acquire(blocking=False) or
+                self._password_retries < 0):
             return
         try:
             self.my_pages.login()
             self._disable_wrong_password_error = False
+            self._password_retries = 1
         except self._verisure.LoginError as ex:
             _LOGGER.error("Wrong user name or password for Verisure MyPages")
             if self._disable_wrong_password_error:
-                self._reconnect_timeout = time.time() + 60
+                self._reconnect_timeout = time.time() + 60*60
             else:
-                self._wrong_password_given = True
+                self._password_retries = self._password_retries - 1
         except self._verisure.MaintenanceError:
             self._disable_wrong_password_error = True
-            self._reconnect_timeout = time.time() + 60
+            self._reconnect_timeout = time.time() + 60*60
             _LOGGER.error("Verisure MyPages down for maintenance")
         except self._verisure.Error as ex:
             _LOGGER.error("Could not login to Verisure MyPages, %s", ex)
-            self._reconnect_timeout = time.time() + 5
+            self._reconnect_timeout = time.time() + 60
         finally:
             self._lock.release()


### PR DESCRIPTION
**Description:**
Add reconnect retry and and longer reconnect timeouts to handle the wrong error messages from verisure mypages.

I have been running this for a while and it has been working so far. 

**Related issue (if applicable):** #
#1289

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
