### PR TITLE
Improve Internet Time calculation.

### DIFF
--- a/homeassistant/components/sensor/time_date.py
+++ b/homeassistant/components/sensor/time_date.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/sensor.time_date/
 """
 import logging
 
+from datetime import timedelta
 import homeassistant.util.dt as dt_util
 from homeassistant.helpers.entity import Entity
 
@@ -15,7 +16,7 @@ OPTION_TYPES = {
     'date': 'Date',
     'date_time': 'Date & Time',
     'time_date': 'Time & Date',
-    'beat': 'Time (beat)',
+    'beat': 'Internet Time',
     'time_utc': 'Time (UTC)',
 }
 
@@ -76,10 +77,13 @@ class TimeDateSensor(Entity):
         time_utc = time_date.strftime(TIME_STR_FORMAT)
         date = dt_util.as_local(time_date).date().isoformat()
 
-        # Calculate the beat (Swatch Internet Time) time without date.
-        hours, minutes, seconds = time_date.strftime('%H:%M:%S').split(':')
-        beat = ((int(seconds) + (int(minutes) * 60) + ((int(hours) + 1) *
-                                                       3600)) / 86.4)
+        # Calculate Swatch Internet Time.
+        time_bmt = time_date + timedelta(hours=1)
+        delta = timedelta(hours=time_bmt.hour,
+                          minutes=time_bmt.minute,
+                          seconds=time_bmt.second,
+                          microseconds=time_bmt.microsecond)
+        beat = int((delta.seconds + delta.microseconds / 1000000.0) / 86.4)
 
         if self.type == 'time':
             self._state = time
@@ -92,4 +96,4 @@ class TimeDateSensor(Entity):
         elif self.type == 'time_utc':
             self._state = time_utc
         elif self.type == 'beat':
-            self._state = '{0:.2f}'.format(beat)
+            self._state = '@{0:03d}'.format(beat)


### PR DESCRIPTION
- Proper calculation of Swatch Internet Time, .beats do not go beyond 1000 anymore, instead they rollover to 0 after 999.
- .beat format changed to three-digit zero-padded value with leading @ sign, decimals dropped as they are not in the concept of the original .beat time.

This time everything is in sensor =)
