### PR TITLE
Qwikswitch fixes

### DIFF
--- a/homeassistant/components/light/qwikswitch.py
+++ b/homeassistant/components/light/qwikswitch.py
@@ -27,10 +27,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     qsusb = qwikswitch.QSUSB[discovery_info['qsusb_id']]
 
     for item in qsusb.ha_devices:
-        if item['id'] in qsusb.ha_objects or \
-           item['type'] not in ['dim', 'rel']:
-            continue
-        if item['type'] == 'rel' and item['name'].lower().endswith(' switch'):
+        if item['type'] not in ['dim', 'rel']:
             continue
         dev = QSLight(item, qsusb)
         add_devices([dev])

--- a/homeassistant/components/switch/qwikswitch.py
+++ b/homeassistant/components/switch/qwikswitch.py
@@ -27,10 +27,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     qsusb = qwikswitch.QSUSB[discovery_info['qsusb_id']]
 
     for item in qsusb.ha_devices:
-        if item['type'] == 'rel' and \
-           item['name'].lower().endswith(' switch'):
-            # Remove the ' Switch' name postfix for HA
-            item['name'] = item['name'][:-7]
+        if item['type'] == 'switch':
             dev = QSSwitch(item, qsusb)
             add_devices([dev])
             qsusb.ha_objects[item['id']] = dev


### PR DESCRIPTION
**Description:**

Needed some adjusting when it went live... 
- Resolved UI flicker (didn't call update_values in all cases)
- Fixed relay light/switch logic. :confused: Previous method was not thread safe inside in the plaforms and sometimes got double entities
- Fixed brightness to go to 255 (only went 0..100 :anguished:)
- Fixed buttons ( I completely broke this at some point )
- While fixing the last two I added two new config vars (dimmer_adjust & button_events) to override pyqwikswitch defaults and introduce new button types with config
