### PR TITLE
Improve config validation for group

### DIFF
--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -39,7 +39,7 @@ def _conf_preprocess(value):
     return value
 
 _SINGLE_GROUP_CONFIG = vol.Schema(vol.All(_conf_preprocess, {
-    vol.Optional(CONF_ENTITIES): vol.Any(None, cv.entity_ids),
+    vol.Optional(CONF_ENTITIES): vol.Any(cv.entity_ids, None),
     CONF_VIEW: bool,
     CONF_NAME: str,
     CONF_ICON: cv.icon,

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -73,12 +73,13 @@ def entity_id(value):
     value = string(value).lower()
     if valid_entity_id(value):
         return value
-    raise vol.Invalid('Entity ID {} does not match format <domain>.<object_id>'
-                      .format(value))
+    raise vol.Invalid('Entity ID {} is an invalid entity id'.format(value))
 
 
 def entity_ids(value):
     """Validate Entity IDs."""
+    if value is None:
+        raise vol.Invalid('Entity IDs can not be None')
     if isinstance(value, str):
         value = [ent_id.strip() for ent_id in value.split(',')]
 


### PR DESCRIPTION
**Description:**
Before an invalid entity id for groups generated this error message:

```
16-06-02 15:09:37 ERROR (MainThread) [homeassistant.bootstrap] Invalid config for [group]: Group petersroom is invalid: not a valid value for dictionary value @ data['entities'] for dictionary value @ data['group']

```

With this change it will be:

```
16-06-02 15:46:24 ERROR (MainThread) [homeassistant.bootstrap] Invalid config for [group]: Group petersroom is invalid: Entity ID group.tracke--rs is an invalid entity id for dictionary value @ data['entities'] for dictionary value @ data['group']
```

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
