### PR TITLE
Consider core running while starting

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -115,7 +115,7 @@ class HomeAssistant(object):
     @property
     def is_running(self) -> bool:
         """Return if Home Assistant is running."""
-        return self.state == CoreState.running
+        return self.state in (CoreState.starting, CoreState.running)
 
     def start(self) -> None:
         """Start home assistant."""


### PR DESCRIPTION
**Description:**
Consider the core in a running state while it is starting too. After we start firing It is running, just not everything might be up yet.

This will also prevent the frontend from returning a 400 Bad Request while some components are still initializing.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
