### PR TITLE
Upgrade Werkzeug to 0.11.10

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -25,7 +25,7 @@ import homeassistant.util.dt as dt_util
 import homeassistant.helpers.config_validation as cv
 
 DOMAIN = "http"
-REQUIREMENTS = ("eventlet==0.19.0", "static3==0.7.0", "Werkzeug==0.11.5")
+REQUIREMENTS = ("eventlet==0.19.0", "static3==0.7.0", "Werkzeug==0.11.10")
 
 CONF_API_PASSWORD = "api_password"
 CONF_SERVER_HOST = "server_host"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -23,7 +23,7 @@ SoCo==0.11.1
 TwitterAPI==2.4.1
 
 # homeassistant.components.http
-Werkzeug==0.11.5
+Werkzeug==0.11.10
 
 # homeassistant.components.apcupsd
 apcaccess==0.0.4


### PR DESCRIPTION
## Version 0.11.10

Released on May 24th 2016.
- Fixed a bug that occurs when running on Python 2.6 and using a broken locale.
- Fixed a crash when running the debugger on Google App Engine.
- Fixed an issue with multipart parsing that could cause memory exhaustion.
## Version 0.11.9

Released on April 24th 2016.
- Corrected an issue that caused the debugger not to use the   machine GUID on POSIX systems.
- Corrected an Unicode error on Python 3 for the debugger's   PIN usage.
- Corrected the timestamp verification in the pin debug code.   Without this fix the pin was remembered for too long.
## Version 0.11.8

Released on April 15th 2016.
- fixed a problem with the machine GUID detection code on OS X on Python 3.
## Version 0.11.7

Released on April 14th 2016.
- fixed a regression on Python 3 for the debugger.
## Version 0.11.6

Released on April 14th 2016.
- werkzeug.serving: Still show the client address on bad requests.
- improved the PIN based protection for the debugger to make it harder to brute force via trying cookies.  Please keep in mind that the debugger  _is not intended for running on production environments_
- increased the pin timeout to a week to make it less annoying for people which should decrease the change that users disable the pin check entirely.
- werkzeug.serving: Fix broken HTTP_HOST when path starts with double slash.

Tested with the following configuration:

``` yaml
http:
  api_password: mypass
```
