### PR TITLE
Rollback voluptuous to 0.8.9

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,7 +4,7 @@ pyyaml>=3.11,<4
 pytz>=2016.6.1
 pip>=7.0.0
 jinja2>=2.8
-voluptuous==0.9.1
+voluptuous==0.8.9
 typing>=3,<4
 sqlalchemy==1.0.14
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ REQUIRES = [
     'pytz>=2016.6.1',
     'pip>=7.0.0',
     'jinja2>=2.8',
-    'voluptuous==0.9.1',
+    'voluptuous==0.8.9',
     'typing>=3,<4',
     'sqlalchemy==1.0.14',
 ]


### PR DESCRIPTION
We've had several users report issues with upgrading to Home Assistant 0.25 because it would hang on the installation of voluptuous. We've traced down the problem but pending a fix we should rollback voluptuous to 0.8.9.

Issue that I raised with voluptuous: https://github.com/alecthomas/voluptuous/issues/189
