### PR TITLE
Recorder: Increase size of the entity column in states table

### DIFF
--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -61,7 +61,7 @@ class States(Base):   # type: ignore
     __tablename__ = 'states'
     state_id = Column(Integer, primary_key=True)
     domain = Column(String(64))
-    entity_id = Column(String(64))
+    entity_id = Column(String(255))
     state = Column(String(255))
     attributes = Column(Text)
     event_id = Column(Integer, ForeignKey('events.event_id'))


### PR DESCRIPTION
**Description:**
This increases the size of the entity column in the states table.

I do not have a local setup to test this. Can someone verify that SQLAlchemy will not blow up if the model has a different definition as the table?

CC @rhooper 

**Related issue (if applicable):** fixes #2697 

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.

Fixes https://github.com/home-assistant/home-assistant/issues/2697
