### PR TITLE
Honeywell hvac mode

### DIFF
--- a/homeassistant/components/thermostat/honeywell.py
+++ b/homeassistant/components/thermostat/honeywell.py
@@ -137,9 +137,18 @@ class RoundThermostat(ThermostatDevice):
         self.device.set_temperature(self._name, temperature)
 
     @property
+    def operation(self):
+        """Get the current operation of the system."""
+        return self.device.system_mode
+
+    @property
     def is_away_mode_on(self):
         """Return true if away mode is on."""
         return self._away
+
+    def set_hvac_mode(self, hvac_mode):
+        """Set the HVAC mode for the thermostat."""
+        self.device.system_mode = hvac_mode
 
     def turn_away_mode_on(self):
         """Turn away on.

--- a/homeassistant/components/thermostat/honeywell.py
+++ b/homeassistant/components/thermostat/honeywell.py
@@ -260,5 +260,5 @@ class HoneywellUSThermostat(ThermostatDevice):
         pass
 
     def set_hvac_mode(self, hvac_mode):
-        """Set the system mode (Cool, Heat, etc.)"""
+        """Set the system mode (Cool, Heat, etc)."""
         self._device.system_mode = hvac_mode

--- a/homeassistant/components/thermostat/honeywell.py
+++ b/homeassistant/components/thermostat/honeywell.py
@@ -219,6 +219,11 @@ class HoneywellUSThermostat(ThermostatDevice):
         else:
             return self._device.setpoint_heat
 
+    @property
+    def operation(self):
+        """Return current operation ie. heat, cool, idle."""
+        return self._device.system_mode
+
     def set_temperature(self, temperature):
         """Set target temperature."""
         import somecomfort
@@ -244,3 +249,7 @@ class HoneywellUSThermostat(ThermostatDevice):
     def turn_away_mode_off(self):
         """Turn away off."""
         pass
+
+    def set_hvac_mode(self, hvac_mode):
+        """Set the system mode (Cool, Heat, etc.)"""
+        self._device.system_mode = hvac_mode

--- a/homeassistant/components/thermostat/honeywell.py
+++ b/homeassistant/components/thermostat/honeywell.py
@@ -137,7 +137,7 @@ class RoundThermostat(ThermostatDevice):
         self.device.set_temperature(self._name, temperature)
 
     @property
-    def operation(self):
+    def operation(self: ThermostatDevice) -> str:
         """Get the current operation of the system."""
         return self.device.system_mode
 
@@ -146,7 +146,7 @@ class RoundThermostat(ThermostatDevice):
         """Return true if away mode is on."""
         return self._away
 
-    def set_hvac_mode(self, hvac_mode):
+    def set_hvac_mode(self: ThermostatDevice, hvac_mode: str) -> None:
         """Set the HVAC mode for the thermostat."""
         self.device.system_mode = hvac_mode
 
@@ -229,7 +229,7 @@ class HoneywellUSThermostat(ThermostatDevice):
             return self._device.setpoint_heat
 
     @property
-    def operation(self):
+    def operation(self: ThermostatDevice) -> str:
         """Return current operation ie. heat, cool, idle."""
         return self._device.system_mode
 
@@ -259,6 +259,6 @@ class HoneywellUSThermostat(ThermostatDevice):
         """Turn away off."""
         pass
 
-    def set_hvac_mode(self, hvac_mode):
+    def set_hvac_mode(self: ThermostatDevice, hvac_mode: str) -> None:
         """Set the system mode (Cool, Heat, etc)."""
         self._device.system_mode = hvac_mode

--- a/tests/components/thermostat/test_honeywell.py
+++ b/tests/components/thermostat/test_honeywell.py
@@ -277,7 +277,7 @@ class TestHoneywellRound(unittest.TestCase):
         self.round1.set_temperature(25)
         self.device.set_temperature.assert_called_once_with('House', 25)
 
-    def test_set_hvac_mode(self):
+    def test_set_hvac_mode(self: unittest.TestCase) -> None:
         """Test setting the system operation."""
         self.round1.set_hvac_mode('cool')
         self.assertEqual('cool', self.round1.operation)
@@ -337,7 +337,7 @@ class TestHoneywellUS(unittest.TestCase):
         self.assertEqual(74, self.device.setpoint_cool)
         self.assertEqual(74, self.honeywell.target_temperature)
 
-    def test_set_hvac_mode(self):
+    def test_set_hvac_mode(self: unittest.TestCase) -> None:
         """Test setting the HVAC mode."""
         self.honeywell.set_hvac_mode('cool')
         self.assertEqual('cool', self.honeywell.operation)

--- a/tests/components/thermostat/test_honeywell.py
+++ b/tests/components/thermostat/test_honeywell.py
@@ -327,6 +327,16 @@ class TestHoneywellUS(unittest.TestCase):
         self.assertEqual(74, self.device.setpoint_cool)
         self.assertEqual(74, self.honeywell.target_temperature)
 
+    def test_set_hvac_mode(self):
+        """Test setting the HVAC mode."""
+        self.honeywell.set_hvac_mode('cool')
+        self.assertEqual('cool', self.honeywell.operation)
+        self.assertEqual('cool', self.device.system_mode)
+
+        self.honeywell.set_hvac_mode('heat')
+        self.assertEqual('heat', self.honeywell.operation)
+        self.assertEqual('heat', self.device.system_mode)
+
     def test_set_temp_fail(self):
         """Test if setting the temperature fails."""
         self.device.setpoint_heat = mock.MagicMock(

--- a/tests/components/thermostat/test_honeywell.py
+++ b/tests/components/thermostat/test_honeywell.py
@@ -277,6 +277,16 @@ class TestHoneywellRound(unittest.TestCase):
         self.round1.set_temperature(25)
         self.device.set_temperature.assert_called_once_with('House', 25)
 
+    def test_set_hvac_mode(self):
+        """Test setting the system operation."""
+        self.round1.set_hvac_mode('cool')
+        self.assertEqual('cool', self.round1.operation)
+        self.assertEqual('cool', self.device.system_mode)
+
+        self.round1.set_hvac_mode('heat')
+        self.assertEqual('heat', self.round1.operation)
+        self.assertEqual('heat', self.device.system_mode)
+
 
 class TestHoneywellUS(unittest.TestCase):
     """A test class for Honeywell US thermostats."""


### PR DESCRIPTION
**Description:**
Update honeywell thermostat platforms to allow setting/retrieving the current system operation mode.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
