### PR TITLE
Support for Wink lock user codes

### DIFF
--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.garage_door import GarageDoorDevice
 from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
+REQUIREMENTS = ['python-wink==0.7.10', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -14,7 +14,7 @@ from homeassistant.util import color as color_util
 from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
 
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
+REQUIREMENTS = ['python-wink==0.7.10', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.lock import LockDevice
 from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
+REQUIREMENTS = ['python-wink==0.7.10', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/rollershutter/wink.py
+++ b/homeassistant/components/rollershutter/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.rollershutter import RollershutterDevice
 from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
+REQUIREMENTS = ['python-wink==0.7.10', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.components.wink import WinkDevice
 from homeassistant.loader import get_component
 
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
+REQUIREMENTS = ['python-wink==0.7.10', 'pubnub==3.8.2']
 
 SENSOR_TYPES = ['temperature', 'humidity']
 

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.entity import ToggleEntity
 
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
+REQUIREMENTS = ['python-wink==0.7.10', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
 from homeassistant.helpers.entity import Entity
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.7.8', 'pubnub==3.7.6']
+REQUIREMENTS = ['python-wink==0.7.10', 'pubnub==3.8.2']
 
 SUBSCRIPTION_HANDLER = None
 CHANNELS = []
@@ -29,7 +29,8 @@ def setup(hass, config):
     from pubnub import Pubnub
     pywink.set_bearer_token(config[DOMAIN][CONF_ACCESS_TOKEN])
     global SUBSCRIPTION_HANDLER
-    SUBSCRIPTION_HANDLER = Pubnub("N/A", pywink.get_subscription_key())
+    SUBSCRIPTION_HANDLER = Pubnub("N/A", pywink.get_subscription_key(),
+                                  ssl_on=True)
     SUBSCRIPTION_HANDLER.set_heartbeat(120)
 
     # Load components for the devices in the Wink that we support
@@ -58,7 +59,7 @@ class WinkDevice(Entity):
         self.wink = wink
         self._battery = self.wink.battery_level
         if self.wink.pubnub_channel in CHANNELS:
-            pubnub = Pubnub("N/A", self.wink.pubnub_key)
+            pubnub = Pubnub("N/A", self.wink.pubnub_key, ssl_on=True)
             pubnub.set_heartbeat(120)
             pubnub.subscribe(self.wink.pubnub_channel,
                              self._pubnub_update,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -240,7 +240,7 @@ psutil==4.3.0
 # homeassistant.components.rollershutter.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-pubnub==3.7.6
+pubnub==3.8.2
 
 # homeassistant.components.notify.pushbullet
 pushbullet.py==0.10.0
@@ -343,7 +343,7 @@ python-twitch==1.2.0
 # homeassistant.components.rollershutter.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.7.8
+python-wink==0.7.10
 
 # homeassistant.components.keyboard
 pyuserinput==0.1.9


### PR DESCRIPTION
**Description:**
Adds support for Wink lock user codes, a binary sensor will be created for each user code defined in the Wink app. These binary sensors will be True for ~30 seconds from the time the user code is entered on the lock. This will allow for automations based on "who" unlocked the door.

This PR also fixes a few issues.

python-wink is now using the non quirky URL which caused some trouble earlier this week in the SSL cert expired. #2500 

We are now using the latest version of pubnub which switched requirements from pycryptodome to pycryptodomex this will allow for pycryptodome to be installed along side of pycrypto. #2420 #2411 Pycryptodomex also installs in Windows, thanks to #brg468 for testing this. #2441 

the pubnub connections are also using SSL now!

**Related issue (if applicable):** fixes #2500 #2420 #2441 #2411 

**Checklist:**

If code communicates with devices, web services, or a:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
