### PR TITLE
Allow templates for script delay configuration sequence items

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -376,7 +376,9 @@ CONDITION_SCHEMA = vol.Any(
 
 _SCRIPT_DELAY_SCHEMA = vol.Schema({
     vol.Optional(CONF_ALIAS): string,
-    vol.Required("delay"): vol.Any(vol.All(time_period, positive_timedelta), template)
+    vol.Required("delay"): vol.Any( \
+        vol.All(time_period, positive_timedelta), \
+        template)
 })
 
 SCRIPT_SCHEMA = vol.All(

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -376,8 +376,8 @@ CONDITION_SCHEMA = vol.Any(
 
 _SCRIPT_DELAY_SCHEMA = vol.Schema({
     vol.Optional(CONF_ALIAS): string,
-    vol.Required("delay"): vol.Any( \
-        vol.All(time_period, positive_timedelta), \
+    vol.Required("delay"): vol.Any(
+        vol.All(time_period, positive_timedelta),
         template)
 })
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -376,7 +376,7 @@ CONDITION_SCHEMA = vol.Any(
 
 _SCRIPT_DELAY_SCHEMA = vol.Schema({
     vol.Optional(CONF_ALIAS): string,
-    vol.Required("delay"): vol.All(time_period, positive_timedelta)
+    vol.Required("delay"): vol.Any(vol.All(time_period, positive_timedelta), template)
 })
 
 SCRIPT_SCHEMA = vol.All(

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -26,6 +26,7 @@ def call_from_config(hass, config, variables=None):
     """Call a script based on a config entry."""
     Script(hass, config).run(variables)
 
+
 class Script():
     """Representation of a script."""
 
@@ -72,14 +73,14 @@ class Script():
                     delay = action[CONF_DELAY]
 
                     if isinstance(delay, str):
-                        t = datetime.strptime( \
-                            template.render( \
-                                self.hass, delay, None), \
+                        time_template = datetime.strptime(
+                            template.render(
+                                self.hass, delay, None),
                                 "%H:%M:%S")
-                        delay = timedelta( \
-                            hours=t.hour, \
-                            minutes=t.minute, \
-                            seconds=t.second)
+                        delay = timedelta(
+                            hours=time_template.hour,
+                            minutes=time_template.minute,
+                            seconds=time_template.second)
 
                     self._delay_listener = track_point_in_utc_time(
                         self.hass, script_delay,

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -69,7 +69,7 @@ class Script():
                         self._delay_listener = None
                         self.run(variables)
 
-                    delay = vol.All(cv.time_period, cv.positive_timedelta)(template.render(self.hass, delay))
+                    delay = vol.All(cv.time_period, cv.positive_timedelta)(template.render(self.hass, action[CONF_DELAY]))
 
                     self._delay_listener = track_point_in_utc_time(
                         self.hass, script_delay,

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1,8 +1,9 @@
 """Helpers to execute scripts."""
-import voluptuous as vol
 import logging
 import threading
 from itertools import islice
+
+import voluptuous as vol
 
 import homeassistant.util.dt as date_util
 from homeassistant.const import EVENT_TIME_CHANGED, CONF_CONDITION
@@ -75,8 +76,7 @@ class Script():
                         delay = vol.All(
                             cv.time_period,
                             cv.positive_timedelta)(
-                            template.render(self.hass, delay)
-                            )
+                                template.render(self.hass, delay))
 
                     self._delay_listener = track_point_in_utc_time(
                         self.hass, script_delay,

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -72,8 +72,14 @@ class Script():
                     delay = action[CONF_DELAY]
 
                     if isinstance(delay, str):
-                        t = datetime.strptime(template.render(self.hass, delay, None), "%H:%M:%S")
-                        delay = timedelta(hours=t.hour, minutes=t.minute, seconds=t.second)
+                        t = datetime.strptime( \
+                            template.render( \
+                                self.hass, delay, None), \
+                                "%H:%M:%S")
+                        delay = timedelta( \
+                            hours=t.hour, \
+                            minutes=t.minute, \
+                            seconds=t.second)
 
                     self._delay_listener = track_point_in_utc_time(
                         self.hass, script_delay,

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1,7 +1,7 @@
 """Helpers to execute scripts."""
+import voluptuous as vol
 import logging
 import threading
-import voluptuous as vol
 from itertools import islice
 
 import homeassistant.util.dt as date_util
@@ -72,7 +72,11 @@ class Script():
                     delay = action[CONF_DELAY]
 
                     if isinstance(delay, str):
-                        delay = vol.All(cv.time_period, cv.positive_timedelta)(template.render(self.hass, delay))
+                        delay = vol.All(
+                            cv.time_period,
+                            cv.positive_timedelta)(
+                            template.render(self.hass, delay)
+                            )
 
                     self._delay_listener = track_point_in_utc_time(
                         self.hass, script_delay,

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -71,6 +71,8 @@ class Script():
 
                     delay = action[CONF_DELAY]
 
+                    _LOGGER.critical(str(delay))
+
                     if isinstance(delay, str):
                         delay = vol.All(cv.time_period, cv.positive_timedelta)(template.render(self.hass, delay))
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -74,6 +74,8 @@ class Script():
                     if isinstance(delay, str):
                         delay = vol.All(cv.time_period, cv.positive_timedelta)(template.render(self.hass, delay))
 
+                    _LOGGER.critical(str(delay))
+
                     self._delay_listener = track_point_in_utc_time(
                         self.hass, script_delay,
                         date_util.utcnow() + delay)

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1,7 +1,7 @@
 """Helpers to execute scripts."""
 import logging
 import threading
-from datetime import datetime, timedelta
+import voluptuous as vol
 from itertools import islice
 
 import homeassistant.util.dt as date_util
@@ -69,17 +69,7 @@ class Script():
                         self._delay_listener = None
                         self.run(variables)
 
-                    delay = action[CONF_DELAY]
-
-                    if isinstance(delay, str):
-                        time_template = datetime.strptime(
-                            template.render(
-                                self.hass, delay, None),
-                            "%H:%M:%S")
-                        delay = timedelta(
-                            hours=time_template.hour,
-                            minutes=time_template.minute,
-                            seconds=time_template.second)
+                    delay = vol.All(cv.time_period, cv.positive_timedelta)(template.render(hass, delay))
 
                     self._delay_listener = track_point_in_utc_time(
                         self.hass, script_delay,

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -76,7 +76,7 @@ class Script():
                         time_template = datetime.strptime(
                             template.render(
                                 self.hass, delay, None),
-                                "%H:%M:%S")
+                            "%H:%M:%S")
                         delay = timedelta(
                             hours=time_template.hour,
                             minutes=time_template.minute,

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -69,7 +69,7 @@ class Script():
                         self._delay_listener = None
                         self.run(variables)
 
-                    delay = vol.All(cv.time_period, cv.positive_timedelta)(template.render(hass, delay))
+                    delay = vol.All(cv.time_period, cv.positive_timedelta)(template.render(self.hass, delay))
 
                     self._delay_listener = track_point_in_utc_time(
                         self.hass, script_delay,

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -69,7 +69,10 @@ class Script():
                         self._delay_listener = None
                         self.run(variables)
 
-                    delay = vol.All(cv.time_period, cv.positive_timedelta)(template.render(self.hass, action[CONF_DELAY]))
+                    delay = action[CONF_DELAY]
+
+                    if isinstance(delay, str):
+                        delay = vol.All(cv.time_period, cv.positive_timedelta)(template.render(self.hass, delay))
 
                     self._delay_listener = track_point_in_utc_time(
                         self.hass, script_delay,

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -71,12 +71,8 @@ class Script():
 
                     delay = action[CONF_DELAY]
 
-                    _LOGGER.critical(str(delay))
-
                     if isinstance(delay, str):
                         delay = vol.All(cv.time_period, cv.positive_timedelta)(template.render(self.hass, delay))
-
-                    _LOGGER.critical(str(delay))
 
                     self._delay_listener = track_point_in_utc_time(
                         self.hass, script_delay,

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -7,8 +7,7 @@ from itertools import islice
 import homeassistant.util.dt as date_util
 from homeassistant.const import EVENT_TIME_CHANGED, CONF_CONDITION
 from homeassistant.helpers.event import track_point_in_utc_time
-from homeassistant.helpers import service, condition
-from homeassistant.helpers import template
+from homeassistant.helpers import service, condition, template
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -154,7 +154,7 @@ class TestScriptHelper(unittest.TestCase):
 
         script_obj = script.Script(self.hass, [
             {'event': event},
-            {'delay': '00:00:{{ 5 }}'}},
+            {'delay': '00:00:{{ 5 }}'},
             {'event': event}])
 
         script_obj.run()

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -153,7 +153,7 @@ class TestScriptHelper(unittest.TestCase):
         self.hass.bus.listen(event, record_event)
 
         script_obj = script.Script(self.hass, [
-            {'event': event,
+            {'event': event},
             {'delay': '00:00:{{ 5 }}'}},
             {'event': event}])
 


### PR DESCRIPTION
**Description:**
Allow templates in the script delay configuration.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#661

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
script:
    delayed:
        sequence:
            delay: '{{ input_slider.hour_delay }}:{{ input_slider.minute_delay }}:{{ input_slider.second_delay }}'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
