### PR TITLE
Hvac fix

### DIFF
--- a/homeassistant/components/hvac/__init__.py
+++ b/homeassistant/components/hvac/__init__.py
@@ -468,12 +468,12 @@ class HvacDevice(Entity):
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        return convert(7, TEMP_CELCIUS, self.unit_of_measurement)
+        return convert(19, TEMP_CELCIUS, self.unit_of_measurement)
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        return convert(35, TEMP_CELCIUS, self.unit_of_measurement)
+        return convert(30, TEMP_CELCIUS, self.unit_of_measurement)
 
     @property
     def min_humidity(self):

--- a/homeassistant/components/hvac/zwave.py
+++ b/homeassistant/components/hvac/zwave.py
@@ -237,9 +237,13 @@ class ZWaveHvac(ZWaveDeviceEntity, HvacDevice):
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        return self._convert_for_display(19)
+        if 'F' in self.unit_of_measurement:
+            return 66.2
+        return 19
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        return self._convert_for_display(30)
+        if 'F' in self.unit_of_measurement:
+            return 86
+        return 30

--- a/homeassistant/components/hvac/zwave.py
+++ b/homeassistant/components/hvac/zwave.py
@@ -233,17 +233,3 @@ class ZWaveHvac(ZWaveDeviceEntity, HvacDevice):
                     class_id=COMMAND_CLASS_CONFIGURATION).values():
                 if value.command_class == 112 and value.index == 33:
                     value.data = int(swing_mode)
-
-    @property
-    def min_temp(self):
-        """Return the minimum temperature."""
-        if 'F' in self.unit_of_measurement:
-            return 66.2
-        return 19
-
-    @property
-    def max_temp(self):
-        """Return the maximum temperature."""
-        if 'F' in self.unit_of_measurement:
-            return 86
-        return 30

--- a/tests/components/hvac/test_demo.py
+++ b/tests/components/hvac/test_demo.py
@@ -43,8 +43,8 @@ class TestDemoHvac(unittest.TestCase):
     def test_default_setup_params(self):
         """Test the setup with default parameters."""
         state = self.hass.states.get(ENTITY_HVAC)
-        self.assertEqual(7, state.attributes.get('min_temp'))
-        self.assertEqual(35, state.attributes.get('max_temp'))
+        self.assertEqual(19, state.attributes.get('min_temp'))
+        self.assertEqual(30, state.attributes.get('max_temp'))
         self.assertEqual(30, state.attributes.get('min_humidity'))
         self.assertEqual(99, state.attributes.get('max_humidity'))
 


### PR DESCRIPTION
**Description:**
Temperature conversion failed for MIN and MAX temp.
This should fix it.

**Related issue (if applicable):** fixes #
#2189

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
