### PR TITLE
Add timeout to request

### DIFF
--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -63,10 +63,11 @@ def distance(lat1, lon1, lat2, lon2):
 
 def elevation(latitude, longitude):
     """Return elevation for given latitude and longitude."""
-    req = requests.get(ELEVATION_URL, params={
-        'locations': '{},{}'.format(latitude, longitude),
-        'sensor': 'false',
-    })
+    req = requests.get(ELEVATION_URL,
+                       params={'locations': '{},{}'.format(latitude,
+                                                           longitude),
+                               'sensor': 'false'},
+                       timeout=10)
 
     if req.status_code != 200:
         return 0


### PR DESCRIPTION
**Description:**
The request for the elevation to Google Map API could slowdown the launch of HA. The 10 s timeout should help to avoid long waiting.

Perhaps we should think about using https for the requests, too.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
Default configuration will work.
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
