### PR TITLE
Added name support for Forecast.io

### DIFF
--- a/homeassistant/components/sensor/forecast.py
+++ b/homeassistant/components/sensor/forecast.py
@@ -45,6 +45,7 @@ SENSOR_TYPES = {
     'visibility': ['Visibility', 'km', 'm', 'km', 'km', 'm'],
     'ozone': ['Ozone', 'DU', 'DU', 'DU', 'DU', 'DU'],
 }
++DEFAULT_NAME = "Forecast.io"
 
 # Return cached results if last scan was less then this time ago.
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=120)
@@ -78,11 +79,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error(error)
         return False
 
+    name = config.get('name', DEFAULT_NAME)
+
     # Initialize and add all of the sensors.
     sensors = []
     for variable in config['monitored_conditions']:
         if variable in SENSOR_TYPES:
-            sensors.append(ForeCastSensor(forecast_data, variable))
+            sensors.append(ForeCastSensor(forecast_data, variable, name))
         else:
             _LOGGER.error('Sensor type: "%s" does not exist', variable)
 
@@ -93,9 +96,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class ForeCastSensor(Entity):
     """Implementation of a Forecast.io sensor."""
 
-    def __init__(self, forecast_data, sensor_type):
+    def __init__(self, forecast_data, sensor_type, name):
         """Initialize the sensor."""
-        self.client_name = 'Weather'
+        self.client_name = name
         self._name = SENSOR_TYPES[sensor_type][0]
         self.forecast_data = forecast_data
         self.type = sensor_type

--- a/homeassistant/components/sensor/forecast.py
+++ b/homeassistant/components/sensor/forecast.py
@@ -45,7 +45,7 @@ SENSOR_TYPES = {
     'visibility': ['Visibility', 'km', 'm', 'km', 'km', 'm'],
     'ozone': ['Ozone', 'DU', 'DU', 'DU', 'DU', 'DU'],
 }
-+DEFAULT_NAME = "Forecast.io"
+DEFAULT_NAME = "Forecast.io"
 
 # Return cached results if last scan was less then this time ago.
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=120)


### PR DESCRIPTION
**Description:**

Added name support for Forecast.io and changed default name to "Forecast.io" since "Weather" has conflict with Yahoo weather and Open weather map.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: forecast
    api_key: !secret forecast_api
    monitored_conditions:
      - apparent_temperature
      - temperature
      - summary
      - icon
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] Tests have been added to verify that the new code works.
