### PR TITLE
Upgrade websocket-client to 0.37.0

### DIFF
--- a/homeassistant/components/media_player/gpmdp.py
+++ b/homeassistant/components/media_player/gpmdp.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     STATE_PLAYING, STATE_PAUSED, STATE_OFF)
 
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ['websocket-client==0.35.0']
+REQUIREMENTS = ['websocket-client==0.37.0']
 SUPPORT_GPMDP = SUPPORT_PAUSE | SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -410,7 +410,7 @@ vsure==0.8.1
 wakeonlan==0.2.2
 
 # homeassistant.components.media_player.gpmdp
-websocket-client==0.35.0
+websocket-client==0.37.0
 
 # homeassistant.components.zigbee
 xbee-helper==0.0.7


### PR DESCRIPTION
## ChangeLog
- 0.37.0
  - fixed failure that `websocket.create_connection` does not accept `origin` as a parameter
- 0.36.0
  - added support for using custom connection class
  - use Named logger
  - implement ping/pong timeout
  - Corrects the syntax highlight code
  - fixed failure to join thread before it is started

Tested with the following configuration:

``` yaml
media_player:
  - platform: gpmdp
    address: localhost
    name: GPMDP
```
