### PR TITLE
sensor/gtfs: add sanity check, origin earlier than destination

### DIFF
--- a/homeassistant/components/sensor/gtfs.py
+++ b/homeassistant/components/sensor/gtfs.py
@@ -68,6 +68,7 @@ def get_next_departure(sched, start_station_id, end_station_id):
                AND time(origin_stop_time.departure_time) > time(:now_str)
     AND start_station.stop_id = :origin_station_id
                AND end_station.stop_id = :end_station_id
+    AND origin_stop_time.stop_sequence < destination_stop_time.stop_sequence
     ORDER BY origin_stop_time.departure_time LIMIT 1;
     """.format(day_name=day_name))
     result = sched.engine.execute(sql_query, now_str=now_str,


### PR DESCRIPTION
**Description:**

Previously experienced issues on routes where services operate in both directions. The query picked up not just paths where service goes from Origin ->  Destination, but trips going Destination -> Origin,
and shown bogus results.

Ensure that this doesn't happen by requiring the origin station's `stop_sequence` value to be lower than the destination station.

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
