### PR TITLE
Bring back delayed Zwave light refresh

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -8,6 +8,7 @@ import logging
 
 # Because we do not compile openzwave on CI
 # pylint: disable=import-error
+from threading import Timer
 from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, \
     ATTR_RGB_COLOR, DOMAIN, Light
 from homeassistant.components import zwave
@@ -108,7 +109,22 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
         """Called when a value has changed on the network."""
         if self._value.value_id == value.value_id or \
            self._value.node == value.node:
-            self.update_properties()
+
+            if self._refreshing:
+                self._refreshing = False
+                self.update_properties()
+            else:
+                def _refresh_value():
+                    """Used timer callback for delayed value refresh."""
+                    self._refreshing = True
+                    self._value.refresh()
+
+                if self._timer is not None and self._timer.isAlive():
+                    self._timer.cancel()
+
+                self._timer = Timer(2, _refresh_value)
+                self._timer.start()
+
             self.update_ha_state()
 
     @property


### PR DESCRIPTION
**Description:**

Brings back the delayed refresh behavior in the Zwave light component that was removed in https://github.com/home-assistant/home-assistant/pull/2595. When this behavior was added in https://github.com/home-assistant/home-assistant/pull/592 by @leoc, the motivation was described as:

> I have been playing with zwave wall plug dimmers. I am using AD142 Plug-In Dimmer Module.
> When handling value change events I noticed some weird behaviour. The value.data property did only return the old value. That's why I had to trick myself around this issue, sleep'ing for two seconds, then refresh the value. Maybe there are better solutions.

I can confirm that without this behavior, my Zwave lights (`Leviton VRMX1-1LZ`) get out of sync with HA after turning them off and on. This PR brings things back into sync.

The combination of this PR and #2595 seems to fix this behavior mentioned by @leoc:

> Still there is a problem with changing the state quickly in the HA GUI. The dimmer change is not done directly but swallowed, causing the state switch GUI element to pop back to the off state, when the Timer runs off.

I've been turning lights off and on on this branch for the past few minutes and haven't seen that since. ✨ 

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully.

/cc @turbokongen
