### PR TITLE
Add media_player `group_players` service

### DIFF
--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -145,3 +145,11 @@ select_source:
     source:
       description: Name of the source to switch to. Platform dependent.
       example: 'video1'
+
+sonos_group_players:
+  description: Send Sonos media player the command for grouping all players into one (party mode).
+
+  fields:
+    entity_id:
+      description: Name(s) of entites that will coordinate the grouping. Platform dependent.
+      example: 'media_player.living_room_sonos'


### PR DESCRIPTION
**Description:**
Sonos platform supports a `party mode` feature that groups all
available players into a single group, of which the calling player
will be the coordinator.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. 
