### PR TITLE
Remove SQLAlchemy as core dependency

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,6 @@ pip>=7.0.0
 jinja2>=2.8
 voluptuous==0.8.9
 typing>=3,<4
-sqlalchemy==1.0.14
 
 # homeassistant.components.isy994
 PyISY==1.0.6

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ REQUIRES = [
     'jinja2>=2.8',
     'voluptuous==0.8.9',
     'typing>=3,<4',
-    'sqlalchemy==1.0.14',
 ]
 
 setup(


### PR DESCRIPTION
**Description:**
We had it as a core dependency to help people that are running the migration to get started. Now that we have had two releases out, we can remove it.

**Related issue (if applicable):** fixes #2699 

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
