### PR TITLE
Fixed REST API URL in readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Build home automation on top of your devices:
 -  Turn on the lights when people get home after sunset
 -  Turn on lights slowly during sunset to compensate for less light
 -  Turn off all lights and devices when everybody leaves the house
--  Offers a `REST API <https://home-assistant.io/developers/api/>`__
+-  Offers a `REST API <https://home-assistant.io/developers/rest_api/>`__
    and can interface with MQTT for easy integration with other projects
    like `OwnTracks <http://owntracks.org/>`__
 -  Allow sending notifications using


### PR DESCRIPTION
**Description:**
Simply fixed URL to REST API documentation at https://home-assistant.io in repository readme file.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
