### PR TITLE
add photo functionality to telegram

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -38,7 +38,7 @@ NOTIFY_SERVICE_SCHEMA = vol.Schema({
     vol.Required(ATTR_MESSAGE): cv.template,
     vol.Optional(ATTR_TITLE, default=ATTR_TITLE_DEFAULT): cv.string,
     vol.Optional(ATTR_TARGET): cv.string,
-    vol.Optional(ATTR_DATA): dict,      # nobody seems to be using this (yet)
+    vol.Optional(ATTR_DATA): dict,
 })
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/notify/services.yaml
+++ b/homeassistant/components/notify/services.yaml
@@ -13,3 +13,7 @@ notify:
     target:
       description: Target of the notification. Optional depending on the platform
       example: platform specific
+
+    data:
+      description: Extended information for notification. Optional depending on the platform
+      example: platform specific

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -4,17 +4,27 @@ Telegram platform for notify component.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.telegram/
 """
+import io
 import logging
 import urllib
+import requests
+from requests.auth import HTTPBasicAuth
 
 from homeassistant.components.notify import (
-    ATTR_TITLE, DOMAIN, BaseNotificationService)
+    ATTR_TITLE, ATTR_DATA, DOMAIN, BaseNotificationService)
 from homeassistant.const import CONF_API_KEY
 from homeassistant.helpers import validate_config
 
 _LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = ['python-telegram-bot==4.3.3']
+
+ATTR_PHOTO = "photo"
+ATTR_FILE = "file"
+ATTR_URL = "url"
+ATTR_CAPTION = "caption"
+ATTR_USERNAME = "username"
+ATTR_PASSWORD = "password"
 
 
 def get_service(hass, config):
@@ -54,9 +64,51 @@ class TelegramNotificationService(BaseNotificationService):
         import telegram
 
         title = kwargs.get(ATTR_TITLE)
+        data = kwargs.get(ATTR_DATA, {})
 
+        # send message
         try:
             self.bot.sendMessage(chat_id=self._chat_id,
                                  text=title + "  " + message)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending message.")
+            return
+
+        # send photo
+        if ATTR_PHOTO in data:
+            # if not a list
+            if not isinstance(data[ATTR_PHOTO], list):
+                photos = [data[ATTR_PHOTO]]
+            else:
+                photos = data[ATTR_PHOTO]
+
+            try:
+                for photo_data in photos:
+                    caption = photo_data.get(ATTR_CAPTION, None)
+
+                    # file is a url
+                    if ATTR_URL in photo_data:
+                        # use http authenticate
+                        if ATTR_USERNAME in photo_data or\
+                           ATTR_PASSWORD in photo_data:
+                            req = requests.get(
+                                photo_data[ATTR_URL],
+                                auth=HTTPBasicAuth(photo_data[ATTR_USERNAME],
+                                                   photo_data[ATTR_PASSWORD])
+                            )
+                        else:
+                            req = requests.get(photo_data[ATTR_URL])
+                        file_id = io.BytesIO(req.content)
+                    elif ATTR_FILE in photo_data:
+                        file_id = open(photo_data[ATTR_FILE], "rb")
+                    else:
+                        _LOGGER.error("No url or path is set for photo!")
+                        continue
+
+                    self.bot.sendPhoto(chat_id=self._chat_id,
+                                       photo=file_id, caption=caption)
+
+            except (OSError, IOError, telegram.error.TelegramError,
+                    urllib.error.HTTPError):
+                _LOGGER.exception("Error sending photo.")
+                return

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -89,7 +89,7 @@ class TelegramNotificationService(BaseNotificationService):
                     # file is a url
                     if ATTR_URL in photo_data:
                         # use http authenticate
-                        if ATTR_USERNAME in photo_data or\
+                        if ATTR_USERNAME in photo_data and\
                            ATTR_PASSWORD in photo_data:
                             req = requests.get(
                                 photo_data[ATTR_URL],


### PR DESCRIPTION
**Description:**

Add photo functionality to telegram. Required is '_file_' for local image or '_url_' for remote picture. It support basic authenticate with '_username_' and '_password_' option. Also optional is '_caption_' for photo title.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#634

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
automation:
  alias: Test Notifiy
  trigger:
    platform: state
    entity_id: input_boolean.notify_test
    from: "off"
    to: "on"

  action:
    service: notify.telegram
    data:
      title: "ALARM"
      message: "Alarm is running!!!"
      data:
        photo:
         - url: http://192.168.1.40/dms.jpg
           username: admin
           password: password
           caption: Camera 1
         - url: https://blable.alarmcam01.local/picture.png
           caption: Camera 2
         - file: /tmp/rapsberry_cam.jpg
           caption: Camera 3
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
