### PR TITLE
Added scale and offset to the Temper component

### DIFF
--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/sensor.temper/
 import logging
 import voluptuous as vol
 
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME, DEVICE_DEFAULT_NAME, TEMP_FAHRENHEIT
 from homeassistant.helpers.entity import Entity
 
@@ -19,11 +20,10 @@ REQUIREMENTS = ['https://github.com/rkabadi/temper-python/archive/'
 CONF_SCALE = 'scale'
 CONF_OFFSET = 'offset'
 
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required('platform'): 'temper',
-    vol.Optional(CONF_NAME): vol.Coerce(str),
-    vol.Optional(CONF_SCALE): vol.Coerce(float),
-    vol.Optional(CONF_OFFSET): vol.Coerce(float)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): vol.Coerce(str),
+    vol.Optional(CONF_SCALE, default=1): vol.Coerce(float),
+    vol.Optional(CONF_OFFSET, default=0): vol.Coerce(float)
 })
 
 
@@ -33,10 +33,10 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     from temperusb.temper import TemperHandler
 
     temp_unit = hass.config.units.temperature_unit
-    name = config.get(CONF_NAME, DEVICE_DEFAULT_NAME)
+    name = config.get(CONF_NAME)
     scaling = {
-        "scale": config.get(CONF_SCALE, 1),
-        "offset": config.get(CONF_OFFSET, 0)
+        "scale": config.get(CONF_SCALE),
+        "offset": config.get(CONF_OFFSET)
     }
     temper_devices = TemperHandler().get_devices()
     add_devices_callback([TemperSensor(dev,

--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -38,7 +38,10 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     temper_devices = TemperHandler().get_devices()
     add_devices_callback([TemperSensor(dev,
                                        temp_unit,
-                                       name if name != DEVICE_DEFAULT_NAME else name + '_' + str(idx), scale, offset)
+                                       name if name != DEVICE_DEFAULT_NAME
+                                       else name + '_' + str(idx),
+                                       scale,
+                                       offset)
                           for idx, dev in enumerate(temper_devices)])
 
 
@@ -74,7 +77,8 @@ class TemperSensor(Entity):
         try:
             format_str = ('fahrenheit' if self.temp_unit == TEMP_FAHRENHEIT
                           else 'celsius')
-            self.current_value = self.scale * self.temper_device.get_temperature(format_str) + self.offset
+            sensor_value = self.temper_device.get_temperature(format_str)
+            self.current_value = self.scale * sensor_value + self.offset
         except IOError:
             _LOGGER.error('Failed to get temperature due to insufficient '
                           'permissions. Try running with "sudo"')

--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -33,27 +33,28 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     temp_unit = hass.config.units.temperature_unit
     name = config.get(CONF_NAME, DEVICE_DEFAULT_NAME)
-    scale = config.get(CONF_SCALE, 1)
-    offset = config.get(CONF_OFFSET, 0)
+    scaling = {
+        "scale": config.get(CONF_SCALE, 1),
+        "offset": config.get(CONF_OFFSET, 0)
+    }
     temper_devices = TemperHandler().get_devices()
     add_devices_callback([TemperSensor(dev,
                                        temp_unit,
                                        name if name != DEVICE_DEFAULT_NAME
                                        else name + '_' + str(idx),
-                                       scale,
-                                       offset)
+                                       scaling)
                           for idx, dev in enumerate(temper_devices)])
 
 
 class TemperSensor(Entity):
     """Representation of a Temper temperature sensor."""
 
-    def __init__(self, temper_device, temp_unit, name, scale, offset):
+    def __init__(self, temper_device, temp_unit, name, scaling):
         """Initialize the sensor."""
         self.temper_device = temper_device
         self.temp_unit = temp_unit
-        self.scale = scale
-        self.offset = offset
+        self.scale = scaling["scale"]
+        self.offset = scaling["offset"]
         self.current_value = None
         self._name = name
 

--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -26,6 +26,7 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Optional(CONF_OFFSET): vol.Coerce(float)
 })
 
+
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the Temper sensors."""

--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -83,7 +83,8 @@ class TemperSensor(Entity):
         try:
             format_str = ('fahrenheit' if self.temp_unit == TEMP_FAHRENHEIT
                           else 'celsius')
-            self.current_value = self.temper_device.get_temperature(format_str)
+            sensor_value = self.temper_device.get_temperature(format_str)
+            self.current_value = round(sensor_value, 1)
         except IOError:
             _LOGGER.error('Failed to get temperature due to insufficient '
                           'permissions. Try running with "sudo"')

--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -13,9 +13,7 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['https://github.com/rkabadi/temper-python/archive/'
-                '3dbdaf2d87b8db9a3cd6e5585fc704537dd2d09b.zip'
-                '#temperusb==1.2.3']
+REQUIREMENTS = ['temperusb==1.5.1']
 
 CONF_SCALE = 'scale'
 CONF_OFFSET = 'offset'
@@ -59,6 +57,12 @@ class TemperSensor(Entity):
         self.current_value = None
         self._name = name
 
+        # set calibration data
+        self.temper_device.set_calibration_data(
+            scale=self.scale,
+            offset=self.offset
+        )
+
     @property
     def name(self):
         """Return the name of the temperature sensor."""
@@ -79,8 +83,7 @@ class TemperSensor(Entity):
         try:
             format_str = ('fahrenheit' if self.temp_unit == TEMP_FAHRENHEIT
                           else 'celsius')
-            sensor_value = self.temper_device.get_temperature(format_str)
-            self.current_value = self.scale * sensor_value + self.offset
+            self.current_value = self.temper_device.get_temperature(format_str)
         except IOError:
             _LOGGER.error('Failed to get temperature due to insufficient '
                           'permissions. Try running with "sudo"')

--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -41,7 +41,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     temper_devices = TemperHandler().get_devices()
     add_devices_callback([TemperSensor(dev,
                                        temp_unit,
-                                       name if name != DEVICE_DEFAULT_NAME
+                                       name if idx == 0
                                        else name + '_' + str(idx),
                                        scaling)
                           for idx, dev in enumerate(temper_devices)])

--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -33,8 +33,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     temp_unit = hass.config.units.temperature_unit
     name = config.get(CONF_NAME)
     scaling = {
-        "scale": config.get(CONF_SCALE),
-        "offset": config.get(CONF_OFFSET)
+        'scale': config.get(CONF_SCALE),
+        'offset': config.get(CONF_OFFSET)
     }
     temper_devices = TemperHandler().get_devices()
     devices = []
@@ -54,8 +54,8 @@ class TemperSensor(Entity):
         """Initialize the sensor."""
         self.temper_device = temper_device
         self.temp_unit = temp_unit
-        self.scale = scaling["scale"]
-        self.offset = scaling["offset"]
+        self.scale = scaling['scale']
+        self.offset = scaling['offset']
         self.current_value = None
         self._name = name
 

--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -26,7 +26,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 # pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Temper sensors."""
     from temperusb.temper import TemperHandler
 
@@ -37,12 +37,14 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         "offset": config.get(CONF_OFFSET)
     }
     temper_devices = TemperHandler().get_devices()
-    add_devices_callback([TemperSensor(dev,
-                                       temp_unit,
-                                       name if idx == 0
-                                       else name + '_' + str(idx),
-                                       scaling)
-                          for idx, dev in enumerate(temper_devices)])
+    devices = []
+
+    for idx, dev in enumerate(temper_devices):
+        if idx != 0:
+            name = name + '_' + str(idx)
+        devices.append(TemperSensor(dev, temp_unit, name, scaling))
+
+    add_devices(devices)
 
 
 class TemperSensor(Entity):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -166,9 +166,6 @@ https://github.com/nkgilley/python-join-api/archive/3e1e849f1af0b4080f551b62270c
 # homeassistant.components.switch.edimax
 https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f3700.zip#pyedimax==0.1
 
-# homeassistant.components.sensor.temper
-temperusb==1.5.1
-
 # homeassistant.components.sensor.gtfs
 https://github.com/robbiet480/pygtfs/archive/00546724e4bbcb3053110d844ca44e2246267dd8.zip#pygtfs==0.1.3
 
@@ -436,6 +433,9 @@ tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
 tellive-py==0.5.2
+
+# homeassistant.components.sensor.temper
+temperusb==1.5.1
 
 # homeassistant.components.sensor.transmission
 # homeassistant.components.switch.transmission

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -167,7 +167,7 @@ https://github.com/nkgilley/python-join-api/archive/3e1e849f1af0b4080f551b62270c
 https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f3700.zip#pyedimax==0.1
 
 # homeassistant.components.sensor.temper
-https://github.com/rkabadi/temper-python/archive/3dbdaf2d87b8db9a3cd6e5585fc704537dd2d09b.zip#temperusb==1.2.3
+temperusb==1.5.1
 
 # homeassistant.components.sensor.gtfs
 https://github.com/robbiet480/pygtfs/archive/00546724e4bbcb3053110d844ca44e2246267dd8.zip#pygtfs==0.1.3


### PR DESCRIPTION
**Description:**
I updated the TEMPer sensor component to allow for fine adjustment of the returned sensor values, as some of these sensors tend to be consistently off ([also described here for example](http://dev-random.net/temper-v1-4-usb-thermometer-temperature-recorder-review/)). Apart from that I added voluptuous checks and cleaned up the naming system.

**Related issue (if applicable):** none

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#791

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor: 
   platform: temper  
   name: 'My TEMPer' 
   scale: 1 
   offset: 0
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
