### PR TITLE
Better calculation and presentation of Swatch Internet Time (.beats)

### DIFF
--- a/homeassistant/components/sensor/time_date.py
+++ b/homeassistant/components/sensor/time_date.py
@@ -15,7 +15,7 @@ OPTION_TYPES = {
     'date': 'Date',
     'date_time': 'Date & Time',
     'time_date': 'Time & Date',
-    'beat': 'Time (beat)',
+    'beat': 'Internet Time',
     'time_utc': 'Time (UTC)',
 }
 
@@ -75,11 +75,7 @@ class TimeDateSensor(Entity):
         time = dt_util.as_local(time_date).strftime(TIME_STR_FORMAT)
         time_utc = time_date.strftime(TIME_STR_FORMAT)
         date = dt_util.as_local(time_date).date().isoformat()
-
-        # Calculate the beat (Swatch Internet Time) time without date.
-        hours, minutes, seconds = time_date.strftime('%H:%M:%S').split(':')
-        beat = ((int(seconds) + (int(minutes) * 60) + ((int(hours) + 1) *
-                                                       3600)) / 86.4)
+        beats = dt_util.beatsnow()
 
         if self.type == 'time':
             self._state = time
@@ -92,4 +88,4 @@ class TimeDateSensor(Entity):
         elif self.type == 'time_utc':
             self._state = time_utc
         elif self.type == 'beat':
-            self._state = '{0:.2f}'.format(beat)
+            self._state = '@{0:03d}'.format(int(beats))

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -41,6 +41,18 @@ def utcnow():
     return dt.datetime.now(UTC)
 
 
+def beatsnow():
+    """Return time of the day in .beats (Swatch Internet Time)."""
+    bmt_now = dt.datetime.utcnow() + dt.timedelta(hours=1)
+    delta = dt.timedelta(
+        hours=bmt_now.hour,
+        minutes=bmt_now.minute,
+        seconds=bmt_now.second,
+        microseconds=bmt_now.microsecond
+    )
+    return (delta.seconds + delta.microseconds / 1000000.0) / 86.4
+
+
 def now(time_zone=None):
     """Get now in specified time zone."""
     return dt.datetime.now(time_zone or DEFAULT_TIME_ZONE)


### PR DESCRIPTION
- Proper calculation of Swatch Internet Time, .beats do not go beyond 1000 anymore, instead they rollover to 0 after 999.
- .beat format changed to three-digit zero-padded value with leading @ sign, decimals dropped as they are not in the concept of the original .beat time.
