### PR TITLE
Round output of wind speed and humidity

### DIFF
--- a/homeassistant/components/sensor/openweathermap.py
+++ b/homeassistant/components/sensor/openweathermap.py
@@ -127,9 +127,9 @@ class OpenWeatherMapSensor(Entity):
             else:
                 self._state = round(data.get_temperature()['temp'], 1)
         elif self.type == 'wind_speed':
-            self._state = data.get_wind()['speed']
+            self._state = round(data.get_wind()['speed'], 1)
         elif self.type == 'humidity':
-            self._state = data.get_humidity()
+            self._state = round(data.get_humidity(), 1)
         elif self.type == 'pressure':
             self._state = round(data.get_pressure()['press'], 0)
         elif self.type == 'clouds':


### PR DESCRIPTION
**Description:**
Wind speed and humidity output is now rounded to avoid long decimal output.

**Related issue (if applicable):** :point_up: [July 16, 2016 8:56 AM](https://gitter.im/home-assistant/home-assistant?at=5789daa3914c51592b235e63)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: openweathermap
    api_key: !secret owm_api
    monitored_conditions:
      - temperature
      - wind_speed
      - humidity
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
