### PR TITLE
Tidy / Refactor Vera

### DIFF
--- a/homeassistant/components/binary_sensor/vera.py
+++ b/homeassistant/components/binary_sensor/vera.py
@@ -6,9 +6,6 @@ https://home-assistant.io/components/binary_sensor.vera/
 """
 import logging
 
-import homeassistant.util.dt as dt_util
-from homeassistant.const import (
-    ATTR_ARMED, ATTR_BATTERY_LEVEL, ATTR_LAST_TRIP_TIME, ATTR_TRIPPED)
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice)
 from homeassistant.components.vera import (

--- a/homeassistant/components/binary_sensor/vera.py
+++ b/homeassistant/components/binary_sensor/vera.py
@@ -35,30 +35,6 @@ class VeraBinarySensor(VeraDevice, BinarySensorDevice):
         VeraDevice.__init__(self, vera_device, controller)
 
     @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        attr = {}
-        if self.vera_device.has_battery:
-            attr[ATTR_BATTERY_LEVEL] = self.vera_device.battery_level + '%'
-
-        if self.vera_device.is_armable:
-            armed = self.vera_device.is_armed
-            attr[ATTR_ARMED] = 'True' if armed else 'False'
-
-        if self.vera_device.is_trippable:
-            last_tripped = self.vera_device.last_trip
-            if last_tripped is not None:
-                utc_time = dt_util.utc_from_timestamp(int(last_tripped))
-                attr[ATTR_LAST_TRIP_TIME] = utc_time.isoformat()
-            else:
-                attr[ATTR_LAST_TRIP_TIME] = None
-            tripped = self.vera_device.is_tripped
-            attr[ATTR_TRIPPED] = 'True' if tripped else 'False'
-
-        attr['Vera Device Id'] = self.vera_device.vera_device_id
-        return attr
-
-    @property
     def is_on(self):
         """Return true if sensor is on."""
         return self._state

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -57,31 +57,6 @@ class VeraLight(VeraDevice, Light):
         self.update_ha_state()
 
     @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        attr = {}
-
-        if self.vera_device.has_battery:
-            attr[ATTR_BATTERY_LEVEL] = self.vera_device.battery_level + '%'
-
-        if self.vera_device.is_armable:
-            armed = self.vera_device.is_armed
-            attr[ATTR_ARMED] = 'True' if armed else 'False'
-
-        if self.vera_device.is_trippable:
-            last_tripped = self.vera_device.last_trip
-            if last_tripped is not None:
-                utc_time = dt_util.utc_from_timestamp(int(last_tripped))
-                attr[ATTR_LAST_TRIP_TIME] = utc_time.isoformat()
-            else:
-                attr[ATTR_LAST_TRIP_TIME] = None
-            tripped = self.vera_device.is_tripped
-            attr[ATTR_TRIPPED] = 'True' if tripped else 'False'
-
-        attr['Vera Device Id'] = self.vera_device.vera_device_id
-        return attr
-
-    @property
     def is_on(self):
         """Return true if device is on."""
         return self._state

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -6,10 +6,8 @@ https://home-assistant.io/components/light.vera/
 """
 import logging
 
-import homeassistant.util.dt as dt_util
 from homeassistant.components.light import ATTR_BRIGHTNESS, Light
 from homeassistant.const import (
-    ATTR_ARMED, ATTR_BATTERY_LEVEL, ATTR_LAST_TRIP_TIME, ATTR_TRIPPED,
     STATE_OFF, STATE_ON)
 from homeassistant.components.vera import (
     VeraDevice, VERA_DEVICES, VERA_CONTROLLER)

--- a/homeassistant/components/lock/vera.py
+++ b/homeassistant/components/lock/vera.py
@@ -8,7 +8,7 @@ import logging
 
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import (
-    ATTR_BATTERY_LEVEL, STATE_LOCKED, STATE_UNLOCKED)
+    STATE_LOCKED, STATE_UNLOCKED)
 from homeassistant.components.vera import (
     VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
 

--- a/homeassistant/components/lock/vera.py
+++ b/homeassistant/components/lock/vera.py
@@ -32,16 +32,6 @@ class VeraLock(VeraDevice, LockDevice):
         self._state = None
         VeraDevice.__init__(self, vera_device, controller)
 
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes of the device."""
-        attr = {}
-        if self.vera_device.has_battery:
-            attr[ATTR_BATTERY_LEVEL] = self.vera_device.battery_level + '%'
-
-        attr['Vera Device Id'] = self.vera_device.vera_device_id
-        return attr
-
     def lock(self, **kwargs):
         """Lock the device."""
         self.vera_device.lock()

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -6,9 +6,7 @@ https://home-assistant.io/components/sensor.vera/
 """
 import logging
 
-import homeassistant.util.dt as dt_util
 from homeassistant.const import (
-    ATTR_ARMED, ATTR_BATTERY_LEVEL, ATTR_LAST_TRIP_TIME, ATTR_TRIPPED,
     TEMP_CELSIUS, TEMP_FAHRENHEIT)
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.vera import (

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -50,30 +50,6 @@ class VeraSensor(VeraDevice, Entity):
         elif self.vera_device.category == "Humidity Sensor":
             return '%'
 
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        attr = {}
-        if self.vera_device.has_battery:
-            attr[ATTR_BATTERY_LEVEL] = self.vera_device.battery_level + '%'
-
-        if self.vera_device.is_armable:
-            armed = self.vera_device.is_armed
-            attr[ATTR_ARMED] = 'True' if armed else 'False'
-
-        if self.vera_device.is_trippable:
-            last_tripped = self.vera_device.last_trip
-            if last_tripped is not None:
-                utc_time = dt_util.utc_from_timestamp(int(last_tripped))
-                attr[ATTR_LAST_TRIP_TIME] = utc_time.isoformat()
-            else:
-                attr[ATTR_LAST_TRIP_TIME] = None
-            tripped = self.vera_device.is_tripped
-            attr[ATTR_TRIPPED] = 'True' if tripped else 'False'
-
-        attr['Vera Device Id'] = self.vera_device.vera_device_id
-        return attr
-
     def update(self):
         """Update the state."""
         if self.vera_device.category == "Temperature Sensor":

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -6,10 +6,9 @@ https://home-assistant.io/components/switch.vera/
 """
 import logging
 
-import homeassistant.util.dt as dt_util
+from homeassistant.util import convert
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (
-    ATTR_ARMED, ATTR_BATTERY_LEVEL, ATTR_LAST_TRIP_TIME, ATTR_TRIPPED,
     STATE_OFF, STATE_ON)
 from homeassistant.components.vera import (
     VeraDevice, VERA_DEVICES, VERA_CONTROLLER)

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -34,32 +34,6 @@ class VeraSwitch(VeraDevice, SwitchDevice):
         self._state = False
         VeraDevice.__init__(self, vera_device, controller)
 
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes of the device."""
-        attr = {}
-
-        if self.vera_device.has_battery:
-            attr[ATTR_BATTERY_LEVEL] = self.vera_device.battery_level + '%'
-
-        if self.vera_device.is_armable:
-            armed = self.vera_device.is_armed
-            attr[ATTR_ARMED] = 'True' if armed else 'False'
-
-        if self.vera_device.is_trippable:
-            last_tripped = self.vera_device.last_trip
-            if last_tripped is not None:
-                utc_time = dt_util.utc_from_timestamp(int(last_tripped))
-                attr[ATTR_LAST_TRIP_TIME] = utc_time.isoformat()
-            else:
-                attr[ATTR_LAST_TRIP_TIME] = None
-            tripped = self.vera_device.is_tripped
-            attr[ATTR_TRIPPED] = 'True' if tripped else 'False'
-
-        attr['Vera Device Id'] = self.vera_device.vera_device_id
-
-        return attr
-
     def turn_on(self, **kwargs):
         """Turn device on."""
         self.vera_device.switch_on()

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -73,6 +73,13 @@ class VeraSwitch(VeraDevice, SwitchDevice):
         self.update_ha_state()
 
     @property
+    def current_power_mwh(self):
+        """Current power usage in mWh."""
+        power = self.vera_device.power
+        if power:
+            return convert(power, float, 0.0) * 1000
+
+    @property
     def is_on(self):
         """Return true if device is on."""
         return self._state

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -9,8 +9,12 @@ from collections import defaultdict
 
 from requests.exceptions import RequestException
 
+
+from homeassistant.util.dt import utc_from_timestamp
 from homeassistant.helpers import discovery
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import (
+    ATTR_ARMED, ATTR_BATTERY_LEVEL, ATTR_LAST_TRIP_TIME, ATTR_TRIPPED,
+    EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['pyvera==0.2.13']
@@ -139,7 +143,7 @@ class VeraDevice(Entity):
         if self.vera_device.is_trippable:
             last_tripped = self.vera_device.last_trip
             if last_tripped is not None:
-                utc_time = dt_util.utc_from_timestamp(int(last_tripped))
+                utc_time = utc_from_timestamp(int(last_tripped))
                 attr[ATTR_LAST_TRIP_TIME] = utc_time.isoformat()
             else:
                 attr[ATTR_LAST_TRIP_TIME] = None

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -161,7 +161,7 @@ class VeraDevice(Entity):
 
         power = self.vera_device.power
         if power:
-           attr[ATTR_CURRENT_POWER_MWH] = convert(power, float, 0.0) * 1000
+            attr[ATTR_CURRENT_POWER_MWH] = convert(power, float, 0.0) * 1000
 
         attr['Vera Device Id'] = self.vera_device.vera_device_id
 

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -123,3 +123,29 @@ class VeraDevice(Entity):
     def should_poll(self):
         """No polling needed."""
         return False
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the device."""
+        attr = {}
+
+        if self.vera_device.has_battery:
+            attr[ATTR_BATTERY_LEVEL] = self.vera_device.battery_level + '%'
+
+        if self.vera_device.is_armable:
+            armed = self.vera_device.is_armed
+            attr[ATTR_ARMED] = 'True' if armed else 'False'
+
+        if self.vera_device.is_trippable:
+            last_tripped = self.vera_device.last_trip
+            if last_tripped is not None:
+                utc_time = dt_util.utc_from_timestamp(int(last_tripped))
+                attr[ATTR_LAST_TRIP_TIME] = utc_time.isoformat()
+            else:
+                attr[ATTR_LAST_TRIP_TIME] = None
+            tripped = self.vera_device.is_tripped
+            attr[ATTR_TRIPPED] = 'True' if tripped else 'False'
+
+        attr['Vera Device Id'] = self.vera_device.vera_device_id
+
+        return attr

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyvera==0.2.13']
+REQUIREMENTS = ['pyvera==0.2.14']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -349,7 +349,7 @@ python-wink==0.7.8
 pyuserinput==0.1.9
 
 # homeassistant.components.vera
-pyvera==0.2.13
+pyvera==0.2.14
 
 # homeassistant.components.wemo
 pywemo==0.4.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -349,7 +349,7 @@ python-wink==0.7.8
 pyuserinput==0.1.9
 
 # homeassistant.components.vera
-pyvera==0.2.14
+pyvera==0.2.15
 
 # homeassistant.components.wemo
 pywemo==0.4.3


### PR DESCRIPTION
**Description:**
This tidies up a few aspects of vera:-
- Refactor device attributes into the base class
- Tidy vera to HA device mapping to be based on pyvera classes - rather than raw vera device categories (which vary between Vera controller versions)

It also adds a new power useage device attribute for devices that support it 

It superceedes https://github.com/home-assistant/home-assistant/pull/2511

(Now back with my vera so have tested!)

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/2394

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
