### PR TITLE
Google travel time improvements

### DIFF
--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -57,7 +57,7 @@ def convert_time_to_utc(timestr):
     combined = datetime.combine(dt_util.start_of_local_day(),
                                 dt_util.parse_time(timestr))
     if combined < datetime.now():
-      combined = combined + timedelta(days=1)
+        combined = combined + timedelta(days=1)
     return dt_util.as_timestamp(combined)
 
 

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -54,8 +54,11 @@ PLATFORM_SCHEMA = vol.Schema({
 
 def convert_time_to_utc(timestr):
     """Take a string like 08:00:00 and convert it to a unix timestamp."""
-    return dt_util.as_timestamp(datetime.combine(dt_util.start_of_local_day(),
-                                                 dt_util.parse_time(timestr)))
+    combined = datetime.combine(dt_util.start_of_local_day(),
+                                dt_util.parse_time(timestr))
+    if combined < datetime.now():
+      combined = combined + timedelta(days=1)
+    return dt_util.as_timestamp(combined)
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -95,6 +95,7 @@ class GoogleTravelTimeSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         res = self._matrix.copy()
+        res['mode'] = self._travel_mode
         del res['rows']
         _data = self._matrix['rows'][0]['elements'][0]
         if 'duration_in_traffic' in _data:

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -72,10 +72,14 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     travel_mode = config.get(CONF_TRAVEL_MODE)
     mode = options.get(CONF_MODE)
 
-    if travel_mode is not None and mode is None:
-        options[CONF_MODE] = travel_mode
+    if travel_mode is not None:
+        wstr = ("Google Travel Time: travel_mode is deprecated, please add "
+                "mode to the options dictionary instead!")
+        _LOGGER.warning(wstr)
+        if mode is None:
+            options[CONF_MODE] = travel_mode
 
-    titled_mode = options[CONF_MODE].title()
+    titled_mode = mode.title()
     formatted_name = "Google Travel Time - {}".format(titled_mode)
     name = config.get(CONF_NAME, formatted_name)
     api_key = config.get(CONF_API_KEY)
@@ -156,9 +160,9 @@ class GoogleTravelTimeSensor(Entity):
         departure_time = self._options.get('departure_time')
         arrival_time = self._options.get('arrival_time')
         if departure_time is not None and arrival_time is not None:
-            estr = ("Google Travel Time: You can not provide both arrival",
-                    "and departure times! Clearing the arrival time...")
-            _LOGGER.warn(" ".join(estr))
+            wstr = ("Google Travel Time: You can not provide both arrival "
+                    "and departure times! Deleting the arrival time...")
+            _LOGGER.warning(wstr)
             del self._options['arrival_time']
 
         self._matrix = self._client.distance_matrix(self._origin,

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -35,7 +35,7 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_API_KEY): vol.Coerce(str),
     vol.Required(CONF_ORIGIN): vol.Coerce(str),
     vol.Required(CONF_DESTINATION): vol.Coerce(str),
-    vol.Optional(CONF_TRAVEL_MODE, default='driving'):
+    vol.Optional(CONF_TRAVEL_MODE):
         vol.In(["driving", "walking", "bicycling", "transit"]),
     vol.Optional(CONF_OPTIONS): vol.All(
         dict, vol.Schema({
@@ -79,7 +79,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         if mode is None:
             options[CONF_MODE] = travel_mode
 
-    titled_mode = mode.title()
+    titled_mode = options.get(CONF_MODE, 'driving').title()
     formatted_name = "Google Travel Time - {}".format(titled_mode)
     name = config.get(CONF_NAME, formatted_name)
     api_key = config.get(CONF_API_KEY)

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -56,7 +56,8 @@ class GoogleTravelTimeSensor(Entity):
     """Representation of a tavel time sensor."""
 
     # pylint: disable=too-many-arguments
-    def __init__(self, name, api_key, origin, destination, travel_mode, is_metric):
+    def __init__(self, name, api_key, origin, destination,
+                 travel_mode, is_metric):
         """Initialize the sensor."""
         self._name = name
         if is_metric:

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -156,6 +156,9 @@ class GoogleTravelTimeSensor(Entity):
         departure_time = self._options.get('departure_time')
         arrival_time = self._options.get('arrival_time')
         if departure_time is not None and arrival_time is not None:
+            estr = ("Google Travel Time: You can not provide both arrival",
+                    "and departure times! Clearing the arrival time...")
+            _LOGGER.warn(" ".join(estr))
             del self._options['arrival_time']
 
         self._matrix = self._client.distance_matrix(self._origin,

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -26,6 +26,7 @@ CONF_TRAVEL_MODE = 'travel_mode'
 
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required('platform'): 'google_travel_time',
+    vol.Optional('name'): vol.Coerce(str),
     vol.Required(CONF_API_KEY): vol.Coerce(str),
     vol.Required(CONF_ORIGIN): vol.Coerce(str),
     vol.Required(CONF_DESTINATION): vol.Coerce(str),
@@ -37,14 +38,14 @@ PLATFORM_SCHEMA = vol.Schema({
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the travel time platform."""
     # pylint: disable=too-many-locals
-
+    name = config.get("name", "Google Travel time")
     is_metric = (hass.config.temperature_unit == TEMP_CELSIUS)
     api_key = config.get(CONF_API_KEY)
     origin = config.get(CONF_ORIGIN)
     destination = config.get(CONF_DESTINATION)
     travel_mode = config.get(CONF_TRAVEL_MODE)
 
-    sensor = GoogleTravelTimeSensor(api_key, origin, destination,
+    sensor = GoogleTravelTimeSensor(name, api_key, origin, destination,
                                     travel_mode, is_metric)
 
     if sensor.valid_api_connection:
@@ -55,8 +56,9 @@ class GoogleTravelTimeSensor(Entity):
     """Representation of a tavel time sensor."""
 
     # pylint: disable=too-many-arguments
-    def __init__(self, api_key, origin, destination, travel_mode, is_metric):
+    def __init__(self, name, api_key, origin, destination, travel_mode, is_metric):
         """Initialize the sensor."""
+        self._name = name
         if is_metric:
             self._unit = 'metric'
         else:
@@ -84,7 +86,7 @@ class GoogleTravelTimeSensor(Entity):
     @property
     def name(self):
         """Get the name of the sensor."""
-        return "Google Travel time"
+        return self._name
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -29,14 +29,14 @@ CONF_OPTIONS = 'options'
 CONF_MODE = 'mode'
 CONF_NAME = 'name'
 
-languages = ['ar', 'bg', 'bn', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es',
-             'eu', 'fa', 'fi', 'fr', 'gl', 'gu', 'hi', 'hr', 'hu', 'id',
-             'it', 'iw', 'ja', 'kn', 'ko', 'lt', 'lv', 'ml', 'mr', 'nl',
-             'no', 'pl', 'pt', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl',
-             'sr', 'sv', 'ta', 'te', 'th', 'tl', 'tr', 'uk', 'vi', 'zh-CN',
-             'zh-TW']
+ALL_LANGUAGES = ['ar', 'bg', 'bn', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es',
+                 'eu', 'fa', 'fi', 'fr', 'gl', 'gu', 'hi', 'hr', 'hu', 'id',
+                 'it', 'iw', 'ja', 'kn', 'ko', 'lt', 'lv', 'ml', 'mr', 'nl',
+                 'no', 'pl', 'pt', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl',
+                 'sr', 'sv', 'ta', 'te', 'th', 'tl', 'tr', 'uk', 'vi',
+                 'zh-CN', 'zh-TW']
 
-transit_prefs = ['less_walking', 'fewer_transfers']
+TRANSIT_PREFS = ['less_walking', 'fewer_transfers']
 
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required('platform'): 'google_travel_time',
@@ -50,18 +50,18 @@ PLATFORM_SCHEMA = vol.Schema({
         dict, vol.Schema({
             vol.Optional(CONF_MODE, default='driving'):
                 vol.In(["driving", "walking", "bicycling", "transit"]),
-            vol.Optional('language'): vol.In(languages),
+            vol.Optional('language'): vol.In(ALL_LANGUAGES),
             vol.Optional('avoid'): vol.In(['tolls', 'highways',
                                            'ferries', 'indoor']),
             vol.Optional('units'): vol.In(['metric', 'imperial']),
             vol.Exclusive('arrival_time', 'time'): cv.string,
             vol.Exclusive('departure_time', 'time'): cv.string,
             vol.Optional('traffic_model'): vol.In(['best_guess',
-                                                  'pessimistic',
-                                                  'optimistic']),
+                                                   'pessimistic',
+                                                   'optimistic']),
             vol.Optional('transit_mode'): vol.In(['bus', 'subway', 'train',
                                                   'tram', 'rail']),
-            vol.Optional('transit_routing_preference'): vol.In(transit_prefs)
+            vol.Optional('transit_routing_preference'): vol.In(TRANSIT_PREFS)
         }))
 })
 

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -29,6 +29,15 @@ CONF_OPTIONS = 'options'
 CONF_MODE = 'mode'
 CONF_NAME = 'name'
 
+languages = ['ar', 'bg', 'bn', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es',
+             'eu', 'fa', 'fi', 'fr', 'gl', 'gu', 'hi', 'hr', 'hu', 'id',
+             'it', 'iw', 'ja', 'kn', 'ko', 'lt', 'lv', 'ml', 'mr', 'nl',
+             'no', 'pl', 'pt', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl',
+             'sr', 'sv', 'ta', 'te', 'th', 'tl', 'tr', 'uk', 'vi', 'zh-CN',
+             'zh-TW']
+
+transit_prefs = ['less_walking', 'fewer_transfers']
+
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required('platform'): 'google_travel_time',
     vol.Optional(CONF_NAME): vol.Coerce(str),
@@ -39,15 +48,20 @@ PLATFORM_SCHEMA = vol.Schema({
         vol.In(["driving", "walking", "bicycling", "transit"]),
     vol.Optional(CONF_OPTIONS): vol.All(
         dict, vol.Schema({
-            CONF_MODE: cv.string,
-            'language': cv.string,
-            'avoid': cv.string,
-            'units': cv.string,
-            'arrival_time': cv.string,
-            'departure_time': cv.string,
-            'traffic_model': cv.string,
-            'transit_mode': cv.string,
-            'transit_routing_preference': cv.string
+            vol.Optional(CONF_MODE, default='driving'):
+                vol.In(["driving", "walking", "bicycling", "transit"]),
+            vol.Optional('language'): vol.In(languages),
+            vol.Optional('avoid'): vol.In(['tolls', 'highways',
+                                           'ferries', 'indoor']),
+            vol.Optional('units'): vol.In(['metric', 'imperial']),
+            vol.Exclusive('arrival_time', 'time'): cv.string,
+            vol.Exclusive('departure_time', 'time'): cv.string,
+            vol.Optional('traffic_model'): vol.In(['best_guess',
+                                                  'pessimistic',
+                                                  'optimistic']),
+            vol.Optional('transit_mode'): vol.In(['bus', 'subway', 'train',
+                                                  'tram', 'rail']),
+            vol.Optional('transit_routing_preference'): vol.In(transit_prefs)
         }))
 })
 

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -38,12 +38,13 @@ PLATFORM_SCHEMA = vol.Schema({
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the travel time platform."""
     # pylint: disable=too-many-locals
-    name = config.get("name", "Google Travel time")
+    travel_mode = config.get(CONF_TRAVEL_MODE)
+    formatted_name = "Google Travel Time - {}".format(travel_mode.title())
+    name = config.get("name", formatted_name)
     is_metric = (hass.config.temperature_unit == TEMP_CELSIUS)
     api_key = config.get(CONF_API_KEY)
     origin = config.get(CONF_ORIGIN)
     destination = config.get(CONF_DESTINATION)
-    travel_mode = config.get(CONF_TRAVEL_MODE)
 
     sensor = GoogleTravelTimeSensor(name, api_key, origin, destination,
                                     travel_mode, is_metric)

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -149,22 +149,24 @@ class GoogleTravelTimeSensor(Entity):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data from Google."""
-        dtime = self._options.get('departure_time')
-        atime = self._options.get('arrival_time')
+        options_copy = self._options.copy()
+        dtime = options_copy.get('departure_time')
+        atime = options_copy.get('arrival_time')
         if dtime is not None and ':' in dtime:
-            self._options['departure_time'] = convert_time_to_utc(dtime)
+            options_copy['departure_time'] = convert_time_to_utc(dtime)
 
         if atime is not None and ':' in atime:
-            self._options['arrival_time'] = convert_time_to_utc(atime)
+            options_copy['arrival_time'] = convert_time_to_utc(atime)
 
-        departure_time = self._options.get('departure_time')
-        arrival_time = self._options.get('arrival_time')
+        departure_time = options_copy.get('departure_time')
+        arrival_time = options_copy.get('arrival_time')
         if departure_time is not None and arrival_time is not None:
             wstr = ("Google Travel Time: You can not provide both arrival "
                     "and departure times! Deleting the arrival time...")
             _LOGGER.warning(wstr)
+            del options_copy['arrival_time']
             del self._options['arrival_time']
 
         self._matrix = self._client.distance_matrix(self._origin,
                                                     self._destination,
-                                                    **self._options)
+                                                    **options_copy)

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -53,7 +53,7 @@ PLATFORM_SCHEMA = vol.Schema({
 
 
 def convert_time_to_utc(timestr):
-    """Take a string like 08:00:00 and convert it to a unix timestamp"""
+    """Take a string like 08:00:00 and convert it to a unix timestamp."""
     return dt_util.as_timestamp(datetime.combine(dt_util.start_of_local_day(),
                                                  dt_util.parse_time(timestr)))
 

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -52,6 +52,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         add_devices_callback([sensor])
 
 
+# pylint: disable=too-many-instance-attributes
 class GoogleTravelTimeSensor(Entity):
     """Representation of a tavel time sensor."""
 


### PR DESCRIPTION
**Description:**
Big improvements to the Google Travel Time sensor. 
- Allow passing any options that Google supports in the options dict of your configuration. 
- Deprecate travel_mode.
- Change name format to show the mode
- Support providing departure_time and arrival_time as simple timestamps (i.e. 08:00:00 for departure times at 8am that morning)

**Related issue (if applicable):** #2024, #2025, home-assistant/home-assistant.io#468

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: google_travel_time
  api_key: API_KEY
  origin: 37.8156380,-122.2628050
  destination: 37.7968520,-122.4055500
  options:
    mode: transit
    transit_mode: rail
    transit_routing_preference: less_walking
```

**Checklist:**

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
