### PR TITLE
Fix media player art

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -667,6 +667,7 @@ class MediaPlayerDevice(Entity):
 class MediaPlayerImageView(HomeAssistantView):
     """Media player view to serve an image."""
 
+    requires_auth = False
     url = "/api/media_player_proxy/<entity(domain=media_player):entity_id>"
     name = "api:media_player:image"
 

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -2,6 +2,7 @@
 import unittest
 from unittest.mock import patch
 from homeassistant import bootstrap
+from homeassistant.const import HTTP_HEADER_HA_AUTH
 import homeassistant.components.media_player as mp
 import homeassistant.components.http as http
 
@@ -13,6 +14,8 @@ from tests.common import get_test_home_assistant, get_test_instance_port
 
 SERVER_PORT = get_test_instance_port()
 HTTP_BASE_URL = 'http://127.0.0.1:{}'.format(SERVER_PORT)
+API_PASSWORD = "test1234"
+HA_HEADERS = {HTTP_HEADER_HA_AUTH: API_PASSWORD}
 
 hass = None
 
@@ -26,7 +29,8 @@ def setUpModule():   # pylint: disable=invalid-name
     hass = get_test_home_assistant()
     bootstrap.setup_component(hass, http.DOMAIN, {
         http.DOMAIN: {
-            http.CONF_SERVER_PORT: SERVER_PORT
+            http.CONF_SERVER_PORT: SERVER_PORT,
+            http.CONF_API_PASSWORD: API_PASSWORD,
         },
     })
 


### PR DESCRIPTION
**Description:**
Media player art was not shown when an API password was set.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
