### PR TITLE
Upgrade googlemaps to 2.4.4

### DIFF
--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -17,7 +17,7 @@ import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['googlemaps==2.4.3']
+REQUIREMENTS = ['googlemaps==2.4.4']
 
 # Return cached results if last update was less then this time ago
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -85,7 +85,7 @@ fuzzywuzzy==0.11.0
 gntp==1.0.3
 
 # homeassistant.components.sensor.google_travel_time
-googlemaps==2.4.3
+googlemaps==2.4.4
 
 # homeassistant.components.mqtt.server
 hbmqtt==0.7.1


### PR DESCRIPTION
2.4.4
- Fixed bug where requests version was incorrectly interpreted.
- handle {} json response of snap to roads api
- Fix: channel argument should always be allowed when there is a client_id
- Bump requests max version requirement to 2.10.0

Tested with the following configuration:

``` yaml
sensor:
  - platform: google_travel_time
    name: BE-ZH
    api_key: !secret google_api
    origin: Bern
    destination: Zürich
```
