### PR TITLE
Improve error message for invalid key in config

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -14,6 +14,7 @@ import homeassistant.components as core_components
 import homeassistant.components.group as group
 import homeassistant.config as config_util
 import homeassistant.core as core
+import homeassistant.helpers.config_validation as cv
 import homeassistant.loader as loader
 import homeassistant.util.dt as date_util
 import homeassistant.util.location as loc_util
@@ -76,7 +77,6 @@ def _handle_requirements(hass, component, name):
 def _setup_component(hass, domain, config):
     """Setup a component for Home Assistant."""
     # pylint: disable=too-many-return-statements,too-many-branches
-    # pylint: disable=too-many-statements
     if domain in hass.config.components:
         return True
 
@@ -104,13 +104,7 @@ def _setup_component(hass, domain, config):
             try:
                 config = component.CONFIG_SCHEMA(config)
             except vol.MultipleInvalid as ex:
-                if 'extra keys not allowed' in ex.error_message:
-                    _LOGGER.error('Invalid config: [%s] is an invalid option'
-                                  ' for [%s]. Check: %s.', ex.path[-1], domain,
-                                  '->'.join('%s' % m for m in ex.path))
-                    return False
-
-                _LOGGER.error('Invalid config for [%s]: %s', domain, ex)
+                cv.log_exception(_LOGGER, ex, domain)
                 return False
 
         elif hasattr(component, 'PLATFORM_SCHEMA'):
@@ -120,14 +114,7 @@ def _setup_component(hass, domain, config):
                 try:
                     p_validated = component.PLATFORM_SCHEMA(p_config)
                 except vol.MultipleInvalid as ex:
-                    if 'extra keys not allowed' in ex.error_message:
-                        _LOGGER.error('Invalid config: [%s] is an invalid'
-                                      ' option for [%s]. Check: %s->%s.',
-                                      ex.path[-1], domain, domain,
-                                      '->'.join('%s' % m for m in ex.path))
-                        return False
-                    _LOGGER.error('Invalid platform config for [%s]: %s. %s',
-                                  domain, ex, p_config)
+                    cv.log_exception(_LOGGER, ex, domain)
                     return False
 
                 # Not all platform components follow same pattern for platforms
@@ -148,9 +135,8 @@ def _setup_component(hass, domain, config):
                     try:
                         p_validated = platform.PLATFORM_SCHEMA(p_validated)
                     except vol.MultipleInvalid as ex:
-                        _LOGGER.error(
-                            'Invalid platform config for [%s.%s]: %s. %s',
-                            domain, p_name, ex, p_config)
+                        cv.log_exception(_LOGGER, ex, '{}.{}'
+                                         .format(domain, p_name))
                         return False
 
                 platforms.append(p_validated)
@@ -246,12 +232,7 @@ def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
         process_ha_core_config(hass, config_util.CORE_CONFIG_SCHEMA(
             config.get(core.DOMAIN, {})))
     except vol.MultipleInvalid as ex:
-        if 'extra keys not allowed' in ex.error_message:
-            _LOGGER.error('Invalid config: [%s] is an invalid option'
-                          ' for [homeassistant]. Check: homeassistant->%s.',
-                          ex.path[-1], '->'.join('%s' % m for m in ex.path))
-            return None
-        _LOGGER.error('Invalid config for [homeassistant]: %s', ex)
+        cv.log_exception(_LOGGER, ex, 'homeassistant')
         return None
 
     process_ha_config_upgrade(hass)

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -76,6 +76,7 @@ def _handle_requirements(hass, component, name):
 def _setup_component(hass, domain, config):
     """Setup a component for Home Assistant."""
     # pylint: disable=too-many-return-statements,too-many-branches
+    # pylint: disable=too-many-statements
     if domain in hass.config.components:
         return True
 
@@ -103,6 +104,12 @@ def _setup_component(hass, domain, config):
             try:
                 config = component.CONFIG_SCHEMA(config)
             except vol.MultipleInvalid as ex:
+                if 'extra keys not allowed' in ex.error_message:
+                    _LOGGER.error('Invalid config: [%s] is an invalid option'
+                                  ' for [%s]. Check: %s.', ex.path[-1], domain,
+                                  '->'.join('%s' % m for m in ex.path))
+                    return False
+
                 _LOGGER.error('Invalid config for [%s]: %s', domain, ex)
                 return False
 
@@ -113,6 +120,12 @@ def _setup_component(hass, domain, config):
                 try:
                     p_validated = component.PLATFORM_SCHEMA(p_config)
                 except vol.MultipleInvalid as ex:
+                    if 'extra keys not allowed' in ex.error_message:
+                        _LOGGER.error('Invalid config: [%s] is an invalid'
+                                      ' option for [%s]. Check: %s->%s.',
+                                      ex.path[-1], domain, domain,
+                                      '->'.join('%s' % m for m in ex.path))
+                        return False
                     _LOGGER.error('Invalid platform config for [%s]: %s. %s',
                                   domain, ex, p_config)
                     return False
@@ -233,6 +246,11 @@ def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
         process_ha_core_config(hass, config_util.CORE_CONFIG_SCHEMA(
             config.get(core.DOMAIN, {})))
     except vol.MultipleInvalid as ex:
+        if 'extra keys not allowed' in ex.error_message:
+            _LOGGER.error('Invalid config: [%s] is an invalid option'
+                          ' for [homeassistant]. Check: homeassistant->%s.',
+                          ex.path[-1], '->'.join('%s' % m for m in ex.path))
+            return None
         _LOGGER.error('Invalid config for [homeassistant]: %s', ex)
         return None
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -146,6 +146,18 @@ def time_period_str(value):
 time_period = vol.Any(time_period_str, timedelta, time_period_dict)
 
 
+def log_exception(logger, ex, domain):
+    """Generate log exception for config validation."""
+    message = 'Invalid config for [{}]: '.format(domain)
+    if 'extra keys not allowed' in ex.error_message:
+        message += '[{}] is an invalid option for [{}]. Check: {}->{}.'\
+                   .format(ex.path[-1], domain, domain,
+                           '->'.join('%s' % m for m in ex.path))
+    else:
+        message += ex.error_message
+    logger.error(message)
+
+
 def match_all(value):
     """Validator that matches all values."""
     return value


### PR DESCRIPTION
**Description:**
I have seen some questions from people that do not understand the error message if there is an invalid key in the configuration. This PR tries to make it easier for the user to find the mistake in the config.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
rfxtrx:
  invalid_key:
```

Will give an error like:
16-05-04 09:50:39 ERROR (MainThread) [homeassistant.bootstrap] Invalid config: [invalid_key] is an invalid option for [rfxtrx]. Check: rfxtrx->invalid_key.
