### PR TITLE
Update unifi.py to support sites

### DIFF
--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -16,6 +16,7 @@ REQUIREMENTS = ['urllib3', 'unifi==1.2.5']
 
 _LOGGER = logging.getLogger(__name__)
 CONF_PORT = 'port'
+CONF_SITE_ID = 'site_id'
 
 
 def get_scanner(hass, config):
@@ -32,6 +33,7 @@ def get_scanner(hass, config):
     host = this_config.get(CONF_HOST, 'localhost')
     username = this_config.get(CONF_USERNAME)
     password = this_config.get(CONF_PASSWORD)
+    site_id = this_config.get(CONF_SITE_ID, 'default')
 
     try:
         port = int(this_config.get(CONF_PORT, 8443))
@@ -40,7 +42,7 @@ def get_scanner(hass, config):
         return False
 
     try:
-        ctrl = Controller(host, username, password, port, 'v4')
+        ctrl = Controller(host, username, password, port, 'v4', site_id)
     except urllib.error.HTTPError as ex:
         _LOGGER.error('Failed to connect to unifi: %s', ex)
         return False

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -24,7 +24,7 @@ class TestUnifiScanner(unittest.TestCase):
         result = unifi.get_scanner(None, config)
         self.assertEqual(unifi.UnifiScanner.return_value, result)
         mock_ctrl.assert_called_once_with('localhost', 'foo', 'password',
-                                          8443, 'v4')
+                                          8443, 'v4', 'default')
         mock_scanner.assert_called_once_with(mock_ctrl.return_value)
 
     @mock.patch('homeassistant.components.device_tracker.unifi.UnifiScanner')
@@ -37,12 +37,13 @@ class TestUnifiScanner(unittest.TestCase):
                 CONF_PASSWORD: 'password',
                 CONF_HOST: 'myhost',
                 'port': 123,
+                'site_id': 'abcdef01',
             }
         }
         result = unifi.get_scanner(None, config)
         self.assertEqual(unifi.UnifiScanner.return_value, result)
         mock_ctrl.assert_called_once_with('myhost', 'foo', 'password',
-                                          123, 'v4')
+                                          123, 'v4', 'abcdef01')
         mock_scanner.assert_called_once_with(mock_ctrl.return_value)
 
     @mock.patch('homeassistant.components.device_tracker.unifi.UnifiScanner')


### PR DESCRIPTION
**Description:**

Unifi controllers can have multiple sites per controller. The current unifi.py does not support sending through the information about which site to survey. This means that the site surveyed is the default site. By adding these three lines, the Site ID can be specified within the configuration, allowing for the user to specify a site for survey.

Tested on current codebase with a live home-assistant website. Works as expected with devices being discovered from the correct site id.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

https://github.com/home-assistant/home-assistant.io/pull/609

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
site_id : 'default'
or
site_id : 'abcdef01' (code is randomised, found in URL: https://CONTROLLER:PORT/manage/site/SITE_ID/dashboard)
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Add support for a site that is not the default within the Unifi Controller.

i.e. A controller with multiple sites:
- Home
- Friends
- Parents (default)

Supplying the identifier for 'Home' now means that the devices tracked will be associated with 'Home'.
