### PR TITLE
Updated braviatv media player to support power status

### DIFF
--- a/homeassistant/components/media_player/braviatv.py
+++ b/homeassistant/components/media_player/braviatv.py
@@ -17,8 +17,8 @@ from homeassistant.const import (
     CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON)
 
 REQUIREMENTS = [
-    'https://github.com/aparraga/braviarc/archive/0.3.2.zip'
-    '#braviarc==0.3.2']
+    'https://github.com/aparraga/braviarc/archive/0.3.3.zip'
+    '#braviarc==0.3.3']
 
 BRAVIA_CONFIG_FILE = 'bravia.conf'
 CLIENTID_PREFIX = 'HomeAssistant'
@@ -220,20 +220,24 @@ class BraviaTVDevice(MediaPlayerDevice):
                 self._refresh_volume()
                 self._refresh_channels()
 
-            playing_info = self._braviarc.get_playing_info()
-            if playing_info is None or len(playing_info) == 0:
-                self._state = STATE_OFF
-            else:
+            power_status = self._braviarc.get_power_status()
+            if power_status == 'active':
                 self._state = STATE_ON
-                self._program_name = playing_info.get('programTitle')
-                self._channel_name = playing_info.get('title')
-                self._program_media_type = playing_info.get(
-                    'programMediaType')
-                self._channel_number = playing_info.get('dispNum')
-                self._source = playing_info.get('source')
-                self._content_uri = playing_info.get('uri')
-                self._duration = playing_info.get('durationSec')
-                self._start_date_time = playing_info.get('startDateTime')
+                playing_info = self._braviarc.get_playing_info()
+                if playing_info is None or len(playing_info) == 0:
+                    self._channel_name = 'App'
+                else:
+                    self._program_name = playing_info.get('programTitle')
+                    self._channel_name = playing_info.get('title')
+                    self._program_media_type = playing_info.get(
+                        'programMediaType')
+                    self._channel_number = playing_info.get('dispNum')
+                    self._source = playing_info.get('source')
+                    self._content_uri = playing_info.get('uri')
+                    self._duration = playing_info.get('durationSec')
+                    self._start_date_time = playing_info.get('startDateTime')
+            else:
+                self._state = STATE_OFF
 
         except Exception as exception_instance:  # pylint: disable=broad-except
             _LOGGER.error(exception_instance)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -114,7 +114,7 @@ https://github.com/TheRealLink/pythinkingcleaner/archive/v0.0.2.zip#pythinkingcl
 https://github.com/Xorso/pyalarmdotcom/archive/0.1.1.zip#pyalarmdotcom==0.1.1
 
 # homeassistant.components.media_player.braviatv
-https://github.com/aparraga/braviarc/archive/0.3.2.zip#braviarc==0.3.2
+https://github.com/aparraga/braviarc/archive/0.3.3.zip#braviarc==0.3.3
 
 # homeassistant.components.media_player.roku
 https://github.com/bah2830/python-roku/archive/3.1.2.zip#roku==3.1.2


### PR DESCRIPTION
**Description:**

Updates the braviatv media player to support the addition of get_power_status() in upstream braviarc (0.3.3).

The reason for the change is KD-43X8307C which runs Android doesn't respond back to get_playing_info() and so was shown as off when in fact it was on but within one of the apps such as Netflix or Amazon video. When the TV was using hdmi 1 or another input this works as normal.

I only have this one device to test on but the api call is documented in the Sony specs so should be compatible with devices as before.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Hopefully I've complied with everything I needed to in this pull request.
