### PR TITLE
Show badge icons for forecast/openweathermap

### DIFF
--- a/homeassistant/components/sensor/forecast.py
+++ b/homeassistant/components/sensor/forecast.py
@@ -46,6 +46,19 @@ SENSOR_TYPES = {
     'ozone': ['Ozone', 'DU', 'DU', 'DU', 'DU', 'DU'],
 }
 
+ICONS = {
+    'clear-day': 'mdi:weather-sunny',
+    'clear-night': 'mdi:weather-night',
+    'rain': 'mdi:weather-rainy',
+    'snow': 'mdi:weather-snowy',
+    'sleet': 'mid:weather-snowy-rainy',
+    'wind': 'mdi:weather-windy',
+    'fog': 'mdi:weather-fog',
+    'cloudy': 'mdi:weather-cloudy',
+    'partly-cloudy-day': 'mdi:weather-partlycloudy',
+    'partly-cloudy-night': 'mdi:weather-cloudy',  # Needs night variant
+}
+
 # Return cached results if last scan was less then this time ago.
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=120)
 
@@ -113,6 +126,13 @@ class ForeCastSensor(Entity):
     def state(self):
         """Return the state of the sensor."""
         return self._state
+
+    @property
+    def entity_picture(self):
+        """Return the entity picture to use in the frontend, if any."""
+        if self.type == 'icon' and self._state in ICONS:
+            return ICONS[self._state]
+        return None
 
     @property
     def unit_of_measurement(self):

--- a/tests/components/sensor/test_forecast.py
+++ b/tests/components/sensor/test_forecast.py
@@ -13,7 +13,7 @@ from homeassistant import core as ha
 from tests.common import load_fixture
 
 
-class TestForecastSetup(unittest.TestCase):
+class TestForecast(unittest.TestCase):
     """Test the forecast.io platform."""
 
     def setUp(self):
@@ -59,3 +59,10 @@ class TestForecastSetup(unittest.TestCase):
         forecast.setup_platform(self.hass, self.config, MagicMock())
         self.assertTrue(mock_get_forecast.called)
         self.assertEqual(mock_get_forecast.call_count, 1)
+
+    def test_weather_icons(self):
+        """Test weather icons for frontend display."""
+        icon_entity = forecast.ForeCastSensor(MagicMock(), "icon")
+        for state, icon in forecast.ICONS.items():
+            icon_entity._state = state
+            self.assertEqual(icon_entity.entity_picture, icon)

--- a/tests/components/sensor/test_openweathermap.py
+++ b/tests/components/sensor/test_openweathermap.py
@@ -1,0 +1,38 @@
+"""The tests for the Open Weather Map platform."""
+import unittest
+from unittest.mock import MagicMock
+
+from homeassistant.components.sensor import openweathermap
+
+ICONS = {
+    200: 'mdi:weather-lightning-rainy',
+    211: 'mdi:weather-lightning',
+    300: 'mdi:weather-rainy',
+    500: 'mdi:weather-rainy',
+    502: 'mdi:weather-pouring',
+    511: 'mdi:weather-snowy-rainy',
+    600: 'mdi:weather-snowy',
+    611: 'mdi:weather-snowy-rainy',
+    741: 'mdi:weather-fog',
+    771: 'mdi:weather-windy',
+    800: 'mdi:weather-sunny',
+    801: 'mdi:weather-partlycloudy',
+    804: 'mdi:weather-cloudy',
+    905: 'mdi:weather-windy',
+    906: 'mdi:weather-hail',
+    951: 'mdi:weather-sunny',
+    956: 'mdi:weather-windy',
+    960: 'mdi:weather-lightning',
+}
+
+
+class TestOpenWeatherMap(unittest.TestCase):
+    """Test the Open Weather Map platform."""
+
+    def test_weather_icons(self):
+        """Test weather icons for frontend display."""
+        weather_entity = openweathermap.OpenWeatherMapSensor(
+            MagicMock(), "weather", None)
+        for code, icon in ICONS.items():
+            weather_entity._weather_code = code
+            self.assertEqual(weather_entity.entity_picture, icon)


### PR DESCRIPTION
**Description:**
As described, shows icons for the current weather conditions on the weather/icon badge. The state is still reported as the text summary for automation rules, and can be seen in the more-info dialog.

Requires: https://github.com/home-assistant/home-assistant-polymer/pull/88

**Checklist:**
If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.

**Screenshots:**
![Weather Icons](http://i.imgur.com/JOaivnW.png)
![More Info](http://i.imgur.com/6J2gbKA.png)

Fixes #1027
