### PR TITLE
Convert numerical values to float (fixes #2767)

### DIFF
--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -131,4 +131,7 @@ class SnmpData(object):
                           errindex and restable[-1][int(errindex) - 1] or '?')
         else:
             for resrow in restable:
-                self.value = resrow[-1]
+                try:
+                    self.value = float(resrow[-1])
+                except (ValueError, TypeError):
+                    self.value = resrow[-1]


### PR DESCRIPTION
**Description:**
Convert return values by a given OID to float if possible.

**Related issue (if applicable):** fixes #2767

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: snmp
    name: SNMP TEST String
    host: demo.snmplabs.com
    community: public
    baseoid: 1.3.6.1.4.1.2021.10.1.3.1
    unit_of_measurement: "load"
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
