### PR TITLE
Add Zwave start and stop network service4

### DIFF
--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -31,3 +31,26 @@ homematic:
       param:
         description: Event to send i.e. PRESS_LONG, PRESS_SHORT
         example: PRESS_LONG
+
+zwave:
+  start_network:
+    description: Start the zwave network. This might take a while, depending on how big your zwave network is.
+
+  stop_network:
+    description: Stop the zwave network, all updates into HASS will stop.
+
+  heal_network:
+    description: Start a zwave network heal. This might take a while and will slow down the zwave network greatly while it is being processed. Refer to OZW.log for details.
+
+  add_node:
+    description: Add a new node to the zwave network. Refer to OZW.log for details.
+
+  remove_node:
+    description: Remove a node from the zwave network. Refer to OZW.log for details.
+
+  test_network:
+    description: This will send test to nodes in the zwave network. This will greatly slow down the zwave network while it is being processed. Refer to OZW.log for details.
+
+  soft_reset:
+    description: This will reset the controller without removing its data. Use carefully because not all controllers support this. Refer to controllers manual.
+

--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -36,6 +36,8 @@ SERVICE_REMOVE_NODE = "remove_node"
 SERVICE_HEAL_NETWORK = "heal_network"
 SERVICE_SOFT_RESET = "soft_reset"
 SERVICE_TEST_NETWORK = "test_network"
+SERVICE_STOP_NETWORK = "stop_network"
+SERVICE_START_NETWORK = "start_network"
 
 EVENT_SCENE_ACTIVATED = "zwave.scene_activated"
 EVENT_NODE_EVENT = "zwave.node_event"
@@ -419,11 +421,11 @@ def setup(hass, config):
         """Test the network by sending commands to all the nodes."""
         NETWORK.test()
 
-    def stop_zwave(event):
+    def stop_zwave(_service_or_event):
         """Stop Z-Wave."""
         NETWORK.stop()
 
-    def start_zwave(event):
+    def start_zwave(_service_or_event):
         """Startup Z-Wave."""
         NETWORK.start()
 
@@ -461,6 +463,8 @@ def setup(hass, config):
         hass.services.register(DOMAIN, SERVICE_HEAL_NETWORK, heal_network)
         hass.services.register(DOMAIN, SERVICE_SOFT_RESET, soft_reset)
         hass.services.register(DOMAIN, SERVICE_TEST_NETWORK, test_network)
+        hass.services.register(DOMAIN, SERVICE_STOP_NETWORK, stop_zwave)
+        hass.services.register(DOMAIN, SERVICE_START_NETWORK, start_zwave)
 
     # Setup autoheal
     if autoheal:


### PR DESCRIPTION
**Description:**
Add start and stop for the zwave network.
This is really useful if you would like to run OZWCP from within HASS in an iframe.
@balloob  Is this the correct way of doing this?
