### PR TITLE
Check for existence of system mode on Honeywell thermostats

### DIFF
--- a/homeassistant/components/thermostat/honeywell.py
+++ b/homeassistant/components/thermostat/honeywell.py
@@ -142,7 +142,7 @@ class RoundThermostat(ThermostatDevice):
         if hasattr(self.device, 'system_mode'):
             return self.device.system_mode
         else:
-            return 'undefined'
+            return None
 
     @property
     def is_away_mode_on(self):
@@ -238,7 +238,7 @@ class HoneywellUSThermostat(ThermostatDevice):
         if hasattr(self._device, 'system_mode'):
             return self._device.system_mode
         else:
-            return 'undefined'
+            return None
 
     def set_temperature(self, temperature):
         """Set target temperature."""

--- a/homeassistant/components/thermostat/honeywell.py
+++ b/homeassistant/components/thermostat/honeywell.py
@@ -139,10 +139,7 @@ class RoundThermostat(ThermostatDevice):
     @property
     def operation(self: ThermostatDevice) -> str:
         """Get the current operation of the system."""
-        if hasattr(self.device, 'system_mode'):
-            return self.device.system_mode
-        else:
-            return None
+        return getattr(self.device, 'system_mode', None)
 
     @property
     def is_away_mode_on(self):
@@ -235,10 +232,7 @@ class HoneywellUSThermostat(ThermostatDevice):
     @property
     def operation(self: ThermostatDevice) -> str:
         """Return current operation ie. heat, cool, idle."""
-        if hasattr(self._device, 'system_mode'):
-            return self._device.system_mode
-        else:
-            return None
+        return getattr(self._device, 'system_mode', None)
 
     def set_temperature(self, temperature):
         """Set target temperature."""

--- a/homeassistant/components/thermostat/honeywell.py
+++ b/homeassistant/components/thermostat/honeywell.py
@@ -139,7 +139,10 @@ class RoundThermostat(ThermostatDevice):
     @property
     def operation(self: ThermostatDevice) -> str:
         """Get the current operation of the system."""
-        return self.device.system_mode
+        if hasattr(self.device, 'system_mode'):
+            return self.device.system_mode
+        else:
+            return 'undefined'
 
     @property
     def is_away_mode_on(self):
@@ -148,7 +151,8 @@ class RoundThermostat(ThermostatDevice):
 
     def set_hvac_mode(self: ThermostatDevice, hvac_mode: str) -> None:
         """Set the HVAC mode for the thermostat."""
-        self.device.system_mode = hvac_mode
+        if hasattr(self.device, 'system_mode'):
+            self.device.system_mode = hvac_mode
 
     def turn_away_mode_on(self):
         """Turn away on.
@@ -231,7 +235,10 @@ class HoneywellUSThermostat(ThermostatDevice):
     @property
     def operation(self: ThermostatDevice) -> str:
         """Return current operation ie. heat, cool, idle."""
-        return self._device.system_mode
+        if hasattr(self._device, 'system_mode'):
+            return self._device.system_mode
+        else:
+            return 'undefined'
 
     def set_temperature(self, temperature):
         """Set target temperature."""
@@ -261,4 +268,5 @@ class HoneywellUSThermostat(ThermostatDevice):
 
     def set_hvac_mode(self: ThermostatDevice, hvac_mode: str) -> None:
         """Set the system mode (Cool, Heat, etc)."""
-        self._device.system_mode = hvac_mode
+        if hasattr(self._device, 'system_mode'):
+            self._device.system_mode = hvac_mode


### PR DESCRIPTION
**Description:**
Not all Honeywell thermostats have an HVAC mode (e.g. the ones commonly sold in Germany for district heating). In 0.26 the Honeywell component would fail setting up in that case, this check whether the `system_mode` parameter exists before it does anything with it

**Related issue (if applicable):** extends #2757 

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
