### PR TITLE
Update to group component to properly handle zone changes in tracked devices

### DIFF
--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -304,8 +304,9 @@ class Group(Entity):
             if gr_on is None:
                 return
 
-            if tr_state is None or (gr_state == gr_on and
-                                    tr_state.state == gr_off):
+            if tr_state is None or ((gr_state == gr_on and
+                                     tr_state.state == gr_off) or
+                                    tr_state.state not in (gr_on, gr_off)):
                 if states is None:
                     states = self._tracking_states
 

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -296,7 +296,7 @@ class TestComponentsGroup(unittest.TestCase):
         self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
 
     def test_group_updated_after_device_tracker_zone_change(self):
-        """Test group state change when device tracker in group changes zone."""
+        """Test group state when device tracker in group changes zone."""
         self.hass.states.set('device_tracker.Adam', STATE_HOME)
         self.hass.states.set('device_tracker.Eve', STATE_NOT_HOME)
         self.hass.pool.block_till_done()

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -5,7 +5,7 @@ import unittest
 from homeassistant.bootstrap import _setup_component
 from homeassistant.const import (
     STATE_ON, STATE_OFF, STATE_HOME, STATE_UNKNOWN, ATTR_ICON, ATTR_HIDDEN,
-    ATTR_ASSUMED_STATE, )
+    ATTR_ASSUMED_STATE, STATE_NOT_HOME, )
 import homeassistant.components.group as group
 
 from tests.common import get_test_home_assistant
@@ -294,3 +294,18 @@ class TestComponentsGroup(unittest.TestCase):
 
         state = self.hass.states.get(test_group.entity_id)
         self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+
+    def test_group_updated_after_device_tracker_zone_change(self):
+        """Test group state is changed when device tracker in group changes
+        zones from home"""
+        self.hass.states.set('device_tracker.Adam', STATE_HOME)
+        self.hass.states.set('device_tracker.Eve', STATE_NOT_HOME)
+        self.hass.pool.block_till_done()
+        group.Group(
+            self.hass, 'peeps',
+            ['device_tracker.Adam', 'device_tracker.Eve'])
+        self.hass.states.set('device_tracker.Adam', 'cool_state_not_home')
+        self.hass.pool.block_till_done()
+        self.assertEqual(STATE_NOT_HOME,
+                         self.hass.states.get(
+                             group.ENTITY_ID_FORMAT.format('peeps')).state)

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -296,8 +296,7 @@ class TestComponentsGroup(unittest.TestCase):
         self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
 
     def test_group_updated_after_device_tracker_zone_change(self):
-        """Test group state is changed when device tracker in group changes
-        zones from home"""
+        """Test group state change when device tracker in group changes zone"""
         self.hass.states.set('device_tracker.Adam', STATE_HOME)
         self.hass.states.set('device_tracker.Eve', STATE_NOT_HOME)
         self.hass.pool.block_till_done()

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -296,7 +296,7 @@ class TestComponentsGroup(unittest.TestCase):
         self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
 
     def test_group_updated_after_device_tracker_zone_change(self):
-        """Test group state change when device tracker in group changes zone"""
+        """Test group state change when device tracker in group changes zone."""
         self.hass.states.set('device_tracker.Adam', STATE_HOME)
         self.hass.states.set('device_tracker.Eve', STATE_NOT_HOME)
         self.hass.pool.block_till_done()


### PR DESCRIPTION
**Description:**
If you have a group that has device trackers that move between zones, sometimes the group incorrectly reports it as home, when all devices are away in other zones. 

**Related issue (if applicable):** fixes #
#1588 and #2157

**Checklist:**
If the code does not interact with devices:
- [ x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ x] Tests have been added to verify that the new code works.
