### PR TITLE
Added LIRC component to receive IR remote signals

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -111,6 +111,7 @@ omit =
     homeassistant/components/light/hyperion.py
     homeassistant/components/light/lifx.py
     homeassistant/components/light/limitlessled.py
+    homeassistant/components/lirc.py
     homeassistant/components/media_player/cast.py
     homeassistant/components/media_player/denon.py
     homeassistant/components/media_player/firetv.py
@@ -164,7 +165,6 @@ omit =
     homeassistant/components/sensor/google_travel_time.py
     homeassistant/components/sensor/gtfs.py
     homeassistant/components/sensor/lastfm.py
-    homeassistant/components/sensor/lirc.py
     homeassistant/components/sensor/loopenergy.py
     homeassistant/components/sensor/netatmo.py
     homeassistant/components/sensor/neurio_energy.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -164,6 +164,7 @@ omit =
     homeassistant/components/sensor/google_travel_time.py
     homeassistant/components/sensor/gtfs.py
     homeassistant/components/sensor/lastfm.py
+    homeassistant/components/sensor/lirc.py
     homeassistant/components/sensor/loopenergy.py
     homeassistant/components/sensor/netatmo.py
     homeassistant/components/sensor/neurio_energy.py

--- a/homeassistant/components/lirc.py
+++ b/homeassistant/components/lirc.py
@@ -15,6 +15,7 @@ import logging
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
+DOMAIN = "lirc"
 REQUIREMENTS = ['python-lirc>=1.2.1']
 _LOGGER = logging.getLogger(__name__)
 ICON = 'mdi:remote'
@@ -22,7 +23,7 @@ EVENT_BUTTON_PRESSED = 'button_pressed'
 BUTTON_NAME = 'button_name'
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+def setup(hass, config):
     """Setup LIRC capability."""
     # Perform safe import of third-party python-lirc module
     try:

--- a/homeassistant/components/lirc.py
+++ b/homeassistant/components/lirc.py
@@ -17,7 +17,7 @@ from homeassistant.const import (EVENT_HOMEASSISTANT_STOP,
                                  EVENT_HOMEASSISTANT_START)
 
 DOMAIN = "lirc"
-REQUIREMENTS = ['python-lirc>=1.2.1']
+REQUIREMENTS = ['python-lirc==1.2.1']
 _LOGGER = logging.getLogger(__name__)
 ICON = 'mdi:remote'
 EVENT_IR_COMMAND_RECEIVED = 'ir_command_received'

--- a/homeassistant/components/sensor/lirc.py
+++ b/homeassistant/components/sensor/lirc.py
@@ -18,7 +18,6 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 LIRC = None
 
-REQUIREMENTS = ['python-lirc==1.2.1']
 _LOGGER = logging.getLogger(__name__)
 ICON = 'mdi:remote'
 

--- a/homeassistant/components/sensor/lirc.py
+++ b/homeassistant/components/sensor/lirc.py
@@ -1,0 +1,109 @@
+"""
+LIRC interface to receive signals from a infrared remote control.
+
+This sensor will momentarily set state to various values as defined
+in the .lintrc file which can be interpreted in home-assistant to
+trigger various actions.
+
+Sending signals to other IR receivers can be accomplished with the
+shell_command component and the irsend command.
+"""
+
+import threading
+import time
+import logging
+
+from homeassistant.helpers.entity import Entity
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+
+LIRC = None
+
+REQUIREMENTS = ['python-lirc==1.2.1']
+_LOGGER = logging.getLogger(__name__)
+ICON = 'mdi:remote'
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup LIRC capability."""
+    # Perform safe import of third-party python-lirc module
+    try:
+        import lirc
+        global LIRC
+        LIRC = lirc
+    except ImportError:
+        _LOGGER.error("You are missing a required dependency: python-lirc.")
+        return False
+
+    LIRC.init('home-assistant', blocking=False)
+    sensor = LircSensor()
+    add_devices([sensor])
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, sensor.stop)
+
+
+class LircSensor(Entity):
+    """Sensor entity for LIRC."""
+
+    def __init__(self, *args, **kwargs):
+        """Contruct a LircSensor entity."""
+        _LOGGER.info('Initializing LIRC sensor')
+        Entity.__init__(self, *args, **kwargs)
+        self.last_key_pressed = ''
+        self._lirc_interface = LircInterface(self)
+        self._lirc_interface.start()
+
+    @property
+    def name(self):
+        """Name of lirc sensor."""
+        return 'lirc'
+
+    @property
+    def state(self):
+        """State of LIRC sensor."""
+        return self.last_key_pressed
+
+    def update_state(self, new_state):
+        """Inform system of update when they occur."""
+        self.last_key_pressed = new_state
+        self.update_ha_state()
+
+    def stop(self, event):
+        """Kill the helper thread on stop."""
+        _LOGGER.info('Ending LIRC interface thread')
+        self._lirc_interface.stopped.set()
+
+
+class LircInterface(threading.Thread):
+    """
+    This interfaces with the lirc daemon to read IR commands.
+
+    When using lirc in blocking mode, sometimes repeated commands get produced
+    in the next read of a command so we use a thread here to just wait
+    around until a non-empty response is obtained from lirc.
+    """
+
+    def __init__(self, parent):
+        """Construct a LIRC interface object."""
+        threading.Thread.__init__(self)
+        self.stopped = threading.Event()
+        self._parent = parent
+
+    def run(self):
+        """Main loop of LIRC interface thread."""
+        while not self.stopped.isSet():
+            code = LIRC.nextcode()  # list; empty if no buttons pressed
+
+            # interpret result from python-lirc
+            if code:
+                code = code[0]
+            else:
+                code = ''
+
+            # update if changed.
+            if code != self._parent.state:
+                _LOGGER.info('Got new LIRC code %s', code)
+                self._parent.update_state(code)
+            else:
+                time.sleep(0.1)  # avoid high CPU in this thread
+
+        _LOGGER.info('LIRC interface thread stopped')

--- a/homeassistant/components/sensor/lirc.py
+++ b/homeassistant/components/sensor/lirc.py
@@ -13,12 +13,13 @@ import threading
 import time
 import logging
 
-from homeassistant.helpers.entity import Entity
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 REQUIREMENTS = ['python-lirc>=1.2.1']
 _LOGGER = logging.getLogger(__name__)
 ICON = 'mdi:remote'
+EVENT_BUTTON_PRESSED = 'button_pressed'
+BUTTON_NAME = 'button_name'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -31,43 +32,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
     # blocking=True gives unexpected behavior (multiple responses for 1 press)
+    # also by not blocking, we allow hass to shut down the thread gracefully
+    # on exit.
     lirc.init('home-assistant', blocking=False)
-    sensor = LircSensor()
-    add_devices([sensor])
+    lirc_interface = LircInterface(hass)
+    lirc_interface.start()
 
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, sensor.stop)
+    def _stop_lirc(_event):
+        lirc_interface.stopped.set()
 
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _stop_lirc)
 
-class LircSensor(Entity):
-    """Sensor entity for LIRC."""
-
-    def __init__(self, *args, **kwargs):
-        """Construct a LircSensor entity."""
-        _LOGGER.info('Initializing LIRC sensor')
-        Entity.__init__(self, *args, **kwargs)
-        self.last_key_pressed = ''
-        self._lirc_interface = LircInterface(self)
-        self._lirc_interface.start()
-
-    @property
-    def name(self):
-        """Name of lirc sensor."""
-        return 'lirc'
-
-    @property
-    def state(self):
-        """State of LIRC sensor."""
-        return self.last_key_pressed
-
-    def update_state(self, new_state):
-        """Inform system of update when they occur."""
-        self.last_key_pressed = new_state
-        self.update_ha_state()
-
-    def stop(self, _event):
-        """Kill the helper thread on stop."""
-        _LOGGER.info('Ending LIRC interface thread')
-        self._lirc_interface.stopped.set()
+    return True
 
 
 class LircInterface(threading.Thread):
@@ -79,28 +55,22 @@ class LircInterface(threading.Thread):
     around until a non-empty response is obtained from lirc.
     """
 
-    def __init__(self, parent):
+    def __init__(self, hass):
         """Construct a LIRC interface object."""
         threading.Thread.__init__(self)
         self.stopped = threading.Event()
-        self._parent = parent
+        self.hass = hass
 
     def run(self):
         """Main loop of LIRC interface thread."""
         import lirc
         while not self.stopped.isSet():
             code = lirc.nextcode()  # list; empty if no buttons pressed
-
             # interpret result from python-lirc
             if code:
                 code = code[0]
-            else:
-                code = ''
-
-            # update if changed.
-            if code != self._parent.state:
                 _LOGGER.info('Got new LIRC code %s', code)
-                self._parent.update_state(code)
+                self.hass.bus.fire(EVENT_BUTTON_PRESSED, {BUTTON_NAME: code})
             else:
                 time.sleep(0.1)  # avoid high CPU in this thread
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -262,7 +262,7 @@ pysnmp==4.2.5
 # homeassistant.components.sensor.forecast
 python-forecastio==1.3.4
 
-# homeassistant.components.sensor.lirc
+# homeassistant.components.lirc
 # python-lirc>=1.2.1
 
 # homeassistant.components.media_player.mpd

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -262,6 +262,9 @@ pysnmp==4.2.5
 # homeassistant.components.sensor.forecast
 python-forecastio==1.3.4
 
+# homeassistant.components.sensor.lirc
+# python-lirc>=1.2.1
+
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -262,6 +262,9 @@ pysnmp==4.2.5
 # homeassistant.components.sensor.forecast
 python-forecastio==1.3.4
 
+# homeassistant.components.sensor.lirc
+python-lirc==1.2.1
+
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -262,9 +262,6 @@ pysnmp==4.2.5
 # homeassistant.components.sensor.forecast
 python-forecastio==1.3.4
 
-# homeassistant.components.sensor.lirc
-python-lirc==1.2.1
-
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -263,7 +263,7 @@ pysnmp==4.2.5
 python-forecastio==1.3.4
 
 # homeassistant.components.lirc
-# python-lirc>=1.2.1
+# python-lirc==1.2.1
 
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -13,6 +13,7 @@ COMMENT_REQUIREMENTS = [
     'fritzconnection',
     'pybluez',
     'bluepy',
+    'python-lirc',
 ]
 
 


### PR DESCRIPTION
**Description:**
Adds LIRC component which can respond to input from any infrared remote control. This allows you to use any random remote for settings triggering actions, etc. It's fun. 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#502

**Example entry for `configuration.yaml`:**

``` yaml
lirc:

automation:
- alias: Off on Remote
  trigger:
    platform: event
    event_type: button_pressed
    event_data:
      button_name: KEY_0
  action:
    service: homeassistant.turn_off
    entity_id: group.a_lights
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)). NOT DONE DUE TO COMPLEX COMPILATION
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`. 
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
