### PR TITLE
Install mysqlclient and psycopg2 in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN script/build_python_openzwave && \
 
 COPY requirements_all.txt requirements_all.txt
 # certifi breaks Debian based installs
-RUN pip3 install --no-cache-dir -r requirements_all.txt && pip3 uninstall -y certifi
+RUN pip3 install --no-cache-dir -r requirements_all.txt && pip3 uninstall -y certifi && \
+    pip3 install mysqlclient psycopg2
 
 # Copy source
 COPY . .


### PR DESCRIPTION
**Description:**
I don't know if this is the right place for this, but I'm tired of having to install mysqlclient or psycopg2 after every docker update if I want to use mysql of postgres.
