### PR TITLE
Exit when command_classes are missing thermostat Zwave

### DIFF
--- a/homeassistant/components/thermostat/zwave.py
+++ b/homeassistant/components/thermostat/zwave.py
@@ -51,6 +51,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             if DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_IGNORE:
                 _LOGGER.debug("Remotec ZXT-120 Zwave Thermostat, ignoring")
                 return
+    if not (value.node.get_values_for_command_class(
+            COMMAND_CLASS_SENSOR_MULTILEVEL) and
+            value.node.get_values_for_command_class(
+                COMMAND_CLASS_THERMOSTAT_SETPOINT)):
+        return
 
     add_devices([ZWaveThermostat(value)])
     _LOGGER.debug("discovery_info=%s and zwave.NETWORK=%s",


### PR DESCRIPTION
**Description:**
Make sure essential values are present. Exit if not.
#2820
