### PR TITLE
Assume that Zwave light state changes are successful to avoid UI flickering

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -132,11 +132,13 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
 
         if self._value.node.set_dimmer(self._value.value_id, brightness):
             self._state = STATE_ON
+            self.update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
         if self._value.node.set_dimmer(self._value.value_id, 0):
             self._state = STATE_OFF
+            self.update_ha_state()
 
 
 def ct_to_rgb(temp):


### PR DESCRIPTION
**Description:**

Previously, turning on a Zwave light via the UI resulted in the switch going from Off to On as normal, briefly back to Off, then to On as soon as the Zwave network reported the state change. 

This PR updates the internal state immediately after the state change is made to prevent this confusing flickering. Zwave state changes are not synchronous, so they cannot return the new state of the device as described in https://home-assistant.io/blog/2016/02/12/classifying-the-internet-of-things/. I'm not sure of a way to avoid this UI flickering without optimistically updating state.

This change has been running with 20+ `Leviton VRMX1-1LZ` lights for a few months, and has been working well in practice.

I see the `assumed_state` method in a handful of components, which seems related. I'm not yet sure if this change requires that we return `True` for this component. Thoughts?

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

/cc @turbokongen @leoc @technicalpickles #2674
