### PR TITLE
Making use of the unit_system configuration parameter to determine the measurement units for Fitbit component.

### DIFF
--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -232,6 +232,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             authd_client.client.refresh_token()
 
         authd_client.system = authd_client.user_profile_get()["user"]["locale"]
+        if authd_client.system != 'en_GB':
+            if hass.config.units.is_metric:
+                authd_client.system = "metric"
+            else:
+                authd_client.system = "en_US"
 
         dev = []
         for resource in config.get("monitored_resources",


### PR DESCRIPTION
**Description:**
Currently, the Fitbit component on HASS supports 3 different measurements sets: `en_US`, `en_GB` and `metric`.  Since unit_system can be `metric` or `imperial` , this patch also takes in consideration if the `en_GB` measurements is preferred by the user for Fibit. If not then it will lookup the unit_system configuration to determine between `metric` or `imperial`. 

Before:
![before](https://cloud.githubusercontent.com/assets/809840/17469371/20ac78f2-5d00-11e6-8779-9fda9dd14840.png)
After:
![after](https://cloud.githubusercontent.com/assets/809840/17469372/28b9e1a6-5d00-11e6-9018-98c6aeb304c1.png)

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
