### PR TITLE
Add a default OPTIONS handler for wsgi

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -443,3 +443,7 @@ class HomeAssistantView(object):
 
         return self.Response(wrap_file(request.environ, fil),
                              mimetype=mimetype, direct_passthrough=True)
+
+    def options(self, request):
+        """Default handler for OPTIONS (necessary for CORS preflight)."""
+        return self.Response('', status=200)


### PR DESCRIPTION
When a browser makes a CORS request, it often makes a 'preflight'
options request in order to make sure the resource is valid, and that
it has the right CORS access. This adds a default OPTIONS handler for
all views. If a view needs to customize the OPTIONS handler for some
reason, it's free to, but this way CORS will work.

**Checklist:**

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [N/A] Tests have been added to verify that the new code works.
