### PR TITLE
Fix initialization state for GPIO switches configured with inverted logic

### DIFF
--- a/homeassistant/components/switch/rpi_gpio.py
+++ b/homeassistant/components/switch/rpi_gpio.py
@@ -39,6 +39,7 @@ class RPiGPIOSwitch(ToggleEntity):
         self._invert_logic = invert_logic
         self._state = False
         rpi_gpio.setup_output(self._port)
+        rpi_gpio.write_output(self._port, 1 if self._invert_logic else 0)
 
     @property
     def name(self):


### PR DESCRIPTION
**Description:**
When the Raspberry Pi GPIO switch component is configured for inverted logic (active LOW) the GPIO pins should be initialized accordingly.
This patch initializes GPIO pins to HIGH (not active) when configured for inverted logic.

**Related issue (if applicable):**
Raspberry PI GPIO service initialized with wrong GPIO pins setting in case of inverted logic

**Checklist:**

If code communicates with devices:
- [x] Local tests with `tox` run successfully.
