### PR TITLE
Upgrade astral to 1.1

### DIFF
--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -15,7 +15,7 @@ from homeassistant.util import dt as dt_util
 from homeassistant.util import location as location_util
 from homeassistant.const import CONF_ELEVATION
 
-REQUIREMENTS = ['astral==1.0']
+REQUIREMENTS = ['astral==1.1']
 DOMAIN = "sun"
 ENTITY_ID = "sun.sun"
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -30,7 +30,7 @@ Werkzeug==0.11.5
 apcaccess==0.0.4
 
 # homeassistant.components.sun
-astral==1.0
+astral==1.1
 
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.7


### PR DESCRIPTION
1.1
- Added methods to calculate Twilight, the Golden Hour and the Blue Hour.

Tested with the following configuration:

``` yaml
sun:
```
