### PR TITLE
Fix transition events with zero accuracy.

### DIFF
--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -108,6 +108,31 @@ REGION_LEAVE_INACCURATE_MESSAGE = {
     '_type': 'transition'}
 
 
+REGION_ENTER_ZERO_MESSAGE = {
+    'lon': 1.0,
+    'event': 'enter',
+    'tid': 'user',
+    'desc': 'inner',
+    'wtst': 1,
+    't': 'b',
+    'acc': 0,
+    'tst': 2,
+    'lat': 2.0,
+    '_type': 'transition'}
+
+REGION_LEAVE_ZERO_MESSAGE = {
+    'lon': 10.0,
+    'event': 'leave',
+    'tid': 'user',
+    'desc': 'inner',
+    'wtst': 1,
+    't': 'b',
+    'acc': 0,
+    'tst': 2,
+    'lat': 20.0,
+    '_type': 'transition'}
+
+
 class TestDeviceTrackerOwnTracks(unittest.TestCase):
     """Test the OwnTrack sensor."""
 
@@ -286,6 +311,24 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         self.send_message(EVENT_TOPIC, REGION_LEAVE_INACCURATE_MESSAGE)
 
         # Exit doesn't use inaccurate gps
+        self.assert_location_latitude(2.1)
+        self.assert_location_accuracy(10.0)
+        self.assert_location_state('inner')
+
+        # But does exit region correctly
+        self.assertFalse(owntracks.REGIONS_ENTERED[USER])
+
+    def test_event_entry_exit_zero_accuracy(self):
+        self.send_message(EVENT_TOPIC, REGION_ENTER_ZERO_MESSAGE)
+
+        # Enter uses the zone's gps co-ords
+        self.assert_location_latitude(2.1)
+        self.assert_location_accuracy(10.0)
+        self.assert_location_state('inner')
+
+        self.send_message(EVENT_TOPIC, REGION_LEAVE_ZERO_MESSAGE)
+
+        # Exit doesn't use zero gps
         self.assert_location_latitude(2.1)
         self.assert_location_accuracy(10.0)
         self.assert_location_state('inner')


### PR DESCRIPTION
**Description:**
Zero accuracy checks prevented beacon transitions working properly

**Related issue (if applicable):** fixes #2830

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
