### PR TITLE
Add websocket API

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -82,7 +82,7 @@ class APIEventStream(HomeAssistantView):
 
         restrict = request.args.get('restrict')
         if restrict:
-            restrict = restrict.split(',')
+            restrict = set(restrict.split(','))
 
         def thread_forward_events(event):
             """Forward events to the open request."""

--- a/homeassistant/components/api_websocket.py
+++ b/homeassistant/components/api_websocket.py
@@ -1,0 +1,70 @@
+"""Websocket API for Home Assistant."""
+import json
+import logging
+
+from homeassistant.const import MATCH_ALL
+import homeassistant.remote as rem
+
+DEPENDENCIES = 'http',
+DOMAIN = 'api_websocket'
+WS_EVENT_FORMAT = "event:{}"
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup(hass, config):
+    """Setup the WebSocket API."""
+    hass.wsgi.register_wsgi_app('/api/websocket', websocket_handler(hass))
+
+    return True
+
+
+def websocket_handler(hass):
+    """Return websocket handler."""
+    from eventlet import websocket
+
+    connections = set()
+
+    @websocket.WebSocketWSGI
+    def handle(wst):
+        """Handle websocket connection."""
+        _LOGGER.debug('Websocket %s connection opened', id(wst))
+        connections.add(wst)
+        events = set()
+
+        def event_listener(event):
+            """Event listener for wst."""
+            if event.event_type not in events:
+                return
+
+            msg = WS_EVENT_FORMAT.format(json.dumps(
+                event,
+                sort_keys=True,
+                cls=rem.JSONEncoder
+            ))
+            _LOGGER.debug('Websocket %s writing event %s', id(wst), msg)
+            wst.send(msg)
+
+        try:
+            while True:
+                msg = wst.wait()
+                if msg is None:
+                    break
+
+                _LOGGER.debug('Websocket %s received %s', id(wst), msg)
+
+                if msg.startswith('event:subscribe:'):
+                    event_type = msg[16:]
+                    events.add(event_type)
+                    if len(events) == 1:
+                        _LOGGER.debug('Websocket %s attaching event listener',
+                                      id(wst))
+                        hass.bus.listen(MATCH_ALL, event_listener)
+
+        finally:
+            _LOGGER.debug('Websocket %s connection closed', id(wst))
+            if events:
+                _LOGGER.debug('Websocket %s removing event listener', id(wst))
+                hass.bus.remove_listener(MATCH_ALL, event_listener)
+            connections.remove(wst)
+
+    return handle

--- a/homeassistant/components/frontend/www_static/websocket_debug.html
+++ b/homeassistant/components/frontend/www_static/websocket_debug.html
@@ -1,0 +1,82 @@
+<!--From: http://pastebin.com/kF82pcjd -->
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <title>WebSocket debug</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width">
+  </head>
+  <body>
+    <div>
+      <textarea id="messageinput" rows='10' cols='80'>event:subscribe:state_changed</textarea>
+    </div>
+    <div>
+      <button type="button" onclick="openSocket();" >Open</button>
+      <button type="button" onclick="send();" >Send</button>
+      <button type="button" onclick="closeSocket();" >Close</button>
+    </div>
+    <!-- Server responses get written here -->
+    <pre id="messages"></pre>
+
+    <!-- Script to utilise the WebSocket -->
+    <script type="text/javascript">
+      var webSocket;
+      var messages = document.getElementById("messages");
+
+      function openSocket(){
+        var isOpen = false;
+        // Ensures only one connection is open at a time
+        if(webSocket !== undefined && webSocket.readyState !== WebSocket.CLOSED){
+          writeResponse("WebSocket is already opened.");
+          return;
+        }
+        // Create a new instance of the websocket
+        webSocket = new WebSocket("ws://localhost:8123/api/websocket");
+
+        /**
+         * Binds functions to the listeners for the websocket.
+         */
+        webSocket.onopen = function(event){
+          if (!isOpen) {
+            isOpen = true;
+            writeResponse('Connection opened');
+          }
+          // For reasons I can't determine, onopen gets called twice
+          // and the first time event.data is undefined.
+          // Leave a comment if you know the answer.
+          if(event.data === undefined)
+            return;
+
+          writeResponse(event.data);
+        };
+
+        webSocket.onmessage = function(event){
+          writeResponse(event.data);
+        };
+
+        webSocket.onclose = function(event){
+          writeResponse("Connection closed");
+        };
+      }
+
+      /**
+       * Sends the value of the text input to the server
+       */
+      function send(){
+        var text = document.getElementById("messageinput").value;
+        webSocket.send(text);
+      }
+
+      function closeSocket(){
+        webSocket.close();
+      }
+
+      function writeResponse(text){
+        messages.innerHTML += "\n" + text;
+      }
+
+      openSocket();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
**Description:**
This adds an API over websockets.

To test locally, open a HA instance without password and navigate to [http://localhost:8123/static/websocket_debug.html](http://localhost:8123/static/websocket_debug.html)

From client, send `event:subscribe:EVENT_TYPE` to subscribe to specific events.
Currently, only messages from server are event JSON dumps prefixed with `event:`.

It does surprisingly not suffer from same issues as our eventstream api.

To do:
- [ ] Tests
- [ ] Authentication

CC @JshWright @robbiet480 

**Related issue (if applicable):** #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
api_websocket:
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
