### PR TITLE
[Pioneer AVR] Display the currently select input source as the media title

### DIFF
--- a/homeassistant/components/media_player/pioneer.py
+++ b/homeassistant/components/media_player/pioneer.py
@@ -164,6 +164,11 @@ class PioneerDevice(MediaPlayerDevice):
         """List of available input sources."""
         return list(self._source_name_to_number.keys())
 
+    @property
+    def media_title(self):
+        """Title of current playing media."""
+        return self._selected_source
+
     def turn_off(self):
         """Turn off media player."""
         self.telnet_command("PF")


### PR DESCRIPTION
**Description:**

I saw few other receiver components setting the "media_title" to the currently selected input source, thought it was a good idea.

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
