### PR TITLE
Fix script condition issue (Thanks @bart274)

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -118,7 +118,7 @@ class Script():
     def _check_condition(self, action, variables):
         """Test if condition is matching."""
         self.last_action = action.get(CONF_ALIAS, action[CONF_CONDITION])
-        check = condition.from_config(action)(self.hass, False)
+        check = condition.from_config(action)(self.hass, variables)
         self._log("Test condition {}: {}".format(self.last_action, check))
         return check
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -3,6 +3,8 @@
 from datetime import timedelta
 import unittest
 
+# Otherwise can't test just this file (import order issue)
+import homeassistant.components  # noqa
 import homeassistant.util.dt as dt_util
 from homeassistant.helpers import script
 
@@ -233,9 +235,8 @@ class TestScriptHelper(unittest.TestCase):
         script_obj = script.Script(self.hass, [
             {'event': event},
             {
-                'condition': 'state',
-                'entity_id': 'test.entity',
-                'state': 'hello',
+                'condition': 'template',
+                'value_template': '{{ states.test.entity.state == "hello" }}',
             },
             {'event': event},
         ])


### PR DESCRIPTION
**Description:**
This fixes a bug where template conditions in scripts would raise an exception.

Bug found by @Bart274 

```
16-05-03 16:36:36 homeassistant.helpers.script: Script Bart komt ergens: Running script
16-05-03 16:36:36 homeassistant.core: BusHandler:Exception doing job
Traceback (most recent call last):
  File "C:\python3\lib\site-packages\homeassistant-0.19.0.dev0-py3.4.egg\homeassistant\core.py", line 801, in job_handler
    func(arg)
  File "C:\python3\lib\site-packages\homeassistant-0.19.0.dev0-py3.4.egg\homeassistant\helpers\event.py", line 51, in state_change_listener
    event.data['new_state'])
  File "C:\python3\lib\site-packages\homeassistant-0.19.0.dev0-py3.4.egg\homeassistant\components\automation\state.py", line 58, in state_automation_listener
    call_action()
  File "C:\python3\lib\site-packages\homeassistant-0.19.0.dev0-py3.4.egg\homeassistant\components\automation\state.py", line 53, in call_action
    'for': time_delta,
  File "C:\python3\lib\site-packages\homeassistant-0.19.0.dev0-py3.4.egg\homeassistant\components\automation\__init__.py", line 134, in action
    script_obj.run(variables)
  File "C:\python3\lib\site-packages\homeassistant-0.19.0.dev0-py3.4.egg\homeassistant\helpers\script.py", line 80, in run
    if not self._check_condition(action, variables):
  File "C:\python3\lib\site-packages\homeassistant-0.19.0.dev0-py3.4.egg\homeassistant\helpers\script.py", line 121, in _check_condition
    check = condition.from_config(action)(self.hass, False)
  File "C:\python3\lib\site-packages\homeassistant-0.19.0.dev0-py3.4.egg\homeassistant\helpers\condition.py", line 222, in template_if
    return template(hass, value_template, variables)
  File "C:\python3\lib\site-packages\homeassistant-0.19.0.dev0-py3.4.egg\homeassistant\helpers\condition.py", line 206, in template
    value = render(hass, value_template, variables)
  File "C:\python3\lib\site-packages\homeassistant-0.19.0.dev0-py3.4.egg\homeassistant\helpers\template.py", line 44, in render
    kwargs.update(variables)
TypeError: 'bool' object is not iterable
```

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
script:
  hello:
    sequence:
      - condition: template
        value_template: '{{ states.device_tracker.hello == "world" }'
```

**Checklist:**
If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
