### PR TITLE
Introducing support for Netatmo Welcome Camera

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -78,6 +78,9 @@ omit =
     homeassistant/components/enocean.py
     homeassistant/components/*/enocean.py
 
+    homeassistant/components/netatmo.py
+    homeassistant/components/*/netatmo.py
+
     homeassistant/components/alarm_control_panel/alarmdotcom.py
     homeassistant/components/alarm_control_panel/nx584.py
     homeassistant/components/binary_sensor/arest.py
@@ -170,7 +173,6 @@ omit =
     homeassistant/components/sensor/gtfs.py
     homeassistant/components/sensor/lastfm.py
     homeassistant/components/sensor/loopenergy.py
-    homeassistant/components/sensor/netatmo.py
     homeassistant/components/sensor/neurio_energy.py
     homeassistant/components/sensor/nzbget.py
     homeassistant/components/sensor/onewire.py

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -9,7 +9,7 @@ import logging
 
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.components import bloomsky
+from homeassistant.components import bloomsky, netatmo
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 from homeassistant.components.http import HomeAssistantView
 
@@ -21,6 +21,7 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 # Maps discovered services to their platforms
 DISCOVERY_PLATFORMS = {
     bloomsky.DISCOVER_CAMERAS: 'bloomsky',
+    netatmo.DISCOVER_CAMERAS: 'netatmo',
 }
 
 STATE_RECORDING = 'recording'

--- a/homeassistant/components/camera/netatmo.py
+++ b/homeassistant/components/camera/netatmo.py
@@ -1,0 +1,79 @@
+"""
+Support for the NetAtmo Weather Service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.netatmo/
+"""
+import logging
+import requests
+
+from homeassistant.components.camera import Camera
+from homeassistant.loader import get_component
+
+DEPENDENCIES = ["netatmo"]
+
+REQUIREMENTS = [
+    'https://github.com/jabesq/netatmo-api-python/archive/'
+    'master.zip'
+    '#lnetatmo==0.4.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Setup access to Netatmo Welcome cameras."""
+    netatmo = get_component('netatmo')
+    data = WelcomeData(netatmo.NETATMO_AUTH)
+
+    for camera_name in data.get_camera_names():
+        add_devices_callback([WelcomeCamera(data, camera_name)])
+
+
+class WelcomeCamera(Camera):
+    """Representation of the images published from the Netatmo Welcome camera."""
+
+    def __init__(self, data, camera_name):
+        """Setup for access to the BloomSky camera images."""
+        super(WelcomeCamera, self).__init__()
+        self._data = data
+        self._name = camera_name
+        self._url = self._data.welcomedata.cameraUrl(camera=camera_name)
+
+    def camera_image(self):
+        """Return a still image response from the camera."""
+        try:
+            response = requests.get('{0}/live/snapshot_720.jpg'.format(self._url))
+        except requests.exceptions.RequestException as error:
+            _LOGGER.error('Welcome VPN url changed: %s', error)
+            self._data.update()
+            self._url = self._data.welcomedata.cameraUrl(camera=self._name)
+            return None
+        return response.content
+
+    @property
+    def name(self):
+        """Return the name of this BloomSky device."""
+        return self._name
+
+
+class WelcomeData(object):
+    """Get the latest data from NetAtmo."""
+
+    def __init__(self, auth):
+        """Initialize the data object."""
+        self.auth = auth
+        self.welcomedata = None
+        self.camera_names = []
+
+    def get_camera_names(self):
+        """Return all module available on the API as a list."""
+        self.update()
+        for camera in self.welcomedata.cameras:
+            self.camera_names.append(camera['name'])
+        return self.camera_names
+
+    def update(self):
+        """Call the NetAtmo API to update the data."""
+        import lnetatmo
+        self.welcomedata = lnetatmo.WelcomeData(self.auth)

--- a/homeassistant/components/camera/netatmo.py
+++ b/homeassistant/components/camera/netatmo.py
@@ -33,9 +33,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
 
 class WelcomeCamera(Camera):
-    """
-    Representation of the images published from the Netatmo Welcome camera.
-    """
+    """Representation of the images published from Welcome camera."""
 
     def __init__(self, data, camera_name, home):
         """Setup for access to the BloomSky camera images."""

--- a/homeassistant/components/camera/netatmo.py
+++ b/homeassistant/components/camera/netatmo.py
@@ -26,10 +26,10 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     data = WelcomeData(netatmo.NETATMO_AUTH, home)
 
     for camera_name in data.get_camera_names():
-        if config[ATTR_CAMERAS]:
-            if camera_name not in config[ATTR_CAMERAS].items():
+        if ATTR_CAMERAS in config:
+            if camera_name not in config[ATTR_CAMERAS]:
                 continue
-        add_devices_callback([WelcomeCamera(data, camera_name)])
+        add_devices_callback([WelcomeCamera(data, camera_name, home)])
 
 
 class WelcomeCamera(Camera):
@@ -37,11 +37,14 @@ class WelcomeCamera(Camera):
     Representation of the images published from the Netatmo Welcome camera.
     """
 
-    def __init__(self, data, camera_name):
+    def __init__(self, data, camera_name, home):
         """Setup for access to the BloomSky camera images."""
         super(WelcomeCamera, self).__init__()
         self._data = data
-        self._name = camera_name
+        if home:
+            self._name = home + ' / ' + camera_name
+        else:
+            self._name = camera_name
         self._vpnurl, self._localurl = self._data.welcomedata.cameraUrls(
             camera=camera_name
             )

--- a/homeassistant/components/camera/netatmo.py
+++ b/homeassistant/components/camera/netatmo.py
@@ -12,11 +12,6 @@ from homeassistant.loader import get_component
 
 DEPENDENCIES = ["netatmo"]
 
-REQUIREMENTS = [
-    'https://github.com/jabesq/netatmo-api-python/archive/'
-    'master.zip'
-    '#lnetatmo==0.4.0']
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/camera/netatmo.py
+++ b/homeassistant/components/camera/netatmo.py
@@ -1,8 +1,8 @@
 """
-Support for the NetAtmo Weather Service.
+Support for the Netatmo Welcome camera.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/sensor.netatmo/
+https://home-assistant.io/components/camera.netatmo/
 """
 import logging
 import requests

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import validate_config
 
 REQUIREMENTS = [
     'https://github.com/jabesq/netatmo-api-python/archive/'
-    'v0.5.0.zip#lnetatmo==0.4.0']
+    'v0.5.0.zip#lnetatmo==0.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -1,0 +1,57 @@
+"""
+Support for the NetAtmo Weather Service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.netatmo/
+"""
+import logging
+from homeassistant.components import discovery
+from homeassistant.const import (
+    CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME)
+from homeassistant.helpers import validate_config
+
+REQUIREMENTS = [
+    'https://github.com/HydrelioxGitHub/netatmo-api-python/archive/'
+    '43ff238a0122b0939a0dc4e8836b6782913fb6e2.zip'
+    '#lnetatmo==0.4.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_SECRET_KEY = 'secret_key'
+
+DOMAIN = "netatmo"
+NETATMO_AUTH = None
+
+_LOGGER = logging.getLogger(__name__)
+
+DISCOVER_SENSORS = 'netatmo.sensors'
+
+
+def setup(hass, config):
+    """Setup the NetAtmo sensor."""
+    if not validate_config(config,
+                           {DOMAIN: [CONF_API_KEY,
+                                     CONF_USERNAME,
+                                     CONF_PASSWORD,
+                                     CONF_SECRET_KEY]},
+                           _LOGGER):
+        return None
+
+    import lnetatmo
+
+    global NETATMO_AUTH
+    NETATMO_AUTH = lnetatmo.ClientAuth(config[DOMAIN][CONF_API_KEY],
+                                       config[DOMAIN][CONF_SECRET_KEY],
+                                       config[DOMAIN][CONF_USERNAME],
+                                       config[DOMAIN][CONF_PASSWORD])
+
+    if not NETATMO_AUTH:
+        _LOGGER.error(
+            "Connection error "
+            "Please check your settings for NetAtmo API.")
+        return False
+
+    discovery.discover(hass, DISCOVER_SENSORS, component='sensor',
+                           hass_config=config)
+
+    return True

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -44,7 +44,8 @@ def setup(hass, config):
                                        config[DOMAIN][CONF_SECRET_KEY],
                                        config[DOMAIN][CONF_USERNAME],
                                        config[DOMAIN][CONF_PASSWORD],
-                                       "read_station read_camera access_camera")
+                                       "read_station read_camera "
+                                       "access_camera")
 
     if not NETATMO_AUTH:
         _LOGGER.error(

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -25,6 +25,7 @@ NETATMO_AUTH = None
 _LOGGER = logging.getLogger(__name__)
 
 DISCOVER_SENSORS = 'netatmo.sensors'
+DISCOVER_CAMERAS = 'netatmo.cameras'
 
 
 def setup(hass, config):
@@ -51,7 +52,9 @@ def setup(hass, config):
             "Please check your settings for NetAtmo API.")
         return False
 
-    discovery.discover(hass, DISCOVER_SENSORS, component='sensor',
-                       hass_config=config)
+    for component, discovery_service in (
+            ('camera', DISCOVER_CAMERAS), ('sensor', DISCOVER_SENSORS)):
+        discovery.discover(hass, discovery_service, component=component,
+                           hass_config=config)
 
     return True

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -44,7 +44,8 @@ def setup(hass, config):
     NETATMO_AUTH = lnetatmo.ClientAuth(config[DOMAIN][CONF_API_KEY],
                                        config[DOMAIN][CONF_SECRET_KEY],
                                        config[DOMAIN][CONF_USERNAME],
-                                       config[DOMAIN][CONF_PASSWORD])
+                                       config[DOMAIN][CONF_PASSWORD],
+                                       "read_station read_camera access_camera")
 
     if not NETATMO_AUTH:
         _LOGGER.error(

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -1,10 +1,11 @@
 """
-Support for the NetAtmo Weather Service.
+Support for the Netatmo devices (Weather Station and Welcome camera).
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/sensor.netatmo/
+https://home-assistant.io/components/netatmo/
 """
 import logging
+from urllib.error import HTTPError
 from homeassistant.components import discovery
 from homeassistant.const import (
     CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME)
@@ -28,7 +29,7 @@ DISCOVER_CAMERAS = 'netatmo.cameras'
 
 
 def setup(hass, config):
-    """Setup the NetAtmo sensor."""
+    """Setup the Netatmo devices."""
     if not validate_config(config,
                            {DOMAIN: [CONF_API_KEY,
                                      CONF_USERNAME,
@@ -40,17 +41,17 @@ def setup(hass, config):
     import lnetatmo
 
     global NETATMO_AUTH
-    NETATMO_AUTH = lnetatmo.ClientAuth(config[DOMAIN][CONF_API_KEY],
-                                       config[DOMAIN][CONF_SECRET_KEY],
-                                       config[DOMAIN][CONF_USERNAME],
-                                       config[DOMAIN][CONF_PASSWORD],
-                                       "read_station read_camera "
-                                       "access_camera")
-
-    if not NETATMO_AUTH:
+    try:
+        NETATMO_AUTH = lnetatmo.ClientAuth(config[DOMAIN][CONF_API_KEY],
+                                           config[DOMAIN][CONF_SECRET_KEY],
+                                           config[DOMAIN][CONF_USERNAME],
+                                           config[DOMAIN][CONF_PASSWORD],
+                                           "read_station read_camera "
+                                           "access_camera")
+    except HTTPError:
         _LOGGER.error(
             "Connection error "
-            "Please check your settings for NetAtmo API.")
+            "Please check your settings for NatAtmo API.")
         return False
 
     for component, discovery_service in (

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -12,8 +12,7 @@ from homeassistant.helpers import validate_config
 
 REQUIREMENTS = [
     'https://github.com/jabesq/netatmo-api-python/archive/'
-    'master.zip'
-    '#lnetatmo==0.4.0']
+    'v0.5.0.zip#lnetatmo==0.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -11,8 +11,8 @@ from homeassistant.const import (
 from homeassistant.helpers import validate_config
 
 REQUIREMENTS = [
-    'https://github.com/HydrelioxGitHub/netatmo-api-python/archive/'
-    '43ff238a0122b0939a0dc4e8836b6782913fb6e2.zip'
+    'https://github.com/jabesq/netatmo-api-python/archive/'
+    'master.zip'
     '#lnetatmo==0.4.0']
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,6 +52,6 @@ def setup(hass, config):
         return False
 
     discovery.discover(hass, DISCOVER_SENSORS, component='sensor',
-                           hass_config=config)
+                       hass_config=config)
 
     return True

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 from homeassistant.components import (
     wink, zwave, isy994, verisure, ecobee, tellduslive, mysensors,
-    bloomsky, vera)
+    bloomsky, vera, netatmo)
 
 DOMAIN = 'sensor'
 SCAN_INTERVAL = 30
@@ -28,6 +28,7 @@ DISCOVERY_PLATFORMS = {
     tellduslive.DISCOVER_SENSORS: 'tellduslive',
     mysensors.DISCOVER_SENSORS: 'mysensors',
     vera.DISCOVER_SENSORS: 'vera',
+    netatmo.DISCOVER_SENSORS: 'netatmo',
 }
 
 

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -36,7 +36,7 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=600)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the available NetAtmo weather sensors."""
+    """Setup the available Netatmo weather sensors."""
     netatmo = get_component('netatmo')
     data = NetAtmoData(netatmo.NETATMO_AUTH, config.get(CONF_STATION, None))
 

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -14,8 +14,8 @@ from homeassistant.loader import get_component
 DEPENDENCIES = ["netatmo"]
 
 REQUIREMENTS = [
-    'https://github.com/HydrelioxGitHub/netatmo-api-python/archive/'
-    '43ff238a0122b0939a0dc4e8836b6782913fb6e2.zip'
+    'https://github.com/jabesq/netatmo-api-python/archive/'
+    'master.zip'
     '#lnetatmo==0.4.0']
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -6,13 +6,12 @@ https://home-assistant.io/components/sensor.netatmo/
 """
 import logging
 from datetime import timedelta
-
-from homeassistant.components.sensor import DOMAIN
-from homeassistant.const import (
-    CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME, TEMP_CELSIUS)
-from homeassistant.helpers import validate_config
+from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
+from homeassistant.loader import get_component
+
+DEPENDENCIES = ["netatmo"]
 
 REQUIREMENTS = [
     'https://github.com/HydrelioxGitHub/netatmo-api-python/archive/'
@@ -32,7 +31,6 @@ SENSOR_TYPES = {
     'sum_rain_24': ['sum_rain_24', 'mm', 'mdi:weather-rainy'],
 }
 
-CONF_SECRET_KEY = 'secret_key'
 CONF_STATION = 'station'
 ATTR_MODULE = 'modules'
 
@@ -43,28 +41,8 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=600)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the NetAtmo sensor."""
-    if not validate_config({DOMAIN: config},
-                           {DOMAIN: [CONF_API_KEY,
-                                     CONF_USERNAME,
-                                     CONF_PASSWORD,
-                                     CONF_SECRET_KEY]},
-                           _LOGGER):
-        return None
-
-    import lnetatmo
-
-    authorization = lnetatmo.ClientAuth(config.get(CONF_API_KEY, None),
-                                        config.get(CONF_SECRET_KEY, None),
-                                        config.get(CONF_USERNAME, None),
-                                        config.get(CONF_PASSWORD, None))
-
-    if not authorization:
-        _LOGGER.error(
-            "Connection error "
-            "Please check your settings for NatAtmo API.")
-        return False
-
+    """Setup the available NetAtmo weather sensors."""
+    netatmo = get_component('netatmo')
     data = NetAtmoData(authorization, config.get(CONF_STATION, None))
 
     dev = []

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -13,11 +13,6 @@ from homeassistant.loader import get_component
 
 DEPENDENCIES = ["netatmo"]
 
-REQUIREMENTS = [
-    'https://github.com/jabesq/netatmo-api-python/archive/'
-    'master.zip'
-    '#lnetatmo==0.4.0']
-
 _LOGGER = logging.getLogger(__name__)
 
 SENSOR_TYPES = {

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -38,7 +38,7 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=600)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the available NetAtmo weather sensors."""
     netatmo = get_component('netatmo')
-    data = NetAtmoData(authorization, config.get(CONF_STATION, None))
+    data = NetAtmoData(netatmo.NETATMO_AUTH, config.get(CONF_STATION, None))
 
     dev = []
     try:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -95,7 +95,7 @@ hikvision==0.4
 # http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
 
 # homeassistant.components.sensor.netatmo
-https://github.com/HydrelioxGitHub/netatmo-api-python/archive/43ff238a0122b0939a0dc4e8836b6782913fb6e2.zip#lnetatmo==0.4.0
+https://github.com/jabesq/netatmo-api-python/archive/master.zip#lnetatmo==0.4.0
 
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.1.1.zip#pyW215==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -94,9 +94,6 @@ hikvision==0.4
 # homeassistant.components.sensor.dht
 # http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
 
-# homeassistant.components.sensor.netatmo
-https://github.com/jabesq/netatmo-api-python/archive/v0.5.0.zip#lnetatmo==0.5.0
-
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.1.1.zip#pyW215==0.1.1
 
@@ -122,6 +119,9 @@ https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.
 
 # homeassistant.components.device_tracker.fritz
 # https://github.com/deisi/fritzconnection/archive/b5c14515e1c8e2652b06b6316a7f3913df942841.zip#fritzconnection==0.4.6
+
+# homeassistant.components.netatmo
+https://github.com/jabesq/netatmo-api-python/archive/v0.5.0.zip#lnetatmo==0.5.0
 
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -95,7 +95,7 @@ hikvision==0.4
 # http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
 
 # homeassistant.components.sensor.netatmo
-https://github.com/jabesq/netatmo-api-python/archive/master.zip#lnetatmo==0.4.0
+https://github.com/jabesq/netatmo-api-python/archive/v0.5.0.zip#lnetatmo==0.5.0
 
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.1.1.zip#pyW215==0.1.1


### PR DESCRIPTION
**Description:**
This change is introducing two things: 
- Global component for Netatmo devices: it allows to share credentials between Netatmo Weather Station, Welcome camera and also for Thermosat (even if not supported yet)
- Support for Netatmo Welcome Camera: Currently it only provides the live feed of the camera. The final goal will be to also to use this camera as a binary sensor and a device tracker 

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/542

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
#Netatmo Component
netatmo:
    api_key: API_KEY
    secret_key: SECRET_KEY
    username: username
    password: password

#Cameras
camera:
    platform: netatmo
    home: home_name (Optional)
    cameras: (Optional)
        - camera_name1
        - camera_name2

sensor:
  platform: netatmo
  modules:
    module_name1:
      - temperature
      - humidity
      - noise
      - pressure
      - co2
      - rain
      - sum_rain_1
      - sum_rain_24
    module_name2:
      - temperature
    rainmeter_name3:
      - rain
      - sum_rain_1
      - sum_rain_24
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
