### PR TITLE
Upgrade cherrypy to 7.1.0

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -25,7 +25,7 @@ import homeassistant.util.dt as dt_util
 import homeassistant.helpers.config_validation as cv
 
 DOMAIN = "http"
-REQUIREMENTS = ("cherrypy==6.1.1", "static3==0.7.0", "Werkzeug==0.11.10")
+REQUIREMENTS = ("cherrypy==7.1.0", "static3==0.7.0", "Werkzeug==0.11.10")
 
 CONF_API_PASSWORD = "api_password"
 CONF_SERVER_HOST = "server_host"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -47,7 +47,7 @@ blockchain==1.3.3
 boto3==1.3.1
 
 # homeassistant.components.http
-cherrypy==6.1.1
+cherrypy==7.1.0
 
 # homeassistant.components.media_player.directv
 directpy==0.1


### PR DESCRIPTION
## 7.1.0

Implement systemd's socket activation mechanism for CherryPy servers, based on work sponsored by Endless Computers.
## 7.0.0

Removed the long-deprecated backward compatibility for legacy config keys in the engine. Use the config for the namespaced-plugins instead:
- autoreload_on -> autoreload.on
- autoreload_frequency -> autoreload.frequency
- autoreload_match -> autoreload.match
- reload_files -> autoreload.files
- deadlock_poll_frequency -> timeout_monitor.frequency
## 6.2.1
- Fix KeyError in Bus.publish when signal handlers set in config.
## 6.2.0
- Added tool to automatically convert request params based on type annotations (primarily in Python 3)

Tested with the following configuration:

``` yaml
http:
```
