### PR TITLE
Remove lxml dependency

### DIFF
--- a/homeassistant/components/sensor/swiss_hydrological_data.py
+++ b/homeassistant/components/sensor/swiss_hydrological_data.py
@@ -16,7 +16,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['beautifulsoup4==4.4.1', 'lxml==3.6.0']
+REQUIREMENTS = ['beautifulsoup4==4.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = 'http://www.hydrodaten.admin.ch/en/'
@@ -148,7 +148,7 @@ class HydrologicalData(object):
 
         try:
             tables = BeautifulSoup(response.content,
-                                   'lxml').findChildren('table')
+                                   'html.parser').findChildren('table')
             rows = tables[0].findChildren(['th', 'tr'])
 
             details = []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -180,9 +180,6 @@ lightify==1.0.3
 # homeassistant.components.light.limitlessled
 limitlessled==1.0.0
 
-# homeassistant.components.sensor.swiss_hydrological_data
-lxml==3.6.0
-
 # homeassistant.components.notify.message_bird
 messagebird==1.2.0
 


### PR DESCRIPTION
**Description:**
Remove the lxml dependency.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: swiss_hydrological_data
    name: Aare
    station: 2135
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
