### PR TITLE
Add Sonos unjoin functionality

### DIFF
--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -154,12 +154,20 @@ sonos_group_players:
       description: Name(s) of entites that will coordinate the grouping. Platform dependent.
       example: 'media_player.living_room_sonos'
 
+sonos_unjoin:
+  description: Unjoin the player from a group.
+
+  fields:
+    entity_id:
+      description: Name(s) of entites that will be unjoined from their group. Platform dependent.
+      example: 'media_player.living_room_sonos'
+
 sonos_snapshot:
   description: Take a snapshot of the media player.
 
   fields:
     entity_id:
-      description: Name(s) of entites that will coordinate the grouping. Platform dependent.
+      description: Name(s) of entites that will be snapshot. Platform dependent.
       example: 'media_player.living_room_sonos'
 
 sonos_restore:
@@ -167,5 +175,5 @@ sonos_restore:
 
   fields:
     entity_id:
-      description: Name(s) of entites that will coordinate the grouping. Platform dependent.
+      description: Name(s) of entites that will be restored. Platform dependent.
       example: 'media_player.living_room_sonos'


### PR DESCRIPTION
**Description:** Additional service to unjoin a Sonos device from a group.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
script:
  group_unpair:
    alias: Group/unpair demo
    sequence:
      - alias: Snapshot Group
        service: media_player.sonos_group_devices
        data:
          entity_id: media_player.lounge
      - alias: Door Bell Play Sound
        service: media_player.play_media
        data:
          entity_id: media_player.lounge
          media_content_id: http://localhost/local/media.mp3
          media_content_type: audio/mp3
      - delay:
          seconds: 6    
      - alias: Snapshot Unpair
        service: media_player.sonos_unpair
```

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
