### PR TITLE
Remove print (already covered by logger)

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -304,7 +304,6 @@ def setup_and_run_hass(config_dir, args):
 
         hass.bus.listen_once(EVENT_HOMEASSISTANT_START, open_browser)
 
-    print('Starting Home-Assistant')
     hass.start()
     exit_code = int(hass.block_till_stopped())
 


### PR DESCRIPTION
**Description:**
Remove a `print` which seems to be used for debugging. 

``` bash
16-05-30 23:21:08 INFO (MainThread) [homeassistant.core] Starting Home Assistant (20 threads)
```

**Related issue (if applicable):** #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):**

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
