### PR TITLE
Upgrade netdisco to 0.7.0

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -13,7 +13,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.helpers.discovery import load_platform, discover
 
 DOMAIN = "discovery"
-REQUIREMENTS = ['netdisco==0.6.7']
+REQUIREMENTS = ['netdisco==0.7.0']
 
 SCAN_INTERVAL = 300  # seconds
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -202,7 +202,7 @@ messagebird==1.2.0
 mficlient==0.3.0
 
 # homeassistant.components.discovery
-netdisco==0.6.7
+netdisco==0.7.0
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.2.10


### PR DESCRIPTION
 0.7.0
- Discover Home Assistant instances (@fabaff)
- Discover DirecTV (@cbulock)
- Plex discovery: Fix crashing when servers had non ascii names (@fabaff) (#32)
- Discover MyStrom devices (@fabaff)

Tested with the following configuration:

``` yaml
discovery:
```

Looking for a Plex media server, myStrom device, and of course Home Assistant itself:

``` bash
16-07-22 11:55:50 INFO (Thread-4) [requests.packages.urllib3.connectionpool] Starting new HTTP connection (1): 192.168.1.36
16-07-22 11:55:50 INFO (Thread-4) [homeassistant.components.discovery] Found new service: home_assistant ('http://192.168.1.32:8123', '0.25.0.dev0', True)
16-07-22 11:55:51 INFO (Thread-4) [homeassistant.components.discovery] Found new service: plex_mediaserver ('media', 'https://192.168.1.36:32400')
[...]
16-07-22 11:55:51 INFO (Thread-4) [homeassistant.core] Bus:Handling <Event platform_discovered[L]: platform=plex, discovered=('media', 'https://192.168.1.36:32400'), service=load_platform.media_player>
16-07-22 11:55:51 INFO (Thread-4) [homeassistant.components.discovery] Found new service: DLNA http://192.168.1.36:32469/DeviceDescription.xml
16-07-22 11:55:51 INFO (Thread-4) [homeassistant.components.discovery] Found new service: mystrom ('Switch-00000', 'http://192.168.1.136', '00:00:00:00:00:00')
16-07-22 11:55:51 INFO (ThreadPool Worker 2) [homeassistant.loader] Loaded media_player.plex from homeassistant.components.media_player.plex
16-07-22 11:55:51 INFO (ThreadPool Worker 2) [homeassistant.components.media_player.plex] Discovered PLEX server: 192.168.1.36:32400
16-07-22 11:55:51 INFO (ThreadPool Worker 2) [plexapi] GET http://192.168.1.36:32400/
```
