### PR TITLE
Allow Template script to use scripts in turn_on and turn_off

### DIFF
--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
 from homeassistant.core import EVENT_STATE_CHANGED
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import generate_entity_id
-from homeassistant.helpers.service import call_from_config
+from homeassistant.helpers.script import call_from_config
 from homeassistant.helpers import template
 from homeassistant.util import slugify
 


### PR DESCRIPTION
**Description:**
Allow scripts to be placed in the `turn_on:` and `turn_off:` parts of template switch

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
  platform: template
  switches:
    delaylight:
      friendly_name: 'Test script'
      value_template: '{{ states.light.buitedl.state }}'
      turn_on:
        - delay: 00:00:01
        - service: light.turn_on
          entity_id: light.buitedl
      turn_off:
        service: light.turn_off
        entity_id: light.buitedl

```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [N/A] Tests have been added to verify that the new code works.
   N/A reuse script
