### PR TITLE
Fix bug in yahoo weather

### DIFF
--- a/homeassistant/components/sensor/yweather.py
+++ b/homeassistant/components/sensor/yweather.py
@@ -69,7 +69,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     yahoo_api = YahooWeatherData(woeid, yunit)
 
     # if update is false, it will never work...
-    if not yahoo_api.update():
+    if not yahoo_api.update() or not yahoo_api.yahoo.Forecast:
         _LOGGER.critical("Can't retrieve weather data from yahoo!")
         return False
 


### PR DESCRIPTION
**Description:**

An invalid woeid gave an TypeError, but now an error message is given.

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/help-with-yahoo-weather-configuration-on-pi/2422

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
  platform: yweather
  woeid: rock-spring-12770998
  forecast: 3
  monitored_conditions:
    - weather
    - temp_min
    - temp_max
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
