### PR TITLE
Expose device specific information in attributes

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -15,13 +15,17 @@ from urllib.parse import urlparse
 import homeassistant.util as util
 import homeassistant.util.color as color_util
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_FLASH, ATTR_RGB_COLOR,
-    ATTR_TRANSITION, ATTR_XY_COLOR, EFFECT_COLORLOOP, EFFECT_RANDOM,
-    FLASH_LONG, FLASH_SHORT, Light)
-from homeassistant.const import CONF_FILENAME, CONF_HOST, DEVICE_DEFAULT_NAME
+    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_FLASH,
+    ATTR_RGB_COLOR, ATTR_TRANSITION, ATTR_XY_COLOR, EFFECT_COLORLOOP,
+    EFFECT_RANDOM, FLASH_LONG, FLASH_SHORT, Light)
+from homeassistant.const import (CONF_FILENAME, CONF_HOST,
+                                 DEVICE_DEFAULT_NAME, ATTR_DEVICE_MANUFACTURER,
+                                 ATTR_DEVICE_MODEL, ATTR_DEVICE_DESCRIPTION,
+                                 ATTR_DEVICE_SERIAL_NUMBER,
+                                 ATTR_DEVICE_VERSION)
 from homeassistant.loader import get_component
 
-REQUIREMENTS = ['phue==0.8']
+REQUIREMENTS = ["phue==0.8"]
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
 
@@ -217,6 +221,22 @@ class HueLight(Light):
     def color_temp(self):
         """Return the CT color value."""
         return self.info['state'].get('ct')
+
+    @property
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
+        return {
+            ATTR_DEVICE_MANUFACTURER: self.info['manufacturername'],
+            ATTR_DEVICE_MODEL: self.info['modelid'],
+            ATTR_DEVICE_DESCRIPTION: self.info['type'],
+            ATTR_DEVICE_SERIAL_NUMBER: self.info['uniqueid'],
+            ATTR_DEVICE_VERSION: self.info['swversion']
+        }
+
+    @property
+    def available(self):
+        """Return true if device is available."""
+        return self.info['state']['reachable']
 
     @property
     def is_on(self):

--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -592,8 +592,3 @@ class ZWaveDeviceEntity:
             attrs[ATTR_DEVICE_VERSION] = version
 
         return attrs
-
-    @property
-    def available(self):
-        """Return true if device is available."""
-        return self._value.node.is_ready

--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -12,8 +12,9 @@ from pprint import pprint
 from homeassistant.helpers import discovery
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL, ATTR_LOCATION, ATTR_ENTITY_ID,
-    CONF_CUSTOMIZE, EVENT_HOMEASSISTANT_START,
-    EVENT_HOMEASSISTANT_STOP)
+    CONF_CUSTOMIZE, EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
+    ATTR_DEVICE_MANUFACTURER, ATTR_DEVICE_MODEL, ATTR_DEVICE_DESCRIPTION,
+    ATTR_DEVICE_VERSION)
 from homeassistant.helpers.event import track_time_change
 from homeassistant.util import convert, slugify
 
@@ -570,4 +571,29 @@ class ZWaveDeviceEntity:
         if location:
             attrs[ATTR_LOCATION] = location
 
+        manufacturer_name = self._value.node.manufacturer_name
+
+        if manufacturer_name:
+            attrs[ATTR_DEVICE_MANUFACTURER] = manufacturer_name
+
+        product_name = self._value.node.product_name
+
+        if product_name:
+            attrs[ATTR_DEVICE_MODEL] = product_name
+
+        device_type = self._value.node.type
+
+        if device_type:
+            attrs[ATTR_DEVICE_DESCRIPTION] = device_type
+
+        version = self._value.node.version
+
+        if version:
+            attrs[ATTR_DEVICE_VERSION] = version
+
         return attrs
+
+    @property
+    def available(self):
+        """Return true if device is available."""
+        return self._value.node.is_ready

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -183,6 +183,21 @@ ATTR_GPS_ACCURACY = 'gps_accuracy'
 # If state is assumed
 ATTR_ASSUMED_STATE = 'assumed_state'
 
+# A device manufacturer
+ATTR_DEVICE_MANUFACTURER = 'device_manufacturer'
+
+# A device model
+ATTR_DEVICE_MODEL = 'device_model'
+
+# A device description
+ATTR_DEVICE_DESCRIPTION = 'device_description'
+
+# A device serial number or other globally unique identifier
+ATTR_DEVICE_SERIAL_NUMBER = 'device_serial_number'
+
+# A device version
+ATTR_DEVICE_VERSION = 'device_version'
+
 # #### SERVICES ####
 SERVICE_HOMEASSISTANT_STOP = "stop"
 SERVICE_HOMEASSISTANT_RESTART = "restart"


### PR DESCRIPTION
**Description:** This PR exposes device specific information like manufacturer and model in an entities attributes.

Here's what a Hue light looks like now:

``` json
{
  "attributes": {
    "device_description": "Extended color light",
    "device_manufacturer": "Philips",
    "device_model": "LCT001",
    "device_serial_number": "00:17:88:01:00:b5:ed:23-0b",
    "device_version": "66013452",
    "friendly_name": "Front Lamp"
  },
  "entity_id": "light.front_lamp",
  "last_changed": "2016-08-09T23:42:20.640885+00:00",
  "last_updated": "2016-08-09T23:42:20.640885+00:00",
  "state": "off"
}
```

And a Z-Wave device:

``` json
{
  "attributes": {
    "battery_level": 100,
    "device_description": "Home Security Sensor",
    "device_manufacturer": "Aeotec",
    "device_model": "MultiSensor 6",
    "device_version": 4,
    "friendly_name": "Living Room MultiSensor Alarm Type",
    "hidden": true,
    "location": "Living Room",
    "node_id": 17
  },
  "entity_id": "sensor.living_room_multisensor_alarm_type_17",
  "last_changed": "2016-08-10T00:26:33.917057+00:00",
  "last_updated": "2016-08-10T00:26:33.917057+00:00",
  "state": "0"
}
```

I'm hoping we can convince platform/component maintainers to add support for this.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
