### PR TITLE
Command-line interface 

### DIFF
--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -21,7 +21,7 @@ import homeassistant.bootstrap as bootstrap
 import homeassistant.core as ha
 from homeassistant.const import (
     HTTP_HEADER_HA_AUTH, SERVER_PORT, URL_API, URL_API_EVENT_FORWARD,
-    URL_API_EVENTS, URL_API_EVENTS_EVENT, URL_API_SERVICES,
+    URL_API_EVENTS, URL_API_EVENTS_EVENT, URL_API_SERVICES, URL_API_CONFIG,
     URL_API_SERVICES_SERVICE, URL_API_STATES, URL_API_STATES_ENTITY,
     HTTP_HEADER_CONTENT_TYPE, CONTENT_TYPE_JSON)
 from homeassistant.exceptions import HomeAssistantError
@@ -523,3 +523,17 @@ def call_service(api, domain, service, service_data=None):
 
     except HomeAssistantError:
         _LOGGER.exception("Error calling service")
+
+
+def get_config(api):
+    """Return configuration."""
+    try:
+        req = api(METHOD_GET, URL_API_CONFIG)
+
+        return req.json() if req.status_code == 200 else {}
+
+    except (HomeAssistantError, ValueError):
+        # ValueError if req.json() can't parse the JSON
+        _LOGGER.exception("Got unexpected configuration results")
+
+        return {}

--- a/homeassistant/scripts/commandline.py
+++ b/homeassistant/scripts/commandline.py
@@ -1,0 +1,63 @@
+"""Script to retrieve information about a Home Assistant instance."""
+
+import argparse
+import pprint
+
+import homeassistant.remote as remote
+
+def run(args):
+    """The actual script body."""
+    # pylint: disable=too-many-locals,invalid-name,too-many-statements
+    parser = argparse.ArgumentParser(
+        description="Command-line interface for a Home Assistant instance")
+    parser.add_argument(
+        '-i', '--info',
+        action='store_true',
+        default=False,
+        help="show information about a Home Assistant instance")
+    parser.add_argument(
+        '-s', '--services',
+        action='store_true',
+        default=False,
+        help="get all available services.")
+    parser.add_argument(
+        '-e', '--entities',
+        action='store_true',
+        default=False,
+        help="get all entity states.")
+    parser.add_argument(
+        '-p', '--password',
+        metavar='api_password',
+        required=True,
+        help="the API password for the Home Assistant instance")
+    parser.add_argument(
+        '-r', '--remote',
+        metavar='ha_instance',
+        default='127.0.0.1',
+        help="the IP address of the Home Assistant instance")
+    parser.add_argument(
+        '--script',
+        choices=['commandline'])
+
+    args = parser.parse_args()
+
+    api = remote.API(args.remote, args.password)
+    if remote.validate_api(api) == 'invalid_password':
+        print('Fatal Error: Password is not valid')
+        return 1
+
+    if args.info:
+        pprint.pprint(remote.get_config(api))
+
+    if args.services:
+        services = remote.get_services(api)
+        for service in services:
+            pprint.pprint(service['services'], depth=4, width=78)
+
+    if args.entities:
+        entities = remote.get_states(api)
+        for entity in entities:
+            print('{} is {}'.format(entity.attributes['friendly_name'],
+                                    entity.state))
+
+    return 0


### PR DESCRIPTION
**Description:**
This is an initial implementation of a command-line interface. So far it's only possible to get details as shown in the [Python API documentation](https://home-assistant.io/developers/python_api/) with alomost no error handling.

``` bash
$ hass --script commandline -h
usage: hass [-h] [-i] [-s] [-e] -p api_password [-r ha_instance]
            [--script {commandline}]

Command-line interface for a Home Assistant instance

optional arguments:
  -h, --help            show this help message and exit
  -i, --info            show information about a Home Assistant instance
  -s, --services        get all available services.
  -e, --entities        get all entity states.
  -p api_password, --password api_password
                        the API password for the Home Assistant instance
  -r ha_instance, --remote ha_instance
                        the IP address of the Home Assistant instance
  --script {commandline}
```

This PR is a RFC.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
http:
  api_password: !secret http_password
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
