### PR TITLE
Round minutes to integer in google travel time, Fix issue #2080

### DIFF
--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -138,7 +138,7 @@ class GoogleTravelTimeSensor(Entity):
         """Return the state of the sensor."""
         try:
             res = self._matrix['rows'][0]['elements'][0]['duration']['value']
-            return res/60.0
+            return round(res/60)
         except KeyError:
             return None
 


### PR DESCRIPTION
**Related issue (if applicable):** #2080 
