### PR TITLE
Use Throttle on speedtest update

### DIFF
--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -34,6 +34,7 @@ SENSOR_TYPES = {
 }
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Speedtest sensor."""
     data = SpeedtestData(hass, config)

--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -7,7 +7,9 @@ https://home-assistant.io/components/sensor.speedtest/
 import logging
 import re
 import sys
+from datetime import timedelta
 from subprocess import check_output
+from homeassistant.util import Throttle
 
 import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import DOMAIN
@@ -30,7 +32,7 @@ SENSOR_TYPES = {
     'download': ['Download', 'Mbit/s'],
     'upload': ['Upload', 'Mbit/s'],
 }
-
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Speedtest sensor."""
@@ -105,6 +107,7 @@ class SpeedtestData(object):
                           hour=config.get(CONF_HOUR, None),
                           day=config.get(CONF_DAY, None))
 
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self, now):
         """Get the latest data from speedtest.net."""
         import speedtest_cli


### PR DESCRIPTION
**Description:**
Bringing back the short 1 minute `Throttle` for the speedtest `update`.  Without it I was seeing the component spawn simultaneous updates for each time listed in the configuration.yaml.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: speedtest
  minute:
    - 0
    - 5
    - 10
    - 15
    - 20
    - 25
    - 30
    - 35
    - 40
    - 45
    - 50
    - 55
  monitored_conditions:
    - ping
    - download
    - upload
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
