### PR TITLE
bug in google travel time

### DIFF
--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -46,7 +46,7 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_DESTINATION): vol.Coerce(str),
     vol.Optional(CONF_TRAVEL_MODE):
         vol.In(["driving", "walking", "bicycling", "transit"]),
-    vol.Optional(CONF_OPTIONS, default=dict()): vol.All(
+    vol.Optional(CONF_OPTIONS, default={CONF_MODE: 'driving'}): vol.All(
         dict, vol.Schema({
             vol.Optional(CONF_MODE, default='driving'):
                 vol.In(["driving", "walking", "bicycling", "transit"]),


### PR DESCRIPTION
**Description:**
Fixes a bug in google travel time, when no options are sat.

```
16-05-22 19:31:31 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up platform google_travel_time
Traceback (most recent call last):
  File "/mnt/dokumneter/privat/home-assistant/homeassistant/helpers/entity_component.py", line 109, in _setup_platform
    discovery_info)
  File "/mnt/dokumneter/privat/home-assistant/homeassistant/components/sensor/google_travel_time.py", line 99, in setup_platform
    titled_mode = options.get(CONF_MODE).title()
AttributeError: 'NoneType' object has no attribute 'title'

```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
