### PR TITLE
Add eventlet to base requirements

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,6 +5,7 @@ pytz>=2016.4
 pip>=7.0.0
 jinja2>=2.8
 voluptuous==0.8.9
+eventlet==0.19.0
 
 # homeassistant.components.isy994
 PyISY==1.0.6

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ REQUIRES = [
     'pip>=7.0.0',
     'jinja2>=2.8',
     'voluptuous==0.8.9',
+    'eventlet==0.19.0',
 ]
 
 setup(


### PR DESCRIPTION
**Description:**
This adds eventlet to the base requirements to work around an issue where using `--target` with pip does not work well with platlib directories.

**Related issue (if applicable):** #2261 
