### PR TITLE
Make sure we exit loop when value is set for zwave thermostat and hvac

### DIFF
--- a/homeassistant/components/hvac/zwave.py
+++ b/homeassistant/components/hvac/zwave.py
@@ -211,6 +211,7 @@ class ZWaveHvac(ZWaveDeviceEntity, HvacDevice):
                 value.data = int(round(temperature, 0))
             else:
                 value.data = int(temperature)
+            break
 
     def set_fan_mode(self, fan):
         """Set new target fan mode."""
@@ -218,6 +219,7 @@ class ZWaveHvac(ZWaveDeviceEntity, HvacDevice):
                 class_id=COMMAND_CLASS_THERMOSTAT_FAN_MODE).values():
             if value.command_class == 68 and value.index == 0:
                 value.data = bytes(fan, 'utf-8')
+                break
 
     def set_operation_mode(self, operation_mode):
         """Set new target operation mode."""
@@ -225,6 +227,7 @@ class ZWaveHvac(ZWaveDeviceEntity, HvacDevice):
                 class_id=COMMAND_CLASS_THERMOSTAT_MODE).values():
             if value.command_class == 64 and value.index == 0:
                 value.data = bytes(operation_mode, 'utf-8')
+                break
 
     def set_swing_mode(self, swing_mode):
         """Set new target swing mode."""
@@ -233,3 +236,4 @@ class ZWaveHvac(ZWaveDeviceEntity, HvacDevice):
                     class_id=COMMAND_CLASS_CONFIGURATION).values():
                 if value.command_class == 112 and value.index == 33:
                     value.data = int(swing_mode)
+                    break

--- a/homeassistant/components/thermostat/zwave.py
+++ b/homeassistant/components/thermostat/zwave.py
@@ -156,3 +156,4 @@ class ZWaveThermostat(zwave.ZWaveDeviceEntity, ThermostatDevice):
                 COMMAND_CLASS_THERMOSTAT_SETPOINT).items():
             if int(value.data) != 0 and value.index == self._index:
                 value.data = temperature
+                break


### PR DESCRIPTION
**Description:**
Make sure we set value only one time to the zwave network.

**Related issue (if applicable):** fixes #
None, but in some cases, value would be set multiple times, this was present especially with AC's that gave an audible notification when a value was received.

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
