### PR TITLE
 Added whitelist option to InfluxDB to select the only entities that will be logged

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -33,6 +33,7 @@ CONF_PASSWORD = 'password'
 CONF_SSL = 'ssl'
 CONF_VERIFY_SSL = 'verify_ssl'
 CONF_BLACKLIST = 'blacklist'
+CONF_WHITELIST = 'whitelist'
 CONF_TAGS = 'tags'
 
 
@@ -57,6 +58,7 @@ def setup(hass, config):
     verify_ssl = util.convert(conf.get(CONF_VERIFY_SSL), bool,
                               DEFAULT_VERIFY_SSL)
     blacklist = conf.get(CONF_BLACKLIST, [])
+    whitelist = conf.get(CONF_WHITELIST, [])
     tags = conf.get(CONF_TAGS, {})
 
     try:
@@ -79,6 +81,9 @@ def setup(hass, config):
             return
 
         try:
+            if len(whitelist) > 0 and state.entity_id not in whitelist:
+                return
+
             _state = state_helper.state_as_number(state)
         except ValueError:
             _state = state.state


### PR DESCRIPTION
**Description:**
This option adds the ability to whitelist some entities to be logged on InfluxDB instead all entities by default. 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/735

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
influxdb:
  host: DB_HOST_IP_ADDRESS
  port: 20000
  database: DB_TO_STORE_EVENTS
  username: MY_USERNAME
  password: MY_PASSWORD
  ssl: true
  verify_ssl: true
  whitelist:
     - entity.id3
     - entity.id4
  tags:
    - instance: prod
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
