### PR TITLE
Hyperion: backwards compatibility

### DIFF
--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -72,6 +72,11 @@ class Hyperion(Light):
         """Get the remote's active color."""
         response = self.json_request({"command": "serverinfo"})
         if response:
+            # workaround for outdated Hyperion
+            if "activeLedColor" not in response["info"]:
+                self._rgb_color = self._default_color
+                return
+
             if response["info"]["activeLedColor"] == []:
                 self._rgb_color = [0, 0, 0]
             else:


### PR DESCRIPTION
Hotfixes #2667 

This change makes Homeassistant not print Python errors when the JSON returned by Hyperion is too old to support getting the active LED color.
Tested with an outdated version of Hyperion and the current development version.
