### PR TITLE
add reload core config service

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -25,8 +25,8 @@ from homeassistant.const import (
     TEMP_CELSIUS, TEMP_FAHRENHEIT, PLATFORM_FORMAT, __version__)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
-    event_decorators, service, config_per_platform, extract_domain_configs)
-from homeassistant.helpers.entity import Entity
+    event_decorators, service, config_per_platform, extract_domain_configs,
+    entity)
 
 _LOGGER = logging.getLogger(__name__)
 _SETUP_LOCK = RLock()
@@ -412,8 +412,7 @@ def process_ha_core_config(hass, config):
     if CONF_TIME_ZONE in config:
         set_time_zone(config.get(CONF_TIME_ZONE))
 
-    for entity_id, attrs in config.get(CONF_CUSTOMIZE).items():
-        Entity.overwrite_attribute(entity_id, attrs.keys(), attrs.values())
+    entity.set_customize(config.get(CONF_CUSTOMIZE))
 
     if CONF_TEMPERATURE_UNIT in config:
         hac.temperature_unit = config[CONF_TEMPERATURE_UNIT]

--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -19,6 +19,8 @@ from homeassistant.const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+SERVICE_RELOAD_CORE_CONFIG = 'reload_core_config'
+
 
 def is_on(hass, entity_id=None):
     """Load up the module to call the is_on method.
@@ -73,6 +75,11 @@ def toggle(hass, entity_id=None, **service_data):
     hass.services.call(ha.DOMAIN, SERVICE_TOGGLE, service_data)
 
 
+def reload_core_config(hass):
+    """Reload the core config."""
+    hass.services.call(ha.DOMAIN, SERVICE_RELOAD_CORE_CONFIG)
+
+
 def setup(hass, config):
     """Setup general services related to Home Assistant."""
     def handle_turn_service(service):
@@ -110,5 +117,22 @@ def setup(hass, config):
     hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, handle_turn_service)
     hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, handle_turn_service)
     hass.services.register(ha.DOMAIN, SERVICE_TOGGLE, handle_turn_service)
+
+    def handle_reload_config(call):
+        """Service handler for reloading core config."""
+        from homeassistant.exceptions import HomeAssistantError
+        from homeassistant import config, bootstrap
+
+        try:
+            path = config.find_config_file(hass.config.config_dir)
+            conf = config.load_yaml_config_file(path)
+        except HomeAssistantError as err:
+            _LOGGER.error(err)
+            return
+
+        bootstrap.process_ha_core_config(hass, conf.get(ha.DOMAIN) or {})
+
+    hass.services.register(ha.DOMAIN, SERVICE_RELOAD_CORE_CONFIG,
+                           handle_reload_config)
 
     return True

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -149,9 +149,9 @@ def load_yaml_config_file(config_path):
     conf_dict = load_yaml(config_path)
 
     if not isinstance(conf_dict, dict):
-        _LOGGER.error(
-            'The configuration file %s does not contain a dictionary',
+        msg = 'The configuration file {} does not contain a dictionary'.format(
             os.path.basename(config_path))
-        raise HomeAssistantError()
+        _LOGGER.error(msg)
+        raise HomeAssistantError(msg)
 
     return conf_dict

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -1,6 +1,6 @@
 """An abstract class for entities."""
+import logging
 import re
-from collections import defaultdict
 
 from homeassistant.const import (
     ATTR_ASSUMED_STATE, ATTR_FRIENDLY_NAME, ATTR_HIDDEN, ATTR_ICON,
@@ -10,8 +10,10 @@ from homeassistant.const import (
 from homeassistant.exceptions import NoEntitySpecifiedError
 from homeassistant.util import ensure_unique_string, slugify
 
-# Dict mapping entity_id to a boolean that overwrites the hidden property
-_OVERWRITE = defaultdict(dict)
+# Entity attributes that we will overwrite
+_OVERWRITE = {}
+
+_LOGGER = logging.getLogger(__name__)
 
 # Pattern for validating entity IDs (format: <domain>.<entity>)
 ENTITY_ID_PATTERN = re.compile(r"^(\w+)\.(\w+)$")
@@ -22,12 +24,19 @@ def generate_entity_id(entity_id_format, name, current_ids=None, hass=None):
     name = (name or DEVICE_DEFAULT_NAME).lower()
     if current_ids is None:
         if hass is None:
-            raise RuntimeError("Missing required parameter currentids or hass")
+            raise ValueError("Missing required parameter currentids or hass")
 
         current_ids = hass.states.entity_ids()
 
     return ensure_unique_string(
         entity_id_format.format(slugify(name)), current_ids)
+
+
+def set_customize(customize):
+    """Overwrite all current customize settings."""
+    global _OVERWRITE
+
+    _OVERWRITE = {key.lower(): val for key, val in customize.items()}
 
 
 def split_entity_id(entity_id):
@@ -207,20 +216,6 @@ class Entity(object):
         """Return the representation."""
         return "<Entity {}: {}>".format(self.name, self.state)
 
-    @staticmethod
-    def overwrite_attribute(entity_id, attrs, vals):
-        """Overwrite any attribute of an entity.
-
-        This function should receive a list of attributes and a
-        list of values. Set attribute to None to remove any overwritten
-        value in place.
-        """
-        for attr, val in zip(attrs, vals):
-            if val is None:
-                _OVERWRITE[entity_id.lower()].pop(attr, None)
-            else:
-                _OVERWRITE[entity_id.lower()][attr] = val
-
 
 class ToggleEntity(Entity):
     """An abstract class for entities that can be turned on and off."""
@@ -238,11 +233,13 @@ class ToggleEntity(Entity):
 
     def turn_on(self, **kwargs):
         """Turn the entity on."""
-        pass
+        _LOGGER.warning('Method turn_on not implemented for %s',
+                        self.entity_id)
 
     def turn_off(self, **kwargs):
         """Turn the entity off."""
-        pass
+        _LOGGER.warning('Method turn_off not implemented for %s',
+                        self.entity_id)
 
     def toggle(self, **kwargs):
         """Toggle the entity off."""


### PR DESCRIPTION
**Description:**
Add a new service `homeassistant/reload_core_config` which will reload the `[homeassistant]` part of `configuration.yaml` (which includes `customize`) and applies it.

Changes to customize attributes on entities will not be reflected until the next time that related entities update.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
