### PR TITLE
Update pyhomematic to version 0.1.10

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import discovery
 from homeassistant.config import load_yaml_config_file
 
 DOMAIN = 'homematic'
-REQUIREMENTS = ["pyhomematic==0.1.9"]
+REQUIREMENTS = ["pyhomematic==0.1.10"]
 
 HOMEMATIC = None
 HOMEMATIC_LINK_DELAY = 0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -282,7 +282,7 @@ pyenvisalink==1.0
 pyfttt==0.3
 
 # homeassistant.components.homematic
-pyhomematic==0.1.9
+pyhomematic==0.1.10
 
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.8.3


### PR DESCRIPTION
**Description:**

pyhomematic update release note:
Version 0.1.10 (2016-07-20)
- Bugfix and stability @pvizeli

User they have a gas meter device (HM-ES-TX-WM) can break the homematic component in Home-Assistant

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
