### PR TITLE
Owntracks fixes

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 
 import homeassistant.components.mqtt as mqtt
 from homeassistant.const import STATE_HOME
-from homeassistant.util import convert
+from homeassistant.util import convert, slugify
 
 DEPENDENCIES = ['mqtt']
 
@@ -91,7 +91,7 @@ def setup_scanner(hass, config, see):
             return
         # OwnTracks uses - at the start of a beacon zone
         # to switch on 'hold mode' - ignore this
-        location = data['desc'].lstrip("-")
+        location = slugify(data['desc'].lstrip("-"))
         if location.lower() == 'home':
             location = STATE_HOME
 

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -53,6 +53,12 @@ def setup_scanner(hass, config, see):
                           'accuracy %s is not met: %s',
                           data_type, max_gps_accuracy, data)
             return None
+        if convert(data.get('acc'), float, 1.0) == 0.0:
+            _LOGGER.debug('Skipping %s update because GPS accuracy'
+                          'is zero',
+                          data_type)
+            return None
+
         return data
 
     def owntracks_location_update(topic, payload, qos):

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -230,6 +230,20 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         # Left clean zone state
         self.assertFalse(owntracks.REGIONS_ENTERED[USER])
 
+    def test_event_with_spaces(self):
+        """Test the entry event."""
+        message = REGION_ENTER_MESSAGE.copy()
+        message['desc'] = "inner 2"
+        self.send_message(EVENT_TOPIC, message)
+        self.assert_location_state('inner_2')
+
+        message = REGION_LEAVE_MESSAGE.copy()
+        message['desc'] = "inner 2"
+        self.send_message(EVENT_TOPIC, message)
+
+        # Left clean zone state
+        self.assertFalse(owntracks.REGIONS_ENTERED[USER])
+
     def test_event_entry_exit_inaccurate(self):
         """Test the event for inaccurate exit."""
         self.send_message(EVENT_TOPIC, REGION_ENTER_MESSAGE)

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -55,6 +55,21 @@ LOCATION_MESSAGE_INACCURATE = {
     'tst': 1,
     'vel': 0}
 
+LOCATION_MESSAGE_ZERO_ACCURACY = {
+    'batt': 92,
+    'cog': 248,
+    'tid': 'user',
+    'lon': 2.0,
+    't': 'u',
+    'alt': 27,
+    'acc': 0,
+    'p': 101.3977584838867,
+    'vac': 4,
+    'lat': 6.0,
+    '_type': 'location',
+    'tst': 1,
+    'vel': 0}
+
 REGION_ENTER_MESSAGE = {
     'lon': 1.0,
     'event': 'enter',
@@ -200,6 +215,14 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         """Test the location for inaccurate GPS information."""
         self.send_message(LOCATION_TOPIC, LOCATION_MESSAGE)
         self.send_message(LOCATION_TOPIC, LOCATION_MESSAGE_INACCURATE)
+
+        self.assert_location_latitude(2.0)
+        self.assert_location_longitude(1.0)
+
+    def test_location_zero_accuracy_gps(self):
+        """Ignore the location for zero accuracy GPS information."""
+        self.send_message(LOCATION_TOPIC, LOCATION_MESSAGE)
+        self.send_message(LOCATION_TOPIC, LOCATION_MESSAGE_ZERO_ACCURACY)
 
         self.assert_location_latitude(2.0)
         self.assert_location_longitude(1.0)


### PR DESCRIPTION
**Description:**
Fixes a couple of reported issues with owntracks. 

**Related issue (if applicable):** #
Closes https://github.com/home-assistant/home-assistant/issues/1986
Closes https://github.com/home-assistant/home-assistant/issues/1957

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
