### PR TITLE
Added LlamaLab Automate notify platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -176,6 +176,7 @@ omit =
     homeassistant/components/notify/group.py
     homeassistant/components/notify/instapush.py
     homeassistant/components/notify/joaoapps_join.py
+    homeassistant/components/notify/llamalab_automate.py
     homeassistant/components/notify/message_bird.py
     homeassistant/components/notify/nma.py
     homeassistant/components/notify/pushbullet.py

--- a/homeassistant/components/notify/llamalab_automate.py
+++ b/homeassistant/components/notify/llamalab_automate.py
@@ -1,0 +1,49 @@
+"""
+LlamaLab Automate notification service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.llamalab_automate/
+"""
+import logging
+import requests
+
+from homeassistant.components.notify import (
+    DOMAIN, BaseNotificationService)
+from homeassistant.helpers import validate_config
+
+_LOGGER = logging.getLogger(__name__)
+_RESOURCE = 'https://llamalab.com/automate/cloud/message'
+
+
+def get_service(hass, config):
+    """Get the LlamaLab Automate notification service."""
+    if not validate_config({DOMAIN: config},
+                           {DOMAIN: ['secret', 'to']},
+                           _LOGGER):
+        return None
+
+    return AutomateNotificationService(config['secret'], config['to'])
+
+
+# pylint: disable=too-few-public-methods
+class AutomateNotificationService(BaseNotificationService):
+    """Implement the notification service for LlamaLab Automate."""
+
+    def __init__(self, secret, to):
+        """Initialize the service."""
+        self._secret = secret
+        self._to = to
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to a user."""
+        _LOGGER.debug("Sending to: " + str(self._to))
+        data = {
+            "secret": self._secret,
+            "to": self._to,
+            "device": None,
+            "payload": message,
+        }
+
+        response = requests.post(_RESOURCE, json=data)
+        if response.status_code != 200:
+            _LOGGER.error("Error sending message: " + str(response))

--- a/homeassistant/components/notify/llamalab_automate.py
+++ b/homeassistant/components/notify/llamalab_automate.py
@@ -8,21 +8,21 @@ import logging
 import requests
 import voluptuous as vol
 
-from homeassistant.components.notify import BaseNotificationService
-from homeassistant.const import (CONF_API_KEY, CONF_NAME, CONF_PLATFORM)
+from homeassistant.components.notify import (BaseNotificationService,
+                                             PLATFORM_SCHEMA)
+from homeassistant.const import CONF_API_KEY
+from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
-_RESOURCE = 'https://llamalab.com/automate/cloud/message'
 
 CONF_TO = 'to'
 CONF_DEVICE = 'device'
+_RESOURCE = 'https://llamalab.com/automate/cloud/message'
 
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_PLATFORM): "llamalab_automate",
-    vol.Optional(CONF_NAME):  vol.Coerce(str),
-    vol.Required(CONF_API_KEY):  vol.Coerce(str),
-    vol.Required(CONF_TO):  vol.Coerce(str),
-    vol.Optional(CONF_DEVICE, default=""):  vol.Coerce(str),
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY):  cv.string,
+    vol.Required(CONF_TO):  cv.string,
+    vol.Optional(CONF_DEVICE):  cv.string,
 })
 
 
@@ -31,8 +31,6 @@ def get_service(hass, config):
     secret = config.get(CONF_API_KEY)
     recipient = config.get(CONF_TO)
     device = config.get(CONF_DEVICE)
-    if not device:
-        device = None
 
     return AutomateNotificationService(secret, recipient, device)
 

--- a/homeassistant/components/notify/llamalab_automate.py
+++ b/homeassistant/components/notify/llamalab_automate.py
@@ -6,41 +6,54 @@ https://home-assistant.io/components/notify.llamalab_automate/
 """
 import logging
 import requests
+import voluptuous as vol
 
-from homeassistant.components.notify import (
-    DOMAIN, BaseNotificationService)
-from homeassistant.helpers import validate_config
+from homeassistant.components.notify import BaseNotificationService
+from homeassistant.const import (CONF_API_KEY, CONF_NAME, CONF_PLATFORM)
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = 'https://llamalab.com/automate/cloud/message'
 
+CONF_TO = 'to'
+CONF_DEVICE = 'device'
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_PLATFORM): "llamalab_automate",
+    vol.Optional(CONF_NAME):  vol.Coerce(str),
+    vol.Required(CONF_API_KEY):  vol.Coerce(str),
+    vol.Required(CONF_TO):  vol.Coerce(str),
+    vol.Optional(CONF_DEVICE, default=""):  vol.Coerce(str),
+})
+
 
 def get_service(hass, config):
     """Get the LlamaLab Automate notification service."""
-    if not validate_config({DOMAIN: config},
-                           {DOMAIN: ['secret', 'to']},
-                           _LOGGER):
-        return None
+    secret = config.get(CONF_API_KEY)
+    recipient = config.get(CONF_TO)
+    device = config.get(CONF_DEVICE)
+    if not device:
+        device = None
 
-    return AutomateNotificationService(config['secret'], config['to'])
+    return AutomateNotificationService(secret, recipient, device)
 
 
 # pylint: disable=too-few-public-methods
 class AutomateNotificationService(BaseNotificationService):
     """Implement the notification service for LlamaLab Automate."""
 
-    def __init__(self, secret, to):
+    def __init__(self, secret, recipient, device=None):
         """Initialize the service."""
         self._secret = secret
-        self._to = to
+        self._recipient = recipient
+        self._device = device
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        _LOGGER.debug("Sending to: " + str(self._to))
+        _LOGGER.debug("Sending to: %s, %s", self._recipient, str(self._device))
         data = {
             "secret": self._secret,
-            "to": self._to,
-            "device": None,
+            "to": self._recipient,
+            "device": self._device,
             "payload": message,
         }
 


### PR DESCRIPTION
**Description:** This PR adds support for push-notifications to Android Smartphones running LlamaLabs [Automate](https://llamalab.com/automate/). Googles Cloud Messaging Services are used for this. Automate is kind of like Tasker, but with a different approach at creating automations. With this notification platform it's possible to trigger automations on your smartphone.
To use (and test) the service you need to obtain a secret. Get it here: [https://llamalab.com/automate/cloud/](https://llamalab.com/automate/cloud/)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
notify:
  name: automate
  platform: llamalab_automate
  api_key: 1.abcefghijklmnopqrstuvwxyz=
  to: example@gmail.com
  device: SAMSUNG GT-I9515 #optional
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New files were added to `.coveragerc`.
