### PR TITLE
Added Russound RNET support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -152,6 +152,7 @@ omit =
     homeassistant/components/media_player/pioneer.py
     homeassistant/components/media_player/plex.py
     homeassistant/components/media_player/roku.py
+    homeassistant/components/media_player/russound_rnet.py
     homeassistant/components/media_player/samsungtv.py
     homeassistant/components/media_player/snapcast.py
     homeassistant/components/media_player/sonos.py

--- a/homeassistant/components/media_player/russound_rnet.py
+++ b/homeassistant/components/media_player/russound_rnet.py
@@ -1,10 +1,8 @@
-"""
-
-Support for interfacing with Russound CAV units
+"""Support for interfacing with Russound CAV units
 via RNET Protocol.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/media_player.russound_rnet/
+https://home-assistant.io/components/media_player.russound_rnet/ .
 """
 import logging
 
@@ -64,6 +62,7 @@ class RussoundRNETDevice(MediaPlayerDevice):
         self._state = STATE_OFF
         self._sources = sources
         self._zone_id = zone_id
+        self._volume = 0
 
     @property
     def name(self):
@@ -83,12 +82,12 @@ class RussoundRNETDevice(MediaPlayerDevice):
     @property
     def volume_level(self):
         """Volume level of the media player (0..1)."""
-        return 0
+        return self._volume
 
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
-        volume = volume * 100
-        self._russ.set_volume('1', self._zone_id, volume)
+        self._volume = volume * 100
+        self._russ.set_volume('1', self._zone_id, self._volume)
 
     def turn_on(self):
         """Turn the media player on."""

--- a/homeassistant/components/media_player/russound_rnet.py
+++ b/homeassistant/components/media_player/russound_rnet.py
@@ -1,0 +1,121 @@
+"""
+Support for interfacing with Russound CAV units
+via RNET Protocol
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.russound_rnet/
+"""
+import logging
+
+from homeassistant.loader import get_component
+from homeassistant.components.media_player import (
+    SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
+    SUPPORT_SELECT_SOURCE, MediaPlayerDevice)
+from homeassistant.const import (
+    CONF_HOST, CONF_PORT, CONF_NAME, STATE_OFF, STATE_ON)
+
+REQUIREMENTS = [
+    'https://github.com/laf/russound/archive/0.1.6.zip'
+    '#russound==0.1.6']
+
+ZONES = 'zones'
+SOURCES = 'sources'
+
+SUPPORTED_COMMANDS = SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET | \
+                     SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE
+
+_LOGGER = logging.getLogger(__name__)
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """ Setup the Russound RNET platform """
+
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    keypad = config.get('keypad', '70')
+
+    if host is None or port is None:
+        _LOGGER.error('Invalid config. Expected %s and %s',
+                      CONF_HOST, CONF_PORT)
+        return False
+
+    from russound import russound
+
+    russ = russound.Russound(host, port)
+    russ.connect(keypad)
+
+    sources = []
+    for source in config[SOURCES]:
+        sources.append(source['name'])
+
+    if russ.is_connected():
+        for zone_id, extra in config[ZONES].items():
+            add_devices([RussoundRNETDevice(hass, russ, sources, zone_id, extra)])
+    else:
+        _LOGGER.error('Not connected to %s:%s', host, port)
+
+# pylint: disable=abstract-method, too-many-public-methods,
+# pylint: disable=too-many-instance-attributes, too-many-arguments
+class RussoundRNETDevice(MediaPlayerDevice):
+    """ Representation of a Russound RNET device. """
+
+    def __init__(self, hass, russ, sources, zone_id, extra):
+        self._name = extra['name']
+        self._russ = russ
+        self._state = STATE_OFF
+        self._sources = sources
+        self._zone_id = zone_id
+
+    @property
+    def name(self):
+        """Return the name of the zone."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def supported_media_commands(self):
+        """Flag of media commands that are supported."""
+        return SUPPORTED_COMMANDS
+
+    @property
+    def volume_level(self):
+        """Volume level of the media player (0..1)."""
+        return 0
+
+    def set_volume_level(self, volume):
+        """Set volume level, range 0..1."""
+        volume = volume * 100
+        self._russ.set_volume('1', self._zone_id, volume)
+
+    def turn_on(self):
+        """Turn the media player on."""
+        self._russ.set_power('1', self._zone_id, '1')
+        self._state = STATE_ON
+
+    def turn_off(self):
+        """Turn off media player."""
+        self._russ.set_power('1', self._zone_id, '0')
+        self._state = STATE_OFF
+
+    def mute_volume(self, mute):
+        """Send mute command."""
+        self._russ.toggle_mute('1', self._zone_id)
+
+    def select_source(self, source):
+        """Set the input source."""
+        if source in self._sources:
+            index = self._sources.index(source)+1
+            self._russ.set_source('1', self._zone_id, index)
+
+    @property
+    def state(self):
+        return self._state
+
+    @property
+    def source_list(self):
+        """List of available input sources."""
+
+        return self._sources

--- a/homeassistant/components/media_player/russound_rnet.py
+++ b/homeassistant/components/media_player/russound_rnet.py
@@ -1,18 +1,18 @@
 """
+
 Support for interfacing with Russound CAV units
-via RNET Protocol
+via RNET Protocol.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.russound_rnet/
 """
 import logging
 
-from homeassistant.loader import get_component
 from homeassistant.components.media_player import (
     SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_SELECT_SOURCE, MediaPlayerDevice)
 from homeassistant.const import (
-    CONF_HOST, CONF_PORT, CONF_NAME, STATE_OFF, STATE_ON)
+    CONF_HOST, CONF_PORT, STATE_OFF, STATE_ON)
 
 REQUIREMENTS = [
     'https://github.com/laf/russound/archive/0.1.6.zip'
@@ -27,8 +27,7 @@ SUPPORTED_COMMANDS = SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET | \
 _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """ Setup the Russound RNET platform """
-
+    """Setup the Russound RNET platform."""
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
     keypad = config.get('keypad', '70')
@@ -49,16 +48,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if russ.is_connected():
         for zone_id, extra in config[ZONES].items():
-            add_devices([RussoundRNETDevice(hass, russ, sources, zone_id, extra)])
+            add_devices([RussoundRNETDevice(hass, russ, sources, zone_id,
+                                            extra)])
     else:
         _LOGGER.error('Not connected to %s:%s', host, port)
 
 # pylint: disable=abstract-method, too-many-public-methods,
 # pylint: disable=too-many-instance-attributes, too-many-arguments
 class RussoundRNETDevice(MediaPlayerDevice):
-    """ Representation of a Russound RNET device. """
-
+    """Representation of a Russound RNET device."""
     def __init__(self, hass, russ, sources, zone_id, extra):
+        """Initialise the Russound RNET device."""
         self._name = extra['name']
         self._russ = russ
         self._state = STATE_OFF
@@ -111,11 +111,7 @@ class RussoundRNETDevice(MediaPlayerDevice):
             self._russ.set_source('1', self._zone_id, index)
 
     @property
-    def state(self):
-        return self._state
-
-    @property
     def source_list(self):
         """List of available input sources."""
-
         return self._sources
+

--- a/homeassistant/components/media_player/russound_rnet.py
+++ b/homeassistant/components/media_player/russound_rnet.py
@@ -1,8 +1,8 @@
-"""Support for interfacing with Russound CAV units
-via RNET Protocol.
+"""
+Support for interfacing with Russound via RNET Protocol.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/media_player.russound_rnet/ .
+https://home-assistant.io/components/media_player.russound_rnet/
 """
 import logging
 
@@ -19,10 +19,11 @@ REQUIREMENTS = [
 ZONES = 'zones'
 SOURCES = 'sources'
 
-SUPPORTED_COMMANDS = SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET | \
+SUPPORT_RUSSOUND = SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET | \
                      SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE
 
 _LOGGER = logging.getLogger(__name__)
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Russound RNET platform."""
@@ -51,10 +52,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     else:
         _LOGGER.error('Not connected to %s:%s', host, port)
 
+
 # pylint: disable=abstract-method, too-many-public-methods,
 # pylint: disable=too-many-instance-attributes, too-many-arguments
 class RussoundRNETDevice(MediaPlayerDevice):
     """Representation of a Russound RNET device."""
+
     def __init__(self, hass, russ, sources, zone_id, extra):
         """Initialise the Russound RNET device."""
         self._name = extra['name']
@@ -77,7 +80,7 @@ class RussoundRNETDevice(MediaPlayerDevice):
     @property
     def supported_media_commands(self):
         """Flag of media commands that are supported."""
-        return SUPPORTED_COMMANDS
+        return SUPPORT_RUSSOUND
 
     @property
     def volume_level(self):
@@ -113,4 +116,3 @@ class RussoundRNETDevice(MediaPlayerDevice):
     def source_list(self):
         """List of available input sources."""
         return self._sources
-

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -454,3 +454,6 @@ yahooweather==0.4
 
 # homeassistant.components.zeroconf
 zeroconf==0.17.6
+
+# homeassistant.components.media_player.russound_rnet
+https://github.com/laf/russound/archive/0.1.6.zip#russound==0.1.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -142,6 +142,9 @@ https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad591540925
 # homeassistant.components.qwikswitch
 https://github.com/kellerza/pyqwikswitch/archive/v0.4.zip#pyqwikswitch==0.4
 
+# homeassistant.components.media_player.russound_rnet
+https://github.com/laf/russound/archive/0.1.6.zip#russound==0.1.6
+
 # homeassistant.components.ecobee
 https://github.com/nkgilley/python-ecobee-api/archive/4856a704670c53afe1882178a89c209b5f98533d.zip#python-ecobee==0.0.6
 
@@ -454,6 +457,3 @@ yahooweather==0.4
 
 # homeassistant.components.zeroconf
 zeroconf==0.17.6
-
-# homeassistant.components.media_player.russound_rnet
-https://github.com/laf/russound/archive/0.1.6.zip#russound==0.1.6


### PR DESCRIPTION
**Description:**

This adds support for Russound RNET based devices over TCP.

I've only been able to test against a CAV6.6 unit but there should be no reason this doesn't work with any RNET based devices.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io# 

Pull request 669 done.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
media_player:
  platform: russound_rnet
  host: 192.168.1.10
  port: 1337
  name: Russound
  zones:
    1:
      name: Main Bedroom
    2:
      name: Living Room
    3:
      name: Kitchen
    4:
      name: Bathroom
    5:
      name: Dining Room
    6:
      name: Guest Bedroom
  sources:
    - name: Sonos
    - name: Sky+
    - name: iPod
    - name: Unused 1
    - name: Unused 2
    - name: Kodi
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
