### PR TITLE
Fix profile usage with aws notify platforms

### DIFF
--- a/homeassistant/components/notify/aws_lambda.py
+++ b/homeassistant/components/notify/aws_lambda.py
@@ -50,8 +50,10 @@ def get_service(hass, config):
     del aws_config[CONF_NAME]
     del aws_config[CONF_CONTEXT]
 
-    if aws_config[CONF_PROFILE_NAME]:
-        boto3.setup_default_session(profile_name=aws_config[CONF_PROFILE_NAME])
+    profile = aws_config.get(CONF_PROFILE_NAME)
+
+    if profile is not None:
+        boto3.setup_default_session(profile_name=profile)
         del aws_config[CONF_PROFILE_NAME]
 
     lambda_client = boto3.client("lambda", **aws_config)

--- a/homeassistant/components/notify/aws_sns.py
+++ b/homeassistant/components/notify/aws_sns.py
@@ -41,8 +41,10 @@ def get_service(hass, config):
     del aws_config[CONF_PLATFORM]
     del aws_config[CONF_NAME]
 
-    if aws_config[CONF_PROFILE_NAME]:
-        boto3.setup_default_session(profile_name=aws_config[CONF_PROFILE_NAME])
+    profile = aws_config.get(CONF_PROFILE_NAME)
+
+    if profile is not None:
+        boto3.setup_default_session(profile_name=profile)
         del aws_config[CONF_PROFILE_NAME]
 
     sns_client = boto3.client("sns", **aws_config)

--- a/homeassistant/components/notify/aws_sqs.py
+++ b/homeassistant/components/notify/aws_sqs.py
@@ -41,8 +41,10 @@ def get_service(hass, config):
     del aws_config[CONF_PLATFORM]
     del aws_config[CONF_NAME]
 
-    if aws_config[CONF_PROFILE_NAME]:
-        boto3.setup_default_session(profile_name=aws_config[CONF_PROFILE_NAME])
+    profile = aws_config.get(CONF_PROFILE_NAME)
+
+    if profile is not None:
+        boto3.setup_default_session(profile_name=profile)
         del aws_config[CONF_PROFILE_NAME]
 
     sqs_client = boto3.client("sqs", **aws_config)


### PR DESCRIPTION
Leaving out a profile in your AWS config was crashing the platforms.
