### PR TITLE
Wink pubnub subscription support and base Wink device

### DIFF
--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -7,9 +7,10 @@ https://home-assistant.io/components/garage_door.wink/
 import logging
 
 from homeassistant.components.garage_door import GarageDoorDevice
-from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
+from homeassistant.components.wink import WinkDevice
+from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.7']
+REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.8']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -31,37 +32,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 pywink.get_garage_doors())
 
 
-class WinkGarageDoorDevice(GarageDoorDevice):
+class WinkGarageDoorDevice(WinkDevice, GarageDoorDevice):
     """Representation of a Wink garage door."""
 
     def __init__(self, wink):
         """Initialize the garage door."""
-        self.wink = wink
-        self._battery = self.wink.battery_level
-
-    @property
-    def unique_id(self):
-        """Return the ID of this wink garage door."""
-        return "{}.{}".format(self.__class__, self.wink.device_id())
-
-    @property
-    def name(self):
-        """Return the name of the garage door if any."""
-        return self.wink.name()
-
-    def update(self):
-        """Update the state of the garage door."""
-        self.wink.update_state()
+        WinkDevice.__init__(self, wink)
 
     @property
     def is_closed(self):
         """Return true if door is closed."""
         return self.wink.state() == 0
-
-    @property
-    def available(self):
-        """True if connection == True."""
-        return self.wink.available
 
     def close_door(self):
         """Close the door."""
@@ -70,16 +51,3 @@ class WinkGarageDoorDevice(GarageDoorDevice):
     def open_door(self):
         """Open the door."""
         self.wink.set_state(1)
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        if self._battery:
-            return {
-                ATTR_BATTERY_LEVEL: self._battery_level,
-            }
-
-    @property
-    def _battery_level(self):
-        """Return the battery level."""
-        return self.wink.battery_level * 100

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -8,12 +8,13 @@ import logging
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, \
     Light, ATTR_RGB_COLOR
+from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.util import color as color_util
 from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
 
-REQUIREMENTS = ['python-wink==0.7.7']
+REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.8']
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
@@ -35,26 +36,12 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         WinkLight(light) for light in pywink.get_bulbs())
 
 
-class WinkLight(Light):
+class WinkLight(WinkDevice, Light):
     """Representation of a Wink light."""
 
     def __init__(self, wink):
-        """
-        Initialize the light.
-
-        :type wink: pywink.devices.standard.bulb.WinkBulb
-        """
-        self.wink = wink
-
-    @property
-    def unique_id(self):
-        """Return the ID of this Wink light."""
-        return "{}.{}".format(self.__class__, self.wink.device_id())
-
-    @property
-    def name(self):
-        """Return the name of the light if any."""
-        return self.wink.name()
+        """Initialize the Wink device."""
+        WinkDevice.__init__(self, wink)
 
     @property
     def is_on(self):
@@ -65,11 +52,6 @@ class WinkLight(Light):
     def brightness(self):
         """Return the brightness of the light."""
         return int(self.wink.brightness() * 255)
-
-    @property
-    def available(self):
-        """True if connection == True."""
-        return self.wink.available
 
     @property
     def xy_color(self):
@@ -112,7 +94,3 @@ class WinkLight(Light):
     def turn_off(self):
         """Turn the switch off."""
         self.wink.set_state(False)
-
-    def update(self):
-        """Update state of the light."""
-        self.wink.update_state(require_desired_state_fulfilled=True)

--- a/homeassistant/components/rollershutter/wink.py
+++ b/homeassistant/components/rollershutter/wink.py
@@ -7,9 +7,10 @@ https://home-assistant.io/components/rollershutter.wink/
 import logging
 
 from homeassistant.components.rollershutter import RollershutterDevice
+from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.7']
+REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.8']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -31,37 +32,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 pywink.get_shades())
 
 
-class WinkRollershutterDevice(RollershutterDevice):
+class WinkRollershutterDevice(WinkDevice, RollershutterDevice):
     """Representation of a Wink rollershutter (shades)."""
 
     def __init__(self, wink):
         """Initialize the rollershutter."""
-        self.wink = wink
-        self._battery = None
+        WinkDevice.__init__(self, wink)
 
     @property
     def should_poll(self):
         """Wink Shades don't track their position."""
         return False
-
-    @property
-    def unique_id(self):
-        """Return the ID of this wink rollershutter."""
-        return "{}.{}".format(self.__class__, self.wink.device_id())
-
-    @property
-    def name(self):
-        """Return the name of the rollershutter if any."""
-        return self.wink.name()
-
-    def update(self):
-        """Update the state of the rollershutter."""
-        return self.wink.update_state()
-
-    @property
-    def available(self):
-        """True if connection == True."""
-        return self.wink.available
 
     def move_down(self):
         """Close the shade."""

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -6,10 +6,11 @@ https://home-assistant.io/components/switch.wink/
 """
 import logging
 
-from homeassistant.components.wink import WinkToggleDevice
+from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.helpers.entity import ToggleEntity
 
-REQUIREMENTS = ['python-wink==0.7.7']
+REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.8']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -31,3 +32,24 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(WinkToggleDevice(switch) for switch in
                 pywink.get_powerstrip_outlets())
     add_devices(WinkToggleDevice(switch) for switch in pywink.get_sirens())
+
+
+class WinkToggleDevice(WinkDevice, ToggleEntity):
+    """Represents a Wink toggle (switch) device."""
+
+    def __init__(self, wink):
+        """Initialize the Wink device."""
+        WinkDevice.__init__(self, wink)
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self.wink.state()
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        self.wink.set_state(True)
+
+    def turn_off(self):
+        """Turn the device off."""
+        self.wink.set_state(False)

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -5,13 +5,17 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/wink/
 """
 import logging
+import json
 
-from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
 from homeassistant.helpers import validate_config, discovery
-from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
+from homeassistant.helpers.entity import Entity
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.7.7']
+REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.8']
+
+SUBSCRIPTION_HANDLER = None
+CHANNELS = []
 
 
 def setup(hass, config):
@@ -22,7 +26,11 @@ def setup(hass, config):
         return False
 
     import pywink
+    from pubnub import Pubnub
     pywink.set_bearer_token(config[DOMAIN][CONF_ACCESS_TOKEN])
+    global SUBSCRIPTION_HANDLER
+    SUBSCRIPTION_HANDLER = Pubnub("N/A", pywink.get_subscription_key())
+    SUBSCRIPTION_HANDLER.set_heartbeat(120)
 
     # Load components for the devices in the Wink that we support
     for component_name, func_exists in (
@@ -41,13 +49,33 @@ def setup(hass, config):
     return True
 
 
-class WinkToggleDevice(ToggleEntity):
-    """Represents a Wink toggle (switch) device."""
+class WinkDevice(Entity):
+    """Represents a base Wink device."""
 
     def __init__(self, wink):
         """Initialize the Wink device."""
+        from pubnub import Pubnub
         self.wink = wink
         self._battery = self.wink.battery_level
+        if self.wink.pubnub_channel in CHANNELS:
+            pubnub = Pubnub("N/A", self.wink.pubnub_key)
+            pubnub.set_heartbeat(120)
+            pubnub.subscribe(self.wink.pubnub_channel,
+                             self._pubnub_update,
+                             error=self._pubnub_error)
+        else:
+            CHANNELS.append(self.wink.pubnub_channel)
+            SUBSCRIPTION_HANDLER.subscribe(self.wink.pubnub_channel,
+                                           self._pubnub_update,
+                                           error=self._pubnub_error)
+
+    def _pubnub_update(self, message, channel):
+        self.wink.pubnub_update(json.loads(message))
+        self.update_ha_state()
+
+    def _pubnub_error(self, message):
+        logging.getLogger(__name__).error(
+            "Error on pubnub update for " + self.wink.name())
 
     @property
     def unique_id(self):
@@ -60,26 +88,18 @@ class WinkToggleDevice(ToggleEntity):
         return self.wink.name()
 
     @property
-    def is_on(self):
-        """Return true if device is on."""
-        return self.wink.state()
-
-    @property
     def available(self):
         """True if connection == True."""
         return self.wink.available
 
-    def turn_on(self, **kwargs):
-        """Turn the device on."""
-        self.wink.set_state(True)
-
-    def turn_off(self):
-        """Turn the device off."""
-        self.wink.set_state(False)
-
     def update(self):
         """Update state of the device."""
         self.wink.update_state()
+
+    @property
+    def should_poll(self):
+        """Only poll if we are not subscribed to pubnub."""
+        return self.wink.pubnub_channel is None
 
     @property
     def device_state_attributes(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -220,6 +220,16 @@ proliphix==0.1.0
 # homeassistant.components.sensor.systemmonitor
 psutil==4.3.0
 
+# homeassistant.components.wink
+# homeassistant.components.binary_sensor.wink
+# homeassistant.components.garage_door.wink
+# homeassistant.components.light.wink
+# homeassistant.components.lock.wink
+# homeassistant.components.rollershutter.wink
+# homeassistant.components.sensor.wink
+# homeassistant.components.switch.wink
+pubnub==3.7.8
+
 # homeassistant.components.notify.pushbullet
 pushbullet.py==0.10.0
 
@@ -324,7 +334,7 @@ python-twitch==1.2.0
 # homeassistant.components.rollershutter.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.7.7
+python-wink==0.7.8
 
 # homeassistant.components.keyboard
 pyuserinput==0.1.9


### PR DESCRIPTION
**Description:**
This will migrate all Wink devices from the current polling method of updating to a push based update. This results in faster updates. This PR also creates a base Wink device that all other devices extend from which should make future updates easier. 

I have tested powerstrips, lights, binary sensors, sensors, and locks. I don't own a garage door, or any non-wink z-wave devices so if anyone could test those out that would be cool.

There are two minor issues I have noticed.
1. Occasionally the state will not update. Based on some testing it looks like the pubnub updates come in out of order. The new state followed by the old state. Doesn't happen often and I think I have noticed it in the official Wink app too so it might not be possible to fix it.
2. This one is strange but I noticed that after ~8 hours (could be less) of inactivity, state updates stop functioning until I manually change the state of a light bulb and then everything starts functioning again. I have fixed this temporarily by running a script every hour to turn a light on and then off. I also just updated the pubnub version from 3.7.6 to 3.7.8 in this PR so I am not sure if this issue remains in the new version.

Should a configuration option be added to switch back to polling based updates?

I will be out of town starting tomorrow 6/19-6/22 so it may be awhile before I can make any updates that may be required for this PR.

**Related issue (if applicable):** fixes #2314 

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [X] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
