### PR TITLE
Rfxtrx sensor

### DIFF
--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -100,6 +100,7 @@ DEVICE_SCHEMA = vol.Schema({
 
 DEVICE_SCHEMA_SENSOR = vol.Schema({
     vol.Optional(ATTR_NAME, default=None): cv.string,
+    vol.Optional(ATTR_FIREEVENT, default=False): cv.boolean,
     vol.Optional(ATTR_DATA_TYPE, default=[]):
         vol.All(cv.ensure_list, [vol.In(DATA_TYPES.keys())]),
 })

--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -12,7 +12,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 from homeassistant.components.rfxtrx import (
-    ATTR_AUTOMATIC_ADD, ATTR_NAME, ATTR_FIREEVENT, ATTR_STATE,
+    ATTR_AUTOMATIC_ADD, ATTR_NAME, ATTR_FIREEVENT,
     CONF_DEVICES, ATTR_DATA_TYPE, DATA_TYPES, ATTR_ENTITY_ID)
 
 DEPENDENCIES = ['rfxtrx']
@@ -47,7 +47,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                     data_types = [data_type]
                     break
         for _data_type in data_types:
-            new_sensor = RfxtrxSensor(event, entity_info[ATTR_NAME],
+            new_sensor = RfxtrxSensor(None, entity_info[ATTR_NAME],
                                       _data_type, entity_info[ATTR_FIREEVENT])
             sensors.append(new_sensor)
             sub_sensors[_data_type] = new_sensor
@@ -73,7 +73,6 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                         "signal_received", {
                             ATTR_ENTITY_ID:
                                 sensors[key].entity_id,
-                            ATTR_STATE: event.values[sensor.data_type],
                         }
                     )
 

--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -12,8 +12,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 from homeassistant.components.rfxtrx import (
-    ATTR_AUTOMATIC_ADD, ATTR_NAME,
-    CONF_DEVICES, ATTR_DATA_TYPE, DATA_TYPES)
+    ATTR_AUTOMATIC_ADD, ATTR_NAME, ATTR_FIREEVENT, ATTR_STATE,
+    CONF_DEVICES, ATTR_DATA_TYPE, DATA_TYPES, ATTR_ENTITY_ID)
 
 DEPENDENCIES = ['rfxtrx']
 
@@ -47,8 +47,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                     data_types = [data_type]
                     break
         for _data_type in data_types:
-            new_sensor = RfxtrxSensor(None, entity_info[ATTR_NAME],
-                                      _data_type)
+            new_sensor = RfxtrxSensor(event, entity_info[ATTR_NAME],
+                                      _data_type, entity_info[ATTR_FIREEVENT])
             sensors.append(new_sensor)
             sub_sensors[_data_type] = new_sensor
         rfxtrx.RFX_DEVICES[device_id] = sub_sensors
@@ -65,7 +65,18 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         if device_id in rfxtrx.RFX_DEVICES:
             sensors = rfxtrx.RFX_DEVICES[device_id]
             for key in sensors:
-                sensors[key].event = event
+                sensor = sensors[key]
+                sensor.event = event
+                # Fire event
+                if sensors[key].should_fire_event:
+                    sensor.hass.bus.fire(
+                        "signal_received", {
+                            ATTR_ENTITY_ID:
+                                sensors[key].entity_id,
+                            ATTR_STATE: event.values[sensor.data_type],
+                        }
+                    )
+
             return
 
         # Add entity if not exist and the automatic_add is True
@@ -94,10 +105,11 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 class RfxtrxSensor(Entity):
     """Representation of a RFXtrx sensor."""
 
-    def __init__(self, event, name, data_type):
+    def __init__(self, event, name, data_type, should_fire_event=False):
         """Initialize the sensor."""
         self.event = event
         self._name = name
+        self.should_fire_event = should_fire_event
         if data_type not in DATA_TYPES:
             data_type = "Unknown"
         self.data_type = data_type


### PR DESCRIPTION
**Description:**
Allow fire event when receiving signal from a Rfxtrx sensor

**Related issue (if applicable):** fixes some problems mentioned here #2290

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#660

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
