### PR TITLE
Fixed issue with edimax SP-1101 switches

### DIFF
--- a/homeassistant/components/switch/edimax.py
+++ b/homeassistant/components/switch/edimax.py
@@ -59,7 +59,7 @@ class SmartPlugSwitch(SwitchDevice):
         """Return the current power usage in mWh."""
         try:
             return float(self.smartplug.now_power) / 1000000.0
-        except ValueError:
+        except TypeError:
             return None
 
     @property
@@ -67,7 +67,7 @@ class SmartPlugSwitch(SwitchDevice):
         """Return the today total power usage in mW."""
         try:
             return float(self.smartplug.now_energy_day) / 1000.0
-        except ValueError:
+        except TypeError:
             return None
 
     @property

--- a/homeassistant/components/switch/edimax.py
+++ b/homeassistant/components/switch/edimax.py
@@ -59,6 +59,8 @@ class SmartPlugSwitch(SwitchDevice):
         """Return the current power usage in mWh."""
         try:
             return float(self.smartplug.now_power) / 1000000.0
+        except ValueError:
+            return None
         except TypeError:
             return None
 
@@ -67,6 +69,8 @@ class SmartPlugSwitch(SwitchDevice):
         """Return the today total power usage in mW."""
         try:
             return float(self.smartplug.now_energy_day) / 1000.0
+        except ValueError:
+            return None
         except TypeError:
             return None
 


### PR DESCRIPTION
**Description:**
Fix to regression in commit 6a7e28cc8565eec9a540cb0d8ea61f75e4372131

When used with SP-1101 switch, following exception is thrown:

```
Traceback (most recent call last):
  File "/usr/lib/python3.4/site-packages/homeassistant/helpers/entity_component.py", line 98, in _setup_platform
    discovery_info)
  File "/usr/lib/python3.4/site-packages/homeassistant/components/switch/edimax.py", line 41, in setup_platform
    add_devices_callback([SmartPlugSwitch(SmartPlug(host, auth), name)])
  File "/usr/lib/python3.4/site-packages/homeassistant/helpers/entity_component.py", line 155, in add_entities
    if self.component.add_entity(entity, self):
  File "/usr/lib/python3.4/site-packages/homeassistant/helpers/entity_component.py", line 125, in add_entity
    entity.update_ha_state()
  File "/usr/lib/python3.4/site-packages/homeassistant/helpers/entity.py", line 148, in update_ha_state
    attr = self.state_attributes or {}
  File "/usr/lib/python3.4/site-packages/homeassistant/components/switch/__init__.py", line 149, in state_attributes
    value = getattr(self, prop)
  File "/usr/lib/python3.4/site-packages/homeassistant/components/switch/edimax.py", line 61, in current_power_mwh
    return float(self.smartplug.now_power) / 1000000.0
  File "/home/hass/.homeassistant/deps/pyedimax/smartplug.py", line 208, in now_power
    float(res)
TypeError: float() argument must be a string or a number, not 'NoneType'
```

That's due to wrong exception handling in `today_power_mw` and `current_power_mwh` methods. Exception type is `TypeError`, not `ValueError`.
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
