### PR TITLE
Support more types of 1wire sensors and bus masters

### DIFF
--- a/homeassistant/components/sensor/onewire.py
+++ b/homeassistant/components/sensor/onewire.py
@@ -109,7 +109,8 @@ class OneWire(Entity):
                 try:
                     temp = round(float(temp_read[0]), 1)
                 except ValueError:
-                    _LOGGER.warning('Invalid temperature value read from ' + self._device_file)
+                    _LOGGER.warning('Invalid temperature value read from ' +
+                                    self._device_file)
 
         if temp < -55 or temp > 125:
             return

--- a/homeassistant/components/sensor/onewire.py
+++ b/homeassistant/components/sensor/onewire.py
@@ -12,21 +12,24 @@ from glob import glob
 from homeassistant.const import STATE_UNKNOWN, TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 
-BASE_DIR = '/sys/bus/w1/devices/'
-DEVICE_FOLDERS = glob(os.path.join(BASE_DIR, '28*'))
-SENSOR_IDS = []
-DEVICE_FILES = []
-for device_folder in DEVICE_FOLDERS:
-    SENSOR_IDS.append(os.path.split(device_folder)[1])
-    DEVICE_FILES.append(os.path.join(device_folder, 'w1_slave'))
-
 _LOGGER = logging.getLogger(__name__)
 
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the one wire Sensors."""
-    if DEVICE_FILES == []:
+    base_dir = config.get('mount_dir', '/sys/bus/w1/devices/')
+    device_folders = glob(os.path.join(base_dir, '[10,22,28,3B,42]*'))
+    sensor_ids = []
+    device_files = []
+    for device_folder in device_folders:
+        sensor_ids.append(os.path.split(device_folder)[1])
+        if base_dir.startswith('/sys/bus/w1/devices'):
+            device_files.append(os.path.join(device_folder, 'w1_slave'))
+        else:
+            device_files.append(os.path.join(device_folder, 'temperature'))
+
+    if device_files == []:
         _LOGGER.error('No onewire sensor found.')
         _LOGGER.error('Check if dtoverlay=w1-gpio,gpiopin=4.')
         _LOGGER.error('is in your /boot/config.txt and')
@@ -34,7 +37,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return
 
     devs = []
-    names = SENSOR_IDS
+    names = sensor_ids
 
     for key in config.keys():
         if key == "names":
@@ -47,9 +50,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             # map names to ids.
             elif isinstance(config['names'], dict):
                 names = []
-                for sensor_id in SENSOR_IDS:
+                for sensor_id in sensor_ids:
                     names.append(config['names'].get(sensor_id, sensor_id))
-    for device_file, name in zip(DEVICE_FILES, names):
+    for device_file, name in zip(device_files, names):
         devs.append(OneWire(name, device_file))
     add_devices(devs)
 
@@ -88,14 +91,26 @@ class OneWire(Entity):
 
     def update(self):
         """Get the latest data from the device."""
-        lines = self._read_temp_raw()
-        while lines[0].strip()[-3:] != 'YES':
-            time.sleep(0.2)
+        temp = -99
+        if self._device_file.startswith('/sys/bus/w1/devices'):
             lines = self._read_temp_raw()
-        equals_pos = lines[1].find('t=')
-        if equals_pos != -1:
-            temp_string = lines[1][equals_pos+2:]
-            temp = round(float(temp_string) / 1000.0, 1)
-            if temp < -55 or temp > 125:
-                return
-            self._state = temp
+            while lines[0].strip()[-3:] != 'YES':
+                time.sleep(0.2)
+                lines = self._read_temp_raw()
+            equals_pos = lines[1].find('t=')
+            if equals_pos != -1:
+                temp_string = lines[1][equals_pos+2:]
+                temp = round(float(temp_string) / 1000.0, 1)
+        else:
+            ds_device_file = open(self._device_file, 'r')
+            temp_read = ds_device_file.readlines()
+            ds_device_file.close()
+            if len(temp_read) == 1:
+                try:
+                    temp = round(float(temp_read[0]), 1)
+                except ValueError:
+                    _LOGGER.warning('Invalid temperature value read from ' + self._device_file)
+
+        if temp < -55 or temp > 125:
+            return
+        self._state = temp


### PR DESCRIPTION
**Description:**

**Related issue (if applicable):** fixes #2088 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: onewire
    mount_dir: "/mnt/1wire"
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
- Added support for DS18S20, DS1822, DS1825 and DS28EA00 temperature sensors
- Added support for bus masters which use fuse to mount device tree.
  Mount can be specified by 'mount_dir' configuration parameter.
