### PR TITLE
Upgrade pylint to 1.5.5

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 flake8>=2.5.1
-pylint>=1.5.3
+pylint>=1.5.5
 coveralls>=1.1
 pytest>=2.8.0
 pytest-cov>=2.2.0


### PR DESCRIPTION
```
$ pylint --version
pylint 1.5.5, 
astroid 1.4.5
Python 3.4.3 (default, Mar 31 2016, 20:42:37) 
[GCC 5.3.1 20151207 (Red Hat 5.3.1-2)]
(home-assistant) [fab@laptop019 home-assistant]$ script/lint 
GLOB sdist-make: /home/fab/Documents/repos/home-assistant/setup.py
....
```
