### PR TITLE
Fix physical manual update of state to zwave device

### DIFF
--- a/homeassistant/components/garage_door/zwave.py
+++ b/homeassistant/components/garage_door/zwave.py
@@ -51,7 +51,7 @@ class ZwaveGarageDoor(zwave.ZWaveDeviceEntity, GarageDoorDevice):
 
     def value_changed(self, value):
         """Called when a value has changed on the network."""
-        if self._value.node == value.node:
+        if self._value.value_id == value.value_id:
             self._state = value.data
             self.update_ha_state(True)
             _LOGGER.debug("Value changed on network %s", value)
@@ -59,7 +59,7 @@ class ZwaveGarageDoor(zwave.ZWaveDeviceEntity, GarageDoorDevice):
     @property
     def is_closed(self):
         """Return the current position of Zwave garage door."""
-        return self._state
+        return not self._state
 
     def close_door(self):
         """Close the garage door."""

--- a/homeassistant/components/hvac/zwave.py
+++ b/homeassistant/components/hvac/zwave.py
@@ -98,7 +98,7 @@ class ZWaveHvac(ZWaveDeviceEntity, HvacDevice):
 
     def value_changed(self, value):
         """Called when a value has changed on the network."""
-        if self._value.node == value.node:
+        if self._value.value_id == value.value_id:
             self.update_properties()
             self.update_ha_state(True)
             _LOGGER.debug("Value changed on network %s", value)

--- a/homeassistant/components/rollershutter/zwave.py
+++ b/homeassistant/components/rollershutter/zwave.py
@@ -49,7 +49,7 @@ class ZwaveRollershutter(zwave.ZWaveDeviceEntity, RollershutterDevice):
 
     def value_changed(self, value):
         """Called when a value has changed on the network."""
-        if self._value.node == value.node:
+        if self._value.value_id == value.value_id:
             self.update_ha_state(True)
             _LOGGER.debug("Value changed on network %s", value)
 

--- a/homeassistant/components/thermostat/zwave.py
+++ b/homeassistant/components/thermostat/zwave.py
@@ -81,7 +81,7 @@ class ZWaveThermostat(zwave.ZWaveDeviceEntity, ThermostatDevice):
 
     def value_changed(self, value):
         """Called when a value has changed on the network."""
-        if self._value.node == value.node:
+        if self._value.value_id == value.value_id:
             self.update_properties()
             self.update_ha_state()
 


### PR DESCRIPTION
**Description:**
Bugfix for new Rollershutter and garage door zwave. Also fix for HVAC and thermostat.
1. Fix reporting of manual state changes happening at the physical switch.
2. Wrong state reported for garage door position

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
