### PR TITLE
Fixed slack component bug with getting the channel when sending a mes…

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -51,7 +51,7 @@ class SlackNotificationService(BaseNotificationService):
         """Send a message to a user."""
         import slacker
 
-        channel = kwargs.get('channel', self._default_channel)
+        channel = kwargs.get('target', self._default_channel)
         try:
             self.slack.chat.post_message(channel, message)
         except slacker.Error:


### PR DESCRIPTION
**Description:**
Fixed notification issue with the Slack component and specifying a user or channel.

Current slack is looking for the "channel" argument when sending a message but this is not accepted by the base notification object. I've updated to accept the target argument for the channel or user.
