### PR TITLE
Bump to pywemo 0.4.5 - fixes bug with requests 2.11.0

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -10,7 +10,7 @@ from homeassistant.components.discovery import SERVICE_WEMO
 from homeassistant.helpers import discovery
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.4.3']
+REQUIREMENTS = ['pywemo==0.4.5']
 
 DOMAIN = 'wemo'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -377,7 +377,7 @@ pyuserinput==0.1.9
 pyvera==0.2.15
 
 # homeassistant.components.wemo
-pywemo==0.4.3
+pywemo==0.4.5
 
 # homeassistant.components.thermostat.radiotherm
 radiotherm==1.2


### PR DESCRIPTION
**Description:**
This PR upgrades to a new version of pywemo (0.4.5).

Requests 2.11.0 was incompatible with the subscriptions code in pywemo, and this broke pywemo in HA.

This resolves that issue.

0.4.4 contained a contributed fix for Wemo hubs which may help with https://github.com/home-assistant/home-assistant/issues/2650

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/2793

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
