### PR TITLE
Add Gravatar support to device_tracker

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -258,7 +258,7 @@ class Device(Entity):
     _state = STATE_NOT_HOME
 
     def __init__(self, hass, consider_home, home_range, track, dev_id, mac,
-                 name=None, picture=None, away_hide=False):
+                 name=None, picture=None, gravatar=None, away_hide=False):
         """Initialize a device."""
         self.hass = hass
         self.entity_id = ENTITY_ID_FORMAT.format(dev_id)
@@ -280,8 +280,8 @@ class Device(Entity):
         self.config_name = name
 
         # Configured picture
-        if picture is not None and "@" in picture:
-            self.config_picture = get_gravatar_for_email(picture)
+        if gravatar is not None:
+            self.config_picture = get_gravatar_for_email(gravatar)
         else:
             self.config_picture = picture
 
@@ -386,6 +386,7 @@ def load_config(path, hass, consider_home, home_range):
             Device(hass, consider_home, home_range, device.get('track', False),
                    str(dev_id).lower(), str(device.get('mac')).upper(),
                    device.get('name'), device.get('picture'),
+                   device.get('gravatar'),
                    device.get(CONF_AWAY_HIDE, DEFAULT_AWAY_HIDE))
             for dev_id, device in load_yaml_config_file(path).items()]
     except HomeAssistantError:

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -280,7 +280,11 @@ class Device(Entity):
         self.config_name = name
 
         # Configured picture
-        self.config_picture = picture
+        if picture is not None and "@" in picture:
+            self.config_picture = get_gravatar_for_email(picture)
+        else:
+            self.config_picture = picture
+
         self.away_hide = away_hide
 
     @property
@@ -425,3 +429,10 @@ def update_config(path, dev_id, device):
                            (CONF_AWAY_HIDE,
                             'yes' if device.away_hide else 'no')):
             out.write('  {}: {}\n'.format(key, '' if value is None else value))
+
+
+def get_gravatar_for_email(email):
+    """Return an 80px Gravatar for the given email address."""
+    import hashlib
+    url = "https://www.gravatar.com/avatar/{}.jpg?s=80&d=wavatar"
+    return url.format(hashlib.md5(email.encode('utf-8').lower()).hexdigest())

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -95,6 +95,27 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         assert config[0].dev_id == 'dev1'
         assert config[0].track
 
+    def test_gravatar(self):
+        """Test the Gravatar generation."""
+        dev_id = 'test'
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), 0, True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', gravatar='test@example.com')
+        gravatar_url = ("https://www.gravatar.com/avatar/"
+                        "55502f40dc8b7c769880b10874abc9d0.jpg?s=80&d=wavatar")
+        self.assertEqual(device.config_picture, gravatar_url)
+
+    def test_gravatar_and_picture(self):
+        """Test that Gravatar overrides picture."""
+        dev_id = 'test'
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), 0, True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
+            gravatar='test@example.com')
+        gravatar_url = ("https://www.gravatar.com/avatar/"
+                        "55502f40dc8b7c769880b10874abc9d0.jpg?s=80&d=wavatar")
+        self.assertEqual(device.config_picture, gravatar_url)
+
     def test_discovery(self):
         """Test discovery."""
         scanner = get_component('device_tracker.test').SCANNER

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -63,7 +63,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         dev_id = 'test'
         device = device_tracker.Device(
             self.hass, timedelta(seconds=180), 0, True, dev_id,
-            'AB:CD:EF:GH:IJ', 'Test name', 'http://test.picture', True)
+            'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
+            away_hide=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
         self.assertTrue(device_tracker.setup(self.hass, {}))
         config = device_tracker.load_config(self.yaml_devices, self.hass,


### PR DESCRIPTION
**Description:** Support passing an email address linked to Gravatar as the picture in known_devices.yaml. If a Gravatar isn't found it will fallback to a randomly generated image that Gravatar supplies.

Thanks to @ngrhd for suggesting it on the [forums](https://community.home-assistant.io/t/pull-avatars-from-gravatars-for-known-devices/3009). I was already using Gravatar but had the URLs hardcoded.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#788

**Example entry for `known_devices.yaml`:**

``` yaml
robbiesiphone:
  name: robbiesiphone
  mac:
  picture: fakeemail@gmail.com
  track: yes
  hide_if_away: no
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
