### PR TITLE
Upgrade cherrypy to 6.1.1

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -25,7 +25,7 @@ import homeassistant.util.dt as dt_util
 import homeassistant.helpers.config_validation as cv
 
 DOMAIN = "http"
-REQUIREMENTS = ("cherrypy==6.0.2", "static3==0.7.0", "Werkzeug==0.11.10")
+REQUIREMENTS = ("cherrypy==6.1.1", "static3==0.7.0", "Werkzeug==0.11.10")
 
 CONF_API_PASSWORD = "api_password"
 CONF_SERVER_HOST = "server_host"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -46,7 +46,7 @@ blockchain==1.3.3
 boto3==1.3.1
 
 # homeassistant.components.http
-cherrypy==6.0.2
+cherrypy==6.1.1
 
 # homeassistant.components.notify.xmpp
 dnspython3==1.12.0


### PR DESCRIPTION
## 6.1.1
- Issue #1411: Fix issue where autoreload fails when   the host interpreter for CherryPy was launched using   `python -m`.
## 6.1.0
- Combined wsgiserver2 and wsgiserver3 modules into a single module, `cherrypy.wsgiserver`.

Tested with the following configuration:

``` yaml
http:
```
