### PR TITLE
Add AWS notify platforms (Lambda, SNS, SQS)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -128,6 +128,7 @@ omit =
     homeassistant/components/media_player/squeezebox.py
     homeassistant/components/media_player/yamaha.py
     homeassistant/components/notify/aws_sns.py
+    homeassistant/components/notify/aws_sqs.py
     homeassistant/components/notify/free_mobile.py
     homeassistant/components/notify/gntp.py
     homeassistant/components/notify/googlevoice.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -127,6 +127,7 @@ omit =
     homeassistant/components/media_player/sonos.py
     homeassistant/components/media_player/squeezebox.py
     homeassistant/components/media_player/yamaha.py
+    homeassistant/components/notify/aws_lambda.py
     homeassistant/components/notify/aws_sns.py
     homeassistant/components/notify/aws_sqs.py
     homeassistant/components/notify/free_mobile.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -127,6 +127,7 @@ omit =
     homeassistant/components/media_player/sonos.py
     homeassistant/components/media_player/squeezebox.py
     homeassistant/components/media_player/yamaha.py
+    homeassistant/components/notify/aws_sns.py
     homeassistant/components/notify/free_mobile.py
     homeassistant/components/notify/gntp.py
     homeassistant/components/notify/googlevoice.py

--- a/homeassistant/components/notify/aws_lambda.py
+++ b/homeassistant/components/notify/aws_lambda.py
@@ -74,14 +74,14 @@ class AWSLambda(BaseNotificationService):
 
         for target in targets:
             cleaned_kwargs = dict((k, v) for k, v in kwargs.items() if v)
-            payload = {'message': message}
+            payload = {"message": message}
             payload.update(cleaned_kwargs)
 
             context_str = json.dumps(self.hass_config)
-            context_b64 = base64.b64encode(context_str.encode('utf-8'))
+            context_b64 = base64.b64encode(context_str.encode("utf-8"))
             context = context_b64.decode("utf-8")
 
             self.client.invoke(FunctionName=target,
-                               InvocationType='Event',
+                               InvocationType="Event",
                                Payload=json.dumps(payload),
                                ClientContext=context)

--- a/homeassistant/components/notify/aws_lambda.py
+++ b/homeassistant/components/notify/aws_lambda.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from homeassistant.const import (
     CONF_PLATFORM, CONF_NAME)
 from homeassistant.components.notify import (
-    ATTR_TITLE, ATTR_TARGET, BaseNotificationService)
+    ATTR_TARGET, BaseNotificationService)
 
 _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = ["boto3==1.3.1"]

--- a/homeassistant/components/notify/aws_lambda.py
+++ b/homeassistant/components/notify/aws_lambda.py
@@ -1,0 +1,87 @@
+"""
+AWS Lambda platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.aws_lambda/
+"""
+import logging
+import json
+import base64
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_PLATFORM, CONF_NAME)
+from homeassistant.components.notify import (
+    ATTR_TITLE, ATTR_TARGET, BaseNotificationService)
+
+_LOGGER = logging.getLogger(__name__)
+REQUIREMENTS = ["boto3==1.3.1"]
+
+CONF_REGION = "region_name"
+CONF_ACCESS_KEY_ID = "aws_access_key_id"
+CONF_SECRET_ACCESS_KEY = "aws_secret_access_key"
+CONF_PROFILE_NAME = "profile_name"
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_PLATFORM): "aws_lambda",
+    vol.Optional(CONF_NAME): vol.Coerce(str),
+    vol.Optional(CONF_REGION, default="us-east-1"): vol.Coerce(str),
+    vol.Inclusive(CONF_ACCESS_KEY_ID, "credentials"): vol.Coerce(str),
+    vol.Inclusive(CONF_SECRET_ACCESS_KEY, "credentials"): vol.Coerce(str),
+    vol.Exclusive(CONF_PROFILE_NAME, "credentials"): vol.Coerce(str)
+})
+
+
+def get_service(hass, config):
+    """Get the AWS Lambda notification service."""
+
+    # pylint: disable=import-error
+    import boto3
+
+    aws_config = config.copy()
+
+    del aws_config[CONF_PLATFORM]
+    del aws_config[CONF_NAME]
+
+    if aws_config[CONF_PROFILE_NAME]:
+        boto3.setup_default_session(profile_name=aws_config[CONF_PROFILE_NAME])
+        del aws_config[CONF_PROFILE_NAME]
+
+    lambda_client = boto3.client("lambda", **aws_config)
+
+    return AWSLambda(lambda_client, hass.config.as_dict())
+
+
+# pylint: disable=too-few-public-methods
+class AWSLambda(BaseNotificationService):
+    """Implement the notification service for the AWS Lambda service."""
+
+    def __init__(self, lambda_client, hass_config):
+        """Initialize the service."""
+        self.client = lambda_client
+        self.hass_config = hass_config
+
+    def send_message(self, message="", **kwargs):
+        """Send notification to specified LAMBDA ARN."""
+        targets = kwargs.get(ATTR_TARGET)
+
+        if not targets:
+            _LOGGER.info("At least 1 target is required")
+            return
+
+        if not isinstance(targets, list):
+            targets = [targets]
+
+        for target in targets:
+            cleaned_kwargs = dict((k, v) for k, v in kwargs.items() if v)
+            payload = {'message': message}
+            payload.update(cleaned_kwargs)
+
+            context_str = json.dumps(self.hass_config)
+            context_b64 = base64.b64encode(context_str.encode('utf-8'))
+            context = context_b64.decode("utf-8")
+
+            self.client.invoke(FunctionName=target,
+                               InvocationType='Event',
+                               Payload=json.dumps(payload),
+                               ClientContext=context)

--- a/homeassistant/components/notify/aws_lambda.py
+++ b/homeassistant/components/notify/aws_lambda.py
@@ -34,7 +34,6 @@ PLATFORM_SCHEMA = vol.Schema({
 
 def get_service(hass, config):
     """Get the AWS Lambda notification service."""
-
     # pylint: disable=import-error
     import boto3
 

--- a/homeassistant/components/notify/aws_sns.py
+++ b/homeassistant/components/notify/aws_sns.py
@@ -73,8 +73,8 @@ class AWSSNS(BaseNotificationService):
         cleaned_kwargs = dict((k, v) for k, v in kwargs.items() if v)
         message_attributes = {}
         for key, val in cleaned_kwargs.items():
-            message_attributes[key] = {'StringValue': json.dumps(val),
-                                       'DataType': 'String'}
+            message_attributes[key] = {"StringValue": json.dumps(val),
+                                       "DataType": "String"}
 
         for target in targets:
             self.client.publish(TargetArn=target, Message=message,

--- a/homeassistant/components/notify/aws_sns.py
+++ b/homeassistant/components/notify/aws_sns.py
@@ -69,12 +69,9 @@ class AWSSNS(BaseNotificationService):
         if not isinstance(targets, list):
             targets = [targets]
 
-        cleaned_kwargs = dict((k, v) for k, v in kwargs.items() if v)
-        message_attributes = {}
-        for key, val in cleaned_kwargs.items():
-            message_attributes[key] = {"StringValue": json.dumps(val),
-                                       "DataType": "String"}
-
+        message_attributes = {k: {"StringValue": json.dumps(v),
+                                  "DataType": "String"}
+                              for k, v in kwargs.items() if v}
         for target in targets:
             self.client.publish(TargetArn=target, Message=message,
                                 Subject=kwargs.get(ATTR_TITLE),

--- a/homeassistant/components/notify/aws_sns.py
+++ b/homeassistant/components/notify/aws_sns.py
@@ -33,7 +33,6 @@ PLATFORM_SCHEMA = vol.Schema({
 
 def get_service(hass, config):
     """Get the AWS SNS notification service."""
-
     # pylint: disable=import-error
     import boto3
 

--- a/homeassistant/components/notify/aws_sns.py
+++ b/homeassistant/components/notify/aws_sns.py
@@ -1,0 +1,73 @@
+"""
+AWS SNS platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.aws_sns/
+"""
+import logging
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_PLATFORM, CONF_NAME)
+from homeassistant.components.notify import (
+    ATTR_TITLE, ATTR_TARGET, BaseNotificationService)
+
+_LOGGER = logging.getLogger(__name__)
+REQUIREMENTS = ["boto3==1.3.1"]
+
+CONF_REGION = "region_name"
+CONF_ACCESS_KEY_ID = "aws_access_key_id"
+CONF_SECRET_ACCESS_KEY = "aws_secret_access_key"
+CONF_PROFILE_NAME = "profile_name"
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_PLATFORM): "aws_sns",
+    vol.Optional(CONF_NAME): vol.Coerce(str),
+    vol.Optional(CONF_REGION, default="us-east-1"): vol.Coerce(str),
+    vol.Inclusive(CONF_ACCESS_KEY_ID, "credentials"): vol.Coerce(str),
+    vol.Inclusive(CONF_SECRET_ACCESS_KEY, "credentials"): vol.Coerce(str),
+    vol.Exclusive(CONF_PROFILE_NAME, "credentials"): vol.Coerce(str)
+})
+
+def get_service(hass, config):
+    """Get the AWS SNS notification service."""
+
+    # pylint: disable=import-error
+    import boto3
+
+    aws_config = config.copy()
+
+    del aws_config[CONF_PLATFORM]
+    del aws_config[CONF_NAME]
+
+    if aws_config[CONF_PROFILE_NAME]:
+        boto3.setup_default_session(profile_name=aws_config[CONF_PROFILE_NAME])
+        del aws_config[CONF_PROFILE_NAME]
+
+    sns_client = boto3.client("sns", **aws_config)
+
+    return AWSSNS(sns_client)
+
+
+# pylint: disable=too-few-public-methods
+class AWSSNS(BaseNotificationService):
+    """Implement the notification service for the AWS SNS service."""
+
+    def __init__(self, sns_client):
+        """Initialize the service."""
+        self.client = sns_client
+
+    def send_message(self, message="", **kwargs):
+        """Send notification to specified SNS ARN."""
+        targets = kwargs.get(ATTR_TARGET)
+
+        if not targets:
+            _LOGGER.info("At least 1 target is required")
+            return
+
+        if not isinstance(targets, list):
+            targets = [targets]
+
+        for target in targets:
+            self.client.publish(TargetArn=target, Message=message,
+                                Subject=kwargs.get(ATTR_TITLE))

--- a/homeassistant/components/notify/aws_sqs.py
+++ b/homeassistant/components/notify/aws_sqs.py
@@ -1,0 +1,83 @@
+"""
+AWS SQS platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.aws_sqs/
+"""
+import logging
+import json
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_PLATFORM, CONF_NAME)
+from homeassistant.components.notify import (
+    ATTR_TARGET, BaseNotificationService)
+
+_LOGGER = logging.getLogger(__name__)
+REQUIREMENTS = ["boto3==1.3.1"]
+
+CONF_REGION = "region_name"
+CONF_ACCESS_KEY_ID = "aws_access_key_id"
+CONF_SECRET_ACCESS_KEY = "aws_secret_access_key"
+CONF_PROFILE_NAME = "profile_name"
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_PLATFORM): "aws_sqs",
+    vol.Optional(CONF_NAME): vol.Coerce(str),
+    vol.Optional(CONF_REGION, default="us-east-1"): vol.Coerce(str),
+    vol.Inclusive(CONF_ACCESS_KEY_ID, "credentials"): vol.Coerce(str),
+    vol.Inclusive(CONF_SECRET_ACCESS_KEY, "credentials"): vol.Coerce(str),
+    vol.Exclusive(CONF_PROFILE_NAME, "credentials"): vol.Coerce(str)
+})
+
+
+def get_service(hass, config):
+    """Get the AWS SQS notification service."""
+
+    # pylint: disable=import-error
+    import boto3
+
+    aws_config = config.copy()
+
+    del aws_config[CONF_PLATFORM]
+    del aws_config[CONF_NAME]
+
+    if aws_config[CONF_PROFILE_NAME]:
+        boto3.setup_default_session(profile_name=aws_config[CONF_PROFILE_NAME])
+        del aws_config[CONF_PROFILE_NAME]
+
+    sqs_client = boto3.client("sqs", **aws_config)
+
+    return AWSSQS(sqs_client)
+
+
+# pylint: disable=too-few-public-methods
+class AWSSQS(BaseNotificationService):
+    """Implement the notification service for the AWS SQS service."""
+
+    def __init__(self, sqs_client):
+        """Initialize the service."""
+        self.client = sqs_client
+
+    def send_message(self, message="", **kwargs):
+        """Send notification to specified SQS ARN."""
+        targets = kwargs.get(ATTR_TARGET)
+
+        if not targets:
+            _LOGGER.info("At least 1 target is required")
+            return
+
+        if not isinstance(targets, list):
+            targets = [targets]
+
+        for target in targets:
+            cleaned_kwargs = dict((k, v) for k, v in kwargs.items() if v)
+            message_body = {'message': message}
+            message_body.update(cleaned_kwargs)
+            message_attributes = {}
+            for key, val in cleaned_kwargs.items():
+                message_attributes[key] = {'StringValue': json.dumps(val),
+                                           'DataType': 'String'}
+            self.client.send_message(QueueUrl=target,
+                                     MessageBody=json.dumps(message_body),
+                                     MessageAttributes=message_attributes)

--- a/homeassistant/components/notify/aws_sqs.py
+++ b/homeassistant/components/notify/aws_sqs.py
@@ -72,12 +72,12 @@ class AWSSQS(BaseNotificationService):
 
         for target in targets:
             cleaned_kwargs = dict((k, v) for k, v in kwargs.items() if v)
-            message_body = {'message': message}
+            message_body = {"message": message}
             message_body.update(cleaned_kwargs)
             message_attributes = {}
             for key, val in cleaned_kwargs.items():
-                message_attributes[key] = {'StringValue': json.dumps(val),
-                                           'DataType': 'String'}
+                message_attributes[key] = {"StringValue": json.dumps(val),
+                                           "DataType": "String"}
             self.client.send_message(QueueUrl=target,
                                      MessageBody=json.dumps(message_body),
                                      MessageAttributes=message_attributes)

--- a/homeassistant/components/notify/aws_sqs.py
+++ b/homeassistant/components/notify/aws_sqs.py
@@ -33,7 +33,6 @@ PLATFORM_SCHEMA = vol.Schema({
 
 def get_service(hass, config):
     """Get the AWS SQS notification service."""
-
     # pylint: disable=import-error
     import boto3
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -38,6 +38,7 @@ blockchain==1.3.1
 # bluepy_devices>=0.2.0
 
 # homeassistant.components.notify.aws_sns
+# homeassistant.components.notify.aws_sqs
 boto3==1.3.1
 
 # homeassistant.components.notify.xmpp

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -37,6 +37,9 @@ blockchain==1.3.1
 # homeassistant.components.thermostat.eq3btsmart
 # bluepy_devices>=0.2.0
 
+# homeassistant.components.notify.aws_sns
+boto3==1.3.1
+
 # homeassistant.components.notify.xmpp
 dnspython3==1.12.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -37,6 +37,7 @@ blockchain==1.3.1
 # homeassistant.components.thermostat.eq3btsmart
 # bluepy_devices>=0.2.0
 
+# homeassistant.components.notify.aws_lambda
 # homeassistant.components.notify.aws_sns
 # homeassistant.components.notify.aws_sqs
 boto3==1.3.1


### PR DESCRIPTION
**Description:** This PR adds 3 new notify platforms all of which are offered by Amazon Web Services (AWS).
- [AWS Lambda](https://aws.amazon.com/lambda/)
- [AWS Simple Notification Service (SNS)](https://aws.amazon.com/sns/)
- [AWS Simple Queue Service (SQS)](https://aws.amazon.com/sns/)

**Related issue (if applicable):** #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#478

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
notify:
  - name: SNS
    platform: aws_sns
    aws_access_key_id: AWS_ACCESS_KEY_ID
    aws_secret_access_key: AWS_SECRET_ACCESS_KEY
    profile_name: AWS_PROFILE
    region_name: 'us-east-1'

  - name: SQS
    platform: aws_sqs
    aws_access_key_id: AWS_ACCESS_KEY_ID
    aws_secret_access_key: AWS_SECRET_ACCESS_KEY
    profile_name: AWS_PROFILE
    region_name: 'us-east-1'

  - name: Lambda
    platform: aws_lambda
    aws_access_key_id: AWS_ACCESS_KEY_ID
    aws_secret_access_key: AWS_SECRET_ACCESS_KEY
    profile_name: AWS_PROFILE
    region_name: 'us-east-1'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
