### PR TITLE
Raspberry Pi Garage Door Opener

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -107,6 +107,7 @@ omit =
     homeassistant/components/downloader.py
     homeassistant/components/feedreader.py
     homeassistant/components/garage_door/wink.py
+    homeassistant/components/garage_door/raspberry.py
     homeassistant/components/ifttt.py
     homeassistant/components/keyboard.py
     homeassistant/components/light/blinksticklight.py

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -93,4 +93,3 @@ class RaspberryGarageDoor(GarageDoorDevice):
         # _LOGGER.info('state='+str(self._state))
         if self.is_closed:
             self._click()
-            

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -1,5 +1,4 @@
 """
-
 Support for Raspberry Pi garage door opener.
 
 Developed by Johann 'KellerZA' Kellerman
@@ -8,7 +7,6 @@ https://github.com/andrewshilliday/garage-door-controller
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/garage_door.raspberry/
-
 """
 
 import logging

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -23,7 +23,7 @@ GD_SET = '{}/clk'
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Wink garage door platform."""
+    """Setup the garage door platform."""
     import requests
 
     url = config.get('url', 'http://127.0.0.1:8080')
@@ -47,7 +47,7 @@ class RaspberryGarageDoor(GarageDoorDevice):
 
     @property
     def unique_id(self):
-        """Return the ID of this wink garage door."""
+        """Return the ID of this garage door."""
         return "{}.{}".format(self.__class__, self._name)
 
     @property

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -1,0 +1,95 @@
+"""
+Support for Raspberry Pi garage door opener.
+Developed by Johann 'KellerZA' Kellerman
+
+https://github.com/andrewshilliday/garage-door-controller
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/garage_door.raspberry/
+"""
+import logging
+_LOGGER = logging.getLogger(__name__)
+
+from homeassistant.components.garage_door import GarageDoorDevice
+
+REQUIREMENTS = ['requests']
+
+# Get returns
+# {"timestamp": 1464627981, "update": [["left", "open", 1464627945.459889]]}
+GD_GET = '{}/upd'
+# Set using: ?id=left
+GD_SET = '{}/clk'
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Wink garage door platform."""
+    import requests
+
+    url = config.get('url', 'http://127.0.0.1:8080')
+
+    req = requests.get(GD_GET.format(url))
+    if req.status_code == 200:
+        res = req.json()
+        _LOGGER.error(str(res))
+        _LOGGER.error(str(res['update']))
+        add_devices([RaspberryGarageDoor(url, door[0]) for door in res['update']])
+
+class RaspberryGarageDoor(GarageDoorDevice):
+    """Representation of a Raspberry garage door."""
+
+    def __init__(self, url, name):
+        """Initialize the garage door."""
+        self._url = url
+        self._name = name
+        self._state = ''
+
+    @property
+    def unique_id(self):
+        """Return the ID of this wink garage door."""
+        return "{}.{}".format(self.__class__, self._name)
+
+    @property
+    def name(self):
+        """Return the name of the garage door if any."""
+        return self._name
+
+    def update(self):
+        """Update the state of the garage door."""
+        import requests
+        req = requests.get(GD_GET.format(self._url))
+        if req.status_code == 200:
+            res = req.json()
+            thedoor = [door[1] for door in res['update'] if door[0] == self._name]
+            if thedoor:
+                self._state = thedoor[0]
+
+    @property
+    def is_closed(self):
+        """Return true if door is closed."""
+        return self._state == 'closed'
+
+    @property
+    def available(self):
+        """True if connection == True."""
+        return True
+
+    def _click(self):
+        import requests
+        _LOGGER.error('Clicking '+str(self._name))
+        requests.get(GD_SET.format(self._url), {'id': self._name})
+
+    def close_door(self):
+        """Close the door."""
+        if not self.is_closed:
+            self._click()
+
+    @property
+    def is_closed(self):
+        """Return true if door is closed."""
+        return str(self._state) == 'closed'
+
+    def open_door(self):
+        """Open the door."""
+        _LOGGER.error('open')
+        _LOGGER.error('state='+str(self._state))
+        if self.is_closed:
+            self._click()

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -1,4 +1,5 @@
 """
+
 Support for Raspberry Pi garage door opener.
 
 Developed by Johann 'KellerZA' Kellerman
@@ -7,6 +8,7 @@ https://github.com/andrewshilliday/garage-door-controller
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/garage_door.raspberry/
+
 """
 
 import logging

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -1,5 +1,6 @@
 """
 Support for Raspberry Pi garage door opener.
+
 Developed by Johann 'KellerZA' Kellerman
 
 https://github.com/andrewshilliday/garage-door-controller
@@ -7,6 +8,7 @@ https://github.com/andrewshilliday/garage-door-controller
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/garage_door.raspberry/
 """
+
 
 import logging
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -1,4 +1,5 @@
 """
+
 Support for Raspberry Pi garage door opener.
 
 Developed by Johann 'KellerZA' Kellerman

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -1,5 +1,5 @@
-"""
 
+"""
 Support for Raspberry Pi garage door opener.
 
 Developed by Johann 'KellerZA' Kellerman

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -1,4 +1,3 @@
-
 """
 Support for Raspberry Pi garage door opener.
 

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -7,6 +7,7 @@ https://github.com/andrewshilliday/garage-door-controller
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/garage_door.raspberry/
 """
+
 import logging
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -14,7 +14,7 @@ from homeassistant.components.garage_door import GarageDoorDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['requests']
+REQUIREMENTS = ['requests>=2,<3']
 
 # Get returns
 # {"timestamp": 1464627981, "update": [["left", "open", 1464627945.459889]]}

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -9,11 +9,10 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/garage_door.raspberry/
 """
 
-
 import logging
-_LOGGER = logging.getLogger(__name__)
-
 from homeassistant.components.garage_door import GarageDoorDevice
+
+_LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = ['requests']
 
@@ -23,6 +22,8 @@ GD_GET = '{}/upd'
 # Set using: ?id=left
 GD_SET = '{}/clk'
 
+
+# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Wink garage door platform."""
     import requests
@@ -32,9 +33,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     req = requests.get(GD_GET.format(url))
     if req.status_code == 200:
         res = req.json()
-        _LOGGER.error(str(res))
-        _LOGGER.error(str(res['update']))
-        add_devices([RaspberryGarageDoor(url, door[0]) for door in res['update']])
+        # _LOGGER.info(str(res))
+        update = res['update']
+        add_devices([RaspberryGarageDoor(url, door[0]) for door in update])
+
 
 class RaspberryGarageDoor(GarageDoorDevice):
     """Representation of a Raspberry garage door."""
@@ -61,7 +63,8 @@ class RaspberryGarageDoor(GarageDoorDevice):
         req = requests.get(GD_GET.format(self._url))
         if req.status_code == 200:
             res = req.json()
-            thedoor = [door[1] for door in res['update'] if door[0] == self._name]
+            upd = res['update']
+            thedoor = [door[1] for door in upd if door[0] == self._name]
             if thedoor:
                 self._state = thedoor[0]
 
@@ -77,7 +80,7 @@ class RaspberryGarageDoor(GarageDoorDevice):
 
     def _click(self):
         import requests
-        _LOGGER.error('Clicking '+str(self._name))
+        # _LOGGER.info('Clicking '+str(self._name))
         requests.get(GD_SET.format(self._url), {'id': self._name})
 
     def close_door(self):
@@ -85,15 +88,9 @@ class RaspberryGarageDoor(GarageDoorDevice):
         if not self.is_closed:
             self._click()
 
-    @property
-    def is_closed(self):
-        """Return true if door is closed."""
-        return str(self._state) == 'closed'
-
     def open_door(self):
         """Open the door."""
-        _LOGGER.error('open')
-        _LOGGER.error('state='+str(self._state))
+        # _LOGGER.info('state='+str(self._state))
         if self.is_closed:
             self._click()
-
+            

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -14,8 +14,6 @@ from homeassistant.components.garage_door import GarageDoorDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['requests>=2,<3']
-
 # Get returns
 # {"timestamp": 1464627981, "update": [["left", "open", 1464627945.459889]]}
 GD_GET = '{}/upd'

--- a/homeassistant/components/garage_door/raspberry.py
+++ b/homeassistant/components/garage_door/raspberry.py
@@ -96,3 +96,4 @@ class RaspberryGarageDoor(GarageDoorDevice):
         _LOGGER.error('state='+str(self._state))
         if self.is_closed:
             self._click()
+


### PR DESCRIPTION
**Description:**
<img width="504" alt="screen shot 2016-05-31 at 1 58 24 pm" src="https://cloud.githubusercontent.com/assets/4186441/15685012/d08ffc98-2737-11e6-8a27-9f2820eec817.png">

This component integrates andrewshilliday's Raspberry Pi Garage Door Opener w/ Home Assistant. It allows you to monitor the status and open/close the garage door directly through the HA Dashboard.

Raspberry Pi project docs/setup guide available here: https://github.com/andrewshilliday/garage-door-controller. You must have andrewshilliday's Garage Door Opener setup and working before you setup this component.  Also you can continue to use the Garage Door Opener web portal alongside HA.

All coding for this component was done by Johann 'kellerza' Kellerman. I did all of the testing.

**Related issue (if applicable):** #
Few seconds delay before HA updates garage door status. 
Need to test w/ multiple garage doors

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
garage_door:
  platform: raspberry
  url: http://IP-ADDRESS:8080/
```

**Checklist:**
If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New files were added to `.coveragerc`.
