### PR TITLE
Fix plex sensor username

### DIFF
--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -96,7 +96,7 @@ class PlexSensor(Entity):
         sessions = self._server.sessions()
         now_playing = []
         for sess in sessions:
-            user = sess.user.title if sess.user is not self._na_type else ""
+            user = sess.username if sess.username is not self._na_type else ""
             title = sess.title if sess.title is not self._na_type else ""
             year = sess.year if sess.year is not self._na_type else ""
             now_playing.append((user, "{0} ({1})".format(title, year)))


### PR DESCRIPTION
**Description:**
When plexapi was updated to 2.0.2 the username in the plex sensor broke.  This fixes it.  Thanks @jgissend10

**Related issue (if applicable):** fixes #2862
