### PR TITLE
Upgrade influxdb to 3.0.0

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -23,7 +23,7 @@ DEFAULT_DATABASE = 'home_assistant'
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = False
 
-REQUIREMENTS = ['influxdb==2.12.0']
+REQUIREMENTS = ['influxdb==3.0.0']
 
 CONF_HOST = 'host'
 CONF_PORT = 'port'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -163,7 +163,7 @@ https://github.com/w1ll1am23/pygooglevoice-sms/archive/7c5ee9969b97a7992fc86a753
 https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 
 # homeassistant.components.influxdb
-influxdb==2.12.0
+influxdb==3.0.0
 
 # homeassistant.components.insteon_hub
 insteon_hub==0.4.5


### PR DESCRIPTION
##  v3.0.0
- New get_list_privileges() method.
- New grant_admin_privileges() method.
- _BREAKING CHANGE_ Removed get_list_series()
- Line protocol: fixed encoding issues

Tested with the following configuration:

``` yaml
influxdb:
  host: 127.0.0.1
  port: 8086
  database: home_assistant
  username: ha
  password: ha_password
```

``` bash
$ influx
Visit https://enterprise.influxdata.com to register for updates, InfluxDB server management, and monitoring.
Connected to http://localhost:8086 version 0.13.0
InfluxDB shell version: 0.13.0
>
```
