### PR TITLE
Fix problem with Slack default channel

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -51,7 +51,7 @@ class SlackNotificationService(BaseNotificationService):
         """Send a message to a user."""
         import slacker
 
-        channel = kwargs.get('target', self._default_channel)
+        channel = kwargs.get('target') or self._default_channel
         try:
             self.slack.chat.post_message(channel, message)
         except slacker.Error:


### PR DESCRIPTION
**Description:** The default channel is always ignored because the target key always exists (see [here](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/notify/__init__.py#L87)) though it is `None`, unless specified in the service call. This caused Slack notifications to stop working unless a `target` was specified.

**Related issue (if applicable):** #1954

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
