### PR TITLE
Added autohub service

### DIFF
--- a/homeassistant/components/autohub.py
+++ b/homeassistant/components/autohub.py
@@ -1,0 +1,89 @@
+"""
+Support for Autohub.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/autohub/
+"""
+import logging
+import time
+
+from homeassistant.components.discovery import SERVICE_AUTOHUB
+
+
+from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME, EVENT_HOMEASSISTANT_STOP
+from homeassistant.helpers import validate_config, discovery
+
+from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.loader import get_component
+
+DOMAIN = "autohub"
+REQUIREMENTS = ['pyautohub==0.1.0']
+AUTOHUB = None
+DISCOVER_LIGHTS = "autohub.light"
+
+
+# Mapping from Wemo model_name to service.
+AUTOHUB_MODEL_DISPATCH = {
+}
+
+AUTOHUB_SERVICE_DISPATCH = {
+    DISCOVER_LIGHTS: 'light',
+}
+
+AUTOHUBWS = None
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup(hass, config):
+    """Setup Autohub Hub component.
+
+    This will automatically import associated lights.
+    """
+    if not validate_config(
+            config,
+            {DOMAIN: [CONF_USERNAME, CONF_PASSWORD, CONF_API_KEY]},
+            _LOGGER):
+        return False
+
+    import pyautohub
+
+    global AUTOHUBWS
+    AUTOHUBWS = pyautohub.AutohubWS()
+
+    #callback handler
+    def OnDeviceAdded(device):
+        config_autohub = config.get("autohub")
+        kDevices = config_autohub.get("devices", {})
+        if device.device_address_ in kDevices:
+          device.device_name_ = kDevices[device.device_address_].get("name", device.device_name_)
+        discovery_info = (device.device_address_, device.device_name_)
+        discovery.discover(hass, SERVICE_AUTOHUB, discovery_info)
+
+    #register callback handler with pyautohub
+    AUTOHUBWS.on_device_added(OnDeviceAdded)
+	
+    def autohub_stop(event):
+      _LOGGER.info("Shutting down Authub sockets")
+      AUTOHUBWS.stop()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, autohub_stop)
+
+    def discovery_dispatch(service, device):
+        """Dispatcher for autohub discovery events."""
+        # name, model, location, mac
+        device_address, device_name = device
+		
+        service = DISCOVER_LIGHTS
+        component = AUTOHUB_SERVICE_DISPATCH.get(service)
+		
+        discovery.load_platform(hass, component, DOMAIN, device, config)
+
+        discovery.discover(hass, service, device, component, config)
+
+    discovery.listen(hass, SERVICE_AUTOHUB, discovery_dispatch)
+    AUTOHUBWS.start()
+    #AUTOHUBWS.getDeviceList()
+
+    return True
+

--- a/homeassistant/components/autohub.py
+++ b/homeassistant/components/autohub.py
@@ -5,16 +5,13 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/autohub/
 """
 import logging
-import time
 
 from homeassistant.components.discovery import SERVICE_AUTOHUB
 
 
-from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import (CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME, 
+EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers import validate_config, discovery
-
-from homeassistant.helpers.entity import ToggleEntity
-from homeassistant.loader import get_component
 
 DOMAIN = "autohub"
 REQUIREMENTS = ['pyautohub==0.1.0']
@@ -37,7 +34,6 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup(hass, config):
     """Setup Autohub Hub component.
-
     This will automatically import associated lights.
     """
     if not validate_config(
@@ -51,7 +47,7 @@ def setup(hass, config):
     global AUTOHUBWS
     AUTOHUBWS = pyautohub.AutohubWS()
 
-    #callback handler
+    # callback handler
     def OnDeviceAdded(device):
         config_autohub = config.get("autohub")
         kDevices = config_autohub.get("devices", {})
@@ -60,7 +56,7 @@ def setup(hass, config):
         discovery_info = (device.device_address_, device.device_name_)
         discovery.discover(hass, SERVICE_AUTOHUB, discovery_info)
 
-    #register callback handler with pyautohub
+    # register callback handler with pyautohub
     AUTOHUBWS.on_device_added(OnDeviceAdded)
 	
     def autohub_stop(event):
@@ -83,7 +79,7 @@ def setup(hass, config):
 
     discovery.listen(hass, SERVICE_AUTOHUB, discovery_dispatch)
     AUTOHUBWS.start()
-    #AUTOHUBWS.getDeviceList()
+    # AUTOHUBWS.getDeviceList()
 
     return True
 

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -17,10 +17,12 @@ REQUIREMENTS = ['netdisco==0.6.7']
 
 SCAN_INTERVAL = 300  # seconds
 
+SERVICE_AUTOHUB = 'autohub'
 SERVICE_WEMO = 'belkin_wemo'
 SERVICE_NETGEAR = 'netgear_router'
 
 SERVICE_HANDLERS = {
+    SERVICE_AUTOHUB: ('autohub', None),
     SERVICE_NETGEAR: ('device_tracker', None),
     SERVICE_WEMO: ('wemo', None),
     'philips_hue': ('light', 'hue'),

--- a/homeassistant/components/light/autohub.py
+++ b/homeassistant/components/light/autohub.py
@@ -4,13 +4,12 @@ Support for Autohub lights.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.autohub/
 """
-import time
 import logging
 
 from homeassistant.components.autohub import AUTOHUBWS
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_RGB_COLOR, Light)
+    ATTR_BRIGHTNESS, Light)
 from homeassistant.loader import get_component
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,8 +22,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     devs.append(AutohubToggleDevice(device))
     add_devices(devs)
     return
-
-    
 
 class AutohubToggleDevice(Light):
     """An abstract Class for an Autohub node."""
@@ -99,10 +96,4 @@ class AutohubToggleDevice(Light):
 
     def update(self):
         """Update state of the sensor."""
-        #resp = self.node.send_command('status', wait=False)
-        #try:
-            #print(resp)
-        #self.node.reload_details()
         self._value = self.node._properties_.get("light_status", 0)
-        #except KeyError:
-            #pass

--- a/homeassistant/components/light/autohub.py
+++ b/homeassistant/components/light/autohub.py
@@ -1,0 +1,108 @@
+"""
+Support for Autohub lights.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.autohub/
+"""
+import time
+import logging
+
+from homeassistant.components.autohub import AUTOHUBWS
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_RGB_COLOR, Light)
+from homeassistant.loader import get_component
+
+_LOGGER = logging.getLogger(__name__)
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Autohub Hub light platform."""
+    devs = []
+    device_address, device_name = discovery_info
+    device = AUTOHUBWS.getDeviceFromAddress(device_address)
+    devs.append(AutohubToggleDevice(device))
+    add_devices(devs)
+    return
+
+    
+
+class AutohubToggleDevice(Light):
+    """An abstract Class for an Autohub node."""
+
+    def __init__(self, node):
+        """Initialize the device."""
+        self.node = node
+        self.insight_params = None
+        self.maker_params = None
+        self._state = None
+        self.light_id = node.device_address_
+		
+        self._value = self.node._properties_.get("light_status", 0)
+        self.node.on_device_update(self._update_callback)
+
+    def _update_callback(self):
+        """Called by the Wemo device callback to update state."""
+        _LOGGER.info(
+            'Subscription update for  %s',
+            self.node.device_address_)
+        if not hasattr(self, 'hass'):
+            self.update()
+            return
+        self.update_ha_state(True)
+
+    @property
+    def unique_id(self):
+        """Return the ID of this autohub node."""
+        return self.node.device_address_
+
+    @property
+    def name(self):
+        """Return the the name of the node."""
+        return self.node.device_name_
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return self.node._properties_.get('light_status', 0)
+
+    @property
+    def is_on(self):
+        """Return the boolean response if the node is on."""
+        return self.node._properties_.get('light_status', 0) != 0
+
+    @property
+    def should_poll(self):
+        """Return True if entity has to be polled for state.
+
+        False if entity pushes its state to HA.
+        """
+        return False
+
+    def turn_on(self, **kwargs):
+        """Turn device on."""
+        level = self.node._properties_.get("button_on_level", 255)
+
+        if ATTR_BRIGHTNESS in kwargs:
+            level = kwargs[ATTR_BRIGHTNESS]
+
+        self._value = level
+        self.node._properties_["light_status"] = self._value
+        self.node.send_command('on', level)
+        self.update_ha_state()
+
+    def turn_off(self, **kwargs):
+        """Turn device off."""
+        self._value = 0
+        self.node._properties_["light_status"] = self._value
+        self.node.send_command('off')
+        self.update_ha_state()
+
+    def update(self):
+        """Update state of the sensor."""
+        #resp = self.node.send_command('status', wait=False)
+        #try:
+            #print(resp)
+        #self.node.reload_details()
+        self._value = self.node._properties_.get("light_status", 0)
+        #except KeyError:
+            #pass

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -247,6 +247,9 @@ pyasn1-modules==0.0.8
 # homeassistant.components.notify.xmpp
 pyasn1==0.1.9
 
+# homeassistant.components.autohub
+pyautohub==0.1.0
+
 # homeassistant.components.device_tracker.bluetooth_tracker
 # pybluez==0.22
 


### PR DESCRIPTION
**Description:**
Would like to add support for Autohubpp. Autohubpp has recently been released as open source.
Autohub server is a linux system daemon used to communicate with Insteon PLM's and Insteon HUBs.
Autohub server does not require an Insteon account or API key.
https://github.com/gitaaronc/autohubpp

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
