### PR TITLE
Add get_config

### DIFF
--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -21,7 +21,7 @@ import homeassistant.bootstrap as bootstrap
 import homeassistant.core as ha
 from homeassistant.const import (
     HTTP_HEADER_HA_AUTH, SERVER_PORT, URL_API, URL_API_EVENT_FORWARD,
-    URL_API_EVENTS, URL_API_EVENTS_EVENT, URL_API_SERVICES,
+    URL_API_EVENTS, URL_API_EVENTS_EVENT, URL_API_SERVICES, URL_API_CONFIG,
     URL_API_SERVICES_SERVICE, URL_API_STATES, URL_API_STATES_ENTITY,
     HTTP_HEADER_CONTENT_TYPE, CONTENT_TYPE_JSON)
 from homeassistant.exceptions import HomeAssistantError
@@ -524,3 +524,17 @@ def call_service(api, domain, service, service_data=None, timeout=5):
 
     except HomeAssistantError:
         _LOGGER.exception("Error calling service")
+
+
+def get_config(api):
+    """Return configuration."""
+    try:
+        req = api(METHOD_GET, URL_API_CONFIG)
+
+        return req.json() if req.status_code == 200 else {}
+
+    except (HomeAssistantError, ValueError):
+        # ValueError if req.json() can't parse the JSON
+        _LOGGER.exception("Got unexpected configuration results")
+
+        return {}

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -295,3 +295,7 @@ class TestRemoteClasses(unittest.TestCase):
         hass.pool.block_till_done()
 
         self.assertEqual(1, len(test_value))
+
+    def test_get_config(self):
+        """Test the return of the configuration."""
+        self.assertEqual(hass.config.as_dict(), remote.get_config(master_api))


### PR DESCRIPTION
**Description:**
Add `get_config` to Python API (was part of #2610). 

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#676

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
