### PR TITLE
Recorder: Close session after execute.

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -58,14 +58,17 @@ def execute(q):
     This method also retries a few times in the case of stale connections.
     """
     import sqlalchemy.exc
-    for _ in range(0, RETRIES):
-        try:
-            return [
-                row for row in
-                (row.to_native() for row in q)
-                if row is not None]
-        except sqlalchemy.exc.SQLAlchemyError as e:
-            log_error(e, retry_wait=QUERY_RETRY_WAIT, rollback=True)
+    try:
+        for _ in range(0, RETRIES):
+            try:
+                return [
+                    row for row in
+                    (row.to_native() for row in q)
+                    if row is not None]
+            except sqlalchemy.exc.SQLAlchemyError as e:
+                log_error(e, retry_wait=QUERY_RETRY_WAIT, rollback=True)
+    finally:
+        Session().close()
     return []
 
 


### PR DESCRIPTION
**Description:**
Closes the thread's session after a `recoder.execute()`

**Related issue (if applicable):** fixes #2663 
