### PR TITLE
Fixed bug in google travel time 

### DIFF
--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -178,7 +178,7 @@ class GoogleTravelTimeSensor(Entity):
             options_copy['departure_time'] = convert_time_to_utc(dtime)
         elif dtime is not None:
             options_copy['departure_time'] = dtime
-        else:
+        elif atime is None:
             options_copy['departure_time'] = 'now'
 
         if atime is not None and ':' in atime:


### PR DESCRIPTION
**Description:**
Departure time is sat to 'now' if arrival_time time is given in settings.
@robbiet480 Do you agree?

**Related issue (if applicable):** fixes  https://community.home-assistant.io/t/is-google-travel-time-broken/1479

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Checklist:**

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Fixed bug in google time travel  when arrival time is given
