### PR TITLE
Clamp brightness between 0 and 255

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -67,12 +67,13 @@ PROP_TO_ATTR = {
 
 # Service call validation schemas
 VALID_TRANSITION = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=900))
+VALID_BRIGHTNESS = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255))
 
 LIGHT_TURN_ON_SCHEMA = vol.Schema({
     ATTR_ENTITY_ID: cv.entity_ids,
     ATTR_PROFILE: str,
     ATTR_TRANSITION: VALID_TRANSITION,
-    ATTR_BRIGHTNESS: cv.byte,
+    ATTR_BRIGHTNESS: VALID_BRIGHTNESS,
     ATTR_COLOR_NAME: str,
     ATTR_RGB_COLOR: vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
                             vol.Coerce(tuple)),

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -42,11 +42,6 @@ ATTR_COLOR_NAME = "color_name"
 # int with value 0 .. 255 representing brightness of the light.
 ATTR_BRIGHTNESS = "brightness"
 
-# String representing weather to turn the light on or off.
-ATTR_POWER = "power"
-POWER_ON = "on"
-POWER_OFF = "off"
-
 # String representing a profile (built-in ones or external defined).
 ATTR_PROFILE = "profile"
 
@@ -70,26 +65,22 @@ PROP_TO_ATTR = {
     'xy_color': ATTR_XY_COLOR,
 }
 
-SERVICE_SET_STATE = "set_state"
-
 # Service call validation schemas
 VALID_TRANSITION = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=900))
-VALID_BRIGHTNESS = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255))
 
 LIGHT_TURN_ON_SCHEMA = vol.Schema({
     ATTR_ENTITY_ID: cv.entity_ids,
     ATTR_PROFILE: str,
     ATTR_TRANSITION: VALID_TRANSITION,
-    ATTR_BRIGHTNESS: VALID_BRIGHTNESS,
+    ATTR_BRIGHTNESS: cv.byte,
     ATTR_COLOR_NAME: str,
     ATTR_RGB_COLOR: vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
                             vol.Coerce(tuple)),
     ATTR_XY_COLOR: vol.All(vol.ExactSequence((cv.small_float, cv.small_float)),
                            vol.Coerce(tuple)),
-    ATTR_COLOR_TEMP: vol.All(vol.int, vol.Range(min=154, max=500)),
+    ATTR_COLOR_TEMP: vol.All(int, vol.Range(min=154, max=500)),
     ATTR_FLASH: vol.In([FLASH_SHORT, FLASH_LONG]),
     ATTR_EFFECT: vol.In([EFFECT_COLORLOOP, EFFECT_RANDOM, EFFECT_WHITE]),
-    ATTR_POWER: vol.In([POWER_OFF, POWER_ON]),
 })
 
 LIGHT_TURN_OFF_SCHEMA = vol.Schema({
@@ -118,7 +109,7 @@ def is_on(hass, entity_id=None):
 # pylint: disable=too-many-arguments
 def turn_on(hass, entity_id=None, transition=None, brightness=None,
             rgb_color=None, xy_color=None, color_temp=None, profile=None,
-            flash=None, effect=None, color_name=None, power=None):
+            flash=None, effect=None, color_name=None):
     """Turn all or specified light on."""
     data = {
         key: value for key, value in [
@@ -132,11 +123,11 @@ def turn_on(hass, entity_id=None, transition=None, brightness=None,
             (ATTR_FLASH, flash),
             (ATTR_EFFECT, effect),
             (ATTR_COLOR_NAME, color_name),
-            (ATTR_POWER, power),
         ] if value is not None
     }
 
     hass.services.call(DOMAIN, SERVICE_TURN_ON, data)
+
 
 def turn_off(hass, entity_id=None, transition=None):
     """Turn all or specified light off."""
@@ -250,13 +241,15 @@ def setup(hass, config):
     hass.services.register(DOMAIN, SERVICE_TOGGLE, handle_light_service,
                            descriptions.get(SERVICE_TOGGLE),
                            schema=LIGHT_TOGGLE_SCHEMA)
+
     return True
 
 
 class Light(ToggleEntity):
     """Representation of a light."""
 
-    # pylint: disable=no-self-use
+    # pylint: disable=no-self-use, abstract-method
+
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""


### PR DESCRIPTION
**Description:**
Allows for the brightness to exceed the range of 0 to 255 in config without throwing an error. Extremely useful if you want a light to be a set level brighter or dimmer than the rest of the lights without requiring additional logic in the config. 

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
