### PR TITLE
Fixed typo in OS X plist

### DIFF
--- a/homeassistant/scripts/macos/launchd.plist
+++ b/homeassistant/scripts/macos/launchd.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
     <key>Label</key>
-    <string>org.homeassitant</string>
+    <string>org.homeassistant</string>
 
     <key>EnvironmentVariables</key>
     <dict>
@@ -27,10 +27,10 @@
     </dict>
 
     <key>StandardErrorPath</key>
-    <string>/Users/$USER$/Library/Logs/homeassitant.log</string>
+    <string>/Users/$USER$/Library/Logs/homeassistant.log</string>
 
     <key>StandardOutPath</key>
-    <string>/Users/$USER$/Library/Logs/homeassitant.log</string>
+    <string>/Users/$USER$/Library/Logs/homeassistant.log</string>
 
   </dict>
 </plist>


### PR DESCRIPTION
**Description:**
Noticed a typo in the plist file for OS X. It had me running in circles figuring out why I had 2 processes running and why I couldn't find my logs. At least I'm assuming this is a typo ... if not, just ignore :)
