### PR TITLE
Support color and brightness for flux light

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -9,11 +9,12 @@ import logging
 import socket
 import voluptuous as vol
 
-from homeassistant.components.light import Light
+from homeassistant.components.light import (ATTR_BRIGHTNESS, ATTR_RGB_COLOR,
+                                            Light)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['https://github.com/Danielhiversen/flux_led/archive/0.3.zip'
-                '#flux_led==0.3']
+REQUIREMENTS = ['https://github.com/Danielhiversen/flux_led/archive/0.5.zip'
+                '#flux_led==0.5']
 
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = "flux_led"
@@ -37,7 +38,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     light_ips = []
     for ipaddr, device_config in config["devices"].items():
         device = {}
-        device['id'] = device_config[ATTR_NAME]
+        device['name'] = device_config[ATTR_NAME]
         device['ipaddr'] = ipaddr
         light = FluxLight(device)
         if light.is_valid:
@@ -50,11 +51,14 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     # Find the bulbs on the LAN
     scanner = flux_led.BulbScanner()
-    scanner.scan(timeout=20)
+    scanner.scan(timeout=10)
     for device in scanner.getBulbInfo():
-        light = FluxLight(device)
         ipaddr = device['ipaddr']
-        if light.is_valid and ipaddr not in light_ips:
+        if ipaddr in light_ips:
+            continue
+        device['name'] = device['id'] + " " + ipaddr
+        light = FluxLight(device)
+        if light.is_valid:
             lights.append(light)
             light_ips.append(ipaddr)
 
@@ -69,7 +73,7 @@ class FluxLight(Light):
         """Initialize the light."""
         import flux_led
 
-        self._name = device['id']
+        self._name = device['name']
         self._ipaddr = device['ipaddr']
         self.is_valid = True
         self._bulb = None
@@ -96,9 +100,26 @@ class FluxLight(Light):
         """Return true if device is on."""
         return self._bulb.isOn()
 
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return self._bulb.getWarmWhite255()
+
+    @property
+    def rgb_color(self):
+        """Return the color property."""
+        return self._bulb.getRgb()
+
     def turn_on(self, **kwargs):
         """Turn the specified or all lights on."""
-        self._bulb.turnOn()
+        rgb = kwargs.get(ATTR_RGB_COLOR)
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+        if rgb:
+            self._bulb.setRgb(*tuple(rgb))
+        elif brightness:
+            self._bulb.setWarmWhite255(brightness)
+        else:
+            self._bulb.turnOn()
 
     def turn_off(self, **kwargs):
         """Turn the specified or all lights off."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -101,7 +101,7 @@ hikvision==0.4
 # http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
 
 # homeassistant.components.light.flux_led
-https://github.com/Danielhiversen/flux_led/archive/0.3.zip#flux_led==0.3
+https://github.com/Danielhiversen/flux_led/archive/0.5.zip#flux_led==0.5
 
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.1.1.zip#pyW215==0.1.1


### PR DESCRIPTION
**Description:**
Support color and brightness for flux light

https://community.home-assistant.io/t/magiclight-flux-wifi-color-led-light-component/2271

Many thanks to mplawner and @tchellomello for helping me with testing
Specially thanks to mplawner who donated three flux bulbs to me.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
