### PR TITLE
Yaml secret fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ config/panels/*
 !config/panels/react.html
 
 tests/testing_config/deps
+tests/testing_config/subFolder/*
 tests/testing_config/home-assistant.log
 
 # Hide sublime text stuff

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ config/panels/*
 !config/panels/react.html
 
 tests/testing_config/deps
-tests/testing_config/subFolder/*
 tests/testing_config/home-assistant.log
 
 # Hide sublime text stuff

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -19,6 +19,7 @@ import homeassistant.config as conf_util
 import homeassistant.core as core
 import homeassistant.loader as loader
 import homeassistant.util.package as pkg_util
+from homeassistant.util.yaml import clear_secret_cache
 from homeassistant.const import EVENT_COMPONENT_LOADED, PLATFORM_FORMAT
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
@@ -308,6 +309,8 @@ def from_config_file(config_path: str,
         config_dict = conf_util.load_yaml_config_file(config_path)
     except HomeAssistantError:
         return None
+    finally:
+        clear_secret_cache()
 
     return from_config_dict(config_dict, hass, enable_log=False,
                             skip_pip=skip_pip)

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -38,7 +38,6 @@ def load_yaml(fname: str) -> Union[List, Dict]:
         with open(fname, encoding='utf-8') as conf_file:
             # If configuration file is empty YAML returns None
             # We convert that to an empty dict
-            _SECRET_CACHE = {}
             return yaml.load(conf_file, Loader=SafeLineLoader) or {}
     except yaml.YAMLError as exc:
         _LOGGER.error(exc)

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -145,7 +145,6 @@ def _env_var_yaml(loader: SafeLineLoader,
 def _secret_yaml(loader: SafeLineLoader,
                  node: yaml.nodes.Node):
     """Load secrets and embed it into the configuration YAML."""
-
     secret_path = os.path.dirname(loader.name)
     if secret_path not in _SECRET_CACHE:
         if os.path.isfile(os.path.join(secret_path, _SECRET_YAML)):

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -49,6 +49,7 @@ def clear_secret_cache() -> None:
     """Clear the secrete cache."""
     __SECRET_CACHE.clear()
 
+
 def _include_yaml(loader: SafeLineLoader,
                   node: yaml.nodes.Node) -> Union[List, Dict]:
     """Load another YAML file and embeds it using the !include tag.

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -149,7 +149,8 @@ def _secret_yaml(loader: SafeLineLoader,
     secret_path = os.path.dirname(loader.name)
     if secret_path not in _SECRET_CACHE:
         if os.path.isfile(os.path.join(secret_path, _SECRET_YAML)):
-            _SECRET_CACHE[secret_path] = load_yaml(os.path.join(secret_path, _SECRET_YAML))
+            _SECRET_CACHE[secret_path] = load_yaml(
+                os.path.join(secret_path, _SECRET_YAML))
             secrets = _SECRET_CACHE[secret_path]
             if 'logger' in secrets:
                 logger = str(secrets['logger']).lower()

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -16,7 +16,7 @@ from homeassistant.exceptions import HomeAssistantError
 _LOGGER = logging.getLogger(__name__)
 _SECRET_NAMESPACE = 'homeassistant'
 _SECRET_YAML = 'secrets.yaml'
-_SECRET_CACHE = {}
+_SECRET_CACHE = {}  # type: Dict
 
 
 # pylint: disable=too-many-ancestors

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -44,6 +44,10 @@ def load_yaml(fname: str) -> Union[List, Dict]:
         raise HomeAssistantError(exc)
 
 
+def clear_secret_cache() -> None:
+    """Clear the secrete cache."""
+    __SECRET_CACHE.clear()
+
 def _include_yaml(loader: SafeLineLoader,
                   node: yaml.nodes.Node) -> Union[List, Dict]:
     """Load another YAML file and embeds it using the !include tag.

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -149,6 +149,7 @@ def _secret_yaml(loader: SafeLineLoader,
         loader._SECRET_CACHE = {}
 
     secret_path = os.path.join(os.path.dirname(loader.name), _SECRET_YAML)
+    print(str(loader._SECRET_CACHE))
     print(secret_path)
     if secret_path not in loader._SECRET_CACHE:
         if os.path.isfile(secret_path):

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -16,7 +16,7 @@ from homeassistant.exceptions import HomeAssistantError
 _LOGGER = logging.getLogger(__name__)
 _SECRET_NAMESPACE = 'homeassistant'
 _SECRET_YAML = 'secrets.yaml'
-_SECRET_CACHE = {}  # type: Dict
+__SECRET_CACHE = {}  # type: Dict
 
 
 # pylint: disable=too-many-ancestors

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -172,7 +172,6 @@ def _secret_yaml(loader: SafeLineLoader,
     secret_path = os.path.dirname(loader.name)
     while os.path.exists(secret_path) and not secret_path == os.path.dirname(
             sys.path[0]):
-        _LOGGER.debug('Checking path %s', secret_path)
         if secret_path not in __SECRET_CACHE:
             __SECRET_CACHE[secret_path] = _load_secret_yaml(secret_path)
         secrets = __SECRET_CACHE[secret_path]

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -147,7 +147,7 @@ def _env_var_yaml(loader: SafeLineLoader,
 
 
 def _load_secret_yaml(secret_path: str) -> Dict:
-    """Loads the secrets yaml from path."""
+    """Load the secrets yaml from path."""
     _LOGGER.debug('Loading %s', os.path.join(secret_path, _SECRET_YAML))
     secrets = {}
     if os.path.isfile(os.path.join(secret_path, _SECRET_YAML)):

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -170,6 +170,8 @@ def _secret_yaml(loader: SafeLineLoader,
         _LOGGER.debug('Secret %s retrieved from secrets.yaml.', node.value)
         return secrets[node.value]
     for sname, sdict in loader._SECRET_CACHE.items():
+        print(str(sname))
+        print(str(sdict))
         if node.value in sdict:
             _LOGGER.debug('Secret %s retrieved from secrets.yaml in other '
                           'folder %s', node.value, sname)

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -194,7 +194,7 @@ def _secret_yaml(loader: SafeLineLoader,
         _LOGGER.debug('Checking path %s', secret_path)
         secrets = _SECRET_CACHE[secret_path]
         if node.value in secrets:
-            _LOGGER.debug('Secret %s retrieved from secrets.yaml in other '
+            _LOGGER.debug('Secret %s retrieved from secrets.yaml in '
                           'folder %s', node.value, secret_path)
             return secrets[node.value]
         secret_path = os.path.abspath(os.path.join(secret_path, '..'))

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -172,9 +172,8 @@ def _secret_yaml(loader: SafeLineLoader,
     secret_path = os.path.dirname(loader.name)
     while os.path.exists(secret_path) and not secret_path == os.path.dirname(
             sys.path[0]):
-        if secret_path not in __SECRET_CACHE:
-            __SECRET_CACHE[secret_path] = _load_secret_yaml(secret_path)
-        secrets = __SECRET_CACHE[secret_path]
+        secrets = __SECRET_CACHE.get(secret_path,
+                                     _load_secret_yaml(secret_path))
         if node.value in secrets:
             _LOGGER.debug('Secret %s retrieved from secrets.yaml in '
                           'folder %s', node.value, secret_path)

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -145,6 +145,24 @@ def _env_var_yaml(loader: SafeLineLoader,
         raise HomeAssistantError(node.value)
 
 
+def _load_secret_yaml(secret_path: str) -> Dict:
+    """Loads the secrets yaml from path."""
+    _LOGGER.debug('Loading %s', os.path.join(secret_path, _SECRET_YAML))
+    secrets = {}
+    if os.path.isfile(os.path.join(secret_path, _SECRET_YAML)):
+        secrets = load_yaml(
+            os.path.join(secret_path, _SECRET_YAML))
+        if 'logger' in secrets:
+            logger = str(secrets['logger']).lower()
+            if logger == 'debug':
+                _LOGGER.setLevel(logging.DEBUG)
+            else:
+                _LOGGER.error("secrets.yaml: 'logger: debug' expected,"
+                              " but 'logger: %s' found", logger)
+            del secrets['logger']
+    return secrets
+
+
 # pylint: disable=protected-access
 def _secret_yaml(loader: SafeLineLoader,
                  node: yaml.nodes.Node):

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -149,6 +149,7 @@ def _secret_yaml(loader: SafeLineLoader,
         loader._SECRET_CACHE = {}
 
     secret_path = os.path.join(os.path.dirname(loader.name), _SECRET_YAML)
+    print(secret_path)
     if secret_path not in loader._SECRET_CACHE:
         if os.path.isfile(secret_path):
             loader._SECRET_CACHE[secret_path] = load_yaml(secret_path)

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -162,7 +162,7 @@ def _secret_yaml(loader: SafeLineLoader,
                                   " but 'logger: %s' found", logger)
                 del secrets['logger']
         else:
-            loader._SECRET_CACHE[secret_path] = None
+            loader._SECRET_CACHE[secret_path] = {}
     secrets = loader._SECRET_CACHE[secret_path]
 
     # Retrieve secret, first from secrets.yaml, then from keyring

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -168,6 +168,12 @@ class TestSecrets(unittest.TestCase):
         self._yaml_path = os.path.join(config_dir,
                                        config_util.YAML_CONFIG_FILE)
         self._secret_path = os.path.join(config_dir, 'secrets.yaml')
+        self._sub_folder_path = os.path.join(config_dir, 'subFolder')
+        if not os.path.exists(self._sub_folder_path):
+            os.makedirs(self._sub_folder_path)
+        self._unrelated_path = os.path.join(config_dir, 'unrelated')
+        if not os.path.exists(self._unrelated_path):
+            os.makedirs(self._unrelated_path)
 
         load_yaml(self._secret_path,
                   'http_pw: pwhttp\n'
@@ -185,7 +191,8 @@ class TestSecrets(unittest.TestCase):
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Clean up secrets."""
-        for path in [self._yaml_path, self._secret_path]:
+        for path in [self._yaml_path, self._secret_path, self._sub_folder_path,
+                     self._unrelated_path]:
             if os.path.isfile(path):
                 os.remove(path)
 

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -166,6 +166,7 @@ class TestSecrets(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Create & load secrets file."""
         config_dir = get_test_config_dir()
+        yaml._SECRET_CACHE = {}
         self._yaml_path = os.path.join(config_dir,
                                        config_util.YAML_CONFIG_FILE)
         self._secret_path = os.path.join(config_dir, 'secrets.yaml')

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -209,6 +209,7 @@ class TestSecrets(unittest.TestCase):
     def test_secrets_from_parent_folder(self):
         """Test loading secrets from parent foler."""
         expected = {'api_password': 'pwhttp'}
+        self._yaml = load_yaml(os.path.join(self._sub_folder_path, 'sub.yaml'),
                                'http:\n'
                                '  api_password: !secret http_pw\n'
                                'component:\n'

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -199,6 +199,22 @@ class TestSecrets(unittest.TestCase):
             'password': 'pw1'}
         self.assertEqual(expected, self._yaml['component'])
 
+    def test_secrets_from_different_folder(self):
+        """Test loading secrets from a different foler."""
+        expected = {'api_password': 'pwhttp'}
+        path = os.path.join(get_test_config_dir(), 'subFolder')
+        if not os.path.exists(path):
+            os.makedirs(path)
+        self._yaml = load_yaml(os.path.join(path, 'sub.yaml'),
+                               'http:\n'
+                               '  api_password: !secret http_pw\n'
+                               'component:\n'
+                               '  username: !secret comp1_un\n'
+                               '  password: !secret comp1_pw\n'
+                               '')
+
+        self.assertEqual(expected, self._yaml['http'])
+
     def test_secrets_keyring(self):
         """Test keyring fallback & get_password."""
         yaml.keyring = None  # Ensure its not there

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -193,9 +193,11 @@ class TestSecrets(unittest.TestCase):
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Clean up secrets."""
-        for path in [self._yaml_path, self._secret_path, self._sub_folder_path,
-                     self._unrelated_path]:
         yaml.SECRET_CACHE = {}
+        for path in [self._yaml_path, self._secret_path,
+                     os.path.join(self._sub_folder_path, 'sub.yaml'),
+                     os.path.join(self._sub_folder_path, yaml._SECRET_YAML),
+                     os.path.join(self._unrelated_path, yaml._SECRET_YAML)]:
             if os.path.isfile(path):
                 os.remove(path)
 

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -195,6 +195,7 @@ class TestSecrets(unittest.TestCase):
         """Clean up secrets."""
         for path in [self._yaml_path, self._secret_path, self._sub_folder_path,
                      self._unrelated_path]:
+        yaml.SECRET_CACHE = {}
             if os.path.isfile(path):
                 os.remove(path)
 

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -169,7 +169,7 @@ class TestSecrets(unittest.TestCase):
         yaml._SECRET_CACHE = {}
         self._yaml_path = os.path.join(config_dir,
                                        config_util.YAML_CONFIG_FILE)
-        self._secret_path = os.path.join(config_dir, 'secrets.yaml')
+        self._secret_path = os.path.join(config_dir, yaml._SECRET_YAML)
         self._sub_folder_path = os.path.join(config_dir, 'subFolder')
         if not os.path.exists(self._sub_folder_path):
             os.makedirs(self._sub_folder_path)

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -206,8 +206,8 @@ class TestSecrets(unittest.TestCase):
             'password': 'pw1'}
         self.assertEqual(expected, self._yaml['component'])
 
-    def test_secrets_from_different_folder(self):
-        """Test loading secrets from a different foler."""
+    def test_secrets_from_parent_folder(self):
+        """Test loading secrets from parent foler."""
         expected = {'api_password': 'pwhttp'}
         path = os.path.join(get_test_config_dir(), 'subFolder')
         if not os.path.exists(path):

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -166,7 +166,7 @@ class TestSecrets(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Create & load secrets file."""
         config_dir = get_test_config_dir()
-        yaml._SECRET_CACHE = {}
+        yaml.clear_secret_cache()
         self._yaml_path = os.path.join(config_dir,
                                        config_util.YAML_CONFIG_FILE)
         self._secret_path = os.path.join(config_dir, yaml._SECRET_YAML)
@@ -193,7 +193,7 @@ class TestSecrets(unittest.TestCase):
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Clean up secrets."""
-        yaml.SECRET_CACHE = {}
+        yaml.clear_secret_cache()
         for path in [self._yaml_path, self._secret_path,
                      os.path.join(self._sub_folder_path, 'sub.yaml'),
                      os.path.join(self._sub_folder_path, yaml._SECRET_YAML),

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -226,8 +226,8 @@ class TestSecrets(unittest.TestCase):
 
     def test_secrets_from_unrelated_fails(self):
         """Test loading secrets from unrelated folder fails."""
-        load_yaml(os.path.join(self._unrelated_path, 'secrets.yaml'),
-                               'test: failure')
+        load_yaml(os.path.join(self._unrelated_path, yaml._SECRET_YAML),
+                  'test: failure')
         with self.assertRaises(HomeAssistantError):
             load_yaml(os.path.join(self._sub_folder_path, 'sub.yaml'),
                       'http:\n'

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -3,6 +3,7 @@ import io
 import unittest
 import os
 import tempfile
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import yaml
 import homeassistant.config as config_util
 from tests.common import get_test_config_dir
@@ -218,6 +219,15 @@ class TestSecrets(unittest.TestCase):
                                '')
 
         self.assertEqual(expected, self._yaml['http'])
+
+    def test_secrets_from_unrelated_fails(self):
+        """Test loading secrets from unrelated folder fails."""
+        load_yaml(os.path.join(self._unrelated_path, 'secrets.yaml'),
+                               'test: failure')
+        with self.assertRaises(HomeAssistantError):
+            load_yaml(os.path.join(self._sub_folder_path, 'sub.yaml'),
+                      'http:\n'
+                      '  api_password: !secret test')
 
     def test_secrets_keyring(self):
         """Test keyring fallback & get_password."""

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -209,10 +209,6 @@ class TestSecrets(unittest.TestCase):
     def test_secrets_from_parent_folder(self):
         """Test loading secrets from parent foler."""
         expected = {'api_password': 'pwhttp'}
-        path = os.path.join(get_test_config_dir(), 'subFolder')
-        if not os.path.exists(path):
-            os.makedirs(path)
-        self._yaml = load_yaml(os.path.join(path, 'sub.yaml'),
                                'http:\n'
                                '  api_password: !secret http_pw\n'
                                'component:\n'

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -224,6 +224,21 @@ class TestSecrets(unittest.TestCase):
 
         self.assertEqual(expected, self._yaml['http'])
 
+    def test_secret_overrides_parent(self):
+        """Test loading current directory secret overrides the parent."""
+        expected = {'api_password': 'override'}
+        load_yaml(os.path.join(self._sub_folder_path, yaml._SECRET_YAML),
+                  'http_pw: override')
+        self._yaml = load_yaml(os.path.join(self._sub_folder_path, 'sub.yaml'),
+                               'http:\n'
+                               '  api_password: !secret http_pw\n'
+                               'component:\n'
+                               '  username: !secret comp1_un\n'
+                               '  password: !secret comp1_pw\n'
+                               '')
+
+        self.assertEqual(expected, self._yaml['http'])
+
     def test_secrets_from_unrelated_fails(self):
         """Test loading secrets from unrelated folder fails."""
         load_yaml(os.path.join(self._unrelated_path, yaml._SECRET_YAML),


### PR DESCRIPTION
**Description:**
Allow YAML secrets to fall back to other `secrets.yaml` files, not just the current loader directory. Current code requires a `secrets.yaml` to be in the same folder that the yaml file being loaded is.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
