### PR TITLE
Add divide() template helper function.

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -249,6 +249,15 @@ def multiply(value, amount):
         return value
 
 
+def divide(value, amount):
+    """Filter to convert value to float and divide it."""
+    try:
+        return float(value) / amount
+    except (ValueError, TypeError):
+        # If value can't be converted to float
+        return value
+
+
 def timestamp_local(value):
     """Filter to convert given timestamp to local date/time."""
     try:
@@ -286,5 +295,6 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
 ENV = TemplateEnvironment()
 ENV.filters['round'] = forgiving_round
 ENV.filters['multiply'] = multiply
+ENV.filters['divide'] = divide
 ENV.filters['timestamp_local'] = timestamp_local
 ENV.filters['timestamp_utc'] = timestamp_utc


### PR DESCRIPTION
**Description:**

This adds a new `divide()` template helper function, useful for making templates which convert units from a sensor to a desired scalar.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: disk_free
        arg: /

  - platform: template
    sensors:
      disk_free_tb:
          value_template: '{{ states.sensor.disk_free_.state | divide(1024) }}'
          friendly_name: 'Disk Free'
          unit_of_measurement: 'TB'
```

Tested locally, result is the expected input sensor value divided by the value given in the template.
