### PR TITLE
Fixing MJPEG streaming in Werkzeug

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -82,8 +82,6 @@ class Camera(Entity):
     def mjpeg_stream(self, response):
         """Generate an HTTP MJPEG stream from camera images."""
         import eventlet
-        response.content_type = ('multipart/x-mixed-replace; '
-                                 'boundary=--jpegboundary')
 
         def stream():
             """Stream images as mjpeg stream."""
@@ -105,9 +103,11 @@ class Camera(Entity):
             except GeneratorExit:
                 pass
 
-        response.response = stream()
-
-        return response
+        return response(
+            stream(),
+            content_type=('multipart/x-mixed-replace; '
+                          'boundary=--jpegboundary')
+        )
 
     @property
     def state(self):
@@ -189,4 +189,4 @@ class CameraMjpegStream(CameraView):
 
     def handle(self, camera):
         """Serve camera image."""
-        return camera.mjpeg_stream(self.Response())
+        return camera.mjpeg_stream(self.Response)

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -70,9 +70,11 @@ class MjpegCamera(Camera):
     def mjpeg_stream(self, response):
         """Generate an HTTP MJPEG stream from the camera."""
         stream = self.camera_stream()
-        response.mimetype = stream.headers[CONTENT_TYPE_HEADER]
-        response.response = stream.iter_content(chunk_size=1024)
-        return response
+        return response(
+            stream.iter_content(chunk_size=1024),
+            mimetype=stream.headers[CONTENT_TYPE_HEADER],
+            direct_passthrough=True
+        )
 
     @property
     def name(self):


### PR DESCRIPTION
**Description:** This fixes MJPEG streaming by changing the response to include [`direct_passthrough`](http://werkzeug.pocoo.org/docs/0.11/wrappers/#werkzeug.wrappers.BaseResponse).

The only downside to this change was that I had to change how `Response` is passed into `mjpeg_stream` so that I could pass this flag.

**Related issue (if applicable):** fixes #2260

**Checklist:**

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
