### PR TITLE
zwave auto heal at midnight

### DIFF
--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -216,7 +216,7 @@ def setup(hass, config):
 
     # Setup autoheal
     if autoheal:
-        _LOGGER.debug("ZWave network autoheal is enabled.")
+        _LOGGER.info("ZWave network autoheal is enabled.")
         track_time_change(hass, lambda: heal_network(None),
                           hour=0, minute=0, second=0)
 
@@ -301,6 +301,7 @@ def setup(hass, config):
 
     def heal_network(event):
         """Heal the network."""
+        _LOGGER.info("ZWave heal running.")
         NETWORK.heal()
 
     def soft_reset(event):


### PR DESCRIPTION
**Description:** Automatically run zwave heal every night

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#527

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
zwave:
  autoheal: true
```

Optional, defaults to true.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
