### PR TITLE
Push State

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -204,12 +204,12 @@ class APIEntityStateView(HomeAssistantView):
             return self.json_message('No state specified', HTTP_BAD_REQUEST)
 
         attributes = request.json.get('attributes')
-        push_state = request.json.get('push_state', False)
+        force_update = request.json.get('force_update', False)
 
         is_new_state = self.hass.states.get(entity_id) is None
 
         # Write state
-        self.hass.states.set(entity_id, new_state, attributes, push_state)
+        self.hass.states.set(entity_id, new_state, attributes, force_update)
 
         # Read the state back for our response
         resp = self.json(self.hass.states.get(entity_id))

--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -204,11 +204,12 @@ class APIEntityStateView(HomeAssistantView):
             return self.json_message('No state specified', HTTP_BAD_REQUEST)
 
         attributes = request.json.get('attributes')
+        push_state = request.json.get('push_state', False)
 
         is_new_state = self.hass.states.get(entity_id) is None
 
         # Write state
-        self.hass.states.set(entity_id, new_state, attributes)
+        self.hass.states.set(entity_id, new_state, attributes, push_state)
 
         # Read the state back for our response
         resp = self.json(self.hass.states.get(entity_id))

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -472,8 +472,8 @@ class StateMachine(object):
             old_state = self._states.get(entity_id)
 
             is_existing = old_state is not None
-            same_state = (is_existing and old_state.state == new_state
-                          and not push_state)
+            same_state = (is_existing and old_state.state == new_state and
+                          not push_state)
             same_attr = is_existing and old_state.attributes == attributes
 
             if same_state and same_attr:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -456,7 +456,7 @@ class StateMachine(object):
 
             return True
 
-    def set(self, entity_id, new_state, attributes=None):
+    def set(self, entity_id, new_state, attributes=None, push_state=False):
         """Set the state of an entity, add entity if it does not exist.
 
         Attributes is an optional dict to specify attributes of this state.
@@ -472,7 +472,8 @@ class StateMachine(object):
             old_state = self._states.get(entity_id)
 
             is_existing = old_state is not None
-            same_state = is_existing and old_state.state == new_state
+            same_state = (is_existing and old_state.state == new_state
+                          and not push_state)
             same_attr = is_existing and old_state.attributes == attributes
 
             if same_state and same_attr:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -456,7 +456,7 @@ class StateMachine(object):
 
             return True
 
-    def set(self, entity_id, new_state, attributes=None, push_state=False):
+    def set(self, entity_id, new_state, attributes=None, force_update=False):
         """Set the state of an entity, add entity if it does not exist.
 
         Attributes is an optional dict to specify attributes of this state.
@@ -473,7 +473,7 @@ class StateMachine(object):
 
             is_existing = old_state is not None
             same_state = (is_existing and old_state.state == new_state and
-                          not push_state)
+                          not force_update)
             same_attr = is_existing and old_state.attributes == attributes
 
             if same_state and same_attr:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -126,8 +126,8 @@ class Entity(object):
         return False
 
     @property
-    def push_state(self):
-        """Return True if state changes should be pushed.
+    def force_update(self):
+        """Return True if state updates should be forced.
 
         If True, a state change will be triggered anytime the state property is
         updated, not just when the value changes.
@@ -200,7 +200,7 @@ class Entity(object):
             state = str(state)
 
         return self.hass.states.set(
-            self.entity_id, state, attr, self.push_state)
+            self.entity_id, state, attr, self.force_update)
 
     def _attr_setter(self, name, typ, attr, attrs):
         """Helper method to populate attributes based on properties."""

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -125,6 +125,15 @@ class Entity(object):
         """Return True if unable to access real state of the entity."""
         return False
 
+    @property
+    def push_state(self):
+        """Return True if state changes should be pushed.
+
+        If True, a state change will be triggered anytime the state property is
+        updated, not just when the value changes.
+        """
+        return False
+
     def update(self):
         """Retrieve latest state."""
         pass
@@ -190,7 +199,8 @@ class Entity(object):
                     state, attr[ATTR_UNIT_OF_MEASUREMENT])
             state = str(state)
 
-        return self.hass.states.set(self.entity_id, state, attr)
+        return self.hass.states.set(
+            self.entity_id, state, attr, self.push_state)
 
     def _attr_setter(self, name, typ, attr, attrs):
         """Helper method to populate attributes based on properties."""

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -259,9 +259,9 @@ class StateMachine(ha.StateMachine):
         """
         return remove_state(self._api, entity_id)
 
-    def set(self, entity_id, new_state, attributes=None):
+    def set(self, entity_id, new_state, attributes=None, push_state=False):
         """Call set_state on remote API."""
-        set_state(self._api, entity_id, new_state, attributes)
+        set_state(self._api, entity_id, new_state, attributes, push_state)
 
     def mirror(self):
         """Discard current data and mirrors the remote state machine."""
@@ -450,7 +450,7 @@ def remove_state(api, entity_id):
         return False
 
 
-def set_state(api, entity_id, new_state, attributes=None):
+def set_state(api, entity_id, new_state, attributes=None, push_state=False):
     """Tell API to update state for entity_id.
 
     Return True if success.
@@ -458,7 +458,8 @@ def set_state(api, entity_id, new_state, attributes=None):
     attributes = attributes or {}
 
     data = {'state': new_state,
-            'attributes': attributes}
+            'attributes': attributes,
+            'push_state': push_state}
 
     try:
         req = api(METHOD_POST,

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -259,9 +259,9 @@ class StateMachine(ha.StateMachine):
         """
         return remove_state(self._api, entity_id)
 
-    def set(self, entity_id, new_state, attributes=None, push_state=False):
+    def set(self, entity_id, new_state, attributes=None, force_update=False):
         """Call set_state on remote API."""
-        set_state(self._api, entity_id, new_state, attributes, push_state)
+        set_state(self._api, entity_id, new_state, attributes, force_update)
 
     def mirror(self):
         """Discard current data and mirrors the remote state machine."""
@@ -450,7 +450,7 @@ def remove_state(api, entity_id):
         return False
 
 
-def set_state(api, entity_id, new_state, attributes=None, push_state=False):
+def set_state(api, entity_id, new_state, attributes=None, force_update=False):
     """Tell API to update state for entity_id.
 
     Return True if success.
@@ -459,7 +459,7 @@ def set_state(api, entity_id, new_state, attributes=None, push_state=False):
 
     data = {'state': new_state,
             'attributes': attributes,
-            'push_state': push_state}
+            'force_update': force_update}
 
     try:
         req = api(METHOD_POST,

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -137,6 +137,27 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(400, req.status_code)
 
     # pylint: disable=invalid-name
+    def test_api_state_change_push(self):
+        """Test if we can push a change the state of an entity."""
+        hass.states.set("test.test", "not_to_be_set")
+
+        events = []
+        hass.bus.listen(const.EVENT_STATE_CHANGED, events.append)
+
+        requests.post(_url(const.URL_API_STATES_ENTITY.format("test.test")),
+                      data=json.dumps({"state": "not_to_be_set"}),
+                      headers=HA_HEADERS)
+        hass.bus._pool.block_till_done()
+        self.assertEqual(0, len(events))
+
+        requests.post(_url(const.URL_API_STATES_ENTITY.format("test.test")),
+                      data=json.dumps({"state": "not_to_be_set",
+                                       "push_state": True}),
+                      headers=HA_HEADERS)
+        hass.bus._pool.block_till_done()
+        self.assertEqual(1, len(events))
+
+    # pylint: disable=invalid-name
     def test_api_fire_event_with_no_data(self):
         """Test if the API allows us to fire an event."""
         test_value = []

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -152,7 +152,7 @@ class TestAPI(unittest.TestCase):
 
         requests.post(_url(const.URL_API_STATES_ENTITY.format("test.test")),
                       data=json.dumps({"state": "not_to_be_set",
-                                       "push_state": True}),
+                                       "force_update": True}),
                       headers=HA_HEADERS)
         hass.bus._pool.block_till_done()
         self.assertEqual(1, len(events))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -335,6 +335,7 @@ class TestStateMachine(unittest.TestCase):
                          self.states.get('light.Bowl').last_changed)
 
     def test_push_state(self):
+        """Test push state option"""
         self.pool.add_worker()
         events = []
         self.bus.listen(EVENT_STATE_CHANGED, events.append)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -334,8 +334,8 @@ class TestStateMachine(unittest.TestCase):
         self.assertEqual(state.last_changed,
                          self.states.get('light.Bowl').last_changed)
 
-    def test_push_state(self):
-        """Test push state option"""
+    def test_force_update(self):
+        """Test force update option."""
         self.pool.add_worker()
         events = []
         self.bus.listen(EVENT_STATE_CHANGED, events.append)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -334,6 +334,19 @@ class TestStateMachine(unittest.TestCase):
         self.assertEqual(state.last_changed,
                          self.states.get('light.Bowl').last_changed)
 
+    def test_push_state(self):
+        self.pool.add_worker()
+        events = []
+        self.bus.listen(EVENT_STATE_CHANGED, events.append)
+
+        self.states.set('light.bowl', 'on')
+        self.bus._pool.block_till_done()
+        self.assertEqual(0, len(events))
+
+        self.states.set('light.bowl', 'on', None, True)
+        self.bus._pool.block_till_done()
+        self.assertEqual(1, len(events))
+
 
 class TestServiceCall(unittest.TestCase):
     """Test ServiceCall class."""

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -166,7 +166,7 @@ class TestRemoteMethods(unittest.TestCase):
         self.assertEqual(1, len(events))
 
         remote.set_state(
-            master_api, 'test.test', 'set_test_2', push_state=True)
+            master_api, 'test.test', 'set_test_2', force_update=True)
         hass.bus._pool.block_till_done()
         self.assertEqual(2, len(events))
 


### PR DESCRIPTION
**Description:**
Add ability to push state changes, even if the value has not changed. Based on [Pivotal Story #113224701](https://www.pivotaltracker.com/story/show/113224701), the following has been completed:
- [x] StateMachine.set should accept a new optional parameter to not discard a duplicate state
- [x] Entity ABC should get new boolean property to indicate if a state should always be pushed
- [ ] Platforms that we know that need this, like Z-Wave, can now overwrite that property in their sensor entity
- [x] Update Rest API for setting state
- [x] Add option to `homeassistant.remote`

I think the third check point should be in a separate PR, but if someone disagrees, I would be happy to add it in. I'm not sure what platforms need to be updated with this ability to push state, but I assume that it should be user configurable. I'm interested in adding it as an option to MQTT sensors.

**Related issue (if applicable):** fixes #1135, #1705, and [Pivotal Story #113224701](https://www.pivotaltracker.com/story/show/113224701)

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
