### PR TITLE
Depreciate ssl2/3

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -39,6 +39,7 @@ DATA_API_PASSWORD = 'api_password'
 
 # TLS configuation follows the best-practice guidelines
 # specified here: https://wiki.mozilla.org/Security/Server_Side_TLS
+# Intermediate guidelines are followed.
 SSL_VERSION = ssl.PROTOCOL_TLSv1
 CIPHERS = "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:" \
           "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:" \

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -37,7 +37,8 @@ CONF_CORS_ORIGINS = 'cors_allowed_origins'
 
 DATA_API_PASSWORD = 'api_password'
 
-# https://mozilla.github.io/server-side-tls/ssl-config-generator/
+# TLS configuation follows the best-practice guidelines
+# specified here: https://wiki.mozilla.org/Security/Server_Side_TLS
 SSL_VERSION = ssl.PROTOCOL_TLSv1
 CIPHERS = "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:" \
           "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:" \


### PR DESCRIPTION
**Description:**
Depreciate sslv2 and sslv3

```
Following the best practices as defind here:
https://mozilla.github.io/server-side-tls/ssl-config-generator/
```

**Related issue (if applicable):** fixes #2364

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**
As discussed this is not configurable. It should work with anything made in the last 10 years.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [N/A] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [N/A] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [N/A] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [N/A] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Following the best practices as defind here:
https://mozilla.github.io/server-side-tls/ssl-config-generator/
