### PR TITLE
New Switch Platform: TPLink Switch (HS100 / HS110)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -222,6 +222,7 @@ omit =
     homeassistant/components/switch/pulseaudio_loopback.py
     homeassistant/components/switch/rest.py
     homeassistant/components/switch/rpi_rf.py
+    homeassistant/components/switch/tplink.py
     homeassistant/components/switch/transmission.py
     homeassistant/components/switch/wake_on_lan.py
     homeassistant/components/thermostat/eq3btsmart.py

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -1,7 +1,7 @@
 """Support for TPLink HS100/HS110 smart switch.
 
-It is able to monitor current switch status, as well as turn on and off the switch. 
-
+It is able to monitor current switch status, as well as turn on and off
+the switch. Will work with both HS100 and HS110 switch models.
 """
 
 import logging
@@ -12,21 +12,21 @@ from homeassistant.const import (
 
 # constants
 DEVICE_DEFAULT_NAME = 'HS100'
-REQUIREMENTS = ['http://github.com/gadgetreactor/pyHS100/archive/'
-                '27dd078e57628e76a1de89cc9d81b703f8e846d1'
-                '#pyHS100==0.1.0']
+REQUIREMENTS = ['https://github.com/gadgetreactor/pyHS100/archive/'
+                'master.zip#pyHS100==0.1.2']
 
-# setup logger
-_LOGGER = logging.getLogger(__name__)
+# pylint: disable=unused-argument
+
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
-    import pyHS100
+    from pyHS100.pyHS100 import SmartPlug
     """Setup the TPLink platform in configuration.yaml."""
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME, DEVICE_DEFAULT_NAME)
 
-    add_devices_callback([SmartPlugSwitch(pyHS100.SmartPlug(host),
+    add_devices_callback([SmartPlugSwitch(SmartPlug(host),
                                           name)])
+
 
 class SmartPlugSwitch(SwitchDevice):
     """Representation of a TPLink Smart Plug switch."""

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -4,8 +4,6 @@ It is able to monitor current switch status, as well as turn on and off
 the switch. Will work with both HS100 and HS110 switch models.
 """
 
-import logging
-
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (
     CONF_HOST, CONF_NAME)
@@ -19,8 +17,8 @@ REQUIREMENTS = ['https://github.com/gadgetreactor/pyHS100/archive/'
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
-    from pyHS100.pyHS100 import SmartPlug
     """Setup the TPLink platform in configuration.yaml."""
+    from pyHS100.pyHS100 import SmartPlug
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME, DEVICE_DEFAULT_NAME)
 

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -14,18 +14,20 @@ from homeassistant.const import (
 
 # constants
 DEVICE_DEFAULT_NAME = 'HS100'
+REQUIREMENTS = ['http://github.com/gadgetreactor/pyHS100/archive/'
+                '27dd078e57628e76a1de89cc9d81b703f8e846d1'
+                '#pyHS100==0.1.0']
 
 # setup logger
 _LOGGER = logging.getLogger(__name__)
 
-# pylint: disable=unused-argument
-
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    import pyHS100
     """Setup the TPLink platform in configuration.yaml."""
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME, DEVICE_DEFAULT_NAME)
 
-    add_devices_callback([SmartPlugSwitch(SmartPlug(host),
+    add_devices_callback([SmartPlugSwitch(pyHS100.SmartPlug(host),
                                           name)])
 
 class SmartPlugSwitch(SwitchDevice):
@@ -53,103 +55,3 @@ class SmartPlugSwitch(SwitchDevice):
     def turn_off(self):
         """Turn the switch off."""
         self.smartplug.state = 'OFF'
-
-class SmartPlug(object):
-    """Class to access TPLink Switch.
-    
-    Usage example when used as library:
-    p = SmartPlug("192.168.1.105")
-    # change state of plug
-    p.state = "OFF"
-    p.state = "ON"
-    # query and print current state of plug
-    print(p.state)
-    Note:
-    The library references the same structure as defined for the D-Link Switch
-    """
-
-    def __init__(self, ip):
-        """Create a new SmartPlug instance identified by the IP."""
-        self.ip = ip
-        self.port = 9999
-        self._error_report = False
-
-    @property
-    def state(self):
-        """Get the device state (i.e. ON or OFF)."""
-        response = self.hs100_status()
-        if response is None:
-            return 'unknown'
-        elif response == 0:
-            return "OFF"
-        elif response == 1:
-            return "ON"
-        else:
-            _LOGGER.warning("Unknown state %s returned" % str(response))
-            return 'unknown'
-
-    @state.setter
-    def state(self, value):
-        """Set device state.
-
-        :type value: str
-        :param value: Future state (either ON or OFF)
-        """
-        if value.upper() == 'ON':
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.connect((self.ip, self.port))
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.connect((self.ip, self.port))
-            on_str = '0000002ad0f281f88bff9af7d5',
-                     'ef94b6c5a0d48bf99cf091e8b7',
-                     'c4b0d1a5c0e2d8a381f286e793',
-                     'f6d4eedfa2dfa2'
-            data = codecs.decode(on_str, 'hex_codec')
-            s.send(data)
-            s.close()
-
-        elif value.upper() == 'OFF':
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.connect((self.ip, self.port))
-            off_str = '0000002ad0f281f88bff9af7d5',
-                      'ef94b6c5a0d48bf99cf091e8b7',
-                      'c4b0d1a5c0e2d8a381f286e793f',
-                      '6d4eedea3dea3'
-            data = codecs.decode(off_str, 'hex_codec')
-            s.send(data)
-            s.close()
-
-        else:
-            raise TypeError("State %s is not valid." % str(value))
-
-    def hs100_status(self):
-        """Query HS100 for relay status."""
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.connect((self.ip, self.port))
-        skip = 4
-        code = 171
-        response = ""
-        query_str = '00000023d0f0d2a1d8abdfbad7',
-                    'f5cfb494b6d1b4c09fec95e68f',
-                    'e187e8caf09eeb87ebcbb696eb'
-        data = codecs.decode(query_str, 'hex_codec')
-        s.send(data)
-        reply = s.recv(4096)
-        s.shutdown(1)
-        s.close()
-
-        for value in reply:
-            if skip > 0:
-                skip = skip - 1
-            else:
-                change = (value ^ code)
-                response = response + chr(change)
-                code = value
-
-        import json
-        info = json.loads(response)
-        # info is reserved for future expansion.
-        # The JSON response from the smartplug provide smartplug system information
-        sys_info = info["system"]["get_sysinfo"]
-        relay_state = sys_info["relay_state"]
-        return relay_state

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -5,8 +5,6 @@ It is able to monitor current switch status, as well as turn on and off the swit
 """
 
 import logging
-import socket
-import codecs
 
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -1,0 +1,150 @@
+"""
+Support for tp-link HS100/HS110 smart switch.
+"""
+
+import logging
+import socket
+import codecs
+
+from homeassistant.components.switch import DOMAIN, SwitchDevice
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME)
+
+# constants
+DEVICE_DEFAULT_NAME = 'HS100'
+
+# setup logger
+_LOGGER = logging.getLogger(__name__)
+
+# pylint: disable=unused-argument
+#def setup_platform(hass, config, add_devices_callback):
+
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    host = config.get(CONF_HOST)
+    name = config.get(CONF_NAME, DEVICE_DEFAULT_NAME)
+
+    add_devices_callback([SmartPlugSwitch(SmartPlug(host),
+                                          name)])
+
+
+class SmartPlugSwitch(SwitchDevice):
+    """Representation of a TPLink Smart Plug switch."""
+
+    def __init__(self, smartplug, name):
+        """Initialize the switch."""
+        self.smartplug = smartplug
+        self._name = name
+
+    @property
+    def name(self):
+        """Return the name of the Smart Plug, if any."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self.smartplug.state == 'ON'
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
+        self.smartplug.state = 'ON'
+
+    def turn_off(self):
+        """Turn the switch off."""
+        self.smartplug.state = 'OFF'
+
+class SmartPlug(object):
+    """
+    Class to access TPLink Switch
+    Usage example when used as library:
+    p = SmartPlug("192.168.1.105")
+    # change state of plug
+    p.state = "OFF"
+    p.state = "ON"
+    # query and print current state of plug
+    print(p.state)
+    Note:
+    The library references the same structure as defined for the D-Link Switch
+    """
+
+    def __init__(self, ip):
+        """
+        Create a new SmartPlug instance identified by the IP.
+        :rtype : object
+        :param host: The IP/hostname of the SmartPlug. E.g. '192.168.1.105'
+        """
+        self.ip = ip
+        self.port = 9999
+        self._error_report = False
+
+    @property
+    def state(self):
+        """Get the device state (i.e. ON or OFF)."""
+
+        response =  self.hs100_status()
+
+        if response is None:
+            return 'unknown'
+        elif response == 0:
+            return "OFF"
+        elif response == 1:
+            return "ON"
+        else:
+            _LOGGER.warning("Unknown state %s returned" % str(response))
+            return 'unknown'
+
+    @state.setter
+    def state(self, value):
+        """
+        Set device state.
+        :type value: str
+        :param value: Future state (either ON or OFF)
+        """
+        if value.upper() == 'ON':
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.connect((self.ip, self.port))
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.connect((self.ip, self.port))
+            data = codecs.decode('0000002ad0f281f88bff9af7d5ef94b6c5a0d48bf99cf091e8b7c4b0d1a5c0e2d8a381f286e793f6d4eedfa2dfa2', 'hex_codec')
+            s.send(data)
+            s.close()
+
+        elif value.upper() == 'OFF':
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.connect((self.ip, self.port))
+            data = codecs.decode('0000002ad0f281f88bff9af7d5ef94b6c5a0d48bf99cf091e8b7c4b0d1a5c0e2d8a381f286e793f6d4eedea3dea3', 'hex_codec')
+            s.send(data)
+            s.close()
+
+        else:
+            raise TypeError("State %s is not valid." % str(value))
+
+    def hs100_status(self):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((self.ip, self.port))
+        skip = 4
+        code = 171
+        response = ""
+        data = codecs.decode('00000023d0f0d2a1d8abdfbad7f5cfb494b6d1b4c09fec95e68fe187e8caf09eeb87ebcbb696eb', 'hex_codec')
+        s.send(data)
+
+        reply = s.recv(4096)
+        s.shutdown(1)
+        s.close()
+
+        for value in reply:
+            if skip > 0:
+                skip = skip -1
+            else:
+                change = (value ^ code)
+                response = response + chr(change)
+                code = value
+
+        import json
+        info = json.loads (response)
+        """
+        info is reserved for future expansion.
+        The JSON response from the smartplug provide smartplug system information
+        """
+        relay_state = info["system"]["get_sysinfo"]["relay_state"]
+        return relay_state

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -114,7 +114,7 @@ https://github.com/TheRealLink/pythinkingcleaner/archive/v0.0.2.zip#pythinkingcl
 https://github.com/Xorso/pyalarmdotcom/archive/0.1.1.zip#pyalarmdotcom==0.1.1
 
 # homeassistant.components.media_player.braviatv
-https://github.com/aparraga/braviarc/archive/0.3.2.zip#braviarc==0.3.2
+https://github.com/aparraga/braviarc/archive/0.3.3.zip#braviarc==0.3.3
 
 # homeassistant.components.media_player.roku
 https://github.com/bah2830/python-roku/archive/3.1.2.zip#roku==3.1.2
@@ -292,7 +292,7 @@ pynetio==0.1.6
 pynx584==0.2
 
 # homeassistant.components.sensor.openweathermap
-pyowm==2.3.1
+pyowm==2.3.2
 
 # homeassistant.components.switch.acer_projector
 pyserial<=3.0
@@ -320,7 +320,7 @@ python-nmap==0.6.0
 python-pushover==0.2
 
 # homeassistant.components.notify.telegram
-python-telegram-bot==4.3.1
+python-telegram-bot==4.3.2
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.2.0
@@ -366,7 +366,7 @@ scsgate==0.1.0
 sendgrid>=1.6.0,<1.7.0
 
 # homeassistant.components.notify.slack
-slacker==0.9.18
+slacker==0.9.21
 
 # homeassistant.components.notify.xmpp
 sleekxmpp==1.3.1
@@ -433,5 +433,11 @@ xbee-helper==0.0.7
 # homeassistant.components.sensor.yr
 xmltodict
 
+# homeassistant.components.sensor.yweather
+yahooweather==0.4
+
 # homeassistant.components.zeroconf
 zeroconf==0.17.5
+
+# homeassistant.components.switch.tplink
+https://github.com/gadgetreactor/pyHS100/archive/master.zip#pyHS100==0.1.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -114,7 +114,7 @@ https://github.com/TheRealLink/pythinkingcleaner/archive/v0.0.2.zip#pythinkingcl
 https://github.com/Xorso/pyalarmdotcom/archive/0.1.1.zip#pyalarmdotcom==0.1.1
 
 # homeassistant.components.media_player.braviatv
-https://github.com/aparraga/braviarc/archive/0.3.3.zip#braviarc==0.3.3
+https://github.com/aparraga/braviarc/archive/0.3.2.zip#braviarc==0.3.2
 
 # homeassistant.components.media_player.roku
 https://github.com/bah2830/python-roku/archive/3.1.2.zip#roku==3.1.2
@@ -127,6 +127,9 @@ https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.
 
 # homeassistant.components.device_tracker.fritz
 # https://github.com/deisi/fritzconnection/archive/b5c14515e1c8e2652b06b6316a7f3913df942841.zip#fritzconnection==0.4.6
+
+# homeassistant.components.switch.tplink
+https://github.com/gadgetreactor/pyHS100/archive/master.zip#pyHS100==0.1.2
 
 # homeassistant.components.netatmo
 https://github.com/jabesq/netatmo-api-python/archive/v0.5.0.zip#lnetatmo==0.5.0
@@ -292,7 +295,7 @@ pynetio==0.1.6
 pynx584==0.2
 
 # homeassistant.components.sensor.openweathermap
-pyowm==2.3.2
+pyowm==2.3.1
 
 # homeassistant.components.switch.acer_projector
 pyserial<=3.0
@@ -320,7 +323,7 @@ python-nmap==0.6.0
 python-pushover==0.2
 
 # homeassistant.components.notify.telegram
-python-telegram-bot==4.3.2
+python-telegram-bot==4.3.1
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.2.0
@@ -366,7 +369,7 @@ scsgate==0.1.0
 sendgrid>=1.6.0,<1.7.0
 
 # homeassistant.components.notify.slack
-slacker==0.9.21
+slacker==0.9.18
 
 # homeassistant.components.notify.xmpp
 sleekxmpp==1.3.1
@@ -433,11 +436,5 @@ xbee-helper==0.0.7
 # homeassistant.components.sensor.yr
 xmltodict
 
-# homeassistant.components.sensor.yweather
-yahooweather==0.4
-
 # homeassistant.components.zeroconf
 zeroconf==0.17.5
-
-# homeassistant.components.switch.tplink
-https://github.com/gadgetreactor/pyHS100/archive/master.zip#pyHS100==0.1.2


### PR DESCRIPTION
**Description:**

The TPLink switch platform allows you to control the state of your TPLink Wi-Fi Smart Plugs.

Supported devices (tested):
HS100 (UK)
It should also work with the HS110 and other HS100 variants.

To use your TPLink smart plugs in your installation, add the following to your configuration.yaml file:

"""
# Example configuration.yaml entry

switch:
  platform: tplink
  host: IP_ADRRESS
  name: TPLink Switch
"""
### Configuration variables:

host (Required): The IP address of your TPlink plug, eg. http://192.168.1.105
name (Optional): The name to use when displaying this switch.

**Related issue (if applicable): Nill

**Checklist:**

If code communicates with devices, web services, or a:
- [x ] Local tests with `tox` run successfully. 
