### PR TITLE
Fix unit log message

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -267,8 +267,9 @@ def process_ha_core_config(hass, config):
         else:
             hac.units = IMPERIAL_SYSTEM
         _LOGGER.warning("Found deprecated temperature unit in core config, "
-                        "expected unit system. Replace 'temperature: %s' with "
-                        "'unit_system: %s'", unit, hac.units.name)
+                        "expected unit system. Replace '%s: %s' with "
+                        "'%s: %s'", CONF_TEMPERATURE_UNIT, unit,
+                        CONF_UNIT_SYSTEM, hac.units.name)
 
     # Shortcut if no auto-detection necessary
     if None not in (hac.latitude, hac.longitude, hac.units,

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -1,10 +1,10 @@
 """YAML utility functions."""
+import glob
 import logging
 import os
 from collections import OrderedDict
 from typing import Union, List, Dict
 
-import glob
 import yaml
 try:
     import keyring


### PR DESCRIPTION
**Description:**
- Use string formatting and pass constant variables as arguments in log
  message to show correct name of config keys.
- Fix import order.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
homeassistant:
  temperature_unit: C
```

**Checklist:**
If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

I get some unrelated errors from pydocstyle during local tox run, from `homeassistant/components/frontend/www_static/home-assistant-polymer/node_modules/polymer-cli/node_modules/web-component-tester/`.
