### PR TITLE
Log successful and failed login attempts

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -1,4 +1,9 @@
-"""This module provides WSGI application to serve the Home Assistant API."""
+"""
+This module provides WSGI application to serve the Home Assistant API.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/http/
+"""
 import hmac
 import json
 import logging
@@ -19,7 +24,7 @@ import homeassistant.util.dt as dt_util
 import homeassistant.helpers.config_validation as cv
 
 DOMAIN = "http"
-REQUIREMENTS = ("eventlet==0.19.0", "static3==0.7.0", "Werkzeug==0.11.5",)
+REQUIREMENTS = ("eventlet==0.19.0", "static3==0.7.0", "Werkzeug==0.11.5")
 
 CONF_API_PASSWORD = "api_password"
 CONF_SERVER_HOST = "server_host"
@@ -395,7 +400,12 @@ class HomeAssistantView(object):
                                  self.hass.wsgi.api_password):
             authenticated = True
 
-        if self.requires_auth and not authenticated:
+        if authenticated:
+            _LOGGER.info('Successful login/request from %s',
+                         request.remote_addr)
+        elif self.requires_auth and not authenticated:
+            _LOGGER.warning('Login attempt or request with an invalid'
+                            'password from %s', request.remote_addr)
             raise Unauthorized()
 
         request.authenticated = authenticated


### PR DESCRIPTION
**Description:**
This is basically the same feature which was introduced with #1558. Instead of only showing:

``` bash
16-06-21 21:31:35 INFO (WSGI-server) [homeassistant.components.http] 127.0.0.1 - - [21/Jun/2016 21:31:35] "GET /api/bootstrap HTTP/1.1" 200 14754 0.001991
```

and 

``` bash
16-06-21 21:51:35 INFO (WSGI-server) [homeassistant.components.http] 127.0.0.1 - - [21/Jun/2016 21:51:35] "GET /api/bootstrap HTTP/1.1" 401 186 0.001866
```

There will be a human-readable log entry with the source additionally to the 200/401 HTTP message.

``` bash
16-06-21 21:31:35 INFO (WSGI-server) [homeassistant.components.http] Successful login from 127.0.0.1
```

or 

```
16-06-21 21:51:35 WARNING (WSGI-server) [homeassistant.components.http] Login attempt with an invalid password from 127.0.0.1
```

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
http:
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
