### PR TITLE
Fix discovery

### DIFF
--- a/homeassistant/components/ecobee.py
+++ b/homeassistant/components/ecobee.py
@@ -71,7 +71,7 @@ def setup_ecobee(hass, network, config):
 
     discovery.load_platform(hass, 'thermostat', DOMAIN,
                             {'hold_temp': hold_temp}, config)
-    discovery.load_platform(hass, 'sensor', DOMAIN, None, config)
+    discovery.load_platform(hass, 'sensor', DOMAIN, {}, config)
 
 
 # pylint: disable=too-few-public-methods

--- a/homeassistant/components/insteon_hub.py
+++ b/homeassistant/components/insteon_hub.py
@@ -40,6 +40,6 @@ def setup(hass, config):
         return
 
     for component in 'light':
-        discovery.load_platform(hass, component, DOMAIN, None, config)
+        discovery.load_platform(hass, component, DOMAIN, {}, config)
 
     return True

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -74,7 +74,7 @@ def setup(hass, config):
 
     # Load platforms for the devices in the ISY controller that we support.
     for component in ('sensor', 'light', 'switch'):
-        discovery.load_platform(hass, component, DOMAIN, None, config)
+        discovery.load_platform(hass, component, DOMAIN, {}, config)
 
     ISY.auto_update = True
     return True

--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -109,7 +109,7 @@ def setup(hass, config):  # pylint: disable=too-many-locals
             device, persistence_file, baud_rate, tcp_port)
 
     for component in 'sensor', 'switch', 'light', 'binary_sensor':
-        discovery.load_platform(hass, component, DOMAIN, None, config)
+        discovery.load_platform(hass, component, DOMAIN, {}, config)
 
     return True
 

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -51,6 +51,6 @@ def setup(hass, config):
         return False
 
     for component in 'camera', 'sensor':
-        discovery.load_platform(hass, component, DOMAIN, None, config)
+        discovery.load_platform(hass, component, DOMAIN, {}, config)
 
     return True

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -92,7 +92,7 @@ def setup(hass, base_config):
         VERA_DEVICES[dev_type].append(device)
 
     for component in 'binary_sensor', 'sensor', 'light', 'switch':
-        discovery.load_platform(hass, component, DOMAIN, None, base_config)
+        discovery.load_platform(hass, component, DOMAIN, {}, base_config)
 
     return True
 

--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -36,7 +36,7 @@ def setup(hass, config):
         return False
 
     for component in ('sensor', 'switch', 'alarm_control_panel', 'lock'):
-        discovery.load_platform(hass, component, DOMAIN, None, config)
+        discovery.load_platform(hass, component, DOMAIN, {}, config)
 
     return True
 


### PR DESCRIPTION
**Description:**
Migration to new discovery method broke some implementations because we were passing in `discovery_info=None` which tricked platforms into thinking they were loaded via the config.
