### PR TITLE
Fix bug with imap sensor

### DIFF
--- a/homeassistant/components/sensor/imap.py
+++ b/homeassistant/components/sensor/imap.py
@@ -90,12 +90,11 @@ class ImapSensor(Entity):
             self.connection.select()
             self._unread_count = len(self.connection.search(
                 None, 'UnSeen')[1][0].split())
-        except imaplib.IMAP4.abort:
+        except imaplib.IMAP4.error:
             _LOGGER.info("Connection to %s lost, attempting to reconnect",
                          self._server)
             try:
-                self._login()
-                self.update()
+                self.connection = self._login()
             except imaplib.IMAP4.error:
                 _LOGGER.error("Failed to reconnect.")
 


### PR DESCRIPTION
**Description:**
Fixed bug in the IMAP sensor where the new connection was not saved when a reconnect
attempt was made.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Fixed bug where the new connection was not saved when a reconnect
attempt was made; broadened the exception catching.
