### PR TITLE
Ugrade to PyMata 2.12

### DIFF
--- a/homeassistant/components/arduino.py
+++ b/homeassistant/components/arduino.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
 from homeassistant.helpers import validate_config
 
 DOMAIN = "arduino"
-REQUIREMENTS = ['PyMata==2.07a']
+REQUIREMENTS = ['PyMata==2.12']
 BOARD = None
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -11,7 +11,7 @@ voluptuous==0.8.9
 PyISY==1.0.5
 
 # homeassistant.components.arduino
-PyMata==2.07a
+PyMata==2.12
 
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.6.1


### PR DESCRIPTION
2.12
- This release assures that all data sent to Firmata is restricted to 7 bit bytes.

2.11
- Implemented gengshenghong's performance fix

2.09
- This release adds a small delay to the pymata_serial loop as suggested in issue 19.

Tested with the following configuration and Arduino Nano:

``` yaml
  - platform: arduino
    pins:
      10:
        name: Pin 10
        type: digital
        default: on
      12:
        name: Pin 12
        type: digital
```
