### PR TITLE
Split secrets from configuration files

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -27,6 +27,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     event_decorators, service, config_per_platform, extract_domain_configs)
 from homeassistant.helpers.entity import Entity
+import homeassistant.util.secrets as secrets
 
 _LOGGER = logging.getLogger(__name__)
 _SETUP_LOCK = RLock()
@@ -297,6 +298,7 @@ def from_config_file(config_path, hass=None, verbose=False, skip_pip=True,
 
     try:
         config_dict = config_util.load_yaml_config_file(config_path)
+        config_dict = secrets.decode(config_dict, config_path, hass)
     except HomeAssistantError:
         return None
 

--- a/homeassistant/util/password.py
+++ b/homeassistant/util/password.py
@@ -1,8 +1,0 @@
-import keyring
-
-# ALLPW can be used to refresh passwords
-ALLPW = []
-
-def load_passwords(config_path, config):
-    
-    

--- a/homeassistant/util/password.py
+++ b/homeassistant/util/password.py
@@ -1,0 +1,8 @@
+import keyring
+
+# ALLPW can be used to refresh passwords
+ALLPW = []
+
+def load_passwords(config_path, config):
+    
+    

--- a/homeassistant/util/secrets.py
+++ b/homeassistant/util/secrets.py
@@ -1,0 +1,132 @@
+"""Module to help keep passwords and other secrets."""
+
+import os
+import logging
+import collections
+from enum import Enum
+from homeassistant.config import load_yaml_config_file
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.const import EVENT_HOMEASSISTANT_START
+try:
+    import keyring  # pylint: disable=wrong-import-order,wrong-import-position
+except ImportError:
+    keyring = None
+
+# Contains secrets resolved by get_secret (from config files & components)
+# History can be used to edit secrets through the frontend after HA started.
+HISTORY = {}
+"""HISTORY will be used to store secrets extracted from the configuration files
+and make it available for editing later."""  # pylint: disable=W0105
+SECRET_PLACEHOLDER = '(-)'
+SECRET_DICT = None
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.DEBUG)
+
+
+class SSource(Enum):
+    """Source for secrets."""
+
+    yaml = 1
+    keyring = 2
+
+
+def get_secret(namespace, username):
+    """Retrieve a secret from the secrets.yaml or keyring.
+
+    The full secret path will be: namespace/username
+
+    Once retrieved, the source will be saved in the HISTORY
+
+    Depending on availability of the system and existance of the secret's path,
+    the secret will be extracted in the following order:
+      (1) secrets.yaml: Located in the configuration.yaml directory
+          Format: /path/to/username: secret
+      (2) keyring: http://pythonhosted.org/keyring/
+    """
+    fullpath = (str(namespace) + '/' + str(username)).replace(' ', '_')
+
+    global HISTORY  # pylint: disable=global-variable-not-assigned
+    HISTORY[fullpath] = None
+
+    if SECRET_DICT:
+        try:
+            HISTORY[fullpath] = (SECRET_DICT[fullpath], SSource.yaml)
+            _LOGGER.debug('from secrets.yaml: %s [%s]', fullpath,
+                          SECRET_DICT[fullpath])
+            return HISTORY[fullpath][0]
+        except (TypeError, IndexError, KeyError):
+            pass
+
+    if keyring:
+        pwd = keyring.get_password(namespace, username)
+        if pwd:
+            HISTORY[fullpath] = (pwd, SSource.keyring)
+            _LOGGER.debug('from keyring: %s [%s]', fullpath, pwd)
+            return HISTORY[fullpath][0]
+
+    _LOGGER.warning('Secret not found: %s', fullpath)
+    return None
+
+
+def load_secrets_config_file(config_path, filename='secrets.yaml'):
+    """Try to load secrets.yaml."""
+    global SECRET_DICT
+    try:
+        SECRET_DICT = load_yaml_config_file(
+            os.path.join(os.path.dirname(config_path), filename))
+        _LOGGER.info(filename + ' loaded')
+    except FileNotFoundError:
+        SECRET_DICT = None
+    except HomeAssistantError:
+        _LOGGER.error('Could not load %s', filename)
+        SECRET_DICT = None
+
+
+def decode(config_dict, config_path=None, hass=None):
+    """Decode secrets contained in the config_dict using get_password."""
+    if config_path:
+        load_secrets_config_file(config_path)
+    if keyring:
+        _LOGGER.info('keyring active')
+    if not SECRET_DICT and not keyring:
+        _LOGGER.info('Secrets not protected')
+        return config_dict
+
+    def iterate(cdict, path):
+        """Iterate over the dictionary and populate secrets."""
+        for key, value in cdict.items():
+            new_path = path + '/' + key
+            if isinstance(value, collections.OrderedDict):
+                iterate(value, new_path)
+            elif isinstance(value, list):
+                # Process items in lists, might be too deep?
+                for val in value:
+                    iterate(val, new_path)
+            elif isinstance(value, str):
+                # Expand properties containing the placeholder
+                if value == SECRET_PLACEHOLDER:
+                    cdict[key] = get_secret(path, key)
+                    _LOGGER.debug('%s = %s', new_path, cdict[key])
+                # Special handling for password if username found
+                if key == 'username' and 'password' not in cdict:
+                    cdict['password'] = get_secret(path, 'password')
+                    _LOGGER.debug('%s/password = %s', path, cdict['password'])
+
+    iterate(config_dict, '')
+
+    if hass:
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_START,
+                             lambda event: check_stale_secrets())
+    return config_dict
+
+
+def check_stale_secrets():
+    """Check is SECRET_DICT contains unused secrets."""
+    if not SECRET_DICT:
+        return
+    stale = []
+    for key in SECRET_DICT.keys():
+        if key not in HISTORY:
+            stale.append(key)
+    if len(stale) > 0:
+        _LOGGER.warning('Stale secrets: ' + ', '.join(stale))

--- a/homeassistant/util/secrets.py
+++ b/homeassistant/util/secrets.py
@@ -120,7 +120,7 @@ def decode(config_dict, config_path=None, hass=None):
     return config_dict
 
 
-def check_stale_secrets():
+def check_stale_secrets(log_warning=True):
     """Check is SECRET_DICT contains unused secrets."""
     if not SECRET_DICT:
         return
@@ -128,5 +128,6 @@ def check_stale_secrets():
     for key in SECRET_DICT.keys():
         if key not in HISTORY:
             stale.append(key)
-    if len(stale) > 0:
+    if log_warning and len(stale) > 0:
         _LOGGER.warning('Stale secrets: ' + ', '.join(stale))
+    return stale

--- a/tests/util/test_secrets.py
+++ b/tests/util/test_secrets.py
@@ -1,0 +1,140 @@
+"""Test config utils."""
+# pylint: disable=too-many-public-methods,protected-access
+import unittest
+import os
+import collections
+import logging
+
+import homeassistant.config as config_util
+import homeassistant.util.secrets as secrets
+
+from tests.common import get_test_config_dir
+CONFIG_DIR = get_test_config_dir()
+YAML_PATH = os.path.join(CONFIG_DIR, config_util.YAML_CONFIG_FILE)
+# YAML_PATH = "/home/pi/test_conf.yaml"
+
+
+def ordered_dict(cdict):
+    """Recursively convert dict to OrderedDict."""
+    if isinstance(cdict, dict):
+        odict = collections.OrderedDict(cdict)
+        for key, value in odict.items():
+            odict[key] = ordered_dict(value)
+        return odict
+    elif isinstance(cdict, list):
+        # pylint: disable=consider-using-enumerate
+        for idx in range(len(cdict)):
+            cdict[idx] = ordered_dict(cdict[idx])
+        return cdict
+    else:
+        return cdict
+
+
+def load_yaml(string):
+    """Write a string to file and load."""
+    with open(YAML_PATH, 'w') as file:
+        file.write(string)
+    return config_util.load_yaml_config_file(YAML_PATH)
+
+
+class TestSecrets(unittest.TestCase):
+    """Test the secrets utility."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Create & load secrets file."""
+        load_yaml('/password: pw1\n'
+                  '/section/secret: pw2\n'
+                  '/section_2/password: pw3\n'
+                  '/section/b: the_b\n'
+                  '/stale/and/placeholder/: ' + secrets.SECRET_PLACEHOLDER)
+        secrets.load_secrets_config_file(YAML_PATH,
+                                         os.path.basename(YAML_PATH))
+        # To enable logging for secrets module, uncomment the next line:
+        # secrets.logging.disable(logging.NOTSET)
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Clean up."""
+        for path in [YAML_PATH]:
+            if os.path.isfile(path):
+                os.remove(path)
+
+    def test_secrets_prepared_ok(self):
+        """Did secrets load ok."""
+        self.assertEqual(len(secrets.SECRET_DICT), 5)
+
+    def test_secret_placeholder_parsing(self):
+        """Make sure the placeholder was parsed correctly in secrets."""
+        self.assertEqual(secrets.SECRET_DICT['/stale/and/placeholder/'],
+                         secrets.SECRET_PLACEHOLDER)
+
+    def test_ordered_dict(self):
+        """Test order_dict method."""
+        as_string = load_yaml('section:\n'
+                              '  items:\n'
+                              '    - item1: one\n'
+                              '    - item2:\n'
+                              '        two: 2')
+        as_dict = ordered_dict({
+            'section': {
+                'items': [{'item1': 'one'},
+                          {'item2': {'two': 2}}],
+            }})
+        self.assertEqual(as_dict, as_string)
+
+    def test_add_password(self):
+        """Add password on username."""
+        decoded = secrets.decode(ordered_dict({
+            'username': 'un1'}))
+        expected = {
+            'username': 'un1',
+            'password': 'pw1'}
+        self.assertEqual(expected, decoded)
+
+    def test_preserve_existing_password(self):
+        """Don't overwrite existing password."""
+        decoded = secrets.decode(ordered_dict({
+            'username': 'un1',
+            'password': 'pw**'}))
+        expected = {
+            'username': 'un1',
+            'password': 'pw**'}
+        self.assertEqual(expected, decoded)
+
+    def test_add_password_placeholder(self):
+        """Dont overwrite existing password."""
+        decoded = secrets.decode(ordered_dict({
+            'username': 'un1',
+            'password': secrets.SECRET_PLACEHOLDER}))
+        expected = {
+            'username': 'un1',
+            'password': 'pw1'}
+        self.assertEqual(expected, decoded)
+
+    def test_other_secret_placeholder(self):
+        """Secret placeholder."""
+        decoded = secrets.decode(ordered_dict({
+            'section': {
+                'secret': secrets.SECRET_PLACEHOLDER}}))
+        expected = {'section': {'secret': 'pw2'}}
+        self.assertEqual(expected, decoded)
+
+    def test_placeholder_in_section(self):
+        """Secret placeholder."""
+        decoded = secrets.decode(ordered_dict({
+            'section 2': {
+                'password': secrets.SECRET_PLACEHOLDER}}))
+        expected = {'section 2': {'password': 'pw3'}}
+        self.assertEqual(expected, decoded)
+
+    def test_in_list(self):
+        """Item in list."""
+        decoded = secrets.decode(ordered_dict({
+            'section': [{'a': 'a'}, {'b': secrets.SECRET_PLACEHOLDER}]}))
+        expected = {'section': [{'a': 'a'}, {'b': 'the_b'}]}
+        self.assertEqual(expected, decoded)
+
+    def test_z_stale_sectrets(self):
+        """Test stale."""
+        stale = secrets.check_stale_secrets(False)
+        expected = ['/stale/and/placeholder/']
+        self.assertEqual(expected, stale)

--- a/tests/util/test_secrets.py
+++ b/tests/util/test_secrets.py
@@ -3,7 +3,6 @@
 import unittest
 import os
 import collections
-import logging
 
 import homeassistant.config as config_util
 import homeassistant.util.secrets as secrets


### PR DESCRIPTION
**Description:**
Option to split secrets from configuration files. Secrets can be stored in (one or both):
- `secrets.yaml` (in same folder as configuration.yaml)
- [keyring](http://pythonhosted.org/keyring/) (optional, only if dep installed)**

This uses the loaded `configuration.yaml` and inserts secrets where applicable:
- It is completely dependent on `configuration.yaml`. So the user can choose to remove secrets (if at all).
- Placing a `(-)` in the value will resolve the secret. 
- If a `username` is present, and no `password` the password will be resolved. The username can also contain a `(-)`
- If `password` present it will be left as is. Or resolved if it contains `(-)`
- If a secret can't be resolved a WARNING will be logged.
- Stale secrets in `secrets.yaml` raises a warning
- Using a list of the resolved secrets, a UI interface can be created to update secrets in secrets.yaml / keyring 
  - Until a UI exists editing secrets.yaml would be the best way to store secrets
  - Easiest way to populate keyring would be a command line option like `--passwords`?

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml`:**

``` yaml
sensor:
   api_key: (-)
http:
  api_password: (-)
mycomponent:
  username: (-)
mycomponent2:
  username: un02
  password: (-)
```

resolves to:

``` yaml
sensor:
  api_key: ABCDEF
http:
  api_password: JKLMNOP
mycomponent:
  username: un01
  password: pw01
mycomponent 2:
  username: un02
  password: pw02
```

using `secrets.yaml` file:

``` yaml
/http/api_password: JKLMNOP
/sensor/api_key: ABCDEF  
/mycomponent/username: un01
/mycomponent/password: pw01
/mycomponent_2/password: pw02
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
