### PR TITLE
Add Twilio SMS notify component component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -141,6 +141,7 @@ omit =
     homeassistant/components/notify/smtp.py
     homeassistant/components/notify/syslog.py
     homeassistant/components/notify/telegram.py
+    homeassistant/components/notify/twilio_sms.py
     homeassistant/components/notify/twitter.py
     homeassistant/components/notify/xmpp.py
     homeassistant/components/scene/hunterdouglas_powerview.py

--- a/homeassistant/components/notify/twilio_sms.py
+++ b/homeassistant/components/notify/twilio_sms.py
@@ -1,0 +1,62 @@
+"""
+Twilio SMS platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.twilio_sms/
+"""
+import logging
+
+from homeassistant.components.notify import (
+    ATTR_TARGET, DOMAIN, BaseNotificationService)
+from homeassistant.helpers import validate_config
+
+_LOGGER = logging.getLogger(__name__)
+REQUIREMENTS = ["twilio==5.4.0"]
+
+CONF_ACCOUNT_SID = "account_sid"
+CONF_AUTH_TOKEN = "auth_token"
+CONF_FROM_NUMBER = "from_number"
+
+
+def get_service(hass, config):
+    """Get the Twilio SMS notification service."""
+    if not validate_config({DOMAIN: config},
+                           {DOMAIN: [CONF_ACCOUNT_SID,
+                                     CONF_AUTH_TOKEN,
+                                     CONF_FROM_NUMBER]},
+                           _LOGGER):
+        return None
+
+    # pylint: disable=import-error
+    from twilio.rest import TwilioRestClient
+
+    twilio_client = TwilioRestClient(config[CONF_ACCOUNT_SID],
+                                     config[CONF_AUTH_TOKEN])
+
+    return TwilioSMSNotificationService(twilio_client,
+                                        config[CONF_FROM_NUMBER])
+
+
+# pylint: disable=too-few-public-methods
+class TwilioSMSNotificationService(BaseNotificationService):
+    """Implement the notification service for the Twilio SMS service."""
+
+    def __init__(self, twilio_client, from_number):
+        """Initialize the service."""
+        self.client = twilio_client
+        self.from_number = from_number
+
+    def send_message(self, message="", **kwargs):
+        """Send SMS to specified target user cell."""
+        targets = kwargs.get(ATTR_TARGET)
+
+        if not targets:
+            _LOGGER.info("At least 1 target is required")
+            return
+
+        if not isinstance(targets, list):
+            targets = [targets]
+
+        for target in targets:
+            self.client.messages.create(to=target, body=message,
+                                        from_=self.from_number)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -329,6 +329,9 @@ tellive-py==0.5.2
 # homeassistant.components.switch.transmission
 transmissionrpc==0.11
 
+# homeassistant.components.notify.twilio_sms
+twilio==5.4.0
+
 # homeassistant.components.sensor.uber
 uber_rides==0.2.1
 


### PR DESCRIPTION
**Description:**
This adds a [Twilio](http://twilio.com) SMS notify component.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#476.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
notify:
  name: Twilio
  platform: twilio_sms
  account_sid: ACCOUNT_SID_FROM_TWILIO
  auth_token: AUTH_TOKEN_FROM_TWILIO
  from_number: E164_PHONE_NUMBER
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
