### PR TITLE
Don't send MQTT "ON" payload when changing brightness

### DIFF
--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -213,9 +213,9 @@ class MqttLight(Light):
             if self._optimistic_brightness:
                 self._brightness = kwargs[ATTR_BRIGHTNESS]
                 should_update = True
-
-        mqtt.publish(self._hass, self._topic["command_topic"],
-                     self._payload["on"], self._qos, self._retain)
+        else:
+            mqtt.publish(self._hass, self._topic["command_topic"],
+                         self._payload["on"], self._qos, self._retain)
 
         if self._optimistic:
             # Optimistically assume that switch has changed state.


### PR DESCRIPTION
**Description:**
Sending "ON" payload when brightness or color changes is unnecessary/redundant and causes problems for devices that have default brightness or color associated to an "ON" command. See issue https://github.com/home-assistant/home-assistant/issues/2161
**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
