### PR TITLE
Upgrade python-telegram-bot to 4.3.1

### DIFF
--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import validate_config
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['python-telegram-bot==4.2.1']
+REQUIREMENTS = ['python-telegram-bot==4.3.1']
 
 
 def get_service(hass, config):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -320,7 +320,7 @@ python-pushover==0.2
 python-statsd==1.7.2
 
 # homeassistant.components.notify.telegram
-python-telegram-bot==4.2.1
+python-telegram-bot==4.3.1
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.2.0


### PR DESCRIPTION
v4.3.1
- Update wrong requirement: urllib3>=1.10

v4.3
- Use urllib3.PoolManager for connection re-use
- Rewrite run_async decorator to re-use threads
  - New requirements: urllib3 and certifi

Tested with the following configuration:

``` yaml
notify:
  - platform: telegram
    name: telegram
    api_key: 1234xxxxx:AAxxxxxxxg
    chat_id: 10xxxxxx
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```
