### PR TITLE
homematic update to pyhomematic 0.1.9

### DIFF
--- a/homeassistant/components/sensor/homematic.py
+++ b/homeassistant/components/sensor/homematic.py
@@ -28,7 +28,10 @@ HM_UNIT_HA_CAST = {
     "POWER": "W",
     "CURRENT": "mA",
     "VOLTAGE": "V",
-    "ENERGY_COUNTER": "Wh"
+    "ENERGY_COUNTER": "Wh",
+    "GAS_POWER": "m3",
+    "GAS_ENERGY_COUNTER": "m3",
+    "LUX": "lux"
 }
 
 

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -14,3 +14,20 @@ persistent_notification:
       notification_id:
         description: Target ID of the notification, will replace a notification with the same Id. [Optional]
         example: 1234
+
+homematic:
+  virtualkey:
+    description: Press a virtual key from CCU/Homegear or simulate keypress
+
+    fields:
+      address:
+        description: Address of homematic device or BidCoS-RF for virtual remote
+        example: BidCoS-RF
+
+      channel:
+        description: Channel for calling a keypress
+        example: 1
+
+      param:
+        description: Event to send i.e. PRESS_LONG, PRESS_SHORT
+        example: PRESS_LONG

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -280,7 +280,7 @@ pyenvisalink==1.0
 pyfttt==0.3
 
 # homeassistant.components.homematic
-pyhomematic==0.1.8
+pyhomematic==0.1.9
 
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.8.3


### PR DESCRIPTION
**Description:**
- Fix bug with UNREACH and RSSI will never update after start HA
- Add service homematic.virtualkey for keypress simulation and CCU/Homegear function keys
- Add more device support (show at pyhomematic)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
