### PR TITLE
Logbook: Query logbook databse as_utc(). dt: Use pytz's localize

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -94,6 +94,7 @@ class LogbookView(HomeAssistantView):
         else:
             start_day = dt_util.start_of_local_day()
 
+        start_day = dt_util.as_utc(start_day)
         end_day = start_day + timedelta(days=1)
 
         events = recorder.get_model('Events')

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -92,8 +92,7 @@ def start_of_local_day(dt_or_d=None):
     elif isinstance(dt_or_d, dt.datetime):
         dt_or_d = dt_or_d.date()
 
-    return dt.datetime.combine(dt_or_d, dt.time()).replace(
-        tzinfo=DEFAULT_TIME_ZONE)
+    return DEFAULT_TIME_ZONE.localize(dt.datetime.combine(dt_or_d, dt.time()))
 
 
 # Copyright (c) Django Software Foundation and individual contributors.


### PR DESCRIPTION
**Description:**
- The fix to `/api/logbook/` ensures that the result contains events for the day in the configured timezone of HASS.
- The fix to `dt.py` uses pytz's `localize()` instead of dt's `replace()` according to their documentation on building localized time. replace returns `LMT` iso `UTC`

These all seem related, but require a fix in the frontend as well #1920 #1971 #2331 

Proposed frontend fix (but I dont have a dev environment for that yet)
- Probably [Initial state](https://github.com/home-assistant/home-assistant-js/blob/master/src/modules/entity-history/stores/current-entity-history-date-store.js#L8) as explained by @robo-hamburger in https://github.com/home-assistant/home-assistant/issues/1971.
- When selecting the date in the UI date picker, the previous day is filled in the text box & and sent to the HASS API. (I am in GMT+2, and guess everyone on the wrong side of GMT won't see this behaviour :smile: )

Both uses [dateToStr()](https://github.com/home-assistant/home-assistant-js/blob/master/src/util/date-to-str.js#L2) which forces UTC date (without adding the "+00:00" TZ) and when writing back to the frontend causes it to jump around depending on your TZ. But you do not really want to see the TZ in the frontend, so guessing this method should be updated to not return UTC time (since your selection is always for today)

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
