### PR TITLE
Add group state for locks

### DIFF
--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -64,7 +64,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 # List of ON/OFF state tuples for groupable states
 _GROUP_TYPES = [(STATE_ON, STATE_OFF), (STATE_HOME, STATE_NOT_HOME),
-                (STATE_OPEN, STATE_CLOSED)]
+                (STATE_OPEN, STATE_CLOSED), (STATE_LOCKED, STATE_UNLOCKED)]
 
 
 def _get_group_on_off(state):

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -12,8 +12,8 @@ import voluptuous as vol
 import homeassistant.core as ha
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_ICON, CONF_NAME, STATE_CLOSED, STATE_HOME,
-    STATE_NOT_HOME, STATE_OFF, STATE_ON, STATE_OPEN, STATE_LOCKED, STATE_UNLOCKED, 
-    STATE_UNKNOWN, ATTR_ASSUMED_STATE)
+    STATE_NOT_HOME, STATE_OFF, STATE_ON, STATE_OPEN, STATE_LOCKED, 
+    STATE_UNLOCKED, STATE_UNKNOWN, ATTR_ASSUMED_STATE)
 from homeassistant.helpers.entity import (
     Entity, generate_entity_id, split_entity_id)
 from homeassistant.helpers.event import track_state_change

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 import homeassistant.core as ha
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_ICON, CONF_NAME, STATE_CLOSED, STATE_HOME,
-    STATE_NOT_HOME, STATE_OFF, STATE_ON, STATE_OPEN, STATE_LOCKED, 
+    STATE_NOT_HOME, STATE_OFF, STATE_ON, STATE_OPEN, STATE_LOCKED,
     STATE_UNLOCKED, STATE_UNKNOWN, ATTR_ASSUMED_STATE)
 from homeassistant.helpers.entity import (
     Entity, generate_entity_id, split_entity_id)

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -12,8 +12,8 @@ import voluptuous as vol
 import homeassistant.core as ha
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_ICON, CONF_NAME, STATE_CLOSED, STATE_HOME,
-    STATE_NOT_HOME, STATE_OFF, STATE_ON, STATE_OPEN, STATE_UNKNOWN,
-    ATTR_ASSUMED_STATE, )
+    STATE_NOT_HOME, STATE_OFF, STATE_ON, STATE_OPEN, STATE_LOCKED, STATE_UNLOCKED, 
+    STATE_UNKNOWN, ATTR_ASSUMED_STATE )
 from homeassistant.helpers.entity import (
     Entity, generate_entity_id, split_entity_id)
 from homeassistant.helpers.event import track_state_change

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -13,7 +13,7 @@ import homeassistant.core as ha
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_ICON, CONF_NAME, STATE_CLOSED, STATE_HOME,
     STATE_NOT_HOME, STATE_OFF, STATE_ON, STATE_OPEN, STATE_LOCKED, STATE_UNLOCKED, 
-    STATE_UNKNOWN, ATTR_ASSUMED_STATE )
+    STATE_UNKNOWN, ATTR_ASSUMED_STATE)
 from homeassistant.helpers.entity import (
     Entity, generate_entity_id, split_entity_id)
 from homeassistant.helpers.event import track_state_change


### PR DESCRIPTION
**Description:**

Adding a group state for locks.

**Related issue (if applicable):** fixes #
https://github.com/home-assistant/home-assistant/issues/2646

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Added  ", (STATE_LOCKED, STATE_UNLOCKED)" to _GROUP_TYPES

Don't have a working HA right now, so can't test.. Nor do I know how!
