### PR TITLE
Upgrade python-telegram-bot to 4.2.0

### DIFF
--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import validate_config
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['python-telegram-bot==4.1.1']
+REQUIREMENTS = ['python-telegram-bot==4.2.0']
 
 
 def get_service(hass, config):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -286,7 +286,7 @@ python-pushover==0.2
 python-statsd==1.7.2
 
 # homeassistant.components.notify.telegram
-python-telegram-bot==4.1.1
+python-telegram-bot==4.2.0
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.2.0


### PR DESCRIPTION
v4.2
- Implement Bot API 2.1
- Move botan module to telegram.contrib
- New exception type: BadRequest

v4.1.2
- Fix MessageEntity decoding with Bot API 2.1 changes

Tested with the following configuration:

``` yaml
notify:
  - platform: telegram
    name: telegram
    api_key: 1234xxxxx:AAxxxxxxxg
    chat_id: 10xxxxxx
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```
