### PR TITLE
Upgrade astral to 1.2

### DIFF
--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -15,7 +15,7 @@ from homeassistant.util import dt as dt_util
 from homeassistant.util import location as location_util
 from homeassistant.const import CONF_ELEVATION
 
-REQUIREMENTS = ['astral==1.1']
+REQUIREMENTS = ['astral==1.2']
 DOMAIN = "sun"
 ENTITY_ID = "sun.sun"
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -29,7 +29,7 @@ Werkzeug==0.11.5
 apcaccess==0.0.4
 
 # homeassistant.components.sun
-astral==1.1
+astral==1.2
 
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.7


### PR DESCRIPTION
- Added handling for when unicode literals are used. This may possibly affect your code if you’re using Python 2 (there are tests for this but they may not catch all uses.) (Bug 1588198)
- Changed timezone for Phoenix, AZ to America/Phoenix (Bug 1561258)

Tested with the following configuration:

``` yaml
sun:
```
