### PR TITLE
Simplify Let's Encrypt support

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -29,6 +29,10 @@ def setup(hass, config):
         "/robots.txt",
         os.path.join(www_static_path, "robots.txt")
     )
+    hass.wsgi.register_static_path(
+        "/.well-known",
+        os.path.join(www_static_path, ".well-known")
+    )
     hass.wsgi.register_static_path("/static", www_static_path)
     hass.wsgi.register_static_path("/local", hass.config.path('www'))
 


### PR DESCRIPTION
**Description:**
Allow to use webroot functionality of certbot and then automate certificate renewal.

Current procedure require to stop webserver, run certbot then restart
the webserver.
Instead, we can use the webroot fonctionnality of certbot like that:
certbot certonly --agree-tos --renew-by-default --webroot -w
PATH_TO_INSTALL/homeassistant/components/frontend/www_static/
-d home.xxxxx --email xxx@xxx
And then just reload webserver and thus avoid a down time
