### PR TITLE
Upgrade sendgrid to 3.0.7

### DIFF
--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -10,7 +10,7 @@ from homeassistant.components.notify import (
     ATTR_TITLE, DOMAIN, BaseNotificationService)
 from homeassistant.helpers import validate_config
 
-REQUIREMENTS = ['sendgrid>=1.6.0,<1.7.0']
+REQUIREMENTS = ['sendgrid==3.0.7']
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -24,27 +24,50 @@ def get_service(hass, config):
     api_key = config['api_key']
     sender = config['sender']
     recipient = config['recipient']
+
     return SendgridNotificationService(api_key, sender, recipient)
 
 
 # pylint: disable=too-few-public-methods
 class SendgridNotificationService(BaseNotificationService):
-    """Implement the notification service for email via Sendgrid."""
+    """Implementation the notification service for email via Sendgrid."""
 
     def __init__(self, api_key, sender, recipient):
         """Initialize the service."""
+        from sendgrid import SendGridAPIClient
+
         self.api_key = api_key
         self.sender = sender
         self.recipient = recipient
 
-        from sendgrid import SendGridClient
-        self._sg = SendGridClient(self.api_key)
+        self._sg = SendGridAPIClient(apikey=self.api_key)
 
     def send_message(self, message='', **kwargs):
         """Send an email to a user via SendGrid."""
         subject = kwargs.get(ATTR_TITLE)
 
-        from sendgrid import Mail
-        mail = Mail(from_email=self.sender, to=self.recipient,
-                    html=message, text=message, subject=subject)
-        self._sg.send(mail)
+        data = {
+            "personalizations": [
+                {
+                    "to": [
+                        {
+                            "email": self.recipient
+                        }
+                    ],
+                    "subject": subject
+                }
+            ],
+            "from": {
+                "email": self.sender
+            },
+            "content": [
+                {
+                    "type": "text/plain",
+                    "value": message
+                }
+            ]
+        }
+
+        response = self._sg.client.mail.send.post(request_body=data)
+        if response.status_code is not 202:
+            _LOGGER.error('Unable to send notification with SendGrid')

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -378,7 +378,7 @@ schiene==0.17
 scsgate==0.1.0
 
 # homeassistant.components.notify.sendgrid
-sendgrid>=1.6.0,<1.7.0
+sendgrid==3.0.7
 
 # homeassistant.components.notify.slack
 slacker==0.9.21


### PR DESCRIPTION
3.0.7
- README updates
- Update introduction blurb to include information regarding our forward path
- Update the v3 /mail/send example to include non-helper usage
- Update the generic v3 example to include non-fluent interface usage

3.0.6
- Update docs, unit tests and examples to include Sender ID

3.0.5
- Fixed logic errors related to issue #189

3.0.4
- Dependency update to fix issue #186

3.0.3
- Tests now mocked automatically against prism

3.0.1
- Issue 185: Getting HTTP Error 406 when getting bounces ### Updated
- Examples, USAGE.md and Unit Tests with updated content and new endpoints

3.0.0
- Breaking change to support the v3 Web API
- New HTTP client
- v3 Mail Send helper

2.1.1
- you can now pass a path to your .env file to the SendGridAPIClient

2.1.1
- you can now pass an apikey to the SendGridAPIClient, per issue #168. Thanks Matt!
- fix .rst formatting for PyPi

2.0.0
- breaking change is only for the Web API v3 endpoints
- we now have support for all Web API v3 endpoints

Tested with the following configuration:

``` yaml
notify:
  - name: sendgrid
    platform: sendgrid
    api_key: !secret sendgrid_api
    sender: you@example.com
    recipient: me@example.com
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```
