### PR TITLE
Single process restart fixes

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -395,7 +395,10 @@ def main():
 
     # Create new process group if we can
     if hasattr(os, 'setpgid'):
-        os.setpgid(0, 0)
+        try:
+            os.setpgid(0, 0)
+        except PermissionError:
+            pass
 
     exit_code = setup_and_run_hass(config_dir, args)
     if exit_code == RESTART_EXIT_CODE and not args.runner:

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -174,6 +174,10 @@ def check_pid(pid_file):
         # PID File does not exist
         return
 
+    # If we just restarted, we just found our own pidfile.
+    if pid == os.getpid():
+        return
+
     try:
         os.kill(pid, 0)
     except OSError:

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -257,6 +257,9 @@ def closefds_osx(min_fd, max_fd):
 
 def cmdline():
     """Collect path and arguments to re-execute the current hass instance."""
+    if sys.argv[0].endswith('/__main__.py'):
+        modulepath = os.path.dirname(sys.argv[0])
+        os.environ['PYTHONPATH'] = os.path.dirname(modulepath)
     return [sys.executable] + [arg for arg in sys.argv if arg != '--daemon']
 
 


### PR DESCRIPTION
**Description:**

Fixes:
- startup on Docker (ignore setpgid error)
- restart when using a pidfile
- restart when started with `python -m homeassistant`

**Related issue (if applicable):** #1793

**Checklist:**

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
