### PR TITLE
Add option to heat_control component to set min cycle duration

### DIFF
--- a/tests/components/thermostat/test_heat_control.py
+++ b/tests/components/thermostat/test_heat_control.py
@@ -1,5 +1,8 @@
 """The tests for the heat control thermostat."""
+import datetime
 import unittest
+from unittest import mock
+
 
 from homeassistant.bootstrap import _setup_component
 from homeassistant.const import (
@@ -277,6 +280,187 @@ class TestThermostatHeatControlACMode(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('switch', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+
+    def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
+        """Setup the test sensor."""
+        self.hass.states.set(ENT_SENSOR, temp, {
+            ATTR_UNIT_OF_MEASUREMENT: unit
+        })
+
+    def _setup_switch(self, is_on):
+        """Setup the test switch."""
+        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
+        self.calls = []
+
+        def log_call(call):
+            """Log service calls."""
+            self.calls.append(call)
+
+        self.hass.services.register('switch', SERVICE_TURN_ON, log_call)
+        self.hass.services.register('switch', SERVICE_TURN_OFF, log_call)
+
+
+class TestThermostatHeatControlACModeMinCycle(unittest.TestCase):
+    """Test the Heat Control thermostat."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.config.temperature_unit = TEMP_CELSIUS
+        thermostat.setup(self.hass, {'thermostat': {
+            'platform': 'heat_control',
+            'name': 'test',
+            'heater': ENT_SWITCH,
+            'target_sensor': ENT_SENSOR,
+            'ac_mode': True,
+            'min_cycle_duration': datetime.timedelta(minutes=10)
+        }})
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_temp_change_ac_trigger_on_not_long_enough(self):
+        """Test if temperature change turn ac on."""
+        self._setup_switch(False)
+        thermostat.set_temperature(self.hass, 25)
+        self.hass.pool.block_till_done()
+        self._setup_sensor(30)
+        self.hass.pool.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
+    def test_temp_change_ac_trigger_on_long_enough(self):
+        """Test if temperature change turn ac on."""
+        fake_changed = datetime.datetime(1918, 11, 11, 11, 11, 11,
+                                         tzinfo=datetime.timezone.utc)
+        with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
+                        return_value=fake_changed):
+            self._setup_switch(False)
+        thermostat.set_temperature(self.hass, 25)
+        self.hass.pool.block_till_done()
+        self._setup_sensor(30)
+        self.hass.pool.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('switch', call.domain)
+        self.assertEqual(SERVICE_TURN_ON, call.service)
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+
+    def test_temp_change_ac_trigger_off_not_long_enough(self):
+        """Test if temperature change turn ac on."""
+        self._setup_switch(True)
+        thermostat.set_temperature(self.hass, 30)
+        self.hass.pool.block_till_done()
+        self._setup_sensor(25)
+        self.hass.pool.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
+    def test_temp_change_ac_trigger_off_long_enough(self):
+        """Test if temperature change turn ac on."""
+        fake_changed = datetime.datetime(1918, 11, 11, 11, 11, 11,
+                                         tzinfo=datetime.timezone.utc)
+        with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
+                        return_value=fake_changed):
+            self._setup_switch(True)
+        thermostat.set_temperature(self.hass, 30)
+        self.hass.pool.block_till_done()
+        self._setup_sensor(25)
+        self.hass.pool.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('switch', call.domain)
+        self.assertEqual(SERVICE_TURN_OFF, call.service)
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+
+    def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
+        """Setup the test sensor."""
+        self.hass.states.set(ENT_SENSOR, temp, {
+            ATTR_UNIT_OF_MEASUREMENT: unit
+        })
+
+    def _setup_switch(self, is_on):
+        """Setup the test switch."""
+        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
+        self.calls = []
+
+        def log_call(call):
+            """Log service calls."""
+            self.calls.append(call)
+
+        self.hass.services.register('switch', SERVICE_TURN_ON, log_call)
+        self.hass.services.register('switch', SERVICE_TURN_OFF, log_call)
+
+
+class TestThermostatHeatControlMinCycle(unittest.TestCase):
+    """Test the Heat Control thermostat."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.config.temperature_unit = TEMP_CELSIUS
+        thermostat.setup(self.hass, {'thermostat': {
+            'platform': 'heat_control',
+            'name': 'test',
+            'heater': ENT_SWITCH,
+            'target_sensor': ENT_SENSOR,
+            'min_cycle_duration': datetime.timedelta(minutes=10)
+        }})
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_temp_change_heater_trigger_off_not_long_enough(self):
+        """Test if temp change doesn't turn heater off because of time."""
+        self._setup_switch(True)
+        thermostat.set_temperature(self.hass, 25)
+        self.hass.pool.block_till_done()
+        self._setup_sensor(30)
+        self.hass.pool.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
+    def test_temp_change_heater_trigger_on_not_long_enough(self):
+        """Test if temp change doesn't turn heater on because of time."""
+        self._setup_switch(False)
+        thermostat.set_temperature(self.hass, 30)
+        self.hass.pool.block_till_done()
+        self._setup_sensor(25)
+        self.hass.pool.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
+    def test_temp_change_heater_trigger_on_long_enough(self):
+        """Test if temperature change turn heater on after min cycle."""
+        fake_changed = datetime.datetime(1918, 11, 11, 11, 11, 11,
+                                         tzinfo=datetime.timezone.utc)
+        with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
+                        return_value=fake_changed):
+            self._setup_switch(False)
+        thermostat.set_temperature(self.hass, 30)
+        self.hass.pool.block_till_done()
+        self._setup_sensor(25)
+        self.hass.pool.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('switch', call.domain)
+        self.assertEqual(SERVICE_TURN_ON, call.service)
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+
+    def test_temp_change_heater_trigger_off_long_enough(self):
+        """Test if temperature change turn heater off after min cycle."""
+        fake_changed = datetime.datetime(1918, 11, 11, 11, 11, 11,
+                                         tzinfo=datetime.timezone.utc)
+        with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
+                        return_value=fake_changed):
+            self._setup_switch(True)
+        thermostat.set_temperature(self.hass, 25)
+        self.hass.pool.block_till_done()
+        self._setup_sensor(30)
+        self.hass.pool.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('switch', call.domain)
+        self.assertEqual(SERVICE_TURN_OFF, call.service)
         self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def _setup_sensor(self, temp, unit=TEMP_CELSIUS):


### PR DESCRIPTION
**Description:**
This commit adds a new config option min_cycle_duration which when specified will add a minimum duration that the thermostat must keep the switch in each state prior to switching it either off or on. The motivation is primarily for AC mode, because window and in-wall AC units are not nearly as efficient during the first few minutes of operation. This gives users a tunable to fine tune exactly how frequently heat control can power cycle their devices.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#733

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
thermostat:
  platform: heat_control
  name: Study
  heater: switch.study_heater
  target_sensor: sensor.study_temperature
  min_temp: 15
  max_temp: 21
  target_temp: 15
  min_cycle_duration:
     days: 2
     hours: 1
     minutes: 10
     seconds: 5
     milliseconds: 20
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [X] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

This commit adds a new config option to the heat_control thermostat
component, min_cycle_duration. Some heaters and/or ACs don't like
being constantly cycled on and off. Prior to this patch the
heat_control component can end up cycling the switch quite
frequently. (depending on how quickly the temperature changes) The
new option added is used for setting a minimum duration that must
have elapsed in either the on or off state before the thermostat will
send the service call to cycle the switch. This should enable users to
hand tune how frequently heat_control can switch the device on or off
to best suit the device being used.
