### PR TITLE
Last.fm sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -157,6 +157,7 @@ omit =
     homeassistant/components/sensor/glances.py
     homeassistant/components/sensor/google_travel_time.py
     homeassistant/components/sensor/gtfs.py
+    homeassistant/components/sensor/lastfm.py
     homeassistant/components/sensor/loopenergy.py
     homeassistant/components/sensor/netatmo.py
     homeassistant/components/sensor/neurio_energy.py

--- a/homeassistant/components/sensor/lastfm.py
+++ b/homeassistant/components/sensor/lastfm.py
@@ -26,7 +26,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class LastfmSensor(Entity):
     """A class for the Last.fm account."""
 
-    # pylint: disable=abstract-method
+    # pylint: disable=abstract-method, too-many-instance-attributes
     def __init__(self, user, lastfm):
         """Initialize the sensor."""
         self._user = lastfm.get_user(user)

--- a/homeassistant/components/sensor/lastfm.py
+++ b/homeassistant/components/sensor/lastfm.py
@@ -60,11 +60,13 @@ class LastfmSensor(Entity):
         self._cover = self._user.get_image()
         self._playcount = self._user.get_playcount()
         last = self._user.get_recent_tracks(limit=2)[0]
-        self._lastplayed = "{} - {}".format(last.track.artist, last.track.title)
+        self._lastplayed = "{} - {}".format(last.track.artist,
+                                            last.track.title)
         top = self._user.get_top_tracks(limit=1)[0]
         toptitle = re.search("', '(.+?)',", str(top))
         topartist = re.search("'(.+?)',", str(top))
-        self._topplayed = "{} - {}".format(topartist.group(1), toptitle.group(1))
+        self._topplayed = "{} - {}".format(topartist.group(1),
+                                           toptitle.group(1))
         if self._user.get_now_playing() is None:
             self._state = "Not Scrobbling"
             return

--- a/homeassistant/components/sensor/lastfm.py
+++ b/homeassistant/components/sensor/lastfm.py
@@ -59,16 +59,19 @@ class LastfmSensor(Entity):
             self._state = (now.title + " - " + str(now.artist))
         self._playcount = self._user.get_playcount()
         last = self._user.get_recent_tracks(limit=2)[0]
-        self._lastplayed = (last.track.title + " - " + str(last.track.artist))
+        self._lastplayed = (last.track.title + " - " +
+                            str(last.track.artist))
         top = self._user.get_top_tracks(limit=1)
         toptitle = re.search("', '(.+?)',", str(top))
         topartist = re.search("'(.+?)',", str(top))
-        self._topplayed = (toptitle.group(1) + " - " + topartist.group(1))
+        self._topplayed = (toptitle.group(1) + " - " +
+                           topartist.group(1))
 
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {'Playcount': self._playcount, 'Last Played': self._lastplayed, 'Top Played': self._topplayed}
+        return {'Playcount': self._playcount, 'Last Played':
+                self._lastplayed, 'Top Played': self._topplayed}
 
     @property
     def entity_picture(self):

--- a/homeassistant/components/sensor/lastfm.py
+++ b/homeassistant/components/sensor/lastfm.py
@@ -56,16 +56,16 @@ class LastfmSensor(Entity):
             self._state = "Not Scrobbling"
         else:
             now = self._user.get_now_playing()
-            self._state = (now.title + " - " + str(now.artist))
+            self._state = (str(now.artist) + " - " + now.title)
         self._playcount = self._user.get_playcount()
         last = self._user.get_recent_tracks(limit=2)[0]
-        self._lastplayed = (last.track.title + " - " +
-                            str(last.track.artist))
+        self._lastplayed = (str(last.track.artist) + " - " +
+                            last.track.title)
         top = self._user.get_top_tracks(limit=1)
         toptitle = re.search("', '(.+?)',", str(top))
         topartist = re.search("'(.+?)',", str(top))
-        self._topplayed = (toptitle.group(1) + " - " +
-                           topartist.group(1))
+        self._topplayed = (topartist.group(1) + " - " +
+                           toptitle.group(1))
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/sensor/lastfm.py
+++ b/homeassistant/components/sensor/lastfm.py
@@ -4,9 +4,9 @@ Sensor for Last.fm account status.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.lastfm/
 """
+import re
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import CONF_API_KEY
-import re
 
 ICON = 'mdi:lastfm'
 
@@ -15,13 +15,13 @@ REQUIREMENTS = ['pylast==1.6.0']
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Last.fm platform"""
+    """Setup the Last.fm platform."""
     import pylast as lastfm
-    network = lastfm.LastFMNetwork(api_key = config.get(CONF_API_KEY),
-        api_secret = config.get('api_secret'))
+    network = lastfm.LastFMNetwork(api_key=config.get(CONF_API_KEY),
+                                   api_secret=config.get('api_secret'))
     add_devices(
         [LastfmSensor(username,
-            network) for username in config.get('users', [])])
+                      network) for username in config.get('users', [])])
 
 
 class LastfmSensor(Entity):
@@ -52,6 +52,7 @@ class LastfmSensor(Entity):
 
     # pylint: disable=no-member
     def update(self):
+        """Update device state."""
         if self._user.get_now_playing() is None:
             self._state = "Not Scrobbling"
         else:

--- a/homeassistant/components/sensor/lastfm.py
+++ b/homeassistant/components/sensor/lastfm.py
@@ -1,0 +1,81 @@
+"""
+Sensor for Last.fm account status.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.lastfm/
+"""
+from homeassistant.helpers.entity import Entity
+from homeassistant.const import CONF_API_KEY
+import re
+
+ICON = 'mdi:lastfm'
+
+REQUIREMENTS = ['pylast==1.6.0']
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Last.fm platform"""
+    import pylast as lastfm
+    network = lastfm.LastFMNetwork(api_key = config.get(CONF_API_KEY),
+        api_secret = config.get('api_secret'))
+    add_devices(
+        [LastfmSensor(username,
+            network) for username in config.get('users', [])])
+
+
+class LastfmSensor(Entity):
+    """A class for the Last.fm account."""
+
+    # pylint: disable=abstract-method
+    def __init__(self, user, lastfm):
+        """Initialize the sensor."""
+        self._user = lastfm.get_user(user)
+        self._name = user
+        self._lastfm = lastfm
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def entity_id(self):
+        """Return the entity ID."""
+        return 'sensor.lastfm_{}'.format(self._name)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    # pylint: disable=no-member
+    def update(self):
+        if self._user.get_now_playing() is None:
+            self._state = "Not Scrobbling"
+        else:
+            now = self._user.get_now_playing()
+            self._state = (now.title + " - " + str(now.artist))
+        self._playcount = self._user.get_playcount()
+        last = self._user.get_recent_tracks(limit=2)[0]
+        self._lastplayed = (last.track.title + " - " + str(last.track.artist))
+        top = self._user.get_top_tracks(limit=1)
+        toptitle = re.search("', '(.+?)',", str(top))
+        topartist = re.search("'(.+?)',", str(top))
+        self._topplayed = (toptitle.group(1) + " - " + topartist.group(1))
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {'Playcount': self._playcount, 'Last Played': self._lastplayed, 'Top Played': self._topplayed}
+
+    @property
+    def entity_picture(self):
+        """Avatar of the user."""
+        return self._user.get_image()
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return ICON

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -218,6 +218,9 @@ pyfttt==0.3
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.8.3
 
+# homeassistant.components.sensor.lastfm
+pylast==1.6.0
+
 # homeassistant.components.sensor.loopenergy
 pyloopenergy==0.0.10
 


### PR DESCRIPTION
**Description:** Adds a Last.fm sensor made by me and @darookee that reports back the currently scrobbling song, amount of plays, recent song and top song of users.
![](http://puu.sh/oRUP2/1ab67954e9.png)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: lastfm
  api_key: "[API Key]"
  api_secret: "[API Secret]"
  users:
    - GreenTurtwig
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
