### PR TITLE
Handle accuracy zero correctly in enter/leave events.

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -54,14 +54,14 @@ def setup_scanner(hass, config, see):
             return data
         if max_gps_accuracy is not None and \
                 convert(data.get('acc'), float, 0.0) > max_gps_accuracy:
-            _LOGGER.debug('Skipping %s update because expected GPS '
-                          'accuracy %s is not met: %s',
-                          data_type, max_gps_accuracy, data)
+            _LOGGER.warning('Ignoring %s update because expected GPS '
+                            'accuracy %s is not met: %s',
+                            data_type, max_gps_accuracy, payload)
             return None
         if convert(data.get('acc'), float, 1.0) == 0.0:
-            _LOGGER.debug('Skipping %s update because GPS accuracy'
-                          'is zero',
-                          data_type)
+            _LOGGER.warning('Ignoring %s update because GPS accuracy'
+                            'is zero: %s',
+                            data_type, payload)
             return None
 
         return data
@@ -152,17 +152,20 @@ def setup_scanner(hass, config, see):
                     if 'acc' in data:
                         if data['acc'] == 0.0:
                             valid_gps = False
-                            _LOGGER.info("Zero GPS reported")
+                            _LOGGER.warning(
+                                'Ignoring GPS in region exit because accuracy'
+                                'is zero: %s',
+                                payload)
                         if (max_gps_accuracy is not None and
                                 data['acc'] > max_gps_accuracy):
                             valid_gps = False
-                            _LOGGER.info("Inaccurate GPS reported")
-
+                            _LOGGER.warning(
+                                'Ignoring GPS in region exit because expected '
+                                'GPS accuracy %s is not met: %s',
+                                max_gps_accuracy, payload)
                     if valid_gps:
                         see(**kwargs)
                         see_beacons(dev_id, kwargs)
-                    else:
-                        _LOGGER.info("Inaccurate GPS reported")
 
                 beacons = MOBILE_BEACONS_ACTIVE[dev_id]
                 if location in beacons:

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -29,6 +29,9 @@ LOCK = threading.Lock()
 
 CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
 
+VALIDATE_LOCATION = 'location'
+VALIDATE_TRANSITION = 'transition'
+
 
 def setup_scanner(hass, config, see):
     """Setup an OwnTracks tracker."""
@@ -47,6 +50,8 @@ def setup_scanner(hass, config, see):
                           'because of missing or malformatted data: %s',
                           data_type, data)
             return None
+        if data_type == VALIDATE_TRANSITION:
+            return data
         if max_gps_accuracy is not None and \
                 convert(data.get('acc'), float, 0.0) > max_gps_accuracy:
             _LOGGER.debug('Skipping %s update because expected GPS '
@@ -65,7 +70,7 @@ def setup_scanner(hass, config, see):
         """MQTT message received."""
         # Docs on available data:
         # http://owntracks.org/booklet/tech/json/#_typelocation
-        data = validate_payload(payload, 'location')
+        data = validate_payload(payload, VALIDATE_LOCATION)
         if not data:
             return
 
@@ -86,7 +91,7 @@ def setup_scanner(hass, config, see):
         """MQTT event (geofences) received."""
         # Docs on available data:
         # http://owntracks.org/booklet/tech/json/#_typetransition
-        data = validate_payload(payload, 'transition')
+        data = validate_payload(payload, VALIDATE_TRANSITION)
         if not data:
             return
 
@@ -143,10 +148,17 @@ def setup_scanner(hass, config, see):
                 else:
                     _LOGGER.info("Exit to GPS")
                     # Check for GPS accuracy
-                    if not ('acc' in data and
-                            max_gps_accuracy is not None and
-                            data['acc'] > max_gps_accuracy):
+                    valid_gps = True
+                    if 'acc' in data:
+                        if data['acc'] == 0.0:
+                            valid_gps = False
+                            _LOGGER.info("Zero GPS reported")
+                        if (max_gps_accuracy is not None and
+                                data['acc'] > max_gps_accuracy):
+                            valid_gps = False
+                            _LOGGER.info("Inaccurate GPS reported")
 
+                    if valid_gps:
                         see(**kwargs)
                         see_beacons(dev_id, kwargs)
                     else:

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -108,6 +108,31 @@ REGION_LEAVE_INACCURATE_MESSAGE = {
     '_type': 'transition'}
 
 
+REGION_ENTER_ZERO_MESSAGE = {
+    'lon': 1.0,
+    'event': 'enter',
+    'tid': 'user',
+    'desc': 'inner',
+    'wtst': 1,
+    't': 'b',
+    'acc': 0,
+    'tst': 2,
+    'lat': 2.0,
+    '_type': 'transition'}
+
+REGION_LEAVE_ZERO_MESSAGE = {
+    'lon': 10.0,
+    'event': 'leave',
+    'tid': 'user',
+    'desc': 'inner',
+    'wtst': 1,
+    't': 'b',
+    'acc': 0,
+    'tst': 2,
+    'lat': 20.0,
+    '_type': 'transition'}
+
+
 class TestDeviceTrackerOwnTracks(unittest.TestCase):
     """Test the OwnTrack sensor."""
 
@@ -286,6 +311,24 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         self.send_message(EVENT_TOPIC, REGION_LEAVE_INACCURATE_MESSAGE)
 
         # Exit doesn't use inaccurate gps
+        self.assert_location_latitude(2.1)
+        self.assert_location_accuracy(10.0)
+        self.assert_location_state('inner')
+
+        # But does exit region correctly
+        self.assertFalse(owntracks.REGIONS_ENTERED[USER])
+
+    def test_event_entry_exit_zero_accuracy(self):
+        self.send_message(EVENT_TOPIC, REGION_ENTER_ZERO_MESSAGE)
+
+        # Enter uses the zone's gps co-ords
+        self.assert_location_latitude(2.1)
+        self.assert_location_accuracy(10.0)
+        self.assert_location_state('inner')
+
+        self.send_message(EVENT_TOPIC, REGION_LEAVE_ZERO_MESSAGE)
+
+        # Exit doesn't use zero gps
         self.assert_location_latitude(2.1)
         self.assert_location_accuracy(10.0)
         self.assert_location_state('inner')

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -319,6 +319,7 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         self.assertFalse(owntracks.REGIONS_ENTERED[USER])
 
     def test_event_entry_exit_zero_accuracy(self):
+        """Test entry/exit events with accuracy zero."""
         self.send_message(EVENT_TOPIC, REGION_ENTER_ZERO_MESSAGE)
 
         # Enter uses the zone's gps co-ords


### PR DESCRIPTION
**Description:**
Zero accuracy checks prevented beacon transitions working properly.

**Related issue (if applicable):** fixes #2830 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
