### PR TITLE
Added battery level to wink devices

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -7,10 +7,10 @@ at https://home-assistant.io/components/sensor.wink/
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-wink==0.7.5']
+REQUIREMENTS = ['python-wink==0.7.6']
 
 # These are the available sensors mapped to binary_sensor class
 SENSOR_TYPES = {
@@ -48,6 +48,7 @@ class WinkBinarySensorDevice(BinarySensorDevice, Entity):
         """Initialize the Wink binary sensor."""
         self.wink = wink
         self._unit_of_measurement = self.wink.UNIT
+        self._battery = self.wink.battery_level
         self.capability = self.wink.capability()
 
     @property
@@ -85,3 +86,16 @@ class WinkBinarySensorDevice(BinarySensorDevice, Entity):
     def update(self):
         """Update state of the sensor."""
         self.wink.update_state()
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        if self._battery:
+            return {
+                ATTR_BATTERY_LEVEL: self._battery_level,
+            }
+
+    @property
+    def _battery_level(self):
+        """Return the battery level."""
+        return self.wink.battery_level * 100

--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -7,9 +7,9 @@ https://home-assistant.io/components/garage_door.wink/
 import logging
 
 from homeassistant.components.garage_door import GarageDoorDevice
-from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
 
-REQUIREMENTS = ['python-wink==0.7.5']
+REQUIREMENTS = ['python-wink==0.7.6']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -37,6 +37,7 @@ class WinkGarageDoorDevice(GarageDoorDevice):
     def __init__(self, wink):
         """Initialize the garage door."""
         self.wink = wink
+        self._battery = self.wink.battery_level
 
     @property
     def unique_id(self):
@@ -69,3 +70,16 @@ class WinkGarageDoorDevice(GarageDoorDevice):
     def open_door(self):
         """Open the door."""
         self.wink.set_state(1)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        if self._battery:
+            return {
+                ATTR_BATTERY_LEVEL: self._battery_level,
+            }
+
+    @property
+    def _battery_level(self):
+        """Return the battery level."""
+        return self.wink.battery_level * 100

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -13,7 +13,7 @@ from homeassistant.util import color as color_util
 from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
 
-REQUIREMENTS = ['python-wink==0.7.5']
+REQUIREMENTS = ['python-wink==0.7.6']
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -7,9 +7,9 @@ https://home-assistant.io/components/lock.wink/
 import logging
 
 from homeassistant.components.lock import LockDevice
-from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
 
-REQUIREMENTS = ['python-wink==0.7.5']
+REQUIREMENTS = ['python-wink==0.7.6']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -36,6 +36,7 @@ class WinkLockDevice(LockDevice):
     def __init__(self, wink):
         """Initialize the lock."""
         self.wink = wink
+        self._battery = self.wink.battery_level
 
     @property
     def unique_id(self):
@@ -68,3 +69,16 @@ class WinkLockDevice(LockDevice):
     def unlock(self, **kwargs):
         """Unlock the device."""
         self.wink.set_state(False)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        if self._battery:
+            return {
+                ATTR_BATTERY_LEVEL: self._battery_level,
+            }
+
+    @property
+    def _battery_level(self):
+        """Return the battery level."""
+        return self.wink.battery_level * 100

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -7,10 +7,11 @@ at https://home-assistant.io/components/sensor.wink/
 import logging
 
 from homeassistant.const import (CONF_ACCESS_TOKEN, STATE_CLOSED,
-                                 STATE_OPEN, TEMP_CELSIUS)
+                                 STATE_OPEN, TEMP_CELSIUS,
+                                 ATTR_BATTERY_LEVEL)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-wink==0.7.5']
+REQUIREMENTS = ['python-wink==0.7.6']
 
 SENSOR_TYPES = ['temperature', 'humidity']
 
@@ -44,6 +45,7 @@ class WinkSensorDevice(Entity):
         """Initialize the sensor."""
         self.wink = wink
         self.capability = self.wink.capability()
+        self._battery = self.wink.battery_level
         if self.wink.UNIT == "°":
             self._unit_of_measurement = TEMP_CELSIUS
         else:
@@ -88,6 +90,19 @@ class WinkSensorDevice(Entity):
         """Return true if door is open."""
         return self.wink.state()
 
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        if self._battery:
+            return {
+                ATTR_BATTERY_LEVEL: self._battery_level,
+            }
+
+    @property
+    def _battery_level(self):
+        """Return the battery level."""
+        return self.wink.battery_level * 100
+
 
 class WinkEggMinder(Entity):
     """Representation of a Wink Egg Minder."""
@@ -95,6 +110,7 @@ class WinkEggMinder(Entity):
     def __init__(self, wink):
         """Initialize the sensor."""
         self.wink = wink
+        self._battery = self.wink.battery_level
 
     @property
     def state(self):
@@ -114,3 +130,16 @@ class WinkEggMinder(Entity):
     def update(self):
         """Update state of the Egg Minder."""
         self.wink.update_state()
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        if self._battery:
+            return {
+                ATTR_BATTERY_LEVEL: self._battery_level,
+            }
+
+    @property
+    def _battery_level(self):
+        """Return the battery level."""
+        return self.wink.battery_level * 100

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.wink import WinkToggleDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.5']
+REQUIREMENTS = ['python-wink==0.7.6']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -9,13 +9,13 @@ import logging
 from homeassistant import bootstrap
 from homeassistant.const import (
     ATTR_DISCOVERED, ATTR_SERVICE, CONF_ACCESS_TOKEN,
-    EVENT_PLATFORM_DISCOVERED)
+    EVENT_PLATFORM_DISCOVERED, ATTR_BATTERY_LEVEL)
 from homeassistant.helpers import validate_config
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.loader import get_component
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.7.5']
+REQUIREMENTS = ['python-wink==0.7.6']
 
 DISCOVER_LIGHTS = "wink.lights"
 DISCOVER_SWITCHES = "wink.switches"
@@ -68,6 +68,7 @@ class WinkToggleDevice(ToggleEntity):
     def __init__(self, wink):
         """Initialize the Wink device."""
         self.wink = wink
+        self._battery = self.wink.battery_level
 
     @property
     def unique_id(self):
@@ -100,3 +101,16 @@ class WinkToggleDevice(ToggleEntity):
     def update(self):
         """Update state of the device."""
         self.wink.update_state()
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        if self._battery:
+            return {
+                ATTR_BATTERY_LEVEL: self._battery_level,
+            }
+
+    @property
+    def _battery_level(self):
+        """Return the battery level."""
+        return self.wink.battery_level * 100

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -258,7 +258,7 @@ python-twitch==1.2.0
 # homeassistant.components.lock.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.7.5
+python-wink==0.7.6
 
 # homeassistant.components.keyboard
 pyuserinput==0.1.9


### PR DESCRIPTION
**Description:**
Add battery attribute to all Wink devices that can return a battery level.

This adds the battery level to the details card on all of my wink devices besides Wink locks. I see the battery level for the lock under the < > tool. Is there something I am missing to get this added to the detailed state card?

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
