### PR TITLE
Bring back custom scan intervals and service for speedtest.net component

### DIFF
--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -10,7 +10,10 @@ import sys
 from datetime import timedelta
 from subprocess import check_output
 
+import homeassistant.util.dt as dt_util
+from homeassistant.components.sensor import DOMAIN
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import track_time_change
 from homeassistant.util import Throttle
 
 REQUIREMENTS = ['speedtest-cli==0.3.4']
@@ -31,12 +34,12 @@ SENSOR_TYPES = {
 }
 
 # Return cached results if last scan was less then this time ago
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=15)
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Speedtest sensor."""
-    data = SpeedtestData()
+    data = SpeedtestData(hass, config)
     dev = []
     for sensor in config[CONF_MONITORED_CONDITIONS]:
         if sensor not in SENSOR_TYPES:
@@ -45,6 +48,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             dev.append(SpeedtestSensor(data, sensor))
 
     add_devices(dev)
+
+    def update(call=None):
+        """Update service for manual updates."""
+        data.update(dt_util.now())
+        for sensor in dev:
+            sensor.update()
+
+    hass.services.register(DOMAIN, 'update_speedtest', update)
 
 
 # pylint: disable=too-few-public-methods
@@ -76,7 +87,6 @@ class SpeedtestSensor(Entity):
 
     def update(self):
         """Get the latest data and update the states."""
-        self.speedtest_client.update()
         data = self.speedtest_client.data
         if data is None:
             return
@@ -92,12 +102,18 @@ class SpeedtestSensor(Entity):
 class SpeedtestData(object):
     """Get the latest data from speedtest.net."""
 
-    def __init__(self):
+    def __init__(self, hass, config):
         """Initialize the data object."""
         self.data = None
+        self.hass = hass
+        self.path = hass.config.path
+        track_time_change(self.hass, self.update,
+                          minute=config.get(CONF_MINUTE, 0),
+                          hour=config.get(CONF_HOUR, None),
+                          day=config.get(CONF_DAY, None))
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def update(self):
+    def update(self, now):
         """Get the latest data from speedtest.net."""
         import speedtest_cli
 

--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -7,14 +7,12 @@ https://home-assistant.io/components/sensor.speedtest/
 import logging
 import re
 import sys
-from datetime import timedelta
 from subprocess import check_output
 
 import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import DOMAIN
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_change
-from homeassistant.util import Throttle
 
 REQUIREMENTS = ['speedtest-cli==0.3.4']
 _LOGGER = logging.getLogger(__name__)
@@ -32,9 +30,6 @@ SENSOR_TYPES = {
     'download': ['Download', 'Mbit/s'],
     'upload': ['Upload', 'Mbit/s'],
 }
-
-# Return cached results if last scan was less then this time ago
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -105,14 +100,11 @@ class SpeedtestData(object):
     def __init__(self, hass, config):
         """Initialize the data object."""
         self.data = None
-        self.hass = hass
-        self.path = hass.config.path
-        track_time_change(self.hass, self.update,
+        track_time_change(hass, self.update,
                           minute=config.get(CONF_MINUTE, 0),
                           hour=config.get(CONF_HOUR, None),
                           day=config.get(CONF_DAY, None))
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self, now):
         """Get the latest data from speedtest.net."""
         import speedtest_cli


### PR DESCRIPTION
**Description:**
Bring back the functionality that was removed in [PR 1717](https://github.com/home-assistant/home-assistant/pull/1717). This includes the speedtest service and the ability to define the scan times in the configuration file.  Restore default functionality of 1 scan per hour on the hour.

**Related issue (if applicable):** #
1906

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: speedtest
  monitored_conditions:
    - download
  minute: 30
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
