### PR TITLE
Add support for UniFi Video >= 3.2.0

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -375,7 +375,7 @@ unifi==1.2.5
 urllib3
 
 # homeassistant.components.camera.uvc
-uvcclient==0.8
+uvcclient==0.9.0
 
 # homeassistant.components.verisure
 vsure==0.8.1


### PR DESCRIPTION
**Description:** Add support for UniFi Video >= 3.2.0

Unfortunately, Ubiquiti changed their (supposedly versioned) API in
3.2.0 which causes us to have to refer to cameras by id instead of
UUID. The firmware for 3.2.x also changed the on-camera login procedures
and snapshot functionality significantly.

This bumps the requirement for uvcclient to 0.9.0, which supports the
newer API and makes the tweaks necessary to interact properly.
**Checklist:**

If code communicates with devices:
- [ X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ X] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ X] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ /] New files were added to `.coveragerc`.
