### PR TITLE
Orange Pi PC initial support

### DIFF
--- a/homeassistant/components/opi_gpio.py
+++ b/homeassistant/components/opi_gpio.py
@@ -1,0 +1,68 @@
+"""
+Support for controlling GPIO pins of a Orange Pi.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/opi_gpio/
+"""
+# pylint: disable=import-error
+import logging
+
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+
+REQUIREMENTS = ['git+git://github.com/duxingkei33/orangepi_PC_gpio_pyH3.git@master#pyA20==0.2.1']
+DOMAIN = "opi_gpio"
+_LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=no-member
+def setup(hass, config):
+    """Setup the Orange PI GPIO component."""
+    from pyA20.gpio import gpio
+
+    def cleanup_gpio(event):
+        """Stuff to do before stopping."""
+        #GPIO.cleanup()
+
+    def prepare_gpio(event):
+        """Stuff to do when home assistant starts."""
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup_gpio)
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, prepare_gpio)
+    gpio.init()
+    return True
+
+
+def setup_output(port):
+    """Setup a GPIO as output."""
+    from pyA20.gpio import gpio
+    gpio.setcfg(port, gpio.OUTPUT)
+
+
+def setup_input(port, pull_mode):
+    """Setup a GPIO as input."""
+    from pyA20.gpio import gpio
+    gpio.setcfg(port, gpio.INPUT)
+    gpio.pullup(port, gpio.PULLDOWN if pull_mode == 'DOWN' else gpio.PULLUP)
+
+
+def write_output(port, value):
+    """Write a value to a GPIO."""
+    from pyA20.gpio import gpio
+    gpio.output(port, value)
+
+
+def read_input(port):
+    """Read a value from a GPIO."""
+    from pyA20.gpio import gpio
+    return gpio.input(port)
+
+
+def edge_detect(port, event_callback, bounce):
+    """Add detection for RISING and FALLING events."""
+#    import RPi.GPIO as GPIO
+#    GPIO.add_event_detect(
+#        port,
+#        GPIO.BOTH,
+#        callback=event_callback,
+#        bouncetime=bounce)

--- a/homeassistant/components/switch/opi_gpio.py
+++ b/homeassistant/components/switch/opi_gpio.py
@@ -1,0 +1,68 @@
+"""
+Allows to configure a switch using OPi GPIO.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.opi_gpio/
+"""
+
+import logging
+
+import homeassistant.components.opi_gpio as opi_gpio
+from homeassistant.const import DEVICE_DEFAULT_NAME
+from homeassistant.helpers.entity import ToggleEntity
+
+DEFAULT_INVERT_LOGIC = False
+
+DEPENDENCIES = ['opi_gpio']
+_LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Orange PI GPIO devices."""
+    invert_logic = config.get('invert_logic', DEFAULT_INVERT_LOGIC)
+
+    switches = []
+    ports = config.get('ports')
+    for port, name in ports.items():
+        switches.append(OPiGPIOSwitch(name, port, invert_logic))
+    add_devices(switches)
+
+
+class OPiGPIOSwitch(ToggleEntity):
+    """Representation of a Orange Pi GPIO."""
+
+    def __init__(self, name, port, invert_logic):
+        """Initialize the pin."""
+        self._name = name or DEVICE_DEFAULT_NAME
+        self._port = port
+        self._invert_logic = invert_logic
+        self._state = False
+        opi_gpio.setup_output(self._port)
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    def turn_on(self):
+        """Turn the device on."""
+        opi_gpio.write_output(self._port, 0 if self._invert_logic else 1)
+        self._state = True
+        self.update_ha_state()
+
+    def turn_off(self):
+        """Turn the device off."""
+        opi_gpio.write_output(self._port, 1 if self._invert_logic else 0)
+        self._state = False
+        self.update_ha_state()


### PR DESCRIPTION
**Description:**

Very basic implementation for Orange Pi (Allwinner H3 CPU) GPIO component

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
  platform: opi_gpio
  ports:
    362: Standby Led
    15: Normal Led
  invert_logic: false

```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

Very basic implementation for Orange Pi (Allwinner H3 CPU) GPIO component
