### PR TITLE
Tweak what is tested with MyPy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,7 @@ commands =
 
 [testenv:typing]
 basepython = python3
+deps =
+     -r{toxinidir}/requirements_test.txt
 commands =
          mypy --silent-imports homeassistant


### PR DESCRIPTION
@fabianhjr is working on adding type information to Home Assistant. This is awesome and a very ambitious project. To keep this manageable, we need the tests to be giving us realistic goals that people can work towards to.

This tweak will limit all type checking to only the core files (`homeassistant/*.py`). When those are done we can start including helpers, util and start whitelisting a few of the core components.
