### PR TITLE
Zwave hvac fix

### DIFF
--- a/homeassistant/components/hvac/zwave.py
+++ b/homeassistant/components/hvac/zwave.py
@@ -167,9 +167,9 @@ class ZWaveHvac(ZWaveDeviceEntity, HvacDevice):
     def unit_of_measurement(self):
         """Return the unit of measurement."""
         unit = self._unit
-        if unit == 'C':
+        if 'C' in unit:
             return TEMP_CELSIUS
-        elif unit == 'F':
+        elif 'F' in unit:
             return TEMP_FAHRENHEIT
         else:
             _LOGGER.exception("unit_of_measurement=%s is not valid",


### PR DESCRIPTION
**Description:**
Temperature conversion failed for MIN and MAX temp.
This should fix it.

**Related issue (if applicable):** fixes #
#2189

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
