### PR TITLE
Bump pywemo version to fix ssdp discovery encoding issue.

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components import discovery
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.4.2']
+REQUIREMENTS = ['pywemo==0.4.3']
 
 DOMAIN = 'wemo'
 DISCOVER_LIGHTS = 'wemo.light'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -307,7 +307,7 @@ pyuserinput==0.1.9
 pyvera==0.2.10
 
 # homeassistant.components.wemo
-pywemo==0.4.2
+pywemo==0.4.3
 
 # homeassistant.components.thermostat.radiotherm
 radiotherm==1.2


### PR DESCRIPTION
**Description:**
Bump pywemo version to fix discovery encoding issue.

**Related issue (if applicable):** fixes #
https://github.com/pavoni/pywemo/issues/46

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
