### PR TITLE
Upgrade sendgrid to 3.1.10

### DIFF
--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -10,7 +10,7 @@ from homeassistant.components.notify import (
     ATTR_TITLE, DOMAIN, BaseNotificationService)
 from homeassistant.helpers import validate_config
 
-REQUIREMENTS = ['sendgrid==3.0.7']
+REQUIREMENTS = ['sendgrid==3.1.10']
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -381,7 +381,7 @@ schiene==0.17
 scsgate==0.1.0
 
 # homeassistant.components.notify.sendgrid
-sendgrid==3.0.7
+sendgrid==3.1.10
 
 # homeassistant.components.notify.slack
 slacker==0.9.24


### PR DESCRIPTION
## 3.1.10
- apikey/api_key fix 3.1.9 was supposed to address is now in this release
## 3.1.9
- api_key / apikey attribute logic incorrect

3.1.8
- Troubleshooting section
## 3.1.7
- Solves issue 195

Tested with the following configuration:

``` yaml
notify:
  - name: sendgrid
    platform: sendgrid
    api_key: !secret sendgrid_api
    sender: you@example.com
    recipient: me@example.com
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```
