### PR TITLE
Upgrade netdisco

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -13,7 +13,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.helpers.discovery import load_platform, discover
 
 DOMAIN = "discovery"
-REQUIREMENTS = ['netdisco==0.7.0']
+REQUIREMENTS = ['netdisco==0.7.1']
 
 SCAN_INTERVAL = 300  # seconds
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -204,7 +204,7 @@ messagebird==1.2.0
 mficlient==0.3.0
 
 # homeassistant.components.discovery
-netdisco==0.7.0
+netdisco==0.7.1
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.2.10


### PR DESCRIPTION
**Description:**
Upgrades netdisco to 0.7.1. Correctly detects homekit as homekit instead of mystrom. Will also prevent some errors from being raised (but not all).

Tested by @robbiet480 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
discovery:
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
