### PR TITLE
Local File Camera - Serves a locl file as a camera

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -84,6 +84,7 @@ omit =
     homeassistant/components/camera/foscam.py
     homeassistant/components/camera/generic.py
     homeassistant/components/camera/mjpeg.py
+    homeassistant/components/camera/local_file_camera.py
     homeassistant/components/camera/rpi_camera.py
     homeassistant/components/device_tracker/actiontec.py
     homeassistant/components/device_tracker/aruba.py

--- a/homeassistant/components/camera/local_file_camera.py
+++ b/homeassistant/components/camera/local_file_camera.py
@@ -1,0 +1,54 @@
+"""Camera that loads a picture from a local file."""
+
+import logging
+import os
+
+from homeassistant.components.camera import Camera
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Camera."""
+    if config.get("file_path") is None:
+        _LOGGER.error("Missing required variable: file_path")
+        return False
+
+    setup_config = (
+        {
+            "name": config.get("name", "Local File Camera"),
+            "file_path": config.get("file_path",
+                                    os.path.join(os.path.dirname(__file__),
+                                                 'image.jpg'))
+        }
+    )
+
+    # check filepath given is readable
+    if not os.access(setup_config["file_path"], os.R_OK):
+        _LOGGER.error("Error: file path is not readable")
+        return False
+
+    add_devices([
+        LocalFileCamera(setup_config)
+    ])
+
+
+class LocalFileCamera(Camera):
+    """Local camera."""
+
+    def __init__(self, device_info):
+        """Initialize Local camera component."""
+        super().__init__()
+
+        self._name = device_info["name"]
+        self._config = device_info
+
+    def camera_image(self):
+        """Return image response."""
+        with open(self._config["file_path"], 'rb') as file:
+            return file.read()
+
+    @property
+    def name(self):
+        """Return the name of this camera."""
+        return self._name


### PR DESCRIPTION
**Description:**
The `Local File Camera` allows you to integrate any readable image file from disk into Home Assistant.
This can for example be used with various camera platforms that save a temporary images locally.
It's heavily based on the rpi_camera component with a few tweaks.

**Related issue (if applicable):** #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
camera:
  platform: local_file_camera
  name: Local File Camera
  file_path: /tmp/image.jpg
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
