### PR TITLE
Type Hints - __main__

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
     - python: "3.5"
       env: TOXENV=lint
     - python: "3.5"
+      env: TOXENV=typing
+    - python: "3.5"
       env: TOXENV=py35
   allow_failures:
     - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
       env: TOXENV=lint
     - python: "3.5"
       env: TOXENV=py35
+  allow_failures:
+    - python: "3.5"
+      env: TOXENV=typing
 cache:
   directories:
     - $HOME/.cache/pip

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -6,10 +6,10 @@ import os
 import sys
 from collections import defaultdict
 from threading import RLock
+from typing import Any, Optional, Dict
 
 import voluptuous as vol
 
-from typing import Any, Optional, Dict
 
 import homeassistant.components as core_components
 from homeassistant.components import group, persistent_notification
@@ -205,12 +205,12 @@ def prepare_setup_platform(hass, config, domain, platform_name):
 
 # pylint: disable=too-many-branches, too-many-statements, too-many-arguments
 def from_config_dict(config: Dict[str, Any],
-                     hass: Optional[core.HomeAssistant] = None,
-                     config_dir: Optional[str] = None,
-                     enable_log: bool = True,
-                     verbose: bool = False,
-                     skip_pip: bool = False,
-                     log_rotate_days: Any = None) \
+                     hass: Optional[core.HomeAssistant]=None,
+                     config_dir: Optional[str]=None,
+                     enable_log: bool=True,
+                     verbose: bool=False,
+                     skip_pip: bool=False,
+                     log_rotate_days: Any=None) \
                      -> Optional[core.HomeAssistant]:
     """Try to configure Home Assistant from a config dict.
 
@@ -274,10 +274,10 @@ def from_config_dict(config: Dict[str, Any],
 
 
 def from_config_file(config_path: str,
-                     hass: Optional[core.HomeAssistant] = None,
-                     verbose: bool = False,
-                     skip_pip: bool = True,
-                     log_rotate_days: Any = None):
+                     hass: Optional[core.HomeAssistant]=None,
+                     verbose: bool=False,
+                     skip_pip: bool=True,
+                     log_rotate_days: Any=None):
     """Read the configuration file and try to start all the functionality.
 
     Will add functionality to 'hass' parameter if given,

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -9,6 +9,8 @@ from threading import RLock
 
 import voluptuous as vol
 
+from typing import Any, Optional, Dict
+
 import homeassistant.components as core_components
 from homeassistant.components import group, persistent_notification
 import homeassistant.config as conf_util
@@ -202,9 +204,14 @@ def prepare_setup_platform(hass, config, domain, platform_name):
 
 
 # pylint: disable=too-many-branches, too-many-statements, too-many-arguments
-def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
-                     verbose=False, skip_pip=False,
-                     log_rotate_days=None):
+def from_config_dict(config: Dict[str, Any],
+                     hass: Optional[core.HomeAssistant] = None,
+                     config_dir: Optional[str] = None,
+                     enable_log: bool = True,
+                     verbose: bool = False,
+                     skip_pip: bool = False,
+                     log_rotate_days: Any = None) \
+                     -> Optional[core.HomeAssistant]:
     """Try to configure Home Assistant from a config dict.
 
     Dynamically loads required components and its dependencies.
@@ -266,8 +273,11 @@ def from_config_dict(config, hass=None, config_dir=None, enable_log=True,
     return hass
 
 
-def from_config_file(config_path, hass=None, verbose=False, skip_pip=True,
-                     log_rotate_days=None):
+def from_config_file(config_path: str,
+                     hass: Optional[core.HomeAssistant] = None,
+                     verbose: bool = False,
+                     skip_pip: bool = True,
+                     log_rotate_days: Any = None):
     """Read the configuration file and try to start all the functionality.
 
     Will add functionality to 'hass' parameter if given,

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -73,14 +73,14 @@ CORE_CONFIG_SCHEMA = vol.Schema({
 })
 
 
-def get_default_config_dir():
+def get_default_config_dir() -> str:
     """Put together the default configuration directory based on OS."""
     data_dir = os.getenv('APPDATA') if os.name == "nt" \
         else os.path.expanduser('~')
     return os.path.join(data_dir, CONFIG_DIR_NAME)
 
 
-def ensure_config_exists(config_dir, detect_location=True):
+def ensure_config_exists(config_dir: str, detect_location: bool=True) -> str:
     """Ensure a config file exists in given configuration directory.
 
     Creating a default one if needed.

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -57,7 +57,7 @@ class CoreState(enum.Enum):
     running = "RUNNING"
     stopping = "STOPPING"
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return the event."""
         return self.value
 
@@ -75,11 +75,11 @@ class HomeAssistant(object):
         self.state = CoreState.not_running
 
     @property
-    def is_running(self):
+    def is_running(self) -> bool:
         """Return if Home Assistant is running."""
         return self.state == CoreState.running
 
-    def start(self):
+    def start(self) -> None:
         """Start home assistant."""
         _LOGGER.info(
             "Starting Home Assistant (%d threads)", self.pool.worker_count)
@@ -90,7 +90,7 @@ class HomeAssistant(object):
         self.pool.block_till_done()
         self.state = CoreState.running
 
-    def block_till_stopped(self):
+    def block_till_stopped(self) -> int:
         """Register service homeassistant/stop and will block until called."""
         request_shutdown = threading.Event()
         request_restart = threading.Event()
@@ -132,7 +132,7 @@ class HomeAssistant(object):
 
         return RESTART_EXIT_CODE if request_restart.isSet() else 0
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop Home Assistant and shuts down all threads."""
         _LOGGER.info("Stopping")
         self.state = CoreState.stopping
@@ -290,7 +290,7 @@ class EventBus(object):
             # available to execute this listener it might occur that the
             # listener gets lined up twice to be executed.
             # This will make sure the second time it does nothing.
-            onetime_listener.run = True
+            setattr(onetime_listener, 'run', True)
 
             self.remove_listener(event_type, onetime_listener)
 

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -3,7 +3,7 @@ import importlib
 import os
 
 
-def run(args):
+def run(args: str) -> int:
     """Run a script."""
     scripts = [fil[:-3] for fil in os.listdir(os.path.dirname(__file__))
                if fil.endswith('.py') and fil != '__init__.py']

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -19,4 +19,4 @@ def run(args: str) -> int:
         return 1
 
     script = importlib.import_module('homeassistant.scripts.' + args[0])
-    return script.run(args[1:])
+    return script.run(args[1:])  # type: ignore

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,6 +5,7 @@ pytz>=2016.6.1
 pip>=7.0.0
 jinja2>=2.8
 voluptuous==0.8.9
+typing>=3.5
 sqlalchemy==1.0.14
 
 # homeassistant.components.isy994

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,7 +5,7 @@ pytz>=2016.6.1
 pip>=7.0.0
 jinja2>=2.8
 voluptuous==0.8.9
-typing>=3.5
+typing>=3,<4
 sqlalchemy==1.0.14
 
 # homeassistant.components.isy994

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,3 +7,4 @@ pytest-timeout>=1.0.0
 pytest-capturelog>=0.7
 pydocstyle>=1.0.0
 requests_mock>=1.0
+mypy-lang>=0.4

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,13 @@ DOWNLOAD_URL = ('https://github.com/home-assistant/home-assistant/archive/'
 PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 
 REQUIRES = [
-    'typing>=3',
     'requests>=2,<3',
     'pyyaml>=3.11,<4',
     'pytz>=2016.6.1',
     'pip>=7.0.0',
     'jinja2>=2.8',
     'voluptuous==0.8.9',
+    'typing>=3,<4',
     'sqlalchemy==1.0.14',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ DOWNLOAD_URL = ('https://github.com/home-assistant/home-assistant/archive/'
 PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 
 REQUIRES = [
+    'typing>=3',
     'requests>=2,<3',
     'pyyaml>=3.11,<4',
     'pytz>=2016.6.1',

--- a/tox.ini
+++ b/tox.ini
@@ -33,4 +33,4 @@ commands =
 [testenv:typing]
 basepython = python3
 commands =
-         mypy --silent-imports --disallow-untyped-calls --check-untyped-defs --warn-incomplete-stub homeassistant
+         mypy --silent-imports homeassistant

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, lint, requirements
+envlist = py34, py35, lint, requirements, typing
 skip_missing_interpreters = True
 
 [testenv]
@@ -29,3 +29,9 @@ basepython = python3
 deps =
 commands =
          python script/gen_requirements_all.py validate
+
+[testenv:typing]
+basepython = python3
+deps =
+commands =
+         mypy --silent-imports --disallow-untyped-calls --check-untyped-defs --warn-incomplete-stub homeassistant

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,5 @@ commands =
 
 [testenv:typing]
 basepython = python3
-deps =
 commands =
          mypy --silent-imports --disallow-untyped-calls --check-untyped-defs --warn-incomplete-stub homeassistant


### PR DESCRIPTION
This is a WIP to add Type Hints [PEP 483 and 484] to home-assistant using mypy for type checking with `--disallow-untyped-calls --check-untyped-defs`.

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
