### PR TITLE
InfluxDB can't store field with different type under the same measure…

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -77,7 +77,7 @@ def setup(hass, config):
             return
 
         try:
-            _state = state_helper.state_as_number(state)
+            _state = float(state.state)
         except ValueError:
             _state = state.state
 


### PR DESCRIPTION
**Description:**
For the components like media_players the possible states:
STATE_IDLE, STATE_OFF,  STATE_PAUSED, STATE_PLAYING, STATE_UNKNOWN

The helper function state_as_number can't convert STATE_IDLE, STATE_PAUSED, STATE_PLAYING to numeric value:

```
if state.state in (STATE_ON, STATE_LOCKED, STATE_ABOVE_HORIZON,
                   STATE_OPEN):
    return 1
elif state.state in (STATE_OFF, STATE_UNLOCKED, STATE_UNKNOWN,
                     STATE_BELOW_HORIZON, STATE_CLOSED):
    return 0

return float(state.state)
```

It is not clear how to classify STATE_IDLE as 0 or 1.

When media player state is  IDLE, PAUSED or PLAYING the user would like to have this information stored in the InfluxDB.

My suggestion is that instead of using state_as_number function rather trying to convert to float directly. If state is a number represented by string or is already a number it will be stored as a number, if state is string it will raise a ValueError and will be stored as a string into InfluxDB.

With the current implementation the STATE_OFF is converted to number 0 but other states are strings. InfluxDB does not allow to store the same field with different type under single measurement.

I haven't updated the test and it fails now but first wanted to discuss if this change makes any sense.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

…ment
