### PR TITLE
Kill celcius with fire, replacing it with celsius

### DIFF
--- a/homeassistant/components/hvac/__init__.py
+++ b/homeassistant/components/hvac/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.temperature import convert
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_TEMPERATURE, STATE_ON, STATE_OFF, STATE_UNKNOWN,
-    TEMP_CELCIUS)
+    TEMP_CELSIUS)
 
 DOMAIN = "hvac"
 
@@ -462,12 +462,12 @@ class HvacDevice(Entity):
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        return convert(19, TEMP_CELCIUS, self.unit_of_measurement)
+        return convert(19, TEMP_CELSIUS, self.unit_of_measurement)
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        return convert(30, TEMP_CELCIUS, self.unit_of_measurement)
+        return convert(30, TEMP_CELSIUS, self.unit_of_measurement)
 
     @property
     def min_humidity(self):
@@ -487,7 +487,7 @@ class HvacDevice(Entity):
         value = convert(temp, self.unit_of_measurement,
                         self.hass.config.temperature_unit)
 
-        if self.hass.config.temperature_unit is TEMP_CELCIUS:
+        if self.hass.config.temperature_unit is TEMP_CELSIUS:
             decimal_count = 1
         else:
             # Users of fahrenheit generally expect integer units.

--- a/homeassistant/components/sensor/mold_indicator.py
+++ b/homeassistant/components/sensor/mold_indicator.py
@@ -109,7 +109,7 @@ class MoldIndicator(Entity):
 
         # convert to celsius if necessary
         if unit == TEMP_FAHRENHEIT:
-            return util.temperature.fahrenheit_to_celcius(temp)
+            return util.temperature.fahrenheit_to_celsius(temp)
         elif unit == TEMP_CELSIUS:
             return temp
         else:
@@ -260,9 +260,9 @@ class MoldIndicator(Entity):
         else:
             return {
                 ATTR_DEWPOINT:
-                    util.temperature.celcius_to_fahrenheit(
+                    util.temperature.celsius_to_fahrenheit(
                         self._dewpoint),
                 ATTR_CRITICAL_TEMP:
-                    util.temperature.celcius_to_fahrenheit(
+                    util.temperature.celsius_to_fahrenheit(
                         self._crit_temp),
             }

--- a/homeassistant/components/thermostat/eq3btsmart.py
+++ b/homeassistant/components/thermostat/eq3btsmart.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/thermostat.eq3btsmart/
 import logging
 
 from homeassistant.components.thermostat import ThermostatDevice
-from homeassistant.const import TEMP_CELCIUS
+from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.temperature import convert
 
 REQUIREMENTS = ['bluepy_devices==0.2.0']
@@ -51,7 +51,7 @@ class EQ3BTSmartThermostat(ThermostatDevice):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement that is used."""
-        return TEMP_CELCIUS
+        return TEMP_CELSIUS
 
     @property
     def current_temperature(self):
@@ -76,13 +76,13 @@ class EQ3BTSmartThermostat(ThermostatDevice):
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        return convert(self._thermostat.min_temp, TEMP_CELCIUS,
+        return convert(self._thermostat.min_temp, TEMP_CELSIUS,
                        self.unit_of_measurement)
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        return convert(self._thermostat.max_temp, TEMP_CELCIUS,
+        return convert(self._thermostat.max_temp, TEMP_CELSIUS,
                        self.unit_of_measurement)
 
     def update(self):

--- a/homeassistant/components/thermostat/knx.py
+++ b/homeassistant/components/thermostat/knx.py
@@ -43,7 +43,7 @@ class KNXThermostat(KNXMultiAddressDevice, ThermostatDevice):
                                        ["temperature", "setpoint"],
                                        ["mode"])
 
-        self._unit_of_measurement = TEMP_CELSIUS  # KNX always used celcius
+        self._unit_of_measurement = TEMP_CELSIUS  # KNX always used celsius
         self._away = False  # not yet supported
         self._is_fan_on = False  # not yet supported
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -114,7 +114,6 @@ ATTR_UNIT_OF_MEASUREMENT = "unit_of_measurement"
 
 # Temperature attribute
 ATTR_TEMPERATURE = "temperature"
-TEMP_CELCIUS = "°C"
 TEMP_CELSIUS = "°C"
 TEMP_FAHRENHEIT = "°F"
 

--- a/homeassistant/util/temperature.py
+++ b/homeassistant/util/temperature.py
@@ -1,27 +1,9 @@
 """Temperature util functions."""
 
-import logging
-
-
-def fahrenheit_to_celcius(fahrenheit: float) -> float:
-    """**DEPRECATED** Convert a Fahrenheit temperature to Celsius."""
-    logging.getLogger(__name__).warning(
-        'fahrenheit_to_celcius is now fahrenheit_to_celsius '
-        'correcting a spelling mistake')
-    return fahrenheit_to_celsius(fahrenheit)
-
 
 def fahrenheit_to_celsius(fahrenheit: float) -> float:
     """Convert a Fahrenheit temperature to Celsius."""
     return (fahrenheit - 32.0) / 1.8
-
-
-def celcius_to_fahrenheit(celcius: float) -> float:
-    """**DEPRECATED** Convert a Celsius temperature to Fahrenheit."""
-    logging.getLogger(__name__).warning(
-        'celcius_to_fahrenheit is now celsius_to_fahrenheit correcting '
-        'a spelling mistake')
-    return celsius_to_fahrenheit(celcius)
 
 
 def celsius_to_fahrenheit(celsius: float) -> float:


### PR DESCRIPTION
**Description:** Finally replaces all occurrences of "celcius" with "celsius".

**Related issue (if applicable):** fixes #1860

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
