### PR TITLE
Don't even bother trying to kill stray child processes.

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import argparse
 import os
 import platform
-import signal
 import subprocess
 import sys
 import threading
@@ -334,29 +333,6 @@ def try_to_restart():
     except AssertionError:
         sys.stderr.write("Failed to count non-daemonic threads.\n")
 
-    # Send terminate signal to all processes in our process group which
-    # should be any children that have not themselves changed the process
-    # group id. Don't bother if couldn't even call setpgid.
-    if hasattr(os, 'setpgid'):
-        sys.stderr.write("Signalling child processes to terminate...\n")
-        os.kill(0, signal.SIGTERM)
-
-        # wait for child processes to terminate
-        try:
-            while True:
-                time.sleep(1)
-                if os.waitpid(0, os.WNOHANG) == (0, 0):
-                    break
-        except OSError:
-            pass
-
-    elif os.name == 'nt':
-        # Maybe one of the following will work, but how do we indicate which
-        # processes are our children if there is no process group?
-        # os.kill(0, signal.CTRL_C_EVENT)
-        # os.kill(0, signal.CTRL_BREAK_EVENT)
-        pass
-
     # Try to not leave behind open filedescriptors with the emphasis on try.
     try:
         max_fd = os.sysconf("SC_OPEN_MAX")
@@ -407,13 +383,6 @@ def main():
         daemonize()
     if args.pid_file:
         write_pid(args.pid_file)
-
-    # Create new process group if we can
-    if hasattr(os, 'setpgid'):
-        try:
-            os.setpgid(0, 0)
-        except PermissionError:
-            pass
 
     exit_code = setup_and_run_hass(config_dir, args)
     if exit_code == RESTART_EXIT_CODE and not args.runner:


### PR DESCRIPTION
**Description:**
When we change our process group id we don't get keyboard interrupt signals when our parent is a bash script.

**Related issue (if applicable):** #2136

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

When we change our process group id we don't get keyboard interrupt
signals passed if our parent is a bash script.
