### PR TITLE
Convert null to 0 for temp and % sensors

### DIFF
--- a/homeassistant/components/sensor/octoprint.py
+++ b/homeassistant/components/sensor/octoprint.py
@@ -95,6 +95,9 @@ class OctoPrintSensor(Entity):
         """Return the state of the sensor."""
         sensor_unit = self.unit_of_measurement
         if sensor_unit == TEMP_CELSIUS or sensor_unit == "%":
+            # API sometimes returns null and not 0
+            if self._state is None:
+                self._state = 0
             return round(self._state, 2)
         else:
             return self._state


### PR DESCRIPTION
**Description:**
The variable "completion" from the octoprint API appears to sometimes get returned as Null and not 0. This will check if the value is Null for all temp and % sensors and convert it to a 0. 

**Related issue (if applicable):** fixes #2708 

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
