### PR TITLE
Upgrade paho-mqtt to 1.2

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -29,7 +29,7 @@ MQTT_CLIENT = None
 SERVICE_PUBLISH = 'publish'
 EVENT_MQTT_MESSAGE_RECEIVED = 'mqtt_message_received'
 
-REQUIREMENTS = ['paho-mqtt==1.1']
+REQUIREMENTS = ['paho-mqtt==1.2']
 
 CONF_EMBEDDED = 'embedded'
 CONF_BROKER = 'broker'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -197,7 +197,7 @@ neurio==0.2.10
 orvibo==1.1.1
 
 # homeassistant.components.mqtt
-paho-mqtt==1.1
+paho-mqtt==1.2
 
 # homeassistant.components.media_player.panasonic_viera
 panasonic_viera==0.2


### PR DESCRIPTION
v1.2 - 2016-06-03
- Client.publish() now returns an MQTTMessageInfo object. The MQTTMessageInfo   object behaves like a tuple of (rc, mid) for backwards compatibility but   also provides two functions: is_published() and wait_for_published(). This allows a client to determine whether any given message has been published without need for a callback, and also allows the client to block waiting until the message has been sent.
- Further fix for Client constructor for the case where "localhost" is unresolvable.
- Add paho.mqtt.subscribe module, with simple() and callback() helper functions.
- Allow ^C to interrupt client loop.
- Fix for keepalive=0 causing an infinite disconnect/reconnect loop. 
- Modify callbacks definition/structure to allow classical inheritence.
- Add websockets support.
- Default MQTT version is again changed to v3.1.1.
- Client.subscribe() now accepts unicode type topic inputs on Python 2. 
- paho.mqtt.publish() now raises an MQTTException on a CONNECT failure, rather  than blindly continuing.
- Don't block on TLS sockets on Python 3
- Client.publish() now accepts bytes() payloads on Python 3.
- Don't attempt to join() own thread.
- Allow the use of Client.message_callback_add() from inside callbacks.
- Use a monotonic time source for keeping track of time, if available.

Tested with the following configuration:

``` yaml
mqtt:

binary_sensor:
  - platform: mqtt
    name: Bathroom door
    state_topic: "home/bathroom/door"
    payload_on: "ON"
    payload_off: "OFF"
    sensor_class: opening

sensor:
  - platform: mqtt
    state_topic: "home/kitchen/temperature"
    name: "Kitchen Temperature"
    unit_of_measurement: "°C"

switch:
  - platform: mqtt
    name: "Power Office"
    state_topic: "home/power01"
    command_topic: "home/power01/set"
    payload_on: "1"
    payload_off: "0"
```

Message sent with `mosquitto_pub`.

``` bash
$ mosquitto_pub -h localhost -V mqttv311 -t "home/bathroom/door" -m ON
$ mosquitto_pub -h localhost -V mqttv311 -t "home/bathroom/door" -m OFF

16-06-20 16:38:07 INFO (Thread-4) [homeassistant.core] Bus:Handling <Event mqtt_message_received[L]: topic=home/bathroom/door, payload=ON, qos=0>
16-06-20 16:38:07 INFO (ThreadPool Worker 17) [homeassistant.core] Bus:Handling <Event state_changed[L]: old_state=<state binary_sensor.bathroom_door=off; sensor_class=opening, friendly_name=Bathroom door @ 2016-06-20T16:36:55.215345+02:00>, entity_id=binary_sensor.bathroom_door, new_state=<state binary_sensor.bathroom_door=on; sensor_class=opening, friendly_name=Bathroom door @ 2016-06-20T16:38:07.656739+02:00>>
16-06-20 16:38:15 INFO (Thread-4) [homeassistant.core] Bus:Handling <Event mqtt_message_received[L]: topic=home/bathroom/door, payload=OFF, qos=0>
16-06-20 16:38:15 INFO (ThreadPool Worker 10) [homeassistant.core] Bus:Handling <Event state_changed[L]: old_state=<state binary_sensor.bathroom_door=on; sensor_class=opening, friendly_name=Bathroom door @ 2016-06-20T16:38:07.656739+02:00>, entity_id=binary_sensor.bathroom_door, new_state=<state binary_sensor.bathroom_door=off; sensor_class=opening, friendly_name=Bathroom door @ 2016-06-20T16:38:15.178655+02:00>>
```

``` bash
16-06-20 16:41:07 INFO (WSGI-server) [homeassistant.core] Bus:Handling <Event call_service[L]: service_data=entity_id=switch.power_office, service=turn_on, domain=homeassistant, service_call_id=139769310997752-1>
16-06-20 16:41:07 INFO (ThreadPool Worker 9) [homeassistant.core] Bus:Handling <Event call_service[L]: service_data=entity_id=['switch.power_office'], service=turn_on, domain=switch, service_call_id=139769310997752-2>
16-06-20 16:41:07 INFO (ThreadPool Worker 11) [homeassistant.core] Bus:Handling <Event call_service[L]: service_data=payload=1, qos=0, topic=home/power01/set, retain=False, service=publish, domain=mqtt, service_call_id=139769310997752-3>

$ mosquitto_sub -h localhost -V mqttv311 -d -v -t "home/#"
[...]
Client mosqsub/9137-laptop019 received PUBLISH (d0, q0, r0, m0, 'home/power01/set', ... (1 bytes))
home/power01/set 1
```

``` bash
16-06-20 16:45:34 INFO (Thread-4) [homeassistant.core] Bus:Handling <Event mqtt_message_received[L]: qos=0, topic=home/kitchen/temperature, payload=19>

$ mosquitto_sub -h localhost -V mqttv311 -d -v -t "home/#"
[...]
Client mosqsub/9722-laptop019 received PUBLISH (d0, q0, r0, m0, 'home/kitchen/temperature', ... (2 bytes))
home/kitchen/temperature 19
```

I would like to see a couple of :+1: because this is an update of a major component and only tested with HBMQTT and the configuration above. Thanks.
