### PR TITLE
Adding Digest Auth for webcam image retrieval

### DIFF
--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -7,8 +7,7 @@ https://home-assistant.io/components/camera.generic/
 import logging
 
 import requests
-from requests.auth import HTTPBasicAuth
-from requests.auth import HTTPDigestAuth
+from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 
 from homeassistant.components.camera import DOMAIN, Camera
 from homeassistant.helpers import validate_config

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -17,6 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 BASIC_AUTHENTICATION = 'basic'
 DIGEST_AUTHENTICATION = 'digest'
 
+
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup a generic IP Camera."""

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -36,7 +36,8 @@ class GenericCamera(Camera):
         """Initialize a generic camera."""
         super().__init__()
         self._name = device_info.get('name', 'Generic Camera')
-        self._authentication = device_info.get('authentication', BASIC_AUTHENTICATION)
+        self._authentication = device_info.get('authentication',
+                                               BASIC_AUTHENTICATION)
         self._username = device_info.get('username')
         self._password = device_info.get('password')
         self._still_image_url = device_info['still_image_url']

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -20,6 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 BASIC_AUTHENTICATION = 'basic'
 DIGEST_AUTHENTICATION = 'digest'
 
+
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup a MJPEG IP Camera."""

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -9,6 +9,7 @@ from contextlib import closing
 
 import requests
 from requests.auth import HTTPBasicAuth
+from requests.auth import HTTPDigestAuth
 
 from homeassistant.components.camera import DOMAIN, Camera
 from homeassistant.helpers import validate_config
@@ -17,6 +18,8 @@ CONTENT_TYPE_HEADER = 'Content-Type'
 
 _LOGGER = logging.getLogger(__name__)
 
+BASIC_AUTHENTICATION = 'basic'
+DIGEST_AUTHENTICATION = 'digest'
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
@@ -36,6 +39,7 @@ class MjpegCamera(Camera):
         """Initialize a MJPEG camera."""
         super().__init__()
         self._name = device_info.get('name', 'Mjpeg Camera')
+        self._authentication = device_info.get('authentication', BASIC_AUTHENTICATION)
         self._username = device_info.get('username')
         self._password = device_info.get('password')
         self._mjpeg_url = device_info['mjpeg_url']
@@ -43,9 +47,12 @@ class MjpegCamera(Camera):
     def camera_stream(self):
         """Return a MJPEG stream image response directly from the camera."""
         if self._username and self._password:
+            if self._authentication == DIGEST_AUTHENTICATION:
+                auth = HTTPDigestAuth(self._username, self._password)
+            else:
+                auth = HTTPBasicAuth(self._username, self._password)
             return requests.get(self._mjpeg_url,
-                                auth=HTTPBasicAuth(self._username,
-                                                   self._password),
+                                auth=auth,
                                 stream=True, timeout=10)
         else:
             return requests.get(self._mjpeg_url, stream=True, timeout=10)

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -8,8 +8,7 @@ import logging
 from contextlib import closing
 
 import requests
-from requests.auth import HTTPBasicAuth
-from requests.auth import HTTPDigestAuth
+from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 
 from homeassistant.components.camera import DOMAIN, Camera
 from homeassistant.helpers import validate_config

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -39,7 +39,8 @@ class MjpegCamera(Camera):
         """Initialize a MJPEG camera."""
         super().__init__()
         self._name = device_info.get('name', 'Mjpeg Camera')
-        self._authentication = device_info.get('authentication', BASIC_AUTHENTICATION)
+        self._authentication = device_info.get('authentication',
+                                               BASIC_AUTHENTICATION)
         self._username = device_info.get('username')
         self._password = device_info.get('password')
         self._mjpeg_url = device_info['mjpeg_url']


### PR DESCRIPTION
**Description:**
Some webcams require digest auth. This patch enables configuration of 'basic' (default) or 'digest' auth.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#781

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
camera:
  platform: mjpeg
  mjpeg_url: http://192.168.23.60/mjpeg/snap.cgi?chn=0
  authentication: digest
  name: my sample camera
  username: admin
  password: password
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
