### PR TITLE
Removed webcolors dependency in favor of dictionary lookup.

### DIFF
--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -23,9 +23,9 @@ COLORS = {
 
 def color_name_to_rgb(color_name):
     """Convert color name to RGB hex value."""
-    try:
-        hex_value = COLORS[color_name.lower()]
-    except KeyError:
+    hex_value = COLORS.get(color_name.lower())
+
+    if not hex_value:
         _LOGGER.error('unknown color supplied %s default to white', color_name)
         hex_value = COLORS['white']
 

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -10,8 +10,7 @@ HASS_COLOR_MIN = 154
 
 
 def color_name_to_rgb(color_name):
-    """ Converts color name to RGB hex value. """
-
+    """Convert color name to RGB hex value."""
     colors = {
         'white': (255, 255, 255), 'beige': (245, 245, 220),
         'tan': (210, 180, 140), 'gray': (128, 128, 128),

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -1,10 +1,36 @@
 """Color util methods."""
+import logging
 import math
 # pylint: disable=unused-import
-from webcolors import html5_parse_legacy_color as color_name_to_rgb  # noqa
+
+_LOGGER = logging.getLogger(__name__)
 
 HASS_COLOR_MAX = 500  # mireds (inverted)
 HASS_COLOR_MIN = 154
+
+
+def color_name_to_rgb(color_name):
+    """ Converts color name to RGB hex value. """
+
+    colors = {
+        'white': (255, 255, 255), 'beige': (245, 245, 220),
+        'tan': (210, 180, 140), 'gray': (128, 128, 128),
+        'navy blue': (0, 0, 128), 'royal blue': (8, 76, 158),
+        'blue': (0, 0, 255), 'azure': (0, 127, 255), 'aqua': (127, 255, 212),
+        'teal': (0, 128, 128), 'green': (0, 255, 0),
+        'forest green': (34, 139, 34), 'olive': (128, 128, 0),
+        'chartreuse': (127, 255, 0), 'lime': (191, 255, 0),
+        'golden': (255, 215, 0), 'red': (255, 0, 0), 'coral': (0, 63, 72),
+        'hot pink': (252, 15, 192), 'fuchsia': (255, 119, 255),
+        'lavender': (181, 126, 220), 'indigo': (75, 0, 130),
+        'maroon': (128, 0, 0), 'crimson': (220, 20, 60)}
+    try:
+        hex_value = colors[color_name.lower()]
+    except KeyError:
+        _LOGGER.error('unknown color supplied %s default to white', color_name)
+        hex_value = colors['white']
+
+    return hex_value
 
 
 # Taken from:

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -7,27 +7,27 @@ _LOGGER = logging.getLogger(__name__)
 
 HASS_COLOR_MAX = 500  # mireds (inverted)
 HASS_COLOR_MIN = 154
+COLORS = {
+    'white': (255, 255, 255), 'beige': (245, 245, 220),
+    'tan': (210, 180, 140), 'gray': (128, 128, 128),
+    'navy blue': (0, 0, 128), 'royal blue': (8, 76, 158),
+    'blue': (0, 0, 255), 'azure': (0, 127, 255), 'aqua': (127, 255, 212),
+    'teal': (0, 128, 128), 'green': (0, 255, 0),
+    'forest green': (34, 139, 34), 'olive': (128, 128, 0),
+    'chartreuse': (127, 255, 0), 'lime': (191, 255, 0),
+    'golden': (255, 215, 0), 'red': (255, 0, 0), 'coral': (0, 63, 72),
+    'hot pink': (252, 15, 192), 'fuchsia': (255, 119, 255),
+    'lavender': (181, 126, 220), 'indigo': (75, 0, 130),
+    'maroon': (128, 0, 0), 'crimson': (220, 20, 60)}
 
 
 def color_name_to_rgb(color_name):
     """Convert color name to RGB hex value."""
-    colors = {
-        'white': (255, 255, 255), 'beige': (245, 245, 220),
-        'tan': (210, 180, 140), 'gray': (128, 128, 128),
-        'navy blue': (0, 0, 128), 'royal blue': (8, 76, 158),
-        'blue': (0, 0, 255), 'azure': (0, 127, 255), 'aqua': (127, 255, 212),
-        'teal': (0, 128, 128), 'green': (0, 255, 0),
-        'forest green': (34, 139, 34), 'olive': (128, 128, 0),
-        'chartreuse': (127, 255, 0), 'lime': (191, 255, 0),
-        'golden': (255, 215, 0), 'red': (255, 0, 0), 'coral': (0, 63, 72),
-        'hot pink': (252, 15, 192), 'fuchsia': (255, 119, 255),
-        'lavender': (181, 126, 220), 'indigo': (75, 0, 130),
-        'maroon': (128, 0, 0), 'crimson': (220, 20, 60)}
     try:
-        hex_value = colors[color_name.lower()]
+        hex_value = COLORS[color_name.lower()]
     except KeyError:
         _LOGGER.error('unknown color supplied %s default to white', color_name)
-        hex_value = colors['white']
+        hex_value = COLORS['white']
 
     return hex_value
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,7 +5,6 @@ pytz>=2016.4
 pip>=7.0.0
 jinja2>=2.8
 voluptuous==0.8.9
-webcolors==1.5
 
 # homeassistant.components.isy994
 PyISY==1.0.6

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ REQUIRES = [
     'pip>=7.0.0',
     'jinja2>=2.8',
     'voluptuous==0.8.9',
-    'webcolors==1.5',
 ]
 
 setup(

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -60,6 +60,7 @@ class TestColorUtil(unittest.TestCase):
                          color_util.rgb_hex_to_rgb_list('3399ff00'))
 
     def test_color_name_to_rgb_valid_name(self):
+        """Test color_name_to_rgb."""
         self.assertEqual((255, 0, 0),
                          color_util.color_name_to_rgb('red'))
 
@@ -70,6 +71,7 @@ class TestColorUtil(unittest.TestCase):
                          color_util.color_name_to_rgb('green'))
 
     def test_color_name_to_rgb_unknown_name_default_white(self):
+        """Test color_name_to_rgb."""
         self.assertEqual((255, 255, 255),
                          color_util.color_name_to_rgb('not a color'))
 

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -59,6 +59,20 @@ class TestColorUtil(unittest.TestCase):
         self.assertEqual([51, 153, 255, 0],
                          color_util.rgb_hex_to_rgb_list('3399ff00'))
 
+    def test_color_name_to_rgb_valid_name(self):
+        self.assertEqual((255, 0, 0),
+                         color_util.color_name_to_rgb('red'))
+
+        self.assertEqual((0, 0, 255),
+                         color_util.color_name_to_rgb('blue'))
+
+        self.assertEqual((0, 255, 0),
+                         color_util.color_name_to_rgb('green'))
+
+    def test_color_name_to_rgb_unknown_name_default_white(self):
+        self.assertEqual((255, 255, 255),
+                         color_util.color_name_to_rgb('not a color'))
+
 
 class ColorTemperatureMiredToKelvinTests(unittest.TestCase):
     """Test color_temperature_mired_to_kelvin."""


### PR DESCRIPTION
**Description:**
Removed webcolors module in favor of dictionary lookup.

**Related issue (if applicable):** fixes #
https://www.pivotaltracker.com/story/show/120785401

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
