### PR TITLE
Link prefetch panels

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -196,6 +196,6 @@ class IndexView(HomeAssistantView):
         resp = template.render(
             core_url=core_url, ui_url=ui_url, no_auth=no_auth,
             icons_url=icons_url, icons=FINGERPRINTS['mdi.html'],
-            panel_url=panel_url)
+            panel_url=panel_url, panels=PANELS)
 
         return self.Response(resp, mimetype='text/html')

--- a/homeassistant/components/frontend/templates/index.html
+++ b/homeassistant/components/frontend/templates/index.html
@@ -8,6 +8,9 @@
     <link rel='icon' href='/static/icons/favicon.ico'>
     <link rel='apple-touch-icon' sizes='180x180'
           href='/static/icons/favicon-apple-180x180.png'>
+    {% for panel in panels.values() -%}
+      <link rel='prefetch' href='{{ panel.url }}'>
+    {% endfor -%}
     <meta name='apple-mobile-web-app-capable' content='yes'>
     <meta name="msapplication-square70x70logo" content="/static/icons/tile-win-70x70.png"/>
     <meta name="msapplication-square150x150logo" content="/static/icons/tile-win-150x150.png"/>
@@ -86,9 +89,9 @@
     {# <script src='/static/home-assistant-polymer/build/_demo_data_compiled.js'></script> #}
     <script src='{{ core_url }}'></script>
     <link rel='import' href='{{ ui_url }}' onerror='initError()'>
-    {% if panel_url %}
+    {% if panel_url -%}
       <link rel='import' href='{{ panel_url }}' onerror='initError()' async>
-    {% endif %}
+    {% endif -%}
     <link rel='import' href='{{ icons_url }}' async>
     <script>
       var webComponentsSupported = (

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -473,15 +473,15 @@ class HomeAssistantView(object):
                                  self.hass.wsgi.api_password):
             authenticated = True
 
-        if authenticated:
-            _LOGGER.info('Successful login/request from %s',
-                         request.remote_addr)
-        elif self.requires_auth and not authenticated:
+        if self.requires_auth and not authenticated:
             _LOGGER.warning('Login attempt or request with an invalid'
                             'password from %s', request.remote_addr)
             raise Unauthorized()
 
         request.authenticated = authenticated
+
+        _LOGGER.info('Serving %s to %s (auth: %s)',
+                     request.path, request.remote_addr, authenticated)
 
         result = handler(request, **values)
 


### PR DESCRIPTION
**Description:**
- Add hints to the index.html page for browsers to prefetch the panel assets while browser is idle
- Change the HTTP logging message `Successful login from X` to `Serving /api/stream to 192.168.1.10 (auth: True)`

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
