### PR TITLE
Ensure Slack messages appear as correct user

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -52,6 +52,6 @@ class SlackNotificationService(BaseNotificationService):
 
         channel = kwargs.get('target') or self._default_channel
         try:
-            self.slack.chat.post_message(channel, message)
+            self.slack.chat.post_message(channel, message, as_user=True)
         except slacker.Error:
             _LOGGER.exception("Could not send slack notification")


### PR DESCRIPTION
**Description:**

Current documentation suggests to use personal API tokens. This isn't
ideal because for a few reasons:
- messages will come as your own user, so it's hard to tell it's coming
  from hass
- it's harder to manage if multiple people are using Slack and home
- assistant, since you'd have to coordinate rolling of it

It is possible to use Slack bot users already. Just make a new one from https://your-team.slack.com/apps/build/custom-integration, and use the token for that. You can even add an icon from the web frontend for home assistant.

However, the message will appear as a bot without a name or icon. This pull requests fixes this by passing the as_user parameter, which uses the bot user's name and icon.

One caveat is you need to invite the bot user into the room you want to
post to. This probably was an issue before though.

:tophat: to @jnewland who pointed me to this in his branch

**Related issue (if applicable):** fixes comment in https://github.com/home-assistant/home-assistant/pull/236#issuecomment-166755650

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
