### PR TITLE
Fix issue #2290 for rfxtrx

### DIFF
--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -14,7 +14,6 @@ from homeassistant.util import slugify
 from homeassistant.components.rfxtrx import (
     ATTR_AUTOMATIC_ADD, ATTR_NAME,
     CONF_DEVICES, ATTR_DATA_TYPE, DATA_TYPES)
-from homeassistant.const import STATE_UNKNOWN
 
 DEPENDENCIES = ['rfxtrx']
 
@@ -113,7 +112,7 @@ class RfxtrxSensor(Entity):
         """Return the state of the sensor."""
         if self.event:
             return self.event.values[self.data_type]
-        return STATE_UNKNOWN
+        return None
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -14,6 +14,7 @@ from homeassistant.util import slugify
 from homeassistant.components.rfxtrx import (
     ATTR_AUTOMATIC_ADD, ATTR_NAME,
     CONF_DEVICES, ATTR_DATA_TYPE, DATA_TYPES)
+from homeassistant.const import STATE_UNKNOWN
 
 DEPENDENCIES = ['rfxtrx']
 
@@ -47,7 +48,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                     data_types = [data_type]
                     break
         for _data_type in data_types:
-            new_sensor = RfxtrxSensor(event, entity_info[ATTR_NAME],
+            new_sensor = RfxtrxSensor(None, entity_info[ATTR_NAME],
                                       _data_type)
             sensors.append(new_sensor)
             sub_sensors[_data_type] = new_sensor
@@ -110,9 +111,9 @@ class RfxtrxSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        if self.data_type:
+        if self.event:
             return self.event.values[self.data_type]
-        return None
+        return STATE_UNKNOWN
 
     @property
     def name(self):
@@ -122,7 +123,8 @@ class RfxtrxSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return self.event.values
+        if self.event:
+            return self.event.values
 
     @property
     def unit_of_measurement(self):

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -44,12 +44,6 @@ class TestSensorRfxtrx(unittest.TestCase):
         entity = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']
         self.assertEqual('Test', entity.name)
         self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
-        self.assertEqual(14.9, entity.state)
-        self.assertEqual({'Humidity status': 'normal', 'Temperature': 14.9,
-                          'Rssi numeric': 6, 'Humidity': 34,
-                          'Battery numeric': 9,
-                          'Humidity status numeric': 2},
-                         entity.device_state_attributes)
 
     def test_one_sensor(self):
         """Test with 1 sensor."""
@@ -64,12 +58,6 @@ class TestSensorRfxtrx(unittest.TestCase):
         entity = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']
         self.assertEqual('Test', entity.name)
         self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
-        self.assertEqual(14.9, entity.state)
-        self.assertEqual({'Humidity status': 'normal', 'Temperature': 14.9,
-                          'Rssi numeric': 6, 'Humidity': 34,
-                          'Battery numeric': 9,
-                          'Humidity status numeric': 2},
-                         entity.device_state_attributes)
 
     def test_one_sensor_no_datatype(self):
         """Test with 1 sensor."""
@@ -83,12 +71,6 @@ class TestSensorRfxtrx(unittest.TestCase):
         entity = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']
         self.assertEqual('Test', entity.name)
         self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
-        self.assertEqual(14.9, entity.state)
-        self.assertEqual({'Humidity status': 'normal', 'Temperature': 14.9,
-                          'Rssi numeric': 6, 'Humidity': 34,
-                          'Battery numeric': 9,
-                          'Humidity status numeric': 2},
-                         entity.device_state_attributes)
 
     def test_several_sensors(self):
         """Test with 3 sensors."""
@@ -112,35 +94,16 @@ class TestSensorRfxtrx(unittest.TestCase):
                 _entity_temp = rfxtrx_core.RFX_DEVICES[id]['Temperature']
                 _entity_hum = rfxtrx_core.RFX_DEVICES[id]['Humidity']
                 self.assertEqual('%', _entity_hum.unit_of_measurement)
-                self.assertEqual(14, _entity_hum.state)
-                self.assertEqual({'Battery numeric': 9, 'Temperature': 25.5,
-                                  'Humidity': 14, 'Humidity status': 'normal',
-                                  'Humidity status numeric': 2,
-                                  'Rssi numeric': 6},
-                                 _entity_hum.device_state_attributes)
                 self.assertEqual('Bath', _entity_hum.__str__())
 
                 self.assertEqual(TEMP_CELSIUS,
                                  _entity_temp.unit_of_measurement)
-                self.assertEqual(25.5, _entity_temp.state)
-                self.assertEqual({'Battery numeric': 9, 'Temperature': 25.5,
-                                  'Humidity': 14, 'Humidity status': 'normal',
-                                  'Humidity status numeric': 2,
-                                  'Rssi numeric': 6},
-                                 _entity_temp.device_state_attributes)
                 self.assertEqual('Bath', _entity_temp.__str__())
             elif id == 'sensor_0502':
                 device_num = device_num + 1
                 entity = rfxtrx_core.RFX_DEVICES[id]['Temperature']
 
                 self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
-                self.assertEqual(14.9, entity.state)
-                self.assertEqual({'Humidity status': 'normal',
-                                  'Temperature': 14.9,
-                                  'Rssi numeric': 6, 'Humidity': 34,
-                                  'Battery numeric': 9,
-                                  'Humidity status numeric': 2},
-                                 entity.device_state_attributes)
                 self.assertEqual('Test', entity.__str__())
 
         self.assertEqual(2, device_num)
@@ -252,35 +215,16 @@ class TestSensorRfxtrx(unittest.TestCase):
                 _entity_temp = rfxtrx_core.RFX_DEVICES[id]['Temperature']
                 _entity_hum = rfxtrx_core.RFX_DEVICES[id]['Humidity']
                 self.assertEqual('%', _entity_hum.unit_of_measurement)
-                self.assertEqual(14, _entity_hum.state)
-                self.assertEqual({'Battery numeric': 9, 'Temperature': 25.5,
-                                  'Humidity': 14, 'Humidity status': 'normal',
-                                  'Humidity status numeric': 2,
-                                  'Rssi numeric': 6},
-                                 _entity_hum.device_state_attributes)
                 self.assertEqual('Bath', _entity_hum.__str__())
 
                 self.assertEqual(TEMP_CELSIUS,
                                  _entity_temp.unit_of_measurement)
-                self.assertEqual(25.5, _entity_temp.state)
-                self.assertEqual({'Battery numeric': 9, 'Temperature': 25.5,
-                                  'Humidity': 14, 'Humidity status': 'normal',
-                                  'Humidity status numeric': 2,
-                                  'Rssi numeric': 6},
-                                 _entity_temp.device_state_attributes)
                 self.assertEqual('Bath', _entity_temp.__str__())
             elif id == 'sensor_0502':
                 device_num = device_num + 1
                 entity = rfxtrx_core.RFX_DEVICES[id]['Temperature']
 
                 self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
-                self.assertEqual(14.9, entity.state)
-                self.assertEqual({'Humidity status': 'normal',
-                                  'Temperature': 14.9,
-                                  'Rssi numeric': 6, 'Humidity': 34,
-                                  'Battery numeric': 9,
-                                  'Humidity status numeric': 2},
-                                 entity.device_state_attributes)
                 self.assertEqual('Test', entity.__str__())
 
         self.assertEqual(2, device_num)

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -44,6 +44,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         entity = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']
         self.assertEqual('Test', entity.name)
         self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
+        self.assertEqual('unknown', entity.state)
 
     def test_one_sensor(self):
         """Test with 1 sensor."""
@@ -58,6 +59,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         entity = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']
         self.assertEqual('Test', entity.name)
         self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
+        self.assertEqual('unknown', entity.state)
 
     def test_one_sensor_no_datatype(self):
         """Test with 1 sensor."""
@@ -71,6 +73,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         entity = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']
         self.assertEqual('Test', entity.name)
         self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
+        self.assertEqual('unknown', entity.state)
 
     def test_several_sensors(self):
         """Test with 3 sensors."""
@@ -95,14 +98,14 @@ class TestSensorRfxtrx(unittest.TestCase):
                 _entity_hum = rfxtrx_core.RFX_DEVICES[id]['Humidity']
                 self.assertEqual('%', _entity_hum.unit_of_measurement)
                 self.assertEqual('Bath', _entity_hum.__str__())
-
+                self.assertEqual('unknown', _entity_hum.state)
                 self.assertEqual(TEMP_CELSIUS,
                                  _entity_temp.unit_of_measurement)
                 self.assertEqual('Bath', _entity_temp.__str__())
             elif id == 'sensor_0502':
                 device_num = device_num + 1
                 entity = rfxtrx_core.RFX_DEVICES[id]['Temperature']
-
+                self.assertEqual('unknown', entity.state)
                 self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
                 self.assertEqual('Test', entity.__str__())
 
@@ -216,14 +219,14 @@ class TestSensorRfxtrx(unittest.TestCase):
                 _entity_hum = rfxtrx_core.RFX_DEVICES[id]['Humidity']
                 self.assertEqual('%', _entity_hum.unit_of_measurement)
                 self.assertEqual('Bath', _entity_hum.__str__())
-
+                self.assertEqual('unknown', _entity_temp.state)
                 self.assertEqual(TEMP_CELSIUS,
                                  _entity_temp.unit_of_measurement)
                 self.assertEqual('Bath', _entity_temp.__str__())
             elif id == 'sensor_0502':
                 device_num = device_num + 1
                 entity = rfxtrx_core.RFX_DEVICES[id]['Temperature']
-
+                self.assertEqual('unknown', entity.state)
                 self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
                 self.assertEqual('Test', entity.__str__())
 

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -44,7 +44,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         entity = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']
         self.assertEqual('Test', entity.name)
         self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
-        self.assertEqual('unknown', entity.state)
+        self.assertEqual(None, entity.state)
 
     def test_one_sensor(self):
         """Test with 1 sensor."""
@@ -59,7 +59,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         entity = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']
         self.assertEqual('Test', entity.name)
         self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
-        self.assertEqual('unknown', entity.state)
+        self.assertEqual(None, entity.state)
 
     def test_one_sensor_no_datatype(self):
         """Test with 1 sensor."""
@@ -73,7 +73,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         entity = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']
         self.assertEqual('Test', entity.name)
         self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
-        self.assertEqual('unknown', entity.state)
+        self.assertEqual(None, entity.state)
 
     def test_several_sensors(self):
         """Test with 3 sensors."""
@@ -98,14 +98,14 @@ class TestSensorRfxtrx(unittest.TestCase):
                 _entity_hum = rfxtrx_core.RFX_DEVICES[id]['Humidity']
                 self.assertEqual('%', _entity_hum.unit_of_measurement)
                 self.assertEqual('Bath', _entity_hum.__str__())
-                self.assertEqual('unknown', _entity_hum.state)
+                self.assertEqual(None, _entity_hum.state)
                 self.assertEqual(TEMP_CELSIUS,
                                  _entity_temp.unit_of_measurement)
                 self.assertEqual('Bath', _entity_temp.__str__())
             elif id == 'sensor_0502':
                 device_num = device_num + 1
                 entity = rfxtrx_core.RFX_DEVICES[id]['Temperature']
-                self.assertEqual('unknown', entity.state)
+                self.assertEqual(None, entity.state)
                 self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
                 self.assertEqual('Test', entity.__str__())
 
@@ -219,14 +219,14 @@ class TestSensorRfxtrx(unittest.TestCase):
                 _entity_hum = rfxtrx_core.RFX_DEVICES[id]['Humidity']
                 self.assertEqual('%', _entity_hum.unit_of_measurement)
                 self.assertEqual('Bath', _entity_hum.__str__())
-                self.assertEqual('unknown', _entity_temp.state)
+                self.assertEqual(None, _entity_temp.state)
                 self.assertEqual(TEMP_CELSIUS,
                                  _entity_temp.unit_of_measurement)
                 self.assertEqual('Bath', _entity_temp.__str__())
             elif id == 'sensor_0502':
                 device_num = device_num + 1
                 entity = rfxtrx_core.RFX_DEVICES[id]['Temperature']
-                self.assertEqual('unknown', entity.state)
+                self.assertEqual(None, entity.state)
                 self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
                 self.assertEqual('Test', entity.__str__())
 


### PR DESCRIPTION
**Description:**
The state of a rfxtrx sensor will now be unknown after start up and until a signal from is received from the sensor.

**Related issue (if applicable):** fixes #2290 

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
