### PR TITLE
Add url to validation

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -256,6 +256,7 @@ def time_zone(value):
 weekdays = vol.All(ensure_list, [vol.In(WEEKDAYS)])
 
 
+# pylint: disable=no-value-for-parameter
 def url(value: Any) -> str:
     """Validate an URL."""
     url_in = str(value)

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -260,10 +260,9 @@ weekdays = vol.All(ensure_list, [vol.In(WEEKDAYS)])
 def url(value: Any) -> str:
     """Validate an URL."""
     url_in = str(value)
-    url_schema = vol.Schema(vol.Url())
 
     if urlparse(url_in).scheme in ['http', 'https']:
-        return url_schema(url_in)
+        return vol.Schema(vol.Url())(url_in)
 
     raise vol.Invalid('invalid url')
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1,5 +1,6 @@
 """Helpers for config validation using voluptuous."""
 from datetime import timedelta
+from urllib.parse import urlparse
 
 from typing import Any, Union, TypeVar, Callable, Sequence, List, Dict
 
@@ -253,6 +254,17 @@ def time_zone(value):
         'http://en.wikipedia.org/wiki/List_of_tz_database_time_zones')
 
 weekdays = vol.All(ensure_list, [vol.In(WEEKDAYS)])
+
+
+def url(value: Any) -> str:
+    """Validate an URL."""
+    url_in = str(value)
+    url_schema = vol.Schema(vol.Url())
+
+    if urlparse(url_in).scheme in ['http', 'https']:
+        return url_schema(url_in)
+
+    raise vol.Invalid('invalid url')
 
 
 # Validator helpers

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -48,15 +48,30 @@ def test_longitude():
 
 
 def test_port():
-    """Test tcp/udp network port."""
+    """Test TCP/UDP network port."""
     schema = vol.Schema(cv.port)
 
-    for value in('invalid', None, -1, 0, 80000, '81000'):
+    for value in ('invalid', None, -1, 0, 80000, '81000'):
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
 
     for value in ('1000', 21, 24574):
         schema(value)
+
+
+def test_url():
+    """Test URL."""
+    schema = vol.Schema(cv.url)
+
+    for value in ('invalid', None, 100, 'htp://ha.io', 'http//ha.io',
+                  'http://??,**', 'https://??,**'):
+        with pytest.raises(vol.MultipleInvalid):
+            schema(value)
+
+    for value in ('http://localhost', 'https://localhost/test/index.html',
+                  'http://home-assistant.io', 'http://home-assistant.io/test/',
+                  'https://community.home-assistant.io/'):
+        assert schema(value)
 
 
 def test_platform_config():


### PR DESCRIPTION
**Description:**
Shortcut for the validation of URLs. `voluptuous` is using `urllib.parse` to validate an URL but I think that we should be more restrictive and only allow `http`/`https` as `htp` will definitely not lead to a success.

``` python
>>> import voluptuous as vol
>>> vol.Schema(vol.Url())('htp://localhost')
'htp://localhost'
>>> from urllib.parse import urlparse
>>> urlparse('htp://localhost')
ParseResult(scheme='htp', netloc='localhost', path='', params='', query='', fragment='')
```

Schemas for REST/aREST could benefit from this.

**Related issue (if applicable):** fixes #2800 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
