### PR TITLE
Add voluptuous validation to template sensor.

### DIFF
--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -5,8 +5,10 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.template/
 """
 import logging
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
 
-from homeassistant.components.sensor import ENTITY_ID_FORMAT
+from homeassistant.components.sensor import ENTITY_ID_FORMAT, PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE,
     ATTR_ENTITY_ID, MATCH_ALL)
@@ -14,37 +16,31 @@ from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import Entity, generate_entity_id
 from homeassistant.helpers import template
 from homeassistant.helpers.event import track_state_change
-from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 CONF_SENSORS = 'sensors'
+
+SENSOR_SCHEMA = vol.Schema({
+    vol.Required(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
+    vol.Optional(ATTR_UNIT_OF_MEASUREMENT): cv.string,
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SENSORS): vol.Schema({cv.slug: SENSOR_SCHEMA}),
+})
 
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the template sensors."""
     sensors = []
-    if config.get(CONF_SENSORS) is None:
-        _LOGGER.error("Missing configuration data for sensor platform")
-        return False
 
     for device, device_config in config[CONF_SENSORS].items():
-        if device != slugify(device):
-            _LOGGER.error("Found invalid key for sensor.template: %s. "
-                          "Use %s instead", device, slugify(device))
-            continue
-
-        if not isinstance(device_config, dict):
-            _LOGGER.error("Missing configuration data for sensor %s", device)
-            continue
-
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         unit_of_measurement = device_config.get(ATTR_UNIT_OF_MEASUREMENT)
         state_template = device_config.get(CONF_VALUE_TEMPLATE)
-        if state_template is None:
-            _LOGGER.error(
-                "Missing %s for sensor %s", CONF_VALUE_TEMPLATE, device)
-            continue
 
         entity_ids = device_config.get(ATTR_ENTITY_ID, MATCH_ALL)
 

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -1,5 +1,5 @@
 """The test for the Template sensor platform."""
-import homeassistant.components.sensor as sensor
+import homeassistant.bootstrap as bootstrap
 
 from tests.common import get_test_home_assistant
 
@@ -17,7 +17,7 @@ class TestTemplateSensor:
 
     def test_template(self):
         """Test template."""
-        assert sensor.setup(self.hass, {
+        assert bootstrap.setup_component(self.hass, 'sensor', {
             'sensor': {
                 'platform': 'template',
                 'sensors': {
@@ -39,7 +39,7 @@ class TestTemplateSensor:
 
     def test_template_syntax_error(self):
         """Test templating syntax error."""
-        assert sensor.setup(self.hass, {
+        assert not bootstrap.setup_component(self.hass, 'sensor', {
             'sensor': {
                 'platform': 'template',
                 'sensors': {
@@ -50,15 +50,11 @@ class TestTemplateSensor:
                 }
             }
         })
-
-        self.hass.states.set('sensor.test_state', 'Works')
-        self.hass.pool.block_till_done()
-        state = self.hass.states.get('sensor.test_template_sensor')
-        assert state.state == 'unknown'
+        assert self.hass.states.all() == []
 
     def test_template_attribute_missing(self):
         """Test missing attribute template."""
-        assert sensor.setup(self.hass, {
+        assert bootstrap.setup_component(self.hass, 'sensor', {
             'sensor': {
                 'platform': 'template',
                 'sensors': {
@@ -75,7 +71,7 @@ class TestTemplateSensor:
 
     def test_invalid_name_does_not_create(self):
         """Test invalid name."""
-        assert sensor.setup(self.hass, {
+        assert not bootstrap.setup_component(self.hass, 'sensor', {
             'sensor': {
                 'platform': 'template',
                 'sensors': {
@@ -90,7 +86,7 @@ class TestTemplateSensor:
 
     def test_invalid_sensor_does_not_create(self):
         """Test invalid sensor."""
-        assert sensor.setup(self.hass, {
+        assert not bootstrap.setup_component(self.hass, 'sensor', {
             'sensor': {
                 'platform': 'template',
                 'sensors': {
@@ -102,7 +98,7 @@ class TestTemplateSensor:
 
     def test_no_sensors_does_not_create(self):
         """Test no sensors."""
-        assert sensor.setup(self.hass, {
+        assert not bootstrap.setup_component(self.hass, 'sensor', {
             'sensor': {
                 'platform': 'template'
             }
@@ -111,7 +107,7 @@ class TestTemplateSensor:
 
     def test_missing_template_does_not_create(self):
         """Test missing template."""
-        assert sensor.setup(self.hass, {
+        assert not bootstrap.setup_component(self.hass, 'sensor', {
             'sensor': {
                 'platform': 'template',
                 'sensors': {


### PR DESCRIPTION
**Description:**
This adds voluptuous validation to the template sensor.

My first attempt to use voluptuous - so happy to change, add more tests etc as required.

Once this works OK - I'll add to the the binary_sensor.template and switch.template

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
