### PR TITLE
Round temp and percentage for octoprint sensors

### DIFF
--- a/homeassistant/components/sensor/octoprint.py
+++ b/homeassistant/components/sensor/octoprint.py
@@ -93,7 +93,11 @@ class OctoPrintSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self._state
+        sensor_unit = self.unit_of_measurement
+        if sensor_unit == TEMP_CELSIUS or sensor_unit == "%":
+            return round(self._state, 2)
+        else:
+            return self._state
 
     @property
     def unit_of_measurement(self):


### PR DESCRIPTION
**Description:**
percentages weren't rounded resulting in super long decimals being displayed in the frontend.

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
