### PR TITLE
Bump pyloopenergy version.

### DIFF
--- a/homeassistant/components/sensor/loopenergy.py
+++ b/homeassistant/components/sensor/loopenergy.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "loopenergy"
 
-REQUIREMENTS = ['pyloopenergy==0.0.12']
+REQUIREMENTS = ['pyloopenergy==0.0.13']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -246,7 +246,7 @@ pyicloud==0.8.3
 pylast==1.6.0
 
 # homeassistant.components.sensor.loopenergy
-pyloopenergy==0.0.12
+pyloopenergy==0.0.13
 
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.3.3


### PR DESCRIPTION
**Description:**
Current library assumes connection is dead if it gets no updates for 15s.

The new library waits for 60s. 

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

…n is dead and reconnecting.
