### PR TITLE
Create OpenExchangeRates Sensor

### DIFF
--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -38,14 +38,16 @@ class openexchangeratesSensor(Entity):
 
     @property
     def name(self):
+        """Return the name of the sensor."""
         return self._name
     @property
     def state(self):
+        """Return the state of the sensor."""
         return self._state
     @property
     def device_state_attributes(self):
+        """Return other attributes of the sensor."""
         return self.rest.data
-
     def update(self):
         """Update current conditions."""
         self.rest.update()
@@ -55,6 +57,7 @@ class openexchangeratesSensor(Entity):
 class openexchangeratesData(object):
     """Get data from Openexchangerates.org."""
     def __init__(self, resource, api_key, base, quote, data):
+        """Initialize the data object."""
         self._resource = resource
         self._api_key = api_key
         self._base = base

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -1,0 +1,68 @@
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+from homeassistant.const import CONF_API_KEY
+import requests
+import logging
+from datetime import timedelta
+
+_RESOURCE = 'https://openexchangerates.org/api/latest.json'
+_LOGGER = logging.getLogger(__name__)
+# Return cached results if last scan was less then this time ago.
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=100)
+
+CONF_BASE = 'base'
+CONF_QUOTE = 'quote'
+CONF_NAME = 'name'
+DEFAULT_NAME = 'Exchange Rate Sensor'
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    payload=config.get('payload', None)
+    rest = openexchangeratesData(_RESOURCE, config.get(CONF_API_KEY),config.get(CONF_BASE,'USD'),config.get(CONF_QUOTE),payload)
+    rest.update()
+    add_devices([openexchangeratesSensor(rest,config.get(CONF_NAME,DEFAULT_NAME),config.get(CONF_QUOTE))])
+
+class openexchangeratesSensor(Entity):
+
+    def __init__(self, rest, name, quote):
+        self.rest = rest
+        self._name = name
+        self._quote = quote
+        self.update()
+
+    @property
+    def name(self):
+        return self._name    
+    @property
+    def state(self):
+        return self._state
+    @property
+    def device_state_attributes(self):
+        return self.rest.data
+		
+    def update(self):
+        """Update current conditions"""
+
+        self.rest.update()
+        value = self.rest.data
+        self._state = round(value[str(self._quote)],4)
+
+class openexchangeratesData(object):
+
+    def __init__(self, resource, api_key, base, quote, data):
+        self._resource = resource
+        self._api_key = api_key
+        self._base = base
+        self._quote = quote
+        self.data=None
+
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Get the latest data from openexchangerates"""
+        try:
+            result = requests.get(self._resource + '?base=' + self._base + '&app_id=' + self._api_key)
+            self.data =  result.json()['rates']
+            _LOGGER.debug(result.json()['timestamp'])
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error("No route to host/endpoint: %s", self._resource)
+            self.data = None

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -19,13 +19,13 @@ DEFAULT_NAME = 'Exchange Rate Sensor'
 """Setup the Openexchangerates sensor."""
 def setup_platform(hass, config, add_devices, discovery_info=None):
     payload = config.get('payload', None)
-    rest = openexchangeratesData(_RESOURCE, config.get(CONF_API_KEY), 
+    rest = OpenexchangeratesData(_RESOURCE, config.get(CONF_API_KEY), 
             config.get(CONF_BASE, 'USD'), config.get(CONF_QUOTE), payload)
     rest.update()
-    add_devices([openexchangeratesSensor(rest, config.get(CONF_NAME, DEFAULT_NAME), 
+    add_devices([OpenexchangeratesSensor(rest, config.get(CONF_NAME, DEFAULT_NAME), 
             config.get(CONF_QUOTE))])
 
-class openexchangeratesSensor(Entity):
+class OpenexchangeratesSensor(Entity):
     """Implementing the Openexchangerates sensor."""
     def __init__(self, rest, name, quote):
         """Initialize the sensor."""
@@ -51,7 +51,7 @@ class openexchangeratesSensor(Entity):
         value = self.rest.data
         self._state = round(value[str(self._quote)], 4)
 
-class openexchangeratesData(object):
+class OpenexchangeratesData(object):
     """Get data from Openexchangerates.org."""
     def __init__(self, resource, api_key, base, quote, data):
         """Initialize the data object."""

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -30,7 +30,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class OpenexchangeratesSensor(Entity):
-    
     """Implementing the Openexchangerates sensor."""
     def __init__(self, rest, name, quote):
         """Initialize the sensor."""
@@ -62,7 +61,6 @@ class OpenexchangeratesSensor(Entity):
 
 
 class OpenexchangeratesData(object):
-    
     """Get data from Openexchangerates.org."""
     def __init__(self, resource, api_key, base, quote, data):
         """Initialize the data object."""

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -46,20 +46,17 @@ class openexchangeratesSensor(Entity):
 
     def update(self):
         """Update current conditions"""
-
         self.rest.update()
         value = self.rest.data
         self._state = round(value[str(self._quote)], 4)
 
 class openexchangeratesData(object):
-
     def __init__(self, resource, api_key, base, quote, data):
         self._resource = resource
         self._api_key = api_key
         self._base = base
         self._quote = quote
         self.data=None
-
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -31,6 +31,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class openexchangeratesSensor(Entity):
     """Implementing the Openexchangerates sensor."""
     def __init__(self, rest, name, quote):
+        """Initialize the sensor."""
         self.rest = rest
         self._name = name
         self._quote = quote

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -25,8 +25,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                  config.get(CONF_BASE, 'USD'),
                                  config.get(CONF_QUOTE), payload)
     rest.update()
-    add_devices([OpenexchangeratesSensor(rest, config.get(CONF_NAME,
-                                         DEFAULT_NAME),
+    add_devices([OpenexchangeratesSensor(rest,
+                                         config.get(CONF_NAME, DEFAULT_NAME),
                                          config.get(CONF_QUOTE))])
 
 

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -11,6 +11,7 @@ from homeassistant.util import Throttle
 from homeassistant.const import CONF_API_KEY
 from datetime import timedelta
 
+"""Initialize variables or setup default values."""
 _RESOURCE = 'https://openexchangerates.org/api/latest.json'
 _LOGGER = logging.getLogger(__name__)
 # Return cached results if last scan was less then this time ago.

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -1,10 +1,10 @@
 """Support for openexchangerates.org exchange rates service."""
 import logging
 import requests
+from datetime import timedelta
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.const import CONF_API_KEY
-from datetime import timedelta
 
 """Initialize variables or setup default values."""
 _RESOURCE = 'https://openexchangerates.org/api/latest.json'
@@ -20,10 +20,10 @@ DEFAULT_NAME = 'Exchange Rate Sensor'
 def setup_platform(hass, config, add_devices, discovery_info=None):
     payload = config.get('payload', None)
     rest = OpenexchangeratesData(_RESOURCE, config.get(CONF_API_KEY), 
-            config.get(CONF_BASE, 'USD'), config.get(CONF_QUOTE), payload)
+                                 config.get(CONF_BASE, 'USD'), config.get(CONF_QUOTE), payload)
     rest.update()
     add_devices([OpenexchangeratesSensor(rest, config.get(CONF_NAME, DEFAULT_NAME), 
-            config.get(CONF_QUOTE))])
+                                         config.get(CONF_QUOTE))])
 
 class OpenexchangeratesSensor(Entity):
     """Implementing the Openexchangerates sensor."""
@@ -66,7 +66,7 @@ class OpenexchangeratesData(object):
         """Get the latest data from openexchangerates."""
         try:
             result = requests.get(self._resource + '?base=' + self._base +
-                        '&app_id=' + self._api_key)
+                                  '&app_id=' + self._api_key)
             self.data = result.json()['rates']
             _LOGGER.debug(result.json()['timestamp'])
         except requests.exceptions.ConnectionError:

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -19,6 +19,7 @@ DEFAULT_NAME = 'Exchange Rate Sensor'
 
 """Setup the Openexchangerates sensor."""
 def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Openexchangerates sensor."""
     payload = config.get('payload', None)
     rest = OpenexchangeratesData(_RESOURCE, config.get(CONF_API_KEY),
                                  config.get(CONF_BASE, 'USD'),

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -66,7 +66,7 @@ class openexchangeratesData(object):
         """Get the latest data from openexchangerates"""
         try:
             result = requests.get(self._resource + '?base=' + self._base + '&app_id=' + self._api_key)
-            self.data =  result.json()['rates']
+            self.data = result.json()['rates']
             _LOGGER.debug(result.json()['timestamp'])
         except requests.exceptions.ConnectionError:
             _LOGGER.error("No route to host/endpoint: %s", self._resource)

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -1,7 +1,7 @@
 """Support for openexchangerates.org exchange rates service."""
+from datetime import timedelta
 import logging
 import requests
-from datetime import timedelta
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.const import CONF_API_KEY
@@ -16,13 +16,14 @@ CONF_QUOTE = 'quote'
 CONF_NAME = 'name'
 DEFAULT_NAME = 'Exchange Rate Sensor'
 
+
 """Setup the Openexchangerates sensor."""
 def setup_platform(hass, config, add_devices, discovery_info=None):
     payload = config.get('payload', None)
-    rest = OpenexchangeratesData(_RESOURCE, config.get(CONF_API_KEY), 
+    rest = OpenexchangeratesData(_RESOURCE, config.get(CONF_API_KEY),
                                  config.get(CONF_BASE, 'USD'), config.get(CONF_QUOTE), payload)
     rest.update()
-    add_devices([OpenexchangeratesSensor(rest, config.get(CONF_NAME, DEFAULT_NAME), 
+    add_devices([OpenexchangeratesSensor(rest, config.get(CONF_NAME, DEFAULT_NAME),
                                          config.get(CONF_QUOTE))])
 
 class OpenexchangeratesSensor(Entity):

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -31,6 +31,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class OpenexchangeratesSensor(Entity):
+    
     """Implementing the Openexchangerates sensor."""
     def __init__(self, rest, name, quote):
         """Initialize the sensor."""
@@ -62,6 +63,7 @@ class OpenexchangeratesSensor(Entity):
 
 
 class OpenexchangeratesData(object):
+    
     """Get data from Openexchangerates.org."""
     def __init__(self, resource, api_key, base, quote, data):
         """Initialize the data object."""

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -38,7 +38,6 @@ class openexchangeratesSensor(Entity):
         self._name = name
         self._quote = quote
         self.update()
-
     @property
     def name(self):
         """Return the name of the sensor."""

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -21,8 +21,8 @@ CONF_QUOTE = 'quote'
 CONF_NAME = 'name'
 DEFAULT_NAME = 'Exchange Rate Sensor'
 
+"""Setup the Openexchangerates sensor."""
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Openexchangerates sensor."""
     payload = config.get('payload', None)
     rest = openexchangeratesData(_RESOURCE, config.get(CONF_API_KEY), 
            config.get(CONF_BASE,'USD'), config.get(CONF_QUOTE), payload)

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -17,12 +17,17 @@ CONF_NAME = 'name'
 DEFAULT_NAME = 'Exchange Rate Sensor'
 
 
+"""Setup the Openexchangerates sensor."""
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Openexchangerates sensor."""
     payload = config.get('payload', None)
-    rest = OpenexchangeratesData(_RESOURCE, config.get(CONF_API_KEY),
-                                 config.get(CONF_BASE, 'USD'),
-                                 config.get(CONF_QUOTE), payload)
+    rest = OpenexchangeratesData(
+        _RESOURCE,
+        config.get(CONF_API_KEY),
+        config.get(CONF_BASE, 'USD'),
+        config.get(CONF_QUOTE),
+        payload
+    )
     rest.update()
     add_devices([OpenexchangeratesSensor(rest,
                                          config.get(CONF_NAME, DEFAULT_NAME),
@@ -31,6 +36,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 class OpenexchangeratesSensor(Entity):
     """Implementing the Openexchangerates sensor."""
+    
     def __init__(self, rest, name, quote):
         """Initialize the sensor."""
         self.rest = rest
@@ -62,6 +68,7 @@ class OpenexchangeratesSensor(Entity):
 
 class OpenexchangeratesData(object):
     """Get data from Openexchangerates.org."""
+    
     def __init__(self, resource, api_key, base, quote, data):
         """Initialize the data object."""
         self._resource = resource

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -36,7 +36,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 class OpenexchangeratesSensor(Entity):
     """Implementing the Openexchangerates sensor."""
-    
+
     def __init__(self, rest, name, quote):
         """Initialize the sensor."""
         self.rest = rest
@@ -68,7 +68,7 @@ class OpenexchangeratesSensor(Entity):
 
 class OpenexchangeratesData(object):
     """Get data from Openexchangerates.org."""
-    
+
     def __init__(self, resource, api_key, base, quote, data):
         """Initialize the data object."""
         self._resource = resource

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -63,6 +63,7 @@ class OpenexchangeratesSensor(Entity):
         value = self.rest.data
         self._state = round(value[str(self._quote)], 4)
 
+
 # pylint: disable=too-few-public-methods
 class OpenexchangeratesData(object):
     """Get data from Openexchangerates.org."""

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -1,3 +1,8 @@
+"""
+Support for openexchangerates.org exchange rates service.
+For more details about this platform, please refer to the documentation at
+
+"""
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.const import CONF_API_KEY

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -17,7 +17,6 @@ CONF_NAME = 'name'
 DEFAULT_NAME = 'Exchange Rate Sensor'
 
 
-"""Setup the Openexchangerates sensor."""
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Openexchangerates sensor."""
     payload = config.get('payload', None)

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -16,7 +16,6 @@ CONF_NAME = 'name'
 DEFAULT_NAME = 'Exchange Rate Sensor'
 
 
-"""Setup the Openexchangerates sensor."""
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Openexchangerates sensor."""
     payload = config.get('payload', None)

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -36,14 +36,14 @@ class openexchangeratesSensor(Entity):
 
     @property
     def name(self):
-        return self._name    
+        return self._name
     @property
     def state(self):
         return self._state
     @property
     def device_state_attributes(self):
         return self.rest.data
-		
+
     def update(self):
         """Update current conditions"""
 

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -16,7 +16,7 @@ CONF_NAME = 'name'
 DEFAULT_NAME = 'Exchange Rate Sensor'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    payload=config.get('payload', None)
+    payload = config.get('payload', None)
     rest = openexchangeratesData(_RESOURCE, config.get(CONF_API_KEY),config.get(CONF_BASE,'USD'),config.get(CONF_QUOTE),payload)
     rest.update()
     add_devices([openexchangeratesSensor(rest,config.get(CONF_NAME,DEFAULT_NAME),config.get(CONF_QUOTE))])

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -23,10 +23,10 @@ DEFAULT_NAME = 'Exchange Rate Sensor'
 def setup_platform(hass, config, add_devices, discovery_info=None):
     payload = config.get('payload', None)
     rest = openexchangeratesData(_RESOURCE, config.get(CONF_API_KEY), 
-    config.get(CONF_BASE,'USD'), config.get(CONF_QUOTE), payload)
+           config.get(CONF_BASE,'USD'), config.get(CONF_QUOTE), payload)
     rest.update()
     add_devices([openexchangeratesSensor(rest, config.get(CONF_NAME,DEFAULT_NAME), 
-    config.get(CONF_QUOTE))])
+                config.get(CONF_QUOTE))])
 
 class openexchangeratesSensor(Entity):
 

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -1,19 +1,20 @@
 """
 Support for openexchangerates.org exchange rates service.
 For more details about this platform, please refer to the documentation at (working on it).
+
 """
+import requests
+import logging
+
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.const import CONF_API_KEY
-import requests
-import logging
 from datetime import timedelta
 
 _RESOURCE = 'https://openexchangerates.org/api/latest.json'
 _LOGGER = logging.getLogger(__name__)
 # Return cached results if last scan was less then this time ago.
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=100)
-
 CONF_BASE = 'base'
 CONF_QUOTE = 'quote'
 CONF_NAME = 'name'

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -22,9 +22,11 @@ DEFAULT_NAME = 'Exchange Rate Sensor'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     payload = config.get('payload', None)
-    rest = openexchangeratesData(_RESOURCE, config.get(CONF_API_KEY), config.get(CONF_BASE,'USD'), config.get(CONF_QUOTE), payload)
+    rest = openexchangeratesData(_RESOURCE, config.get(CONF_API_KEY), 
+    config.get(CONF_BASE,'USD'), config.get(CONF_QUOTE), payload)
     rest.update()
-    add_devices([openexchangeratesSensor(rest, config.get(CONF_NAME,DEFAULT_NAME), config.get(CONF_QUOTE))])
+    add_devices([openexchangeratesSensor(rest, config.get(CONF_NAME,DEFAULT_NAME), 
+    config.get(CONF_QUOTE))])
 
 class openexchangeratesSensor(Entity):
 

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -1,7 +1,6 @@
 """
 Support for openexchangerates.org exchange rates service.
-For more details about this platform, please refer to the documentation at
-
+For more details about this platform, please refer to the documentation at (working on it).
 """
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
@@ -21,6 +20,7 @@ CONF_NAME = 'name'
 DEFAULT_NAME = 'Exchange Rate Sensor'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Openexchangerates sensor."""
     payload = config.get('payload', None)
     rest = openexchangeratesData(_RESOURCE, config.get(CONF_API_KEY), 
            config.get(CONF_BASE,'USD'), config.get(CONF_QUOTE), payload)
@@ -29,7 +29,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 config.get(CONF_QUOTE))])
 
 class openexchangeratesSensor(Entity):
-
+    """Implementing the Openexchangerates sensor."""
     def __init__(self, rest, name, quote):
         self.rest = rest
         self._name = name
@@ -47,12 +47,13 @@ class openexchangeratesSensor(Entity):
         return self.rest.data
 
     def update(self):
-        """Update current conditions"""
+        """Update current conditions."""
         self.rest.update()
         value = self.rest.data
         self._state = round(value[str(self._quote)], 4)
 
 class openexchangeratesData(object):
+    """Get data from Openexchangerates.org."""
     def __init__(self, resource, api_key, base, quote, data):
         self._resource = resource
         self._api_key = api_key
@@ -62,7 +63,7 @@ class openexchangeratesData(object):
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        """Get the latest data from openexchangerates"""
+        """Get the latest data from openexchangerates."""
         try:
             result = requests.get(self._resource + '?base=' + 
                      self._base + '&app_id=' + self._api_key)

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -22,9 +22,9 @@ DEFAULT_NAME = 'Exchange Rate Sensor'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     payload = config.get('payload', None)
-    rest = openexchangeratesData(_RESOURCE, config.get(CONF_API_KEY),config.get(CONF_BASE,'USD'),config.get(CONF_QUOTE),payload)
+    rest = openexchangeratesData(_RESOURCE, config.get(CONF_API_KEY), config.get(CONF_BASE,'USD'), config.get(CONF_QUOTE), payload)
     rest.update()
-    add_devices([openexchangeratesSensor(rest,config.get(CONF_NAME,DEFAULT_NAME),config.get(CONF_QUOTE))])
+    add_devices([openexchangeratesSensor(rest, config.get(CONF_NAME,DEFAULT_NAME), config.get(CONF_QUOTE))])
 
 class openexchangeratesSensor(Entity):
 
@@ -49,7 +49,7 @@ class openexchangeratesSensor(Entity):
 
         self.rest.update()
         value = self.rest.data
-        self._state = round(value[str(self._quote)],4)
+        self._state = round(value[str(self._quote)], 4)
 
 class openexchangeratesData(object):
 

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -82,7 +82,7 @@ class OpenexchangeratesData(object):
         """Get the latest data from openexchangerates."""
         try:
             result = requests.get(self._resource + '?base=' + self._base +
-                                  '&app_id=' + self._api_key)
+                                  '&app_id=' + self._api_key, timeout=10)
             self.data = result.json()['rates']
             _LOGGER.debug(result.json()['timestamp'])
         except requests.exceptions.ConnectionError:

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -6,7 +6,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.const import CONF_API_KEY
 
-"""Initialize variables or setup default values."""
 _RESOURCE = 'https://openexchangerates.org/api/latest.json'
 _LOGGER = logging.getLogger(__name__)
 # Return cached results if last scan was less then this time ago.

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -64,7 +64,8 @@ class openexchangeratesData(object):
     def update(self):
         """Get the latest data from openexchangerates"""
         try:
-            result = requests.get(self._resource + '?base=' + self._base + '&app_id=' + self._api_key)
+            result = requests.get(self._resource + '?base=' + 
+                     self._base + '&app_id=' + self._api_key)
             self.data = result.json()['rates']
             _LOGGER.debug(result.json()['timestamp'])
         except requests.exceptions.ConnectionError:

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -63,10 +63,11 @@ class OpenexchangeratesSensor(Entity):
         value = self.rest.data
         self._state = round(value[str(self._quote)], 4)
 
-
+# pylint: disable=too-few-public-methods
 class OpenexchangeratesData(object):
     """Get data from Openexchangerates.org."""
 
+    # pylint: disable=too-many-arguments
     def __init__(self, resource, api_key, base, quote, data):
         """Initialize the data object."""
         self._resource = resource

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -20,10 +20,10 @@ DEFAULT_NAME = 'Exchange Rate Sensor'
 def setup_platform(hass, config, add_devices, discovery_info=None):
     payload = config.get('payload', None)
     rest = openexchangeratesData(_RESOURCE, config.get(CONF_API_KEY), 
-    config.get(CONF_BASE, 'USD'), config.get(CONF_QUOTE), payload)
+            config.get(CONF_BASE, 'USD'), config.get(CONF_QUOTE), payload)
     rest.update()
     add_devices([openexchangeratesSensor(rest, config.get(CONF_NAME, DEFAULT_NAME), 
-    config.get(CONF_QUOTE))])
+            config.get(CONF_QUOTE))])
 
 class openexchangeratesSensor(Entity):
     """Implementing the Openexchangerates sensor."""
@@ -65,8 +65,8 @@ class openexchangeratesData(object):
     def update(self):
         """Get the latest data from openexchangerates."""
         try:
-            result = requests.get(self._resource + '?base=' + 
-            self._base + '&app_id=' + self._api_key)
+            result = requests.get(self._resource + '?base=' + self._base +
+                        '&app_id=' + self._api_key)
             self.data = result.json()['rates']
             _LOGGER.debug(result.json()['timestamp'])
         except requests.exceptions.ConnectionError:

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -1,7 +1,6 @@
 """
 Support for openexchangerates.org exchange rates service.
 For more details about this platform, please refer to the documentation at (working on it).
-
 """
 import requests
 import logging

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -1,7 +1,6 @@
 """Support for openexchangerates.org exchange rates service."""
-import requests
 import logging
-
+import requests
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.const import CONF_API_KEY

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -1,7 +1,4 @@
-"""
-Support for openexchangerates.org exchange rates service.
-For more details about this platform, please refer to the documentation at (working on it).
-"""
+"""Support for openexchangerates.org exchange rates service."""
 import requests
 import logging
 

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -21,10 +21,13 @@ DEFAULT_NAME = 'Exchange Rate Sensor'
 def setup_platform(hass, config, add_devices, discovery_info=None):
     payload = config.get('payload', None)
     rest = OpenexchangeratesData(_RESOURCE, config.get(CONF_API_KEY),
-                                 config.get(CONF_BASE, 'USD'), config.get(CONF_QUOTE), payload)
+                                 config.get(CONF_BASE, 'USD'),
+                                 config.get(CONF_QUOTE), payload)
     rest.update()
-    add_devices([OpenexchangeratesSensor(rest, config.get(CONF_NAME, DEFAULT_NAME),
+    add_devices([OpenexchangeratesSensor(rest, config.get(CONF_NAME,
+                                         DEFAULT_NAME),
                                          config.get(CONF_QUOTE))])
+
 
 class OpenexchangeratesSensor(Entity):
     """Implementing the Openexchangerates sensor."""
@@ -34,23 +37,28 @@ class OpenexchangeratesSensor(Entity):
         self._name = name
         self._quote = quote
         self.update()
+
     @property
     def name(self):
         """Return the name of the sensor."""
         return self._name
+
     @property
     def state(self):
         """Return the state of the sensor."""
         return self._state
+
     @property
     def device_state_attributes(self):
         """Return other attributes of the sensor."""
         return self.rest.data
+
     def update(self):
         """Update current conditions."""
         self.rest.update()
         value = self.rest.data
         self._state = round(value[str(self._quote)], 4)
+
 
 class OpenexchangeratesData(object):
     """Get data from Openexchangerates.org."""

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -56,7 +56,7 @@ class openexchangeratesData(object):
         self._api_key = api_key
         self._base = base
         self._quote = quote
-        self.data=None
+        self.data = None
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -20,10 +20,10 @@ DEFAULT_NAME = 'Exchange Rate Sensor'
 def setup_platform(hass, config, add_devices, discovery_info=None):
     payload = config.get('payload', None)
     rest = openexchangeratesData(_RESOURCE, config.get(CONF_API_KEY), 
-           config.get(CONF_BASE,'USD'), config.get(CONF_QUOTE), payload)
+    config.get(CONF_BASE, 'USD'), config.get(CONF_QUOTE), payload)
     rest.update()
-    add_devices([openexchangeratesSensor(rest, config.get(CONF_NAME,DEFAULT_NAME), 
-                config.get(CONF_QUOTE))])
+    add_devices([openexchangeratesSensor(rest, config.get(CONF_NAME, DEFAULT_NAME), 
+    config.get(CONF_QUOTE))])
 
 class openexchangeratesSensor(Entity):
     """Implementing the Openexchangerates sensor."""
@@ -66,7 +66,7 @@ class openexchangeratesData(object):
         """Get the latest data from openexchangerates."""
         try:
             result = requests.get(self._resource + '?base=' + 
-                     self._base + '&app_id=' + self._api_key)
+            self._base + '&app_id=' + self._api_key)
             self.data = result.json()['rates']
             _LOGGER.debug(result.json()['timestamp'])
         except requests.exceptions.ConnectionError:


### PR DESCRIPTION
**Description:** Initial version to obtain current exchange rate between any two currency pair from [OpenExchangeRates](https://openexchangerates.org/). 

Obtain API key [here](https://openexchangerates.org/signup/free). Free accounts allow 1000 requests per month. 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: openexchangerates
  api_key: your_api_key
  base: USD #optional
  quote: EUR
  name: USDEUR #optional
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Get the current exchange rate between any two supported currency pair.
