### PR TITLE
adding pull mode and relay time for you garage door

### DIFF
--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -56,8 +56,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiGPIOGarageDoor(GarageDoorDevice):
     """Representation of a Raspberry garage door."""
 
-    def __init__(self, name, relay_pin, state_pin, 
-    state_pull_mode, relay_time):# pylint: disable=too-many-arguments
+    def __init__(self, name, relay_pin, state_pin,
+                                        state_pull_mode, relay_time):# pylint: disable=too-many-arguments
         """Initialize the garage door."""
         self._name = name
         self._state = False

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -52,6 +52,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                        relay_time))
     add_devices(doors)
 
+
 class RPiGPIOGarageDoor(GarageDoorDevice):
     """Representation of a Raspberry garage door."""
 

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -55,8 +55,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 class RPiGPIOGarageDoor(GarageDoorDevice):
     """Representation of a Raspberry garage door."""
-
-    def __init__(self, name, relay_pin, state_pin,  # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments
+    def __init__(self, name, relay_pin, state_pin,
                  state_pull_mode, relay_time):
         """Initialize the garage door."""
         self._name = name

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -56,8 +56,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiGPIOGarageDoor(GarageDoorDevice):
     """Representation of a Raspberry garage door."""
 
-    def __init__(self, name, relay_pin, state_pin,
-                 state_pull_mode, relay_time):  # pylint: disable=too-many-arguments
+    def __init__(self, name, relay_pin, state_pin,  # pylint: disable=too-many-arguments
+                 state_pull_mode, relay_time):
         """Initialize the garage door."""
         self._name = name
         self._state = False

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -56,8 +56,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiGPIOGarageDoor(GarageDoorDevice):
     """Representation of a Raspberry garage door."""
 
-    def __init__(self, name, relay_pin, state_pin,
-                                        state_pull_mode, relay_time):# pylint: disable=too-many-arguments
+    def __init__(self, name, relay_pin, state_pin, state_pull_mode, relay_time):# pylint: disable=too-many-arguments
         """Initialize the garage door."""
         self._name = name
         self._state = False

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -44,7 +44,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the garage door platform."""
     doors = []
     doors_conf = config.get('doors')
-    
+
     for door in doors_conf:
         doors.append(RPiGPIOGarageDoor(door['name'], door['relay_pin'],
                                        door['state_pin'],

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -56,7 +56,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiGPIOGarageDoor(GarageDoorDevice):
     """Representation of a Raspberry garage door."""
 
-    def __init__(self, name, relay_pin, state_pin, state_pull_mode, relay_time):# pylint: disable=too-many-arguments
+    def __init__(self, name, relay_pin, state_pin,
+                                       state_pull_mode, relay_time):  # pylint: disable=too-many-arguments
         """Initialize the garage door."""
         self._name = name
         self._state = False

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -56,8 +56,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiGPIOGarageDoor(GarageDoorDevice):
     """Representation of a Raspberry garage door."""
 
-    def __init__(self, name, relay_pin, state_pin,
-                                       state_pull_mode, relay_time):  # pylint: disable=too-many-arguments
+    def __init__(self, name, relay_pin, state_pin, state_pull_mode, relay_time):  # pylint: disable=too-many-arguments
         """Initialize the garage door."""
         self._name = name
         self._state = False

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -37,7 +37,7 @@ PLATFORM_SCHEMA = vol.Schema({
     'platform': str,
     vol.Required('doors'): _DOORS_SCHEMA,
     vol.Optional(STATE_PULL_MODE, default=DEFAULT_PULL_MODE): cv.string,
-    vol.Optional(RELAY_TIME, default=DEFAULT_RELAY_TIME): cv.string,
+    vol.Optional(RELAY_TIME, default=DEFAULT_RELAY_TIME): vol.Coerce(int),
 })
 
 

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -56,7 +56,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiGPIOGarageDoor(GarageDoorDevice):
     """Representation of a Raspberry garage door."""
 
-    def __init__(self, name, relay_pin, state_pin, state_pull_mode, relay_time):  # pylint: disable=too-many-arguments
+    def __init__(self, name, relay_pin, state_pin,
+                 state_pull_mode, relay_time):  # pylint: disable=too-many-arguments
         """Initialize the garage door."""
         self._name = name
         self._state = False

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -29,7 +29,7 @@ _DOORS_SCHEMA = vol.All(
             'relay_pin': int,
             'relay_time': int,
             'state_pin': int,
-	    'state_pull_mode': str,
+            'state_pull_mode': str,
         })
     ]
 )
@@ -48,7 +48,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     relay_time = config.get('relay_time', DEFAULT_RELAY_TIME)
     for door in doors_conf:
         doors.append(RPiGPIOGarageDoor(door['name'], door['relay_pin'],
-                                       door['state_pin'], door['state_pull_mode'], door['relay_time']))
+                                       door['state_pin'], 
+                                       door['state_pull_mode'],
+                                       door['relay_time']))
     add_devices(doors)
 
 

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -15,7 +15,9 @@ from homeassistant.components.garage_door import GarageDoorDevice
 import homeassistant.components.rpi_gpio as rpi_gpio
 import homeassistant.helpers.config_validation as cv
 
-DEFAULT_PULL_MODE = "UP"
+RELAY_TIME = 'relay_time'
+STATE_PULL_MODE = 'state_pull_mode'
+DEFAULT_PULL_MODE = 'UP'
 DEFAULT_RELAY_TIME = .2
 DEPENDENCIES = ['rpi_gpio']
 
@@ -34,14 +36,16 @@ _DOORS_SCHEMA = vol.All(
 PLATFORM_SCHEMA = vol.Schema({
     'platform': str,
     vol.Required('doors'): _DOORS_SCHEMA,
+    vol.Optional(STATE_PULL_MODE, default=DEFAULT_PULL_MODE): cv.string,
+    vol.Optional(RELAY_TIME, default=DEFAULT_RELAY_TIME): cv.string,
 })
 
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the garage door platform."""
-    relay_time = config.get('relay_time', DEFAULT_RELAY_TIME)
-    state_pull_mode = config.get('state_pull_mode', DEFAULT_PULL_MODE)
+    relay_time = config.get(RELAY_TIME)
+    state_pull_mode = config.get(STATE_PULL_MODE)
     doors = []
     doors_conf = config.get('doors')
 

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -42,14 +42,17 @@ PLATFORM_SCHEMA = vol.Schema({
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the garage door platform."""
+    
+    relay_time = config.get('relay_time', DEFAULT_RELAY_TIME)
+    state_pull_mode = config.get('state_pull_mode', DEFAULT_PULL_MODE)
     doors = []
     doors_conf = config.get('doors')
 
     for door in doors_conf:
         doors.append(RPiGPIOGarageDoor(door['name'], door['relay_pin'],
                                        door['state_pin'],
-                                       door['state_pull_mode'],
-                                       door['relay_time']))
+                                       state_pull_mode,
+                                       relay_time))
     add_devices(doors)
 
 class RPiGPIOGarageDoor(GarageDoorDevice):

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -27,9 +27,7 @@ _DOORS_SCHEMA = vol.All(
         vol.Schema({
             'name': str,
             'relay_pin': int,
-            'relay_time': int,
             'state_pin': int,
-            'state_pull_mode': str,
         })
     ]
 )
@@ -42,7 +40,6 @@ PLATFORM_SCHEMA = vol.Schema({
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the garage door platform."""
-    
     relay_time = config.get('relay_time', DEFAULT_RELAY_TIME)
     state_pull_mode = config.get('state_pull_mode', DEFAULT_PULL_MODE)
     doors = []

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -56,7 +56,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiGPIOGarageDoor(GarageDoorDevice):
     """Representation of a Raspberry garage door."""
 
-    def __init__(self, name, relay_pin, state_pin, state_pull_mode, relay_time):
+    def __init__(self, name, relay_pin, state_pin, 
+    state_pull_mode, relay_time):# pylint: disable=too-many-arguments
         """Initialize the garage door."""
         self._name = name
         self._state = False

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -44,11 +44,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the garage door platform."""
     doors = []
     doors_conf = config.get('doors')
-    state_pull_mode = config.get('state_pull_mode', DEFAULT_PULL_MODE)
-    relay_time = config.get('relay_time', DEFAULT_RELAY_TIME)
+    
     for door in doors_conf:
         doors.append(RPiGPIOGarageDoor(door['name'], door['relay_pin'],
-                                       door['state_pin'], 
+                                       door['state_pin'],
                                        door['state_pull_mode'],
                                        door['relay_time']))
     add_devices(doors)

--- a/homeassistant/components/garage_door/rpi_gpio.py
+++ b/homeassistant/components/garage_door/rpi_gpio.py
@@ -52,9 +52,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                        door['relay_time']))
     add_devices(doors)
 
-
 class RPiGPIOGarageDoor(GarageDoorDevice):
     """Representation of a Raspberry garage door."""
+
     # pylint: disable=too-many-arguments
     def __init__(self, name, relay_pin, state_pin,
                  state_pull_mode, relay_time):


### PR DESCRIPTION
**Description:**
I have added configuration options for the state pin being either up or down and also added relay time on configuration if you need the relay on for longer than .2 seconds.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

https://github.com/home-assistant/home-assistant.io/pull/803

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
see documentation PR
```

home-assistant/home-assistant.io#803

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
