### PR TITLE
Fixes two bugs in with the netatmo components

### DIFF
--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -51,7 +51,7 @@ def setup(hass, config):
         return False
 
     raw_wellcome_data = lnetatmo.postRequest(lnetatmo._GETHOMEDATA_REQ,
-                                             {"access_token": NETATMO_AUTH.accessToken})
+                        {"access_token": NETATMO_AUTH.accessToken})
     cameras = raw_wellcome_data['body']['homes']
 
     if cameras:

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -23,6 +23,8 @@ NETATMO_AUTH = None
 
 _LOGGER = logging.getLogger(__name__)
 
+BASE_URL       = "https://api.netatmo.com/"
+GETHOMEDATA_REQ = BASE_URL + "api/gethomedata"
 
 def setup(hass, config):
     """Setup the Netatmo devices."""
@@ -51,7 +53,7 @@ def setup(hass, config):
         return False
 
     raw_wellcome_data = lnetatmo.postRequest(
-        lnetatmo._GETHOMEDATA_REQ,
+        GETHOMEDATA_REQ,
         {"access_token": NETATMO_AUTH.accessToken},
     )
 

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -24,6 +24,20 @@ NETATMO_AUTH = None
 _LOGGER = logging.getLogger(__name__)
 
 
+def have_netatmo_component(component, config):
+
+    cameras = (value for key, value in config.items() if component in key)
+    for camera in cameras:
+        if isinstance(camera, list):
+            for sub_camera in camera:
+                if sub_camera['platform'] == 'netatmo':
+                    return True
+        else:
+            if camera['platform'] == 'netatmo':
+                return True
+    return False
+
+
 def setup(hass, config):
     """Setup the Netatmo devices."""
     if not validate_config(config,
@@ -50,7 +64,10 @@ def setup(hass, config):
             "Please check your settings for NatAtmo API.")
         return False
 
-    for component in 'camera', 'sensor':
+    components = [component for component in ('camera', 'sensor')
+                  if have_netatmo_component(component, config)]
+
+    for component in components:
         discovery.load_platform(hass, component, DOMAIN, {}, config)
 
     return True

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -53,7 +53,7 @@ def setup(hass, config):
     components = ['sensor']
 
     raw_wellcome_data = lnetatmo.postRequest(lnetatmo._GETHOMEDATA_REQ,
-                                             {"access_token": NETATMO_AUTH.accessToken})
+                        {"access_token": NETATMO_AUTH.accessToken})
     cameras = raw_wellcome_data['body']['homes']
 
     if cameras:

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -23,7 +23,7 @@ NETATMO_AUTH = None
 
 _LOGGER = logging.getLogger(__name__)
 
-BASE_URL       = "https://api.netatmo.com/"
+BASE_URL = "https://api.netatmo.com/"
 GETHOMEDATA_REQ = BASE_URL + "api/gethomedata"
 
 def setup(hass, config):
@@ -51,7 +51,6 @@ def setup(hass, config):
             "Connection error "
             "Please check your settings for NatAtmo API.")
         return False
-
     raw_wellcome_data = lnetatmo.postRequest(
         GETHOMEDATA_REQ,
         {"access_token": NETATMO_AUTH.accessToken},

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -25,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def have_netatmo_component(component, config):
-
+    """ Test if a certain netatmo component is among the configuration variables. """
     cameras = (value for key, value in config.items() if component in key)
     for camera in cameras:
         if isinstance(camera, list):

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -50,8 +50,11 @@ def setup(hass, config):
             "Please check your settings for NatAtmo API.")
         return False
 
-    raw_wellcome_data = lnetatmo.postRequest(lnetatmo._GETHOMEDATA_REQ,
-                    {"access_token": NETATMO_AUTH.accessToken})
+    raw_wellcome_data = lnetatmo.postRequest(
+        lnetatmo._GETHOMEDATA_REQ,
+        {"access_token": NETATMO_AUTH.accessToken},
+    )
+
     cameras = raw_wellcome_data['body']['homes']
 
     if cameras:

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -25,7 +25,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def have_netatmo_component(component, config):
-    """ Test if a certain netatmo component is among the configuration variables. """
+    """Test if a certain netatmo component
+       is among the configuration variables."""
     cameras = (value for key, value in config.items() if component in key)
     for camera in cameras:
         if isinstance(camera, list):

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -51,7 +51,7 @@ def setup(hass, config):
         return False
 
     raw_wellcome_data = lnetatmo.postRequest(lnetatmo._GETHOMEDATA_REQ,
-                        {"access_token": NETATMO_AUTH.accessToken})
+                    {"access_token": NETATMO_AUTH.accessToken})
     cameras = raw_wellcome_data['body']['homes']
 
     if cameras:

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -50,16 +50,13 @@ def setup(hass, config):
             "Please check your settings for NatAtmo API.")
         return False
 
-    components = ['sensor']
-
     raw_wellcome_data = lnetatmo.postRequest(lnetatmo._GETHOMEDATA_REQ,
-                        {"access_token": NETATMO_AUTH.accessToken})
+                                             {"access_token": NETATMO_AUTH.accessToken})
     cameras = raw_wellcome_data['body']['homes']
 
     if cameras:
-        components.append('camera')
+        discovery.load_platform(hass, 'camera', DOMAIN, {}, config)
 
-    for component in components:
-        discovery.load_platform(hass, component, DOMAIN, {}, config)
+    discovery.load_platform(hass, 'sensor', DOMAIN, {}, config)
 
     return True

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -26,6 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 BASE_URL = "https://api.netatmo.com/"
 GETHOMEDATA_REQ = BASE_URL + "api/gethomedata"
 
+
 def setup(hass, config):
     """Setup the Netatmo devices."""
     if not validate_config(config,
@@ -51,6 +52,7 @@ def setup(hass, config):
             "Connection error "
             "Please check your settings for NatAtmo API.")
         return False
+
     raw_wellcome_data = lnetatmo.postRequest(
         GETHOMEDATA_REQ,
         {"access_token": NETATMO_AUTH.accessToken},

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -48,7 +48,6 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=600)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the available Netatmo weather sensors."""
-
     try:
         NETATMO_AUTH = lnetatmo.ClientAuth(config['netatmo'][CONF_API_KEY],
                                            config['netatmo'][CONF_SECRET_KEY],

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -10,6 +10,9 @@ from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.loader import get_component
+from homeassistant.const import (
+    CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME)
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,8 +47,20 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=600)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the available Netatmo weather sensors."""
-    netatmo = get_component('netatmo')
-    data = NetAtmoData(netatmo.NETATMO_AUTH, config.get(CONF_STATION, None))
+
+        try:
+            NETATMO_AUTH = lnetatmo.ClientAuth(config[DOMAIN][CONF_API_KEY],
+                                               config[DOMAIN][CONF_SECRET_KEY],
+                                               config[DOMAIN][CONF_USERNAME],
+                                               config[DOMAIN][CONF_PASSWORD],
+                                               "read_station read_camera "
+                                               "access_camera")
+        except HTTPError:
+            _LOGGER.error(
+                "Connection error "
+                "Please check your settings for NatAtmo API.")
+
+    data = NetAtmoData(NETATMO_AUTH, config.get(CONF_STATION, None))
 
     dev = []
     try:

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -10,6 +10,7 @@ from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.loader import get_component
+from urllib.error import HTTPError
 from homeassistant.const import (
     CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME)
 

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -48,17 +48,17 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=600)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the available Netatmo weather sensors."""
 
-        try:
-            NETATMO_AUTH = lnetatmo.ClientAuth(config[DOMAIN][CONF_API_KEY],
-                                               config[DOMAIN][CONF_SECRET_KEY],
-                                               config[DOMAIN][CONF_USERNAME],
-                                               config[DOMAIN][CONF_PASSWORD],
-                                               "read_station read_camera "
-                                               "access_camera")
-        except HTTPError:
-            _LOGGER.error(
-                "Connection error "
-                "Please check your settings for NatAtmo API.")
+    try:
+        NETATMO_AUTH = lnetatmo.ClientAuth(config[DOMAIN][CONF_API_KEY],
+                                           config[DOMAIN][CONF_SECRET_KEY],
+                                           config[DOMAIN][CONF_USERNAME],
+                                           config[DOMAIN][CONF_PASSWORD],
+                                           "read_station read_camera "
+                                           "access_camera")
+    except HTTPError:
+        _LOGGER.error(
+            "Connection error "
+            "Please check your settings for NatAtmo API.")
 
     data = NetAtmoData(NETATMO_AUTH, config.get(CONF_STATION, None))
 

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -13,7 +13,7 @@ from homeassistant.loader import get_component
 from urllib.error import HTTPError
 from homeassistant.const import (
     CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME)
-
+import lnetatmo
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,10 +50,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the available Netatmo weather sensors."""
 
     try:
-        NETATMO_AUTH = lnetatmo.ClientAuth(config[DOMAIN][CONF_API_KEY],
-                                           config[DOMAIN][CONF_SECRET_KEY],
-                                           config[DOMAIN][CONF_USERNAME],
-                                           config[DOMAIN][CONF_PASSWORD],
+        NETATMO_AUTH = lnetatmo.ClientAuth(config['netatmo'][CONF_API_KEY],
+                                           config['netatmo'][CONF_SECRET_KEY],
+                                           config['netatmo'][CONF_USERNAME],
+                                           config['netatmo'][CONF_PASSWORD],
                                            "read_station read_camera "
                                            "access_camera")
     except HTTPError:
@@ -235,7 +235,6 @@ class NetAtmoData(object):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Call the NetAtmo API to update the data."""
-        import lnetatmo
         dev_list = lnetatmo.DeviceList(self.auth)
 
         if self.station is not None:

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -11,9 +11,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.loader import get_component
 
-
-DEPENDENCIES = ["netatmo"]
-
 _LOGGER = logging.getLogger(__name__)
 
 SENSOR_TYPES = {


### PR DESCRIPTION
**Description:**

For #2600 i have simply remove the dependency on the 'NETATMO' component in the /sensors/netatmo.py because that leads to a circular dependency relation. (See #2600).

For #2601 I checked if the user has a netatmo camera or a netatmo sensor and then only launch discover on the components that the user has specify in the configuration file.

Comments about efficiency:

To search for netatmo components I perform a linear search over the keys of the 'config' dictionary because we do not know in which "camera" or "sensor" the netatmo camera/sensor is. So we need to obtain those (key,value) pairs where 'camera' is a substring of key and then for any of theese we check if value['platform'] == 'netatmo'. But we have to take care also if the value is a list of cameras (so another nested loop here). *\* As hash tables do not support substring search we need the linear probe in the nested structure of the config dict**. 

**Related issue (if applicable):** 

fixes #2600
fixes #2601 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
