### PR TITLE
Report whether SSL is required in discovery

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -167,7 +167,8 @@ class APIDiscoveryView(HomeAssistantView):
             'base_url': self.hass.config.api.base_url,
             'location_name': self.hass.config.location_name,
             'requires_api_password': needs_auth,
-            'version': __version__
+            'version': __version__,
+            'use_ssl': self.hass.config.api.use_ssl
         })
 
 

--- a/homeassistant/components/zeroconf.py
+++ b/homeassistant/components/zeroconf.py
@@ -33,7 +33,8 @@ def setup(hass, config):
 
     requires_api_password = (hass.config.api.api_password is not None)
     params = {"version": __version__, "base_url": hass.config.api.base_url,
-              "requires_api_password": requires_api_password}
+              "requires_api_password": requires_api_password,
+              "use_ssl": hass.config.api.use_ssl}
 
     info = ServiceInfo(ZEROCONF_TYPE, zeroconf_name,
                        socket.inet_aton(hass.config.api.host),

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -55,7 +55,8 @@ class API(object):
         self.host = host
         self.port = port or SERVER_PORT
         self.api_password = api_password
-        if use_ssl:
+        self.use_ssl = use_ssl
+        if self.use_ssl:
             self.base_url = "https://{}:{}".format(host, self.port)
         else:
             self.base_url = "http://{}:{}".format(host, self.port)


### PR DESCRIPTION
This adds a `use_ssl` property to `/api/discovery_info` and ZeroConf.
