### PR TITLE
Upgrade python-telegram-bot to 5.0.0

### DIFF
--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import validate_config
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['python-telegram-bot==4.3.3']
+REQUIREMENTS = ['python-telegram-bot==5.0.0']
 
 ATTR_PHOTO = "photo"
 ATTR_FILE = "file"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -331,7 +331,7 @@ python-nmap==0.6.0
 python-pushover==0.2
 
 # homeassistant.components.notify.telegram
-python-telegram-bot==4.3.3
+python-telegram-bot==5.0.0
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.2.0


### PR DESCRIPTION
## v5.0.0
- Rework JobQueue
- Introduce ConversationHandler
## v4.3.4
- Fix proxy support with urllib3 when proxy requires auth

Tested with the following configuration:

``` yaml
notify:
  - platform: telegram
    name: telegram
    api_key: !secret telegram_api
    chat_id: !secret telegram_client
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```
