### PR TITLE
Added support for AP mode in asuswrt

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -148,7 +148,7 @@ class AsusWrtDeviceScanner(object):
             return (neighbors, leases_result, arp_result)
         except pxssh.ExceptionPxssh as exc:
             _LOGGER.exception('Unexpected response from router: %s', exc)
-            return ('', '')
+            return ('', '', '')
 
     def telnet_connection(self):
         """Retrieve data from ASUSWRT via the telnet protocol."""
@@ -177,11 +177,11 @@ class AsusWrtDeviceScanner(object):
             return (neighbors, leases_result, arp_result)
         except EOFError:
             _LOGGER.exception("Unexpected response from router")
-            return ('', '')
+            return ('', '', '')
         except ConnectionRefusedError:
             _LOGGER.exception("Connection refused by router,"
                               " is telnet enabled?")
-            return ('', '')
+            return ('', '', '')
 
     def get_asuswrt_data(self):
         """Retrieve data from ASUSWRT and return parsed result."""


### PR DESCRIPTION
**Description:** Uses wl command to get associated clients (instead of relying on DHCP leases). This allows AP operating mode users to also be able to use presence tracking. Default is set to `router` mode, the original method of detecting connected users. However, it is likely (but untested by me) that `wl assoclist` should work for `router` mode as well. 

**Related issue (if applicable):** fixes #607 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#545

``` yaml
# Example configuration.yaml entry
device_tracker:
  platform: asuswrt
  host: YOUR_ROUTER_IP
  protocol: telnet
  mode: ap
  username: YOUR_ADMIN_USERNAME
  password: YOUR_ADMIN_PASSWORD
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
