### PR TITLE
add some include_dir options

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -60,7 +60,9 @@ def _include_dir_merge_named_yaml(loader, node):
     mapping = OrderedDict()
     files = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
     for fname in glob.glob(files):
-        mapping.update(load_yaml(fname))
+        loaded_yaml = load_yaml(fname)
+        if isinstance(loaded_yaml, dict):
+            mapping.update(loaded_yaml)
     return mapping
 
 
@@ -75,7 +77,9 @@ def _include_dir_merge_list_yaml(loader, node):
     files = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
     merged_list = []
     for fname in glob.glob(files):
-        merged_list += load_yaml(fname)
+        loaded_yaml = load_yaml(fname)
+        if isinstance(loaded_yaml, list):
+            merged_list.extend(loaded_yaml)
     return merged_list
 
 

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -46,7 +46,7 @@ def _include_yaml(loader, node):
 
 
 def _include_dir_named_yaml(loader, node):
-    """Load multiple files from dir."""
+    """Load multiple files from dir as a dict."""
     mapping = OrderedDict()
     files = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
     for fname in glob.glob(files):
@@ -55,10 +55,28 @@ def _include_dir_named_yaml(loader, node):
     return mapping
 
 
+def _include_dir_merge_named_yaml(loader, node):
+    """Load multiple files from dir as a merged dict."""
+    mapping = OrderedDict()
+    files = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
+    for fname in glob.glob(files):
+        mapping.update(load_yaml(fname))
+    return mapping
+
+
 def _include_dir_list_yaml(loader, node):
-    """Load multiple files from dir."""
+    """Load multiple files from dir as a list."""
     files = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
     return [load_yaml(f) for f in glob.glob(files)]
+
+
+def _include_dir_merge_list_yaml(loader, node):
+    """Load multiple files from dir as a merged list."""
+    files = os.path.join(os.path.dirname(loader.name), node.value, '*.yaml')
+    merged_list = []
+    for fname in glob.glob(files):
+        merged_list += load_yaml(fname)
+    return merged_list
 
 
 def _ordered_dict(loader, node):
@@ -102,4 +120,8 @@ yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                                 _ordered_dict)
 yaml.SafeLoader.add_constructor('!env_var', _env_var_yaml)
 yaml.SafeLoader.add_constructor('!include_dir_list', _include_dir_list_yaml)
+yaml.SafeLoader.add_constructor('!include_dir_merge_list',
+                                _include_dir_merge_list_yaml)
 yaml.SafeLoader.add_constructor('!include_dir_named', _include_dir_named_yaml)
+yaml.SafeLoader.add_constructor('!include_dir_merge_named',
+                                _include_dir_merge_named_yaml)


### PR DESCRIPTION
Adds two additional `!include_dir` options.

`!include_dir_merge_list` merges yaml files containing lists into one big list. This enables splitting out, for example, big `sensor` and `switch` lists into logical groupings.

`configuration.yaml`:

``` yaml
sensor: !include_dir_merge_list sensors
```

and the directory `sensors`, where each file might list multiple sensors:

```
.homeassistant/sensors/
├── forecastio.yaml
├── glances.yaml
├── google_travel.yaml
├── mqtt.yaml
├── speedtest.yaml
├── supervisord.yaml
└── twitch.yaml
```

And a file would look like:

``` yaml
- platform: mqtt
  name: "Bedroom Humidity"
  state_topic: "sensor/3/humidity"
- platform: mqtt
  name: "Bedroom Motion"
  state_topic: "sensor/3/motion"
```

`!include_dir_merge_named` merges yaml files containing dicts into one big dict. Useful for logically grouping automations or customizations, etc. Works the same as the `merge_list` described above.
