### PR TITLE
MagicLight/Flux WiFi Color LED Light Component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -129,6 +129,7 @@ omit =
     homeassistant/components/joaoapps_join.py
     homeassistant/components/keyboard.py
     homeassistant/components/light/blinksticklight.py
+    homeassistant/components/light/flux_led.py
     homeassistant/components/light/hue.py
     homeassistant/components/light/hyperion.py
     homeassistant/components/light/lifx.py

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -1,0 +1,116 @@
+"""
+Support for Flux lights.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.flux_led/
+"""
+
+import logging
+import socket
+import voluptuous as vol
+
+from homeassistant.components.light import Light
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['https://github.com/Danielhiversen/flux_led/archive/master.zip'
+                '#flux_led==0.2']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "flux_led"
+
+ATTR_NAME = 'name'
+
+DEVICE_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_NAME): cv.string,
+})
+
+
+def _valid_lights(value):
+    """Validate a dictionary of light definitions."""
+    config = {}
+    for key, device in value.items():
+        config[key] = DEVICE_SCHEMA(device)
+    return config
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required("platform"): DOMAIN,
+    vol.Optional('devices', default={}): vol.All(dict, _valid_lights),
+    vol.Optional('automatic_add', default=False):  cv.boolean,
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Setup the Flux lights."""
+    import flux_led
+    lights = []
+    light_ips = []
+    for ipaddr, device_config in config["devices"].items():
+        _LOGGER.info(ipaddr)
+        device = {}
+        device["id"] = device_config[ATTR_NAME]
+        device["ipaddr"] = ipaddr
+        light = FluxLight(device)
+        if light.is_valid:
+            lights.append(light)
+            light_ips.append(ipaddr)
+
+    # Find the bulbs on the LAN
+    scanner = flux_led.BulbScanner()
+    scanner.scan(timeout=20)
+    for device in scanner.getBulbInfo():
+        light = FluxLight(device)
+        ipaddr = device['ipaddr']
+        if light.is_valid and ipaddr not in light_ips:
+            lights.append(light)
+            light_ips.append(ipaddr)
+
+    add_devices_callback(lights)
+
+
+class FluxLight(Light):
+    """Representation of a Flux light."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, device):
+        """Initialize the light."""
+        import flux_led
+
+        self._name = device['id']
+        ipaddr = device['ipaddr']
+        self.is_valid = True
+        self._bulb = None
+        _LOGGER.info(ipaddr)
+        try:
+            self._bulb = flux_led.WifiLedBulb(ipaddr)
+        except socket.error:
+            self.is_valid = False
+
+    @property
+    def unique_id(self):
+        """Return the ID of this light."""
+        return "{}.{}".format(
+            self.__class__, self._name)
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        self.update()
+        return self._bulb.isOn()
+
+    def turn_on(self, **kwargs):
+        """Turn the specified or all lights on."""
+        self._bulb.turnOn()
+
+    def turn_off(self, **kwargs):
+        """Turn the specified or all lights off."""
+        self._bulb.turnOff()
+
+    def update(self):
+        """Synchronize state with bulb."""
+        self._bulb.refreshState()

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -12,8 +12,8 @@ import voluptuous as vol
 from homeassistant.components.light import Light
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['https://github.com/Danielhiversen/flux_led/archive/master.zip'
-                '#flux_led==0.2']
+REQUIREMENTS = ['https://github.com/Danielhiversen/flux_led/archive/0.3.zip'
+                '#flux_led==0.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,7 +46,6 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     lights = []
     light_ips = []
     for ipaddr, device_config in config["devices"].items():
-        _LOGGER.info(ipaddr)
         device = {}
         device["id"] = device_config[ATTR_NAME]
         device["ipaddr"] = ipaddr
@@ -80,11 +79,12 @@ class FluxLight(Light):
         ipaddr = device['ipaddr']
         self.is_valid = True
         self._bulb = None
-        _LOGGER.info(ipaddr)
         try:
             self._bulb = flux_led.WifiLedBulb(ipaddr)
         except socket.error:
             self.is_valid = False
+            _LOGGER.error("Failed to connect to bulb %s, %s",
+                          ipaddr, self._name)
 
     @property
     def unique_id(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -96,6 +96,9 @@ hikvision==0.4
 # homeassistant.components.sensor.dht
 # http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
 
+# homeassistant.components.light.flux_led
+https://github.com/Danielhiversen/flux_led/archive/master.zip#flux_led==0.2
+
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.1.1.zip#pyW215==0.1.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -97,7 +97,7 @@ hikvision==0.4
 # http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
 
 # homeassistant.components.light.flux_led
-https://github.com/Danielhiversen/flux_led/archive/master.zip#flux_led==0.2
+https://github.com/Danielhiversen/flux_led/archive/0.3.zip#flux_led==0.3
 
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.1.1.zip#pyW215==0.1.1


### PR DESCRIPTION
**Description:**

https://community.home-assistant.io/t/magiclight-flux-wifi-color-led-light-component/2271

Many thanks to mplawner and @tchellomello for helping me with testing

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#649

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
light:                                                                                                                                                                                                            
   platform: flux_led                                                                                                                                                                                               
   automatic_add: True                                                                                                                                                                                              
   devices:                                                                                                                                                                                                         
     192.168.1.5:                                                                                                                                                                                                   
       name: test                                                                                                                                                                                                   
     192.168.1.3:                                                                                                                                                                                                   
       name: test2
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
