### PR TITLE
Add timeout (fixes #2661)

### DIFF
--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -95,7 +95,10 @@ class CommandSensorData(object):
         _LOGGER.info('Running command: %s', self.command)
 
         try:
-            return_value = subprocess.check_output(self.command, shell=True)
+            return_value = subprocess.check_output(self.command, shell=True,
+                                                   timeout=15)
             self.value = return_value.strip().decode('utf-8')
         except subprocess.CalledProcessError:
             _LOGGER.error('Command failed: %s', self.command)
+        except subprocess.TimeoutExpired:
+            _LOGGER.error('Timeout for command: %s', self.command)


### PR DESCRIPTION
**Description:**
This PR adds a timeout. If the command (like executing `ping 192.168.0.17` in bash on a Linux system) doesn't return in the given time (15 s) the exception is catched and a log entry created.

**Related issue (if applicable):** fixes #2661

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: command_line
    command: ping 192.168.0.17
    name: Ping host
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
