### PR TITLE
Include BloomSky Voltage sensor

### DIFF
--- a/homeassistant/components/sensor/bloomsky.py
+++ b/homeassistant/components/sensor/bloomsky.py
@@ -17,16 +17,18 @@ SENSOR_TYPES = ["Temperature",
                 "Humidity",
                 "Pressure",
                 "Luminance",
-                "UVIndex"]
+                "UVIndex",
+                "Voltage"]
 
 # Sensor units - these do not currently align with the API documentation
 SENSOR_UNITS = {"Temperature": TEMP_FAHRENHEIT,
                 "Humidity": "%",
                 "Pressure": "inHg",
-                "Luminance": "cd/m²"}
+                "Luminance": "cd/m²",
+                "Voltage": "mV"}
 
 # Which sensors to format numerically
-FORMAT_NUMBERS = ["Temperature", "Pressure"]
+FORMAT_NUMBERS = ["Temperature", "Pressure", "Voltage"]
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
**Description:** Add voltage information for BloomSky. No changes required elsewhere (including config). 

Addresses the request that I raised [here](https://community.home-assistant.io/t/bloomsky-voltage-sensor/1687)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#555

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

The API provides the voltage information and will be useful for people to troubleshoot their BloomSky.
