### PR TITLE
Use voluptuous for blinkstick

### DIFF
--- a/homeassistant/components/light/blinksticklight.py
+++ b/homeassistant/components/light/blinksticklight.py
@@ -6,26 +6,37 @@ https://home-assistant.io/components/light.blinksticklight/
 """
 import logging
 
+import voluptuous as vol
+
 from homeassistant.components.light import (ATTR_RGB_COLOR, SUPPORT_RGB_COLOR,
-                                            Light)
+                                            Light, PLATFORM_SCHEMA)
+from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
+
+CONF_SERIAL = 'serial'
+DEFAULT_NAME = 'Blinkstick'
+REQUIREMENTS = ["blinkstick==1.1.8"]
+SUPPORT_BLINKSTICK = SUPPORT_RGB_COLOR
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SERIAL): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
 
 _LOGGER = logging.getLogger(__name__)
 
 
-REQUIREMENTS = ["blinkstick==1.1.7"]
-
-
-SUPPORT_BLINKSTICK = SUPPORT_RGB_COLOR
-
-
 # pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Add device specified by serial number."""
     from blinkstick import blinkstick
 
-    stick = blinkstick.find_by_serial(config['serial'])
+    name = config.get(CONF_NAME)
+    serial = config.get(CONF_SERIAL)
 
-    add_devices_callback([BlinkStickLight(stick, config['name'])])
+    stick = blinkstick.find_by_serial(serial)
+
+    add_devices([BlinkStickLight(stick, name)])
 
 
 class BlinkStickLight(Light):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -35,7 +35,7 @@ apcaccess==0.0.4
 astral==1.2
 
 # homeassistant.components.light.blinksticklight
-blinkstick==1.1.7
+blinkstick==1.1.8
 
 # homeassistant.components.sensor.bitcoin
 blockchain==1.3.3


### PR DESCRIPTION
**Description:**
Migrate the configuration of Blinkstick devices to voluptuous. Feedback would be welcome because this also upgrade to the latest release of the dependency.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
light:
  platform: blinksticklight
  serial: BS000795-1.1
  name: Living Room
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
