### PR TITLE
Re-add config validation for the http component

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -5,6 +5,7 @@ import logging
 import mimetypes
 import threading
 import re
+import voluptuous as vol
 
 import homeassistant.core as ha
 import homeassistant.remote as rem
@@ -13,6 +14,7 @@ from homeassistant.const import (
     SERVER_PORT, HTTP_HEADER_HA_AUTH, HTTP_HEADER_CACHE_CONTROL)
 from homeassistant.helpers.entity import split_entity_id
 import homeassistant.util.dt as dt_util
+import homeassistant.helpers.config_validation as cv
 
 DOMAIN = "http"
 REQUIREMENTS = ("eventlet==0.19.0", "static3==0.7.0", "Werkzeug==0.11.5",)
@@ -29,6 +31,18 @@ DATA_API_PASSWORD = 'api_password'
 _FINGERPRINT = re.compile(r'^(.+)-[a-z0-9]{32}\.(\w+)$', re.IGNORECASE)
 
 _LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_API_PASSWORD): cv.string,
+        vol.Optional(CONF_SERVER_HOST): cv.string,
+        vol.Optional(CONF_SERVER_PORT, default=SERVER_PORT):
+            vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
+        vol.Optional(CONF_DEVELOPMENT): cv.string,
+        vol.Optional(CONF_SSL_CERTIFICATE): cv.isfile,
+        vol.Optional(CONF_SSL_KEY): cv.isfile,
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 class HideSensitiveFilter(logging.Filter):


### PR DESCRIPTION
This commit adds back the config validation for the http component. It
was removed during the WSGI shuffle. This is just a direct copy of what
@robbiet480 added in ab294d12f7 (with some testing to verify it still
works).

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- (N/A) Tests have been added to verify that the new code works.
