### PR TITLE
Upgrade zeroconf to 0.17.6

### DIFF
--- a/homeassistant/components/zeroconf.py
+++ b/homeassistant/components/zeroconf.py
@@ -11,7 +11,7 @@ import socket
 
 from homeassistant.const import (EVENT_HOMEASSISTANT_STOP, __version__)
 
-REQUIREMENTS = ["zeroconf==0.17.5"]
+REQUIREMENTS = ["zeroconf==0.17.6"]
 
 DEPENDENCIES = ["api"]
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -443,4 +443,4 @@ xmltodict
 yahooweather==0.4
 
 # homeassistant.components.zeroconf
-zeroconf==0.17.5
+zeroconf==0.17.6


### PR DESCRIPTION
## 0.17.6
- Many improvements to address race conditions and exceptions during ZC() startup and shutdown,
- Added more test coverage
- Speed up browser startup
- Add ZeroconfServiceTypes() query class to discover all advertised service types
- Add full validation for service names, types and subtypes
- Fix for subtype browsing
- Fix DNSHInfo support

Tested with the following configuration:

``` yaml
zeroconf:
```

Discovery is working as expected.

``` bash
$ avahi-discover
Browsing domain 'local' on -1.-1 ...
Browsing for services of type '_home-assistant._tcp' in domain 'local' on 8.0 ...
Browsing for services of type '_home-assistant._tcp' in domain 'local' on 4.0 ...
Found service 'Development room' of type '_home-assistant._tcp' in domain 'local' on 8.0.
Found service 'Development room' of type '_home-assistant._tcp' in domain 'local' on 4.0.
Service data for service 'Development room' of type '_home-assistant._tcp' in domain 'local' on 8.0:
    Host Development\032room._home-assistant._tcp.local (192.168.1.5), port 8123, TXT data: ['base_url=http://192.168.1.5:8123', 'version=0.24.0.dev0', 'requires_api_password=true']
```
