### PR TITLE
Reduce template warnings

### DIFF
--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -29,7 +29,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
         result = template.setup_platform(hass, config, add_devices)
         self.assertTrue(result)
         mock_template.assert_called_once_with(hass, 'test', 'virtual thingy',
-                                              'motion', '{{ foo }}')
+                                              'motion', '{{ foo }}', True)
         add_devices.assert_called_once_with([mock_template.return_value])
 
     def test_setup_no_sensors(self):
@@ -77,7 +77,8 @@ class TestBinarySensorTemplate(unittest.TestCase):
         """"Test the attributes."""
         hass = mock.MagicMock()
         vs = template.BinarySensorTemplate(hass, 'parent', 'Parent',
-                                           'motion', '{{ 1 > 1 }}')
+                                           'motion', '{{ 1 > 1 }}',
+                                           True)
         self.assertFalse(vs.should_poll)
         self.assertEqual('motion', vs.sensor_class)
         self.assertEqual('Parent', vs.name)
@@ -93,7 +94,8 @@ class TestBinarySensorTemplate(unittest.TestCase):
         """"Test the event."""
         hass = get_test_home_assistant()
         vs = template.BinarySensorTemplate(hass, 'parent', 'Parent',
-                                           'motion', '{{ 1 > 1 }}')
+                                           'motion', '{{ 1 > 1 }}',
+                                           True)
         vs.update_ha_state()
         hass.pool.block_till_done()
 
@@ -110,7 +112,8 @@ class TestBinarySensorTemplate(unittest.TestCase):
         """"Test the template update error."""
         hass = mock.MagicMock()
         vs = template.BinarySensorTemplate(hass, 'parent', 'Parent',
-                                           'motion', '{{ 1 > 1 }}')
+                                           'motion', '{{ 1 > 1 }}',
+                                           True)
         mock_render.side_effect = TemplateError('foo')
         vs.update()
         mock_render.side_effect = TemplateError(


### PR DESCRIPTION
**Description:**
Allow option to remove template sensor warnings on start up.

**Related issue (if applicable):** #
Closes https://github.com/home-assistant/home-assistant/issues/2109

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
- platform: template
    sensors:
      solar_angle:
        value_template: '{{ "%+.1f"|format(states.sun.sun.attributes.elevation) }}'
        friendly_name: 'Sun Angle'
        unit_of_measurement: '°'
        warnings: Off
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
