### PR TITLE
Update icloud device_tracker

### DIFF
--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -80,7 +80,7 @@ def setup_scanner(hass, config, see):
     update_minutes = list(range(0, 60, config[CONF_INTERVAL]))
     # Schedule keepalives between the updates
     keepalive_minutes = list(x for x in range(0, 60, KEEPALIVE_INTERVAL)
-                         if x not in update_minutes)
+                             if x not in update_minutes)
 
     track_utc_time_change(hass, update_icloud, second=0, minute=update_minutes)
     track_utc_time_change(hass, keep_alive, second=0, minute=keepalive_minutes)

--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -62,7 +62,7 @@ def setup_scanner(hass, config, see):
                 # If the device has a location add it. If not do nothing
                 if location:
                     see(
-                        dev_id=slugify(status['name']),
+                        dev_id=slugify(status['name'].replace(' ', '', 99)),
                         host_name=status['name'],
                         gps=(location['latitude'], location['longitude']),
                         battery=status['batteryLevel']*100,

--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -5,10 +5,11 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.icloud/
 """
 import logging
-import re
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (CONF_PASSWORD, CONF_USERNAME,
+                                 EVENT_HOMEASSISTANT_START)
 from homeassistant.helpers.event import track_utc_time_change
+from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,9 +36,7 @@ def setup_scanner(hass, config, see):
     try:
         _LOGGER.info('Logging into iCloud Account')
         # Attempt the login to iCloud
-        api = PyiCloudService(username,
-                              password,
-                              verify=True)
+        api = PyiCloudService(username, password, verify=True)
     except PyiCloudFailedLoginException as error:
         _LOGGER.exception('Error logging into iCloud Service: %s', error)
         return False
@@ -47,14 +46,14 @@ def setup_scanner(hass, config, see):
         api.authenticate()
         _LOGGER.info("Authenticate against iCloud")
 
-    track_utc_time_change(hass, keep_alive, second=0)
+    track_utc_time_change(hass, keep_alive, second=0, minute=4)
 
     def update_icloud(now):
         """Authenticate against iCloud and scan for devices."""
         try:
             # The session timeouts if we are not using it so we
             # have to re-authenticate. This will send an email.
-            api.authenticate()
+            keep_alive(None)
             # Loop through every device registered with the iCloud account
             for device in api.devices:
                 status = device.status()
@@ -62,9 +61,7 @@ def setup_scanner(hass, config, see):
                 # If the device has a location add it. If not do nothing
                 if location:
                     see(
-                        dev_id=re.sub(r"(\s|\W|')",
-                                      '',
-                                      status['name']),
+                        dev_id=slugify(status['name']),
                         host_name=status['name'],
                         gps=(location['latitude'], location['longitude']),
                         battery=status['batteryLevel']*100,
@@ -76,10 +73,11 @@ def setup_scanner(hass, config, see):
         except PyiCloudNoDevicesException:
             _LOGGER.info('No iCloud Devices found!')
 
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, update_icloud)
+
     track_utc_time_change(
-        hass, update_icloud,
-        minute=range(0, 60, config.get(CONF_INTERVAL, DEFAULT_INTERVAL)),
-        second=0
+        hass, update_icloud, second=0,
+        minute=range(0, 60, config.get(CONF_INTERVAL, DEFAULT_INTERVAL))
     )
 
     return True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -288,7 +288,7 @@ pyfttt==0.3
 pyhomematic==0.1.10
 
 # homeassistant.components.device_tracker.icloud
-pyicloud==0.8.3
+pyicloud==0.9.1
 
 # homeassistant.components.sensor.lastfm
 pylast==1.6.0


### PR DESCRIPTION
**Description:**
- `slugify()` for dev_id (fixes #2162)
- pyicloud upgrade
- config validation
- Only poll icloud every 4 minutes.... if this time out. please let me know & I will revert it to 1min
- Immediately pull device state on HASS start
- Added new test with icloud char e' acute [chr(233)]

**Related issue (if applicable):** fixes #
#2162

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
