### PR TITLE
Not sure why, but this fixed a bad filedescriptor error.

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -156,11 +156,13 @@ def daemonize():
         sys.exit(0)
 
     # redirect standard file descriptors to devnull
+    infd = open(os.devnull, 'r')
+    outfd = open(os.devnull, 'a+')
     sys.stdout.flush()
     sys.stderr.flush()
-    os.dup2(open(os.devnull, 'r').fileno(), sys.stdin.fileno())
-    os.dup2(open(os.devnull, 'a+').fileno(), sys.stdout.fileno())
-    os.dup2(open(os.devnull, 'a+').fileno(), sys.stderr.fileno())
+    os.dup2(infd.fileno(), sys.stdin.fileno())
+    os.dup2(outfd.fileno(), sys.stdout.fileno())
+    os.dup2(outfd.fileno(), sys.stderr.fileno())
 
 
 def check_pid(pid_file):


### PR DESCRIPTION
**Description:**
The current dev branch reliably gives me,

```
Traceback (most recent call last):
  File "env/bin/hass", line 9, in <module>
    load_entry_point('homeassistant==0.20.0.dev0', 'console_scripts', 'hass')()
  File "homeassistant/__main__.py", line 390, in main
    daemonize()
  File "homeassistant/__main__.py", line 161, in daemonize
    os.dup2(open(os.devnull, 'r').fileno(), sys.stdin.fileno())
OSError: [Errno 9] Bad file descriptor
```

But when I broke out the `open(os.devnull, ...)` part to debug the problem, leaving the rest of the code identical, the error went away so I have no clue _why_ this works.
