### PR TITLE
Allow time condition windows to cross midnight.

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -224,15 +224,34 @@ def template_from_config(config, config_validation=True):
     return template_if
 
 
+def _in_time_window(now, before=None, after=None):
+    """Test if 'now' falls between 'after' and 'before'.
+
+    Handle the fact that time is continuous and we may be testing for
+    a period that crosses midnight. In that case it is easier to test
+    for the opposite. "(23:59 <= now < 00:01)" would be the same as
+    "not (00:01 <= now < 23:59)".
+    """
+    in_window = True
+    if before is not None and after is not None:
+        if before > after:
+            before, after = after, before
+            in_window = False
+
+    if before is not None and now >= before:
+        return not in_window
+
+    if after is not None and now < after:
+        return not in_window
+
+    return in_window
+
+
 def time(before=None, after=None, weekday=None):
     """Test if local time condition matches."""
     now = dt_util.now()
-    now_time = now.time()
 
-    if before is not None and now_time > before:
-        return False
-
-    if after is not None and now_time < after:
+    if not _in_time_window(now.time(), before, after):
         return False
 
     if weekday is not None:

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -224,35 +224,28 @@ def template_from_config(config, config_validation=True):
     return template_if
 
 
-def _in_time_window(now, before=None, after=None):
-    """Test if 'now' falls between 'after' and 'before'.
+def time(before=None, after=None, weekday=None):
+    """Test if local time condition matches.
 
     Handle the fact that time is continuous and we may be testing for
     a period that crosses midnight. In that case it is easier to test
     for the opposite. "(23:59 <= now < 00:01)" would be the same as
     "not (00:01 <= now < 23:59)".
     """
-    in_window = True
-    if before is not None and after is not None:
-        if before > after:
-            before, after = after, before
-            in_window = False
-
-    if before is not None and now >= before:
-        return not in_window
-
-    if after is not None and now < after:
-        return not in_window
-
-    return in_window
-
-
-def time(before=None, after=None, weekday=None):
-    """Test if local time condition matches."""
     now = dt_util.now()
+    now_time = now.time()
 
-    if not _in_time_window(now.time(), before, after):
-        return False
+    if after is None:
+        after = dt_util.dt.time(0)
+    if before is None:
+        before = dt_util.dt.time(23, 59, 59, 999999)
+
+    if after < before:
+        if not after <= now_time < before:
+            return False
+    else:
+        if before <= now_time < after:
+            return False
 
     if weekday is not None:
         now_weekday = WEEKDAYS[now.weekday()]

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -1,4 +1,6 @@
 """Test the condition helper."""
+from unittest.mock import patch
+
 from homeassistant.helpers import condition
 from homeassistant.util import dt
 
@@ -73,6 +75,22 @@ class TestConditionHelper:
         sixam = dt.parse_time("06:00:00")
         sixpm = dt.parse_time("18:00:00")
 
-        day = condition.time(after=sixam, before=sixpm)
-        night = condition.time(after=sixpm, before=sixam)
-        assert (day and not night) or (night and not day)
+        with patch('homeassistant.helpers.condition.dt_util.now',
+                   return_value=dt.now().replace(hour=3)):
+            assert not condition.time(after=sixam, before=sixpm)
+            assert condition.time(after=sixpm, before=sixam)
+
+        with patch('homeassistant.helpers.condition.dt_util.now',
+                   return_value=dt.now().replace(hour=9)):
+            assert condition.time(after=sixam, before=sixpm)
+            assert not condition.time(after=sixpm, before=sixam)
+
+        with patch('homeassistant.helpers.condition.dt_util.now',
+                   return_value=dt.now().replace(hour=15)):
+            assert condition.time(after=sixam, before=sixpm)
+            assert not condition.time(after=sixpm, before=sixam)
+
+        with patch('homeassistant.helpers.condition.dt_util.now',
+                   return_value=dt.now().replace(hour=21)):
+            assert not condition.time(after=sixam, before=sixpm)
+            assert condition.time(after=sixpm, before=sixam)

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -1,5 +1,6 @@
 """Test the condition helper."""
 from homeassistant.helpers import condition
+from homeassistant.util import dt
 
 from tests.common import get_test_home_assistant
 
@@ -66,3 +67,12 @@ class TestConditionHelper:
 
         self.hass.states.set('sensor.temperature', 100)
         assert test(self.hass)
+
+    def test_time_window(self):
+        """Test time condition windows."""
+        sixam = dt.parse_time("06:00:00")
+        sixpm = dt.parse_time("18:00:00")
+
+        day = condition.time(after=sixam, before=sixpm)
+        night = condition.time(after=sixpm, before=sixam)
+        assert (day and not night) or (night and not day)


### PR DESCRIPTION
**Description:**
Allow time conditions to cross the midnight boundary.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
condition:
  - condition: time
     after: "23:00:00"
     before: "01:00:00"
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
