### PR TITLE
bump proliphix library to 0.3.1

### DIFF
--- a/homeassistant/components/thermostat/proliphix.py
+++ b/homeassistant/components/thermostat/proliphix.py
@@ -9,7 +9,7 @@ from homeassistant.components.thermostat import (
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, TEMP_FAHRENHEIT)
 
-REQUIREMENTS = ['proliphix==0.2.0']
+REQUIREMENTS = ['proliphix==0.3.1']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -234,7 +234,7 @@ plexapi==1.1.0
 pmsensor==0.2
 
 # homeassistant.components.thermostat.proliphix
-proliphix==0.2.0
+proliphix==0.3.1
 
 # homeassistant.components.sensor.systemmonitor
 psutil==4.3.0


### PR DESCRIPTION
The 0.3.1 version of the library includes fixes for time syncing the
thermostat under the covers when needed. All changes are done on the
library side, we just need to bump the required level in home
assistant.
