### PR TITLE
New option for the netatmo platform: station

### DIFF
--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -33,6 +33,7 @@ SENSOR_TYPES = {
 }
 
 CONF_SECRET_KEY = 'secret_key'
+CONF_STATION = 'station'
 ATTR_MODULE = 'modules'
 
 # Return cached results if last scan was less then this time ago
@@ -64,7 +65,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             "Please check your settings for NatAtmo API.")
         return False
 
-    data = NetAtmoData(authorization)
+    data = NetAtmoData(authorization, config.get(CONF_STATION, None))
 
     dev = []
     try:
@@ -149,10 +150,11 @@ class NetAtmoSensor(Entity):
 class NetAtmoData(object):
     """Get the latest data from NetAtmo."""
 
-    def __init__(self, auth):
+    def __init__(self, auth, station):
         """Initialize the data object."""
         self.auth = auth
         self.data = None
+        self.station = station
 
     def get_module_names(self):
         """Return all module available on the API as a list."""
@@ -164,4 +166,8 @@ class NetAtmoData(object):
         """Call the NetAtmo API to update the data."""
         import lnetatmo
         dev_list = lnetatmo.DeviceList(self.auth)
-        self.data = dev_list.lastData(exclude=3600)
+
+        if self.station is not None:
+            self.data = dev_list.lastData(station=self.station, exclude=3600)
+        else:
+            self.data = dev_list.lastData(exclude=3600)


### PR DESCRIPTION
**Description:**
If you have several stations in your Netatmo account, the Netatmo sensor will randomly not be found when starting HA.

This fix adds another configuration for the Netatmo sensor.

**Related issue (if applicable):** #927

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io/pull/516

**Example entry for `configuration.yaml`:**

``` yaml
sensor:
  platform: netatmo
  ...
  station: STATION_NAME
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

This is necessary if multiple weather stations are associated with
one Netatmo account.
