### PR TITLE
Float value for input slider

### DIFF
--- a/homeassistant/components/input_slider.py
+++ b/homeassistant/components/input_slider.py
@@ -34,7 +34,7 @@ SERVICE_SELECT_VALUE = 'select_value'
 
 SERVICE_SELECT_VALUE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Required(ATTR_VALUE): vol.Coerce(int),
+    vol.Required(ATTR_VALUE): vol.Coerce(float),
 })
 
 
@@ -152,7 +152,7 @@ class InputSlider(Entity):
 
     def select_value(self, value):
         """Select new value."""
-        num_value = int(value)
+        num_value = float(value)
         if num_value < self._minimum or num_value > self._maximum:
             _LOGGER.warning('Invalid value: %s (range %s - %s)',
                             num_value, self._minimum, self._maximum)

--- a/tests/components/test_input_slider.py
+++ b/tests/components/test_input_slider.py
@@ -49,16 +49,22 @@ class TestInputSlider(unittest.TestCase):
         entity_id = 'input_slider.test_1'
 
         state = self.hass.states.get(entity_id)
-        self.assertEqual('50', state.state)
+        self.assertEqual(50, float(state.state))
+
+        input_slider.select_value(self.hass, entity_id, '30.4')
+        self.hass.pool.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(30.4, float(state.state))
 
         input_slider.select_value(self.hass, entity_id, '70')
         self.hass.pool.block_till_done()
 
         state = self.hass.states.get(entity_id)
-        self.assertEqual('70', state.state)
+        self.assertEqual(70, float(state.state))
 
         input_slider.select_value(self.hass, entity_id, '110')
         self.hass.pool.block_till_done()
 
         state = self.hass.states.get(entity_id)
-        self.assertEqual('70', state.state)
+        self.assertEqual(70, float(state.state))


### PR DESCRIPTION
**Description:**
For controlling a thermostat I need an input slider with a 0.5 step which is possible but select_value method does only allow integer value. This change allow float value for input slider. 

**Checklist:**
- [X] Local tests with `tox` run successfully. 
- [X] Tests have been added to verify that the new code works.
