### PR TITLE
Extend `customize:` behavior to treat some attributes as **defaults**

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -22,7 +22,8 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
-
+# OVERWRITE contains customize attributes from the config
+from homeassistant.helpers.entity import _OVERWRITE as OVERWRITE
 
 DOMAIN = "light"
 SCAN_INTERVAL = 30
@@ -79,6 +80,11 @@ PROP_TO_ATTR = {
     'rgb_color': ATTR_RGB_COLOR,
     'xy_color': ATTR_XY_COLOR,
 }
+
+# Attributes that will use OVERWRITE as default if not in turn_on
+TURN_ON_OVERWRITE_DEFAULTS = [
+    ATTR_TRANSITION, ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATTR_XY_COLOR,
+    ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_COLOR_NAME]
 
 # Service call validation schemas
 VALID_TRANSITION = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=900))
@@ -237,6 +243,13 @@ def setup(hass, config):
             params[ATTR_RGB_COLOR] = color_util.color_name_to_rgb(color_name)
 
         for light in target_lights:
+            print('**params original '+str(params))  # debug
+            # Add default attributes for light's using OVERWRITE
+            for key, value in OVERWRITE.get(light.entity_id, {}).items():
+                if key in TURN_ON_OVERWRITE_DEFAULTS and key not in params:
+                    params[key] = value
+            print('**params with defaults '+str(params))  # debug
+
             light.turn_on(**params)
 
         for light in target_lights:


### PR DESCRIPTION
**Description:**
`customize` behavior for fixed attributes (name, picture, etc) is applied correctly, but once you add `customize` attributes that can be switched (brightness, color) the behavior seems wrong.

This is a proposal to rather treat these types of values as **defaults** for the turn_on command.

Currently it seems as if these are treated as fixed values (but not enforced to the Entities turn_on function, so behavior is component&platform dependent and not uniform across HA). What I've observed (in a non-polling Entity) is that turn_on switches turns the dimmer to 100%. But the subsequent update_ha_state() will reset the brightness to the `customize` value, causing an incorrect state in HA.

 In the example below brightness would be a default for turn on, the rest should be treated as is.

```
  customize:
    light.mydimmer:
      brightness: 50
      entity_picture: http://your_picture.jpg
      friendly_name: MyDim
```

**For discussion:**
- A second phase of this proposal would be to NOT overwrite attributes in the `TURN_ON_OVERWRITE_DEFAULTS` array in the update_ha_state() method.
- A better name for this array might even be `CUSTOMIZE_TREAT_AS_DEFAULTS` and possibly even move it to homeassistant.helpers.entity?
- _OVERWRITE seems like its supposed to be private at the moment, possibly rename to OVERWRITE as well

**Tests:***
`tox` do not currently pass on my dev branch, so larger impact not 100% clear at the moment.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
