### PR TITLE
Removed error log on roku connection error

### DIFF
--- a/homeassistant/components/media_player/roku.py
+++ b/homeassistant/components/media_player/roku.py
@@ -88,7 +88,8 @@ class RokuDevice(MediaPlayerDevice):
                 self.current_app = None
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.ReadTimeout):
-            _LOGGER.error("Unable to connect to roku at %s", self.ip_address)
+
+            pass
 
     def get_source_list(self):
         """Get the list of applications to be used as sources."""


### PR DESCRIPTION
**Description:**
If the Roku is powered off or not on the network it is currently logging an error every 10 seconds. It is not uncommon for the roku to off the network at any given time so logging this is just filling up the logs for no benefit. Once the roku appears on the network again it continues working normally.
