### PR TITLE
Rfxtrx tests

### DIFF
--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -148,6 +148,32 @@ class TestLightRfxtrx(unittest.TestCase):
         self.assertTrue(entity.is_on)
         self.assertEqual(entity.brightness, 255)
 
+        entity.turn_off()
+        entity_id = rfxtrx_core.RFX_DEVICES['213c7f216'].entity_id
+        entity_hass = self.hass.states.get(entity_id)
+        self.assertEqual('Test', entity_hass.name)
+        self.assertEqual('off', entity_hass.state)
+
+        entity.turn_on()
+        entity_hass = self.hass.states.get(entity_id)
+        self.assertEqual('on', entity_hass.state)
+
+        entity.turn_off()
+        entity_hass = self.hass.states.get(entity_id)
+        self.assertEqual('off', entity_hass.state)
+
+        entity.turn_on(brightness=100)
+        entity_hass = self.hass.states.get(entity_id)
+        self.assertEqual('on', entity_hass.state)
+
+        entity.turn_on(brightness=10)
+        entity_hass = self.hass.states.get(entity_id)
+        self.assertEqual('on', entity_hass.state)
+
+        entity.turn_on(brightness=255)
+        entity_hass = self.hass.states.get(entity_id)
+        self.assertEqual('on', entity_hass.state)
+
     def test_several_lights(self):
         """Test with 3 lights."""
         self.assertTrue(_setup_component(self.hass, 'light', {

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -75,8 +75,9 @@ class TestSensorRfxtrx(unittest.TestCase):
         self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
         self.assertEqual(None, entity.state)
 
-        entity_id = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature'].entity_id
-        entity = self.hass.states.get(entity_id)   
+        entity_id = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature']\
+            .entity_id
+        entity = self.hass.states.get(entity_id)
         self.assertEqual('Test', entity.name)
         self.assertEqual('unknown', entity.state)
 

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -75,6 +75,11 @@ class TestSensorRfxtrx(unittest.TestCase):
         self.assertEqual(TEMP_CELSIUS, entity.unit_of_measurement)
         self.assertEqual(None, entity.state)
 
+        entity_id = rfxtrx_core.RFX_DEVICES['sensor_0502']['Temperature'].entity_id
+        entity = self.hass.states.get(entity_id)   
+        self.assertEqual('Test', entity.name)
+        self.assertEqual('unknown', entity.state)
+
     def test_several_sensors(self):
         """Test with 3 sensors."""
         self.assertTrue(_setup_component(self.hass, 'sensor', {

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -155,11 +155,11 @@ class TestSwitchRfxtrx(unittest.TestCase):
         self.assertFalse(entity.is_on)
 
         entity_id = rfxtrx_core.RFX_DEVICES['213c7f216'].entity_id
-        entity_hass = self.hass.states.get(entity_id)   
+        entity_hass = self.hass.states.get(entity_id)
         self.assertEqual('Test', entity_hass.name)
         self.assertEqual('off', entity_hass.state)
         entity.turn_on()
-        entity_hass = self.hass.states.get(entity_id)   
+        entity_hass = self.hass.states.get(entity_id)
         self.assertEqual('on', entity_hass.state)
         entity.turn_off()
         entity_hass = self.hass.states.get(entity_id)

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -154,6 +154,17 @@ class TestSwitchRfxtrx(unittest.TestCase):
         entity.turn_off()
         self.assertFalse(entity.is_on)
 
+        entity_id = rfxtrx_core.RFX_DEVICES['213c7f216'].entity_id
+        entity_hass = self.hass.states.get(entity_id)   
+        self.assertEqual('Test', entity_hass.name)
+        self.assertEqual('off', entity_hass.state)
+        entity.turn_on()
+        entity_hass = self.hass.states.get(entity_id)   
+        self.assertEqual('on', entity_hass.state)
+        entity.turn_off()
+        entity_hass = self.hass.states.get(entity_id)
+        self.assertEqual('off', entity_hass.state)
+
     def test_several_switches(self):
         """Test with 3 switches."""
         self.assertTrue(_setup_component(self.hass, 'switch', {

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -108,6 +108,7 @@ class TestRFXTRX(unittest.TestCase):
 
         self.assertEqual(event.values['Command'], "On")
         self.assertEqual('on', entity.state)
+        self.assertEqual(self.hass.states.get('switch.test').state, 'on')
         self.assertEqual(1, len(rfxtrx.RFX_DEVICES))
         self.assertEqual(1, len(calls))
         self.assertEqual(calls[0].data,


### PR DESCRIPTION
**Description:**
Add some rfxtrx tests

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
