### PR TITLE
known devices yaml robustness

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -377,12 +377,16 @@ def load_config(path, hass, consider_home, home_range):
     """Load devices from YAML configuration file."""
     if not os.path.isfile(path):
         return []
-    return [
-        Device(hass, consider_home, home_range, device.get('track', False),
-               str(dev_id).lower(), str(device.get('mac')).upper(),
-               device.get('name'), device.get('picture'),
-               device.get(CONF_AWAY_HIDE, DEFAULT_AWAY_HIDE))
-        for dev_id, device in load_yaml_config_file(path).items()]
+    try:
+        return [
+            Device(hass, consider_home, home_range, device.get('track', False),
+                   str(dev_id).lower(), str(device.get('mac')).upper(),
+                   device.get('name'), device.get('picture'),
+                   device.get(CONF_AWAY_HIDE, DEFAULT_AWAY_HIDE))
+            for dev_id, device in load_yaml_config_file(path).items()]
+    except HomeAssistantError:
+        # When YAML file could not be loaded/did not contain a dict
+        return []
 
 
 def setup_scanner_platform(hass, config, scanner, see_device):

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import patch
 from datetime import datetime, timedelta
 import os
+import tempfile
 
 from homeassistant.loader import get_component
 import homeassistant.util.dt as dt_util
@@ -44,6 +45,18 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         self.hass.states.set(entity_id, STATE_NOT_HOME)
 
         self.assertFalse(device_tracker.is_on(self.hass, entity_id))
+
+    def test_reading_broken_yaml_config(self):
+        """Test when known devices contains invalid data."""
+        with tempfile.NamedTemporaryFile() as fp:
+            # file is empty
+            assert device_tracker.load_config(fp.name, None, False, 0) == []
+
+            fp.write('100'.encode('utf-8'))
+            fp.flush()
+
+            # file contains a non-dict format
+            assert device_tracker.load_config(fp.name, None, False, 0) == []
 
     def test_reading_yaml_config(self):
         """Test the rendering of the YAML configuration."""


### PR DESCRIPTION
**Description:**
Inspired by https://github.com/home-assistant/home-assistant/issues/1015#issuecomment-231609647 I was looking at the known devices yaml code. I could find one use case that caused an exception so I fixed it.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/1015#issuecomment-231609647

**Example entry for `known_devices.yaml` (if applicable):**

``` yaml
hello
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
