### PR TITLE
garage door rpi_gpio.py fix

### DIFF
--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -72,7 +72,7 @@ class RPiGPIOGarageDoor(GarageDoorDevice):
 
     def update(self):
         """Update the state of the garage door."""
-        self._state = rpi_gpio.read_input(self._state_pin) is True
+        self._state = rpi_gpio.read_input(self._state_pin)
 
     @property
     def is_closed(self):


### PR DESCRIPTION
**Description:**
The rpi_gpio garage door component would not show any garage door status changes. The code change here fixed the issue for me and now the status changes as expected.

The setup I am using can be found at https://github.com/andrewshilliday/garage-door-controller

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
