### PR TITLE
Updated pyqwikswitch & QS<->HA UI behaviour

### DIFF
--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -88,6 +88,7 @@ class QSToggleEntity(object):
             self.update_value(0)
 
 
+# pylint: disable=too-many-locals
 def setup(hass, config):
     """Setup the QSUSB component."""
     from pyqwikswitch import (QSUsb, CMD_BUTTONS, QS_NAME, QS_ID, QS_CMD,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -119,7 +119,7 @@ https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
 
 # homeassistant.components.qwikswitch
-https://github.com/kellerza/pyqwikswitch/archive/v0.1.zip#pyqwikswitch==0.1
+https://github.com/kellerza/pyqwikswitch/archive/v0.3.zip#pyqwikswitch==0.3
 
 # homeassistant.components.ecobee
 https://github.com/nkgilley/python-ecobee-api/archive/4a884bc146a93991b4210f868f3d6aecf0a181e6.zip#python-ecobee==0.0.5


### PR DESCRIPTION
**Description:**
- Update pyqwikswith & added constants, handling server restarts
- Ensure QS is set before updateing HA state to prevent repeat LOG entries introduced by fixing flicker in previous release

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
qwikswitch:
  url: http://127.0.0.1:2020
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [N/A] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Tests: flake8, docstrings & pylint
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [N/A] New files were added to `.coveragerc`.
