### PR TITLE
Support for RFY protocol

### DIFF
--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -14,7 +14,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (ATTR_ENTITY_ID, TEMP_CELSIUS)
 
-REQUIREMENTS = ['pyRFXtrx==0.7.0']
+REQUIREMENTS = ['pyRFXtrx==0.8.0']
 
 DOMAIN = "rfxtrx"
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -219,7 +219,7 @@ pushetta==1.0.15
 py-cpuinfo==0.2.3
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.7.0
+pyRFXtrx==0.8.0
 
 # homeassistant.components.notify.xmpp
 pyasn1-modules==0.0.8


### PR DESCRIPTION
Increment the pyRFXtrx dependency to add support for RFY protocol

**Example entry for `configuration.yaml`:**

``` yaml
rollershutter:
  platform: rfxtrx
  automatic_add: True
  signal_repetitions: 2
  devices:
    071a00000a000101:
      name: Bedroom Blind
```

You need to have set the blind up in `rfxmngr`, once set up, you can add the blind with the following id `071a0000` `id` `unitcode` - always include the prefix of `071a0000` (this denotes the packet length and the RFY protocol for the device). Devices will not auto add since the rfxtrx433e device does not support receive for the RFY protocol.

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
