### PR TITLE
add link ability to configurator

### DIFF
--- a/homeassistant/components/configurator.py
+++ b/homeassistant/components/configurator.py
@@ -19,6 +19,8 @@ SERVICE_CONFIGURE = "configure"
 STATE_CONFIGURE = "configure"
 STATE_CONFIGURED = "configured"
 
+ATTR_LINK_NAME = "link_name"
+ATTR_LINK_URL = "link_url"
 ATTR_CONFIGURE_ID = "configure_id"
 ATTR_DESCRIPTION = "description"
 ATTR_DESCRIPTION_IMAGE = "description_image"
@@ -34,7 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 # pylint: disable=too-many-arguments
 def request_config(
         hass, name, callback, description=None, description_image=None,
-        submit_caption=None, fields=None):
+        submit_caption=None, fields=None, link_name=None, link_url=None):
     """Create a new request for configuration.
 
     Will return an ID to be used for sequent calls.
@@ -43,7 +45,8 @@ def request_config(
 
     request_id = instance.request_config(
         name, callback,
-        description, description_image, submit_caption, fields)
+        description, description_image, submit_caption,
+        fields, link_name, link_url)
 
     _REQUESTS[request_id] = instance
 
@@ -100,7 +103,8 @@ class Configurator(object):
     # pylint: disable=too-many-arguments
     def request_config(
             self, name, callback,
-            description, description_image, submit_caption, fields):
+            description, description_image, submit_caption,
+            fields, link_name, link_url):
         """Setup a request for configuration."""
         entity_id = generate_entity_id(ENTITY_ID_FORMAT, name, hass=self.hass)
 
@@ -121,6 +125,8 @@ class Configurator(object):
                 (ATTR_DESCRIPTION, description),
                 (ATTR_DESCRIPTION_IMAGE, description_image),
                 (ATTR_SUBMIT_CAPTION, submit_caption),
+                (ATTR_LINK_NAME, link_name),
+                (ATTR_LINK_URL, link_url),
             ] if value is not None
         })
 


### PR DESCRIPTION
**Description:**
Not thrilled with this but unsure of what would be better. This allows the dev to construct his description in such a way to have it end with a link like the few components I looked at do anyway.

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
