### PR TITLE
Add service set_hvac_mode

### DIFF
--- a/homeassistant/components/thermostat/__init__.py
+++ b/homeassistant/components/thermostat/__init__.py
@@ -176,7 +176,7 @@ def setup(hass, config):
         schema=SET_FAN_MODE_SCHEMA)
 
     def hvac_mode_set_service(service):
-        """Set fvac mode on target thermostats."""
+        """Set hvac mode on target thermostats."""
         target_thermostats = component.extract_from_service(service)
 
         hvac_mode = service.data[ATTR_HVAC_MODE]

--- a/homeassistant/components/thermostat/__init__.py
+++ b/homeassistant/components/thermostat/__init__.py
@@ -28,6 +28,7 @@ SCAN_INTERVAL = 60
 SERVICE_SET_AWAY_MODE = "set_away_mode"
 SERVICE_SET_TEMPERATURE = "set_temperature"
 SERVICE_SET_FAN_MODE = "set_fan_mode"
+SERVICE_SET_HVAC_MODE = "set_hvac_mode"
 
 STATE_HEAT = "heat"
 STATE_COOL = "cool"
@@ -36,6 +37,7 @@ STATE_IDLE = "idle"
 ATTR_CURRENT_TEMPERATURE = "current_temperature"
 ATTR_AWAY_MODE = "away_mode"
 ATTR_FAN = "fan"
+ATTR_HVAC_MODE = "hvac_mode"
 ATTR_MAX_TEMP = "max_temp"
 ATTR_MIN_TEMP = "min_temp"
 ATTR_TEMPERATURE_LOW = "target_temp_low"
@@ -55,6 +57,10 @@ SET_TEMPERATURE_SCHEMA = vol.Schema({
 SET_FAN_MODE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Required(ATTR_FAN): cv.boolean,
+})
+SET_HVAC_MODE_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_HVAC_MODE): cv.string,
 })
 
 
@@ -90,6 +96,17 @@ def set_fan_mode(hass, fan_mode, entity_id=None):
         data[ATTR_ENTITY_ID] = entity_id
 
     hass.services.call(DOMAIN, SERVICE_SET_FAN_MODE, data)
+
+def set_hvac_mode(hass, hvac_mode, entity_id=None):
+    """Set specified thermostat hvac mode."""
+    data = {
+        ATTR_HVAC_MODE: hvac_mode
+    }
+
+    if entity_id:
+        data[ATTR_ENTITY_ID] = entity_id
+
+    hass.services.call(DOMAIN, SERVICE_SET_HVAC_MODE, data)
 
 
 # pylint: disable=too-many-branches
@@ -156,6 +173,22 @@ def setup(hass, config):
         DOMAIN, SERVICE_SET_FAN_MODE, fan_mode_set_service,
         descriptions.get(SERVICE_SET_FAN_MODE),
         schema=SET_FAN_MODE_SCHEMA)
+
+    def hvac_mode_set_service(service):
+        """Set fvac mode on target thermostats."""
+        target_thermostats = component.extract_from_service(service)
+
+        hvac_mode = service.data[ATTR_HVAC_MODE]
+
+        for thermostat in target_thermostats:
+            thermostat.set_hvac_mode(hvac_mode)
+
+            thermostat.update_ha_state(True)
+
+    hass.services.register(
+        DOMAIN, SERVICE_SET_HVAC_MODE, hvac_mode_set_service,
+        descriptions.get(SERVICE_SET_HVAC_MODE),
+        schema=SET_HVAC_MODE_SCHEMA)
 
     return True
 
@@ -241,6 +274,10 @@ class ThermostatDevice(Entity):
 
     def set_temperate(self, temperature):
         """Set new target temperature."""
+        pass
+
+    def set_hvac_mode(self, hvac_mode):
+        """Set hvac mode."""
         pass
 
     def turn_away_mode_on(self):

--- a/homeassistant/components/thermostat/__init__.py
+++ b/homeassistant/components/thermostat/__init__.py
@@ -97,6 +97,7 @@ def set_fan_mode(hass, fan_mode, entity_id=None):
 
     hass.services.call(DOMAIN, SERVICE_SET_FAN_MODE, data)
 
+
 def set_hvac_mode(hass, hvac_mode, entity_id=None):
     """Set specified thermostat hvac mode."""
     data = {


### PR DESCRIPTION
**Description:**
Adds service for thermostat/set_hvac_mode to change thermostat to auto/coo/heat/off. This should be universal for Nest/Ecobee/Zwave thermostats. Please provide input as I only have Ecobee to test. 

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
