### PR TITLE
Upgrade pyowm to 2.3.2 (fixes #2452)

### DIFF
--- a/homeassistant/components/sensor/openweathermap.py
+++ b/homeassistant/components/sensor/openweathermap.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyowm==2.3.1']
+REQUIREMENTS = ['pyowm==2.3.2']
 _LOGGER = logging.getLogger(__name__)
 SENSOR_TYPES = {
     'weather': ['Condition', None],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -292,7 +292,7 @@ pynetio==0.1.6
 pynx584==0.2
 
 # homeassistant.components.sensor.openweathermap
-pyowm==2.3.1
+pyowm==2.3.2
 
 # homeassistant.components.switch.acer_projector
 pyserial<=3.0


### PR DESCRIPTION
Release 2.3.2
- Bugfix: no crashes when data about wind, snow and rain in JSON API responses are null

**Related issue (if applicable):** fixes #2452

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: openweathermap
    api_key: !secret owm_api
    forecast: 1
    monitored_conditions:
      - weather
      - temperature
      - wind_speed
      - humidity
      - pressure
      - clouds
      - rain
      - snow
```
