### PR TITLE
vera lock support

### DIFF
--- a/homeassistant/components/lock/vera.py
+++ b/homeassistant/components/lock/vera.py
@@ -1,0 +1,64 @@
+"""
+Support for Vera locks.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/lock.vera/
+"""
+import logging
+
+from homeassistant.components.lock import LockDevice
+from homeassistant.const import (
+    ATTR_BATTERY_LEVEL, STATE_LOCKED, STATE_UNLOCKED)
+from homeassistant.components.vera import (
+    VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
+
+DEPENDENCIES = ['vera']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Find and return Vera switches."""
+    add_devices_callback(
+        VeraLock(device, VERA_CONTROLLER) for
+        device in VERA_DEVICES['lock'])
+
+
+class VeraLock(VeraDevice, LockDevice):
+    """Representation of a Vera Lock."""
+
+    def __init__(self, vera_device, controller):
+        """Initialize the Vera device."""
+        self._state = None
+        VeraDevice.__init__(self, vera_device, controller)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the device."""
+        attr = {}
+        if self.vera_device.has_battery:
+            attr[ATTR_BATTERY_LEVEL] = self.vera_device.battery_level + '%'
+
+        attr['Vera Device Id'] = self.vera_device.vera_device_id
+        return attr
+
+    def lock(self, **kwargs):
+        """Lock."""
+        self.vera_device.lock()
+        self._state = STATE_LOCKED
+        self.update_ha_state()
+
+    def unlock(self, **kwargs):
+        """Unlock."""
+        self.vera_device.unlock()
+        self._state = STATE_UNLOCKED
+        self.update_ha_state()
+
+    @property
+    def is_locked(self):
+        """Return true if device is on."""
+        return self._state == STATE_LOCKED
+
+    def update(self):
+        """Called by the vera device callback to update state."""
+        self._state = STATE_LOCKED if self.vera_device.is_locked(True) else STATE_UNLOCKED

--- a/homeassistant/components/lock/vera.py
+++ b/homeassistant/components/lock/vera.py
@@ -61,4 +61,5 @@ class VeraLock(VeraDevice, LockDevice):
 
     def update(self):
         """Called by the vera device callback to update state."""
-        self._state = STATE_LOCKED if self.vera_device.is_locked(True) else STATE_UNLOCKED
+        self._state = (STATE_LOCKED if self.vera_device.is_locked(True)
+                       else STATE_UNLOCKED)

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -13,11 +13,12 @@ from homeassistant.helpers import discovery
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyvera==0.2.10']
+REQUIREMENTS = ['pyvera==0.2.12']
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'vera'
+
 
 VERA_CONTROLLER = None
 
@@ -33,6 +34,7 @@ DEVICE_CATEGORIES = {
     'Switch': 'switch',
     'Armable Sensor': 'switch',
     'On/Off Switch': 'switch',
+    'Doorlock': 'lock',
     # 'Window Covering': NOT SUPPORTED YET
 }
 
@@ -91,7 +93,7 @@ def setup(hass, base_config):
             dev_type = 'light'
         VERA_DEVICES[dev_type].append(device)
 
-    for component in 'binary_sensor', 'sensor', 'light', 'switch':
+    for component in 'binary_sensor', 'sensor', 'light', 'switch', 'lock':
         discovery.load_platform(hass, component, DOMAIN, {}, base_config)
 
     return True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -333,7 +333,7 @@ python-wink==0.7.7
 pyuserinput==0.1.9
 
 # homeassistant.components.vera
-pyvera==0.2.10
+pyvera==0.2.12
 
 # homeassistant.components.wemo
 pywemo==0.4.3


### PR DESCRIPTION
**Description:**

Add Vera Lock support using pyvera 0.2.12

**Related issue (if applicable):** fixes #603

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#598

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [X] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
