### PR TITLE
Don't overwrite the config directory

### DIFF
--- a/homeassistant/scripts/db_migrator.py
+++ b/homeassistant/scripts/db_migrator.py
@@ -83,8 +83,6 @@ def run(args):
             print(('Fatal Error: Specified configuration directory does '
                    'not exist {} ').format(config_dir))
             return 1
-    else:
-        config_dir = config_util.get_default_config_dir()
 
     src_db = '{}/home-assistant.db'.format(config_dir)
     dst_db = '{}/home-assistant_v2.db'.format(config_dir)


### PR DESCRIPTION
**Description:** Fixes a bug where a non-default config directory path was being overwritten by the default config directory path.

**Related issue (if applicable):** fixes #2566

Closes #2566

The `else` seems to have been an error and was overwriting a non-default config directory with the default location.
