### PR TITLE
Allow service data to be passed to shell_command

### DIFF
--- a/homeassistant/components/shell_command.py
+++ b/homeassistant/components/shell_command.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/shell_command/
 """
 import logging
 import subprocess
+import shlex
 
 import voluptuous as vol
 
@@ -22,8 +23,6 @@ CONFIG_SCHEMA = vol.Schema({
         cv.slug: cv.string,
     }),
 }, extra=vol.ALLOW_EXTRA)
-
-SHELL_COMMAND_SCHEMA = vol.Schema({})
 
 
 def setup(hass, config):
@@ -44,8 +43,7 @@ def setup(hass, config):
             _LOGGER.exception('Error running command: %s', cmd)
 
     for name in conf.keys():
-        hass.services.register(DOMAIN, name, service_handler,
-                               schema=SHELL_COMMAND_SCHEMA)
+        hass.services.register(DOMAIN, name, service_handler)
     return True
 
 
@@ -64,6 +62,6 @@ def _parse_command(hass, cmd, variables):
         shell = True
     else:
         # template used. Must break into list and use shell=False for security
-        cmd = [prog] + rendered_args.split()
+        cmd = [prog] + shlex.split(rendered_args)
         shell = False
     return cmd, shell


### PR DESCRIPTION
**Description:**
Remove the shell command schema so that service data can successfully be passed to the shell command.
Parse args with `shlex` instead, allowing spaces to be used in the variable data that is passed.

**Related issue (if applicable):** fixes #2268 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
shell_command:
  garage_opened: './garage_opened.sh --device="{{ device }}" --door={{ door }}'


automation:
  alias: Garage Door is Open
  trigger:
    platform: state
    entity_id: sensor.garage_door
    state: 'open'
  action:
    service: shell_command.garage_opened
    data:
      device: Garage Door
      door: 1
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
