### PR TITLE
Upgrade fuzzywuzzy to 0.10.0

### DIFF
--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -27,7 +27,7 @@ SERVICE_PROCESS_SCHEMA = vol.Schema({
 
 REGEX_TURN_COMMAND = re.compile(r'turn (?P<name>(?: |\w)+) (?P<command>\w+)')
 
-REQUIREMENTS = ['fuzzywuzzy==0.8.0']
+REQUIREMENTS = ['fuzzywuzzy==0.10.0']
 
 
 def setup(hass, config):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -74,7 +74,7 @@ fitbit==0.2.2
 freesms==0.1.0
 
 # homeassistant.components.conversation
-fuzzywuzzy==0.8.0
+fuzzywuzzy==0.10.0
 
 # homeassistant.components.notify.gntp
 gntp==1.0.3


### PR DESCRIPTION
0.10.0 (2016-03-13)
- Handle None inputs same as empty string (Issue #94)

0.9.0 (2016-03-07)
- Pull down all keys when updating local copy.

0.8.2 (2016-02-26)
- Remove the warning for "slow" sequence matcher on PyPy.
  -where it's preferable to use the pure-python implementation.

0.8.1 (2016-01-25)
- Minor release changes.
- Clean up wiki link in readme.

Tested with the following configuration:

``` yaml
conversation:
```

Seems to work but not with my accent.
