### PR TITLE
Upgrade psutil to 4.3.0

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -10,7 +10,7 @@ import homeassistant.util.dt as dt_util
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['psutil==4.2.0']
+REQUIREMENTS = ['psutil==4.3.0']
 SENSOR_TYPES = {
     'disk_use_percent': ['Disk Use', '%', 'mdi:harddisk'],
     'disk_use': ['Disk Use', 'GiB', 'mdi:harddisk'],

--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -1,5 +1,5 @@
 """
-Support for monitoring the local system..
+Support for monitoring the local system.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.systemmonitor/

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -218,7 +218,7 @@ plexapi==1.1.0
 proliphix==0.1.0
 
 # homeassistant.components.sensor.systemmonitor
-psutil==4.2.0
+psutil==4.3.0
 
 # homeassistant.components.notify.pushbullet
 pushbullet.py==0.10.0


### PR DESCRIPTION
#4.3.0 - 2016-06-18

**Enhancements**
- [Linux] different speedup improvements:
  Process.ppid() is 20% faster
  Process.status() is 28% faster
  Process.name() is 25% faster
  Process.num_threads is 20% faster on Python 3

**Bug fixes**
- [Windows] Windows wheels are incompatible with pip 7.1.2.
- [NetBSD] fix compilation on NetBSD-5.x.
- [NetBSD] virtual_memory() raises TypeError on Python 3.
- [UNIX] psutil.disk_usage() percent field takes root reserved space into account.
- [Windows] fixed net_io_counter() values wrapping after 4.3GB in Windows Vista (NT 6.0) and above using 64bit values from newer win APIs.

Tested with the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
      - type: 'memory_use_percent'
      - type: 'memory_use'
      - type: 'memory_free'
      - type: 'swap_use_percent'
      - type: 'swap_use'
      - type: 'swap_free'
      - type: 'network_in'
        arg: 'wlp1s0'
      - type: 'network_out'
        arg: 'wlp1s0'
      - type: 'packets_in'
        arg: 'wlp1s0'
      - type: 'packets_out'
        arg: 'wlp1s0'
      - type: 'ipv4_address'
        arg: 'wlp1s0'
      - type: 'ipv6_address'
        arg: 'wlp1s0'
      - type: 'processor_use'
      - type: 'last_boot'
      - type: 'since_last_boot'
```
