### PR TITLE
Add a group notify platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -172,6 +172,7 @@ omit =
     homeassistant/components/notify/aws_sns.py
     homeassistant/components/notify/aws_sqs.py
     homeassistant/components/notify/free_mobile.py
+    homeassistant/components/notify/group.py
     homeassistant/components/notify/gntp.py
     homeassistant/components/notify/instapush.py
     homeassistant/components/notify/joaoapps_join.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -172,8 +172,8 @@ omit =
     homeassistant/components/notify/aws_sns.py
     homeassistant/components/notify/aws_sqs.py
     homeassistant/components/notify/free_mobile.py
-    homeassistant/components/notify/group.py
     homeassistant/components/notify/gntp.py
+    homeassistant/components/notify/group.py
     homeassistant/components/notify/instapush.py
     homeassistant/components/notify/joaoapps_join.py
     homeassistant/components/notify/message_bird.py

--- a/homeassistant/components/notify/group.py
+++ b/homeassistant/components/notify/group.py
@@ -19,9 +19,9 @@ CONF_ENTITIES = "entities"
 
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): "group",
-    vol.Optional(CONF_NAME): vol.Coerce(str),
+    vol.Required(CONF_NAME): vol.Coerce(str),
     vol.Required(CONF_ENTITIES): vol.All(cv.ensure_list, [{
-        vol.Optional(CONF_ENTITY_ID): vol.Any(cv.string, None),
+        vol.Required(CONF_ENTITY_ID): vol.Any(cv.string, None),
         vol.Optional(ATTR_DATA): dict,
     }])
 })

--- a/homeassistant/components/notify/group.py
+++ b/homeassistant/components/notify/group.py
@@ -8,21 +8,20 @@ import collections
 import logging
 import voluptuous as vol
 
-from homeassistant.const import (CONF_PLATFORM, CONF_NAME,
-                                 CONF_ENTITY_ID)
+from homeassistant.const import (CONF_PLATFORM, CONF_NAME, ATTR_SERVICE)
 from homeassistant.components.notify import (DOMAIN, ATTR_MESSAGE, ATTR_DATA,
                                              BaseNotificationService)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_ENTITIES = "entities"
+CONF_SERVICES = "services"
 
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): "group",
     vol.Required(CONF_NAME): vol.Coerce(str),
-    vol.Required(CONF_ENTITIES): vol.All(cv.ensure_list, [{
-        vol.Required(CONF_ENTITY_ID): vol.Any(cv.string, None),
+    vol.Required(CONF_SERVICES): vol.All(cv.ensure_list, [{
+        vol.Required(ATTR_SERVICE): vol.Any(cv.string, None),
         vol.Optional(ATTR_DATA): dict,
     }])
 })
@@ -41,7 +40,7 @@ def update(input_dict, update_source):
 
 def get_service(hass, config):
     """Get the Group notification service."""
-    return GroupNotifyPlatform(hass, config.get(CONF_ENTITIES))
+    return GroupNotifyPlatform(hass, config.get(CONF_SERVICES))
 
 
 # pylint: disable=too-few-public-methods
@@ -62,5 +61,5 @@ class GroupNotifyPlatform(BaseNotificationService):
             sending_payload = payload.copy()
             if entity.get(ATTR_DATA) is not None:
                 update(sending_payload, entity.get(ATTR_DATA))
-            self.hass.services.call(DOMAIN, entity.get(CONF_ENTITY_ID),
+            self.hass.services.call(DOMAIN, entity.get(ATTR_SERVICE),
                                     sending_payload)

--- a/homeassistant/components/notify/group.py
+++ b/homeassistant/components/notify/group.py
@@ -21,7 +21,7 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): "group",
     vol.Required(CONF_NAME): vol.Coerce(str),
     vol.Required(CONF_SERVICES): vol.All(cv.ensure_list, [{
-        vol.Required(ATTR_SERVICE): vol.Any(cv.slug),
+        vol.Required(ATTR_SERVICE): cv.slug,
         vol.Optional(ATTR_DATA): dict,
     }])
 })

--- a/homeassistant/components/notify/group.py
+++ b/homeassistant/components/notify/group.py
@@ -21,7 +21,7 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): "group",
     vol.Required(CONF_NAME): vol.Coerce(str),
     vol.Required(CONF_SERVICES): vol.All(cv.ensure_list, [{
-        vol.Required(ATTR_SERVICE): vol.Any(cv.string, None),
+        vol.Required(ATTR_SERVICE): vol.Any(cv.slug),
         vol.Optional(ATTR_DATA): dict,
     }])
 })

--- a/homeassistant/components/notify/group.py
+++ b/homeassistant/components/notify/group.py
@@ -4,6 +4,7 @@ Group platform for notify component.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.group/
 """
+import collections
 import logging
 import voluptuous as vol
 
@@ -25,6 +26,17 @@ PLATFORM_SCHEMA = vol.Schema({
         vol.Optional(ATTR_DATA): dict,
     }])
 })
+
+
+def update(input_dict, update_source):
+    """Deep update a dictionary."""
+    for key, val in update_source.items():
+        if isinstance(val, collections.Mapping):
+            recurse = update(input_dict.get(key, {}), val)
+            input_dict[key] = recurse
+        else:
+            input_dict[key] = update_source[key]
+    return input_dict
 
 
 def get_service(hass, config):
@@ -49,6 +61,6 @@ class GroupNotifyPlatform(BaseNotificationService):
         for entity in self.entities:
             sending_payload = payload.copy()
             if entity.get(ATTR_DATA) is not None:
-                sending_payload.update(entity.get(ATTR_DATA))
+                update(sending_payload, entity.get(ATTR_DATA))
             self.hass.services.call(DOMAIN, entity.get(CONF_ENTITY_ID),
                                     sending_payload)

--- a/homeassistant/components/notify/group.py
+++ b/homeassistant/components/notify/group.py
@@ -1,0 +1,55 @@
+"""
+Group platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.group/
+"""
+import logging
+import voluptuous as vol
+
+from homeassistant.const import (CONF_PLATFORM, CONF_NAME,
+                                 CONF_ENTITY_ID)
+from homeassistant.components.notify import (DOMAIN, ATTR_MESSAGE, ATTR_DATA,
+                                             BaseNotificationService)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ENTITIES = "entities"
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_PLATFORM): "group",
+    vol.Optional(CONF_NAME): vol.Coerce(str),
+    vol.Required(CONF_ENTITIES): vol.All(cv.ensure_list, [{
+        vol.Optional(CONF_ENTITY_ID): vol.Any(cv.string, None),
+        vol.Optional(ATTR_DATA): dict,
+    }])
+})
+
+
+def get_service(hass, config):
+    """Get the Group notification service."""
+    return GroupNotifyPlatform(hass, config.get(CONF_ENTITIES))
+
+
+# pylint: disable=too-few-public-methods
+class GroupNotifyPlatform(BaseNotificationService):
+    """Implement the notification service for the group notify playform."""
+
+    def __init__(self, hass, entities):
+        """Initialize the service."""
+        self.hass = hass
+        self.entities = entities
+
+    def send_message(self, message="", **kwargs):
+        """Send message to all entities in the group."""
+        cleaned_kwargs = dict((k, v) for k, v in kwargs.items() if v)
+        payload = dict({ATTR_MESSAGE: message})
+        payload.update(cleaned_kwargs)
+
+        for entity in self.entities:
+            sending_payload = payload.copy()
+            if entity.get(ATTR_DATA) is not None:
+                sending_payload.update(entity.get(ATTR_DATA))
+            self.hass.services.call(DOMAIN, entity.get(CONF_ENTITY_ID),
+                                    sending_payload)

--- a/homeassistant/components/notify/group.py
+++ b/homeassistant/components/notify/group.py
@@ -43,9 +43,8 @@ class GroupNotifyPlatform(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send message to all entities in the group."""
-        cleaned_kwargs = dict((k, v) for k, v in kwargs.items() if v)
-        payload = dict({ATTR_MESSAGE: message})
-        payload.update(cleaned_kwargs)
+        payload = {ATTR_MESSAGE: message}
+        payload.update({key: val for key, val in kwargs.items() if val})
 
         for entity in self.entities:
             sending_payload = payload.copy()

--- a/tests/components/notify/test_group.py
+++ b/tests/components/notify/test_group.py
@@ -27,9 +27,9 @@ class TestNotifyGroup(unittest.TestCase):
             }
         }))
 
-        self.service = group.get_service(self.hass, {'entities': [
-            {'entity_id': 'demo1'},
-            {'entity_id': 'demo2',
+        self.service = group.get_service(self.hass, {'services': [
+            {'service': 'demo1'},
+            {'service': 'demo2',
              'data': {'target': 'unnamed device',
                       'data': {'test': 'message'}}}]})
 

--- a/tests/components/notify/test_group.py
+++ b/tests/components/notify/test_group.py
@@ -1,4 +1,4 @@
-"""The tests for the notify group platform."""
+"""The tests for the notify.group platform."""
 import unittest
 
 import homeassistant.components.notify as notify
@@ -8,7 +8,7 @@ from tests.common import get_test_home_assistant
 
 
 class TestNotifyGroup(unittest.TestCase):
-    """Test the group notify platform."""
+    """Test the notify.group platform."""
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
@@ -56,7 +56,7 @@ class TestNotifyGroup(unittest.TestCase):
         self.assertEqual(last_event.data[notify.ATTR_MESSAGE], 'Hello')
 
     def test_send_message_with_data(self):
-        """Test sending a message to a notify group."""
+        """Test sending a message with to a notify group."""
         notify_data = {'hello': 'world'}
         self.service.send_message('Hello', title='Test notification',
                                   data=notify_data)
@@ -68,7 +68,7 @@ class TestNotifyGroup(unittest.TestCase):
         self.assertEqual(last_event.data[notify.ATTR_DATA], notify_data)
 
     def test_entity_data_passes_through(self):
-        """Test sending a message to a notify group."""
+        """Test sending a message with data to merge to a notify group."""
         notify_data = {'hello': 'world'}
         self.service.send_message('Hello', title='Test notification',
                                   data=notify_data)

--- a/tests/components/notify/test_group.py
+++ b/tests/components/notify/test_group.py
@@ -1,0 +1,82 @@
+"""The tests for the notify group platform."""
+import unittest
+
+import homeassistant.components.notify as notify
+from homeassistant.components.notify import group
+
+from tests.common import get_test_home_assistant
+
+
+class TestNotifyGroup(unittest.TestCase):
+    """Test the group notify platform."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.events = []
+        self.assertTrue(notify.setup(self.hass, {
+            'notify': {
+                'name': 'demo1',
+                'platform': 'demo'
+            }
+        }))
+        self.assertTrue(notify.setup(self.hass, {
+            'notify': {
+                'name': 'demo2',
+                'platform': 'demo'
+            }
+        }))
+
+        self.service = group.get_service(self.hass, {'entities': [
+            {'entity_id': 'demo1'},
+            {'entity_id': 'demo2',
+             'data': {'target': 'unnamed device',
+                      'data': {'test': 'message'}}}]})
+
+        assert self.service is not None
+
+        def record_event(event):
+            """Record event to send notification."""
+            self.events.append(event)
+
+        self.hass.bus.listen("notify", record_event)
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """"Stop everything that was started."""
+        self.hass.stop()
+
+    def test_send_message_to_group(self):
+        """Test sending a message to a notify group."""
+        self.service.send_message('Hello', title='Test notification')
+        self.hass.pool.block_till_done()
+        self.assertTrue(len(self.events) == 2)
+        last_event = self.events[-1]
+        self.assertEqual(last_event.data[notify.ATTR_TITLE],
+                         'Test notification')
+        self.assertEqual(last_event.data[notify.ATTR_MESSAGE], 'Hello')
+
+    def test_send_message_with_data(self):
+        """Test sending a message to a notify group."""
+        notify_data = {'hello': 'world'}
+        self.service.send_message('Hello', title='Test notification',
+                                  data=notify_data)
+        self.hass.pool.block_till_done()
+        last_event = self.events[-1]
+        self.assertEqual(last_event.data[notify.ATTR_TITLE],
+                         'Test notification')
+        self.assertEqual(last_event.data[notify.ATTR_MESSAGE], 'Hello')
+        self.assertEqual(last_event.data[notify.ATTR_DATA], notify_data)
+
+    def test_entity_data_passes_through(self):
+        """Test sending a message to a notify group."""
+        notify_data = {'hello': 'world'}
+        self.service.send_message('Hello', title='Test notification',
+                                  data=notify_data)
+        self.hass.pool.block_till_done()
+        data = self.events[-1].data
+        assert {
+            'message': 'Hello',
+            'target': 'unnamed device',
+            'title': 'Test notification',
+            'data': {'hello': 'world', 'test': 'message'}
+        } == data


### PR DESCRIPTION
**Description:** This PR adds a new notify platform, `group`, which allows you to send a single notification to multiple destinations.

**Related issue (if applicable):** home-assistant/home-assistant#2837

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#798

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
notify:
  - platform: group
    name: RobbiesDevices
    entities:
      - entity_id: html5
        data:
          target: "unnamed device"
      - entity_id: robbiesgrowl
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
