### PR TITLE
Upgrade slacker to 0.9.24

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -10,7 +10,7 @@ from homeassistant.components.notify import DOMAIN, BaseNotificationService
 from homeassistant.const import CONF_API_KEY
 from homeassistant.helpers import validate_config
 
-REQUIREMENTS = ['slacker==0.9.21']
+REQUIREMENTS = ['slacker==0.9.24']
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -381,7 +381,7 @@ scsgate==0.1.0
 sendgrid>=1.6.0,<1.7.0
 
 # homeassistant.components.notify.slack
-slacker==0.9.21
+slacker==0.9.24
 
 # homeassistant.components.notify.xmpp
 sleekxmpp==1.3.1


### PR DESCRIPTION
v0.9.24
- Add support for auth.revoke, team.billableinfo and chat.meMessage methods

Tested with the following configuration:

``` yaml
notify:
  - name: slack
    platform: slack
    api_key: !secret slack_api
    default_channel: '#ha'
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```
