### PR TITLE
Allow device_tracker and sensor entity for google travel times

### DIFF
--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -273,10 +273,7 @@ class GoogleTravelTimeSensor(Entity):
     def _resolve_zone(self, friendly_name):
         entities = self._hass.states.all()
         for entity in entities:
-            if not entity.entity_id.startswith('zone.'):
-                continue
-
-            if entity.attributes.get('friendly_name', '') is friendly_name:
+            if entity.domain == 'zone' and entity.name == friendly_name:
                 return self._get_location_from_attributes(entity)
 
         return friendly_name

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -69,7 +69,7 @@ PLATFORM_SCHEMA = vol.Schema({
         }))
 })
 
-TRACKABLE_DOMAINS = ["device_tracker.", "sensor.", "zone."]
+TRACKABLE_DOMAINS = ["device_tracker", "sensor", "zone"]
 
 
 def convert_time_to_utc(timestr):
@@ -138,12 +138,12 @@ class GoogleTravelTimeSensor(Entity):
         self.valid_api_connection = True
 
         # Check if location is a trackable entity
-        if any(origin.startswith(d) for d in TRACKABLE_DOMAINS):
+        if origin.split('.', 1)[0] in TRACKABLE_DOMAINS:
             self._origin_entity_id = origin
         else:
             self._origin = origin
 
-        if any(destination.startswith(d) for d in TRACKABLE_DOMAINS):
+        if destination.split('.', 1)[0] in TRACKABLE_DOMAINS:
             self._destination_entity_id = destination
         else:
             self._destination = destination

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -248,7 +248,7 @@ class GoogleTravelTimeSensor(Entity):
                 "%s is in %s, getting zone location.",
                 entity_id, zone_entity.entity_id
             )
-            return self._get_locatiom_from_attributes(zone_entity)
+            return self._get_location_from_attributes(zone_entity)
 
         # If zone was not found in state then use the state as the location
         if entity_id.startswith("sensor."):
@@ -256,22 +256,13 @@ class GoogleTravelTimeSensor(Entity):
 
         # For everything else look for location attributes
         if location.has_location(entity):
-            return self._get_locatiom_from_attributes(entity)
+            return self._get_location_from_attributes(entity)
 
         # When everything fails just return nothing
         return None
 
     @staticmethod
-    def _get_locatiom_from_attributes(entity):
+    def _get_location_from_attributes(entity):
         """Get the lat/long string from an entities attributes."""
-        if location.has_location(entity):
-            attr = entity.attributes
-            return "%s,%s" % (attr.get(ATTR_LATITUDE),
-                              attr.get(ATTR_LONGITUDE))
-
-        _LOGGER.warning(
-            "No longitude or latitude attribute found for %s",
-            entity.entity_id
-        )
-
-        return None
+        attr = entity.attributes
+        return "%s,%s" % (attr.get(ATTR_LATITUDE), attr.get(ATTR_LONGITUDE))

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -227,6 +227,9 @@ class GoogleTravelTimeSensor(Entity):
                 self._destination_entity_id
             )
 
+        self._destination = self._resolve_zone(self._destination)
+        self._origin = self._resolve_zone(self._origin)
+
         if self._destination is not None and self._origin is not None:
             self._matrix = self._client.distance_matrix(self._origin,
                                                         self._destination,
@@ -266,3 +269,14 @@ class GoogleTravelTimeSensor(Entity):
         """Get the lat/long string from an entities attributes."""
         attr = entity.attributes
         return "%s,%s" % (attr.get(ATTR_LATITUDE), attr.get(ATTR_LONGITUDE))
+
+    def _resolve_zone(self, friendly_name):
+        entities = self._hass.states.all()
+        for entity in entities:
+            if not entity.entity_id.startswith('zone.'):
+                continue
+
+            if entity.attributes.get('friendly_name', '') is friendly_name:
+                return self._get_location_from_attributes(entity)
+
+        return friendly_name


### PR DESCRIPTION
**Description:**
This one was a bit tricky. It allows the google travel time component to use an entity_id as the origin or destination. During update and init it checks if it's an entity and if so looks for the longitude and latitude attributes if it's a device_tracker or the state if it's a sensor. If found it returns them in the proper format for the google api.

**Allowed Entities**
- device_tracker
- sensor
- zone

**Gotchas**
- During home assistant start if the entity state updates after it will report a warning log that it can't find the attributes.
  - **BUT** there is logic to make the platform wait until the event HOMEASSISTANT_START event is sent out. This allows it to make sure the entity is valid even if it's state or attributes are not accurate at the time. 
    - If the entity is not found it will log an error and not continue loading that instance of the component.
  - If the entity is found but no attributes it will continue to load and show no state for the travel time entity. This is to allow the next polling update to check for the entity state after everything has had a chance to load and be populated.
  - Yes this could cause people that ignore their logs to never get travel times if they give it a bad entity with invalid location data. But this is already the case if you give it a bad address so no difference.

**Behaviors**
- device_trackers
  - If state is not a zone it will look for longitude and latitude attributes.
  - If the state is a defined zone entity it will use the longitude and latitude of the zone.
- sensors
  -  If state is not a zone it will just send the state as is to the google api.
    - This is the same behavior as the current setup.
  - If the state is a zone it will load the longitude and latitude of the zone.
- zones
  - Just loads the longitude and latitude from the attributes.
    - Useful for only defining a location once in home assistant

**Backward Compatibility**
- All existing methods of import for origin and destination are still working exactly the same and will show no differences.

This can be used for origin or destination or both if you want to get travel times between two devices.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
- platform: google_travel_time
  name: Work Travel Time
  api_key: !env_var GOOGLE_API
  origin: device_tracker.owntracks_device
  destination: 123 abc street
```

**Checklist:**
If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
