### PR TITLE
Justyns purge old data

### DIFF
--- a/homeassistant/components/recorder.py
+++ b/homeassistant/components/recorder.py
@@ -13,8 +13,8 @@ import logging
 import queue
 import sqlite3
 import threading
-import voluptuous as vol
 from datetime import date, datetime, timedelta
+import voluptuous as vol
 
 import homeassistant.util.dt as dt_util
 from homeassistant.const import (

--- a/tests/components/test_recorder.py
+++ b/tests/components/test_recorder.py
@@ -1,6 +1,8 @@
 """The tests for the Recorder component."""
 # pylint: disable=too-many-public-methods,protected-access
 import unittest
+import time
+import json
 from unittest.mock import patch
 
 from homeassistant.const import MATCH_ALL
@@ -10,7 +12,7 @@ from tests.common import get_test_home_assistant
 
 
 class TestRecorder(unittest.TestCase):
-    """Test the chromecast module."""
+    """Test the recorder module."""
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
@@ -24,6 +26,66 @@ class TestRecorder(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
         recorder._INSTANCE.block_till_done()
+
+    def _add_test_states(self):
+        """Adds multiple states to the db for testing."""
+        now = int(time.time())
+        five_days_ago = now - (60*60*24*5)
+        attributes = {'test_attr': 5, 'test_attr_10': 'nice'}
+
+        test_states = """
+        INSERT INTO states (
+        entity_id, domain, state, attributes, last_changed, last_updated,
+        created, utc_offset, event_id)
+        VALUES
+        ('test.recorder2', 'sensor', 'purgeme', '{attr}', {five_days_ago},
+            {five_days_ago}, {five_days_ago}, -18000, 1001),
+        ('test.recorder2', 'sensor', 'purgeme', '{attr}', {five_days_ago},
+            {five_days_ago}, {five_days_ago}, -18000, 1002),
+        ('test.recorder2', 'sensor', 'purgeme', '{attr}', {five_days_ago},
+            {five_days_ago}, {five_days_ago}, -18000, 1002),
+        ('test.recorder2', 'sensor', 'dontpurgeme', '{attr}', {now},
+            {now}, {now}, -18000, 1003),
+        ('test.recorder2', 'sensor', 'dontpurgeme', '{attr}', {now},
+            {now}, {now}, -18000, 1004);
+        """.format(
+            attr=json.dumps(attributes),
+            five_days_ago=five_days_ago,
+            now=now,
+        )
+
+        # insert test states
+        self.hass.pool.block_till_done()
+        recorder._INSTANCE.block_till_done()
+        recorder.query(test_states)
+
+    def _add_test_events(self):
+        """Adds a few events for testing."""
+        now = int(time.time())
+        five_days_ago = now - (60*60*24*5)
+        event_data = {'test_attr': 5, 'test_attr_10': 'nice'}
+
+        test_events = """
+        INSERT INTO events (
+        event_type, event_data, origin, created, time_fired, utc_offset
+        ) VALUES
+        ('EVENT_TEST_PURGE', '{event_data}', 'LOCAL', {five_days_ago},
+            {five_days_ago}, -18000),
+        ('EVENT_TEST_PURGE', '{event_data}', 'LOCAL', {five_days_ago},
+            {five_days_ago}, -18000),
+        ('EVENT_TEST', '{event_data}', 'LOCAL', {now}, {five_days_ago}, -18000),
+        ('EVENT_TEST', '{event_data}', 'LOCAL', {now}, {five_days_ago}, -18000),
+        ('EVENT_TEST', '{event_data}', 'LOCAL', {now}, {five_days_ago}, -18000);
+        """.format(
+            event_data=json.dumps(event_data),
+            now=now,
+            five_days_ago=five_days_ago
+        )
+
+        # insert test events
+        self.hass.pool.block_till_done()
+        recorder._INSTANCE.block_till_done()
+        recorder.query(test_events)
 
     def test_saving_state(self):
         """Test saving and restoring a state."""
@@ -64,3 +126,58 @@ class TestRecorder(unittest.TestCase):
             'SELECT * FROM events WHERE event_type = ?', (event_type, ))
 
         self.assertEqual(events, db_events)
+
+    def test_purge_old_states(self):
+        """Tests deleting old states."""
+        self._add_test_states()
+        # make sure we start with 5 states
+        states = recorder.query_states('SELECT * FROM states')
+        self.assertEqual(len(states), 5)
+
+        # run purge_old_data()
+        recorder._INSTANCE.purge_days = 4
+        recorder._INSTANCE._purge_old_data()
+
+        # we should only have 2 states left after purging
+        states = recorder.query_states('SELECT * FROM states')
+        self.assertEqual(len(states), 2)
+
+    def test_purge_old_events(self):
+        """Tests deleting old events."""
+        self._add_test_events()
+        events = recorder.query_events('SELECT * FROM events WHERE '
+                                       'event_type LIKE "EVENT_TEST%"')
+        self.assertEqual(len(events), 5)
+
+        # run purge_old_data()
+        recorder._INSTANCE.purge_days = 4
+        recorder._INSTANCE._purge_old_data()
+
+        # now we should only have 3 events left
+        events = recorder.query_events('SELECT * FROM events WHERE '
+                                       'event_type LIKE "EVENT_TEST%"')
+        self.assertEqual(len(events), 3)
+
+
+    def test_purge_disabled(self):
+        """Tests leaving purge_days disabled."""
+        self._add_test_states()
+        self._add_test_events()
+        # make sure we start with 5 states and events
+        states = recorder.query_states('SELECT * FROM states')
+        events = recorder.query_events('SELECT * FROM events WHERE '
+                                       'event_type LIKE "EVENT_TEST%"')
+        self.assertEqual(len(states), 5)
+        self.assertEqual(len(events), 5)
+
+
+        # run purge_old_data()
+        recorder._INSTANCE.purge_days = None
+        recorder._INSTANCE._purge_old_data()
+
+        # we should have all of our states still
+        states = recorder.query_states('SELECT * FROM states')
+        events = recorder.query_events('SELECT * FROM events WHERE '
+                                       'event_type LIKE "EVENT_TEST%"')
+        self.assertEqual(len(states), 5)
+        self.assertEqual(len(events), 5)

--- a/tests/components/test_recorder.py
+++ b/tests/components/test_recorder.py
@@ -141,7 +141,7 @@ class TestRecorder(unittest.TestCase):
         self.assertEqual(len(states), 2)
 
     def test_purge_old_events(self):
-        """Tests deleting old events."""
+        """Test deleting old events."""
         self._add_test_events()
         events = recorder.query_events('SELECT * FROM events WHERE '
                                        'event_type LIKE "EVENT_TEST%"')

--- a/tests/components/test_recorder.py
+++ b/tests/components/test_recorder.py
@@ -28,7 +28,7 @@ class TestRecorder(unittest.TestCase):
         recorder._INSTANCE.block_till_done()
 
     def _add_test_states(self):
-        """Adds multiple states to the db for testing."""
+        """Add multiple states to the db for testing."""
         now = int(time.time())
         five_days_ago = now - (60*60*24*5)
         attributes = {'test_attr': 5, 'test_attr_10': 'nice'}
@@ -52,7 +52,7 @@ class TestRecorder(unittest.TestCase):
                             timestamp, -18000, event_id + 1000))
 
     def _add_test_events(self):
-        """Adds a few events for testing."""
+        """Add a few events for testing."""
         now = int(time.time())
         five_days_ago = now - (60*60*24*5)
         event_data = {'test_attr': 5, 'test_attr_10': 'nice'}
@@ -126,7 +126,7 @@ class TestRecorder(unittest.TestCase):
             db_event.time_fired.replace(microsecond=0)
 
     def test_purge_old_states(self):
-        """Tests deleting old states."""
+        """Test deleting old states."""
         self._add_test_states()
         # make sure we start with 5 states
         states = recorder.query_states('SELECT * FROM states')
@@ -157,7 +157,7 @@ class TestRecorder(unittest.TestCase):
         self.assertEqual(len(events), 3)
 
     def test_purge_disabled(self):
-        """Tests leaving purge_days disabled."""
+        """Test leaving purge_days disabled."""
         self._add_test_states()
         self._add_test_events()
         # make sure we start with 5 states and events

--- a/tests/components/test_recorder.py
+++ b/tests/components/test_recorder.py
@@ -43,12 +43,13 @@ class TestRecorder(unittest.TestCase):
                 timestamp = now
                 state = 'dontpurgeme'
             recorder.query("INSERT INTO states ("
-                           "entity_id, domain, state, attributes, last_changed,"
-                           "last_updated, created, utc_offset, event_id)"
+                           "entity_id, domain, state, attributes,"
+                           "last_changed, last_updated, created,"
+                           "utc_offset, event_id)"
                            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                            ('test.recorder2', 'sensor', state,
-                           json.dumps(attributes), timestamp, timestamp,
-                           timestamp, -18000, event_id + 1000))
+                            json.dumps(attributes), timestamp, timestamp,
+                            timestamp, -18000, event_id + 1000))
 
     def _add_test_events(self):
         """Adds a few events for testing."""
@@ -155,7 +156,6 @@ class TestRecorder(unittest.TestCase):
                                        'event_type LIKE "EVENT_TEST%"')
         self.assertEqual(len(events), 3)
 
-
     def test_purge_disabled(self):
         """Tests leaving purge_days disabled."""
         self._add_test_states()
@@ -166,7 +166,6 @@ class TestRecorder(unittest.TestCase):
                                        'event_type LIKE "EVENT_TEST%"')
         self.assertEqual(len(states), 5)
         self.assertEqual(len(events), 5)
-
 
         # run purge_old_data()
         recorder._INSTANCE.purge_days = None


### PR DESCRIPTION
**Description**: Auto purge data older the configured time on startup of hass.

Each time HASS starts, the recorder component will run `_purge_old_data()` before going into the event loop. `_purge_old_data()` will delete records from the events and states tables older than X days. After deleting those records, `VACUUM` is run on the database to free up disk space taken by the deleted records.

This also adds a `purge_days` config option to the history component. By default it is set to -1 which means no old records will be deleted.

Started by @justyns, this is just a clean up and some fixes to hopefully allow us to merge it soon. 

**Related issue (if applicable):** #1681

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
# Enables support for tracking state changes over time.
recorder:
  # Delete events and states older than 2 weeks
  purge_days: 14
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
