### PR TITLE
Added Sonos snapshot feature

### DIFF
--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -153,3 +153,19 @@ sonos_group_players:
     entity_id:
       description: Name(s) of entites that will coordinate the grouping. Platform dependent.
       example: 'media_player.living_room_sonos'
+
+sonos_snapshot:
+  description: Take a snapshot of the media player.
+
+  fields:
+    entity_id:
+      description: Name(s) of entites that will coordinate the grouping. Platform dependent.
+      example: 'media_player.living_room_sonos'
+
+sonos_restore:
+  description: Restore a snapshot of the media player.
+
+  fields:
+    entity_id:
+      description: Name(s) of entites that will coordinate the grouping. Platform dependent.
+      example: 'media_player.living_room_sonos'

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -175,7 +175,7 @@ class SonosDevice(MediaPlayerDevice):
         super(SonosDevice, self).__init__()
         self._player = player
         self.update()
-        self.socoSnapshot = Snapshot(self._player)
+        self.soco_snapshot = Snapshot(self._player)
 
     @property
     def should_poll(self):
@@ -358,12 +358,12 @@ class SonosDevice(MediaPlayerDevice):
     @only_if_coordinator
     def snapshot(self, service):
         """Snapshot the player."""
-        self.socoSnapshot.snapshot()
+        self.soco_snapshot.snapshot()
 
     @only_if_coordinator
     def restore(self, service):
         """Restore snapshot for the player."""
-        self.socoSnapshot.restore(True)
+        self.soco_snapshot.restore(True)
 
     @property
     def available(self):

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -102,7 +102,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             device.update_ha_state(True)
 
     def restore(service):
-        """Restore a snapshot. """
+        """Restore a snapshot."""
         entity_id = service.data.get('entity_id')
 
         if entity_id:
@@ -357,10 +357,12 @@ class SonosDevice(MediaPlayerDevice):
 
     @only_if_coordinator
     def snapshot(self, service):
+        """Snapshot the player."""
         self.socoSnapshot.snapshot()
 
     @only_if_coordinator
     def restore(self, service):
+        """Restore snapshot for the player."""
         self.socoSnapshot.restore(True)
 
     @property

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -8,7 +8,6 @@ import datetime
 import logging
 import socket
 from os import path
-from soco.snapshot import Snapshot
 
 from homeassistant.components.media_player import (
     ATTR_MEDIA_ENQUEUE, DOMAIN, MEDIA_TYPE_MUSIC, SUPPORT_NEXT_TRACK,
@@ -175,6 +174,7 @@ class SonosDevice(MediaPlayerDevice):
         super(SonosDevice, self).__init__()
         self._player = player
         self.update()
+        from soco.snapshot import Snapshot
         self.soco_snapshot = Snapshot(self._player)
 
     @property


### PR DESCRIPTION
**Description:**
This exposes soco snapshot and restore features.
Enabling the ability to have a Sonos player play something then return to its previous state.  My use case is to play a door bell sound effect, but I also envisage it being useful for things like TTS.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
script:
  doorbell:
    alias: Door Bell Automation
    sequence:
      - alias: Snapshot Sonos
        service: media_player.sonos_snapshot
        data:
          entity_id: media_player.lounge
      - alias: Door Bell Play Sound
        service: media_player.play_media
        data:
          entity_id: media_player.lounge
          media_content_id: http://192.168.1.41:8123/local/doorbell.mp3
          media_content_type: audio/mp3
      - delay:
          seconds: 6    
      - alias: Restore Sonos      
        service: media_player.sonos_restore
        data:
          entity_id: media_player.lounge
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
