### PR TITLE
Expose current mode for thermostats

### DIFF
--- a/homeassistant/components/thermostat/__init__.py
+++ b/homeassistant/components/thermostat/__init__.py
@@ -41,6 +41,7 @@ ATTR_MAX_TEMP = "max_temp"
 ATTR_MIN_TEMP = "min_temp"
 ATTR_TEMPERATURE_LOW = "target_temp_low"
 ATTR_TEMPERATURE_HIGH = "target_temp_high"
+ATTR_THERMOSTAT_MODE = "thermostat_mode"
 ATTR_OPERATION = "current_operation"
 
 _LOGGER = logging.getLogger(__name__)
@@ -196,6 +197,10 @@ class ThermostatDevice(Entity):
         if operation is not None:
             data[ATTR_OPERATION] = operation
 
+        mode = self.thermostat_mode
+        if mode is not None:
+            data[ATTR_THERMOSTAT_MODE] = self.thermostat_mode
+
         is_away = self.is_away_mode_on
         if is_away is not None:
             data[ATTR_AWAY_MODE] = STATE_ON if is_away else STATE_OFF
@@ -244,6 +249,11 @@ class ThermostatDevice(Entity):
     @property
     def is_fan_on(self):
         """Return true if the fan is on."""
+        return None
+
+    @property
+    def thermostat_mode(self):
+        """Return the current thermostat mode (e.g. heating/cooling)."""
         return None
 
     def set_temperate(self, temperature):

--- a/homeassistant/components/thermostat/zwave.py
+++ b/homeassistant/components/thermostat/zwave.py
@@ -19,6 +19,12 @@ REMOTEC = 0x5254
 REMOTEC_ZXT_120 = 0x8377
 REMOTEC_ZXT_120_THERMOSTAT = (REMOTEC, REMOTEC_ZXT_120)
 
+COMMAND_CLASS_SENSOR_MULTILEVEL = 0x31
+COMMAND_CLASS_THERMOSTAT_MODE = 0x40
+COMMAND_CLASS_THERMOSTAT_OPERATING_STATE = 0x42
+COMMAND_CLASS_THERMOSTAT_SETPOINT = 0x43
+COMMAND_CLASS_THERMOSTAT_FAN_MODE = 0x44
+
 WORKAROUND_IGNORE = 'ignore'
 
 DEVICE_MAPPINGS = {
@@ -79,19 +85,23 @@ class ZWaveThermostat(zwave.ZWaveDeviceEntity, ThermostatDevice):
 
     def update_properties(self):
         """Callback on data change for the registered node/value pair."""
-        # set point
-        for _, value in self._node.get_values(class_id=0x43).items():
+        # Set point
+        for _, value in self._node.get_values(
+                class_id=COMMAND_CLASS_THERMOSTAT_SETPOINT).items():
             if int(value.data) != 0:
                 self._target_temperature = int(value.data)
         # Operation
-        for _, value in self._node.get_values(class_id=0x40).items():
+        for _, value in self._node.get_values(
+                class_id=COMMAND_CLASS_THERMOSTAT_MODE).items():
             self._current_operation = value.data_as_string
         # Current Temp
-        for _, value in self._node.get_values_for_command_class(0x31).items():
+        for _, value in self._node.get_values_for_command_class(
+                COMMAND_CLASS_SENSOR_MULTILEVEL).items():
             self._current_temperature = int(value.data)
             self._unit = value.units
-        # COMMAND_CLASS_THERMOSTAT_OPERATING_STATE
-        for _, value in self._node.get_values(class_id=0x42).items():
+        # Thermostat mode
+        for _, value in self._node.get_values(
+                class_id=COMMAND_CLASS_THERMOSTAT_OPERATING_STATE).items():
             self._current_operation_state = value.data_as_string
 
     @property
@@ -134,6 +144,12 @@ class ZWaveThermostat(zwave.ZWaveDeviceEntity, ThermostatDevice):
     def set_temperature(self, temperature):
         """Set new target temperature."""
         # set point
-        for _, value in self._node.get_values_for_command_class(0x43).items():
+        for _, value in self._node.get_values_for_command_class(
+                COMMAND_CLASS_THERMOSTAT_SETPOINT).items():
             if int(value.data) != 0:
                 value.data = temperature
+
+    @property
+    def thermostat_mode(self):
+        """Return the current thermostat mode (e.g. heating/cooling)."""
+        return self._current_operation_state


### PR DESCRIPTION
**Description:**
The thermostat mode (heating/cooling/idle/etc.) is current used in the code, but not accessible through the UI/for automation.  This commit exposes the variable, as well as implements it for Z-Wave thermostats.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
