### PR TITLE
Add position to zwave rollershutter

### DIFF
--- a/homeassistant/components/rollershutter/command_line.py
+++ b/homeassistant/components/rollershutter/command_line.py
@@ -32,6 +32,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     add_devices_callback(devices)
 
 
+# pylint: disable=abstract-method
 # pylint: disable=too-many-arguments, too-many-instance-attributes
 class CommandRollershutter(RollershutterDevice):
     """Representation a command line roller shutter."""

--- a/homeassistant/components/rollershutter/demo.py
+++ b/homeassistant/components/rollershutter/demo.py
@@ -60,6 +60,14 @@ class DemoRollershutter(RollershutterDevice):
         self._listen()
         self._moving_up = False
 
+    def move_position(self, position, **kwargs):
+        """Move the roller shutter to a specific position."""
+        if self._position == position:
+            return
+
+        self._listen()
+        self._moving_up = position < self._position
+
     def stop(self, **kwargs):
         """Stop the roller shutter."""
         if self._listener is not None:

--- a/homeassistant/components/rollershutter/homematic.py
+++ b/homeassistant/components/rollershutter/homematic.py
@@ -30,6 +30,7 @@ def setup_platform(hass, config, add_callback_devices, discovery_info=None):
                                                      add_callback_devices)
 
 
+# pylint: disable=abstract-method
 class HMRollershutter(homematic.HMDevice, RollershutterDevice):
     """Represents a Homematic Rollershutter in Home Assistant."""
 

--- a/homeassistant/components/rollershutter/mqtt.py
+++ b/homeassistant/components/rollershutter/mqtt.py
@@ -52,6 +52,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     )])
 
 
+# pylint: disable=abstract-method
 # pylint: disable=too-many-arguments, too-many-instance-attributes
 class MqttRollershutter(RollershutterDevice):
     """Representation of a roller shutter that can be controlled using MQTT."""

--- a/homeassistant/components/rollershutter/rfxtrx.py
+++ b/homeassistant/components/rollershutter/rfxtrx.py
@@ -40,6 +40,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         rfxtrx.RECEIVED_EVT_SUBSCRIBERS.append(rollershutter_update)
 
 
+# pylint: disable=abstract-method
 class RfxtrxRollershutter(rfxtrx.RfxtrxDevice, RollershutterDevice):
     """Representation of an rfxtrx roller shutter."""
 

--- a/homeassistant/components/rollershutter/scsgate.py
+++ b/homeassistant/components/rollershutter/scsgate.py
@@ -37,6 +37,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     add_devices_callback(rollershutters)
 
 
+# pylint: disable=abstract-method
 # pylint: disable=too-many-arguments, too-many-instance-attributes
 class SCSGateRollerShutter(RollershutterDevice):
     """Representation of SCSGate rollershutter."""

--- a/homeassistant/components/rollershutter/services.yaml
+++ b/homeassistant/components/rollershutter/services.yaml
@@ -14,6 +14,14 @@ move_down:
       description: Name(s) of roller shutter(s) to move down
       example: 'rollershutter.living_room'
 
+move_position:
+  description: Move to specific position all or specified roller shutter
+
+  fields:
+    position:
+      description: Position of the rollershutter (0 to 100)
+      example: 30
+
 stop:
   description: Stop all or specified roller shutter
 

--- a/homeassistant/components/rollershutter/wink.py
+++ b/homeassistant/components/rollershutter/wink.py
@@ -32,6 +32,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 pywink.get_shades())
 
 
+# pylint: disable=abstract-method
 class WinkRollershutterDevice(WinkDevice, RollershutterDevice):
     """Representation of a Wink rollershutter (shades)."""
 

--- a/homeassistant/components/rollershutter/zwave.py
+++ b/homeassistant/components/rollershutter/zwave.py
@@ -97,6 +97,10 @@ class ZwaveRollershutter(zwave.ZWaveDeviceEntity, RollershutterDevice):
                 self._lozwmgr.pressButton(value.value_id)
                 break
 
+    def move_position(self, position, **kwargs):
+        """Move the roller shutter to a specific position."""
+        self._node.set_dimmer(self._value.value_id, 100 - position)
+
     def stop(self, **kwargs):
         """Stop the roller shutter."""
         for value in self._node.get_values(

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -216,6 +216,7 @@ SERVICE_CLOSE = "close"
 
 SERVICE_MOVE_UP = 'move_up'
 SERVICE_MOVE_DOWN = 'move_down'
+SERVICE_MOVE_POSITION = 'move_position'
 SERVICE_STOP = 'stop'
 
 # #### API / REMOTE ####

--- a/tests/components/rollershutter/test_demo.py
+++ b/tests/components/rollershutter/test_demo.py
@@ -1,0 +1,55 @@
+"""The tests for the Demo roller shutter platform."""
+import unittest
+import homeassistant.util.dt as dt_util
+
+from homeassistant.components.rollershutter import demo
+from tests.common import fire_time_changed, get_test_home_assistant
+
+
+class TestRollershutterDemo(unittest.TestCase):
+    """Test the Demo roller shutter."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_move_up(self):
+        """Test moving the rollershutter up."""
+        entity = demo.DemoRollershutter(self.hass, 'test', 100)
+        entity.move_up()
+
+        fire_time_changed(self.hass, dt_util.utcnow())
+        self.hass.pool.block_till_done()
+        self.assertEqual(90, entity.current_position)
+
+    def test_move_down(self):
+        """Test moving the rollershutter down."""
+        entity = demo.DemoRollershutter(self.hass, 'test', 0)
+        entity.move_down()
+
+        fire_time_changed(self.hass, dt_util.utcnow())
+        self.hass.pool.block_till_done()
+        self.assertEqual(10, entity.current_position)
+
+    def test_move_position(self):
+        """Test moving the rollershutter to a specific position."""
+        entity = demo.DemoRollershutter(self.hass, 'test', 0)
+        entity.move_position(10)
+
+        fire_time_changed(self.hass, dt_util.utcnow())
+        self.hass.pool.block_till_done()
+        self.assertEqual(10, entity.current_position)
+
+    def test_stop(self):
+        """Test stopping the rollershutter."""
+        entity = demo.DemoRollershutter(self.hass, 'test', 0)
+        entity.move_down()
+        entity.stop()
+
+        fire_time_changed(self.hass, dt_util.utcnow())
+        self.hass.pool.block_till_done()
+        self.assertEqual(0, entity.current_position)


### PR DESCRIPTION
This PR adds a "move_position" command to the Zwave rollershutter. With this I am able to set up an automation script to open my shutter only half-way every morning!

_Note:_ I'll submit a PR to the frontend repo soon that exposes this functionality to the UI in the form of a slider but it would still be great if this were merged since it's useful for users to call this as part of an automation.
