### PR TITLE
Add port to validation

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -29,6 +29,8 @@ latitude = vol.All(vol.Coerce(float), vol.Range(min=-90, max=90),
 longitude = vol.All(vol.Coerce(float), vol.Range(min=-180, max=180),
                     msg='invalid longitude')
 sun_event = vol.All(vol.Lower, vol.Any(SUN_EVENT_SUNSET, SUN_EVENT_SUNRISE))
+port = vol.All(vol.Coerce(int), vol.Range(min=1, max=65535),
+               msg='invalid port')
 
 # typing typevar
 T = TypeVar('T')

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -1,3 +1,4 @@
+"""Test validation helpers."""
 from datetime import timedelta
 
 import pytest
@@ -44,6 +45,18 @@ def test_longitude():
             schema(value)
 
     for value in ('-179', 179, '12.34'):
+        schema(value)
+
+
+def test_port():
+    """Test port validation."""
+    schema = vol.Schema(cv.port)
+
+    for value in ('invalid', None, -1, 0, 65536, '-1', '0', '65536', '1.01A'):
+        with pytest.raises(vol.MultipleInvalid):
+            schema(value)
+
+    for value in (1, '1', 65535, '65535', '8080'):
         schema(value)
 
 


### PR DESCRIPTION
**Description:**

:point_up: [16. August 2016 10:18](https://gitter.im/home-assistant/home-assistant/devs?at=57b2cc6f5a4ad610567e6861)

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
