### PR TITLE
Fix test to test Norway fix

### DIFF
--- a/tests/components/test_sun.py
+++ b/tests/components/test_sun.py
@@ -96,7 +96,7 @@ class TestSun(unittest.TestCase):
 
         june = datetime(2016, 6, 1, tzinfo=dt_util.UTC)
 
-        with patch('homeassistant.helpers.condition.dt_util.now',
+        with patch('homeassistant.helpers.condition.dt_util.utcnow',
                    return_value=june):
             assert sun.setup(self.hass, {sun.DOMAIN: {sun.CONF_ELEVATION: 0}})
 


### PR DESCRIPTION
**Description:**
The test patched the function to get the local time instead of getting the UTC time. This was breaking every build. Only noticed it now because the sun finally was setting again in Norway.

**Related issue (if applicable):** fixes #2625 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
