### PR TITLE
Check for 'unknown' sensor values in ecobee

### DIFF
--- a/homeassistant/components/sensor/ecobee.py
+++ b/homeassistant/components/sensor/ecobee.py
@@ -78,18 +78,10 @@ class EcobeeSensor(Entity):
         data.update()
         for sensor in data.ecobee.get_remote_sensors(self.index):
             for item in sensor['capability']:
-                if (
-                        item['type'] == self.type and
-                        self.type == 'temperature' and
+                if (item['type'] == self.type and
                         self.sensor_name == sensor['name']):
-                    self._state = float(item['value']) / 10
-                elif (
-                        item['type'] == self.type and
-                        self.type == 'humidity' and
-                        self.sensor_name == sensor['name']):
-                    self._state = item['value']
-                elif (
-                        item['type'] == self.type and
-                        self.type == 'occupancy' and
-                        self.sensor_name == sensor['name']):
-                    self._state = item['value']
+                    if (self.type == 'temperature' and
+                            item['value'] != 'unknown'):
+                        self._state = float(item['value']) / 10
+                    else:
+                        self._state = item['value']


### PR DESCRIPTION
**Description:**
When the sensor is unavailable / offline, the ecobee API returns 'unknown' for temp value.  This fix will check for that while simplifying the logic a bit.

**Related issue (if applicable):** #
[1897
](https://github.com/home-assistant/home-assistant/issues/1897)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
