### PR TITLE
check for runtime error during db query

### DIFF
--- a/homeassistant/components/sensor/fastdotcom.py
+++ b/homeassistant/components/sensor/fastdotcom.py
@@ -78,6 +78,8 @@ class SpeedtestSensor(Entity):
                     ).order_by(states.state_id.desc()).limit(1))
             except TypeError:
                 return
+            except RuntimeError:
+                return
             if not last_state:
                 return
             self._state = last_state[0].state

--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -97,6 +97,8 @@ class SpeedtestSensor(Entity):
                     ).order_by(states.state_id.desc()).limit(1))
             except TypeError:
                 return
+            except RuntimeError:
+                return
             if not last_state:
                 return
             self._state = last_state[0].state


### PR DESCRIPTION
**Description:**
Check for the RuntimeError that occurs during db query with no recorder component.

**Related issue (if applicable):** fixes #2829
