### PR TITLE
Flux colour temp support

### DIFF
--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -85,6 +85,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     sunset_colortemp = config.get(CONF_SUNSET_CT)
     stop_colortemp = config.get(CONF_STOP_CT)
     brightness = config.get(CONF_BRIGHTNESS)
+    mode = config.get(CONF_MODE)
     flux = FluxSwitch(name, hass, False, lights, start_time, stop_time,
                       start_colortemp, sunset_colortemp, stop_colortemp,
                       brightness, mode)

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -62,7 +62,7 @@ def set_lights_xy(hass, lights, x_val, y_val, brightness):
                     transition=30)
 
 
-def set_lights_temp(hass, lights, kelvin, mode):
+def set_lights_temp(hass, lights, kelvin, brightness, mode):
     """Set color of array of lights."""
     if mode == 'mired':
         temp=1000000/kelvin
@@ -72,6 +72,7 @@ def set_lights_temp(hass, lights, kelvin, mode):
         if is_on(hass, light):
             turn_on(hass, light,
                     color_temp = int(temp),
+                    brightness=brightness,
                     transition=30)
 
 
@@ -167,9 +168,9 @@ class FluxSwitch(SwitchDevice):
                 temp = self._start_colortemp - temp_offset
             else:
                 temp = self._start_colortemp + temp_offset
+            brightness = self._brightness if self._brightness else b_val
             if self._mode == 'xy':
-                x_val, y_val, b_val = color_RGB_to_xy(*temp_to_rgb(temp))
-                brightness = self._brightness if self._brightness else b_val
+                x_val, y_val, b_val = color_RGB_to_xy(*temp_to_rgb(temp))00
                 set_lights_xy(self.hass, self._lights, x_val,
                               y_val, brightness)
                 _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, "
@@ -177,7 +178,7 @@ class FluxSwitch(SwitchDevice):
                              brightness, round(percentage_of_day_complete*100),
                              as_local(now))
             else:
-                set_lights_temp(self.hass, self._lights, temp, self._mode)
+                set_lights_temp(self.hass, self._lights, temp, brightness, self._mode)
                 _LOGGER.info("Lights updated to temp:%s, %s%%"
                              " of day cycle complete at %s", temp,
                              round(percentage_of_day_complete*100),
@@ -198,9 +199,9 @@ class FluxSwitch(SwitchDevice):
                 temp = self._sunset_colortemp - temp_offset
             else:
                 temp = self._sunset_colortemp + temp_offset
+            brightness = self._brightness if self._brightness else b_val
             if self._mode == 'xy':
                 x_val, y_val, b_val = color_RGB_to_xy(*temp_to_rgb(temp))
-                brightness = self._brightness if self._brightness else b_val
                 set_lights_xy(self.hass, self._lights, x_val,
                               y_val, brightness)
                 _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, %s%%"
@@ -208,7 +209,7 @@ class FluxSwitch(SwitchDevice):
                              brightness, round(percentage_of_night_complete*100),
                              as_local(now))
             else:
-                set_lights_temp(self.hass, self._lights, temp, self._mode)
+                set_lights_temp(self.hass, self._lights, temp, brightness, self._mode)
                 _LOGGER.info("Lights updated to temp:%s, %s%%"
                              " of night cycle complete at %s", temp,
                              round(percentage_of_night_complete*100),

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -176,7 +176,7 @@ class FluxSwitch(SwitchDevice):
                              brightness, round(percentage_of_day_complete*100),
                              as_local(now))
             else:
-                set_lights_mired(self.hass, self._lights, temp, self._mode)
+                set_lights_temp(self.hass, self._lights, temp, self._mode)
                 _LOGGER.info("Lights updated to temp:%s, %s%%"
                             " of day cycle complete at %s", temp,
                             round(percentage_of_day_complete*100),
@@ -207,7 +207,7 @@ class FluxSwitch(SwitchDevice):
                              brightness, round(percentage_of_night_complete*100),
                              as_local(now))
             else:
-                set_lights_mired(self.hass, self._lights, temp, self._mode)
+                set_lights_temp(self.hass, self._lights, temp, self._mode)
                 _LOGGER.info("Lights updated to temp:%s, %s%%"
                             " of night cycle complete at %s", temp,
                             round(percentage_of_night_complete*100),

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -211,7 +211,7 @@ class FluxSwitch(SwitchDevice):
                 _LOGGER.info("Lights updated to temp:%s, %s%%"
                             " of night cycle complete at %s", temp,
                             round(percentage_of_night_complete*100),
-as_local(now))
+                            as_local(now))
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""
         if self._start_time:

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -62,7 +62,7 @@ def set_lights_xy(hass, lights, x_val, y_val, brightness):
                     transition=30)
 
 
-def set_lights_temp(hass, lights, kelvin, brightness, mode):
+def set_lights_temp(hass, lights, kelvin, mode):
     """Set color of array of lights."""
     if mode == 'mired':
         temp=1000000/kelvin
@@ -72,7 +72,6 @@ def set_lights_temp(hass, lights, kelvin, brightness, mode):
         if is_on(hass, light):
             turn_on(hass, light,
                     color_temp = int(temp),
-                    brightness=brightness,
                     transition=30)
 
 
@@ -168,9 +167,9 @@ class FluxSwitch(SwitchDevice):
                 temp = self._start_colortemp - temp_offset
             else:
                 temp = self._start_colortemp + temp_offset
-            brightness = self._brightness if self._brightness else b_val
             if self._mode == 'xy':
                 x_val, y_val, b_val = color_RGB_to_xy(*temp_to_rgb(temp))
+                brightness = self._brightness if self._brightness else b_val
                 set_lights_xy(self.hass, self._lights, x_val,
                               y_val, brightness)
                 _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, "
@@ -178,9 +177,9 @@ class FluxSwitch(SwitchDevice):
                              brightness, round(percentage_of_day_complete*100),
                              as_local(now))
             else:
-                set_lights_temp(self.hass, self._lights, temp, brightness, self._mode)
-                _LOGGER.info("Lights updated to temp:%s brightness:%s, %s%%"
-                             " of day cycle complete at %s", temp, brightness,
+                set_lights_temp(self.hass, self._lights, temp, self._mode)
+                _LOGGER.info("Lights updated to temp:%s, %s%%"
+                             " of day cycle complete at %s", temp,
                              round(percentage_of_day_complete*100),
                              as_local(now))
         else:
@@ -199,9 +198,9 @@ class FluxSwitch(SwitchDevice):
                 temp = self._sunset_colortemp - temp_offset
             else:
                 temp = self._sunset_colortemp + temp_offset
-            brightness = self._brightness if self._brightness else b_val
             if self._mode == 'xy':
                 x_val, y_val, b_val = color_RGB_to_xy(*temp_to_rgb(temp))
+                brightness = self._brightness if self._brightness else b_val
                 set_lights_xy(self.hass, self._lights, x_val,
                               y_val, brightness)
                 _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, %s%%"
@@ -209,9 +208,9 @@ class FluxSwitch(SwitchDevice):
                              brightness, round(percentage_of_night_complete*100),
                              as_local(now))
             else:
-                set_lights_temp(self.hass, self._lights, temp, brightness, self._mode)
-                _LOGGER.info("Lights updated to temp:%s brightness:%s, %s%%"
-                             " of night cycle complete at %s", temp, brightness,
+                set_lights_temp(self.hass, self._lights, temp, self._mode)
+                _LOGGER.info("Lights updated to temp:%s, %s%%"
+                             " of night cycle complete at %s", temp,
                              round(percentage_of_night_complete*100),
                              as_local(now))
     def find_start_time(self, now):

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -61,12 +61,13 @@ def set_lights_xy(hass, lights, x_val, y_val, brightness):
                     brightness=brightness,
                     transition=30)
 
+
 def set_lights_temp(hass, lights, kelvin, mode):
     """Set color of array of lights."""
     if mode == 'mired':
-        temp = 1000000/kelvin
+        temp=1000000/kelvin
     else:
-        temp = kelvin
+        temp=kelvin
     for light in lights:
         if is_on(hass, light):
             turn_on(hass, light,
@@ -117,7 +118,7 @@ class FluxSwitch(SwitchDevice):
         self._sunset_colortemp = sunset_colortemp
         self._stop_colortemp = stop_colortemp
         self._brightness = brightness
-        self._mode = mode        
+        self._mode = mode
         self.tracker = None
 
     @property
@@ -166,21 +167,21 @@ class FluxSwitch(SwitchDevice):
                 temp = self._start_colortemp - temp_offset
             else:
                 temp = self._start_colortemp + temp_offset
-            if self._mode == 'xy':    
+            if self._mode == 'xy':
                 x_val, y_val, b_val = color_RGB_to_xy(*temp_to_rgb(temp))
                 brightness = self._brightness if self._brightness else b_val
                 set_lights_xy(self.hass, self._lights, x_val,
                               y_val, brightness)
-                _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, %s%%"
-                             " of day cycle complete at %s", x_val, y_val,
+                _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, "
+                             "%s%% of day cycle complete at %s", x_val, y_val,
                              brightness, round(percentage_of_day_complete*100),
                              as_local(now))
             else:
                 set_lights_temp(self.hass, self._lights, temp, self._mode)
                 _LOGGER.info("Lights updated to temp:%s, %s%%"
-                            " of day cycle complete at %s", temp,
-                            round(percentage_of_day_complete*100),
-                            as_local(now))
+                             " of day cycle complete at %s", temp,
+                             round(percentage_of_day_complete*100),
+                             as_local(now))
         else:
             # Nightime
             if now < stop_time and now > start_time:
@@ -209,9 +210,9 @@ class FluxSwitch(SwitchDevice):
             else:
                 set_lights_temp(self.hass, self._lights, temp, self._mode)
                 _LOGGER.info("Lights updated to temp:%s, %s%%"
-                            " of night cycle complete at %s", temp,
-                            round(percentage_of_night_complete*100),
-                            as_local(now))
+                             " of night cycle complete at %s", temp,
+                             round(percentage_of_night_complete*100),
+                             as_local(now))
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""
         if self._start_time:

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -196,7 +196,7 @@ class FluxSwitch(SwitchDevice):
                 temp = self._sunset_colortemp - temp_offset
             else:
                 temp = self._sunset_colortemp + temp_offset
-            
+            if self._mode == 'xy':
                 x_val, y_val, b_val = color_RGB_to_xy(*temp_to_rgb(temp))
                 brightness = self._brightness if self._brightness else b_val
                 set_lights_xy(self.hass, self._lights, x_val,

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -170,7 +170,7 @@ class FluxSwitch(SwitchDevice):
                 temp = self._start_colortemp + temp_offset
             brightness = self._brightness if self._brightness else b_val
             if self._mode == 'xy':
-                x_val, y_val, b_val = color_RGB_to_xy(*temp_to_rgb(temp))00
+                x_val, y_val, b_val = color_RGB_to_xy(*temp_to_rgb(temp))
                 set_lights_xy(self.hass, self._lights, x_val,
                               y_val, brightness)
                 _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, "

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -179,8 +179,8 @@ class FluxSwitch(SwitchDevice):
                              as_local(now))
             else:
                 set_lights_temp(self.hass, self._lights, temp, brightness, self._mode)
-                _LOGGER.info("Lights updated to temp:%s, %s%%"
-                             " of day cycle complete at %s", temp,
+                _LOGGER.info("Lights updated to temp:%s brightness:%s, %s%%"
+                             " of day cycle complete at %s", temp, brightness,
                              round(percentage_of_day_complete*100),
                              as_local(now))
         else:
@@ -210,8 +210,8 @@ class FluxSwitch(SwitchDevice):
                              as_local(now))
             else:
                 set_lights_temp(self.hass, self._lights, temp, brightness, self._mode)
-                _LOGGER.info("Lights updated to temp:%s, %s%%"
-                             " of night cycle complete at %s", temp,
+                _LOGGER.info("Lights updated to temp:%s brightness:%s, %s%%"
+                             " of night cycle complete at %s", temp, brightness,
                              round(percentage_of_night_complete*100),
                              as_local(now))
     def find_start_time(self, now):

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -176,7 +176,7 @@ class FluxSwitch(SwitchDevice):
                              brightness, round(percentage_of_day_complete*100),
                              as_local(now))
             else:
-                set_lights_mired(self.hass, self._lights, temp, mode)
+                set_lights_mired(self.hass, self._lights, temp, self._mode)
                 _LOGGER.info("Lights updated to temp:%s, %s%%"
                             " of day cycle complete at %s", temp,
                             round(percentage_of_day_complete*100),
@@ -207,7 +207,7 @@ class FluxSwitch(SwitchDevice):
                              brightness, round(percentage_of_night_complete*100),
                              as_local(now))
             else:
-                set_lights_mired(self.hass, self._lights, temp, mode)
+                set_lights_mired(self.hass, self._lights, temp, self._mode)
                 _LOGGER.info("Lights updated to temp:%s, %s%%"
                             " of night cycle complete at %s", temp,
                             round(percentage_of_night_complete*100),

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -32,6 +32,7 @@ CONF_START_CT = 'start_colortemp'
 CONF_SUNSET_CT = 'sunset_colortemp'
 CONF_STOP_CT = 'stop_colortemp'
 CONF_BRIGHTNESS = 'brightness'
+CONF_MODE = 'mode'
 
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'flux',
@@ -46,7 +47,8 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Optional(CONF_STOP_CT, default=1900):
         vol.All(vol.Coerce(int), vol.Range(min=1000, max=40000)),
     vol.Optional(CONF_BRIGHTNESS):
-        vol.All(vol.Coerce(int), vol.Range(min=0, max=255))
+        vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
+    vol.Optional(CONF_MODE, default="XY"): cv.string
 })
 
 
@@ -57,6 +59,18 @@ def set_lights_xy(hass, lights, x_val, y_val, brightness):
             turn_on(hass, light,
                     xy_color=[x_val, y_val],
                     brightness=brightness,
+                    transition=30)
+
+def set_lights_temp(hass, lights, kelvin, mode):
+    """Set color of array of lights."""
+    if mode == 'mired':
+        temp = 1000000/kelvin
+    else:
+        temp = kelvin
+    for light in lights:
+        if is_on(hass, light):
+            turn_on(hass, light,
+                    color_temp = int(temp),
                     transition=30)
 
 
@@ -73,7 +87,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     brightness = config.get(CONF_BRIGHTNESS)
     flux = FluxSwitch(name, hass, False, lights, start_time, stop_time,
                       start_colortemp, sunset_colortemp, stop_colortemp,
-                      brightness)
+                      brightness, mode)
     add_devices([flux])
 
     def update(call=None):
@@ -90,7 +104,7 @@ class FluxSwitch(SwitchDevice):
     # pylint: disable=too-many-arguments
     def __init__(self, name, hass, state, lights, start_time, stop_time,
                  start_colortemp, sunset_colortemp, stop_colortemp,
-                 brightness):
+                 brightness, mode):
         """Initialize the Flux switch."""
         self._name = name
         self.hass = hass
@@ -102,6 +116,7 @@ class FluxSwitch(SwitchDevice):
         self._sunset_colortemp = sunset_colortemp
         self._stop_colortemp = stop_colortemp
         self._brightness = brightness
+        self._mode = mode        
         self.tracker = None
 
     @property
@@ -150,14 +165,21 @@ class FluxSwitch(SwitchDevice):
                 temp = self._start_colortemp - temp_offset
             else:
                 temp = self._start_colortemp + temp_offset
-            x_val, y_val, b_val = color_RGB_to_xy(*temp_to_rgb(temp))
-            brightness = self._brightness if self._brightness else b_val
-            set_lights_xy(self.hass, self._lights, x_val,
-                          y_val, brightness)
-            _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, %s%%"
-                         " of day cycle complete at %s", x_val, y_val,
-                         brightness, round(percentage_of_day_complete*100),
-                         as_local(now))
+            if self._mode == 'xy':    
+                x_val, y_val, b_val = color_RGB_to_xy(*temp_to_rgb(temp))
+                brightness = self._brightness if self._brightness else b_val
+                set_lights_xy(self.hass, self._lights, x_val,
+                              y_val, brightness)
+                _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, %s%%"
+                             " of day cycle complete at %s", x_val, y_val,
+                             brightness, round(percentage_of_day_complete*100),
+                             as_local(now))
+            else:
+                set_lights_mired(self.hass, self._lights, temp, mode)
+                _LOGGER.info("Lights updated to temp:%s, %s%%"
+                            " of day cycle complete at %s", temp,
+                            round(percentage_of_day_complete*100),
+                            as_local(now))
         else:
             # Nightime
             if now < stop_time and now > start_time:
@@ -174,15 +196,21 @@ class FluxSwitch(SwitchDevice):
                 temp = self._sunset_colortemp - temp_offset
             else:
                 temp = self._sunset_colortemp + temp_offset
-            x_val, y_val, b_val = color_RGB_to_xy(*temp_to_rgb(temp))
-            brightness = self._brightness if self._brightness else b_val
-            set_lights_xy(self.hass, self._lights, x_val,
-                          y_val, brightness)
-            _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, %s%%"
-                         " of night cycle complete at %s", x_val, y_val,
-                         brightness, round(percentage_of_night_complete*100),
-                         as_local(now))
-
+            
+                x_val, y_val, b_val = color_RGB_to_xy(*temp_to_rgb(temp))
+                brightness = self._brightness if self._brightness else b_val
+                set_lights_xy(self.hass, self._lights, x_val,
+                              y_val, brightness)
+                _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, %s%%"
+                             " of night cycle complete at %s", x_val, y_val,
+                             brightness, round(percentage_of_night_complete*100),
+                             as_local(now))
+            else:
+                set_lights_mired(self.hass, self._lights, temp, mode)
+                _LOGGER.info("Lights updated to temp:%s, %s%%"
+                            " of night cycle complete at %s", temp,
+                            round(percentage_of_night_complete*100),
+as_local(now))
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""
         if self._start_time:


### PR DESCRIPTION
**Description:**
add mode to add support for hue ambiance bulbs.
tested and working with hue ambiance and hue strip +.

default mode 'XY' acts as before
Mode mired or kelvin will send the color temp in mired or kelvin

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

- platform: flux
  lights:
    - light.hue_ambiance_lamp_1
    - light.hue_ambiance_lamp_2
    - light.hue_lightstrip_plus_1
  name: Fluxtest
  stop_time: '23:00'
  start_colortemp: 5500
  sunset_colortemp: 2700
  stop_colortemp: 2000
  mode: mired



```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
