### PR TITLE
Add MPC-HC Media Player Component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -147,6 +147,7 @@ omit =
     homeassistant/components/media_player/itunes.py
     homeassistant/components/media_player/kodi.py
     homeassistant/components/media_player/lg_netcast.py
+    homeassistant/components/media_player/mpchc.py
     homeassistant/components/media_player/mpd.py
     homeassistant/components/media_player/onkyo.py
     homeassistant/components/media_player/panasonic_viera.py

--- a/homeassistant/components/media_player/mpchc.py
+++ b/homeassistant/components/media_player/mpchc.py
@@ -44,8 +44,7 @@ class MpcHcDevice(MediaPlayerDevice):
         self._player_variables = dict()
 
         try:
-            with requests.Session() as sess:
-                response = requests.get("{}/variables.html".format(self._host), data=None, timeout=3)
+            response = requests.get("{}/variables.html".format(self._host), data=None, timeout=3)
 
             mpchc_variables = re.findall(r'<p id="(.+?)">(.+?)</p>', response.text)
 

--- a/homeassistant/components/media_player/mpchc.py
+++ b/homeassistant/components/media_player/mpchc.py
@@ -1,0 +1,110 @@
+"""
+Support to interface with the MPC-HC Web API.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.mpchc/
+"""
+import logging
+import requests
+import re
+
+from homeassistant.components.media_player import (
+    MediaPlayerDevice)
+from homeassistant.const import (
+    STATE_OFF, STATE_IDLE, STATE_PAUSED, STATE_PLAYING)
+
+_LOGGER = logging.getLogger(__name__)
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the MPC-HC platform."""
+    name = config.get("name", "MPC-HC")
+    address = config.get("address")
+    port = config.get('port', 13579)
+
+    if address is None:
+        _LOGGER.error("Missing address in config")
+        return False
+
+    add_devices([MpcHcDevice(name, address, port)])
+
+
+class MpcHcDevice(MediaPlayerDevice):
+    """Representation of a MPC-HC server."""
+    def __init__(self, name, address, port):
+        """Initialize the MPC-HC device."""
+        self._name = name
+        self._address = address
+        self._port = port
+        self._host = "http://{}:{}".format(self._address, self._port)
+
+        self.update()
+
+    def update(self):
+        self._player_variables = dict()
+
+        try:
+            with requests.Session() as sess:
+                response = requests.get("{}/variables.html".format(self._host), data=None, timeout=3)
+
+            mpchc_variables = re.findall(r'<p id="(.+?)">(.+?)</p>', response.text)
+
+            self._player_variables = dict()
+            for s in mpchc_variables:
+                self._player_variables[s[0]] = s[1].lower()
+        except requests.exceptions.RequestException:
+            _LOGGER.error("Could not connect to MPC-HC at: {}".format(self._host))
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        try:
+            if self._player_variables['statestring'] == 'playing':
+                return STATE_PLAYING
+            elif self._player_variables['statestring'] == 'paused':
+                return STATE_PAUSED
+            else:
+                return STATE_IDLE
+        except KeyError:
+            return STATE_OFF
+
+
+    @property
+    def media_title(self):
+        """Title of current playing media."""
+        try:
+            return self._player_variables['file']
+        except KeyError:
+            return None
+
+    @property
+    def volume_level(self):
+        """Volume level of the media player (0..1)."""
+        try:
+            return int(self._player_variables['volumelevel']) / 100.0
+        except KeyError:
+            return False
+
+    @property
+    def is_volume_muted(self):
+        """Boolean if volume is currently muted."""
+        try:
+            return self._player_variables['muted'] == '1'
+        except KeyError:
+            return False
+
+    @property
+    def media_duration(self):
+        """Duration of current playing media in seconds."""
+        try:
+            duration_components = self._player_variables['durationstring'].split(':')
+            return int(duration_components[0]) * 3600 + \
+                   int(duration_components[1]) * 60 + \
+                   int(duration_components[2])
+        except KeyError:
+            return False

--- a/homeassistant/components/media_player/mpchc.py
+++ b/homeassistant/components/media_player/mpchc.py
@@ -19,24 +19,21 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the MPC-HC platform."""
     name = config.get("name", "MPC-HC")
-    address = config.get("address")
-    port = config.get('port', 13579)
+    url = '{}:{}'.format(config.get('host'), config.get('port', '13579'))
 
-    if address is None:
-        _LOGGER.error("Missing address in config")
+    if config.get('host') is None:
+        _LOGGER.error("Missing NPC-HC host address in config")
         return False
 
-    add_devices([MpcHcDevice(name, address, port)])
+    add_devices([MpcHcDevice(name, url)])
 
 
 class MpcHcDevice(MediaPlayerDevice):
     """Representation of a MPC-HC server."""
-    def __init__(self, name, address, port):
+    def __init__(self, name, url):
         """Initialize the MPC-HC device."""
         self._name = name
-        self._address = address
-        self._port = port
-        self._host = "http://{}:{}".format(self._address, self._port)
+        self._url = url
 
         self.update()
 
@@ -44,7 +41,7 @@ class MpcHcDevice(MediaPlayerDevice):
         self._player_variables = dict()
 
         try:
-            response = requests.get("{}/variables.html".format(self._host), data=None, timeout=3)
+            response = requests.get("{}/variables.html".format(self._url), data=None, timeout=3)
 
             mpchc_variables = re.findall(r'<p id="(.+?)">(.+?)</p>', response.text)
 

--- a/homeassistant/components/media_player/mpchc.py
+++ b/homeassistant/components/media_player/mpchc.py
@@ -5,8 +5,8 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.mpchc/
 """
 import logging
-import requests
 import re
+import requests
 
 from homeassistant.components.media_player import (
     MediaPlayerDevice)
@@ -28,8 +28,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([MpcHcDevice(name, url)])
 
 
+# pylint: disable=abstract-method
 class MpcHcDevice(MediaPlayerDevice):
     """Representation of a MPC-HC server."""
+
     def __init__(self, name, url):
         """Initialize the MPC-HC device."""
         self._name = name
@@ -46,10 +48,10 @@ class MpcHcDevice(MediaPlayerDevice):
             mpchc_variables = re.findall(r'<p id="(.+?)">(.+?)</p>', response.text)
 
             self._player_variables = dict()
-            for s in mpchc_variables:
-                self._player_variables[s[0]] = s[1].lower()
+            for var in mpchc_variables:
+                self._player_variables[var[0]] = var[1].lower()
         except requests.exceptions.RequestException:
-            _LOGGER.error("Could not connect to MPC-HC at: {}".format(self._host))
+            _LOGGER.error("Could not connect to MPC-HC at: %s", self._url)
 
     @property
     def name(self):

--- a/homeassistant/components/media_player/mpchc.py
+++ b/homeassistant/components/media_player/mpchc.py
@@ -9,11 +9,15 @@ import re
 import requests
 
 from homeassistant.components.media_player import (
-    MediaPlayerDevice)
+    SUPPORT_VOLUME_MUTE, SUPPORT_PAUSE, SUPPORT_STOP, SUPPORT_NEXT_TRACK,
+    SUPPORT_PREVIOUS_TRACK, SUPPORT_VOLUME_STEP, MediaPlayerDevice)
 from homeassistant.const import (
     STATE_OFF, STATE_IDLE, STATE_PAUSED, STATE_PLAYING)
 
 _LOGGER = logging.getLogger(__name__)
+
+SUPPORT_MPCHC = SUPPORT_VOLUME_MUTE | SUPPORT_PAUSE | SUPPORT_STOP | \
+    SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK | SUPPORT_VOLUME_STEP
 
 
 # pylint: disable=unused-argument
@@ -48,13 +52,24 @@ class MpcHcDevice(MediaPlayerDevice):
             response = requests.get("{}/variables.html".format(self._url),
                                     data=None, timeout=3)
 
-            mpchc_variables = re.findall(r'<p id="(.+?)">(.+?)</p>', response.text)
+            mpchc_variables = re.findall(r'<p id="(.+?)">(.+?)</p>',
+                                         response.text)
 
             self._player_variables = dict()
             for var in mpchc_variables:
                 self._player_variables[var[0]] = var[1].lower()
         except requests.exceptions.RequestException:
             _LOGGER.error("Could not connect to MPC-HC at: %s", self._url)
+
+    def _send_command(self, command_id):
+        """Send a command to MPC-HC via its window message ID."""
+        try:
+            params = {"wm_command": command_id}
+            requests.get("{}/command.html".format(self._url),
+                         params=params, timeout=3)
+        except requests.exceptions.RequestException:
+            _LOGGER.error("Could not send command %d to MPC-HC at: %s",
+                          command_id, self._url)
 
     @property
     def name(self):
@@ -95,8 +110,44 @@ class MpcHcDevice(MediaPlayerDevice):
         """Duration of current playing media in seconds."""
         duration = self._player_variables.get('durationstring',
                                               "00:00:00").split(':')
-
         return \
             int(duration[0]) * 3600 + \
             int(duration[1]) * 60 + \
             int(duration[2])
+
+    @property
+    def supported_media_commands(self):
+        """Flag of media commands that are supported."""
+        return SUPPORT_MPCHC
+
+    def volume_up(self):
+        """Volume up the media player."""
+        self._send_command(907)
+
+    def volume_down(self):
+        """Volume down media player."""
+        self._send_command(908)
+
+    def mute_volume(self, mute):
+        """Mute the volume."""
+        self._send_command(909)
+
+    def media_play(self):
+        """Send play command."""
+        self._send_command(887)
+
+    def media_pause(self):
+        """Send pause command."""
+        self._send_command(888)
+
+    def media_stop(self):
+        """Send stop command."""
+        self._send_command(890)
+
+    def media_next_track(self):
+        """Send next track command."""
+        self._send_command(921)
+
+    def media_previous_track(self):
+        """Send previous track command."""
+        self._send_command(920)


### PR DESCRIPTION
**Description:**

This adds a new media player platform, for Media Player Classic Home Cinema (MPC-HC). Currently this is a read-only `media_player` component intended for home automation, but I'm happy to extend it to support play/pause/etc. actions in the immediate future if there's any interest. I'm currently using this to dim my study lights when media is being played.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
media_player:
  - platform: mpchc
    port: 13579
    host: http://127.0.0.1
```

**Documentation**
Submitted as a pull request to the [documentation project here](https://github.com/home-assistant/home-assistant.io/pull/686).
