### PR TITLE
Upgrade python-nmap to 0.6.1

### DIFF
--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -21,10 +21,10 @@ MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 _LOGGER = logging.getLogger(__name__)
 
-# interval in minutes to exclude devices from a scan while they are home
+# Interval in minutes to exclude devices from a scan while they are home
 CONF_HOME_INTERVAL = "home_interval"
 
-REQUIREMENTS = ['python-nmap==0.6.0']
+REQUIREMENTS = ['python-nmap==0.6.1']
 
 
 def get_scanner(hass, config):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -332,7 +332,7 @@ python-mystrom==0.3.6
 python-nest==2.9.2
 
 # homeassistant.components.device_tracker.nmap_tracker
-python-nmap==0.6.0
+python-nmap==0.6.1
 
 # homeassistant.components.notify.pushover
 python-pushover==0.2


### PR DESCRIPTION
## v0.6.1
- Fix UnboundLocalError in scan_progressive
- Fix Scanning fails on nmap warnings
- Fix for empty <hostnames> values which results in blank CSV output
- Fix print(nm.csv()) does not return any results
- Fix nmap program was not found in path
- Fix hostname is no longer reported

Tested with the following configuration:

``` yaml
device_tracker:
  - platform: nmap_tracker
    hosts: 10.100.0.1/24
    home_interval: 10
```

Console output:

``` bash
16-07-31 22:06:36 INFO (ThreadPool Worker 4) [homeassistant.components.device_tracker.nmap_tracker] Scanning
16-07-31 22:06:41 INFO (ThreadPool Worker 4) [homeassistant.components.device_tracker.nmap_tracker] nmap scan successful
```
