### PR TITLE
Fix speedtest, again

### DIFF
--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -7,9 +7,7 @@ https://home-assistant.io/components/sensor.speedtest/
 import logging
 import re
 import sys
-from datetime import timedelta
 from subprocess import check_output
-from homeassistant.util import Throttle
 
 import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import DOMAIN
@@ -24,6 +22,7 @@ _SPEEDTEST_REGEX = re.compile(r'Ping:\s(\d+\.\d+)\sms[\r\n]+'
                               r'Upload:\s(\d+\.\d+)\sMbit/s[\r\n]+')
 
 CONF_MONITORED_CONDITIONS = 'monitored_conditions'
+CONF_SECOND = 'second'
 CONF_MINUTE = 'minute'
 CONF_HOUR = 'hour'
 CONF_DAY = 'day'
@@ -32,7 +31,6 @@ SENSOR_TYPES = {
     'download': ['Download', 'Mbit/s'],
     'upload': ['Upload', 'Mbit/s'],
 }
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -104,11 +102,11 @@ class SpeedtestData(object):
         """Initialize the data object."""
         self.data = None
         track_time_change(hass, self.update,
+                          second=config.get(CONF_SECOND, 0),
                           minute=config.get(CONF_MINUTE, 0),
                           hour=config.get(CONF_HOUR, None),
                           day=config.get(CONF_DAY, None))
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self, now):
         """Get the latest data from speedtest.net."""
         import speedtest_cli


### PR DESCRIPTION
**Description:**
This should be the last of the speedtest fixes for the week :wink:   I removed the `Throttle` as it's not necessary.  The problem was that I wasn't giving a `second` argument to the `track_time_change` function and it was executing 11 tests in a row at seconds 0-10.

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

…ack_time_change
