### PR TITLE
Fix unknown unit of measurement for hvac and thermostat component

### DIFF
--- a/homeassistant/components/hvac/zwave.py
+++ b/homeassistant/components/hvac/zwave.py
@@ -120,8 +120,10 @@ class ZWaveHvac(ZWaveDeviceEntity, HvacDevice):
         # Current Temp
         for value in self._node.get_values(
                 class_id=COMMAND_CLASS_SENSOR_MULTILEVEL).values():
-            self._current_temperature = int(value.data)
-            self._unit = value.units
+            if value.command_class == COMMAND_CLASS_SENSOR_MULTILEVEL and \
+               value.label == 'Temperature':
+                self._current_temperature = int(value.data)
+                self._unit = value.units
         # Fan Mode
         for value in self._node.get_values(
                 class_id=COMMAND_CLASS_THERMOSTAT_FAN_MODE).values():

--- a/homeassistant/components/hvac/zwave.py
+++ b/homeassistant/components/hvac/zwave.py
@@ -120,8 +120,7 @@ class ZWaveHvac(ZWaveDeviceEntity, HvacDevice):
         # Current Temp
         for value in self._node.get_values(
                 class_id=COMMAND_CLASS_SENSOR_MULTILEVEL).values():
-            if value.command_class == COMMAND_CLASS_SENSOR_MULTILEVEL and \
-               value.label == 'Temperature':
+            if value.label == 'Temperature':
                 self._current_temperature = int(value.data)
                 self._unit = value.units
         # Fan Mode

--- a/homeassistant/components/thermostat/zwave.py
+++ b/homeassistant/components/thermostat/zwave.py
@@ -91,8 +91,10 @@ class ZWaveThermostat(zwave.ZWaveDeviceEntity, ThermostatDevice):
         # current Temp
         for _, value in self._node.get_values_for_command_class(
                 COMMAND_CLASS_SENSOR_MULTILEVEL).items():
-            self._current_temperature = int(value.data)
-            self._unit = value.units
+            if value.command_class == COMMAND_CLASS_SENSOR_MULTILEVEL and \
+               value.label == 'Temperature':
+                self._current_temperature = int(value.data)
+                self._unit = value.units
 
         # operation state
         for _, value in self._node.get_values(

--- a/homeassistant/components/thermostat/zwave.py
+++ b/homeassistant/components/thermostat/zwave.py
@@ -91,8 +91,7 @@ class ZWaveThermostat(zwave.ZWaveDeviceEntity, ThermostatDevice):
         # current Temp
         for _, value in self._node.get_values_for_command_class(
                 COMMAND_CLASS_SENSOR_MULTILEVEL).items():
-            if value.command_class == COMMAND_CLASS_SENSOR_MULTILEVEL and \
-               value.label == 'Temperature':
+            if value.label == 'Temperature':
                 self._current_temperature = int(value.data)
                 self._unit = value.units
 


### PR DESCRIPTION
**Description:**
Fixes a problem when a thermostat or HVAC device has a humidity instance in the SENSOR_MULTILEVEL commandclass, making the component unable to setup.
This is only specific to devices with humidity readings in this command class.

**Related issue (if applicable):** fixes #
Discussed in gitter chat tonight
