### PR TITLE
Bust cache for new media player covers

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -4,6 +4,7 @@ Component to interface with various media players.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/media_player/
 """
+import hashlib
 import logging
 import os
 import requests
@@ -32,7 +33,7 @@ SCAN_INTERVAL = 10
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
-ENTITY_IMAGE_URL = '/api/media_player_proxy/{0}?token={1}'
+ENTITY_IMAGE_URL = '/api/media_player_proxy/{0}?token={1}&cache={2}'
 
 SERVICE_PLAY_MEDIA = 'play_media'
 SERVICE_SELECT_SOURCE = 'select_source'
@@ -645,8 +646,17 @@ class MediaPlayerDevice(Entity):
     @property
     def entity_picture(self):
         """Return image of the media playing."""
-        return None if self.state == STATE_OFF else \
-            ENTITY_IMAGE_URL.format(self.entity_id, self.access_token)
+        if self.state == STATE_OFF:
+            return None
+
+        url = self.media_image_url
+
+        if url is None:
+            return None
+
+        return ENTITY_IMAGE_URL.format(
+            self.entity_id, self.access_token,
+            hashlib.md5(url.encode('utf-8')).hexdigest()[:5])
 
     @property
     def state_attributes(self):


### PR DESCRIPTION
**Description:**
Even after #2879 we are still presented with the problem that the cover art is not being updated because the browser is presented with the same url each time. This PR will use the first 5 characters of the md5 hash of the url. This will cause the browser to refresh the image, but only if the cover has changed.

One potential problem here is what if a media player always serves the same url ? (although, that problem existed before we proxied media player images too)

CC @robbiet480 @maddox 

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
