### PR TITLE
bump pyvera version to 0.2.13

### DIFF
--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import discovery
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyvera==0.2.12']
+REQUIREMENTS = ['pyvera==0.2.13']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -339,7 +339,7 @@ python-wink==0.7.8
 pyuserinput==0.1.9
 
 # homeassistant.components.vera
-pyvera==0.2.12
+pyvera==0.2.13
 
 # homeassistant.components.wemo
 pywemo==0.4.3


### PR DESCRIPTION
**Description:**

Bumps pyvera version to 0.2.13 to fix traceback and pyvera thread dying related to bug in 0.2.12.
