### PR TITLE
Add support for sensor classes

### DIFF
--- a/homeassistant/components/binary_sensor/command_line.py
+++ b/homeassistant/components/binary_sensor/command_line.py
@@ -7,7 +7,8 @@ https://home-assistant.io/components/binary_sensor.command/
 import logging
 from datetime import timedelta
 
-from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.binary_sensor import (BinarySensorDevice,
+                                                    SENSOR_CLASSES)
 from homeassistant.components.sensor.command_line import CommandSensorData
 from homeassistant.const import CONF_VALUE_TEMPLATE
 from homeassistant.helpers import template
@@ -15,6 +16,7 @@ from homeassistant.helpers import template
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Binary Command Sensor"
+DEFAULT_SENSOR_CLASS = None
 DEFAULT_PAYLOAD_ON = 'ON'
 DEFAULT_PAYLOAD_OFF = 'OFF'
 
@@ -29,28 +31,35 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error('Missing required variable: "command"')
         return False
 
+    sensor_class = config.get('sensor_class')
+    if sensor_class not in SENSOR_CLASSES:
+        _LOGGER.warning('Unknown sensor class: %s', sensor_class)
+        sensor_class = DEFAULT_SENSOR_CLASS
+
     data = CommandSensorData(config.get('command'))
 
     add_devices([CommandBinarySensor(
         hass,
         data,
         config.get('name', DEFAULT_NAME),
+        sensor_class,
         config.get('payload_on', DEFAULT_PAYLOAD_ON),
         config.get('payload_off', DEFAULT_PAYLOAD_OFF),
         config.get(CONF_VALUE_TEMPLATE)
     )])
 
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments, too-many-instance-attributes
 class CommandBinarySensor(BinarySensorDevice):
     """Represent a command line binary sensor."""
 
-    def __init__(self, hass, data, name, payload_on,
+    def __init__(self, hass, data, name, sensor_class, payload_on,
                  payload_off, value_template):
         """Initialize the Command line binary sensor."""
         self._hass = hass
         self.data = data
         self._name = name
+        self._sensor_class = sensor_class
         self._state = False
         self._payload_on = payload_on
         self._payload_off = payload_off
@@ -66,6 +75,11 @@ class CommandBinarySensor(BinarySensorDevice):
     def is_on(self):
         """Return true if the binary sensor is on."""
         return self._state
+
+    @ property
+    def sensor_class(self):
+        """Return the class of the binary sensor."""
+        return self._sensor_class
 
     def update(self):
         """Get the latest data and updates the state."""

--- a/tests/components/binary_sensor/test_command_line.py
+++ b/tests/components/binary_sensor/test_command_line.py
@@ -1,4 +1,4 @@
-"""The tests fr the Command line Binary sensor platform."""
+"""The tests for the Command line Binary sensor platform."""
 import unittest
 
 from homeassistant.const import (STATE_ON, STATE_OFF)
@@ -60,7 +60,8 @@ class TestCommandSensorBinarySensor(unittest.TestCase):
         data = command_line.CommandSensorData('echo 10')
 
         entity = command_line.CommandBinarySensor(
-            self.hass, data, 'test', '1.0', '0', '{{ value | multiply(0.1) }}')
+            self.hass, data, 'test', None, '1.0', '0',
+            '{{ value | multiply(0.1) }}')
 
         self.assertEqual(STATE_ON, entity.state)
 
@@ -69,6 +70,6 @@ class TestCommandSensorBinarySensor(unittest.TestCase):
         data = command_line.CommandSensorData('echo 0')
 
         entity = command_line.CommandBinarySensor(
-            self.hass, data, 'test', '1', '0', None)
+            self.hass, data, 'test', None, '1', '0', None)
 
         self.assertEqual(STATE_OFF, entity.state)


### PR DESCRIPTION
**Description:**
 The Command line binary sensor didn't support the setting of the sensor class so far. 

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
  - platform: command_line
    name: Printer
    command: ping -c 1 10.100.0.250 &> /dev/null && echo success || echo fail
    payload_on: "success"
    payload_off: "fail"
    sensor_class: connectivity
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
