### PR TITLE
Fix TLS with eventlet

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -243,7 +243,7 @@ class HomeAssistantWSGI(object):
 
         sock = eventlet.listen((self.server_host, self.server_port))
         if self.ssl_certificate:
-            eventlet.wrap_ssl(sock, certfile=self.ssl_certificate,
+            sock = eventlet.wrap_ssl(sock, certfile=self.ssl_certificate,
                               keyfile=self.ssl_key, server_side=True)
         wsgi.server(sock, self)
 

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -244,7 +244,7 @@ class HomeAssistantWSGI(object):
         sock = eventlet.listen((self.server_host, self.server_port))
         if self.ssl_certificate:
             sock = eventlet.wrap_ssl(sock, certfile=self.ssl_certificate,
-                              keyfile=self.ssl_key, server_side=True)
+                                     keyfile=self.ssl_key, server_side=True)
         wsgi.server(sock, self)
 
     def dispatch_request(self, request):


### PR DESCRIPTION
This fixes a simple error on my part when implementing the WSGI stuff.

eventlet.wrap_ssl() returns a wrapped socket, it does not modify the
object passed to it. We need to grab the returned value and use that.
