### PR TITLE
add changed_by attribute to alarm control panel

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.entity_component import EntityComponent
 
 DOMAIN = 'alarm_control_panel'
 SCAN_INTERVAL = 30
+ATTR_CHANGED_BY = 'changed_by'
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
@@ -124,6 +125,11 @@ class AlarmControlPanel(Entity):
         """Regex for code format or None if no code is required."""
         return None
 
+    @property
+    def changed_by(self):
+        """Last change triggered by."""
+        return None
+
     def alarm_disarm(self, code=None):
         """Send disarm command."""
         raise NotImplementedError()
@@ -145,5 +151,6 @@ class AlarmControlPanel(Entity):
         """Return the state attributes."""
         state_attr = {
             ATTR_CODE_FORMAT: self.code_format,
+            ATTR_CHANGED_BY: self.changed_by
         }
         return state_attr

--- a/homeassistant/components/alarm_control_panel/verisure.py
+++ b/homeassistant/components/alarm_control_panel/verisure.py
@@ -37,6 +37,7 @@ class VerisureAlarm(alarm.AlarmControlPanel):
         self._id = device_id
         self._state = STATE_UNKNOWN
         self._digits = int(hub.config.get('code_digits', '4'))
+        self._changed_by = None
 
     @property
     def name(self):
@@ -58,6 +59,11 @@ class VerisureAlarm(alarm.AlarmControlPanel):
         """The code format as regex."""
         return '^\\d{%s}$' % self._digits
 
+    @property
+    def changed_by(self):
+        """Last change triggered by."""
+        return self._changed_by
+
     def update(self):
         """Update alarm status."""
         hub.update_alarms()
@@ -72,6 +78,7 @@ class VerisureAlarm(alarm.AlarmControlPanel):
             _LOGGER.error(
                 'Unknown alarm state %s',
                 hub.alarm_status[self._id].status)
+        self._changed_by = hub.alarm_status[self._id].name
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""


### PR DESCRIPTION
**Description:**
Add a changed_by attribute to alarm control panel in order to be able to take different actions depending on who armed/disarmed the alarm

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
automation:
  - alias: Alarm status changed
    trigger:
      - platform: state
        entity_id: alarm_control_panel.alarm_1
    action:
      - service: notify.notify
        data_template:
          message: >
            Alarm changed from {{ trigger.from_state.state }}
            to {{ trigger.to_state.state }}
            by {{ trigger.to_state.attributes.changed_by }}
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
