### PR TITLE
Fix flood of errors if Plex server goes offline

### DIFF
--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -122,7 +122,11 @@ def setup_plexserver(host, token, hass, add_devices_callback):
         try:
             devices = plexserver.clients()
         except plexapi.exceptions.BadRequest:
-            _LOGGER.exception("Error listing plex devices")
+            _LOGGER.exception('Error listing plex devices')
+            return
+        except OSError:
+            _LOGGER.error(
+                'Could not connect to plex server at http://%s', host)
             return
 
         new_plex_clients = []
@@ -148,7 +152,7 @@ def setup_plexserver(host, token, hass, add_devices_callback):
         try:
             sessions = plexserver.sessions()
         except plexapi.exceptions.BadRequest:
-            _LOGGER.exception("Error listing plex sessions")
+            _LOGGER.exception('Error listing plex sessions')
             return
 
         plex_sessions.clear()
@@ -166,7 +170,7 @@ def request_configuration(host, hass, add_devices_callback):
     # We got an error if this method is called while we are configuring
     if host in _CONFIGURING:
         configurator.notify_errors(
-            _CONFIGURING[host], "Failed to register, please try again.")
+            _CONFIGURING[host], 'Failed to register, please try again.')
 
         return
 
@@ -175,10 +179,10 @@ def request_configuration(host, hass, add_devices_callback):
         setup_plexserver(host, data.get('token'), hass, add_devices_callback)
 
     _CONFIGURING[host] = configurator.request_config(
-        hass, "Plex Media Server", plex_configuration_callback,
+        hass, 'Plex Media Server', plex_configuration_callback,
         description=('Enter the X-Plex-Token'),
-        description_image="/static/images/config_plex_mediaserver.png",
-        submit_caption="Confirm",
+        description_image='/static/images/config_plex_mediaserver.png',
+        submit_caption='Confirm',
         fields=[{'id': 'token', 'name': 'X-Plex-Token', 'type': ''}]
     )
 
@@ -201,7 +205,7 @@ class PlexClient(MediaPlayerDevice):
     @property
     def unique_id(self):
         """Return the id of this plex client."""
-        return "{}.{}".format(
+        return '{}.{}'.format(
             self.__class__, self.device.machineIdentifier or self.device.name)
 
     @property


### PR DESCRIPTION
**Description:**
If a Plex server goes offline, Home Assistant reports a flood of errors at least once per minute. I added an exception for OSError to catch it, and reduce it to one error line per occurrence.

I also updated the quotes to match across the file.

**Related issue (if applicable):** fixes #2363 

**Checklist:**

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
