### PR TITLE
Remove 'remove node (secure)' service; is not a specialized implementation in Python-OZW and standard removal works fine.

### DIFF
--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -51,9 +51,6 @@ zwave:
   remove_node:
     description: Remove a node from the zwave network. Refer to OZW.log for details.
 
-  remove_node_secure:
-    description: Remove a node from the zwave network with secure communications. Node must support this, and network key must be set. Refer to OZW.log for details.
-
   test_network:
     description: This will send test to nodes in the zwave network. This will greatly slow down the zwave network while it is being processed. Refer to OZW.log for details.
 

--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -34,7 +34,6 @@ NETWORK_READY_WAIT_SECS = 30
 SERVICE_ADD_NODE = "add_node"
 SERVICE_ADD_NODE_SECURE = "add_node_secure"
 SERVICE_REMOVE_NODE = "remove_node"
-SERVICE_REMOVE_NODE_SECURE = "remove_node_secure"
 SERVICE_HEAL_NETWORK = "heal_network"
 SERVICE_SOFT_RESET = "soft_reset"
 SERVICE_TEST_NETWORK = "test_network"
@@ -414,10 +413,6 @@ def setup(hass, config):
         """Switch into exclusion mode."""
         NETWORK.controller.remove_node()
 
-    def remove_node_secure(service):
-        """Switch into secure exclusion mode."""
-        NETWORK.controller.remove_node(True)
-
     def heal_network(service):
         """Heal the network."""
         _LOGGER.info("ZWave heal running.")
@@ -471,8 +466,6 @@ def setup(hass, config):
         hass.services.register(DOMAIN, SERVICE_ADD_NODE_SECURE,
                                add_node_secure)
         hass.services.register(DOMAIN, SERVICE_REMOVE_NODE, remove_node)
-        hass.services.register(DOMAIN, SERVICE_REMOVE_NODE_SECURE,
-                               remove_node_secure)
         hass.services.register(DOMAIN, SERVICE_HEAL_NETWORK, heal_network)
         hass.services.register(DOMAIN, SERVICE_SOFT_RESET, soft_reset)
         hass.services.register(DOMAIN, SERVICE_TEST_NETWORK, test_network)


### PR DESCRIPTION
I believe a small mistake was made here: https://github.com/home-assistant/home-assistant/pull/2715/files

Using Python-OpenZWave's `add_node` method with `doSecurity` parameter is a great addition for situations when a user wants to ensure a node is added with security enabled. However, the `remove_node` method in Python-OZW does not take such a `doSecurity` parameter, and normal removal of a secure node should and does work as expected from what I can see. So I believe the "remove_node_secure" service created in that PR is mistaken and unnecessary.

For reference, here is Python-OZW's add_node: https://github.com/OpenZWave/python-openzwave/blob/master/src-api/openzwave/controller.py#L640

And here's remove_node: https://github.com/OpenZWave/python-openzwave/blob/master/src-api/openzwave/controller.py#L662

(Note the missing doSecurity boolean in the latter).

If I'm misreading something, let me know!

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
