### PR TITLE
adds sha512 hash functions but does not convert raw password implemen…

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -1,8 +1,11 @@
 """This module provides WSGI application to serve the Home Assistant API."""
+import hashlib
 import hmac
 import json
 import logging
 import mimetypes
+import random
+import string
 import threading
 import re
 import voluptuous as vol
@@ -20,6 +23,7 @@ DOMAIN = "http"
 REQUIREMENTS = ("eventlet==0.19.0", "static3==0.7.0", "Werkzeug==0.11.5",)
 
 CONF_API_PASSWORD = "api_password"
+CONF_API_HASH = 'api_hash'
 CONF_SERVER_HOST = "server_host"
 CONF_SERVER_PORT = "server_port"
 CONF_DEVELOPMENT = "development"
@@ -27,6 +31,8 @@ CONF_SSL_CERTIFICATE = 'ssl_certificate'
 CONF_SSL_KEY = 'ssl_key'
 
 DATA_API_PASSWORD = 'api_password'
+
+SALT_LENGTH = 8
 
 _FINGERPRINT = re.compile(r'^(.+)-[a-z0-9]{32}\.(\w+)$', re.IGNORECASE)
 
@@ -43,6 +49,54 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_SSL_KEY): cv.isfile,
     }),
 }, extra=vol.ALLOW_EXTRA)
+
+
+def collect_hash(config):
+    """
+    find the password/hash information in http configuration
+
+    Args:
+        config: configuration['http']
+
+    Returns:
+        '$<algorithm>$<salt>$<hash>'
+        or
+        None if password or hash are not configured
+    """
+    if CONF_API_HASH in config:
+        hash_ = config[CONF_API_HASH]
+    elif CONF_API_PASSWORD in config:
+        hash_ = new_hash(config[CONF_API_PASSWORD])
+    else:
+        return None
+    return split_hash(hash_)
+
+
+def new_hash(password, salt=None):
+    """
+    create new sha512 hash from password and random salt
+
+    Args:
+        password: password string
+        salt: arbitrary string
+
+    Returns: '$<algorithm>$<salt>$<hash>'
+
+    """
+    if not salt:
+        alpha_numeric = string.ascii_letters + string.digits
+        salt = ''.join(random.sample(alpha_numeric, SALT_LENGTH))
+    assert '$' not in salt, 'salt contains "$"'
+    hasher = hashlib.sha512()
+    hasher.update((salt + password).encode('utf-8'))
+    return '$sha512${}${}'.format(salt, hasher.hexdigest())
+
+
+def split_hash(hash_string):
+    assert hash_string.count('$') == 3, \
+        'there should be exactly three "$" in hash, got {}'\
+        .format(hash_string.count('$'))
+    return tuple(hash_string.split('$')[1:])
 
 
 class HideSensitiveFilter(logging.Filter):
@@ -374,8 +428,10 @@ class HomeAssistantView(object):
             # A valid auth header has been set
             authenticated = True
 
-        elif hmac.compare_digest(request.args.get(DATA_API_PASSWORD, ''),
-                                 self.hass.wsgi.api_password):
+        elif hmac.compare_digest(
+                request.args.get(DATA_API_PASSWORD, ''),
+                self.hass.wsgi.api_password
+        ):
             authenticated = True
 
         if self.requires_auth and not authenticated:

--- a/tests/components/test_http.py
+++ b/tests/components/test_http.py
@@ -1,6 +1,9 @@
 """The tests for the Home Assistant HTTP component."""
 # pylint: disable=protected-access,too-many-public-methods
+import hashlib
 import logging
+import unittest
+from unittest import mock
 
 import eventlet
 import requests
@@ -50,6 +53,65 @@ def setUpModule():   # pylint: disable=invalid-name
 def tearDownModule():   # pylint: disable=invalid-name
     """Stop the Home Assistant server."""
     hass.stop()
+
+
+class TestCollectHash(unittest.TestCase):
+    """ tests for http.collect_hash() """
+
+    def setUp(self):
+        self.hash = '$a$b$c'
+        self.password = 'pass'
+
+    def test_hash_is_prefered_if_both_hash_and_password_are_present(self):
+        hash_ = '$1$2$3'
+        config = {
+            http.CONF_API_PASSWORD: 'pass',
+            http.CONF_API_HASH: hash_,
+        }
+        self.assertEqual(http.split_hash(hash_), http.collect_hash(config))
+
+    def test_returns_new_hash_tuple_if_password_is_present(self):
+        salt, password = '2', 'pass'
+        config = {http.CONF_API_PASSWORD: password}
+        hash_ = http.split_hash(http.new_hash(password, salt))
+        with mock.patch('random.sample', return_value=['2']):
+            self.assertEqual(http.collect_hash(config), hash_)
+
+    def test_returns_none_if_no_password_or_hash(self):
+        self.assertIs(http.collect_hash({}), None)
+
+    def test_returns_hash_tuple_if_hash_is_present(self):
+        config = {http.CONF_API_HASH: self.hash}
+        self.assertEqual(http.collect_hash(config), ('a', 'b', 'c'))
+
+
+class TestNewHash(unittest.TestCase):
+
+    def setUp(self):
+        self.password = 'password'
+        self.new_hash = http.new_hash(self.password, 'aaa')
+        self.alg, self.salt, self.hash = http.split_hash(self.new_hash)
+
+    def test_new_hash_returns_random_hash(self):
+        hashes = [http.new_hash(self.password)]
+        for _ in range(100):
+            h = http.new_hash(self.password)
+            self.assertNotIn(h, hashes)
+            hashes.append(h)
+
+    def test_new_hash_string_has_hash(self):
+        hasher = hashlib.sha512()
+        hasher.update((self.salt + self.password).encode('utf-8'))
+        self.assertEqual(self.hash, hasher.hexdigest())
+
+    def test_new_hash_string_has_salt(self):
+        self.assertEqual(self.salt, 'aaa')
+
+    def test_new_hash_string_has_hash_algorithm(self):
+        self.assertEqual(self.alg, 'sha512')
+
+    def test_new_hash_returns_dollar_sign_delimited_string(self):
+        self.assertEqual(self.new_hash.count('$'), 3)
 
 
 class TestHttp:


### PR DESCRIPTION
**Description:**
adds hash string parsing and password salting and hashing functions, but does not change current raw password string implementation to use hashes. Conversion is left to someone with a much better understanding of the ways that home-assistant uses passwords. (this may be me in the future if no one else gets to it first...)

**Related issue (if applicable):**
pivotal story: www.pivotaltracker.com/story/show/115886789

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x ] Tests have been added to verify that the new code works.

…tation to salted hash
