### PR TITLE
add cec component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -94,6 +94,7 @@ omit =
     homeassistant/components/camera/generic.py
     homeassistant/components/camera/mjpeg.py
     homeassistant/components/camera/rpi_camera.py
+    homeassistant/components/cec.py
     homeassistant/components/device_tracker/actiontec.py
     homeassistant/components/device_tracker/aruba.py
     homeassistant/components/device_tracker/asuswrt.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -94,7 +94,6 @@ omit =
     homeassistant/components/camera/generic.py
     homeassistant/components/camera/mjpeg.py
     homeassistant/components/camera/rpi_camera.py
-    homeassistant/components/cec.py
     homeassistant/components/device_tracker/actiontec.py
     homeassistant/components/device_tracker/aruba.py
     homeassistant/components/device_tracker/asuswrt.py
@@ -115,6 +114,7 @@ omit =
     homeassistant/components/downloader.py
     homeassistant/components/feedreader.py
     homeassistant/components/garage_door/wink.py
+    homeassistant/components/hdmi_cec.py
     homeassistant/components/ifttt.py
     homeassistant/components/keyboard.py
     homeassistant/components/light/blinksticklight.py

--- a/homeassistant/components/cec.py
+++ b/homeassistant/components/cec.py
@@ -1,0 +1,120 @@
+"""
+CEC platform.
+
+Requires libcec + Python bindings.
+"""
+
+import logging
+import voluptuous as vol
+from homeassistant.const import EVENT_HOMEASSISTANT_START
+import homeassistant.helpers.config_validation as cv
+
+
+_LOGGER = logging.getLogger(__name__)
+_CEC = None
+DOMAIN = 'cec'
+SERVICE_SELECT_DEVICE = 'select_device'
+SERVICE_POWER_ON = 'power_on'
+SERVICE_STANDBY = 'standby'
+CONF_DEVICES = 'devices'
+ATTR_DEVICE = 'device'
+MAX_DEPTH = 4
+
+
+# pylint: disable=unnecessary-lambda
+DEVICE_SCHEMA = vol.Schema({
+    vol.All(cv.positive_int): vol.Any(lambda devices: DEVICE_SCHEMA(devices),
+                                      cv.string)
+})
+
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_DEVICES): DEVICE_SCHEMA
+})
+
+
+def parse_mapping(mapping, parents=None):
+    """Parse configuration device mapping."""
+    if parents is None:
+        parents = []
+    for addr, val in mapping.items():
+        cur = parents + [str(addr)]
+        if isinstance(val, dict):
+            yield from parse_mapping(val, cur)
+        elif isinstance(val, str):
+            yield (val, cur)
+
+
+def pad_physical_address(addr):
+    """Right-pad a physical address"""
+    return addr + ['0'] * (MAX_DEPTH - len(addr))
+
+
+def setup(hass, config):
+    """Setup CEC capability."""
+    global _CEC
+
+    # cec is only available if libcec is properly installed
+    # and the Python bindings are accessible.
+    try:
+        import cec
+    except ImportError:
+        _LOGGER.error("libcec must be installed")
+        return False
+
+    # Parse configuration into a dict of device name
+    # to physical address represented as a list of
+    # four elements.
+    flat = {}
+    for pair in parse_mapping(config[DOMAIN][0].get(CONF_DEVICES, {})):
+        flat[pair[0]] = pad_physical_address(pair[1])
+
+    # Configure libcec.
+    cfg = cec.libcec_configuration()
+    cfg.strDeviceName = 'HASS'
+    cfg.bActivateSource = 0
+    cfg.bMonitorOnly = 1
+    cfg.clientVersion = cec.LIBCEC_VERSION_CURRENT
+
+    # Set up CEC adapter.
+    _CEC = cec.ICECAdapter.Create(cfg)
+
+    def _power_on(call):
+        """Power on all devices."""
+        _CEC.PowerOnDevices()
+
+    def _standby(call):
+        """Standby all devices."""
+        _CEC.StandbyDevices()
+
+    def _select_device(call):
+        """Select the active device."""
+        path = flat.get(call.data[ATTR_DEVICE])
+        if not path:
+            _LOGGER.error("Device not found: %s", call.data[ATTR_DEVICE])
+        cmds = []
+        for i in range(1, MAX_DEPTH - 1):
+            addr = pad_physical_address(path[:i])
+            cmds.append('1f:82:{}{}:{}{}'.format(*addr))
+            cmds.append('1f:86:{}{}:{}{}'.format(*addr))
+        for cmd in cmds:
+            _CEC.Transmit(_CEC.CommandFromString(cmd))
+        _LOGGER.info("Selected %s", call.data[ATTR_DEVICE])
+
+    def _start_cec(event):
+        """Open CEC adapter."""
+        adapters = _CEC.DetectAdapters()
+        if len(adapters) == 0:
+            _LOGGER.error("No CEC adapter found")
+            return
+
+        if _CEC.Open(adapters[0].strComName):
+            hass.services.register(DOMAIN, SERVICE_POWER_ON, _power_on)
+            hass.services.register(DOMAIN, SERVICE_STANDBY, _standby)
+            hass.services.register(DOMAIN, SERVICE_SELECT_DEVICE,
+                                   _select_device)
+        else:
+            _LOGGER.error("Failed to open adapter")
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, _start_cec)
+    return True

--- a/homeassistant/components/cec.py
+++ b/homeassistant/components/cec.py
@@ -46,7 +46,7 @@ def parse_mapping(mapping, parents=None):
 
 
 def pad_physical_address(addr):
-    """Right-pad a physical address"""
+    """Right-pad a physical address."""
     return addr + ['0'] * (MAX_DEPTH - len(addr))
 
 

--- a/homeassistant/components/hdmi_cec.py
+++ b/homeassistant/components/hdmi_cec.py
@@ -1,5 +1,5 @@
 """
-CEC platform.
+CEC component.
 
 Requires libcec + Python bindings.
 """
@@ -12,7 +12,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 _CEC = None
-DOMAIN = 'cec'
+DOMAIN = 'hdmi_cec'
 SERVICE_SELECT_DEVICE = 'select_device'
 SERVICE_POWER_ON = 'power_on'
 SERVICE_STANDBY = 'standby'
@@ -28,8 +28,10 @@ DEVICE_SCHEMA = vol.Schema({
 })
 
 
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_DEVICES): DEVICE_SCHEMA
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_DEVICES): DEVICE_SCHEMA
+    })
 })
 
 

--- a/homeassistant/components/hdmi_cec.py
+++ b/homeassistant/components/hdmi_cec.py
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_DEVICES): DEVICE_SCHEMA
     })
-})
+}, extra=vol.ALLOW_EXTRA)
 
 
 def parse_mapping(mapping, parents=None):
@@ -68,7 +68,7 @@ def setup(hass, config):
     # to physical address represented as a list of
     # four elements.
     flat = {}
-    for pair in parse_mapping(config[DOMAIN][0].get(CONF_DEVICES, {})):
+    for pair in parse_mapping(config[DOMAIN].get(CONF_DEVICES, {})):
         flat[pair[0]] = pad_physical_address(pair[1])
 
     # Configure libcec.


### PR DESCRIPTION
**Description:**
The CEC component provides a service that allows selecting the active device. `libcec` must be installed for this platform to work. Devices are defined in the configuration file by associating HDMI port number and a device name. Connected devices that provide further HDMI ports, such as Soundbars and AVRs are also supported. Devices are listed from the perspective of the CEC-enabled Home Assistant device. Any connected device can be listed, regardless of whether it supports CEC. Ideally the HDMI port number on your device will map correctly the CEC physical address. If it does not, use `cec-client` to listen to traffic on the CEC bus and discover the correct numbers.

In the following example, a Pi Zero running Home Assistant is on a TV's HDMI port 1. HDMI port 2 is attached to a AV receiver. Three devices are attached to the AV receiver on HDMI ports 1 through 3.

This PR achieves the minimum integration and provides a component for further development. Consider the following enhancements:
- Sensor entity per CEC-enabled device
- Media player entity per CEC-enabled device (control via simulated remote key presses)
- Services for various obscure CEC commands

Related PR: https://github.com/home-assistant/home-assistant/pull/801 - Thanks to @lukas-hetzenecker for laying some groundwork

Documentation PR: https://github.com/home-assistant/home-assistant.io/pull/585

Note that `libcec` is a dependency, but I can't add it since it isn't in available via `pip install`.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
hdmi_cec:
  devices:
    1: Pi Zero
    2:
      1: Fire TV Stick
      2: Chromecast
      3: Another Device
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies are only imported inside functions that use them.
- [x] New files were added to `.coveragerc`.
