### PR TITLE
Add suppprt for hyphens in entity names

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -14,7 +14,7 @@ from homeassistant.util import ensure_unique_string, slugify
 _OVERWRITE = defaultdict(dict)
 
 # Pattern for validating entity IDs (format: <domain>.<entity>)
-ENTITY_ID_PATTERN = re.compile(r"^(\w+)\.(\w+)$")
+ENTITY_ID_PATTERN = re.compile(r"^([\w-]+)\.([\w-]+)$")
 
 
 def generate_entity_id(entity_id_format, name, current_ids=None, hass=None):

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -43,3 +43,13 @@ class TestHelpersEntity(unittest.TestCase):
         """Test split_entity_id."""
         self.assertEqual(['domain', 'object_id'],
                          entity.split_entity_id('domain.object_id'))
+
+    def test_valid_entity_id(self):
+        """Test valid_entity_id."""
+        self.assertTrue(entity.valid_entity_id("foo.bar"))
+        self.assertTrue(entity.valid_entity_id("foo.bar_buzz"))
+        self.assertTrue(entity.valid_entity_id("foo.bar-buzz"))
+        self.assertTrue(entity.valid_entity_id("foo.9"))
+        self.assertTrue(entity.valid_entity_id("foo-bar.buzz"))
+        self.assertTrue(entity.valid_entity_id("foo_bar.buzz"))
+        self.assertTrue(entity.valid_entity_id("9.buzz"))


### PR DESCRIPTION
**Description:**
This relaxes the entity_id validation regex to allow hyphens in entity names.

**Checklist:**
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
