### PR TITLE
add include_dir constructor for yaml parsing

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -55,7 +55,7 @@ def _include_dir_named_yaml(loader, node):
     return mapping
 
 
-def _include_dir_flat_yaml(loader, node):
+def _include_dir_list_yaml(loader, node):
     """Load multiple files from dir."""
     files = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
     return [load_yaml(f) for f in glob.glob(files)]
@@ -101,5 +101,5 @@ yaml.SafeLoader.add_constructor('!include', _include_yaml)
 yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                                 _ordered_dict)
 yaml.SafeLoader.add_constructor('!env_var', _env_var_yaml)
-yaml.SafeLoader.add_constructor('!include_dir_flat', _include_dir_flat_yaml)
+yaml.SafeLoader.add_constructor('!include_dir_list', _include_dir_list_yaml)
 yaml.SafeLoader.add_constructor('!include_dir_named', _include_dir_named_yaml)

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -45,7 +45,7 @@ def _include_yaml(loader, node):
     return load_yaml(fname)
 
 
-def _include_dir_yaml(loader, node):
+def _include_dir_named_yaml(loader, node):
     """Load multiple files from dir."""
     mapping = OrderedDict()
     dir = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
@@ -53,6 +53,12 @@ def _include_dir_yaml(loader, node):
         filename = os.path.splitext(os.path.basename(file))[0]
         mapping[filename] = load_yaml(file)
     return mapping
+
+
+def _include_dir_flat_yaml(loader, node):
+    """Load multiple files from dir."""
+    dir = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
+    return [load_yaml(f) for f in glob.glob(dir)]
 
 
 def _ordered_dict(loader, node):
@@ -95,4 +101,5 @@ yaml.SafeLoader.add_constructor('!include', _include_yaml)
 yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                                 _ordered_dict)
 yaml.SafeLoader.add_constructor('!env_var', _env_var_yaml)
-yaml.SafeLoader.add_constructor('!include_dir', _include_dir_yaml)
+yaml.SafeLoader.add_constructor('!include_dir_flat', _include_dir_flat_yaml)
+yaml.SafeLoader.add_constructor('!include_dir_named', _include_dir_named_yaml)

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -3,8 +3,8 @@ import logging
 import os
 from collections import OrderedDict
 
-import yaml
 import glob
+import yaml
 
 from homeassistant.exceptions import HomeAssistantError
 
@@ -48,17 +48,17 @@ def _include_yaml(loader, node):
 def _include_dir_named_yaml(loader, node):
     """Load multiple files from dir."""
     mapping = OrderedDict()
-    dir = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
-    for file in glob.glob(dir):
-        filename = os.path.splitext(os.path.basename(file))[0]
-        mapping[filename] = load_yaml(file)
+    files = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
+    for fname in glob.glob(files):
+        filename = os.path.splitext(os.path.basename(fname))[0]
+        mapping[filename] = load_yaml(fname)
     return mapping
 
 
 def _include_dir_flat_yaml(loader, node):
     """Load multiple files from dir."""
-    dir = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
-    return [load_yaml(f) for f in glob.glob(dir)]
+    files = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
+    return [load_yaml(f) for f in glob.glob(files)]
 
 
 def _ordered_dict(loader, node):

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -4,6 +4,7 @@ import os
 from collections import OrderedDict
 
 import yaml
+import glob
 
 from homeassistant.exceptions import HomeAssistantError
 
@@ -42,6 +43,16 @@ def _include_yaml(loader, node):
     """
     fname = os.path.join(os.path.dirname(loader.name), node.value)
     return load_yaml(fname)
+
+
+def _include_dir_yaml(loader, node):
+    """Load multiple files from dir."""
+    mapping = OrderedDict()
+    dir = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
+    for file in glob.glob(dir):
+        filename = os.path.splitext(os.path.basename(file))[0]
+        mapping[filename] = load_yaml(file)
+    return mapping
 
 
 def _ordered_dict(loader, node):
@@ -84,3 +95,4 @@ yaml.SafeLoader.add_constructor('!include', _include_yaml)
 yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                                 _ordered_dict)
 yaml.SafeLoader.add_constructor('!env_var', _env_var_yaml)
+yaml.SafeLoader.add_constructor('!include_dir', _include_dir_yaml)


### PR DESCRIPTION
**Description:**
When breaking up your config to multiple files you end up with a bunch of includes. This will allow you to include a whole dir which will get parsed out to include all *.yaml files

Before:
configuration.yaml

``` yaml
script: !include scripts.yaml
automation: !include automation.yaml
```

scripts.yaml

``` yaml
script1: !include scripts/script1.yaml
script2: !include scripts/script2.yaml
script3: !include scripts/script3.yaml
```

automation.yaml

``` yaml
- !include automation/auto1.yaml
- !include automation/auto2.yaml
- !include automation/auto3.yaml
```

After:
configuration.yaml

``` yaml
script: !include_named_dir scripts
automation: !include_list_dir automation
```

**Related issue (if applicable):** #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
