### PR TITLE
Added a screenshot to LG Netcast TVs

### DIFF
--- a/homeassistant/components/media_player/lg_netcast.py
+++ b/homeassistant/components/media_player/lg_netcast.py
@@ -163,6 +163,11 @@ class LgTVDevice(MediaPlayerDevice):
         """Flag of media commands that are supported."""
         return SUPPORT_LGTV
 
+    @property
+    def media_image_url(self):
+        """URL for obtaining a screen capture."""
+        return self._client.url + 'data?target=screen_image'
+
     def turn_off(self):
         """Turn off media player."""
         self.send_command(1)


### PR DESCRIPTION
**Description:**
Add a screen shot to the UI of the LG Netcast TV

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
