### PR TITLE
Handle invalid dev ids for dev tracker + owntracks

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.config import load_yaml_config_file
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_per_platform
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
+import homeassistant.helpers.config_validation as cv
 import homeassistant.util as util
 import homeassistant.util.dt as dt_util
 
@@ -26,6 +26,7 @@ from homeassistant.const import (
     ATTR_GPS_ACCURACY, ATTR_LATITUDE, ATTR_LONGITUDE,
     DEVICE_DEFAULT_NAME, STATE_HOME, STATE_NOT_HOME)
 
+PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA
 DOMAIN = "device_tracker"
 DEPENDENCIES = ['zone']
 
@@ -193,7 +194,7 @@ class DeviceTracker(object):
                 if not device:
                     dev_id = util.slugify(host_name or '') or util.slugify(mac)
             else:
-                dev_id = str(dev_id).lower()
+                dev_id = cv.slug(str(dev_id).lower())
                 device = self.devices.get(dev_id)
 
             if device:

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -186,7 +186,7 @@ def setup_scanner(hass, config, see):
 def _parse_see_args(topic, data):
     """Parse the OwnTracks location parameters, into the format see expects."""
     parts = topic.split('/')
-    dev_id = '{}_{}'.format(parts[1], parts[2])
+    dev_id = slugify('{}_{}'.format(parts[1], parts[2]))
     host_name = parts[1]
     kwargs = {
         'dev_id': dev_id,

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -210,3 +210,13 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         config = device_tracker.load_config(self.yaml_devices, self.hass,
                                             timedelta(seconds=0), 0)
         assert len(config) == 2
+
+    def test_not_allow_invalid_dev_id(self):
+        """Test that the device tracker will not allow invalid dev ids."""
+        self.assertTrue(device_tracker.setup(self.hass, {}))
+
+        device_tracker.see(self.hass, dev_id='hello-world')
+
+        config = device_tracker.load_config(self.yaml_devices, self.hass,
+                                            timedelta(seconds=0), 0)
+        assert len(config) == 0

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -203,6 +203,13 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         state = self.hass.states.get(REGION_TRACKER_STATE)
         self.assertEqual(state.attributes.get('gps_accuracy'), accuracy)
 
+    def test_location_invalid_devid(self):
+        """Test the update of a location."""
+        self.send_message('owntracks/paulus/nexus-5x', LOCATION_MESSAGE)
+
+        state = self.hass.states.get('device_tracker.paulus_nexus5x')
+        assert state.state == 'outer'
+
     def test_location_update(self):
         """Test the update of a location."""
         self.send_message(LOCATION_TOPIC, LOCATION_MESSAGE)


### PR DESCRIPTION
**Description:**
This will make the device tracker validate any incoming device ids. OwnTracks has been updated to make sure it won't supply any invalid device ids anymore.

This will prevent OwnTracks from changing `known_devices.yaml` into an invalid state.

**Related issue (if applicable):** #2172 

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
