### PR TITLE
Hotfix 0.23.1

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.entity import Entity
 from homeassistant.loader import get_component
 
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.8']
+REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
 
 # These are the available sensors mapped to binary_sensor class
 SENSOR_TYPES = {

--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.garage_door import GarageDoorDevice
 from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.8']
+REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -41,7 +41,9 @@ DATA_API_PASSWORD = 'api_password'
 # specified here: https://wiki.mozilla.org/Security/Server_Side_TLS
 # Intermediate guidelines are followed.
 SSL_VERSION = ssl.PROTOCOL_SSLv23
-SSL_OPTS = ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_COMPRESSION
+SSL_OPTS = ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3
+if hasattr(ssl, 'OP_NO_COMPRESSION'):
+    SSL_OPTS |= ssl.OP_NO_COMPRESSION
 CIPHERS = "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:" \
           "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:" \
           "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:" \

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -14,7 +14,7 @@ from homeassistant.util import color as color_util
 from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
 
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.8']
+REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.lock import LockDevice
 from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.8']
+REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/rollershutter/wink.py
+++ b/homeassistant/components/rollershutter/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.rollershutter import RollershutterDevice
 from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.8']
+REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.components.wink import WinkDevice
 from homeassistant.loader import get_component
 
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.8']
+REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
 
 SENSOR_TYPES = ['temperature', 'humidity']
 

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.entity import ToggleEntity
 
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.8']
+REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import discovery
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyvera==0.2.12']
+REQUIREMENTS = ['pyvera==0.2.13']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
 from homeassistant.helpers.entity import Entity
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.8']
+REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
 
 SUBSCRIPTION_HANDLER = None
 CHANNELS = []

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """Constants used by Home Assistant components."""
 
-__version__ = "0.23.0"
+__version__ = "0.23.1"
 REQUIRED_PYTHON_VER = (3, 4)
 
 PLATFORM_FORMAT = '{}.{}'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -339,7 +339,7 @@ python-wink==0.7.8
 pyuserinput==0.1.9
 
 # homeassistant.components.vera
-pyvera==0.2.12
+pyvera==0.2.13
 
 # homeassistant.components.wemo
 pywemo==0.4.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -227,7 +227,7 @@ psutil==4.3.0
 # homeassistant.components.rollershutter.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-pubnub==3.7.8
+pubnub==3.7.6
 
 # homeassistant.components.notify.pushbullet
 pushbullet.py==0.10.0


### PR DESCRIPTION
Some issues arose with the release but luckily have been quickly squashed:
- Bump PyVera to 0.2.13 to fix traceback and pyvera thread dying related to bug (@rhooper)
- HTTP - SSL: Check for OP_NO_COMPRESSION support before trying to use it (@AlucardZero)
- Wink: Downgraded pubnub to work around pycryptodome conflicts (@w1ll1am23)
