### PR TITLE
Added ability to validate the code when arming or disarming Simplisafe alarm

### DIFF
--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -94,18 +94,31 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""
+        if not self._validate_code(code, 'disarming'):
+            return
         self.simplisafe.set_state('off')
         _LOGGER.info('SimpliSafe alarm disarming')
         self.update()
 
     def alarm_arm_home(self, code=None):
         """Send arm home command."""
+        if not self._validate_code(code, 'arming home'):
+            return
         self.simplisafe.set_state('home')
         _LOGGER.info('SimpliSafe alarm arming home')
         self.update()
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
+        if not self._validate_code(code, 'arming away'):
+            return
         self.simplisafe.set_state('away')
         _LOGGER.info('SimpliSafe alarm arming away')
         self.update()
+
+    def _validate_code(self, code, state):
+        """Validate given code."""
+        check = self._code is None or code == self._code
+        if not check:
+            _LOGGER.warning('Wrong code entered for %s', state)
+        return check


### PR DESCRIPTION
**Description:**
This patch added the ability for when using the  component alarm_control_panel/Simplisafe to only proceed on the frontend when the code specified via fronted matches with the code on the yaml conf.

note: documentation has already a PR as https://github.com/home-assistant/home-assistant.io/pull/613/

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
alarm_control_panel:
    platform: simplisafe
    name: "HA Alarm"
    code: PASSCODE
    username: YOUR_USERNAME
    password: YOUR_PASSWORD
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
