### PR TITLE
Plex sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -169,6 +169,7 @@ omit =
     homeassistant/components/sensor/nzbget.py
     homeassistant/components/sensor/onewire.py
     homeassistant/components/sensor/openweathermap.py
+    homeassistant/components/sensor/plex.py
     homeassistant/components/sensor/rest.py
     homeassistant/components/sensor/sabnzbd.py
     homeassistant/components/sensor/speedtest.py

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -77,8 +77,8 @@ class PlexSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         data = {}
-        for idx, content in enumerate(self._now_playing):
-            data[str(idx + 1)] = content
+        for content in self._now_playing:
+            data[content[0]] = content[1]
         return data
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
@@ -97,8 +97,6 @@ class PlexSensor(Entity):
                 user = self._user
             video = data['movie_title'][index]
             year = data['movie_year'][index]
-            now_playing.append("{0} is watching {1} ({2})".format(user,
-                                                                  video,
-                                                                  year))
+            now_playing.append((user, "{0} ({1})".format(video, year)))
         self._state = len(data['user_list'])
         self._now_playing = now_playing

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -1,0 +1,104 @@
+"""
+Support for Plex media server monitoring.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.plex/
+"""
+from datetime import timedelta
+import voluptuous as vol
+
+from homeassistant.const import CONF_PLATFORM, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_HOST, CONF_PORT
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = [
+    'https://github.com/nkgilley/python-plex-api/archive/'
+    '22a3279bce552122afac694e481a3064a8ab9b0f.zip#python-plex-api==0.0.1']
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_PLATFORM): 'plex',
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_HOST, default='localhost'): cv.string,
+    vol.Optional(CONF_PORT, default=32400): vol.All(vol.Coerce(int),
+                                                    vol.Range(min=1,
+                                                              max=65535))
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Demo sensors."""
+    plex_user = config.get(CONF_USERNAME)
+    plex_password = config.get(CONF_PASSWORD)
+    plex_host = config.get(CONF_HOST)
+    plex_port = config.get(CONF_PORT)
+    add_devices([PlexSensor('Plex', plex_user, plex_password,
+                            (plex_host, plex_port))])
+
+
+class PlexSensor(Entity):
+    """Plex now playing sensor."""
+
+    def __init__(self, name, plex_user, plex_password, plex_server):
+        """Initialize the sensor."""
+        self._name = name
+        self._state = 0
+        self._now_playing = []
+        self._user = plex_user
+        self._host = plex_server[0]
+        self._port = plex_server[1]
+
+        from pyplex import get_auth_token
+        self._auth_token = get_auth_token(plex_user, plex_password)
+
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit this state is expressed in."""
+        return "Watching"
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        data = {}
+        for idx, content in enumerate(self._now_playing):
+            data[str(idx + 1)] = content
+        return data
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Update method for plex sensor."""
+        from pyplex import get_now_playing
+        data = get_now_playing(auth_token=self._auth_token,
+                               plex_user=self._user,
+                               plex_host=self._host,
+                               plex_port=self._port)
+        now_playing = []
+        for index, user in enumerate(data['user_list']):
+            if data['user_list'][index]:
+                user = data['user_list'][index]
+            else:
+                user = self._user
+            video = data['movie_title'][index]
+            year = data['movie_year'][index]
+            now_playing.append("{0} is watching {1} ({2})".format(user,
+                                                                  video,
+                                                                  year))
+        self._state = len(data['user_list'])
+        self._now_playing = now_playing

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -92,9 +92,11 @@ class PlexSensor(Entity):
                     user_list.append(user_elem.attrib['title'])
                 for state_elem in video_elem.iter('Player'):
                     user_state.append(state_elem.attrib['state'])
+        now_playing = ""
         if len(user_list) > 0:
             for index in range(len(user_list)):
                 user = user_list[index] if user_list[index] else self._user
-                self._state = "{0} is watching {1} ({2})\tState: {3}\n".format(user, movie_title[index], movie_year[index], user_state[index])
+                now_playing += "{0} is watching {1} ({2})\tState: {3}\n".format(user, movie_title[index], movie_year[index], user_state[index])
         else:
-            self._state = 'Nobody is Watching Anything!'
+            now_playing = 'Nobody is Watching Anything!'
+        self._state = now_playing

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -1,0 +1,96 @@
+import requests
+import voluptuous as vol
+import xml.etree.cElementTree as ET
+
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_HOST, CONF_PORT
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+
+DOMAIN = 'plex'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_HOST): cv.string,
+        vol.Optional(CONF_PORT): vol.All(vol.Coerce(int), vol.Range(min=1, max=65535))
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Demo sensors."""
+    plex_user = config[CONF_USERNAME]
+    plex_password = config[CONF_PASSWORD]
+    plex_host = config[CONF_HOST] if CONF_HOST in config else "localhost"
+    plex_port = config[CONF_PORT] if CONF_PORT in config else 32400
+    plex_url = 'http://' + plex_host + ':' + str(plex_port) + '/status/sessions'
+    add_devices([PlexSensor('Plex', plex_user, plex_password, plex_url)])
+
+class PlexSensor(Entity):
+    """Plex now playing sensor."""
+
+    def __init__(self, name, plex_user, plex_password, plex_url):
+        """Initialize the sensor."""
+        self._name = name
+        self._state = None
+        self._user = plex_user
+        self._auth_token = self.getAuthToken(plex_user, plex_password)
+        self._url = plex_url
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    def getAuthToken(self, plex_user, plex_password):
+        """Get Plex authorization token."""
+        auth_url = 'https://my.plexapp.com/users/sign_in.xml'
+        auth_params = {'user[login]': plex_user,'user[password]': plex_password}
+
+        headers = {
+            'X-Plex-Product': 'Plex API',
+            'X-Plex-Version': "2.0",
+            'X-Plex-Client-Identifier': '012286'
+        }
+
+        response = requests.post(auth_url, data=auth_params, headers=headers)
+        auth_tree = ET.fromstring(response.text)
+        for auth_elem in auth_tree.getiterator():
+            if 'authentication-token' == auth_elem.tag:
+                return auth_elem.text.strip()
+
+
+    def update(self):
+        plex_response = requests.post(self._url + '?X-Plex-Token=' + self._auth_token)
+        tree = ET.fromstring(plex_response.text)
+
+        movie_title = []
+        movie_year = []
+        user_list = []
+        user_state = []
+
+        for elem in tree.getiterator('MediaContainer'):
+            for video_elem in elem.iter('Video'):
+                if video_elem.attrib['type'] == 'episode':
+                        movie_title.append(video_elem.attrib['grandparentTitle'] +
+                                           ' - ' + video_elem.attrib['title'])
+                else:
+                        movie_title.append(video_elem.attrib['title'])
+                movie_year.append(video_elem.attrib['year'])
+                for user_elem in video_elem.iter('User'):
+                    user_list.append(user_elem.attrib['title'])
+                for state_elem in video_elem.iter('Player'):
+                    user_state.append(state_elem.attrib['state'])
+        if len(user_list) > 0:
+            for index in range(len(user_list)):
+                user = user_list[index] if user_list[index] else self._user
+                self._state = "{0} is watching {1} ({2})\tState: {3}\n".format(user, movie_title[index], movie_year[index], user_state[index])
+        else:
+            self._state = 'Nobody is Watching Anything!'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -124,6 +124,9 @@ https://github.com/kellerza/pyqwikswitch/archive/v0.1.zip#pyqwikswitch==0.1
 # homeassistant.components.ecobee
 https://github.com/nkgilley/python-ecobee-api/archive/4a884bc146a93991b4210f868f3d6aecf0a181e6.zip#python-ecobee==0.0.5
 
+# homeassistant.components.sensor.plex
+https://github.com/nkgilley/python-plex-api/archive/22a3279bce552122afac694e481a3064a8ab9b0f.zip#python-plex-api==0.0.1
+
 # homeassistant.components.switch.edimax
 https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f3700.zip#pyedimax==0.1
 


### PR DESCRIPTION
**Description:**
Initial support for plex sensor to see who is watching what.

This is a port from [Python 2 code I found on reddit](https://www.reddit.com/r/PleX/comments/3wk3y8/plexpy_is_there_a_way_to_view_activity_using_cli/cxycgm1) to Python 3 + Home-Assistant.

This pull request acts like a basic version of PlexPy.  It will create a sensor that shows the # of currently watching users as the state.  If you click the sensor for more detail it will show you who is watching what.

![image](https://cloud.githubusercontent.com/assets/1507498/15750220/a80986fe-28b3-11e6-807e-a3f2a6db3185.png)

**Related issue (if applicable):** #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#526

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: plex
  username: plexuser
  password: plexpassword
  host: 192.168.1.100
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
