### PR TITLE
update pyhomematic to version 0.1.11

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import discovery
 from homeassistant.config import load_yaml_config_file
 
 DOMAIN = 'homematic'
-REQUIREMENTS = ["pyhomematic==0.1.10"]
+REQUIREMENTS = ["pyhomematic==0.1.11"]
 
 HOMEMATIC = None
 HOMEMATIC_LINK_DELAY = 0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -290,7 +290,7 @@ pyenvisalink==1.0
 pyfttt==0.3
 
 # homeassistant.components.homematic
-pyhomematic==0.1.10
+pyhomematic==0.1.11
 
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.9.1


### PR DESCRIPTION
**Description:**
update pyhomematic to version 0.1.11
- add new HM device

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
