### PR TITLE
Fix fitbit KeyError

### DIFF
--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -237,7 +237,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         for resource in config.get("monitored_resources",
                                    FITBIT_DEFAULT_RESOURCE_LIST):
             dev.append(FitbitSensor(authd_client, config_path, resource,
-                                    hass.config.temperature_unit))
+                                    hass.config.temperature_unit ==
+                                    TEMP_CELSIUS))
         add_devices(dev)
 
     else:
@@ -315,9 +316,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class FitbitSensor(Entity):
     """Implementation of a Fitbit sensor."""
 
-    def __init__(self, client, config_path, resource_type, temperature_unit):
+    def __init__(self, client, config_path, resource_type, is_metric):
         """Initialize the Fitbit sensor."""
-        self.is_metric = temperature_unit
         self.client = client
         self.config_path = config_path
         self.resource_type = resource_type
@@ -333,7 +333,7 @@ class FitbitSensor(Entity):
             try:
                 measurement_system = FITBIT_MEASUREMENTS[self.client.system]
             except KeyError:
-                if self.is_metric is TEMP_CELSIUS:
+                if is_metric:
                     measurement_system = FITBIT_MEASUREMENTS["metric"]
                 else:
                     measurement_system = FITBIT_MEASUREMENTS["en_US"]

--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -328,7 +328,10 @@ class FitbitSensor(Entity):
         unit_type = FITBIT_RESOURCES_LIST[self.resource_type]
         if unit_type == "":
             split_resource = self.resource_type.split("/")
-            measurement_system = FITBIT_MEASUREMENTS[self.client.system]
+            try:
+                measurement_system = FITBIT_MEASUREMENTS[self.client.system]
+            except KeyError:
+                measurement_system = FITBIT_MEASUREMENTS["metric"]
             unit_type = measurement_system[split_resource[-1]]
         self._unit_of_measurement = unit_type
         self._state = 0


### PR DESCRIPTION
**Description:**
Let fitbit `measurement_system` default to "metric" instead of crashing platform, if `measurement_system` is neither "en_US", "en_GB" or "metric".

Default is of course up for discussion:)

**Related issue (if applicable):** #
I experienced fitbit platform crash because measurement_system was identified as "en_NO"

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
