### PR TITLE
Expose notify platform targets as individual services

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -96,7 +96,7 @@ def setup(hass, config):
             title = template.render(
                 hass, call.data.get(ATTR_TITLE, ATTR_TITLE_DEFAULT))
             if targets.get(call.service) is not None:
-                target = targets[call.service]['target']
+                target = targets[call.service]
             else:
                 target = call.data.get(ATTR_TARGET)
             message = template.render(hass, message)
@@ -113,7 +113,7 @@ def setup(hass, config):
             for name in notify_service.targets.keys():
                 target_name = slugify("{}_{}".format(platform_name_slug,
                                                      name))
-                targets[target_name] = {"target": name}
+                targets[target_name] = name
                 hass.services.register(DOMAIN, target_name,
                                        service_call_handler,
                                        descriptions.get(SERVICE_NOTIFY),

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -109,10 +109,8 @@ def setup(hass, config):
 
         if hasattr(notify_service, 'targets'):
             platform_name = (p_config.get(CONF_NAME) or platform)
-            platform_name_slug = slugify(platform_name)
             for name in notify_service.targets.keys():
-                target_name = slugify("{}_{}".format(platform_name_slug,
-                                                     name))
+                target_name = slugify("{}_{}".format(platform_name, name))
                 targets[target_name] = name
                 hass.services.register(DOMAIN, target_name,
                                        service_call_handler,

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -113,8 +113,7 @@ def setup(hass, config):
             for name in notify_service.get_targets().keys():
                 target_name = slugify("{}_{}".format(platform_name_slug,
                                                      name))
-                targets[target_name] = {"platform": platform_name,
-                                        "target": name}
+                targets[target_name] = {"target": name}
                 hass.services.register(DOMAIN, target_name,
                                        service_call_handler,
                                        descriptions.get(SERVICE_NOTIFY),

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -18,7 +18,6 @@ from homeassistant.const import CONF_NAME, CONF_PLATFORM
 from homeassistant.util import slugify
 
 DOMAIN = "notify"
-GROUP_DOMAIN = "notifygroup"
 
 # Title of notification
 ATTR_TITLE = "title"
@@ -126,18 +125,6 @@ def setup(hass, config):
                                descriptions.get(SERVICE_NOTIFY),
                                schema=NOTIFY_SERVICE_SCHEMA)
         success = True
-
-    def notify_group(group, call):
-        """Notify a group of targets."""
-        for target in group:
-            hass.services.call(DOMAIN, target, call.data)
-
-    if config.get('notifygroups') is not None:
-        for group_name, group in config.get('notifygroups').items():
-            hass.services.register(GROUP_DOMAIN, slugify(group_name),
-                                   partial(notify_group, group),
-                                   descriptions.get(SERVICE_NOTIFY),
-                                   schema=NOTIFY_SERVICE_SCHEMA)
 
     return success
 

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.const import CONF_NAME, CONF_PLATFORM
 from homeassistant.util import slugify
 
 DOMAIN = "notify"
+GROUP_DOMAIN = "notifygroup"
 
 # Title of notification
 ATTR_TITLE = "title"
@@ -131,12 +132,12 @@ def setup(hass, config):
         for target in group:
             hass.services.call(DOMAIN, target, call.data)
 
-    for group_name, group in config.get('notifygroups').items():
-        group_name_slug = "group_{}".format(slugify(group_name))
-        hass.services.register(DOMAIN, group_name_slug,
-                               partial(notify_group, group),
-                               descriptions.get(SERVICE_NOTIFY),
-                               schema=NOTIFY_SERVICE_SCHEMA)
+    if config.get('notifygroups') is not None:
+        for group_name, group in config.get('notifygroups').items():
+            hass.services.register(GROUP_DOMAIN, slugify(group_name),
+                                   partial(notify_group, group),
+                                   descriptions.get(SERVICE_NOTIFY),
+                                   schema=NOTIFY_SERVICE_SCHEMA)
 
     return success
 

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -109,9 +109,9 @@ def setup(hass, config):
 
         if hasattr(notify_service, 'targets'):
             platform_name = (p_config.get(CONF_NAME) or platform)
-            for name in notify_service.targets.keys():
-                target_name = slugify("{}_{}".format(platform_name, name))
-                targets[target_name] = name
+            for target in notify_service.targets:
+                target_name = slugify("{}_{}".format(platform_name, target))
+                targets[target_name] = target
                 hass.services.register(DOMAIN, target_name,
                                        service_call_handler,
                                        descriptions.get(SERVICE_NOTIFY),

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -106,10 +106,10 @@ def setup(hass, config):
                                         data=data)
 
         service_call_handler = partial(notify_message, notify_service)
-        platform_name = (p_config.get(CONF_NAME) or SERVICE_NOTIFY)
-        platform_name_slug = slugify(platform_name)
 
         if hasattr(notify_service, 'targets'):
+            platform_name = (p_config.get(CONF_NAME) or platform)
+            platform_name_slug = slugify(platform_name)
             for name in notify_service.targets.keys():
                 target_name = slugify("{}_{}".format(platform_name_slug,
                                                      name))
@@ -118,6 +118,9 @@ def setup(hass, config):
                                        service_call_handler,
                                        descriptions.get(SERVICE_NOTIFY),
                                        schema=NOTIFY_SERVICE_SCHEMA)
+
+        platform_name = (p_config.get(CONF_NAME) or SERVICE_NOTIFY)
+        platform_name_slug = slugify(platform_name)
 
         hass.services.register(DOMAIN, platform_name_slug,
                                service_call_handler,

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -109,8 +109,8 @@ def setup(hass, config):
         platform_name = (p_config.get(CONF_NAME) or SERVICE_NOTIFY)
         platform_name_slug = slugify(platform_name)
 
-        if hasattr(notify_service, 'get_targets'):
-            for name in notify_service.get_targets().keys():
+        if hasattr(notify_service, 'targets'):
+            for name in notify_service.targets.keys():
                 target_name = slugify("{}_{}".format(platform_name_slug,
                                                      name))
                 targets[target_name] = {"target": name}

--- a/homeassistant/components/notify/demo.py
+++ b/homeassistant/components/notify/demo.py
@@ -22,6 +22,11 @@ class DemoNotificationService(BaseNotificationService):
         """Initialize the service."""
         self.hass = hass
 
+    @property
+    def targets(self):
+        """Return a dictionary of registered targets."""
+        return {"test target": {}}
+
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
         kwargs['message'] = message

--- a/homeassistant/components/notify/demo.py
+++ b/homeassistant/components/notify/demo.py
@@ -25,7 +25,7 @@ class DemoNotificationService(BaseNotificationService):
     @property
     def targets(self):
         """Return a dictionary of registered targets."""
-        return {"test target": {}}
+        return ["test target"]
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -141,7 +141,8 @@ class HTML5NotificationService(BaseNotificationService):
         self._gcm_key = gcm_key
         self.registrations = registrations
 
-    def get_targets(self):
+    @property
+    def targets(self):
         """Return a dictionary of registered targets."""
         return self.registrations
 

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -144,7 +144,7 @@ class HTML5NotificationService(BaseNotificationService):
     @property
     def targets(self):
         """Return a dictionary of registered targets."""
-        return self.registrations
+        return self.registrations.keys()
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -141,6 +141,9 @@ class HTML5NotificationService(BaseNotificationService):
         self._gcm_key = gcm_key
         self.registrations = registrations
 
+    def get_targets(self):
+        return self.registrations
+
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
         from pywebpush import WebPusher

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -142,6 +142,7 @@ class HTML5NotificationService(BaseNotificationService):
         self.registrations = registrations
 
     def get_targets(self):
+        """Return a dictionary of registered targets."""
         return self.registrations
 
     def send_message(self, message="", **kwargs):

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -106,8 +106,7 @@ data_template:
         self.assertIsNotNone(self.hass.services.has_service("notify", service))
 
     def test_messages_to_targets_route(self):
-        """Test that a message to a target routes to the platform with
-        the target attribute correctly filled."""
+        """Test message routing to specific target services."""
         self.hass.bus.listen_once("notify", self.record_calls)
 
         self.hass.services.call("notify", "demo_test_target",

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -102,7 +102,7 @@ data_template:
     def test_targets_are_services(self):
         """Test that all targets are exposed as individual services."""
         self.assertIsNotNone(self.hass.services.has_service("notify", "demo"))
-        service = "notify_test_target"
+        service = "demo_test_target"
         self.assertIsNotNone(self.hass.services.has_service("notify", service))
 
     def test_messages_to_targets_route(self):
@@ -110,7 +110,7 @@ data_template:
         the target attribute correctly filled."""
         self.hass.bus.listen_once("notify", self.record_calls)
 
-        self.hass.services.call("notify", "notify_test_target",
+        self.hass.services.call("notify", "demo_test_target",
                                 {'message': 'my message',
                                  'title': 'my title',
                                  'data': {'hello': 'world'}})
@@ -118,7 +118,7 @@ data_template:
         self.hass.pool.block_till_done()
 
         data = self.calls[0][0].data
-        print("data", data)
+
         assert {
             'message': 'my message',
             'target': 'test target',


### PR DESCRIPTION
**Description:** This PR adds support for creating a service for each target that a platform supports, in addition to retaining the existing one. The use case is for a platform like HTML5 or the upcoming iOS app companion component which both handle their own target registration.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

…that a notification platform supports.
