### PR TITLE
Verisure-lock: Return name of location to lock instead of serial number.

### DIFF
--- a/homeassistant/components/lock/verisure.py
+++ b/homeassistant/components/lock/verisure.py
@@ -39,7 +39,7 @@ class VerisureDoorlock(LockDevice):
     @property
     def name(self):
         """Return the name of the lock."""
-        return 'Lock {}'.format(self._id)
+        return '{}'.format(hub.lock_status[self._id].location)
 
     @property
     def state(self):


### PR DESCRIPTION
**Description:**
Returns the location name of the lock instead of serial number for entity_id.
This makes it less necessary to use customize for verisure locks.

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
