### PR TITLE
Catch ValueError

### DIFF
--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -35,7 +35,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     rest.update()
 
     if rest.data is None:
-        _LOGGER.error('Unable to fetch Rest data')
+        _LOGGER.error('Unable to fetch REST data')
         return False
 
     add_devices([RestBinarySensor(
@@ -77,9 +77,17 @@ class RestBinarySensor(BinarySensorDevice):
             return False
 
         if self._value_template is not None:
-            self.rest.data = template.render_with_possible_json_value(
+            self._state = template.render_with_possible_json_value(
                 self._hass, self._value_template, self.rest.data, False)
-        return bool(int(self.rest.data))
+        else:
+            self._state = self.rest.data
+
+        try:
+            return bool(int(self._state))
+        except ValueError:
+            return {"True": True, "true": True, "TRUE": True, "On": True,
+                    "on": True, "ON": True, "Open": True, "open": True,
+                    "OPEN": True}.get(self._state, False)
 
     def update(self):
         """Get the latest data from REST API and updates the state."""

--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -57,6 +57,7 @@ class RestBinarySensor(BinarySensorDevice):
         self._name = name
         self._sensor_class = sensor_class
         self._state = False
+        self._previous_data = None
         self._value_template = value_template
         self.update()
 
@@ -77,17 +78,14 @@ class RestBinarySensor(BinarySensorDevice):
             return False
 
         if self._value_template is not None:
-            self._state = template.render_with_possible_json_value(
+            response = template.render_with_possible_json_value(
                 self._hass, self._value_template, self.rest.data, False)
-        else:
-            self._state = self.rest.data
 
         try:
-            return bool(int(self._state))
+            return bool(int(response))
         except ValueError:
-            return {"True": True, "true": True, "TRUE": True, "On": True,
-                    "on": True, "ON": True, "Open": True, "open": True,
-                    "OPEN": True}.get(self._state, False)
+            return {"true": True, "on": True, "open": True,
+                    "yes": True}.get(response.lower(), False)
 
     def update(self):
         """Get the latest data from REST API and updates the state."""


### PR DESCRIPTION
**Description:**
The REST binary sensor was only able to handle 0 and 1 so far. This PR catches the ValueError if the return value is something else.

**Related issue (if applicable):** https://community.home-assistant.io/t/restful-binary-sensor-value-template/1779

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
binary_sensor:
  - platform: rest
    resource: https://www.hamburg.ccc.de/dooris/status.json
    method: GET
    name: z9
    sensor_class: opening
    value_template: '{{ value_json.state.open }}'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
