### PR TITLE
Proximity unit of measure

### DIFF
--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -49,15 +49,15 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_proximity_component(hass, config):
     """Set up individual proximity component."""
-    ignored_zones = []
-    if 'ignored_zones' in config:
-        for variable in config['ignored_zones']:
-            ignored_zones.append(variable)
-
     # Get the devices from configuration.yaml.
     if 'devices' not in config:
         _LOGGER.error('devices not found in config')
         return False
+
+    ignored_zones = []
+    if 'ignored_zones' in config:
+        for variable in config['ignored_zones']:
+            ignored_zones.append(variable)
 
     proximity_devices = []
     for variable in config['devices']:

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -36,29 +36,30 @@ ATTR_NEAREST = 'nearest'
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_proximity_device(hass, proximity_config):   # pylint: disable=too-many-locals,too-many-statements
+def setup_proximity_component(hass, config):   # pylint: disable=too-many-locals,too-many-statements
+    """Set up individual proximity component."""
     ignored_zones = []
-    if 'ignored_zones' in proximity_config:
-        for variable in proximity_config['ignored_zones']:
+    if 'ignored_zones' in config:
+        for variable in config['ignored_zones']:
             ignored_zones.append(variable)
 
     # Get the devices from configuration.yaml.
-    if 'devices' not in proximity_config:
+    if 'devices' not in config:
         _LOGGER.error('devices not found in config')
         return False
 
     proximity_devices = []
-    for variable in proximity_config['devices']:
+    for variable in config['devices']:
         proximity_devices.append(variable)
 
     # Get the direction of travel tolerance from configuration.yaml.
-    tolerance = proximity_config.get('tolerance', DEFAULT_TOLERANCE)
+    tolerance = config.get('tolerance', DEFAULT_TOLERANCE)
 
     # Get the zone to monitor proximity to from configuration.yaml.
-    proximity_zone = proximity_config.get('zone', DEFAULT_PROXIMITY_ZONE)
+    proximity_zone = config.get('zone', DEFAULT_PROXIMITY_ZONE)
 
     # Get the unit of measurement from configuration.yaml.
-    unit_of_measure = proximity_config.get(ATTR_UNIT_OF_MEASUREMENT,
+    unit_of_measure = config.get(ATTR_UNIT_OF_MEASUREMENT,
                                            DEFAULT_UNIT_OF_MEASUREMENT)
 
     entity_id = DOMAIN + '.' + proximity_zone

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -84,13 +84,16 @@ def setup_proximity_device(hass, proximity_config):   # pylint: disable=too-many
     track_state_change(hass, proximity_devices,
                        proximity.check_proximity_state_change)
 
+    return True
+
 def setup(hass, config):
     """Get the zones and offsets from configuration.yaml."""
     if isinstance(config[DOMAIN], list):
         for proximity_config in config[DOMAIN]:
-            setup_proximity_device(hass, proximity_config)
-    else:
-        setup_proximity_device(hass, config[DOMAIN])
+            if not setup_proximity_component(hass, proximity_config):
+                return False
+    elif not setup_proximity_component(hass, config[DOMAIN]):
+        return False
 
     return True
 

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -67,28 +67,21 @@ def setup_proximity_component(hass, config):
     tolerance = config.get('tolerance', DEFAULT_TOLERANCE)
 
     # Get the zone to monitor proximity to from configuration.yaml.
-    proximity_zone = config.get('zone', DEFAULT_PROXIMITY_ZONE)
+    proximity_zone = 'zone.' \
+        + config.get('zone', DEFAULT_PROXIMITY_ZONE).lstrip('proximity.')
 
     # Get the unit of measurement from configuration.yaml.
     unit_of_measure = config.get(ATTR_UNIT_OF_MEASUREMENT,
-                                           DEFAULT_UNIT_OF_MEASUREMENT)
-
-    entity_id = DOMAIN + '.' + proximity_zone
-    proximity_zone = 'zone.' + proximity_zone
+                                 DEFAULT_UNIT_OF_MEASUREMENT)
 
     state = hass.states.get(proximity_zone)
     zone_friendly_name = (state.name).lower()
 
-    # Set the default values.
-    dist_to_zone = 'not set'
-    dir_of_travel = 'not set'
-    nearest = 'not set'
-
-    proximity = Proximity(hass, zone_friendly_name, dist_to_zone,
-                          dir_of_travel, nearest, ignored_zones,
-                          proximity_devices, tolerance, proximity_zone,
-                          unit_of_measure)
-    proximity.entity_id = entity_id
+    proximity = Proximity(hass, zone_friendly_name, DEFAULT_DIST_TO_ZONE,
+                          DEFAULT_DIR_OF_TRAVEL, DEFAULT_NEAREST,
+                          ignored_zones, proximity_devices, tolerance,
+                          proximity_zone, unit_of_measure)
+    proximity.entity_id = DOMAIN + '.' + proximity_zone.lstrip('zone.')
 
     proximity.update_ha_state()
 
@@ -97,6 +90,7 @@ def setup_proximity_component(hass, config):
                        proximity.check_proximity_state_change)
 
     return True
+
 
 def setup(hass, config):
     """Get the zones and offsets from configuration.yaml."""

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -74,7 +74,7 @@ def setup_proximity_component(hass, config):
                                  DEFAULT_UNIT_OF_MEASUREMENT)
 
     zone_id = 'zone.{}.'.format(proximity_zone)
-    state = hass.states.get(zone)
+    state = hass.states.get(zone_id)
     zone_friendly_name = (state.name).lower()
 
     proximity = Proximity(hass, zone_friendly_name, DEFAULT_DIST_TO_ZONE,

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -33,47 +33,48 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup(hass, config):  # pylint: disable=too-many-locals,too-many-statements
     """Get the zones and offsets from configuration.yaml."""
-    ignored_zones = []
-    if 'ignored_zones' in config[DOMAIN]:
-        for variable in config[DOMAIN]['ignored_zones']:
-            ignored_zones.append(variable)
+    for prox in config[DOMAIN]:
+        ignored_zones = []
+        if 'ignored_zones' in prox:
+            for variable in prox['ignored_zones']:
+                ignored_zones.append(variable)
 
-    # Get the devices from configuration.yaml.
-    if 'devices' not in config[DOMAIN]:
-        _LOGGER.error('devices not found in config')
-        return False
+        # Get the devices from configuration.yaml.
+        if 'devices' not in prox:
+            _LOGGER.error('devices not found in config')
+            return False
 
-    proximity_devices = []
-    for variable in config[DOMAIN]['devices']:
-        proximity_devices.append(variable)
+        proximity_devices = []
+        for variable in prox['devices']:
+            proximity_devices.append(variable)
 
-    # Get the direction of travel tolerance from configuration.yaml.
-    tolerance = config[DOMAIN].get('tolerance', DEFAULT_TOLERANCE)
+        # Get the direction of travel tolerance from configuration.yaml.
+        tolerance = prox.get('tolerance', DEFAULT_TOLERANCE)
 
-    # Get the zone to monitor proximity to from configuration.yaml.
-    proximity_zone = config[DOMAIN].get('zone', DEFAULT_PROXIMITY_ZONE)
+        # Get the zone to monitor proximity to from configuration.yaml.
+        proximity_zone = prox.get('zone', DEFAULT_PROXIMITY_ZONE)
 
-    entity_id = DOMAIN + '.' + proximity_zone
-    proximity_zone = 'zone.' + proximity_zone
+        entity_id = DOMAIN + '.' + proximity_zone
+        proximity_zone = 'zone.' + proximity_zone
 
-    state = hass.states.get(proximity_zone)
-    zone_friendly_name = (state.name).lower()
+        state = hass.states.get(proximity_zone)
+        zone_friendly_name = (state.name).lower()
 
-    # Set the default values.
-    dist_to_zone = 'not set'
-    dir_of_travel = 'not set'
-    nearest = 'not set'
+        # Set the default values.
+        dist_to_zone = 'not set'
+        dir_of_travel = 'not set'
+        nearest = 'not set'
 
-    proximity = Proximity(hass, zone_friendly_name, dist_to_zone,
-                          dir_of_travel, nearest, ignored_zones,
-                          proximity_devices, tolerance, proximity_zone)
-    proximity.entity_id = entity_id
+        proximity = Proximity(hass, zone_friendly_name, dist_to_zone,
+                              dir_of_travel, nearest, ignored_zones,
+                              proximity_devices, tolerance, proximity_zone)
+        proximity.entity_id = entity_id
 
-    proximity.update_ha_state()
+        proximity.update_ha_state()
 
-    # Main command to monitor proximity of devices.
-    track_state_change(hass, proximity_devices,
-                       proximity.check_proximity_state_change)
+        # Main command to monitor proximity of devices.
+        track_state_change(hass, proximity_devices,
+                           proximity.check_proximity_state_change)
 
     return True
 

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -94,14 +94,15 @@ def setup_proximity_component(hass, config):
 
 def setup(hass, config):
     """Get the zones and offsets from configuration.yaml."""
+    result = True
     if isinstance(config[DOMAIN], list):
         for proximity_config in config[DOMAIN]:
             if not setup_proximity_component(hass, proximity_config):
-                return False
+                result = False
     elif not setup_proximity_component(hass, config[DOMAIN]):
-        return False
+        result = False
 
-    return True
+    return result
 
 
 class Proximity(Entity):  # pylint: disable=too-many-instance-attributes

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -19,6 +19,8 @@ DEPENDENCIES = ['zone', 'device_tracker']
 
 DOMAIN = 'proximity'
 
+NOT_SET = 'not set'
+
 # Default tolerance
 DEFAULT_TOLERANCE = 1
 
@@ -27,6 +29,15 @@ DEFAULT_PROXIMITY_ZONE = 'home'
 
 # Default unit of measure
 DEFAULT_UNIT_OF_MEASUREMENT = 'km'
+
+# Default distance to zone
+DEFAULT_DIST_TO_ZONE = NOT_SET
+
+# Default direction of travel
+DEFAULT_DIR_OF_TRAVEL = NOT_SET
+
+# Default nearest device
+DEFAULT_NEAREST = NOT_SET
 
 # Entity attributes
 ATTR_DIST_FROM = 'dist_to_zone'

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -36,7 +36,7 @@ ATTR_NEAREST = 'nearest'
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_proximity_component(hass, config):   # pylint: disable=too-many-locals,too-many-statements
+def setup_proximity_component(hass, config):
     """Set up individual proximity component."""
     ignored_zones = []
     if 'ignored_zones' in config:

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -73,7 +73,7 @@ def setup_proximity_component(hass, config):
     unit_of_measure = config.get(ATTR_UNIT_OF_MEASUREMENT,
                                  DEFAULT_UNIT_OF_MEASUREMENT)
 
-    zone_id = 'zone.{}.'.format(proximity_zone)
+    zone_id = 'zone.{}'.format(proximity_zone)
     state = hass.states.get(zone_id)
     zone_friendly_name = (state.name).lower()
 

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -73,14 +73,15 @@ def setup_proximity_component(hass, config):
     unit_of_measure = config.get(ATTR_UNIT_OF_MEASUREMENT,
                                  DEFAULT_UNIT_OF_MEASUREMENT)
 
-    state = hass.states.get(proximity_zone)
+    zone_id = 'zone.{}.'.format(proximity_zone)
+    state = hass.states.get(zone)
     zone_friendly_name = (state.name).lower()
 
     proximity = Proximity(hass, zone_friendly_name, DEFAULT_DIST_TO_ZONE,
                           DEFAULT_DIR_OF_TRAVEL, DEFAULT_NEAREST,
                           ignored_zones, proximity_devices, tolerance,
-                          proximity_zone, unit_of_measure)
-    proximity.entity_id = DOMAIN + '.' + proximity_zone.lstrip('zone.')
+                          zone_id, unit_of_measure)
+    proximity.entity_id = '{}.{}'.format(DOMAIN, proximity_zone)
 
     proximity.update_ha_state()
 

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -105,7 +105,7 @@ class Proximity(Entity):  # pylint: disable=too-many-instance-attributes
         self.proximity_devices = proximity_devices
         self.tolerance = tolerance
         self.proximity_zone = proximity_zone
-        self.unit_of_measurement = unit_of_measure
+        self.unit_of_measure = unit_of_measure
 
     @property
     def name(self):
@@ -195,7 +195,7 @@ class Proximity(Entity):  # pylint: disable=too-many-instance-attributes
 
             # Add the device and distance to a dictionary.
             distances_to_zone[device] = round(
-                convert(dist_to_zone, 'm', self.unit_of_measurement), 1)
+                convert(dist_to_zone, 'm', self.unit_of_measure), 1)
 
         # Loop through each of the distances collected and work out the
         # closest.

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -90,7 +90,7 @@ def setup(hass, config):
         for proximity_config in config[DOMAIN]:
             setup_proximity_device(hass, proximity_config)
     else:
-        setup_proximity_device(config[DOMAIN])
+        setup_proximity_device(hass, config[DOMAIN])
 
     return True
 

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -67,8 +67,7 @@ def setup_proximity_component(hass, config):
     tolerance = config.get('tolerance', DEFAULT_TOLERANCE)
 
     # Get the zone to monitor proximity to from configuration.yaml.
-    proximity_zone = 'zone.' \
-        + config.get('zone', DEFAULT_PROXIMITY_ZONE).lstrip('proximity.')
+    proximity_zone = config.get('zone', DEFAULT_PROXIMITY_ZONE)
 
     # Get the unit of measurement from configuration.yaml.
     unit_of_measure = config.get(ATTR_UNIT_OF_MEASUREMENT,

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -120,7 +120,7 @@ class Proximity(Entity):  # pylint: disable=too-many-instance-attributes
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity."""
-        return self.unit_of_measurement
+        return self.unit_of_measure
 
     @property
     def state_attributes(self):

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -56,59 +56,29 @@ def convert(value, unit_1, unit_2):
 
 def __miles_to_meters(miles):
     """Convert miles to meters."""
-    if not isinstance(miles, Number):
-        err = '{} is not a numeric value.'.format(str(miles))
-        _LOGGER.error(err)
-        raise TypeError(err)
-
     return miles * 1609.344
 
 
 def __feet_to_meters(feet):
     """Convert feet to meters."""
-    if not isinstance(feet, Number):
-        err = '{} is not a numeric value.'.format(str(feet))
-        _LOGGER.error(err)
-        raise TypeError(err)
-
     return feet * 0.3048
 
 
 def __kilometers_to_meters(kilometers):
     """Convert kilometers to meters."""
-    if not isinstance(kilometers, Number):
-        err = '{} is not a numeric value.'.format(str(kilometers))
-        _LOGGER.error(err)
-        raise TypeError(err)
-
     return kilometers * 1000
 
 
 def __meters_to_miles(meters):
     """Convert meters to miles."""
-    if not isinstance(meters, Number):
-        err = '{} is not a numeric value.'.format(str(meters))
-        _LOGGER.error(err)
-        raise TypeError(err)
-
     return meters * 0.000621371
 
 
 def __meters_to_feet(meters):
     """Convert meters to feet."""
-    if not isinstance(meters, Number):
-        err = '{} is not a numeric value.'.format(str(meters))
-        _LOGGER.error(err)
-        raise TypeError(err)
-
     return meters * 3.28084
 
 
 def __meters_to_kilometers(meters):
     """Convert meters to kilometers."""
-    if not isinstance(meters, Number):
-        err = '{} is not a numeric value.'.format(str(meters))
-        _LOGGER.error(err)
-        raise TypeError(err)
-
     return meters * 0.001

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -89,32 +89,92 @@ def convert(value, unit_1, unit_2):
     result = None
 
     if unit_1 == 'mi':
-        if unit_2 == 'km':
-            result = miles_to_kilometers(value)
-        elif unit_2 == 'm':
-            result = kilometers_to_meters(miles_to_kilometers(value))
-        elif unit_2 == 'ft':
-            result = miles_to_feet(value)
+        result = __convert_from_miles(value, unit_2)
     elif unit_1 == 'ft':
-        if unit_2 == 'mi':
-            result = feet_to_miles(value)
-        elif unit_2 == 'km':
-            result = meters_to_kilometers(feet_to_meters(value))
-        elif unit_2 == 'm':
-            result = feet_to_meters(value)
+        result = __convert_from_feet(value, unit_2)
     elif unit_1 == 'km':
-        if unit_2 == 'mi':
-            result = kilometers_to_miles(value)
-        elif unit_2 == 'm':
-            result = kilometers_to_meters(value)
-        elif unit_2 == 'ft':
-            result = meters_to_feet(kilometers_to_meters(value))
+        result = __convert_from_kilometers(value, unit_2)
     elif unit_1 == 'm':
-        if unit_2 == 'km':
-            result = meters_to_kilometers(value)
-        elif unit_2 == 'ft':
-            result = meters_to_feet(value)
-        elif unit_2 == 'mi':
-            result = kilometers_to_miles(meters_to_kilometers(value))
+        result = __convert_from_meters(value, unit_2)
+
+    return result
+
+
+def __convert_from_kilometers(kilometers, to_unit):
+    """Convert kilometers to specified unit."""
+    if to_unit not in VALID_UNITS:
+        _LOGGER.error('Unknown unit of measure: ' + str(to_unit))
+        raise ValueError('Unknown unit of measure: ' + str(to_unit))
+
+    result = None
+
+    if to_unit == 'mi':
+        result = kilometers_to_miles(kilometers)
+    elif to_unit == 'm':
+        result = kilometers_to_meters(kilometers)
+    elif to_unit == 'ft':
+        result = meters_to_feet(kilometers_to_meters(kilometers))
+    elif to_unit == 'km':
+        result = kilometers
+
+    return result
+
+
+def __convert_from_meters(meters, to_unit):
+    """Convert meters to specified unit."""
+    if to_unit not in VALID_UNITS:
+        _LOGGER.error('Unknown unit of measure: ' + str(to_unit))
+        raise ValueError('Unknown unit of measure: ' + str(to_unit))
+
+    result = None
+
+    if to_unit == 'km':
+        result = meters_to_kilometers(meters)
+    elif to_unit == 'ft':
+        result = meters_to_feet(meters)
+    elif to_unit == 'mi':
+        result = kilometers_to_miles(meters_to_kilometers(meters))
+    elif to_unit == 'm':
+        result = meters
+
+    return result
+
+
+def __convert_from_miles(miles, to_unit):
+    """Convert miles to specified unit."""
+    if to_unit not in VALID_UNITS:
+        _LOGGER.error('Unknown unit of measure: ' + str(to_unit))
+        raise ValueError('Unknown unit of measure: ' + str(to_unit))
+
+    result = None
+
+    if to_unit == 'km':
+        result = miles_to_kilometers(miles)
+    elif to_unit == 'm':
+        result = kilometers_to_meters(miles_to_kilometers(miles))
+    elif to_unit == 'ft':
+        result = miles_to_feet(miles)
+    elif to_unit == 'mi':
+        result = miles
+
+    return result
+
+
+def __convert_from_feet(feet, to_unit):
+    """Convert feet to specified unit."""
+    if to_unit not in VALID_UNITS:
+        _LOGGER.error('Unknown unit of measure: ' + str(to_unit))
+        raise ValueError('Unknown unit of measure: ' + str(to_unit))
+
+    result = None
+
+    if to_unit == 'mi':
+        result = feet_to_miles(feet)
+    elif to_unit == 'km':
+        result = meters_to_kilometers(feet_to_meters(feet))
+    elif to_unit == 'm':
+        result = feet_to_meters(feet)
+    elif to_unit == 'ft':
+        result = feet
 
     return result

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -86,33 +86,35 @@ def convert(value, unit_1, unit_2):
         _LOGGER.error('Unknown unit of measure: ' + str(unit_2))
         raise ValueError('Unknown unit of measure: ' + str(unit_2))
 
+    result = None
+
     if unit_1 == 'mi':
         if unit_2 == 'km':
-            return miles_to_kilometers(value)
+            result = miles_to_kilometers(value)
         elif unit_2 == 'm':
-            return kilometers_to_meters(miles_to_kilometers(value))
+            result = kilometers_to_meters(miles_to_kilometers(value))
         elif unit_2 == 'ft':
-            return miles_to_ft(value)
+            result = miles_to_feet(value)
     elif unit_1 == 'ft':
         if unit_2 == 'mi':
-            return feet_to_miles(value)
+            result = feet_to_miles(value)
         elif unit_2 == 'km':
-            return meters_to_kilometers(feet_to_meters(value))
+            result = meters_to_kilometers(feet_to_meters(value))
         elif unit_2 == 'm':
-            return feet_to_meters(value)
+            result = feet_to_meters(value)
     elif unit_1 == 'km':
         if unit_2 == 'mi':
-            return kilometers_to_miles(value)
+            result = kilometers_to_miles(value)
         elif unit_2 == 'm':
-            return kilometers_to_meters(value)
+            result = kilometers_to_meters(value)
         elif unit_2 == 'ft':
-            return meters_to_feet(kilometers_to_meters(value))
+            result = meters_to_feet(kilometers_to_meters(value))
     elif unit_1 == 'm':
         if unit_2 == 'km':
-            return meters_to_kilometers(value)
+            result = meters_to_kilometers(value)
         elif unit_2 == 'ft':
-            return meters_to_feet(value)
+            result = meters_to_feet(value)
         elif unit_2 == 'mi':
-            return kilometers_to_miles(meters_to_kilometers(value))
+            result = kilometers_to_miles(meters_to_kilometers(value))
 
-    return None
+    return result

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -7,68 +7,68 @@ _LOGGER = logging.getLogger(__name__)
 VALID_UNITS = ['km', 'm', 'ft', 'mi']
 
 
-def kilometers_to_miles(km):
+def kilometers_to_miles(kilometers):
     """Convert the given kilometers to miles."""
-    if not isinstance(km, Number):
-        raise TypeError(str(km) + ' is not of numeric type')
+    if not isinstance(kilometers, Number):
+        raise TypeError(str(kilometers) + ' is not of numeric type')
 
-    return km * 0.621371
+    return kilometers * 0.621371
 
 
-def miles_to_kilometers(mi):
+def miles_to_kilometers(miles):
     """Convert the given miles to kilometers."""
-    if not isinstance(mi, Number):
-        raise TypeError(str(mi) + ' is not of numeric type')
+    if not isinstance(miles, Number):
+        raise TypeError(str(miles) + ' is not of numeric type')
 
-    return mi * 1.60934
+    return miles * 1.60934
 
 
-def kilometers_to_meters(km):
+def kilometers_to_meters(kilometers):
     """Convert the given kilometers to meters."""
     if not isinstance(km, Number):
-        raise TypeError(str(km) + ' is not of numeric type')
+        raise TypeError(str(kilometers) + ' is not of numeric type')
 
-    return km * 1000
+    return kilometers * 1000
 
 
-def meters_to_kilometers(m):
+def meters_to_kilometers(meters):
     """Convert the given meters to kilometers."""
     if not isinstance(m, Number):
-        raise TypeError(str(m) + ' is not of numeric type')
+        raise TypeError(str(meters) + ' is not of numeric type')
 
-    return m * 0.001
+    return meters * 0.001
 
 
-def meters_to_feet(m):
+def meters_to_feet(meters):
     """Convert the given meters to feet."""
-    if not isinstance(m, Number):
-        raise TypeError(str(m) + ' is not of numeric type')
+    if not isinstance(meters, Number):
+        raise TypeError(str(meters) + ' is not of numeric type')
 
-    return m * 3.28084
+    return meters * 3.28084
 
 
-def feet_to_meters(ft):
+def feet_to_meters(feet):
     """Convert the given feet to meters."""
-    if not isinstance(ft, Number):
-        raise TypeError(str(ft) + ' is not of numeric type')
+    if not isinstance(feet, Number):
+        raise TypeError(str(feet) + ' is not of numeric type')
 
-    return ft * 0.3048
+    return feet * 0.3048
 
 
-def feet_to_miles(ft):
+def feet_to_miles(feet):
     """Convert the given feet to miles."""
-    if not isinstance(ft, Number):
-        raise TypeError(str(ft) + ' is not of numeric type')
+    if not isinstance(feet, Number):
+        raise TypeError(str(feet) + ' is not of numeric type')
 
-    return ft * 0.000189394
+    return feet * 0.000189394
 
 
-def miles_to_ft(mi):
+def miles_to_feet(miles):
     """Convert the given miles to feet."""
-    if not isinstance(mi, Number):
-        raise TypeError(str(mi) + ' is not of numeric type')
+    if not isinstance(miles, Number):
+        raise TypeError(str(miles) + ' is not of numeric type')
 
-    return mi * 5280
+    return miles * 5280
 
 
 def convert(value, unit_1, unit_2):

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -4,71 +4,18 @@ import logging
 from numbers import Number
 
 _LOGGER = logging.getLogger(__name__)
-VALID_UNITS = ['km', 'm', 'ft', 'mi']
 
+KILOMETERS_SYMBOL = 'km'
+METERS_SYMBOL = 'm'
+FEET_SYMBOL = 'ft'
+MILES_SYMBOL = 'mi'
 
-def kilometers_to_miles(kilometers):
-    """Convert the given kilometers to miles."""
-    if not isinstance(kilometers, Number):
-        raise TypeError(str(kilometers) + ' is not of numeric type')
-
-    return kilometers * 0.621371
-
-
-def miles_to_kilometers(miles):
-    """Convert the given miles to kilometers."""
-    if not isinstance(miles, Number):
-        raise TypeError(str(miles) + ' is not of numeric type')
-
-    return miles * 1.60934
-
-
-def kilometers_to_meters(kilometers):
-    """Convert the given kilometers to meters."""
-    if not isinstance(kilometers, Number):
-        raise TypeError(str(kilometers) + ' is not of numeric type')
-
-    return kilometers * 1000
-
-
-def meters_to_kilometers(meters):
-    """Convert the given meters to kilometers."""
-    if not isinstance(meters, Number):
-        raise TypeError(str(meters) + ' is not of numeric type')
-
-    return meters * 0.001
-
-
-def meters_to_feet(meters):
-    """Convert the given meters to feet."""
-    if not isinstance(meters, Number):
-        raise TypeError(str(meters) + ' is not of numeric type')
-
-    return meters * 3.28084
-
-
-def feet_to_meters(feet):
-    """Convert the given feet to meters."""
-    if not isinstance(feet, Number):
-        raise TypeError(str(feet) + ' is not of numeric type')
-
-    return feet * 0.3048
-
-
-def feet_to_miles(feet):
-    """Convert the given feet to miles."""
-    if not isinstance(feet, Number):
-        raise TypeError(str(feet) + ' is not of numeric type')
-
-    return feet * 0.000189394
-
-
-def miles_to_feet(miles):
-    """Convert the given miles to feet."""
-    if not isinstance(miles, Number):
-        raise TypeError(str(miles) + ' is not of numeric type')
-
-    return miles * 5280
+VALID_UNITS = [
+    KILOMETERS_SYMBOL,
+    METERS_SYMBOL,
+    FEET_SYMBOL,
+    MILES_SYMBOL,
+]
 
 
 def convert(value, unit_1, unit_2):
@@ -86,95 +33,82 @@ def convert(value, unit_1, unit_2):
         _LOGGER.error('Unknown unit of measure: ' + str(unit_2))
         raise ValueError('Unknown unit of measure: ' + str(unit_2))
 
-    result = None
+    meters = value
 
-    if unit_1 == 'mi':
-        result = __convert_from_miles(value, unit_2)
-    elif unit_1 == 'ft':
-        result = __convert_from_feet(value, unit_2)
-    elif unit_1 == 'km':
-        result = __convert_from_kilometers(value, unit_2)
-    elif unit_1 == 'm':
-        result = __convert_from_meters(value, unit_2)
+    if unit_1 == MILES_SYMBOL:
+        meters = __miles_to_meters(value)
+    elif unit_1 == FEET_SYMBOL:
+        meters = __feet_to_meters(value)
+    elif unit_1 == KILOMETERS_SYMBOL:
+        meters = __kilometers_to_meters(value)
 
-    return result
+    result = meters
 
-
-def __convert_from_kilometers(kilometers, to_unit):
-    """Convert kilometers to specified unit."""
-    if to_unit not in VALID_UNITS:
-        _LOGGER.error('Unknown unit of measure: ' + str(to_unit))
-        raise ValueError('Unknown unit of measure: ' + str(to_unit))
-
-    result = None
-
-    if to_unit == 'mi':
-        result = kilometers_to_miles(kilometers)
-    elif to_unit == 'm':
-        result = kilometers_to_meters(kilometers)
-    elif to_unit == 'ft':
-        result = meters_to_feet(kilometers_to_meters(kilometers))
-    elif to_unit == 'km':
-        result = kilometers
+    if unit_2 == MILES_SYMBOL:
+        result = __meters_to_miles(meters)
+    elif unit_2 == FEET_SYMBOL:
+        result = __meters_to_feet(meters)
+    elif unit_2 == KILOMETERS_SYMBOL:
+        result = __meters_to_kilometers(meters)
 
     return result
 
 
-def __convert_from_meters(meters, to_unit):
-    """Convert meters to specified unit."""
-    if to_unit not in VALID_UNITS:
-        _LOGGER.error('Unknown unit of measure: ' + str(to_unit))
-        raise ValueError('Unknown unit of measure: ' + str(to_unit))
+def __miles_to_meters(miles):
+    """Convert miles to meters."""
+    if not isinstance(miles, Number):
+        err = '{} is not a numeric value.'.format(str(miles))
+        _LOGGER.error(err)
+        raise TypeError(err)
 
-    result = None
-
-    if to_unit == 'km':
-        result = meters_to_kilometers(meters)
-    elif to_unit == 'ft':
-        result = meters_to_feet(meters)
-    elif to_unit == 'mi':
-        result = kilometers_to_miles(meters_to_kilometers(meters))
-    elif to_unit == 'm':
-        result = meters
-
-    return result
+    return miles * 1609.344
 
 
-def __convert_from_miles(miles, to_unit):
-    """Convert miles to specified unit."""
-    if to_unit not in VALID_UNITS:
-        _LOGGER.error('Unknown unit of measure: ' + str(to_unit))
-        raise ValueError('Unknown unit of measure: ' + str(to_unit))
+def __feet_to_meters(feet):
+    """Convert feet to meters."""
+    if not isinstance(feet, Number):
+        err = '{} is not a numeric value.'.format(str(feet))
+        _LOGGER.error(err)
+        raise TypeError(err)
 
-    result = None
-
-    if to_unit == 'km':
-        result = miles_to_kilometers(miles)
-    elif to_unit == 'm':
-        result = kilometers_to_meters(miles_to_kilometers(miles))
-    elif to_unit == 'ft':
-        result = miles_to_feet(miles)
-    elif to_unit == 'mi':
-        result = miles
-
-    return result
+    return feet * 0.3048
 
 
-def __convert_from_feet(feet, to_unit):
-    """Convert feet to specified unit."""
-    if to_unit not in VALID_UNITS:
-        _LOGGER.error('Unknown unit of measure: ' + str(to_unit))
-        raise ValueError('Unknown unit of measure: ' + str(to_unit))
+def __kilometers_to_meters(kilometers):
+    """Convert kilometers to meters."""
+    if not isinstance(kilometers, Number):
+        err = '{} is not a numeric value.'.format(str(kilometers))
+        _LOGGER.error(err)
+        raise TypeError(err)
 
-    result = None
+    return kilometers * 1000
 
-    if to_unit == 'mi':
-        result = feet_to_miles(feet)
-    elif to_unit == 'km':
-        result = meters_to_kilometers(feet_to_meters(feet))
-    elif to_unit == 'm':
-        result = feet_to_meters(feet)
-    elif to_unit == 'ft':
-        result = feet
 
-    return result
+def __meters_to_miles(meters):
+    """Convert meters to miles."""
+    if not isinstance(meters, Number):
+        err = '{} is not a numeric value.'.format(str(meters))
+        _LOGGER.error(err)
+        raise TypeError(err)
+
+    return meters * 0.000621371
+
+
+def __meters_to_feet(meters):
+    """Convert meters to feet."""
+    if not isinstance(meters, Number):
+        err = '{} is not a numeric value.'.format(str(meters))
+        _LOGGER.error(err)
+        raise TypeError(err)
+
+    return meters * 3.28084
+
+
+def __meters_to_kilometers(meters):
+    """Convert meters to kilometers."""
+    if not isinstance(meters, Number):
+        err = '{} is not a numeric value.'.format(str(meters))
+        _LOGGER.error(err)
+        raise TypeError(err)
+
+    return meters * 0.001

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -97,7 +97,7 @@ def convert(value, unit_1, unit_2):
         if unit_2 == 'mi':
             return feet_to_miles(value)
         elif unit_2 == 'km':
-            return miles_to_kilometers(feet_to_meters(value))
+            return meters_to_kilometers(feet_to_meters(value))
         elif unit_2 == 'm':
             return feet_to_meters(value)
     elif unit_1 == 'km':
@@ -106,7 +106,7 @@ def convert(value, unit_1, unit_2):
         elif unit_2 == 'm':
             return kilometers_to_meters(value)
         elif unit_2 == 'ft':
-            return kilometers_to_meters(meters_to_feet(value))
+            return meters_to_feet(kilometers_to_meters(value))
     elif unit_1 == 'm':
         if unit_2 == 'km':
             return meters_to_kilometers(value)

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -8,53 +8,82 @@ VALID_UNITS = ['km', 'm', 'ft', 'mi']
 
 def kilometers_to_miles(km):
     """Convert the given kilometers to miles."""
+    if not isinstance(km, (int, long, float)):
+        raise TypeError(str(km) ' is not of numeric type')
+
     return km * 0.621371
 
 
 def miles_to_kilometers(mi):
     """Convert the given miles to kilometers."""
+    if not isinstance(mi, (int, long, float)):
+        raise TypeError(str(mi) ' is not of numeric type')
+
     return mi * 1.60934
 
 
 def kilometers_to_meters(km):
     """Convert the given kilometers to meters."""
+    if not isinstance(km, (int, long, float)):
+        raise TypeError(str(km) ' is not of numeric type')
+
     return km * 1000
 
 
 def meters_to_kilometers(m):
     """Convert the given meters to kilometers."""
+    if not isinstance(m, (int, long, float)):
+        raise TypeError(str(m) ' is not of numeric type')
+
     return m * 0.001
 
 
 def meters_to_feet(m):
     """Convert the given meters to feet."""
+    if not isinstance(m, (int, long, float)):
+        raise TypeError(str(m) ' is not of numeric type')
+
     return m * 3.28084
 
 
 def feet_to_meters(ft):
     """Convert the given feet to meters."""
+    if not isinstance(ft, (int, long, float)):
+        raise TypeError(str(ft) ' is not of numeric type')
+
     return ft * 0.3048
 
 
 def feet_to_miles(ft):
     """Convert the given feet to miles."""
+    if not isinstance(ft, (int, long, float)):
+        raise TypeError(str(ft) ' is not of numeric type')
+
     return ft * 0.000189394
 
 
 def miles_to_ft(mi):
     """Convert the given miles to feet."""
+    if not isinstance(mi, (int, long, float)):
+        raise TypeError(str(mi) ' is not of numeric type')
+
     return mi * 5280
 
 
 def convert(value, unit_1, unit_2):
     """Convert one unit of measurement to another."""
+    if not isinstance(value, (int, long, float)):
+        raise TypeError(str(value) ' is not of numeric type')
+
     if unit_1 == unit_2:
         return value
 
     if unit_1 not in VALID_UNITS:
-        _LOGGER.error('Unknown unit of measure: ' + unit_1)
+        _LOGGER.error('Unknown unit of measure: ' + str(unit_1))
+        raise ValueError('Unknown unit of measure: ' + str(unit_1))
     elif unit_2 not in VALID_UNITS:
-        _LOGGER.error('Unknown unit of measure: ' + unit_2)
+        _LOGGER.error('Unknown unit of measure: ' + str(unit_2))
+        raise ValueError('Unknown unit of measure: ' + str(unit_2))
 
     if unit_1 == 'mi':
         if unit_2 == 'km':

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -25,7 +25,7 @@ def miles_to_kilometers(miles):
 
 def kilometers_to_meters(kilometers):
     """Convert the given kilometers to meters."""
-    if not isinstance(km, Number):
+    if not isinstance(kilometers, Number):
         raise TypeError(str(kilometers) + ' is not of numeric type')
 
     return kilometers * 1000
@@ -33,7 +33,7 @@ def kilometers_to_meters(kilometers):
 
 def meters_to_kilometers(meters):
     """Convert the given meters to kilometers."""
-    if not isinstance(m, Number):
+    if not isinstance(meters, Number):
         raise TypeError(str(meters) + ' is not of numeric type')
 
     return meters * 0.001

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -1,6 +1,7 @@
 """Distance util functions."""
 
 import logging
+from numbers import Number
 
 _LOGGER = logging.getLogger(__name__)
 VALID_UNITS = ['km', 'm', 'ft', 'mi']
@@ -8,72 +9,72 @@ VALID_UNITS = ['km', 'm', 'ft', 'mi']
 
 def kilometers_to_miles(km):
     """Convert the given kilometers to miles."""
-    if not isinstance(km, (int, long, float)):
-        raise TypeError(str(km) ' is not of numeric type')
+    if not isinstance(km, Number):
+        raise TypeError(str(km) + ' is not of numeric type')
 
     return km * 0.621371
 
 
 def miles_to_kilometers(mi):
     """Convert the given miles to kilometers."""
-    if not isinstance(mi, (int, long, float)):
-        raise TypeError(str(mi) ' is not of numeric type')
+    if not isinstance(mi, Number):
+        raise TypeError(str(mi) + ' is not of numeric type')
 
     return mi * 1.60934
 
 
 def kilometers_to_meters(km):
     """Convert the given kilometers to meters."""
-    if not isinstance(km, (int, long, float)):
-        raise TypeError(str(km) ' is not of numeric type')
+    if not isinstance(km, Number):
+        raise TypeError(str(km) + ' is not of numeric type')
 
     return km * 1000
 
 
 def meters_to_kilometers(m):
     """Convert the given meters to kilometers."""
-    if not isinstance(m, (int, long, float)):
-        raise TypeError(str(m) ' is not of numeric type')
+    if not isinstance(m, Number):
+        raise TypeError(str(m) + ' is not of numeric type')
 
     return m * 0.001
 
 
 def meters_to_feet(m):
     """Convert the given meters to feet."""
-    if not isinstance(m, (int, long, float)):
-        raise TypeError(str(m) ' is not of numeric type')
+    if not isinstance(m, Number):
+        raise TypeError(str(m) + ' is not of numeric type')
 
     return m * 3.28084
 
 
 def feet_to_meters(ft):
     """Convert the given feet to meters."""
-    if not isinstance(ft, (int, long, float)):
-        raise TypeError(str(ft) ' is not of numeric type')
+    if not isinstance(ft, Number):
+        raise TypeError(str(ft) + ' is not of numeric type')
 
     return ft * 0.3048
 
 
 def feet_to_miles(ft):
     """Convert the given feet to miles."""
-    if not isinstance(ft, (int, long, float)):
-        raise TypeError(str(ft) ' is not of numeric type')
+    if not isinstance(ft, Number):
+        raise TypeError(str(ft) + ' is not of numeric type')
 
     return ft * 0.000189394
 
 
 def miles_to_ft(mi):
     """Convert the given miles to feet."""
-    if not isinstance(mi, (int, long, float)):
-        raise TypeError(str(mi) ' is not of numeric type')
+    if not isinstance(mi, Number):
+        raise TypeError(str(mi) + ' is not of numeric type')
 
     return mi * 5280
 
 
 def convert(value, unit_1, unit_2):
     """Convert one unit of measurement to another."""
-    if not isinstance(value, (int, long, float)):
-        raise TypeError(str(value) ' is not of numeric type')
+    if not isinstance(value, Number):
+        raise TypeError(str(value) + ' is not of numeric type')
 
     if unit_1 == unit_2:
         return value

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -18,12 +18,12 @@ def miles_to_kilometers(mi):
 
 def kilometers_to_meters(km):
     """Convert the given kilometers to meters."""
-    return km * .001
+    return km * 1000
 
 
 def meters_to_kilometers(m):
     """Convert the given meters to kilometers."""
-    return m * 1000
+    return m * 0.001
 
 
 def meters_to_feet(m):

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -1,0 +1,88 @@
+"""Distance util functions."""
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+VALID_UNITS = ['km', 'm', 'ft', 'mi']
+
+
+def kilometers_to_miles(km):
+    """Convert the given kilometers to miles."""
+    return km * 0.621371
+
+
+def miles_to_kilometers(mi):
+    """Convert the given miles to kilometers."""
+    return mi * 1.60934
+
+
+def kilometers_to_meters(km):
+    """Convert the given kilometers to meters."""
+    return km * .001
+
+
+def meters_to_kilometers(m):
+    """Convert the given meters to kilometers."""
+    return m * 1000
+
+
+def meters_to_feet(m):
+    """Convert the given meters to feet."""
+    return m * 3.28084
+
+
+def feet_to_meters(ft):
+    """Convert the given feet to meters."""
+    return ft * 0.3048
+
+
+def feet_to_miles(ft):
+    """Convert the given feet to miles."""
+    return ft * 0.000189394
+
+
+def miles_to_ft(mi):
+    """Convert the given miles to feet."""
+    return mi * 5280
+
+
+def convert(value, unit_1, unit_2):
+    """Convert one unit of measurement to another."""
+    if unit_1 == unit_2:
+        return value
+
+    if unit_1 not in VALID_UNITS:
+        _LOGGER.error('Unknown unit of measure: ' + unit_1)
+    elif unit_2 not in VALID_UNITS:
+        _LOGGER.error('Unknown unit of measure: ' + unit_2)
+
+    if unit_1 == 'mi':
+        if unit_2 == 'km':
+            return miles_to_kilometers(value)
+        elif unit_2 == 'm':
+            return kilometers_to_meters(miles_to_kilometers(value))
+        elif unit_2 == 'ft':
+            return miles_to_ft(value)
+    elif unit_1 == 'ft':
+        if unit_2 == 'mi':
+            return feet_to_miles(value)
+        elif unit_2 == 'km':
+            return miles_to_kilometers(feet_to_meters(value))
+        elif unit_2 == 'm':
+            return feet_to_meters(value)
+    elif unit_1 == 'km':
+        if unit_2 == 'mi':
+            return kilometers_to_miles(value)
+        elif unit_2 == 'm':
+            return kilometers_to_meters(value)
+        elif unit_2 == 'ft':
+            return kilometers_to_meters(meters_to_feet(value))
+    elif unit_1 == 'm':
+        if unit_2 == 'km':
+            return meters_to_kilometers(value)
+        elif unit_2 == 'ft':
+            return meters_to_feet(value)
+        elif unit_2 == 'mi':
+            return kilometers_to_miles(meters_to_kilometers(value))
+
+    return None

--- a/tests/components/test_proximity.py
+++ b/tests/components/test_proximity.py
@@ -66,6 +66,25 @@ class TestProximity:
             state = self.hass.states.get('proximity.' + prox)
             assert state.state == '0'
 
+    def test_proximities_missing_devices(self):
+        """Test a list of proximities with one missing devices."""
+        assert not proximity.setup(self.hass, {
+            'proximity': [{
+                'zone': 'home',
+                'ignored_zones': {
+                    'work'
+                },
+                'devices': {
+                    'device_tracker.test1',
+                    'device_tracker.test2'
+                },
+                'tolerance': '1'
+            }, {
+                'zone': 'work',
+                'tolerance': '1'
+            }]
+        })
+
     def test_proximity(self):
         """Test the proximity."""
         assert proximity.setup(self.hass, {

--- a/tests/components/test_proximity.py
+++ b/tests/components/test_proximity.py
@@ -18,10 +18,53 @@ class TestProximity:
                 'longitude': 1.1,
                 'radius': 10
             })
+        self.hass.states.set(
+            'zone.work', 'zoning',
+            {
+                'name': 'work',
+                'latitude': 2.3,
+                'longitude': 1.3,
+                'radius': 10
+            })
 
     def teardown_method(self, method):
         """Stop everything that was started."""
         self.hass.stop()
+
+    def test_proximities(self):
+        """Test a list of proximities."""
+        assert proximity.setup(self.hass, {
+            'proximity': [{
+                'zone': 'home',
+                'ignored_zones': {
+                    'work'
+                },
+                'devices': {
+                    'device_tracker.test1',
+                    'device_tracker.test2'
+                },
+                'tolerance': '1'
+            }, {
+                'zone': 'work',
+                'devices': {
+                    'device_tracker.test1'
+                },
+                'tolerance': '1'
+            }]
+        })
+
+        proximities = ['home', 'work']
+
+        for prox in proximities:
+            state = self.hass.states.get('proximity.' + prox)
+            assert state.state == 'not set'
+            assert state.attributes.get('nearest') == 'not set'
+            assert state.attributes.get('dir_of_travel') == 'not set'
+
+            self.hass.states.set('proximity.' + prox, '0')
+            self.hass.pool.block_till_done()
+            state = self.hass.states.get('proximity.' + prox)
+            assert state.state == '0'
 
     def test_proximity(self):
         """Test the proximity."""

--- a/tests/util/test_distance.py
+++ b/tests/util/test_distance.py
@@ -3,20 +3,16 @@
 import unittest
 import homeassistant.util.distance as distance_util
 
-epsilon = 0.000001
-
-def is_less_than_epsilon(actual, expected):
-    return abs(actual - expected) < epsilon
 
 class TestDistanceUtil(unittest.TestCase):
     """Test the distance utility functions."""
 
     def test_kilometers_to_miles(self):
         """Test conversion from kilometers to miles."""
-        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_miles(0), 0))
-        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_miles(1), 0.621371))
-        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_miles(0.5), 0.310686))
-        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_miles(-1), -0.621371))
+        self.assertEqual(distance_util.kilometers_to_miles(0), 0)
+        self.assertEqual(distance_util.kilometers_to_miles(1), 0.621371)
+        self.assertEqual(distance_util.kilometers_to_miles(0.5), 0.3106855)
+        self.assertEqual(distance_util.kilometers_to_miles(-1), -0.621371)
 
         exceptionThrown = False
         try:
@@ -28,10 +24,10 @@ class TestDistanceUtil(unittest.TestCase):
 
     def test_miles_to_kilometer(self):
         """Test conversion from miles to kilometers."""
-        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_kilometers(0), 0))
-        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_kilometers(1), 1.60934))
-        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_kilometers(0.5), 0.804672))
-        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_kilometers(-1), -1.60934))
+        self.assertEqual(distance_util.miles_to_kilometers(0), 0)
+        self.assertEqual(distance_util.miles_to_kilometers(1), 1.60934)
+        self.assertEqual(distance_util.miles_to_kilometers(0.5), 0.80467)
+        self.assertEqual(distance_util.miles_to_kilometers(-1), -1.60934)
 
         exceptionThrown = False
         try:
@@ -43,10 +39,10 @@ class TestDistanceUtil(unittest.TestCase):
 
     def test_kilometers_to_meters(self):
         """Test conversion from kilometers to meters."""
-        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_meters(0), 0))
-        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_meters(1), 1000))
-        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_meters(0.5), 500))
-        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_meters(-1), -1000))
+        self.assertEqual(distance_util.kilometers_to_meters(0), 0)
+        self.assertEqual(distance_util.kilometers_to_meters(1), 1000)
+        self.assertEqual(distance_util.kilometers_to_meters(0.5), 500)
+        self.assertEqual(distance_util.kilometers_to_meters(-1), -1000)
 
         exceptionThrown = False
         try:
@@ -58,10 +54,10 @@ class TestDistanceUtil(unittest.TestCase):
 
     def test_meters_to_kilometers(self):
         """Test conversion from meters to kilometers."""
-        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_kilometers(0), 0))
-        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_kilometers(1), 0.001))
-        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_kilometers(500), 0.5))
-        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_kilometers(-1), -0.001))
+        self.assertEqual(distance_util.meters_to_kilometers(0), 0)
+        self.assertEqual(distance_util.meters_to_kilometers(1), 0.001)
+        self.assertEqual(distance_util.meters_to_kilometers(500), 0.5)
+        self.assertEqual(distance_util.meters_to_kilometers(-1), -0.001)
 
         exceptionThrown = False
         try:
@@ -73,10 +69,10 @@ class TestDistanceUtil(unittest.TestCase):
 
     def test_meters_to_feet(self):
         """Test conversion from meters to feet."""
-        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_feet(0), 0))
-        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_feet(1), 3.28084))
-        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_feet(500), 1640.42))
-        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_feet(-1), -3.28084))
+        self.assertEqual(distance_util.meters_to_feet(0), 0)
+        self.assertEqual(distance_util.meters_to_feet(1), 3.28084)
+        self.assertEqual(distance_util.meters_to_feet(500), 1640.42)
+        self.assertEqual(distance_util.meters_to_feet(-1), -3.28084)
 
         exceptionThrown = False
         try:
@@ -88,10 +84,10 @@ class TestDistanceUtil(unittest.TestCase):
 
     def test_feet_to_meters(self):
         """Test conversion from feet to meters."""
-        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_meters(0), 0))
-        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_meters(1), 0.3048))
-        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_meters(500), 152.4))
-        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_meters(-1), -0.3048))
+        self.assertEqual(distance_util.feet_to_meters(0), 0)
+        self.assertEqual(distance_util.feet_to_meters(1), 0.3048)
+        self.assertEqual(distance_util.feet_to_meters(500), 152.4)
+        self.assertEqual(distance_util.feet_to_meters(-1), -0.3048)
 
         exceptionThrown = False
         try:
@@ -103,10 +99,10 @@ class TestDistanceUtil(unittest.TestCase):
 
     def test_feet_to_miles(self):
         """Test conversion from feet to miles."""
-        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_miles(0), 0))
-        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_miles(1), 0.000189394))
-        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_miles(500), 0.094697))
-        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_miles(-1), -0.000189394))
+        self.assertEqual(distance_util.feet_to_miles(0), 0)
+        self.assertEqual(distance_util.feet_to_miles(1), 0.000189394)
+        self.assertEqual(distance_util.feet_to_miles(500), 0.094697)
+        self.assertEqual(distance_util.feet_to_miles(-1), -0.000189394)
 
         exceptionThrown = False
         try:
@@ -118,10 +114,10 @@ class TestDistanceUtil(unittest.TestCase):
 
     def test_miles_to_feet(self):
         """Test conversion from miles to feet."""
-        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_ft(0), 0))
-        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_ft(1), 5280))
-        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_ft(.5), 2740))
-        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_ft(-1), -5280))
+        self.assertEqual(distance_util.miles_to_ft(0), 0)
+        self.assertEqual(distance_util.miles_to_ft(1), 5280)
+        self.assertEqual(distance_util.miles_to_ft(.5), 2640)
+        self.assertEqual(distance_util.miles_to_ft(-1), -5280)
 
         exceptionThrown = False
         try:
@@ -159,27 +155,27 @@ class TestDistanceUtil(unittest.TestCase):
     def test_convert_from_miles(self):
         """Test conversion from miles to other units."""
         miles = 5
-        self.assertTrue(is_less_than_epsilon(distance_util.convert(miles, 'mi', 'km'), 8.04672))
-        self.assertTrue(is_less_than_epsilon(distance_util.convert(miles, 'mi', 'm'), 8046.72))
-        self.assertTrue(is_less_than_epsilon(distance_util.convert(miles, 'mi', 'ft'), 26400))
+        self.assertEqual(distance_util.convert(miles, 'mi', 'km'), 8.0467)
+        self.assertEqual(distance_util.convert(miles, 'mi', 'm'), 8046.7)
+        self.assertEqual(distance_util.convert(miles, 'mi', 'ft'), 26400)
 
     def test_convert_from_feet(self):
         """Test conversion from feet to other units."""
         feet = 5000
-        self.assertTrue(is_less_than_epsilon(distance_util.convert(feet, 'ft', 'km'), 1.524))
-        self.assertTrue(is_less_than_epsilon(distance_util.convert(feet, 'ft', 'm'), 1524))
-        self.assertTrue(is_less_than_epsilon(distance_util.convert(feet, 'ft', 'mi'), 0.9469697))
+        self.assertEqual(distance_util.convert(feet, 'ft', 'km'), 1.524)
+        self.assertEqual(distance_util.convert(feet, 'ft', 'm'), 1524)
+        self.assertEqual(distance_util.convert(feet, 'ft', 'mi'), 0.9469700000000001)
 
     def test_convert_from_kilometers(self):
         """Test conversion from kilometers to other units."""
         km = 5
-        self.assertTrue(is_less_than_epsilon(distance_util.convert(km, 'km', 'ft'), 16404.2208))
-        self.assertTrue(is_less_than_epsilon(distance_util.convert(km, 'km', 'm'), 5000))
-        self.assertTrue(is_less_than_epsilon(distance_util.convert(km, 'km', 'mi'), 3.10686))
+        self.assertEqual(distance_util.convert(km, 'km', 'ft'), 16404.2)
+        self.assertEqual(distance_util.convert(km, 'km', 'm'), 5000)
+        self.assertEqual(distance_util.convert(km, 'km', 'mi'), 3.106855)
 
     def test_convert_from_meters(self):
         """Test conversion from meters to other units."""
         m = 5000
-        self.assertTrue(is_less_than_epsilon(distance_util.convert(m, 'm', 'ft'), 0))
-        self.assertTrue(is_less_than_epsilon(distance_util.convert(m, 'm', 'km'), 5))
-        self.assertTrue(is_less_than_epsilon(distance_util.convert(m, 'm', 'mi'), 0))
+        self.assertEqual(distance_util.convert(m, 'm', 'ft'), 16404.2)
+        self.assertEqual(distance_util.convert(m, 'm', 'km'), 5)
+        self.assertEqual(distance_util.convert(m, 'm', 'mi'), 3.106855)

--- a/tests/util/test_distance.py
+++ b/tests/util/test_distance.py
@@ -164,7 +164,8 @@ class TestDistanceUtil(unittest.TestCase):
         feet = 5000
         self.assertEqual(distance_util.convert(feet, 'ft', 'km'), 1.524)
         self.assertEqual(distance_util.convert(feet, 'ft', 'm'), 1524)
-        self.assertEqual(distance_util.convert(feet, 'ft', 'mi'), 0.9469700000000001)
+        self.assertEqual(distance_util.convert(feet, 'ft', 'mi'),
+                         0.9469700000000001)
 
     def test_convert_from_kilometers(self):
         """Test conversion from kilometers to other units."""

--- a/tests/util/test_distance.py
+++ b/tests/util/test_distance.py
@@ -114,14 +114,14 @@ class TestDistanceUtil(unittest.TestCase):
 
     def test_miles_to_feet(self):
         """Test conversion from miles to feet."""
-        self.assertEqual(distance_util.miles_to_ft(0), 0)
-        self.assertEqual(distance_util.miles_to_ft(1), 5280)
-        self.assertEqual(distance_util.miles_to_ft(.5), 2640)
-        self.assertEqual(distance_util.miles_to_ft(-1), -5280)
+        self.assertEqual(distance_util.miles_to_feet(0), 0)
+        self.assertEqual(distance_util.miles_to_feet(1), 5280)
+        self.assertEqual(distance_util.miles_to_feet(.5), 2640)
+        self.assertEqual(distance_util.miles_to_feet(-1), -5280)
 
         exceptionThrown = False
         try:
-            distance_util.miles_to_ft('a')
+            distance_util.miles_to_feet('a')
         except TypeError:
             exceptionThrown = True
 

--- a/tests/util/test_distance.py
+++ b/tests/util/test_distance.py
@@ -1,0 +1,185 @@
+"""Test homeasssitant distance utility functions."""
+
+import unittest
+import homeassistant.util.distance as distance_util
+
+epsilon = 0.000001
+
+def is_less_than_epsilon(actual, expected):
+    return abs(actual - expected) < epsilon
+
+class TestDistanceUtil(unittest.TestCase):
+    """Test the distance utility functions."""
+
+    def test_kilometers_to_miles(self):
+        """Test conversion from kilometers to miles."""
+        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_miles(0), 0))
+        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_miles(1), 0.621371))
+        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_miles(0.5), 0.310686))
+        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_miles(-1), -0.621371))
+
+        exceptionThrown = False
+        try:
+            distance_util.kilometers_to_miles('a')
+        except TypeError:
+            exceptionThrown
+
+        self.assertTrue(exceptionThrown)
+
+    def test_miles_to_kilometer(self):
+        """Test conversion from miles to kilometers."""
+        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_kilometers(0), 0))
+        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_kilometers(1), 1.60934))
+        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_kilometers(0.5), 0.804672))
+        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_kilometers(-1), -1.60934))
+
+        exceptionThrown = False
+        try:
+            distance_util.miles_to_kilometers('a')
+        except TypeError:
+            exceptionThrown
+
+        self.assertTrue(exceptionThrown)
+
+    def test_kilometers_to_meters(self):
+        """Test conversion from kilometers to meters."""
+        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_meters(0), 0))
+        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_meters(1), 1000))
+        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_meters(0.5), 500))
+        self.assertTrue(is_less_than_epsilon(distance_util.kilometers_to_meters(-1), -1000))
+
+        exceptionThrown = False
+        try:
+            distance_util.kilometers_to_meters('a')
+        except TypeError:
+            exceptionThrown
+
+        self.assertTrue(exceptionThrown)
+
+    def test_meters_to_kilometers(self):
+        """Test conversion from meters to kilometers."""
+        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_kilometers(0), 0))
+        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_kilometers(1), 0.001))
+        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_kilometers(500), 0.5))
+        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_kilometers(-1), -0.001))
+
+        exceptionThrown = False
+        try:
+            distance_util.meters_to_kilometers('a')
+        except TypeError:
+            exceptionThrown
+
+        self.assertTrue(exceptionThrown)
+
+    def test_meters_to_feet(self):
+        """Test conversion from meters to feet."""
+        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_feet(0), 0))
+        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_feet(1), 3.28084))
+        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_feet(500), 1640.42))
+        self.assertTrue(is_less_than_epsilon(distance_util.meters_to_feet(-1), -3.28084))
+
+        exceptionThrown = False
+        try:
+            distance_util.meters_to_feet('a')
+        except TypeError:
+            exceptionThrown
+
+        self.assertTrue(exceptionThrown)
+
+    def test_feet_to_meters(self):
+        """Test conversion from feet to meters."""
+        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_meters(0), 0))
+        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_meters(1), 0.3048))
+        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_meters(500), 152.4))
+        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_meters(-1), -0.3048))
+
+        exceptionThrown = False
+        try:
+            distance_util.feet_to_meters('a')
+        except TypeError:
+            exceptionThrown
+
+        self.assertTrue(exceptionThrown)
+
+    def test_feet_to_miles(self):
+        """Test conversion from feet to miles."""
+        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_miles(0), 0))
+        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_miles(1), 0.000189394))
+        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_miles(500), 0.094697))
+        self.assertTrue(is_less_than_epsilon(distance_util.feet_to_miles(-1), -0.000189394))
+
+        exceptionThrown = False
+        try:
+            distance_util.feet_to_miles('a')
+        except TypeError:
+            exceptionThrown
+
+        self.assertTrue(exceptionThrown)
+
+    def test_miles_to_feet(self):
+        """Test conversion from miles to feet."""
+        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_ft(0), 0))
+        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_ft(1), 5280))
+        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_ft(.5), 2740))
+        self.assertTrue(is_less_than_epsilon(distance_util.miles_to_ft(-1), -5280))
+
+        exceptionThrown = False
+        try:
+            distance_util.miles_to_ft('a')
+        except TypeError:
+            exceptionThrown
+
+        self.assertTrue(exceptionThrown)
+
+    def test_convert_same_unit(self):
+        """Test conversion from any unit to same unit."""
+        self.assertEqual(5, distance_util.convert(5, 'km', 'km'))
+        self.assertEqual(2, distance_util.convert(2, 'm', 'm'))
+        self.assertEqual(10, distance_util.convert(10, 'mi', 'mi'))
+        self.assertEqual(9, distance_util.convert(9, 'ft', 'ft'))
+
+    def test_convert_invalid_unit(self):
+        """Test exception is thrown for invalid units."""
+        exceptionThrown = False
+        try:
+            distance_util.convert(5, 'bob', 'km')
+        except ValueError:
+            exceptionThrown = True
+
+        self.assertTrue(exceptionThrown)
+
+        exceptionThrown = False
+        try:
+            distance_util.convert(5, 'km', 'jim')
+        except ValueError:
+            exceptionThrown = True
+
+        self.assertTrue(exceptionThrown)
+
+    def test_convert_from_miles(self):
+        """Test conversion from miles to other units."""
+        miles = 5
+        self.assertTrue(is_less_than_epsilon(distance_util.convert(miles, 'mi', 'km'), 8.04672))
+        self.assertTrue(is_less_than_epsilon(distance_util.convert(miles, 'mi', 'm'), 8046.72))
+        self.assertTrue(is_less_than_epsilon(distance_util.convert(miles, 'mi', 'ft'), 26400))
+
+    def test_convert_from_feet(self):
+        """Test conversion from feet to other units."""
+        feet = 5000
+        self.assertTrue(is_less_than_epsilon(distance_util.convert(feet, 'ft', 'km'), 1.524))
+        self.assertTrue(is_less_than_epsilon(distance_util.convert(feet, 'ft', 'm'), 1524))
+        self.assertTrue(is_less_than_epsilon(distance_util.convert(feet, 'ft', 'mi'), 0.9469697))
+
+    def test_convert_from_kilometers(self):
+        """Test conversion from kilometers to other units."""
+        km = 5
+        self.assertTrue(is_less_than_epsilon(distance_util.convert(km, 'km', 'ft'), 16404.2208))
+        self.assertTrue(is_less_than_epsilon(distance_util.convert(km, 'km', 'm'), 5000))
+        self.assertTrue(is_less_than_epsilon(distance_util.convert(km, 'km', 'mi'), 3.10686))
+
+    def test_convert_from_meters(self):
+        """Test conversion from meters to other units."""
+        m = 5000
+        self.assertTrue(is_less_than_epsilon(distance_util.convert(m, 'm', 'ft'), 0))
+        self.assertTrue(is_less_than_epsilon(distance_util.convert(m, 'm', 'km'), 5))
+        self.assertTrue(is_less_than_epsilon(distance_util.convert(m, 'm', 'mi'), 0))

--- a/tests/util/test_distance.py
+++ b/tests/util/test_distance.py
@@ -30,6 +30,11 @@ class TestDistanceUtil(unittest.TestCase):
         with self.assertRaises(ValueError):
             distance_util.convert(5, VALID_SYMBOL, INVALID_SYMBOL)
 
+    def test_convert_nonnumeric_value(self):
+        """Test exception is thrown for nonnumeric type."""
+        with self.assertRaises(TypeError):
+            distance_util.convert('a', KILOMETERS, METERS)
+
     def test_convert_from_miles(self):
         """Test conversion from miles to other units."""
         miles = 5

--- a/tests/util/test_distance.py
+++ b/tests/util/test_distance.py
@@ -22,7 +22,7 @@ class TestDistanceUtil(unittest.TestCase):
         try:
             distance_util.kilometers_to_miles('a')
         except TypeError:
-            exceptionThrown
+            exceptionThrown = True
 
         self.assertTrue(exceptionThrown)
 
@@ -37,7 +37,7 @@ class TestDistanceUtil(unittest.TestCase):
         try:
             distance_util.miles_to_kilometers('a')
         except TypeError:
-            exceptionThrown
+            exceptionThrown = True
 
         self.assertTrue(exceptionThrown)
 
@@ -52,7 +52,7 @@ class TestDistanceUtil(unittest.TestCase):
         try:
             distance_util.kilometers_to_meters('a')
         except TypeError:
-            exceptionThrown
+            exceptionThrown = True
 
         self.assertTrue(exceptionThrown)
 
@@ -67,7 +67,7 @@ class TestDistanceUtil(unittest.TestCase):
         try:
             distance_util.meters_to_kilometers('a')
         except TypeError:
-            exceptionThrown
+            exceptionThrown = True
 
         self.assertTrue(exceptionThrown)
 
@@ -82,7 +82,7 @@ class TestDistanceUtil(unittest.TestCase):
         try:
             distance_util.meters_to_feet('a')
         except TypeError:
-            exceptionThrown
+            exceptionThrown = True
 
         self.assertTrue(exceptionThrown)
 
@@ -97,7 +97,7 @@ class TestDistanceUtil(unittest.TestCase):
         try:
             distance_util.feet_to_meters('a')
         except TypeError:
-            exceptionThrown
+            exceptionThrown = True
 
         self.assertTrue(exceptionThrown)
 
@@ -112,7 +112,7 @@ class TestDistanceUtil(unittest.TestCase):
         try:
             distance_util.feet_to_miles('a')
         except TypeError:
-            exceptionThrown
+            exceptionThrown = True
 
         self.assertTrue(exceptionThrown)
 
@@ -127,7 +127,7 @@ class TestDistanceUtil(unittest.TestCase):
         try:
             distance_util.miles_to_ft('a')
         except TypeError:
-            exceptionThrown
+            exceptionThrown = True
 
         self.assertTrue(exceptionThrown)
 

--- a/tests/util/test_distance.py
+++ b/tests/util/test_distance.py
@@ -3,180 +3,61 @@
 import unittest
 import homeassistant.util.distance as distance_util
 
+KILOMETERS = distance_util.KILOMETERS_SYMBOL
+METERS = distance_util.METERS_SYMBOL
+FEET = distance_util.FEET_SYMBOL
+MILES = distance_util.MILES_SYMBOL
+
+INVALID_SYMBOL = 'bob'
+VALID_SYMBOL = KILOMETERS
+
 
 class TestDistanceUtil(unittest.TestCase):
     """Test the distance utility functions."""
 
-    def test_kilometers_to_miles(self):
-        """Test conversion from kilometers to miles."""
-        self.assertEqual(distance_util.kilometers_to_miles(0), 0)
-        self.assertEqual(distance_util.kilometers_to_miles(1), 0.621371)
-        self.assertEqual(distance_util.kilometers_to_miles(0.5), 0.3106855)
-        self.assertEqual(distance_util.kilometers_to_miles(-1), -0.621371)
-
-        exceptionThrown = False
-        try:
-            distance_util.kilometers_to_miles('a')
-        except TypeError:
-            exceptionThrown = True
-
-        self.assertTrue(exceptionThrown)
-
-    def test_miles_to_kilometer(self):
-        """Test conversion from miles to kilometers."""
-        self.assertEqual(distance_util.miles_to_kilometers(0), 0)
-        self.assertEqual(distance_util.miles_to_kilometers(1), 1.60934)
-        self.assertEqual(distance_util.miles_to_kilometers(0.5), 0.80467)
-        self.assertEqual(distance_util.miles_to_kilometers(-1), -1.60934)
-
-        exceptionThrown = False
-        try:
-            distance_util.miles_to_kilometers('a')
-        except TypeError:
-            exceptionThrown = True
-
-        self.assertTrue(exceptionThrown)
-
-    def test_kilometers_to_meters(self):
-        """Test conversion from kilometers to meters."""
-        self.assertEqual(distance_util.kilometers_to_meters(0), 0)
-        self.assertEqual(distance_util.kilometers_to_meters(1), 1000)
-        self.assertEqual(distance_util.kilometers_to_meters(0.5), 500)
-        self.assertEqual(distance_util.kilometers_to_meters(-1), -1000)
-
-        exceptionThrown = False
-        try:
-            distance_util.kilometers_to_meters('a')
-        except TypeError:
-            exceptionThrown = True
-
-        self.assertTrue(exceptionThrown)
-
-    def test_meters_to_kilometers(self):
-        """Test conversion from meters to kilometers."""
-        self.assertEqual(distance_util.meters_to_kilometers(0), 0)
-        self.assertEqual(distance_util.meters_to_kilometers(1), 0.001)
-        self.assertEqual(distance_util.meters_to_kilometers(500), 0.5)
-        self.assertEqual(distance_util.meters_to_kilometers(-1), -0.001)
-
-        exceptionThrown = False
-        try:
-            distance_util.meters_to_kilometers('a')
-        except TypeError:
-            exceptionThrown = True
-
-        self.assertTrue(exceptionThrown)
-
-    def test_meters_to_feet(self):
-        """Test conversion from meters to feet."""
-        self.assertEqual(distance_util.meters_to_feet(0), 0)
-        self.assertEqual(distance_util.meters_to_feet(1), 3.28084)
-        self.assertEqual(distance_util.meters_to_feet(500), 1640.42)
-        self.assertEqual(distance_util.meters_to_feet(-1), -3.28084)
-
-        exceptionThrown = False
-        try:
-            distance_util.meters_to_feet('a')
-        except TypeError:
-            exceptionThrown = True
-
-        self.assertTrue(exceptionThrown)
-
-    def test_feet_to_meters(self):
-        """Test conversion from feet to meters."""
-        self.assertEqual(distance_util.feet_to_meters(0), 0)
-        self.assertEqual(distance_util.feet_to_meters(1), 0.3048)
-        self.assertEqual(distance_util.feet_to_meters(500), 152.4)
-        self.assertEqual(distance_util.feet_to_meters(-1), -0.3048)
-
-        exceptionThrown = False
-        try:
-            distance_util.feet_to_meters('a')
-        except TypeError:
-            exceptionThrown = True
-
-        self.assertTrue(exceptionThrown)
-
-    def test_feet_to_miles(self):
-        """Test conversion from feet to miles."""
-        self.assertEqual(distance_util.feet_to_miles(0), 0)
-        self.assertEqual(distance_util.feet_to_miles(1), 0.000189394)
-        self.assertEqual(distance_util.feet_to_miles(500), 0.094697)
-        self.assertEqual(distance_util.feet_to_miles(-1), -0.000189394)
-
-        exceptionThrown = False
-        try:
-            distance_util.feet_to_miles('a')
-        except TypeError:
-            exceptionThrown = True
-
-        self.assertTrue(exceptionThrown)
-
-    def test_miles_to_feet(self):
-        """Test conversion from miles to feet."""
-        self.assertEqual(distance_util.miles_to_feet(0), 0)
-        self.assertEqual(distance_util.miles_to_feet(1), 5280)
-        self.assertEqual(distance_util.miles_to_feet(.5), 2640)
-        self.assertEqual(distance_util.miles_to_feet(-1), -5280)
-
-        exceptionThrown = False
-        try:
-            distance_util.miles_to_feet('a')
-        except TypeError:
-            exceptionThrown = True
-
-        self.assertTrue(exceptionThrown)
-
     def test_convert_same_unit(self):
         """Test conversion from any unit to same unit."""
-        self.assertEqual(5, distance_util.convert(5, 'km', 'km'))
-        self.assertEqual(2, distance_util.convert(2, 'm', 'm'))
-        self.assertEqual(10, distance_util.convert(10, 'mi', 'mi'))
-        self.assertEqual(9, distance_util.convert(9, 'ft', 'ft'))
+        self.assertEqual(5, distance_util.convert(5, KILOMETERS, KILOMETERS))
+        self.assertEqual(2, distance_util.convert(2, METERS, METERS))
+        self.assertEqual(10, distance_util.convert(10, MILES, MILES))
+        self.assertEqual(9, distance_util.convert(9, FEET, FEET))
 
     def test_convert_invalid_unit(self):
         """Test exception is thrown for invalid units."""
-        exceptionThrown = False
-        try:
-            distance_util.convert(5, 'bob', 'km')
-        except ValueError:
-            exceptionThrown = True
+        with self.assertRaises(ValueError):
+            distance_util.convert(5, INVALID_SYMBOL, VALID_SYMBOL)
 
-        self.assertTrue(exceptionThrown)
-
-        exceptionThrown = False
-        try:
-            distance_util.convert(5, 'km', 'jim')
-        except ValueError:
-            exceptionThrown = True
-
-        self.assertTrue(exceptionThrown)
+        with self.assertRaises(ValueError):
+            distance_util.convert(5, VALID_SYMBOL, INVALID_SYMBOL)
 
     def test_convert_from_miles(self):
         """Test conversion from miles to other units."""
         miles = 5
-        self.assertEqual(distance_util.convert(miles, 'mi', 'km'), 8.0467)
-        self.assertEqual(distance_util.convert(miles, 'mi', 'm'), 8046.7)
-        self.assertEqual(distance_util.convert(miles, 'mi', 'ft'), 26400)
+        self.assertEqual(distance_util.convert(miles, MILES, KILOMETERS),
+                         8.04672)
+        self.assertEqual(distance_util.convert(miles, MILES, METERS), 8046.72)
+        self.assertEqual(distance_util.convert(miles, MILES, FEET),
+                         26400.0008448)
 
     def test_convert_from_feet(self):
         """Test conversion from feet to other units."""
         feet = 5000
-        self.assertEqual(distance_util.convert(feet, 'ft', 'km'), 1.524)
-        self.assertEqual(distance_util.convert(feet, 'ft', 'm'), 1524)
-        self.assertEqual(distance_util.convert(feet, 'ft', 'mi'),
-                         0.9469700000000001)
+        self.assertEqual(distance_util.convert(feet, FEET, KILOMETERS), 1.524)
+        self.assertEqual(distance_util.convert(feet, FEET, METERS), 1524)
+        self.assertEqual(distance_util.convert(feet, FEET, MILES),
+                         0.9469694040000001)
 
     def test_convert_from_kilometers(self):
         """Test conversion from kilometers to other units."""
         km = 5
-        self.assertEqual(distance_util.convert(km, 'km', 'ft'), 16404.2)
-        self.assertEqual(distance_util.convert(km, 'km', 'm'), 5000)
-        self.assertEqual(distance_util.convert(km, 'km', 'mi'), 3.106855)
+        self.assertEqual(distance_util.convert(km, KILOMETERS, FEET), 16404.2)
+        self.assertEqual(distance_util.convert(km, KILOMETERS, METERS), 5000)
+        self.assertEqual(distance_util.convert(km, KILOMETERS, MILES),
+                         3.106855)
 
     def test_convert_from_meters(self):
         """Test conversion from meters to other units."""
         m = 5000
-        self.assertEqual(distance_util.convert(m, 'm', 'ft'), 16404.2)
-        self.assertEqual(distance_util.convert(m, 'm', 'km'), 5)
-        self.assertEqual(distance_util.convert(m, 'm', 'mi'), 3.106855)
+        self.assertEqual(distance_util.convert(m, METERS, FEET), 16404.2)
+        self.assertEqual(distance_util.convert(m, METERS, KILOMETERS), 5)
+        self.assertEqual(distance_util.convert(m, METERS, MILES), 3.106855)


### PR DESCRIPTION
**Description:**
Allow for a list of proximities in configuration along with configurable unit of measurement on the proximity components

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#
https://github.com/home-assistant/home-assistant.io/pull/698

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
proximity:
  - zone: home
    devices:
      - device_tracker.tsiphone
    tolerance: 50
    unit_of_measurement: km
  - zone: work
    devices:
      - device_tracker.elanorsiphone
    tolerance: 10
    unit_of_measurement: mi
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
