### PR TITLE
new yahooweather version and fix update function

### DIFF
--- a/homeassistant/components/sensor/yweather.py
+++ b/homeassistant/components/sensor/yweather.py
@@ -13,7 +13,7 @@ from homeassistant.const import (CONF_PLATFORM, TEMP_CELSIUS,
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ["yahooweather==0.6"]
+REQUIREMENTS = ["yahooweather==0.7"]
 
 SENSOR_TYPES = {
     'weather_current': ['Current', None],
@@ -139,6 +139,9 @@ class YahooWeatherSensor(Entity):
     def update(self):
         """Get the latest data from Yahoo! and updates the states."""
         self._data.update()
+        if not self._data.yahoo.RawData:
+            _LOGGER.info("Don't receive weather data from yahoo!")
+            return
 
         # default code for weather image
         self._code = self._data.yahoo.Now["code"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -473,7 +473,7 @@ xbee-helper==0.0.7
 xmltodict==0.10.2
 
 # homeassistant.components.sensor.yweather
-yahooweather==0.6
+yahooweather==0.7
 
 # homeassistant.components.zeroconf
 zeroconf==0.17.6


### PR DESCRIPTION
**Description:**

Update to yahooweather 0.7 to fix a bug with get_woeid with none internet connections. It also fix a bug in platform component if no update is doing

Bugfix for this message:

```
16-08-15 20:37:30 homeassistant.core: BusHandler:Exception doing job
Traceback (most recent call last):
  File "/opt/hass/lib/python3.4/site-packages/homeassistant/core.py", line 852, in job_handler
    func(*args)
  File "/opt/hass/lib/python3.4/site-packages/homeassistant/helpers/event.py", line 179, in pattern_time_change_listener
    action(now)
  File "/opt/hass/lib/python3.4/site-packages/homeassistant/helpers/entity_component.py", line 180, in _update_entity_states
    entity.update_ha_state(True)
  File "/opt/hass/lib/python3.4/site-packages/homeassistant/helpers/entity.py", line 154, in update_ha_state
    self.update()
  File "/opt/hass/lib/python3.4/site-packages/homeassistant/components/sensor/yweather.py", line 144, in update
    self._code = self._data.yahoo.Now["code"]
TypeError: 'NoneType' object is not subscriptabl
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
