### PR TITLE
Update homematic

### DIFF
--- a/homeassistant/components/rollershutter/homematic.py
+++ b/homeassistant/components/rollershutter/homematic.py
@@ -45,8 +45,8 @@ class HMRollershutter(homematic.HMDevice, RollershutterDevice):
             return int((1 - self._hm_get_state()) * 100)
         return None
 
-    def position(self, **kwargs):
-        """Move to a defined position: 0 (closed) and 100 (open)."""
+    def move_position(self, **kwargs):
+        """Move the roller shutter to a specific position."""
         if self.available:
             if ATTR_CURRENT_POSITION in kwargs:
                 position = float(kwargs[ATTR_CURRENT_POSITION])


### PR DESCRIPTION
**Description:**
- use CONFIG_SCHEMA now
- support rollershutter position service

**Related issue (if applicable):** fixes #2800

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
