### PR TITLE
Make sqlalchemy main dependency to help migration

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,6 +5,7 @@ pytz>=2016.4
 pip>=7.0.0
 jinja2>=2.8
 voluptuous==0.8.9
+sqlalchemy==1.0.14
 
 # homeassistant.components.isy994
 PyISY==1.0.6

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ REQUIRES = [
     'pip>=7.0.0',
     'jinja2>=2.8',
     'voluptuous==0.8.9',
+    'sqlalchemy==1.0.14',
 ]
 
 setup(


### PR DESCRIPTION
Adding SQLAlchemy as a main dependency for the next two releases to help people migrating their database.
