### PR TITLE
Handle MPD exceptions

### DIFF
--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -89,7 +89,13 @@ class MpdDevice(MediaPlayerDevice):
         try:
             self.status = self.client.status()
             self.currentsong = self.client.currentsong()
-        except mpd.ConnectionError:
+        except (mpd.ConnectionError, BrokenPipeError, ValueError):
+            # Cleanly disconnect in case connection is not in valid state
+            try:
+                self.client.disconnect()
+            except mpd.ConnectionError:
+                pass
+
             self.client.connect(self.server, self.port)
 
             if self.password is not None:


### PR DESCRIPTION
MPD can get into a bad state. The module we use, `mpd2`, does not handle these and does not intend to (see https://github.com/Mic92/python-mpd2/issues/31, https://github.com/Mic92/python-mpd2/issues/71). This PR adds some extra protections.

Here's some examples of behavior prior to this fix:

```
  File "homeassistant/components/media_player/mpd.py", line 90, in update
    self.status = self.client.status()
  File "mpd.py", line 629, in decorator
    return wrapper(self, name, args, bound_decorator(self, returnValue))
  File "mpd.py", line 252, in _execute
    self._write_command(command, args)
  File "mpd.py", line 279, in _write_command
    self._write_line(" ".join(parts))
  File "mpd.py", line 258, in _write_line
    self._wfile.write("%s\n" % line)
ValueError: I/O operation on closed file.
```

```
  File "homeassistant/components/media_player/mpd.py", line 90, in update
    self.status = self.client.status()
  File "mpd.py", line 629, in decorator
    return wrapper(self, name, args, bound_decorator(self, returnValue))
  File "mpd.py", line 252, in _execute
    self._write_command(command, args)
  File "mpd.py", line 279, in _write_command
    self._write_line(" ".join(parts))
  File "mpd.py", line 259, in _write_line
    self._wfile.flush()
  File "/usr/lib/python3.4/socket.py", line 394, in write
    return self._sock.send(b)
BrokenPipeError: [Errno 32] Broken pipe

```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
