### PR TITLE
Update rpi_gpio.py to use sensor pullup

### DIFF
--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -57,7 +57,7 @@ class RPiGPIOGarageDoor(GarageDoorDevice):
         self._relay_pin = relay_pin
         self._state_pin = state_pin
         rpi_gpio.setup_output(self._relay_pin)
-        rpi_gpio.setup_input(self._state_pin, 'DOWN')
+        rpi_gpio.setup_input(self._state_pin, 'UP')
         rpi_gpio.write_output(self._relay_pin, True)
 
     @property


### PR DESCRIPTION
**Description:**
Should be pullup, since the sensor pulls to ground (at least the one on AndrewHilliday's site)

Or do we want this configurable?
