### PR TITLE
Update yaml parser for handling environment variables

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -64,6 +64,17 @@ def _ordered_dict(loader, node):
 
     return OrderedDict(nodes)
 
+
+def _env_var_yaml(loader, node):
+    """Load environment variables and embed it into the configuration YAML."""
+    if node.value in os.environ:
+        return os.environ[node.value]
+    else:
+        _LOGGER.error("Environment variable %s not defined.", node.value)
+        raise HomeAssistantError(node.value)
+
+
 yaml.SafeLoader.add_constructor('!include', _include_yaml)
 yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                                 _ordered_dict)
+yaml.SafeLoader.add_constructor('!env_var', _env_var_yaml)


### PR DESCRIPTION
**Description:**
Adds environment variable parser for the yaml config. This allows for setting dynamic values through your host OS which is very useful for debug logging or setting passwords and api tokens when using docker.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
logger:
  default: !env_var HA_LOG_LEVEL

nest:
  username: !env_var NEST_USERNAME
  password: !env_var NEST_PASSWORD
```

**New Errors During Setup Config Verify**
ERROR (MainThread) [homeassistant.util.yaml] Environment variable 'HA_LOG_LEVEL' not defined.
