### PR TITLE
Add sensor for DTE Energy Bridge

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -161,6 +161,7 @@ omit =
     homeassistant/components/sensor/cpuspeed.py
     homeassistant/components/sensor/deutsche_bahn.py
     homeassistant/components/sensor/dht.py
+    homeassistant/components/sensor/dte_energy_bridge.py
     homeassistant/components/sensor/efergy.py
     homeassistant/components/sensor/eliqonline.py
     homeassistant/components/sensor/fitbit.py

--- a/homeassistant/components/sensor/dte_energy_bridge.py
+++ b/homeassistant/components/sensor/dte_energy_bridge.py
@@ -1,0 +1,80 @@
+"""Support for monitoring energy usage using the DTE energy bridge."""
+import logging
+
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+ICON = 'mdi:flash'
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the DTE energy bridge sensor."""
+    ip_address = config.get('ip')
+    if not ip_address:
+        _LOGGER.error(
+            "Configuration Error"
+            "'ip' of the DTE energy bridge is required")
+        return None
+    dev = [DteEnergyBridgeSensor(ip_address)]
+    add_devices(dev)
+
+
+# pylint: disable=too-many-instance-attributes
+class DteEnergyBridgeSensor(Entity):
+    """Implementation of an DTE Energy Bridge sensor."""
+
+    def __init__(self, ip_address):
+        """Initialize the sensor."""
+        self._url = "http://{}/instantaneousdemand".format(ip_address)
+        self._name = "Current Energy Usage"
+        self._unit_of_measurement = "kW"
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of th sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._unit_of_measurement
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return ICON
+
+    def update(self):
+        """Get the energy usage data from the DTE energy bridge."""
+        import requests
+
+        try:
+            response = requests.get(self._url, timeout=5)
+        except (requests.exceptions.RequestException, ValueError):
+            _LOGGER.warning(
+                'Could not update status for DTE Energy Bridge (%s)',
+                self._name)
+            return
+
+        if response.status_code != 200:
+            _LOGGER.warning(
+                'Invalid status_code from DTE Energy Bridge: %s (%s)',
+                response.status_code, self._name)
+            return
+
+        response_split = response.text.split()
+
+        if len(response_split) != 2:
+            _LOGGER.warning(
+                'Invalid response from DTE Energy Bridge: "%s" (%s)',
+                response.text, self._name)
+            return
+
+        self._state = float(response_split[0])


### PR DESCRIPTION
**Description:**

Adds a sensor for the [DTE Energy Bridge](https://www2.dteenergy.com/wps/portal/splashpage/energy%20bridge%20installation%20guide)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
    platform: dte_energy_bridge
    ip: 192.168.1.11
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New files were added to `.coveragerc`.

Currently only measures instantaneous energy usage in kW
