### PR TITLE
Change color_RGB_to_xy formula & return brightness

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -235,9 +235,6 @@ class HueLight(Light):
         if ATTR_TRANSITION in kwargs:
             command['transitiontime'] = kwargs[ATTR_TRANSITION] * 10
 
-        if ATTR_BRIGHTNESS in kwargs:
-            command['bri'] = kwargs[ATTR_BRIGHTNESS]
-
         if ATTR_XY_COLOR in kwargs:
             command['xy'] = kwargs[ATTR_XY_COLOR]
         elif ATTR_RGB_COLOR in kwargs:
@@ -245,6 +242,9 @@ class HueLight(Light):
                 *(int(val) for val in kwargs[ATTR_RGB_COLOR]))
             command['xy'] = xyb[0], xyb[1]
             command['bri'] = xyb[2]
+
+        if ATTR_BRIGHTNESS in kwargs:
+            command['bri'] = kwargs[ATTR_BRIGHTNESS]
 
         if ATTR_COLOR_TEMP in kwargs:
             command['ct'] = kwargs[ATTR_COLOR_TEMP]

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -241,8 +241,10 @@ class HueLight(Light):
         if ATTR_XY_COLOR in kwargs:
             command['xy'] = kwargs[ATTR_XY_COLOR]
         elif ATTR_RGB_COLOR in kwargs:
-            command['xy'] = color_util.color_RGB_to_xy(
+            xyb = color_util.color_RGB_to_xy(
                 *(int(val) for val in kwargs[ATTR_RGB_COLOR]))
+            command['xy'] = xyb[0], xyb[1]
+            command['bri'] = xyb[2]
 
         if ATTR_COLOR_TEMP in kwargs:
             command['ct'] = kwargs[ATTR_COLOR_TEMP]

--- a/homeassistant/components/light/wemo.py
+++ b/homeassistant/components/light/wemo.py
@@ -105,6 +105,7 @@ class WemoLight(Light):
         elif ATTR_RGB_COLOR in kwargs:
             xycolor = color_util.color_RGB_to_xy(
                 *(int(val) for val in kwargs[ATTR_RGB_COLOR]))
+            self.device.turn_on(level=xycolor[2])
         else:
             xycolor = None
 

--- a/homeassistant/components/light/wemo.py
+++ b/homeassistant/components/light/wemo.py
@@ -105,7 +105,7 @@ class WemoLight(Light):
         elif ATTR_RGB_COLOR in kwargs:
             xycolor = color_util.color_RGB_to_xy(
                 *(int(val) for val in kwargs[ATTR_RGB_COLOR]))
-            self.device.turn_on(level=xycolor[2])
+            kwargs.setdefault(ATTR_BRIGHTNESS, xycolor[2])
         else:
             xycolor = None
 

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -97,7 +97,9 @@ class WinkLight(Light):
         }
 
         if rgb_color:
-            state_kwargs['color_xy'] = color_util.color_RGB_to_xy(*rgb_color)
+            xyb = color_util.color_RGB_to_xy(*rgb_color)
+            state_kwargs['color_xy'] = xyb[0], xyb[1]
+            state_kwargs['brightness'] = xyb[2]
 
         if color_temp_mired:
             state_kwargs['color_kelvin'] = mired_to_kelvin(color_temp_mired)

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -7,7 +7,8 @@ HASS_COLOR_MAX = 500  # mireds (inverted)
 HASS_COLOR_MIN = 154
 
 
-# Taken from: http://www.cse.unr.edu/~quiroz/inc/colortransforms.py
+# Taken from:
+# http://www.developers.meethue.com/documentation/color-conversions-rgb-xy
 # License: Code is given as is. Use at your own risk and discretion.
 # pylint: disable=invalid-name
 def color_RGB_to_xy(R, G, B):
@@ -15,36 +16,28 @@ def color_RGB_to_xy(R, G, B):
     if R + G + B == 0:
         return 0, 0
 
-    var_R = (R / 255.)
-    var_G = (G / 255.)
-    var_B = (B / 255.)
+    R = R / 255
+    B = B / 255
+    G = G / 255
 
-    if var_R > 0.04045:
-        var_R = ((var_R + 0.055) / 1.055) ** 2.4
-    else:
-        var_R /= 12.92
+    # Gamma correction
+    R = pow((R + 0.055) / (1.0 + 0.055),
+            2.4) if (R > 0.04045) else (R / 12.92)
+    G = pow((G + 0.055) / (1.0 + 0.055),
+            2.4) if (G > 0.04045) else (G / 12.92)
+    B = pow((B + 0.055) / (1.0 + 0.055),
+            2.4) if (B > 0.04045) else (B / 12.92)
 
-    if var_G > 0.04045:
-        var_G = ((var_G + 0.055) / 1.055) ** 2.4
-    else:
-        var_G /= 12.92
+    # Wide RGB D65 conversion formula
+    x = R * 0.664511 + G * 0.154324 + B * 0.162028
+    y = R * 0.313881 + G * 0.668433 + B * 0.047685
+    z = R * 0.000088 + G * 0.072310 + B * 0.986039
 
-    if var_B > 0.04045:
-        var_B = ((var_B + 0.055) / 1.055) ** 2.4
-    else:
-        var_B /= 12.92
+    # Convert XYZ to xy
+    cx = x / (x + y + z)
+    cy = y / (x + y + z)
 
-    var_R *= 100
-    var_G *= 100
-    var_B *= 100
-
-    # Observer. = 2 deg, Illuminant = D65
-    X = var_R * 0.4124 + var_G * 0.3576 + var_B * 0.1805
-    Y = var_R * 0.2126 + var_G * 0.7152 + var_B * 0.0722
-    Z = var_R * 0.0193 + var_G * 0.1192 + var_B * 0.9505
-
-    # Convert XYZ to xy, see CIE 1931 color space on wikipedia
-    return X / (X + Y + Z), Y / (X + Y + Z)
+    return round(cx, 3), round(cy, 3)
 
 
 # taken from

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -34,10 +34,10 @@ def color_RGB_to_xy(R, G, B):
     Z = R * 0.000088 + G * 0.072310 + B * 0.986039
 
     # Convert XYZ to xy
-    cx = X / (X + Y + Z)
-    cy = Y / (X + Y + Z)
+    x = X / (X + Y + Z)
+    y = Y / (X + Y + Z)
 
-    return round(cx, 3), round(cy, 3)
+    return round(x, 3), round(y, 3)
 
 
 # taken from

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -13,9 +13,6 @@ HASS_COLOR_MIN = 154
 # pylint: disable=invalid-name
 def color_RGB_to_xy(R, G, B):
     """Convert from RGB color to XY color."""
-    if R + G + B == 0:
-        return 0, 0
-
     R = R / 255
     B = B / 255
     G = G / 255
@@ -29,15 +26,22 @@ def color_RGB_to_xy(R, G, B):
             2.4) if (B > 0.04045) else (B / 12.92)
 
     # Wide RGB D65 conversion formula
-    x = R * 0.664511 + G * 0.154324 + B * 0.162028
-    y = R * 0.313881 + G * 0.668433 + B * 0.047685
-    z = R * 0.000088 + G * 0.072310 + B * 0.986039
+    X = R * 0.664511 + G * 0.154324 + B * 0.162028
+    Y = R * 0.313881 + G * 0.668433 + B * 0.047685
+    Z = R * 0.000088 + G * 0.072310 + B * 0.986039
 
     # Convert XYZ to xy
-    cx = x / (x + y + z)
-    cy = y / (x + y + z)
+    try:
+        x = X / (X + Y + Z)
+        y = Y / (X + Y + Z)
+    except ZeroDivisionError:
+        x, y = 0, 0
 
-    return round(cx, 3), round(cy, 3)
+    # Brightness
+    Y = 1 if Y > 1 else Y
+    brightness = round(Y * 255)
+
+    return round(x, 3), round(y, 3), brightness
 
 
 # taken from

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -29,13 +29,13 @@ def color_RGB_to_xy(R, G, B):
             2.4) if (B > 0.04045) else (B / 12.92)
 
     # Wide RGB D65 conversion formula
-    x = R * 0.664511 + G * 0.154324 + B * 0.162028
-    y = R * 0.313881 + G * 0.668433 + B * 0.047685
-    z = R * 0.000088 + G * 0.072310 + B * 0.986039
+    X = R * 0.664511 + G * 0.154324 + B * 0.162028
+    Y = R * 0.313881 + G * 0.668433 + B * 0.047685
+    Z = R * 0.000088 + G * 0.072310 + B * 0.986039
 
     # Convert XYZ to xy
-    cx = x / (x + y + z)
-    cy = y / (x + y + z)
+    cx = X / (X + Y + Z)
+    cy = Y / (X + Y + Z)
 
     return round(cx, 3), round(cy, 3)
 

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -13,6 +13,9 @@ HASS_COLOR_MIN = 154
 # pylint: disable=invalid-name
 def color_RGB_to_xy(R, G, B):
     """Convert from RGB color to XY color."""
+    if R + G + B == 0:
+        return 0, 0, 0
+
     R = R / 255
     B = B / 255
     G = G / 255
@@ -31,11 +34,8 @@ def color_RGB_to_xy(R, G, B):
     Z = R * 0.000088 + G * 0.072310 + B * 0.986039
 
     # Convert XYZ to xy
-    try:
-        x = X / (X + Y + Z)
-        y = Y / (X + Y + Z)
-    except ZeroDivisionError:
-        x, y = 0, 0
+    x = X / (X + Y + Z)
+    y = Y / (X + Y + Z)
 
     # Brightness
     Y = 1 if Y > 1 else Y

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -9,16 +9,17 @@ class TestColorUtil(unittest.TestCase):
     # pylint: disable=invalid-name
     def test_color_RGB_to_xy(self):
         """Test color_RGB_to_xy."""
-        self.assertEqual((0, 0), color_util.color_RGB_to_xy(0, 0, 0))
-        self.assertEqual((0.32, 0.336),
+        self.assertEqual((0, 0, 0), color_util.color_RGB_to_xy(0, 0, 0))
+        self.assertEqual((0.32, 0.336, 255),
                          color_util.color_RGB_to_xy(255, 255, 255))
 
-        self.assertEqual((0.136, 0.04),
+        self.assertEqual((0.136, 0.04, 12),
                          color_util.color_RGB_to_xy(0, 0, 255))
 
-        self.assertEqual((0.172, 0.747), color_util.color_RGB_to_xy(0, 255, 0))
+        self.assertEqual((0.172, 0.747, 170),
+                         color_util.color_RGB_to_xy(0, 255, 0))
 
-        self.assertEqual((0.679, 0.321),
+        self.assertEqual((0.679, 0.321, 80),
                          color_util.color_RGB_to_xy(255, 0, 0))
 
     def test_color_xy_brightness_to_RGB(self):

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -10,15 +10,15 @@ class TestColorUtil(unittest.TestCase):
     def test_color_RGB_to_xy(self):
         """Test color_RGB_to_xy."""
         self.assertEqual((0, 0), color_util.color_RGB_to_xy(0, 0, 0))
-        self.assertEqual((0.3127159072215825, 0.3290014805066623),
+        self.assertEqual((0.32, 0.336),
                          color_util.color_RGB_to_xy(255, 255, 255))
 
-        self.assertEqual((0.15001662234042554, 0.060006648936170214),
+        self.assertEqual((0.136, 0.04),
                          color_util.color_RGB_to_xy(0, 0, 255))
 
-        self.assertEqual((0.3, 0.6), color_util.color_RGB_to_xy(0, 255, 0))
+        self.assertEqual((0.172, 0.747), color_util.color_RGB_to_xy(0, 255, 0))
 
-        self.assertEqual((0.6400744994567747, 0.3299705106316933),
+        self.assertEqual((0.679, 0.321),
                          color_util.color_RGB_to_xy(255, 0, 0))
 
     def test_color_xy_brightness_to_RGB(self):


### PR DESCRIPTION
**Description:**
While developing the Flux component, I was finding that the RGB to XY function wasn't working as I expected.  This PR changes the rgb to xy function as well as the tests for it.  I'm using the instruction from the [Hue developers website](http://www.developers.meethue.com/documentation/color-conversions-rgb-xy).

One thing missing from this function is that if the calculated xy value is outside of the lights gamut triangle, it should calculate the closest point on the color gamut triangle and use that as xy value. The closest value is calculated by making a perpendicular line to one of the lines the triangle consists of and when it is then still not inside the triangle, we choose the closest corner point of the triangle.  For Philips Hue, if you assign a value outside the triangle it will automatically set it appropriately.  I'm not sure about the other lights.

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
