### PR TITLE
Updated to version 3.1.2 and fixed invalid host setup error

### DIFF
--- a/homeassistant/components/media_player/roku.py
+++ b/homeassistant/components/media_player/roku.py
@@ -15,8 +15,8 @@ from homeassistant.const import (
     CONF_HOST, STATE_IDLE, STATE_PLAYING, STATE_UNKNOWN, STATE_HOME)
 
 REQUIREMENTS = [
-    'https://github.com/bah2830/python-roku/archive/3.1.1.zip'
-    '#python-roku==3.1.1']
+    'https://github.com/bah2830/python-roku/archive/3.1.2.zip'
+    '#roku==3.1.2']
 
 KNOWN_HOSTS = []
 DEFAULT_PORT = 8060
@@ -45,8 +45,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     rokus = []
     for host in hosts:
-        rokus.append(RokuDevice(host))
-        KNOWN_HOSTS.append(host)
+        new_roku = RokuDevice(host)
+
+        if new_roku.name is None:
+            _LOGGER.error("Unable to initialize roku at %s", host)
+        else:
+            rokus.append(RokuDevice(host))
+            KNOWN_HOSTS.append(host)
 
     add_devices(rokus)
 
@@ -61,6 +66,11 @@ class RokuDevice(MediaPlayerDevice):
         from roku import Roku
 
         self.roku = Roku(host)
+        self.roku_name = None
+        self.ip_address = host
+        self.channels = []
+        self.current_app = None
+
         self.update()
 
     def update(self):
@@ -78,7 +88,7 @@ class RokuDevice(MediaPlayerDevice):
                 self.current_app = None
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.ReadTimeout):
-            self.current_app = None
+            _LOGGER.error("Unable to connect to roku at %s", self.ip_address)
 
     def get_source_list(self):
         """Get the list of applications to be used as sources."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -117,7 +117,7 @@ https://github.com/Xorso/pyalarmdotcom/archive/0.1.1.zip#pyalarmdotcom==0.1.1
 https://github.com/aparraga/braviarc/archive/0.3.2.zip#braviarc==0.3.2
 
 # homeassistant.components.media_player.roku
-https://github.com/bah2830/python-roku/archive/3.1.1.zip#python-roku==3.1.1
+https://github.com/bah2830/python-roku/archive/3.1.2.zip#roku==3.1.2
 
 # homeassistant.components.modbus
 https://github.com/bashwork/pymodbus/archive/d7fc4f1cc975631e0a9011390e8017f64b612661.zip#pymodbus==1.2.0


### PR DESCRIPTION
**Description:**
- Updated roku version to 3.1.2.
- Fixed pypi package name error causing hass init to install the package(twice!) every time hass was started.
- Fixed error during setup_platform that caused an invalid host to silently setup and cause exceptions later
