### PR TITLE
Add validation and switch python-mystrom

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -317,6 +317,9 @@ python-forecastio==1.3.4
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5
 
+# homeassistant.components.switch.mystrom
+python-mystrom==0.3.6
+
 # homeassistant.components.nest
 python-nest==2.9.2
 


### PR DESCRIPTION
**Description:**
Add validation for the configuration and switch to python-mystrom as dependency.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
  - platform: mystrom
    host: 10.100.0.137
    name: MyStrom Switch
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
