### PR TITLE
Hide NewType ImportErrors

### DIFF
--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -1,18 +1,12 @@
 """Typing Helpers for Home-Assistant."""
-# pylint: disable=invalid-name
-try:
-    from typing import NewType, Dict, Any
-except ImportError:
-    from typing import Dict, Any
-
-    def NewType(name: str, typ: Any) -> Any:
-        """Fake NewType, required for Python 3.5.1."""
-        return typ
+from typing import Dict, Any
 
 import homeassistant.core
 
-ConfigType = NewType('ConfigType', Dict[str, Any])
+# pylint: disable=invalid-name
+
+ConfigType = Dict[str, Any]
 HomeAssistantType = homeassistant.core.HomeAssistant
 
 # Custom type for recorder Queries
-QueryType = NewType('QueryType', Any)
+QueryType = Any

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -1,9 +1,15 @@
 """Typing Helpers for Home-Assistant."""
-
-from typing import NewType, Dict, Any
-import homeassistant.core
-
 # pylint: disable=invalid-name
+try:
+    from typing import NewType, Dict, Any
+except ImportError:
+    from typing import Dict, Any
+
+    def NewType(name: str, typ: Any) -> Any:
+        """Fake NewType, required for Python 3.5.1."""
+        return typ
+
+import homeassistant.core
 
 ConfigType = NewType('ConfigType', Dict[str, Any])
 HomeAssistantType = homeassistant.core.HomeAssistant


### PR DESCRIPTION
**Description:**
This PR hides `NewType` ImportErrors from `typing` (Some history in #2680)
- No issues on Python 3.4 with the imported `typing` library 3.5.2.2
- `typing` should be in the Python 3.5 standard library, but it seems to have issues importing `NewType`

CC: @turbokongen @robbiet480 @fabianhjr @balloob 

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
