### PR TITLE
Hotfix 026 3

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -667,6 +667,7 @@ class MediaPlayerDevice(Entity):
 class MediaPlayerImageView(HomeAssistantView):
     """Media player view to serve an image."""
 
+    requires_auth = False
     url = "/api/media_player_proxy/<entity(domain=media_player):entity_id>"
     name = "api:media_player:image"
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """Constants used by Home Assistant components."""
 
-__version__ = "0.26.2"
+__version__ = "0.26.3"
 REQUIRED_PYTHON_VER = (3, 4)
 
 PLATFORM_FORMAT = '{}.{}'

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -2,6 +2,7 @@
 import unittest
 from unittest.mock import patch
 from homeassistant import bootstrap
+from homeassistant.const import HTTP_HEADER_HA_AUTH
 import homeassistant.components.media_player as mp
 import homeassistant.components.http as http
 
@@ -13,6 +14,8 @@ from tests.common import get_test_home_assistant, get_test_instance_port
 
 SERVER_PORT = get_test_instance_port()
 HTTP_BASE_URL = 'http://127.0.0.1:{}'.format(SERVER_PORT)
+API_PASSWORD = "test1234"
+HA_HEADERS = {HTTP_HEADER_HA_AUTH: API_PASSWORD}
 
 hass = None
 
@@ -26,7 +29,8 @@ def setUpModule():   # pylint: disable=invalid-name
     hass = get_test_home_assistant()
     bootstrap.setup_component(hass, http.DOMAIN, {
         http.DOMAIN: {
-            http.CONF_SERVER_PORT: SERVER_PORT
+            http.CONF_SERVER_PORT: SERVER_PORT,
+            http.CONF_API_PASSWORD: API_PASSWORD,
         },
     })
 


### PR DESCRIPTION
Media Player cover art would not work when an API password was set. Thanks to @maddox for reporting it and @balloob for the fix.
