### PR TITLE
add changed_by attribute to lock

### DIFF
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.components import group
 
 DOMAIN = 'lock'
 SCAN_INTERVAL = 30
+ATTR_CHANGED_BY = 'changed_by'
 
 GROUP_NAME_ALL_LOCKS = 'all locks'
 ENTITY_ID_ALL_LOCKS = group.ENTITY_ID_FORMAT.format('all_locks')
@@ -101,6 +102,11 @@ def setup(hass, config):
 class LockDevice(Entity):
     """Representation of a lock."""
 
+    @property
+    def changed_by(self):
+        """Last change triggered by."""
+        return None
+
     # pylint: disable=no-self-use
     @property
     def code_format(self):
@@ -127,6 +133,7 @@ class LockDevice(Entity):
             return None
         state_attr = {
             ATTR_CODE_FORMAT: self.code_format,
+            ATTR_CHANGED_BY: self.changed_by
         }
         return state_attr
 

--- a/homeassistant/components/lock/verisure.py
+++ b/homeassistant/components/lock/verisure.py
@@ -35,6 +35,7 @@ class VerisureDoorlock(LockDevice):
         self._id = device_id
         self._state = STATE_UNKNOWN
         self._digits = int(hub.config.get('code_digits', '4'))
+        self._changed_by = None
 
     @property
     def name(self):
@@ -50,6 +51,11 @@ class VerisureDoorlock(LockDevice):
     def available(self):
         """Return True if entity is available."""
         return hub.available
+
+    @property
+    def changed_by(self):
+        """Last change triggered by."""
+        return self._changed_by
 
     @property
     def code_format(self):
@@ -68,6 +74,7 @@ class VerisureDoorlock(LockDevice):
             _LOGGER.error(
                 'Unknown lock state %s',
                 hub.lock_status[self._id].status)
+        self._changed_by = hub.lock_status[self._id].name
 
     @property
     def is_locked(self):


### PR DESCRIPTION
**Description:**
Add a changed_by attribute to lock component in order to be able to take different actions depending on who unlocked/locked

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
automation:
  - alias: Lock status changed
    trigger:
      - platform: state
        entity_id: lock.lock_1
    action:
      - service: notify.notify
        data_template:
          message: >
            Lock changed from {{ trigger.from_state.state }}
            to {{ trigger.to_state.state }}
            by {{ trigger.to_state.attributes.changed_by }}
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
