### PR TITLE
add hvac mode support to radiotherm

### DIFF
--- a/homeassistant/components/thermostat/__init__.py
+++ b/homeassistant/components/thermostat/__init__.py
@@ -33,6 +33,7 @@ SERVICE_SET_HVAC_MODE = "set_hvac_mode"
 STATE_HEAT = "heat"
 STATE_COOL = "cool"
 STATE_IDLE = "idle"
+STATE_AUTO = 'auto'
 
 ATTR_CURRENT_TEMPERATURE = "current_temperature"
 ATTR_AWAY_MODE = "away_mode"

--- a/homeassistant/components/thermostat/radiotherm.py
+++ b/homeassistant/components/thermostat/radiotherm.py
@@ -16,6 +16,9 @@ REQUIREMENTS = ['radiotherm==1.2']
 HOLD_TEMP = 'hold_temp'
 _LOGGER = logging.getLogger(__name__)
 
+STATE_OFF = 'off'
+STATE_AUTO = 'auto'
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Radio Thermostat."""
@@ -45,6 +48,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(tstats)
 
 
+# pylint: disable=abstract-method
 class RadioThermostat(ThermostatDevice):
     """Representation of a Radio Thermostat."""
 
@@ -121,3 +125,14 @@ class RadioThermostat(ThermostatDevice):
         now = datetime.datetime.now()
         self.device.time = {'day': now.weekday(),
                             'hour': now.hour, 'minute': now.minute}
+
+    def set_hvac_mode(self, mode):
+        """Set HVAC mode (auto, cool, heat, off)."""
+        if mode == STATE_OFF:
+            self.device.tmode = 0
+        elif mode == STATE_AUTO:
+            self.device.tmode = 3
+        elif mode == STATE_COOL:
+            self.device.t_cool = self._target_temperature
+        elif mode == STATE_HEAT:
+            self.device.t_heat = self._target_temperature

--- a/homeassistant/components/thermostat/radiotherm.py
+++ b/homeassistant/components/thermostat/radiotherm.py
@@ -9,15 +9,13 @@ import logging
 from urllib.error import URLError
 
 from homeassistant.components.thermostat import (
-    STATE_COOL, STATE_HEAT, STATE_IDLE, ThermostatDevice)
+    STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_IDLE, STATE_OFF,
+    ThermostatDevice)
 from homeassistant.const import CONF_HOST, TEMP_FAHRENHEIT
 
 REQUIREMENTS = ['radiotherm==1.2']
 HOLD_TEMP = 'hold_temp'
 _LOGGER = logging.getLogger(__name__)
-
-STATE_OFF = 'off'
-STATE_AUTO = 'auto'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -48,7 +46,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(tstats)
 
 
-# pylint: disable=abstract-method
 class RadioThermostat(ThermostatDevice):
     """Representation of a Radio Thermostat."""
 


### PR DESCRIPTION
**Description:**
Add hvac_mode support to radiothermostat.

Off/Cool/Heat/Auto modes are supported.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

off/cool/heat/auto modes are supported
