### PR TITLE
Upgrade psutil to 4.2.0

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -10,7 +10,7 @@ import homeassistant.util.dt as dt_util
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['psutil==4.1.0']
+REQUIREMENTS = ['psutil==4.2.0']
 SENSOR_TYPES = {
     'disk_use_percent': ['Disk Use', '%', 'mdi:harddisk'],
     'disk_use': ['Disk Use', 'GiB', 'mdi:harddisk'],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -193,7 +193,7 @@ plexapi==1.1.0
 proliphix==0.1.0
 
 # homeassistant.components.sensor.systemmonitor
-psutil==4.1.0
+psutil==4.2.0
 
 # homeassistant.components.notify.pushbullet
 pushbullet.py==0.10.0


### PR DESCRIPTION
**Enhancements**
- [Windows] new APIs to deal with Windows services: win_service_iter() and win_service_get().
- [Linux] psutil.virtual_memory() returns a new "shared" memory field.
- [Linux] speedup /proc parsing:
  - Process.ppid() is 20% faster
  - Process.status() is 28% faster
  - Process.name() is 25% faster
  - Process.num_threads is 20% faster on Python 3

**Bug fixes**
- [Linux] net_if_stats() may raise OSError for certain NIC cards.
- Process.as_dict() should ignore extraneous attribute names which gets
  attached to the Process instance.

Tested with the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
      - type: 'memory_use_percent'
      - type: 'memory_use'
      - type: 'memory_free'
      - type: 'swap_use_percent'
      - type: 'swap_use'
      - type: 'swap_free'
      - type: 'network_in'
        arg: 'wlp1s0'
      - type: 'network_out'
        arg: 'wlp1s0'
      - type: 'packets_in'
        arg: 'wlp1s0'
      - type: 'packets_out'
        arg: 'wlp1s0'
      - type: 'ipv4_address'
        arg: 'wlp1s0'
      - type: 'ipv6_address'
        arg: 'wlp1s0'
      - type: 'processor_use'
      - type: 'last_boot'
      - type: 'since_last_boot'
```
