### PR TITLE
Added mired and kelvin mode to flux

### DIFF
--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -163,7 +163,7 @@ class FluxSwitch(SwitchDevice):
 
         if start_time < now < sunset:
             # Daytime
-            time = 'day'
+            time_state = 'day'
             temp_range = abs(self._start_colortemp - self._sunset_colortemp)
             day_length = int(sunset.timestamp() - start_time.timestamp())
             seconds_from_start = int(now.timestamp() - start_time.timestamp())
@@ -175,7 +175,7 @@ class FluxSwitch(SwitchDevice):
                 temp = self._start_colortemp + temp_offset
         else:
             # Nightime
-            time = 'night'
+            time_state = 'night'
             if now < stop_time and now > start_time:
                 now_time = now
             else:
@@ -198,14 +198,14 @@ class FluxSwitch(SwitchDevice):
             _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, %s%%"
                          " of %s cycle complete at %s", x_val, y_val,
                          brightness, round(
-                             percentage_complete * 100), time,
+                             percentage_complete * 100), time_state,
                          as_local(now))
         else:
             set_lights_temp(self.hass, self._lights, temp, self._mode)
             _LOGGER.info("Lights updated to temp:%s, %s%%"
                          " of %s cycle complete at %s", temp,
                          round(percentage_complete * 100),
-                         time, as_local(now))
+                         time_state, as_local(now))
 
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -480,3 +480,88 @@ class TestSwitchFlux(unittest.TestCase):
         call = turn_on_calls[-3]
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 171)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.452, 0.386])
+
+    def test_flux_with_mired(self):
+        """Test the flux switch´s mode mired"""
+        platform = loader.get_component('light.test')
+        platform.init()
+        self.assertTrue(
+            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+
+        dev1 = platform.DEVICES[0]
+
+        # Verify initial state of light
+        state = self.hass.states.get(dev1.entity_id)
+        self.assertEqual(STATE_ON, state.state)
+        self.assertIsNone(state.attributes.get('color_temp'))
+
+        test_time = dt_util.now().replace(hour=8, minute=30, second=0)
+        sunset_time = test_time.replace(hour=17, minute=0, second=0)
+        sunrise_time = test_time.replace(hour=5,
+                                         minute=0,
+                                         second=0) + timedelta(days=1)
+
+        with patch('homeassistant.util.dt.now', return_value=test_time):
+            with patch('homeassistant.components.sun.next_rising',
+                       return_value=sunrise_time):
+                with patch('homeassistant.components.sun.next_setting',
+                           return_value=sunset_time):
+                    assert setup_component(self.hass, switch.DOMAIN, {
+                        switch.DOMAIN: {
+                            'platform': 'flux',
+                            'name': 'flux',
+                            'lights': [dev1.entity_id],
+                            'mode': 'mired'
+                        }
+                    })
+                    turn_on_calls = mock_service(
+                        self.hass, light.DOMAIN, SERVICE_TURN_ON)
+                    switch.turn_on(self.hass, 'switch.flux')
+                    self.hass.pool.block_till_done()
+                    fire_time_changed(self.hass, test_time)
+                    self.hass.pool.block_till_done()
+        call = turn_on_calls[-1]
+        self.assertEqual(call.data[light.ATTR_COLOR_TEMP], 269)
+
+    def test_flux_with_kelvin(self):
+        """Test the flux switch´s mode kelvin"""
+        platform = loader.get_component('light.test')
+        platform.init()
+        self.assertTrue(
+            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+
+        dev1 = platform.DEVICES[0]
+
+        # Verify initial state of light
+        state = self.hass.states.get(dev1.entity_id)
+        self.assertEqual(STATE_ON, state.state)
+        self.assertIsNone(state.attributes.get('color_temp'))
+
+        test_time = dt_util.now().replace(hour=8, minute=30, second=0)
+        sunset_time = test_time.replace(hour=17, minute=0, second=0)
+        sunrise_time = test_time.replace(hour=5,
+                                         minute=0,
+                                         second=0) + timedelta(days=1)
+
+        with patch('homeassistant.util.dt.now', return_value=test_time):
+            with patch('homeassistant.components.sun.next_rising',
+                       return_value=sunrise_time):
+                with patch('homeassistant.components.sun.next_setting',
+                           return_value=sunset_time):
+                    assert setup_component(self.hass, switch.DOMAIN, {
+                        switch.DOMAIN: {
+                            'platform': 'flux',
+                            'name': 'flux',
+                            'lights': [dev1.entity_id],
+                            'mode': 'kelvin'
+                        }
+                    })
+                    turn_on_calls = mock_service(
+                        self.hass, light.DOMAIN, SERVICE_TURN_ON)
+                    switch.turn_on(self.hass, 'switch.flux')
+                    self.hass.pool.block_till_done()
+                    fire_time_changed(self.hass, test_time)
+                    self.hass.pool.block_till_done()
+        call = turn_on_calls[-1]
+        self.assertEqual(call.data[light.ATTR_COLOR_TEMP], 3708)
+

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -564,4 +564,3 @@ class TestSwitchFlux(unittest.TestCase):
                     self.hass.pool.block_till_done()
         call = turn_on_calls[-1]
         self.assertEqual(call.data[light.ATTR_COLOR_TEMP], 3708)
-


### PR DESCRIPTION
**Description:**
added mode to add support for hue ambiance bulbs.
tested and working with hue ambiance and hue strip +.

default mode 'xy' acts as before
Mode mired or kelvin will send the color temp in mired or kelvin

all color temps provided in the config must be in kelvin

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

- platform: flux
  lights:
    - light.hue_ambiance_lamp_1
    - light.hue_ambiance_lamp_2
    - light.hue_lightstrip_plus_1
  name: Fluxtest
  stop_time: '23:00'
  start_colortemp: 5500
  sunset_colortemp: 2700
  stop_colortemp: 2000
  mode: mired


```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
