### PR TITLE
Upgrade betamax to 0.7.0

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,5 +5,5 @@ pytest>=2.9.1
 pytest-cov>=2.2.0
 pytest-timeout>=1.0.0
 pytest-capturelog>=0.7
-betamax==0.5.1
+betamax==0.7.0
 pydocstyle>=1.0.0


### PR DESCRIPTION
## 0.7.0 - 2016-04-29
- Add `before_record` and `before_playback` hooks
- Allow per-cassette placeholders to be merged and override global placeholders
- Fix bug where the `QueryMatcher` failed matching on high Unicode points
## 0.6.0 - 2016-04-12
- Add `betamax_recorder` pytest fixture
- Change default behaviour to allow duplicate interactions to be recorded in   single cassette
- Add `allow_playback_repeats` to allow an interaction to be used more than   once from a single cassette
- Always return a new `Response` object from an Interaction to allow for a streaming response to be usable multiple times
- Remove CI support for Pythons 2.6 and 3.2

`tox` runs through locally.
