### PR TITLE
Wink Rollershutter

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-wink==0.7.6']
+REQUIREMENTS = ['python-wink==0.7.7']
 
 # These are the available sensors mapped to binary_sensor class
 SENSOR_TYPES = {

--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.garage_door import GarageDoorDevice
 from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
 
-REQUIREMENTS = ['python-wink==0.7.6']
+REQUIREMENTS = ['python-wink==0.7.7']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -13,7 +13,7 @@ from homeassistant.util import color as color_util
 from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
 
-REQUIREMENTS = ['python-wink==0.7.6']
+REQUIREMENTS = ['python-wink==0.7.7']
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
 
-REQUIREMENTS = ['python-wink==0.7.6']
+REQUIREMENTS = ['python-wink==0.7.7']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/rollershutter/wink.py
+++ b/homeassistant/components/rollershutter/wink.py
@@ -1,0 +1,92 @@
+"""
+Support for Wink Shades.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/rollershutter.wink/
+"""
+import logging
+
+from homeassistant.components.rollershutter import RollershutterDevice
+from homeassistant.const import CONF_ACCESS_TOKEN
+
+REQUIREMENTS = ['python-wink==0.7.7']
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Wink rollershutter platform."""
+    import pywink
+
+    if discovery_info is None:
+        token = config.get(CONF_ACCESS_TOKEN)
+
+        if token is None:
+            logging.getLogger(__name__).error(
+                "Missing wink access_token. "
+                "Get one at https://winkbearertoken.appspot.com/")
+            return
+
+        pywink.set_bearer_token(token)
+
+    add_devices(WinkRollershutterDevice(shade) for shade in
+                pywink.get_shades())
+
+
+class WinkRollershutterDevice(RollershutterDevice):
+    """Representation of a Wink rollershutter (shades)."""
+
+    def __init__(self, wink):
+        """Initialize the rollershutter."""
+        self.wink = wink
+        self._battery = None
+
+    @property
+    def should_poll(self):
+        """Wink Shades don't track their position."""
+        return False
+
+    @property
+    def unique_id(self):
+        """Return the ID of this wink rollershutter."""
+        return "{}.{}".format(self.__class__, self.wink.device_id())
+
+    @property
+    def name(self):
+        """Return the name of the rollershutter if any."""
+        return self.wink.name()
+
+    def update(self):
+        """Update the state of the rollershutter."""
+        return self.wink.update_state()
+
+    @property
+    def available(self):
+        """True if connection == True."""
+        return self.wink.available
+
+    def move_down(self):
+        """Close the shade."""
+        self.wink.set_state(0)
+
+    def move_up(self):
+        """Open the shade."""
+        self.wink.set_state(1)
+
+    @property
+    def current_position(self):
+        """Return current position of roller shutter.
+
+        Wink reports blind shade positions as 0 or 1.
+        home-assistant expects:
+        None is unknown, 0 is closed, 100 is fully open.
+        """
+        state = self.wink.state()
+        if state == 0:
+            return 0
+        elif state == 1:
+            return 100
+        else:
+            return None
+
+    def stop(self):
+        """Can't stop Wink rollershutter due to API."""
+        pass

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -11,7 +11,7 @@ from homeassistant.const import (CONF_ACCESS_TOKEN, STATE_CLOSED,
                                  ATTR_BATTERY_LEVEL)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-wink==0.7.6']
+REQUIREMENTS = ['python-wink==0.7.7']
 
 SENSOR_TYPES = ['temperature', 'humidity']
 

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.wink import WinkToggleDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.6']
+REQUIREMENTS = ['python-wink==0.7.7']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -32,6 +32,7 @@ def setup(hass, config):
             ('binary_sensor', pywink.get_sensors),
             ('sensor', lambda: pywink.get_sensors or pywink.get_eggtrays),
             ('lock', pywink.get_locks),
+            ('rollershutter', pywink.get_shades),
             ('garage_door', pywink.get_garage_doors)):
 
         if func_exists():

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import validate_config, discovery
 from homeassistant.helpers.entity import ToggleEntity
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.7.6']
+REQUIREMENTS = ['python-wink==0.7.7']
 
 
 def setup(hass, config):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -301,9 +301,10 @@ python-twitch==1.2.0
 # homeassistant.components.garage_door.wink
 # homeassistant.components.light.wink
 # homeassistant.components.lock.wink
+# homeassistant.components.rollershutter.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.7.6
+python-wink==0.7.7
 
 # homeassistant.components.keyboard
 pyuserinput==0.1.9


### PR DESCRIPTION
**Description:**

Adds support for Wink shades/blinds using the rollershutter component.

Requires additions from python-wink 0.7.7 and it seemed like having a different version would probably break things so I updated `REQUIREMENTS` in all the Wink components. I can squash that or put it in a separate PR if that's the way you all want to do things.

I didn't see any tests for the other Wink components. If there's a good example of a similar component I could take a stab at that.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):**
home-assistant/home-assistant.io#559

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
