### PR TITLE
Zwave Node attributes was missing from binary sensors.

### DIFF
--- a/homeassistant/components/binary_sensor/zwave.py
+++ b/homeassistant/components/binary_sensor/zwave.py
@@ -8,6 +8,7 @@ import logging
 import datetime
 import homeassistant.util.dt as dt_util
 from homeassistant.helpers.event import track_point_in_time
+from homeassistant.helpers.entity import Entity
 from homeassistant.components import zwave
 from homeassistant.components.binary_sensor import (
     DOMAIN,
@@ -61,7 +62,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         add_devices([ZWaveBinarySensor(value, None)])
 
 
-class ZWaveBinarySensor(BinarySensorDevice, zwave.ZWaveDeviceEntity):
+class ZWaveBinarySensor(BinarySensorDevice, zwave.ZWaveDeviceEntity, Entity):
     """Representation of a binary sensor within Z-Wave."""
 
     def __init__(self, value, sensor_class):
@@ -97,7 +98,7 @@ class ZWaveBinarySensor(BinarySensorDevice, zwave.ZWaveDeviceEntity):
             self.update_ha_state()
 
 
-class ZWaveTriggerSensor(ZWaveBinarySensor):
+class ZWaveTriggerSensor(ZWaveBinarySensor, Entity):
     """Representation of a stateless sensor within Z-Wave."""
 
     def __init__(self, sensor_value, sensor_class, hass, re_arm_sec=60):


### PR DESCRIPTION
**Description:**
Zwave node attributes was missing from binary_sensors. This includes them.

**Related issue (if applicable):** fixes #
#2505
