### PR TITLE
Added template rendering to shell_command component

### DIFF
--- a/homeassistant/components/shell_command.py
+++ b/homeassistant/components/shell_command.py
@@ -32,13 +32,11 @@ def setup(hass, config):
 
     def service_handler(call):
         """Execute a shell command service."""
+        cmd, shell = _parse_command(conf[call.service], hass)
         try:
-            cmd = template.render(hass, conf[call.service])
-            subprocess.call(cmd, shell=True,
+            subprocess.call(cmd, shell=shell,
                             stdout=subprocess.DEVNULL,
                             stderr=subprocess.DEVNULL)
-        except TemplateError as ex:
-            _LOGGER.error('Error rendering command template: %s', ex)
         except subprocess.SubprocessError:
             _LOGGER.exception('Error running command: %s', cmd)
 
@@ -46,3 +44,22 @@ def setup(hass, config):
         hass.services.register(DOMAIN, name, service_handler,
                                schema=SHELL_COMMAND_SCHEMA)
     return True
+
+
+def _parse_command(cmd, hass):
+    """Parse command and fill in any template arguments if necessary."""
+    cmds = cmd.split()
+    prog = cmds[0]
+    args = ' '.join(cmds[1:])
+    try:
+        rendered_args = template.render(hass, args)
+    except TemplateError as ex:
+        _LOGGER.error('Error rendering command template: %s', ex)
+    if rendered_args == args:
+        # no template used. default behavior
+        shell = True
+    else:
+        # template used. Must break into list and use shell=False for security
+        cmd = [prog] + rendered_args.split()
+        shell = False
+    return cmd, shell

--- a/tests/components/test_shell_command.py
+++ b/tests/components/test_shell_command.py
@@ -51,6 +51,30 @@ class TestShellCommand(unittest.TestCase):
             }
         })
 
+    def test_template_render_no_template(self):
+        """Ensure shell_commands without templates get rendered properly."""
+        cmd, shell = shell_command._parse_command(self.hass, 'ls /bin', {})
+        self.assertTrue(shell)
+        self.assertEqual(cmd, 'ls /bin')
+
+    def test_template_render(self):
+        """Ensure shell_commands with templates get rendered properly."""
+        self.hass.states.set('sensor.test_state', 'Works')
+        cmd, shell = shell_command._parse_command(
+            self.hass,
+            'ls /bin {{ states.sensor.test_state.state }}', {}
+        )
+        self.assertFalse(shell, False)
+        self.assertEqual(cmd[-1], 'Works')
+
+    def test_invalid_template_fails(self):
+        """Test that shell_commands with invalid templates fail."""
+        cmd, _shell = shell_command._parse_command(
+            self.hass,
+            'ls /bin {{ states. .test_state.state }}', {}
+        )
+        self.assertEqual(cmd, None)
+
     @patch('homeassistant.components.shell_command.subprocess.call',
            side_effect=SubprocessError)
     @patch('homeassistant.components.shell_command._LOGGER.error')


### PR DESCRIPTION
**Description:**
This allows the `shell_command` component to accept templates. I use it to customize the commands that get sent over LIRC to my A/C based on an input slider value. 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
input_slider:
  ac_temperature:
    name: A/C Setting
    initial: 24
    min: 18
    max: 32
    step: 1

input_select:
  fan_on:
    name: Turn on Fan
    options:
     - LOW
     - MEDIUM
     - HIGH
    initial: MEDIUM
    icon: mdi:weather-snowy

shell_command:
  set_ac_to_slider: 'irsend SEND_ONCE DELONGHI AC_{{ states.input_slider.ac_temperature.state}}_AUTO'
  fan_on: 'irsend SEND_ONCE DELONGHI FAN_{{states.input_select.fan_on.state}}'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)  See: https://github.com/home-assistant/home-assistant.io/pull/547

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
