### PR TITLE
Add 5 second timeout to Kodi connections

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -53,7 +53,8 @@ class KodiDevice(MediaPlayerDevice):
         self._url = url
         self._server = jsonrpc_requests.Server(
             '{}/jsonrpc'.format(self._url),
-            auth=auth)
+            auth=auth,
+            timeout=5)
         self._turn_off_action = turn_off_action
         self._players = list()
         self._properties = None


### PR DESCRIPTION
HA got stuck when connecting to a Kodi API that was not behaving correctly.  As no timeout is specified the connection hung and prevented HA from starting up.

This fix implements a 5 second timeout for connections to Kodi to allow HA to start up even if Kodi does not respond in a reasonable time.
