### PR TITLE
add send_message to ecobee via service call

### DIFF
--- a/homeassistant/components/ecobee.py
+++ b/homeassistant/components/ecobee.py
@@ -22,7 +22,7 @@ HOLD_TEMP = 'hold_temp'
 
 REQUIREMENTS = [
     'https://github.com/nkgilley/python-ecobee-api/archive/'
-    '92a2f330cbaf601d0618456fdd97e5a8c42c1c47.zip#python-ecobee==0.0.4']
+    '4a884bc146a93991b4210f868f3d6aecf0a181e6.zip#python-ecobee==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/notify/ecobee.py
+++ b/homeassistant/components/notify/ecobee.py
@@ -1,0 +1,31 @@
+"""
+Support for ecobee Send Message service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.ecobee/
+"""
+import logging
+from homeassistant.components import ecobee
+from homeassistant.components.notify import BaseNotificationService
+
+DEPENDENCIES = ['ecobee']
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_service(hass, config):
+    """Get the Ecobee notification service."""
+    index = int(config['index']) if 'index' in config else 0
+    return EcobeeNotificationService(index)
+
+
+# pylint: disable=too-few-public-methods
+class EcobeeNotificationService(BaseNotificationService):
+    """Implement the notification service for the Ecobee thermostat."""
+
+    def __init__(self, thermostat_index):
+        """Initialize the service."""
+        self.thermostat_index = thermostat_index
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to a command line."""
+        ecobee.NETWORK.ecobee.send_message(self.thermostat_index, message)

--- a/homeassistant/components/thermostat/ecobee.py
+++ b/homeassistant/components/thermostat/ecobee.py
@@ -55,7 +55,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     def send_message_service(service):
         """Send message to thermostats."""
-
         message = service.data['message']
         for thermostat in thermostats:
             thermostat.send_message(message)
@@ -67,6 +66,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 class Thermostat(ThermostatDevice):
     """A thermostat class for Ecobee."""
+
     def __init__(self, data, thermostat_index, hold_temp):
         """Initialize the thermostat."""
         self.data = data

--- a/homeassistant/components/thermostat/ecobee.py
+++ b/homeassistant/components/thermostat/ecobee.py
@@ -54,7 +54,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(thermostats)
 
     def send_message_service(service):
-        """Send message to thermostats"""
+        """Send message to thermostats."""
 
         message = service.data['message']
         for thermostat in thermostats:
@@ -67,7 +67,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 class Thermostat(ThermostatDevice):
     """A thermostat class for Ecobee."""
-
     def __init__(self, data, thermostat_index, hold_temp):
         """Initialize the thermostat."""
         self.data = data
@@ -236,4 +235,3 @@ class Thermostat(ThermostatDevice):
     #     """ Turns sleep mode off. """
     #     self._away = False
     #     self.data.ecobee.resume_program(self.thermostat_index)
-

--- a/homeassistant/components/thermostat/ecobee.py
+++ b/homeassistant/components/thermostat/ecobee.py
@@ -6,15 +6,36 @@ https://home-assistant.io/components/thermostat.ecobee/
 """
 import logging
 
+import voluptuous as vol
+
 from homeassistant.components import ecobee
 from homeassistant.components.thermostat import (
     STATE_COOL, STATE_HEAT, STATE_IDLE, ThermostatDevice)
 from homeassistant.const import STATE_OFF, STATE_ON, TEMP_FAHRENHEIT
 
+
 DEPENDENCIES = ['ecobee']
+DOMAIN = "thermostat"
 _LOGGER = logging.getLogger(__name__)
 ECOBEE_CONFIG_FILE = 'ecobee.conf'
 _CONFIGURING = {}
+
+ATTR_MESSAGE = 'message'
+SEND_MESSAGE_SCHEMA = vol.Schema({
+    vol.Required(ATTR_MESSAGE): vol.Coerce(str),
+})
+
+MESSAGE_DESCRIPTIONS = {
+    'send_message': {
+        'description': 'Send a message to the thermostat',
+        'fields': {
+            'message': {
+                'description': 'Messsage to send to thermostat(s)',
+                'example': 'Hello from Home Assistant!'
+            }
+        }
+    }
+}
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -26,8 +47,22 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     _LOGGER.info(
         "Loading ecobee thermostat component with hold_temp set to %s",
         hold_temp)
-    add_devices(Thermostat(data, index, hold_temp)
-                for index in range(len(data.ecobee.thermostats)))
+
+    thermostats = []
+    for index in range(len(data.ecobee.thermostats)):
+        thermostats.append(Thermostat(data, index, hold_temp))
+    add_devices(thermostats)
+
+    def send_message_service(service):
+        """Send message to thermostats"""
+
+        message = service.data['message']
+        for thermostat in thermostats:
+            thermostat.send_message(message)
+
+    hass.services.register(DOMAIN, 'send_message', send_message_service,
+                           MESSAGE_DESCRIPTIONS.get('send_message'),
+                           SEND_MESSAGE_SCHEMA)
 
 
 class Thermostat(ThermostatDevice):
@@ -176,6 +211,10 @@ class Thermostat(ThermostatDevice):
         """Set HVAC mode (auto, auxHeatOnly, cool, heat, off)."""
         self.data.ecobee.set_hvac_mode(self.thermostat_index, mode)
 
+    def send_message(self, message):
+        """Send message to thermostat."""
+        self.data.ecobee.send_message(self.thermostat_index, message)
+
     # Home and Sleep mode aren't used in UI yet:
 
     # def turn_home_mode_on(self):
@@ -197,3 +236,4 @@ class Thermostat(ThermostatDevice):
     #     """ Turns sleep mode off. """
     #     self._away = False
     #     self.data.ecobee.resume_program(self.thermostat_index)
+

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -110,7 +110,7 @@ https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
 
 # homeassistant.components.ecobee
-https://github.com/nkgilley/python-ecobee-api/archive/92a2f330cbaf601d0618456fdd97e5a8c42c1c47.zip#python-ecobee==0.0.4
+https://github.com/nkgilley/python-ecobee-api/archive/4a884bc146a93991b4210f868f3d6aecf0a181e6.zip#python-ecobee==0.0.5
 
 # homeassistant.components.switch.edimax
 https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f3700.zip#pyedimax==0.1


### PR DESCRIPTION
**Description:**
Add a service to ecobee thermostats that allow the user to send a message to the thermostat.  The message text is defined in the service data as 'message'.

**Example:**
Call the thermostat.send_message service with the following service data:

``` json
{"message":"Hello from Home Assistant!"}
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
