### PR TITLE
Universal media player SUPPORT_SELECT_SOURCE fix

### DIFF
--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -346,7 +346,7 @@ class UniversalMediaPlayer(MediaPlayerDevice):
                 ATTR_MEDIA_VOLUME_MUTED in self._attrs:
             flags |= SUPPORT_VOLUME_MUTE
 
-        if SUPPORT_SELECT_SOURCE in self._cmds:
+        if SERVICE_SELECT_SOURCE in self._cmds:
             flags |= SUPPORT_SELECT_SOURCE
 
         return flags


### PR DESCRIPTION
**Description:**
I want to use the universal `media_player` to control my av setup. I have a onkyo receiver, but it isn't networked, so I opted to manage it with CEC. The commands are send trough a MQTT broker and a MQTT/CEC-bridge since the device that is running HA isn't connected to the receiver.

```
[ Home Assistant ]
   |
   |
   v
[ Mosquitto ] 
   |
   |
   v
[ Raspberry PI ] (running a MQTT/CEC bridge)
   |
   |
   v
[ AV Receiver ]
  + Input: [ Chromecast ] 
  + Input: [ Cable box ] 
  + Input: [ DVD/Bluray ] 
  + Input: [ Radio (internal) ] 
  + Output: [ TV ] 
```

This PR focuesses on the `source_select` part. I have added the required variables based on the onkyo implementation but I'm still struggling with a few things:
- How can I get the selected input value in my `payload_template` of `select_source`? It is passed as `service_data`, but I have no idea how to get that in the template.
- Shouldn't `def current_source(self)` be `def source(self)`? That's the way it's done in the onkyo component, and it seems that the frontend also uses `source()` to get the current source. Also, that function seems to ask the current source to it's children, but I'm not sure if that makes sense. In my setup, the children don't have a source selection, since it's the receiver that decides what is the active source.

**Related issue (if applicable):** #1643 and #2084

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
- platform: universal
  name: living
  commands:
    turn_on:
      service: mqtt.publish
      data:
        topic: "cec/on"
        payload: "5"
    turn_off:
      service: mqtt.publish
      data:
        topic: "cec/off"
        payload: "5"
    select_source:
      service: mqtt.publish
      data:
        topic: "cec/source"
        payload_template: "todo"
    volume_up:
      service: mqtt.publish
      data:
        topic: "cec/volup"
        payload: "5"
    volume_down:
      service: mqtt.publish
      data:
        topic: "cec/voldown"
        payload: "5"
    volume_mute:
      service: mqtt.publish
      data:
        topic: "cec/mute"
        payload: "5"
  attributes:
    state: switch.receiver
  sources:
    radio: 'Radio'
    tv: 'TV'
    chromecast: 'Chromecast'
    dvd: 'DVD/Bluray'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
