### PR TITLE
List entity_ids in config and only react to them

### DIFF
--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -10,7 +10,7 @@ from homeassistant.components.binary_sensor import (BinarySensorDevice,
                                                     ENTITY_ID_FORMAT,
                                                     SENSOR_CLASSES)
 from homeassistant.const import (ATTR_FRIENDLY_NAME, CONF_VALUE_TEMPLATE,
-                                 ATTR_ENTITY_ID)
+                                 ATTR_ENTITY_ID, MATCH_ALL)
 from homeassistant.core import EVENT_STATE_CHANGED
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import generate_entity_id
@@ -41,8 +41,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                           device)
             continue
 
-        entity_ids = device_config.get(ATTR_ENTITY_ID)
-
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         sensor_class = device_config.get('sensor_class')
         value_template = device_config.get(CONF_VALUE_TEMPLATE)
@@ -55,6 +53,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             _LOGGER.error(
                 'Missing %s for sensor %s', CONF_VALUE_TEMPLATE, device)
             continue
+
+        entity_ids = device_config.get(ATTR_ENTITY_ID, MATCH_ALL)
 
         sensors.append(
             BinarySensorTemplate(
@@ -90,21 +90,13 @@ class BinarySensorTemplate(BinarySensorDevice):
 
         self.update()
 
-        def template_bsensor_event_listener(event):
-            """Called when the target device changes state."""
-            self.update_ha_state(True)
-
         def template_bsensor_state_listener(self, entity, old_state,
                                             new_state):
             """Called when the target device changes state."""
             self.update_ha_state(True)
 
-        if entity_ids is None:
-            hass.bus.listen(EVENT_STATE_CHANGED,
-                            template_bsensor_event_listener)
-        else:
-            track_state_change(hass, entity_ids,
-                               template_bsensor_state_listener)
+        track_state_change(hass, entity_ids,
+                           template_bsensor_state_listener)
 
     @property
     def name(self):

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -15,6 +15,7 @@ from homeassistant.core import EVENT_STATE_CHANGED
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers import template
+from homeassistant.helpers.event import track_state_change
 from homeassistant.util import slugify
 
 CONF_SENSORS = 'sensors'

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -8,7 +8,8 @@ import logging
 
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
 from homeassistant.const import (
-    ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE)
+    ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE,
+    ATTR_ENTITY_ID)
 from homeassistant.core import EVENT_STATE_CHANGED
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import Entity, generate_entity_id
@@ -45,13 +46,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 "Missing %s for sensor %s", CONF_VALUE_TEMPLATE, device)
             continue
 
+        entity_ids = device_config.get(ATTR_ENTITY_ID)
+
         sensors.append(
             SensorTemplate(
                 hass,
                 device,
                 friendly_name,
                 unit_of_measurement,
-                state_template)
+                state_template,
+                entity_ids)
             )
     if not sensors:
         _LOGGER.error("No sensors added")
@@ -65,7 +69,7 @@ class SensorTemplate(Entity):
 
     # pylint: disable=too-many-arguments
     def __init__(self, hass, device_id, friendly_name, unit_of_measurement,
-                 state_template):
+                 state_template, entity_ids):
         """Initialize the sensor."""
         self.hass = hass
         self.entity_id = generate_entity_id(ENTITY_ID_FORMAT, device_id,
@@ -81,7 +85,16 @@ class SensorTemplate(Entity):
             """Called when the target device changes state."""
             self.update_ha_state(True)
 
-        hass.bus.listen(EVENT_STATE_CHANGED, template_sensor_event_listener)
+        def template_sensor_state_listener(self, entity, old_state, new_state):
+            """Called when the target device changes state."""
+            self.update_ha_state(True)
+
+        if entity_ids is None:
+            hass.bus.listen(EVENT_STATE_CHANGED,
+                            template_sensor_event_listener)
+        else:
+            track_state_change(hass, entity_ids,
+                               template_sensor_state_listener)
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -14,6 +14,7 @@ from homeassistant.core import EVENT_STATE_CHANGED
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import Entity, generate_entity_id
 from homeassistant.helpers import template
+from homeassistant.helpers.event import track_state_change
 from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE,
-    ATTR_ENTITY_ID)
+    ATTR_ENTITY_ID, MATCH_ALL)
 from homeassistant.core import EVENT_STATE_CHANGED
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import Entity, generate_entity_id
@@ -47,7 +47,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 "Missing %s for sensor %s", CONF_VALUE_TEMPLATE, device)
             continue
 
-        entity_ids = device_config.get(ATTR_ENTITY_ID)
+        entity_ids = device_config.get(ATTR_ENTITY_ID, MATCH_ALL)
 
         sensors.append(
             SensorTemplate(
@@ -82,20 +82,12 @@ class SensorTemplate(Entity):
 
         self.update()
 
-        def template_sensor_event_listener(event):
-            """Called when the target device changes state."""
-            self.update_ha_state(True)
-
         def template_sensor_state_listener(self, entity, old_state, new_state):
             """Called when the target device changes state."""
             self.update_ha_state(True)
 
-        if entity_ids is None:
-            hass.bus.listen(EVENT_STATE_CHANGED,
-                            template_sensor_event_listener)
-        else:
-            track_state_change(hass, entity_ids,
-                               template_sensor_state_listener)
+        track_state_change(hass, entity_ids,
+                           template_sensor_state_listener)
 
     @property
     def name(self):

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchDevice
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, CONF_VALUE_TEMPLATE, STATE_OFF, STATE_ON,
-    ATTR_ENTITY_ID)
+    ATTR_ENTITY_ID, MATCH_ALL)
 from homeassistant.core import EVENT_STATE_CHANGED
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import generate_entity_id
@@ -60,7 +60,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 "Missing action for switch %s", device)
             continue
 
-        entity_ids = device_config.get(ATTR_ENTITY_ID)
+        entity_ids = device_config.get(ATTR_ENTITY_ID, MATCH_ALL)
 
         switches.append(
             SwitchTemplate(
@@ -97,20 +97,12 @@ class SwitchTemplate(SwitchDevice):
 
         self.update()
 
-        def template_switch_event_listener(event):
-            """Called when the target device changes state."""
-            self.update_ha_state(True)
-
         def template_switch_state_listener(self, entity, old_state, new_state):
             """Called when the target device changes state."""
             self.update_ha_state(True)
 
-        if entity_ids is None:
-            hass.bus.listen(EVENT_STATE_CHANGED,
-                            template_switch_event_listener)
-        else:
-            track_state_change(hass, entity_ids,
-                               template_switch_state_listener)
+        track_state_change(hass, entity_ids,
+                           template_switch_state_listener)
 
     @property
     def name(self):

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -15,6 +15,7 @@ from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.service import call_from_config
 from homeassistant.helpers import template
+from homeassistant.helpers.event import track_state_change
 from homeassistant.util import slugify
 
 CONF_SWITCHES = 'switches'

--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -29,7 +29,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
         result = template.setup_platform(hass, config, add_devices)
         self.assertTrue(result)
         mock_template.assert_called_once_with(hass, 'test', 'virtual thingy',
-                                              'motion', '{{ foo }}')
+                                              'motion', '{{ foo }}', None)
         add_devices.assert_called_once_with([mock_template.return_value])
 
     def test_setup_no_sensors(self):
@@ -77,7 +77,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
         """"Test the attributes."""
         hass = mock.MagicMock()
         vs = template.BinarySensorTemplate(hass, 'parent', 'Parent',
-                                           'motion', '{{ 1 > 1 }}')
+                                           'motion', '{{ 1 > 1 }}', None)
         self.assertFalse(vs.should_poll)
         self.assertEqual('motion', vs.sensor_class)
         self.assertEqual('Parent', vs.name)
@@ -93,7 +93,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
         """"Test the event."""
         hass = get_test_home_assistant()
         vs = template.BinarySensorTemplate(hass, 'parent', 'Parent',
-                                           'motion', '{{ 1 > 1 }}')
+                                           'motion', '{{ 1 > 1 }}', None)
         vs.update_ha_state()
         hass.pool.block_till_done()
 
@@ -110,7 +110,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
         """"Test the template update error."""
         hass = mock.MagicMock()
         vs = template.BinarySensorTemplate(hass, 'parent', 'Parent',
-                                           'motion', '{{ 1 > 1 }}')
+                                           'motion', '{{ 1 > 1 }}', None)
         mock_render.side_effect = TemplateError('foo')
         vs.update()
         mock_render.side_effect = TemplateError(


### PR DESCRIPTION
**Description:**
This allows us to define a list of entity_ids in the config to make the template sensor, binary sensor and switch only react to state changes of these entities instead of listening to all state changes.
This configuration is optional, if no list of entity_ids is configured, the component will work like it does now.

**Related issue (if applicable):** #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

This allows us to define a list of entity_ids in the config to make the
template sensor, binary sensor and switch only react to state changes of
these entities instead of listening to all state changes.
