### PR TITLE
Add turn_off_action to kodi media player

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -10,7 +10,7 @@ import urllib
 from homeassistant.components.media_player import (
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK, SUPPORT_SEEK,
     SUPPORT_PLAY_MEDIA, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, SUPPORT_STOP,
-    MediaPlayerDevice)
+    SUPPORT_TURN_OFF, MediaPlayerDevice)
 from homeassistant.const import (
     STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING)
 
@@ -36,7 +36,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             url,
             auth=(
                 config.get('user', ''),
-                config.get('password', ''))),
+                config.get('password', '')),
+            turn_off_action=config.get('turn_off_action', 'none')),
     ])
 
 
@@ -44,7 +45,8 @@ class KodiDevice(MediaPlayerDevice):
     """Representation of a XBMC/Kodi device."""
 
     # pylint: disable=too-many-public-methods, abstract-method
-    def __init__(self, name, url, auth=None):
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self, name, url, auth=None, turn_off_action=None):
         """Initialize the Kodi device."""
         import jsonrpc_requests
         self._name = name
@@ -52,6 +54,7 @@ class KodiDevice(MediaPlayerDevice):
         self._server = jsonrpc_requests.Server(
             '{}/jsonrpc'.format(self._url),
             auth=auth)
+        self._turn_off_action = turn_off_action
         self._players = list()
         self._properties = None
         self._item = None
@@ -181,11 +184,29 @@ class KodiDevice(MediaPlayerDevice):
     @property
     def supported_media_commands(self):
         """Flag of media commands that are supported."""
-        return SUPPORT_KODI
+        supported_media_commands = SUPPORT_KODI
+
+        if self._turn_off_action in [
+                'quit', 'hibernate', 'suspend', 'reboot', 'shutdown']:
+            supported_media_commands |= SUPPORT_TURN_OFF
+
+        return supported_media_commands
 
     def turn_off(self):
-        """Turn off media player."""
-        self._server.System.Shutdown()
+        """Execute turn_off_action to turn off media player."""
+        if self._turn_off_action == 'quit':
+            self._server.Application.Quit()
+        elif self._turn_off_action == 'hibernate':
+            self._server.System.Hibernate()
+        elif self._turn_off_action == 'suspend':
+            self._server.System.Suspend()
+        elif self._turn_off_action == 'reboot':
+            self._server.System.Reboot()
+        elif self._turn_off_action == 'shutdown':
+            self._server.System.Shutdown()
+        else:
+            _LOGGER.warning('turn_off requested but turn_off_action is none')
+
         self.update_ha_state()
 
     def volume_up(self):


### PR DESCRIPTION
**Description:**
A new configuration option `turn_off_action` is added to kodi. It may be one of: none, quit, hibernate, suspend, reboot, or poweroff. The appropriate command is sent to kodi when the turn_off action is requested. Default value is none.

Kodi will only report turn_off supported if it is configured to something other than none.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#533

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
media_player:
  platform: kodi
  turn_off_action: shutdown
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
