### PR TITLE
Fix bug #2493 in rfxtrx for int device id

### DIFF
--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -66,6 +66,9 @@ def _valid_device(value, device_type):
             key = device.get('packetid')
             device.pop('packetid')
 
+        if not len(key) % 2 == 0:
+            key = '0' + key
+
         if get_rfx_object(key) is None:
             raise vol.Invalid('Rfxtrx device {} is invalid: '
                               'Invalid device id for {}'.format(key, value))
@@ -160,7 +163,11 @@ def get_rfx_object(packetid):
     """Return the RFXObject with the packetid."""
     import RFXtrx as rfxtrxmod
 
-    binarypacket = bytearray.fromhex(packetid)
+    try:
+        binarypacket = bytearray.fromhex(packetid)
+    except ValueError:
+        return None
+
     pkt = rfxtrxmod.lowlevel.parse(binarypacket)
     if pkt is None:
         return None

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -34,6 +34,17 @@ class TestSwitchRfxtrx(unittest.TestCase):
                                rfxtrx_core.ATTR_FIREEVENT: True}
                             }}}))
 
+    def test_valid_config_int_device_id(self):
+        """Test configuration."""
+        self.assertTrue(_setup_component(self.hass, 'switch', {
+            'switch': {'platform': 'rfxtrx',
+                       'automatic_add': True,
+                       'devices':
+                           {'710000141010170': {
+                               'name': 'Test',
+                               rfxtrx_core.ATTR_FIREEVENT: True}
+                            }}}))
+
     def test_invalid_config1(self):
         self.assertFalse(_setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',


### PR DESCRIPTION
**Description:**

**Related issue (if applicable):** fixes #2493 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
