### PR TITLE
Upgrade flake8

### DIFF
--- a/homeassistant/components/hvac/zwave.py
+++ b/homeassistant/components/hvac/zwave.py
@@ -1,5 +1,9 @@
-"""ZWave Hvac device."""
+"""
+Support for ZWave HVAC devices.
 
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/hvac.zwave/
+"""
 # Because we do not compile openzwave on CI
 # pylint: disable=import-error
 import logging

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-flake8>=2.5.1
+flake8>=2.5.4
 pylint>=1.5.5
 coveralls>=1.1
 pytest>=2.9.1


### PR DESCRIPTION
2.5.4 - 2016-02-11
- Bug Missed an attribute rename during the v2.5.3 release.

2.5.3 - 2016-02-11
- Bug Actually parse output_file and enable_extensions from config files

2.5.2 - 2016-01-30
- Bug Parse output_file and enable_extensions from config files
- Improvement Raise upper bound on mccabe plugin to allow for version 0.4.0
