### PR TITLE
Add an OhmConnect sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -203,6 +203,7 @@ omit =
     homeassistant/components/sensor/loopenergy.py
     homeassistant/components/sensor/neurio_energy.py
     homeassistant/components/sensor/nzbget.py
+    homeassistant/components/sensor/ohmconnect.py
     homeassistant/components/sensor/onewire.py
     homeassistant/components/sensor/openweathermap.py
     homeassistant/components/sensor/openexchangerates.py

--- a/homeassistant/components/sensor/ohmconnect.py
+++ b/homeassistant/components/sensor/ohmconnect.py
@@ -48,7 +48,7 @@ class OhmconnectSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        if self._data["active"] == "True":
+        if self._data.get("active") == "True":
             return "Active"
         else:
             return "Inactive"
@@ -56,7 +56,7 @@ class OhmconnectSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {"Address": self._data["address"], "ID": self._ohmid}
+        return {"Address": self._data.get("address"), "ID": self._ohmid}
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/sensor/ohmconnect.py
+++ b/homeassistant/components/sensor/ohmconnect.py
@@ -1,0 +1,74 @@
+"""
+Support for OhmConnect.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/sensor.ohmconnect/
+"""
+import logging
+from datetime import timedelta
+import xml.etree.ElementTree as ET
+import requests
+
+from homeassistant.util import Throttle
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+# Return cached results if last scan was less then this time ago.
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the OhmConnect sensors."""
+    ohmid = config.get("id")
+    if ohmid is None:
+        _LOGGER.error("You must provide your OhmConnect ID!")
+        return False
+
+    add_devices([OhmconnectSensor(config.get("name", "OhmConnect Status"),
+                                  ohmid)])
+
+
+class OhmconnectSensor(Entity):
+    """Representation of a OhmConnect sensor."""
+
+    def __init__(self, name, ohmid):
+        """Initialize the sensor."""
+        self._name = name
+        self._ohmid = ohmid
+        self._data = {}
+        self.update()
+
+    @property
+    def name(self):
+        """The name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        if self._data["active"] == "True":
+            return "Active"
+        else:
+            return "Inactive"
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {"Address": self._data["address"], "ID": self._ohmid}
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Get the latest data from OhmConnect."""
+        try:
+            url = ("https://login.ohmconnect.com"
+                   "/verify-ohm-hour/{}").format(self._ohmid)
+            response = requests.get(url, timeout=10)
+            root = ET.fromstring(response.text)
+
+            for child in root:
+                self._data[child.tag] = child.text
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error("No route to host/endpoint: %s", url)
+            self.data = {}


### PR DESCRIPTION
**Description:** This adds a [OhmConnect](http://ohmconnect.com) sensor. 

> OhmConnect monitors real-time conditions on the electricity grid. When dirty and unsustainable power plants turn on, our users receive a notification to save energy. By saving energy at that time, California does not have to turn on additional power plants and California's energy authorities pay **you** for that.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#754

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: ohmconnect
    id: AbCd1e
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
