### PR TITLE
redirect daemon file descriptors

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -151,6 +151,13 @@ def daemonize():
     if pid > 0:
         sys.exit(0)
 
+    # redirect standard file descriptors to devnull
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os.dup2(open(os.devnull, 'r').fileno(), sys.stdin.fileno())
+    os.dup2(open(os.devnull, 'a+').fileno(), sys.stdout.fileno())
+    os.dup2(open(os.devnull, 'a+').fileno(), sys.stderr.fileno())
+
 
 def check_pid(pid_file):
     """Check that HA is not already running."""
@@ -234,15 +241,14 @@ def setup_and_run_hass(config_dir, args, top_process=False):
             'demo': {}
         }
         hass = bootstrap.from_config_dict(
-            config, config_dir=config_dir, daemon=args.daemon,
-            verbose=args.verbose, skip_pip=args.skip_pip,
-            log_rotate_days=args.log_rotate_days)
+            config, config_dir=config_dir, verbose=args.verbose,
+            skip_pip=args.skip_pip, log_rotate_days=args.log_rotate_days)
     else:
         config_file = ensure_config_file(config_dir)
         print('Config directory:', config_dir)
         hass = bootstrap.from_config_file(
-            config_file, daemon=args.daemon, verbose=args.verbose,
-            skip_pip=args.skip_pip, log_rotate_days=args.log_rotate_days)
+            config_file, verbose=args.verbose, skip_pip=args.skip_pip,
+            log_rotate_days=args.log_rotate_days)
 
     if hass is None:
         return

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -215,7 +215,7 @@ def mount_local_lib_path(config_dir):
 
 # pylint: disable=too-many-branches, too-many-statements, too-many-arguments
 def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
-                     verbose=False, daemon=False, skip_pip=False,
+                     verbose=False, skip_pip=False,
                      log_rotate_days=None):
     """Try to configure Home Assistant from a config dict.
 
@@ -240,7 +240,7 @@ def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
     process_ha_config_upgrade(hass)
 
     if enable_log:
-        enable_logging(hass, verbose, daemon, log_rotate_days)
+        enable_logging(hass, verbose, log_rotate_days)
 
     hass.config.skip_pip = skip_pip
     if skip_pip:
@@ -278,8 +278,8 @@ def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
     return hass
 
 
-def from_config_file(config_path, hass=None, verbose=False, daemon=False,
-                     skip_pip=True, log_rotate_days=None):
+def from_config_file(config_path, hass=None, verbose=False, skip_pip=True,
+                     log_rotate_days=None):
     """Read the configuration file and try to start all the functionality.
 
     Will add functionality to 'hass' parameter if given,
@@ -293,7 +293,7 @@ def from_config_file(config_path, hass=None, verbose=False, daemon=False,
     hass.config.config_dir = config_dir
     mount_local_lib_path(config_dir)
 
-    enable_logging(hass, verbose, daemon, log_rotate_days)
+    enable_logging(hass, verbose, log_rotate_days)
 
     try:
         config_dict = config_util.load_yaml_config_file(config_path)
@@ -304,28 +304,27 @@ def from_config_file(config_path, hass=None, verbose=False, daemon=False,
                             skip_pip=skip_pip)
 
 
-def enable_logging(hass, verbose=False, daemon=False, log_rotate_days=None):
+def enable_logging(hass, verbose=False, log_rotate_days=None):
     """Setup the logging."""
-    if not daemon:
-        logging.basicConfig(level=logging.INFO)
-        fmt = ("%(log_color)s%(asctime)s %(levelname)s (%(threadName)s) "
-               "[%(name)s] %(message)s%(reset)s")
-        try:
-            from colorlog import ColoredFormatter
-            logging.getLogger().handlers[0].setFormatter(ColoredFormatter(
-                fmt,
-                datefmt='%y-%m-%d %H:%M:%S',
-                reset=True,
-                log_colors={
-                    'DEBUG': 'cyan',
-                    'INFO': 'green',
-                    'WARNING': 'yellow',
-                    'ERROR': 'red',
-                    'CRITICAL': 'red',
-                }
-            ))
-        except ImportError:
-            pass
+    logging.basicConfig(level=logging.INFO)
+    fmt = ("%(log_color)s%(asctime)s %(levelname)s (%(threadName)s) "
+           "[%(name)s] %(message)s%(reset)s")
+    try:
+        from colorlog import ColoredFormatter
+        logging.getLogger().handlers[0].setFormatter(ColoredFormatter(
+            fmt,
+            datefmt='%y-%m-%d %H:%M:%S',
+            reset=True,
+            log_colors={
+                'DEBUG': 'cyan',
+                'INFO': 'green',
+                'WARNING': 'yellow',
+                'ERROR': 'red',
+                'CRITICAL': 'red',
+            }
+        ))
+    except ImportError:
+        pass
 
     # Log errors to a file if we have write access to file or config dir
     err_log_path = hass.config.path(ERROR_LOG_FILENAME)


### PR DESCRIPTION
**Description:**
There was a printout after the daemon had been created to the parents stdout. This patch will redirect standard file descriptors to /dev/null.
I have also removed the daemon arguments to the logger since they will no longer be needed. 

(This is absolutely no big deal, was just curious about the printout. If the daemonizing was done in that way for a reason just drop this...) 

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
