### PR TITLE
Change lifx state ignoring power state

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -42,7 +42,7 @@ ATTR_COLOR_NAME = "color_name"
 # int with value 0 .. 255 representing brightness of the light.
 ATTR_BRIGHTNESS = "brightness"
 
-# bool to determine if we should just change the state and leave the lights power unchanged
+# bool to determine if we should just change the light state.
 ATTR_POWER_UNCHANGED = 'power_unchanged'
 
 # String representing a profile (built-in ones or external defined).
@@ -111,7 +111,7 @@ def is_on(hass, entity_id=None):
 
 
 # pylint: disable=too-many-arguments
-def turn_on(hass, entity_id=None, transition=None, brightness=None,
+def turn_on(hass, entity_id=None, transition=None, brightness=None, power_unchanged=None,
             rgb_color=None, xy_color=None, color_temp=None, profile=None,
             flash=None, effect=None, color_name=None):
     """Turn all or specified light on."""
@@ -292,4 +292,3 @@ class Light(ToggleEntity):
                     data[ATTR_BRIGHTNESS])
 
         return data
-

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -42,6 +42,9 @@ ATTR_COLOR_NAME = "color_name"
 # int with value 0 .. 255 representing brightness of the light.
 ATTR_BRIGHTNESS = "brightness"
 
+# bool to determine if we should just change the state and leave the lights power unchanged
+ATTR_POWER_UNCHANGED = 'power_unchanged'
+
 # String representing a profile (built-in ones or external defined).
 ATTR_PROFILE = "profile"
 
@@ -73,6 +76,7 @@ LIGHT_TURN_ON_SCHEMA = vol.Schema({
     ATTR_PROFILE: str,
     ATTR_TRANSITION: VALID_TRANSITION,
     ATTR_BRIGHTNESS: cv.byte,
+    ATTR_POWER_UNCHANGED: cv.boolean,
     ATTR_COLOR_NAME: str,
     ATTR_RGB_COLOR: vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
                             vol.Coerce(tuple)),
@@ -123,6 +127,7 @@ def turn_on(hass, entity_id=None, transition=None, brightness=None,
             (ATTR_FLASH, flash),
             (ATTR_EFFECT, effect),
             (ATTR_COLOR_NAME, color_name),
+            (ATTR_POWER_UNCHANGED, power_unchanged),
         ] if value is not None
     }
 
@@ -287,3 +292,4 @@ class Light(ToggleEntity):
                     data[ATTR_BRIGHTNESS])
 
         return data
+

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -10,7 +10,8 @@ import colorsys
 import logging
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_POWER_UNCHANGED, ATTR_COLOR_TEMP, ATTR_RGB_COLOR, ATTR_TRANSITION, Light)
+    ATTR_BRIGHTNESS, ATTR_POWER_UNCHANGED, ATTR_COLOR_TEMP, 
+    ATTR_RGB_COLOR, ATTR_TRANSITION, Light)
 from homeassistant.helpers.event import track_time_change
 
 _LOGGER = logging.getLogger(__name__)
@@ -272,4 +273,3 @@ class LIFXLight(Light):
                       hue, sat, bri, kel, red, green, blue)
 
         self._rgb = [red, green, blue]
-

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -10,7 +10,7 @@ import colorsys
 import logging
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_RGB_COLOR, ATTR_TRANSITION, Light)
+    ATTR_BRIGHTNESS, ATTR_POWER_UNCHANGED, ATTR_COLOR_TEMP, ATTR_RGB_COLOR, ATTR_TRANSITION, Light)
 from homeassistant.helpers.event import track_time_change
 
 _LOGGER = logging.getLogger(__name__)
@@ -208,6 +208,11 @@ class LIFXLight(Light):
         else:
             brightness = self._bri
 
+        if ATTR_POWER_UNCHANGED in kwargs:
+            power_unchanged = kwargs[ATTR_POWER_UNCHANGED]
+        else:
+            power_unchanged = 0
+
         if ATTR_COLOR_TEMP in kwargs:
             # pylint: disable=fixme
             # TODO: Use color_temperature_mired_to_kelvin from util.color
@@ -217,11 +222,13 @@ class LIFXLight(Light):
         else:
             kelvin = self._kel
 
+
+
         _LOGGER.debug("turn_on: %s (%d) %d %d %d %d %d",
                       self._ip, self._power,
                       hue, saturation, brightness, kelvin, fade)
 
-        if self._power == 0:
+        if self._power == 0 and power_unchanged == 0:
             self._liffylights.set_power(self._ip, 65535, fade)
 
         self._liffylights.set_color(self._ip, hue, saturation,
@@ -265,3 +272,4 @@ class LIFXLight(Light):
                       hue, sat, bri, kel, red, green, blue)
 
         self._rgb = [red, green, blue]
+


### PR DESCRIPTION
Code changes allow for lifx bulbs to change their state such as
brightness, hue, and color, without changing the power state of the
bulb.
