### PR TITLE
[notify.pushover] Fix 'NoneType' error on data retrieval

### DIFF
--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -51,10 +51,8 @@ class PushoverNotificationService(BaseNotificationService):
         """Send a message to a user."""
         from pushover import RequestError
 
-        data_ref = kwargs.get(ATTR_DATA)
-
-        # Make a copy and use empty dict if necessary (thanks @balloob)
-        data = dict(data_ref) if data_ref else {}
+        # Make a copy and use empty dict if necessary
+        data = dict(kwargs.get(ATTR_DATA) or {})
 
         data['title'] = kwargs.get(ATTR_TITLE)
 

--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -51,10 +51,13 @@ class PushoverNotificationService(BaseNotificationService):
         """Send a message to a user."""
         from pushover import RequestError
 
-        # Make a copy and use empty dict as default value (thanks @balloob)
-        data = dict(kwargs.get(ATTR_DATA, {}))
+        data_ref = kwargs.get(ATTR_DATA)
+
+        # Make a copy and use empty dict if necessary (thanks @balloob)
+        data = dict(data_ref) if data_ref else {}
 
         data['title'] = kwargs.get(ATTR_TITLE)
+
         target = kwargs.get(ATTR_TARGET)
         if target is not None:
             data['device'] = target


### PR DESCRIPTION
**Description:**
Previous code causes a `'NoneType' object is not iterable` error when no `data:` config is provided to Pushover.

**Related issue (if applicable):** fixes #2309 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
automation:
  alias: Garage Door is Open
  trigger:
    platform: state
    entity_id: sensor.garage_door
    state: 'open'
  action:
    service: notify.pushover
    data:
      title: Garage Door
      message: The garage door is open.
      target: iPhone,MacBookPro
      data:
        url: https://home-assistant.io/
        url_title: Home Assistant
        priority: 1
        timestamp: 1466024112
        sound: siren
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
