### PR TITLE
Upgrade voluptuous to 0.9.1

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,7 +4,7 @@ pyyaml>=3.11,<4
 pytz>=2016.6.1
 pip>=7.0.0
 jinja2>=2.8
-voluptuous==0.8.9
+voluptuous==0.9.1
 typing>=3,<4
 sqlalchemy==1.0.14
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ REQUIRES = [
     'pytz>=2016.6.1',
     'pip>=7.0.0',
     'jinja2>=2.8',
-    'voluptuous==0.8.9',
+    'voluptuous==0.9.1',
     'typing>=3,<4',
     'sqlalchemy==1.0.14',
 ]


### PR DESCRIPTION
0.9.1
- Fix for error import

0.9.0 (~20 backwards-compatible upgrades since the last release)
- Add validate_schema decorator
- Provide basic humanize-error wrappers
- Email validator

Tested with the following configuration:

``` yaml
the whole one: 
```

This is an upgrade of a critical dependency. As far as I remember required the last upgrade some further actions.

I guess that it's in everybody's interest if there are some :+1: before this gets merged.
