### PR TITLE
Implementing set_hvac_mode for Nest

### DIFF
--- a/homeassistant/components/thermostat/nest.py
+++ b/homeassistant/components/thermostat/nest.py
@@ -141,6 +141,10 @@ class NestThermostat(ThermostatDevice):
                 temperature = (self.target_temperature_low, temperature)
         self.device.target = temperature
 
+    def set_hvac_mode(self, hvac_mode):
+        """Set hvac mode."""
+        self.device.mode = hvac_mode
+
     def turn_away_mode_on(self):
         """Turn away on."""
         self.structure.away = True


### PR DESCRIPTION
Ther service set_hvac_mode is now implemented by Nest thermostat. It is possible to change the thermostat mode to 'heat', 'off', 'cool'' or 'heat-cool'. 

The feature request is located here:
https://community.home-assistant.io/t/would-like-to-set-the-nest-mode-to-off-heat-cool-or-heat-cool/2542
