### PR TITLE
Update dht sensor dependency Adafruit_DHT to v1.3.0

### DIFF
--- a/homeassistant/components/sensor/dht.py
+++ b/homeassistant/components/sensor/dht.py
@@ -13,9 +13,9 @@ from homeassistant.util import Throttle
 from homeassistant.util.temperature import celsius_to_fahrenheit
 
 # Update this requirement to upstream as soon as it supports Python 3.
-REQUIREMENTS = ['http://github.com/mala-zaba/Adafruit_Python_DHT/archive/'
-                '4101340de8d2457dd194bca1e8d11cbfc237e919.zip'
-                '#Adafruit_DHT==1.1.0']
+REQUIREMENTS = ['http://github.com/adafruit/Adafruit_Python_DHT/archive/'
+                '310c59b0293354d07d94375f1365f7b9b9110c7d.zip'
+                '#Adafruit_DHT==1.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 SENSOR_TYPES = {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -113,7 +113,7 @@ heatmiserV3==0.9.1
 hikvision==0.4
 
 # homeassistant.components.sensor.dht
-# http://github.com/mala-zaba/Adafruit_Python_DHT/archive/4101340de8d2457dd194bca1e8d11cbfc237e919.zip#Adafruit_DHT==1.1.0
+# http://github.com/adafruit/Adafruit_Python_DHT/archive/310c59b0293354d07d94375f1365f7b9b9110c7d.zip#Adafruit_DHT==1.3.0
 
 # homeassistant.components.light.flux_led
 https://github.com/Danielhiversen/flux_led/archive/0.6.zip#flux_led==0.6


### PR DESCRIPTION
**Description:**
The repository already merged the pull request adding python3 support.
root is no longer required to use the gpio.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#805

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

Signed-off-by: Roi Dayan roi.dayan@gmail.com
