### PR TITLE
Add media_image_url for mpd to get cover art from web server

### DIFF
--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -5,10 +5,8 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.mpd/
 """
 import logging
-import os
 import socket
 
-from urllib.parse import quote
 from homeassistant.components.media_player import (
     MEDIA_TYPE_MUSIC, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE,
     SUPPORT_PREVIOUS_TRACK, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
@@ -72,6 +70,8 @@ class MpdDevice(MediaPlayerDevice):
 
     # MPD confuses pylint
     # pylint: disable=no-member, too-many-public-methods, abstract-method
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-arguments
     def __init__(self, server, port, location, password, baseurl, covername):
         """Initialize the MPD device."""
         import mpd
@@ -145,8 +145,10 @@ class MpdDevice(MediaPlayerDevice):
     @property
     def media_image_url(self):
         """Image url of current playing media."""
+        from os.path import dirname
+        from urllib.parse import quote
         if self.baseurl is not None:
-            albumdir = quote(os.path.dirname(self.currentsong.get('file')))
+            albumdir = quote(dirname(self.currentsong.get('file')))
             coverurl = '{}{}/{}'.format(self.baseurl, albumdir, self.covername)
             return coverurl
         else:

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -63,7 +63,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         else:
             raise
 
-    add_devices([MpdDevice(daemon, port, location, password, baseurl, covername)])
+    add_devices([MpdDevice(daemon, port, location, password,
+                           baseurl, covername)])
 
 
 class MpdDevice(MediaPlayerDevice):


### PR DESCRIPTION
**Description:**
This adds support for cover art in mpd. A web server like nginx will need to have access to the mpd music directory and a image of the cover art needs exist in each album.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** https://github.com/home-assistant/home-assistant.io/pull/726

**Example entry for `configuration.yaml`:**

``` yaml
media_player:
  platform: mpd 
  server: 127.0.0.1
  port: 6600
  baseurl: http://localhost/mpd/cover/
  covername: cover.jpg
  location: bedroom
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully.
