### PR TITLE
lower severity of non critical error

### DIFF
--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -127,7 +127,7 @@ class VerisureHub(object):
                 except AttributeError:
                     status[overview.deviceLabel] = overview
         except self._verisure.Error as ex:
-            _LOGGER.error('Caught connection error %s, tries to reconnect', ex)
+            _LOGGER.info('Caught connection error %s, tries to reconnect', ex)
             self.reconnect()
 
     def reconnect(self):


### PR DESCRIPTION
**Description:**
No need to log error if the connection can be restored. 

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
