### PR TITLE
http: check for OP_NO_COMPRESSION support before trying to use it

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -41,7 +41,9 @@ DATA_API_PASSWORD = 'api_password'
 # specified here: https://wiki.mozilla.org/Security/Server_Side_TLS
 # Intermediate guidelines are followed.
 SSL_VERSION = ssl.PROTOCOL_SSLv23
-SSL_OPTS = ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_COMPRESSION
+SSL_OPTS = ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3
+if hasattr(ssl, 'OP_NO_COMPRESSION'):
+    SSL_OPTS |= ssl.OP_NO_COMPRESSION
 CIPHERS = "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:" \
           "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:" \
           "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:" \


### PR DESCRIPTION
**Description:**
This PR changes the http component to only use ssl.OP_NO_COMPRESSION if ssl.py has support for it.  Apparently MacOS has [an old Python and/or OpenSSL](https://github.com/jkbrzt/httpie-http2/issues/6) where it is not supported, preventing HASS startup.

cc @danieljkemp

**Related issue (if applicable):** 
Should fix https://home-assistant.io/blog/2016/07/01/envisalink-homematic-hdmi-cec-and-sony-bravia-tv/#comment-2761211326 (but I don't have a mac to test in the wild, and as of this writing version details were not reported)
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
