### PR TITLE
Fix Wink component setup

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -4,10 +4,8 @@ Support for Wink sensors.
 For more details about this platform, please refer to the documentation at
 at https://home-assistant.io/components/sensor.wink/
 """
-import logging
-
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
+from homeassistant.const import ATTR_BATTERY_LEVEL
 from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['python-wink==0.7.6']
@@ -24,17 +22,6 @@ SENSOR_TYPES = {
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Wink platform."""
     import pywink
-
-    if discovery_info is None:
-        token = config.get(CONF_ACCESS_TOKEN)
-
-        if token is None:
-            logging.getLogger(__name__).error(
-                "Missing wink access_token. "
-                "Get one at https://winkbearertoken.appspot.com/")
-            return
-
-        pywink.set_bearer_token(token)
 
     for sensor in pywink.get_sensors():
         if sensor.capability() in SENSOR_TYPES:

--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -4,10 +4,8 @@ Support for Wink garage doors.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/garage_door.wink/
 """
-import logging
-
+from homeassistant.const import ATTR_BATTERY_LEVEL
 from homeassistant.components.garage_door import GarageDoorDevice
-from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
 
 REQUIREMENTS = ['python-wink==0.7.6']
 
@@ -15,17 +13,6 @@ REQUIREMENTS = ['python-wink==0.7.6']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Wink garage door platform."""
     import pywink
-
-    if discovery_info is None:
-        token = config.get(CONF_ACCESS_TOKEN)
-
-        if token is None:
-            logging.getLogger(__name__).error(
-                "Missing wink access_token. "
-                "Get one at https://winkbearertoken.appspot.com/")
-            return
-
-        pywink.set_bearer_token(token)
 
     add_devices(WinkGarageDoorDevice(door) for door in
                 pywink.get_garage_doors())

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -4,11 +4,8 @@ Support for Wink lights.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.wink/
 """
-import logging
-
 from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, \
     Light, ATTR_RGB_COLOR
-from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.util import color as color_util
 from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
@@ -19,17 +16,6 @@ REQUIREMENTS = ['python-wink==0.7.6']
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup Wink lights."""
     import pywink
-
-    token = config.get(CONF_ACCESS_TOKEN)
-
-    if not pywink.is_token_set() and token is None:
-        logging.getLogger(__name__).error(
-            "Missing wink access_token - "
-            "get one at https://winkbearertoken.appspot.com/")
-        return
-
-    elif token is not None:
-        pywink.set_bearer_token(token)
 
     add_devices_callback(
         WinkLight(light) for light in pywink.get_bulbs())

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -4,10 +4,8 @@ Support for Wink locks.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/lock.wink/
 """
-import logging
-
 from homeassistant.components.lock import LockDevice
-from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
+from homeassistant.const import ATTR_BATTERY_LEVEL
 
 REQUIREMENTS = ['python-wink==0.7.6']
 
@@ -15,17 +13,6 @@ REQUIREMENTS = ['python-wink==0.7.6']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Wink platform."""
     import pywink
-
-    if discovery_info is None:
-        token = config.get(CONF_ACCESS_TOKEN)
-
-        if token is None:
-            logging.getLogger(__name__).error(
-                "Missing wink access_token. "
-                "Get one at https://winkbearertoken.appspot.com/")
-            return
-
-        pywink.set_bearer_token(token)
 
     add_devices(WinkLockDevice(lock) for lock in pywink.get_locks())
 

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -4,11 +4,8 @@ Support for Wink sensors.
 For more details about this platform, please refer to the documentation at
 at https://home-assistant.io/components/sensor.wink/
 """
-import logging
-
-from homeassistant.const import (CONF_ACCESS_TOKEN, STATE_CLOSED,
-                                 STATE_OPEN, TEMP_CELSIUS,
-                                 ATTR_BATTERY_LEVEL)
+from homeassistant.const import (STATE_CLOSED, STATE_OPEN,
+                                 TEMP_CELSIUS, ATTR_BATTERY_LEVEL)
 from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['python-wink==0.7.6']
@@ -19,17 +16,6 @@ SENSOR_TYPES = ['temperature', 'humidity']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Wink platform."""
     import pywink
-
-    if discovery_info is None:
-        token = config.get(CONF_ACCESS_TOKEN)
-
-        if token is None:
-            logging.getLogger(__name__).error(
-                "Missing wink access_token. "
-                "Get one at https://winkbearertoken.appspot.com/")
-            return
-
-        pywink.set_bearer_token(token)
 
     for sensor in pywink.get_sensors():
         if sensor.capability() in SENSOR_TYPES:

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -4,10 +4,7 @@ Support for Wink switches.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.wink/
 """
-import logging
-
 from homeassistant.components.wink import WinkToggleDevice
-from homeassistant.const import CONF_ACCESS_TOKEN
 
 REQUIREMENTS = ['python-wink==0.7.6']
 
@@ -15,17 +12,6 @@ REQUIREMENTS = ['python-wink==0.7.6']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Wink platform."""
     import pywink
-
-    if discovery_info is None:
-        token = config.get(CONF_ACCESS_TOKEN)
-
-        if token is None:
-            logging.getLogger(__name__).error(
-                "Missing wink access_token. "
-                "Get one at https://winkbearertoken.appspot.com/")
-            return
-
-        pywink.set_bearer_token(token)
 
     add_devices(WinkToggleDevice(switch) for switch in pywink.get_switches())
     add_devices(WinkToggleDevice(switch) for switch in

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -19,6 +19,9 @@ def setup(hass, config):
     logger = logging.getLogger(__name__)
 
     if not validate_config(config, {DOMAIN: [CONF_ACCESS_TOKEN]}, logger):
+        logger.error(
+            "Missing wink access_token - "
+            "get one at https://winkbearertoken.appspot.com/")
         return False
 
     import pywink


### PR DESCRIPTION
**Description:**
In the latest release all wink components except the light component are
failing to configure with the error:

```
ERROR:homeassistant.components.sensor.wink:Missing wink access_token. Get one at https://winkbearertoken.appspot.com/
```

I haven't been able to track down exactly when or why this broke but the
way wink components were configuring didn't make sense anyway. The
master wink component configures the pywink token so there's no need to
have the individual components configure their own.

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
