### PR TITLE
Upgrade fuzzywuzzy to 0.11.0

### DIFF
--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -27,7 +27,7 @@ SERVICE_PROCESS_SCHEMA = vol.Schema({
 
 REGEX_TURN_COMMAND = re.compile(r'turn (?P<name>(?: |\w)+) (?P<command>\w+)')
 
-REQUIREMENTS = ['fuzzywuzzy==0.10.0']
+REQUIREMENTS = ['fuzzywuzzy==0.11.0']
 
 
 def setup(hass, config):
@@ -67,8 +67,8 @@ def setup(hass, config):
             }, blocking=True)
 
         else:
-            logger.error(
-                'Got unsupported command %s from text %s', command, text)
+            logger.error('Got unsupported command %s from text %s',
+                         command, text)
 
     hass.services.register(DOMAIN, SERVICE_PROCESS, process,
                            schema=SERVICE_PROCESS_SCHEMA)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -79,7 +79,7 @@ fixerio==0.1.1
 freesms==0.1.0
 
 # homeassistant.components.conversation
-fuzzywuzzy==0.10.0
+fuzzywuzzy==0.11.0
 
 # homeassistant.components.notify.gntp
 gntp==1.0.3


### PR DESCRIPTION
0.11.0 (2016-06-30)
- Clean-up
- Improving performance
- Performance Improvement
- Fix link to Levenshtein
- Fix readme links
- Add license to StringMatcher.py

Tested with the following configuration:

``` yaml
conversation:
```

Still doesn't seems to like my accent. `penn paul office on` is not equal to `turn power office on` :-)

``` bash
16-07-02 14:08:12 ERROR (ThreadPool Worker 21) [homeassistant.components.conversation] Unable to process: penn paul office on
```
