### PR TITLE
Move Aeotec bulb color logic to Zwave workaround

### DIFF
--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -112,6 +112,39 @@ def color_xy_brightness_to_RGB(vX, vY, brightness):
     return (r, g, b)
 
 
+def _match_max_scale(input_colors, output_colors):
+    """Match the maximum value of the output to the input."""
+    max_in = max(input_colors)
+    max_out = max(output_colors)
+    if max_out == 0:
+        factor = 0
+    else:
+        factor = max_in / max_out
+    return tuple(int(round(i * factor)) for i in output_colors)
+
+
+def color_rgb_to_rgbw(r, g, b):
+    """Convert an rgb color to an rgbw representation."""
+    # Calculate the white channel as the minimum of input rgb channels.
+    # Subtract the white portion from the remaining rgb channels.
+    w = min(r, g, b)
+    rgbw = (r - w, g - w, b - w, w)
+
+    # Match the output maximum value to the input. This ensures the full
+    # channel range is used.
+    return _match_max_scale((r, g, b), rgbw)
+
+
+def color_rgbw_to_rgb(r, g, b, w):
+    """Convert an rgbw color to an rgb representation."""
+    # Add the white channel back into the rgb channels.
+    rgb = (r + w, g + w, b + w)
+
+    # Match the output maximum value to the input. This ensures the the
+    # output doesn't overflow.
+    return _match_max_scale((r, g, b, w), rgb)
+
+
 def rgb_hex_to_rgb_list(hex_string):
     """Return an RGB color value list from a hex color string."""
     return [int(hex_string[i:i + len(hex_string) // 3], 16)

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -75,6 +75,58 @@ class TestColorUtil(unittest.TestCase):
         self.assertEqual((255, 255, 255),
                          color_util.color_name_to_rgb('not a color'))
 
+    def test_color_rgb_to_rgbw(self):
+        """Test color_rgb_to_rgbw."""
+        self.assertEqual((0, 0, 0, 0),
+                         color_util.color_rgb_to_rgbw(0, 0, 0))
+
+        self.assertEqual((0, 0, 0, 255),
+                         color_util.color_rgb_to_rgbw(255, 255, 255))
+
+        self.assertEqual((255, 0, 0, 0),
+                         color_util.color_rgb_to_rgbw(255, 0, 0))
+
+        self.assertEqual((0, 255, 0, 0),
+                         color_util.color_rgb_to_rgbw(0, 255, 0))
+
+        self.assertEqual((0, 0, 255, 0),
+                         color_util.color_rgb_to_rgbw(0, 0, 255))
+
+        self.assertEqual((255, 127, 0, 0),
+                         color_util.color_rgb_to_rgbw(255, 127, 0))
+
+        self.assertEqual((255, 0, 0, 253),
+                         color_util.color_rgb_to_rgbw(255, 127, 127))
+
+        self.assertEqual((0, 0, 0, 127),
+                         color_util.color_rgb_to_rgbw(127, 127, 127))
+
+    def test_color_rgbw_to_rgb(self):
+        """Test color_rgbw_to_rgb."""
+        self.assertEqual((0, 0, 0),
+                         color_util.color_rgbw_to_rgb(0, 0, 0, 0))
+
+        self.assertEqual((255, 255, 255),
+                         color_util.color_rgbw_to_rgb(0, 0, 0, 255))
+
+        self.assertEqual((255, 0, 0),
+                         color_util.color_rgbw_to_rgb(255, 0, 0, 0))
+
+        self.assertEqual((0, 255, 0),
+                         color_util.color_rgbw_to_rgb(0, 255, 0, 0))
+
+        self.assertEqual((0, 0, 255),
+                         color_util.color_rgbw_to_rgb(0, 0, 255, 0))
+
+        self.assertEqual((255, 127, 0),
+                         color_util.color_rgbw_to_rgb(255, 127, 0, 0))
+
+        self.assertEqual((255, 127, 127),
+                         color_util.color_rgbw_to_rgb(255, 0, 0, 253))
+
+        self.assertEqual((127, 127, 127),
+                         color_util.color_rgbw_to_rgb(0, 0, 0, 127))
+
 
 class ColorTemperatureMiredToKelvinTests(unittest.TestCase):
     """Test color_temperature_mired_to_kelvin."""


### PR DESCRIPTION
**Description:**
Default behavior for warm/cold white channels is to assume the white channel is mixed with the rgb. This is a sane default and should support the Fibaro RGBW LED controller.

**Checklist:**
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
