### PR TITLE
Fix error log

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -437,7 +437,7 @@ class HomeAssistantView(object):
                 mimetype = mimetypes.guess_type(fil)[0]
 
             try:
-                fil = open(fil)
+                fil = open(fil, mode='br')
             except IOError:
                 raise NotFound()
 

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -225,7 +225,7 @@ class TestAPI(unittest.TestCase):
 
     def test_api_get_error_log(self):
         """Test the return of the error log."""
-        test_content = 'Test String'
+        test_content = 'Test String°'
         with tempfile.NamedTemporaryFile() as log:
             log.write(test_content.encode('utf-8'))
             log.flush()


### PR DESCRIPTION
**Description:**
Fix fetching an error log in the about screen when the error log contains non-ascii characters.

**Related issue (if applicable):** fixes #2337 
https://www.pivotaltracker.com/story/show/121194985

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
