### PR TITLE
Fix for bad filedescriptor when daemonizing

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -158,9 +158,9 @@ def daemonize():
     # redirect standard file descriptors to devnull
     sys.stdout.flush()
     sys.stderr.flush()
-    os.dup2(open(os.devnull, 'r').fileno(), sys.stdin.fileno())
-    os.dup2(open(os.devnull, 'a+').fileno(), sys.stdout.fileno())
-    os.dup2(open(os.devnull, 'a+').fileno(), sys.stderr.fileno())
+    os.dup2(sys.stdin.fileno(), open(os.devnull, 'r').fileno())
+    os.dup2(sys.stdout.fileno(), open(os.devnull, 'a+').fileno())
+    os.dup2(sys.stderr.fileno(), open(os.devnull, 'a+').fileno())
 
 
 def check_pid(pid_file):


### PR DESCRIPTION
**Description:**
When daemonizing I was getting a bad filedescriptor error, it turned out that the arguments to dup2 were swapped so we were copying the old stdin/stdout/stderr fds to the newly opened /dev/null ones instead of the other way around.

**Related issue (if applicable):** #2103
