### PR TITLE
metric unit of pressure is mbar not mBar

### DIFF
--- a/homeassistant/components/sensor/forecast.py
+++ b/homeassistant/components/sensor/forecast.py
@@ -37,7 +37,7 @@ SENSOR_TYPES = {
     'wind_bearing': ['Wind Bearing', '°', '°', '°', '°', '°'],
     'cloud_cover': ['Cloud Coverage', '%', '%', '%', '%', '%'],
     'humidity': ['Humidity', '%', '%', '%', '%', '%'],
-    'pressure': ['Pressure', 'mBar', 'mBar', 'mBar', 'mBar', 'mBar'],
+    'pressure': ['Pressure', 'mbar', 'mbar', 'mbar', 'mbar', 'mbar'],
     'visibility': ['Visibility', 'km', 'm', 'km', 'km', 'm'],
     'ozone': ['Ozone', 'DU', 'DU', 'DU', 'DU', 'DU'],
 }


### PR DESCRIPTION
**Description:**
This is just a typo issue in the forecast sensor, pressure unit must be mbar and mBar.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

This is useful to vaoid having several graph for the same type of data
According to wikipedia:
Units derived from the bar include the megabar (symbol: Mbar),
kilobar (symbol: kbar), decibar (symbol: dbar), centibar (symbol: cbar),
and millibar (symbol: mbar or mb).
