### PR TITLE
Clean-up, ordering, constants, and extend of schema

### DIFF
--- a/homeassistant/components/sensor/cpuspeed.py
+++ b/homeassistant/components/sensor/cpuspeed.py
@@ -13,13 +13,16 @@ from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
+REQUIREMENTS = ['py-cpuinfo==0.2.3']
+
 _LOGGER = logging.getLogger(__name__)
+
 ATTR_BRAND = 'Brand'
 ATTR_HZ = 'GHz Advertised'
 ATTR_VENDOR = 'Vendor ID'
+
 DEFAULT_NAME = 'CPU speed'
 ICON = 'mdi:pulse'
-REQUIREMENTS = ['py-cpuinfo==0.2.3']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/homeassistant/components/sensor/cpuspeed.py
+++ b/homeassistant/components/sensor/cpuspeed.py
@@ -13,19 +13,17 @@ from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['py-cpuinfo==0.2.3']
-
-DEFAULT_NAME = 'CPU speed'
-ATTR_VENDOR = 'Vendor ID'
+_LOGGER = logging.getLogger(__name__)
 ATTR_BRAND = 'Brand'
 ATTR_HZ = 'GHz Advertised'
+ATTR_VENDOR = 'Vendor ID'
+DEFAULT_NAME = 'CPU speed'
 ICON = 'mdi:pulse'
+REQUIREMENTS = ['py-cpuinfo==0.2.3']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
-
-_LOGGER = logging.getLogger(__name__)
 
 
 # pylint: disable=unused-variable

--- a/homeassistant/components/sensor/deutsche_bahn.py
+++ b/homeassistant/components/sensor/deutsche_bahn.py
@@ -15,12 +15,16 @@ from homeassistant.util import Throttle
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
 
+REQUIREMENTS = ['schiene==0.17']
+
 _LOGGER = logging.getLogger(__name__)
+
 CONF_DESTINATION = 'to'
 CONF_START = 'from'
+
 ICON = 'mdi:train'
+
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=120)
-REQUIREMENTS = ['schiene==0.17']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DESTINATION): cv.string,

--- a/homeassistant/components/sensor/deutsche_bahn.py
+++ b/homeassistant/components/sensor/deutsche_bahn.py
@@ -15,21 +15,17 @@ from homeassistant.util import Throttle
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['schiene==0.17']
-
-CONF_START = 'from'
-CONF_DESTINATION = 'to'
-ICON = 'mdi:train'
-
 _LOGGER = logging.getLogger(__name__)
+CONF_DESTINATION = 'to'
+CONF_START = 'from'
+ICON = 'mdi:train'
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=120)
+REQUIREMENTS = ['schiene==0.17']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DESTINATION): cv.string,
     vol.Required(CONF_START): cv.string,
 })
-
-# Return cached results if last scan was less then this time ago.
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=120)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/dweet.py
+++ b/homeassistant/components/sensor/dweet.py
@@ -18,10 +18,11 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers import template
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['dweepy==0.2.0']
-
+_LOGGER = logging.getLogger(__name__)
 CONF_DEVICE = 'device'
 DEFAULT_NAME = 'Dweet.io Sensor'
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
+REQUIREMENTS = ['dweepy==0.2.0']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DEVICE): cv.string,
@@ -29,11 +30,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
 })
-
-_LOGGER = logging.getLogger(__name__)
-
-# Return cached results if last scan was less then this time ago.
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
 
 # pylint: disable=unused-variable, too-many-function-args

--- a/homeassistant/components/sensor/dweet.py
+++ b/homeassistant/components/sensor/dweet.py
@@ -18,11 +18,15 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers import template
 from homeassistant.util import Throttle
 
-_LOGGER = logging.getLogger(__name__)
-CONF_DEVICE = 'device'
-DEFAULT_NAME = 'Dweet.io Sensor'
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 REQUIREMENTS = ['dweepy==0.2.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_DEVICE = 'device'
+
+DEFAULT_NAME = 'Dweet.io Sensor'
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DEVICE): cv.string,

--- a/homeassistant/components/sensor/fixer.py
+++ b/homeassistant/components/sensor/fixer.py
@@ -15,14 +15,20 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
+REQUIREMENTS = ['fixerio==0.1.1']
+
 _LOGGER = logging.getLogger(__name__)
+
 CONF_BASE = 'base'
 CONF_TARGET = 'target'
+
 DEFAULT_BASE = 'USD'
 DEFAULT_NAME = 'Exchange rate'
+
 ICON = 'mdi:currency'
+
 MIN_TIME_BETWEEN_UPDATES = timedelta(days=1)
-REQUIREMENTS = ['fixerio==0.1.1']
+
 STATE_ATTR_BASE = 'Base currency'
 STATE_ATTR_EXCHANGE_RATE = 'Exchange rate'
 STATE_ATTR_TARGET = 'Target currency'

--- a/homeassistant/components/sensor/fixer.py
+++ b/homeassistant/components/sensor/fixer.py
@@ -9,42 +9,37 @@ from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.const import (CONF_PLATFORM, CONF_NAME)
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['fixerio==0.1.1']
-
 _LOGGER = logging.getLogger(__name__)
-
-DEFAULT_NAME = "Exchange rate"
-ICON = 'mdi:currency'
-
 CONF_BASE = 'base'
 CONF_TARGET = 'target'
-
-STATE_ATTR_BASE = 'Base currency'
-STATE_ATTR_TARGET = 'Target currency'
-STATE_ATTR_EXCHANGE_RATE = 'Exchange rate'
-
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_PLATFORM): 'fixer',
-    vol.Optional(CONF_BASE): cv.string,
-    vol.Optional(CONF_NAME): cv.string,
-    vol.Required(CONF_TARGET): cv.string,
-})
-
-# Return cached results if last scan was less then this time ago.
+DEFAULT_BASE = 'USD'
+DEFAULT_NAME = 'Exchange rate'
+ICON = 'mdi:currency'
 MIN_TIME_BETWEEN_UPDATES = timedelta(days=1)
+REQUIREMENTS = ['fixerio==0.1.1']
+STATE_ATTR_BASE = 'Base currency'
+STATE_ATTR_EXCHANGE_RATE = 'Exchange rate'
+STATE_ATTR_TARGET = 'Target currency'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_TARGET): cv.string,
+    vol.Optional(CONF_BASE, default=DEFAULT_BASE): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Fixer.io sensor."""
     from fixerio import (Fixerio, exceptions)
 
-    name = config.get(CONF_NAME, DEFAULT_NAME)
-    base = config.get(CONF_BASE, 'USD')
+    name = config.get(CONF_NAME)
+    base = config.get(CONF_BASE)
     target = config.get(CONF_TARGET)
 
     try:

--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -17,9 +17,11 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-DEFAULT_NAME = 'Glances'
-DEFAULT_HOST = 'localhost'
+_LOGGER = logging.getLogger(__name__)
 _RESOURCE = 'api/2/all'
+
+DEFAULT_HOST = 'localhost'
+DEFAULT_NAME = 'Glances'
 DEFAULT_PORT = '61208'
 
 SENSOR_TYPES = {
@@ -47,7 +49,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 
-_LOGGER = logging.getLogger(__name__)
 
 # Return cached results if last scan was less then this time ago.
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -21,18 +21,14 @@ import homeassistant.helpers.location as location
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
-
-REQUIREMENTS = ['googlemaps==2.4.4']
-
-# Return cached results if last update was less then this time ago
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
-
-DEFAULT_NAME = 'Google Travel Time'
-CONF_ORIGIN = 'origin'
 CONF_DESTINATION = 'destination'
-CONF_TRAVEL_MODE = 'travel_mode'
-CONF_OPTIONS = 'options'
 CONF_MODE = 'mode'
+CONF_OPTIONS = 'options'
+CONF_ORIGIN = 'origin'
+CONF_TRAVEL_MODE = 'travel_mode'
+DEFAULT_NAME = 'Google Travel Time'
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
+REQUIREMENTS = ['googlemaps==2.4.4']
 
 ALL_LANGUAGES = ['ar', 'bg', 'bn', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es',
                  'eu', 'fa', 'fi', 'fr', 'gl', 'gu', 'hi', 'hr', 'hu', 'id',
@@ -41,10 +37,10 @@ ALL_LANGUAGES = ['ar', 'bg', 'bn', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es',
                  'sr', 'sv', 'ta', 'te', 'th', 'tl', 'tr', 'uk', 'vi',
                  'zh-CN', 'zh-TW']
 
-TRANSIT_PREFS = ['less_walking', 'fewer_transfers']
-TRAVEL_MODE = ['driving', 'walking', 'bicycling', 'transit']
 AVOID = ['tolls', 'highways', 'ferries', 'indoor']
+TRANSIT_PREFS = ['less_walking', 'fewer_transfers']
 TRANSPORT_TYPE = ['bus', 'subway', 'train', 'tram', 'rail']
+TRAVEL_MODE = ['driving', 'walking', 'bicycling', 'transit']
 TRAVEL_MODEL = ['best_guess', 'pessimistic', 'optimistic']
 UNITS = ['metric', 'imperial']
 

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -20,15 +20,19 @@ import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.location as location
 import homeassistant.util.dt as dt_util
 
+REQUIREMENTS = ['googlemaps==2.4.4']
+
 _LOGGER = logging.getLogger(__name__)
+
 CONF_DESTINATION = 'destination'
 CONF_MODE = 'mode'
 CONF_OPTIONS = 'options'
 CONF_ORIGIN = 'origin'
 CONF_TRAVEL_MODE = 'travel_mode'
+
 DEFAULT_NAME = 'Google Travel Time'
+
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
-REQUIREMENTS = ['googlemaps==2.4.4']
 
 ALL_LANGUAGES = ['ar', 'bg', 'bn', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es',
                  'eu', 'fa', 'fi', 'fr', 'gl', 'gu', 'hi', 'hr', 'hu', 'id',

--- a/homeassistant/components/sensor/gpsd.py
+++ b/homeassistant/components/sensor/gpsd.py
@@ -15,16 +15,19 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
+REQUIREMENTS = ['gps3==0.33.2']
+
 _LOGGER = logging.getLogger(__name__)
+
 ATTR_CLIMB = 'climb'
 ATTR_ELEVATION = 'elevation'
 ATTR_GPS_TIME = 'gps_time'
 ATTR_MODE = 'mode'
 ATTR_SPEED = 'speed'
+
 DEFAULT_HOST = 'localhost'
 DEFAULT_NAME = 'GPS'
 DEFAULT_PORT = 2947
-REQUIREMENTS = ['gps3==0.33.2']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/homeassistant/components/sensor/gpsd.py
+++ b/homeassistant/components/sensor/gpsd.py
@@ -8,39 +8,36 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    ATTR_LATITUDE, ATTR_LONGITUDE, STATE_UNKNOWN, CONF_HOST, CONF_PORT,
+    CONF_NAME)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import (ATTR_LATITUDE, ATTR_LONGITUDE, STATE_UNKNOWN,
-                                 CONF_HOST, CONF_PORT, CONF_PLATFORM,
-                                 CONF_NAME)
-
-REQUIREMENTS = ['gps3==0.33.2']
-
-DEFAULT_NAME = 'GPS'
-DEFAULT_HOST = 'localhost'
-DEFAULT_PORT = 2947
-
-ATTR_GPS_TIME = 'gps_time'
-ATTR_ELEVATION = 'elevation'
-ATTR_SPEED = 'speed'
-ATTR_CLIMB = 'climb'
-ATTR_MODE = 'mode'
-
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_PLATFORM): 'gpsd',
-    vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_HOST): cv.string,
-    vol.Optional(CONF_PORT): cv.string,
-})
 
 _LOGGER = logging.getLogger(__name__)
+ATTR_CLIMB = 'climb'
+ATTR_ELEVATION = 'elevation'
+ATTR_GPS_TIME = 'gps_time'
+ATTR_MODE = 'mode'
+ATTR_SPEED = 'speed'
+DEFAULT_HOST = 'localhost'
+DEFAULT_NAME = 'GPS'
+DEFAULT_PORT = 2947
+REQUIREMENTS = ['gps3==0.33.2']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the GPSD component."""
-    name = config.get(CONF_NAME, DEFAULT_NAME)
-    host = config.get(CONF_HOST, DEFAULT_HOST)
-    port = config.get(CONF_PORT, DEFAULT_PORT)
+    name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
 
     # Will hopefully be possible with the next gps3 update
     # https://github.com/wadda/gps3/issues/11

--- a/homeassistant/components/sensor/hp_ilo.py
+++ b/homeassistant/components/sensor/hp_ilo.py
@@ -17,11 +17,14 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
+REQUIREMENTS = ['python-hpilo==3.8']
+
 _LOGGER = logging.getLogger(__name__)
+
 DEFAULT_NAME = 'HP ILO'
 DEFAULT_PORT = 443
+
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=300)
-REQUIREMENTS = ['python-hpilo==3.8']
 
 # Each sensor is defined as follows: 'Descriptive name', 'python-ilo function'
 SENSOR_TYPES = {

--- a/homeassistant/components/sensor/hp_ilo.py
+++ b/homeassistant/components/sensor/hp_ilo.py
@@ -1,26 +1,27 @@
 """
 Support for information from HP ILO sensors.
 
-This allows monitoring of HP server information
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.sensor.hp_ilo/
 """
 import logging
 from datetime import timedelta
 
 import voluptuous as vol
+
 from homeassistant.const import (
     CONF_HOST, CONF_PORT, CONF_USERNAME, CONF_PASSWORD, CONF_NAME,
-    CONF_MONITORED_VARIABLES,
-    STATE_ON, STATE_OFF)
+    CONF_MONITORED_VARIABLES, STATE_ON, STATE_OFF)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-hpilo==3.8']
 _LOGGER = logging.getLogger(__name__)
-
 DEFAULT_NAME = 'HP ILO'
 DEFAULT_PORT = 443
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=300)
+REQUIREMENTS = ['python-hpilo==3.8']
 
 # Each sensor is defined as follows: 'Descriptive name', 'python-ilo function'
 SENSOR_TYPES = {
@@ -43,13 +44,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_MONITORED_VARIABLES, default=['server_name']):
-    vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.positive_int,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
 })
-
-# Return cached results if last scan was less then this time ago.
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=300)
 
 
 # pylint: disable=unused-argument
@@ -82,7 +80,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class HpIloSensor(Entity):
-    """Represents an HP ILO sensor."""
+    """Representation a HP ILO sensor."""
 
     def __init__(self, hp_ilo_data, sensor_type, client_name):
         """Initialize the sensor."""
@@ -167,4 +165,4 @@ class HpIloData(object):
                                   port=self._port)
         except (hpilo.IloError, hpilo.IloCommunicationError,
                 hpilo.IloLoginFailed) as error:
-            raise ValueError("Unable to init HP ILO. - %s", error)
+            raise ValueError("Unable to init HP ILO, %s", error)

--- a/homeassistant/components/sensor/imap.py
+++ b/homeassistant/components/sensor/imap.py
@@ -5,27 +5,23 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.imap/
 """
 import logging
+
 import voluptuous as vol
 
 from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_NAME, CONF_PORT, CONF_USERNAME, CONF_PASSWORD)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
-
+CONF_SERVER = "server"
+DEFAULT_PORT = 993
 ICON = 'mdi:email-outline'
 
-CONF_USER = "user"
-CONF_PASSWORD = "password"
-CONF_SERVER = "server"
-CONF_PORT = "port"
-CONF_NAME = "name"
-
-DEFAULT_PORT = 993
-
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required('platform'): 'imap',
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME): cv.string,
-    vol.Required(CONF_USER): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_SERVER): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
@@ -35,10 +31,10 @@ PLATFORM_SCHEMA = vol.Schema({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the IMAP platform."""
     sensor = ImapSensor(config.get(CONF_NAME, None),
-                        config.get(CONF_USER),
+                        config.get(CONF_USERNAME),
                         config.get(CONF_PASSWORD),
                         config.get(CONF_SERVER),
-                        config.get(CONF_PORT, DEFAULT_PORT))
+                        config.get(CONF_PORT))
 
     if sensor.connection:
         add_devices([sensor])

--- a/homeassistant/components/sensor/imap.py
+++ b/homeassistant/components/sensor/imap.py
@@ -15,7 +15,9 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
+
 CONF_SERVER = "server"
+
 DEFAULT_PORT = 993
 ICON = 'mdi:email-outline'
 

--- a/homeassistant/components/sensor/mfi.py
+++ b/homeassistant/components/sensor/mfi.py
@@ -9,7 +9,8 @@ import logging
 import requests
 
 from homeassistant.components.sensor import DOMAIN
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, TEMP_CELSIUS
+from homeassistant.const import (
+    CONF_PASSWORD, CONF_USERNAME, TEMP_CELSIUS, STATE_ON, STATE_OFF, CONF_HOST)
 from homeassistant.helpers import validate_config
 from homeassistant.helpers.entity import Entity
 
@@ -17,8 +18,6 @@ REQUIREMENTS = ['mficlient==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-STATE_ON = 'on'
-STATE_OFF = 'off'
 DIGITS = {
     'volts': 1,
     'amps': 1,
@@ -40,14 +39,14 @@ CONF_VERIFY_TLS = 'verify_tls'
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup mFi sensors."""
     if not validate_config({DOMAIN: config},
-                           {DOMAIN: ['host',
+                           {DOMAIN: [CONF_HOST,
                                      CONF_USERNAME,
                                      CONF_PASSWORD]},
                            _LOGGER):
         _LOGGER.error('A host, username, and password are required')
         return False
 
-    host = config.get('host')
+    host = config.get(CONF_HOST)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     use_tls = bool(config.get(CONF_TLS, True))

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -9,19 +9,16 @@ import logging
 import voluptuous as vol
 
 import homeassistant.components.mqtt as mqtt
-from homeassistant.const import CONF_NAME, CONF_VALUE_TEMPLATE, STATE_UNKNOWN
+from homeassistant.const import (
+    CONF_NAME, CONF_VALUE_TEMPLATE, STATE_UNKNOWN, CONF_UNIT_OF_MEASUREMENT)
 from homeassistant.components.mqtt import CONF_STATE_TOPIC, CONF_QOS
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers import template
 
 _LOGGER = logging.getLogger(__name__)
-
-DEPENDENCIES = ['mqtt']
-
-CONF_UNIT_OF_MEASUREMENT = 'unit_of_measurement'
-
 DEFAULT_NAME = "MQTT Sensor"
+DEPENDENCIES = ['mqtt']
 
 PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -17,8 +17,10 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers import template
 
 _LOGGER = logging.getLogger(__name__)
-DEFAULT_NAME = "MQTT Sensor"
+
 DEPENDENCIES = ['mqtt']
+
+DEFAULT_NAME = "MQTT Sensor"
 
 PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -27,9 +29,9 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
 
 
 # pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup MQTT Sensor."""
-    add_devices_callback([MqttSensor(
+    add_devices([MqttSensor(
         hass,
         config[CONF_NAME],
         config[CONF_STATE_TOPIC],

--- a/homeassistant/components/sensor/nzbget.py
+++ b/homeassistant/components/sensor/nzbget.py
@@ -18,8 +18,12 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
+_LOGGER = logging.getLogger(__name__)
+
 DEFAULT_NAME = 'NZBGet'
 DEFAULT_PORT = 6789
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 
 SENSOR_TYPES = {
     'article_cache': ['ArticleCacheMB', 'Article Cache', 'MB'],
@@ -39,14 +43,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_USERNAME): cv.string,
 })
-
-_LOGGER = logging.getLogger(__name__)
-
-# Return cached results if last scan was less then this time ago.
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 
 
 # pylint: disable=unused-argument, too-many-locals

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -18,10 +18,13 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = 'https://openexchangerates.org/api/latest.json'
+
 CONF_BASE = 'base'
 CONF_QUOTE = 'quote'
+
 DEFAULT_BASE = 'USD'
 DEFAULT_NAME = 'Exchange Rate Sensor'
+
 MIN_TIME_BETWEEN_UPDATES = timedelta(hours=2)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -16,14 +16,13 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-_RESOURCE = 'https://openexchangerates.org/api/latest.json'
 _LOGGER = logging.getLogger(__name__)
-
+_RESOURCE = 'https://openexchangerates.org/api/latest.json'
 CONF_BASE = 'base'
 CONF_QUOTE = 'quote'
-
-DEFAULT_NAME = 'Exchange Rate Sensor'
 DEFAULT_BASE = 'USD'
+DEFAULT_NAME = 'Exchange Rate Sensor'
+MIN_TIME_BETWEEN_UPDATES = timedelta(hours=2)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
@@ -31,9 +30,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_BASE, default=DEFAULT_BASE): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
-
-# Return cached results if last scan was less then this time ago.
-MIN_TIME_BETWEEN_UPDATES = timedelta(hours=2)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -8,51 +8,58 @@ from datetime import timedelta
 import logging
 import voluptuous as vol
 
-from homeassistant.const import (CONF_NAME, CONF_PLATFORM, CONF_USERNAME,
-                                 CONF_PASSWORD, CONF_HOST, CONF_PORT)
+from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_HOST, CONF_PORT)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['plexapi==2.0.2']
 
-CONF_SERVER = 'server'
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
-
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_PLATFORM): 'plex',
-    vol.Optional(CONF_USERNAME): cv.string,
+CONF_SERVER = 'server'
+
+DEFAULT_HOST = 'localhost'
+DEFAULT_NAME = 'Plex'
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_SERVER): cv.string,
-    vol.Optional(CONF_NAME, default='Plex'): cv.string,
-    vol.Optional(CONF_HOST, default='localhost'): cv.string,
     vol.Optional(CONF_PORT, default=32400): cv.port,
+    vol.Optional(CONF_SERVER): cv.string,
+    vol.Optional(CONF_USERNAME): cv.string,
 })
 
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Demo sensors."""
+    """Setup the Plex sensor."""
     name = config.get(CONF_NAME)
     plex_user = config.get(CONF_USERNAME)
     plex_password = config.get(CONF_PASSWORD)
     plex_server = config.get(CONF_SERVER)
     plex_host = config.get(CONF_HOST)
     plex_port = config.get(CONF_PORT)
-    plex_url = 'http://' + plex_host + ':' + str(plex_port)
-    add_devices([PlexSensor(name, plex_url, plex_user,
-                            plex_password, plex_server)])
+    plex_url = 'http://{}:{}'.format(plex_host, plex_port)
+
+    add_devices([PlexSensor(
+        name, plex_url, plex_user, plex_password, plex_server)])
 
 
 class PlexSensor(Entity):
-    """Plex now playing sensor."""
+    """Representation of a Plex now playing sensor."""
 
     # pylint: disable=too-many-arguments
     def __init__(self, name, plex_url, plex_user, plex_password, plex_server):
         """Initialize the sensor."""
         from plexapi.utils import NA
+        from plexapi.myplex import MyPlexAccount
+        from plexapi.server import PlexServer
 
         self._na_type = NA
         self._name = name
@@ -60,12 +67,10 @@ class PlexSensor(Entity):
         self._now_playing = []
 
         if plex_user and plex_password:
-            from plexapi.myplex import MyPlexAccount
             user = MyPlexAccount.signin(plex_user, plex_password)
             server = plex_server if plex_server else user.resources()[0].name
             self._server = user.resource(server).connect()
         else:
-            from plexapi.server import PlexServer
             self._server = PlexServer(plex_url)
 
         self.update()
@@ -92,7 +97,7 @@ class PlexSensor(Entity):
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        """Update method for plex sensor."""
+        """Update method for Plex sensor."""
         sessions = self._server.sessions()
         now_playing = []
         for sess in sessions:

--- a/homeassistant/components/sensor/sabnzbd.py
+++ b/homeassistant/components/sensor/sabnzbd.py
@@ -22,8 +22,10 @@ REQUIREMENTS = ['https://github.com/jamespcole/home-assistant-nzb-clients/'
 
 _LOGGER = logging.getLogger(__name__)
 _THROTTLED_REFRESH = None
+
 DEFAULT_NAME = 'SABnzbd'
 DEFAULT_PORT = 8080
+
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=1)
 
 SENSOR_TYPES = {

--- a/homeassistant/components/sensor/sabnzbd.py
+++ b/homeassistant/components/sensor/sabnzbd.py
@@ -20,8 +20,11 @@ REQUIREMENTS = ['https://github.com/jamespcole/home-assistant-nzb-clients/'
                 'archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip'
                 '#python-sabnzbd==0.1']
 
+_LOGGER = logging.getLogger(__name__)
+_THROTTLED_REFRESH = None
 DEFAULT_NAME = 'SABnzbd'
 DEFAULT_PORT = 8080
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=1)
 
 SENSOR_TYPES = {
     'current_status': ['Status', None],
@@ -38,14 +41,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MONITORED_VARIABLES, default=['current_status']):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
 })
-
-_LOGGER = logging.getLogger(__name__)
-_THROTTLED_REFRESH = None
-
-# Return cached results if last scan was less then this time ago.
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=1)
 
 
 # pylint: disable=unused-argument

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -16,15 +16,19 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
+REQUIREMENTS = ['pysnmp==4.3.2']
+
 _LOGGER = logging.getLogger(__name__)
+
 CONF_BASEOID = 'baseoid'
 CONF_COMMUNITY = 'community'
+
 DEFAULT_COMMUNITY = 'public'
 DEFAULT_HOST = 'localhost'
 DEFAULT_NAME = 'SNMP'
 DEFAULT_PORT = '161'
+
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
-REQUIREMENTS = ['pysnmp==4.3.2']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_BASEOID): cv.string,

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -6,35 +6,34 @@ https://home-assistant.io/components/sensor.snmp/
 """
 import logging
 from datetime import timedelta
+
 import voluptuous as vol
 
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
-from homeassistant.const import (CONF_HOST, CONF_PLATFORM, CONF_NAME,
-                                 CONF_PORT, ATTR_UNIT_OF_MEASUREMENT)
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, CONF_PORT, CONF_UNIT_OF_MEASUREMENT)
+import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
+_LOGGER = logging.getLogger(__name__)
+CONF_BASEOID = 'baseoid'
+CONF_COMMUNITY = 'community'
+DEFAULT_COMMUNITY = 'public'
+DEFAULT_HOST = 'localhost'
+DEFAULT_NAME = 'SNMP'
+DEFAULT_PORT = '161'
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
 REQUIREMENTS = ['pysnmp==4.3.2']
 
-_LOGGER = logging.getLogger(__name__)
-
-DEFAULT_NAME = "SNMP"
-DEFAULT_COMMUNITY = "public"
-DEFAULT_PORT = "161"
-CONF_COMMUNITY = "community"
-CONF_BASEOID = "baseoid"
-
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_PLATFORM): 'snmp',
-    vol.Optional(CONF_NAME): vol.Coerce(str),
-    vol.Required(CONF_HOST): vol.Coerce(str),
-    vol.Optional(CONF_PORT): vol.Coerce(int),
-    vol.Optional(CONF_COMMUNITY): vol.Coerce(str),
-    vol.Required(CONF_BASEOID): vol.Coerce(str),
-    vol.Optional(ATTR_UNIT_OF_MEASUREMENT): vol.Coerce(str),
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_BASEOID): cv.string,
+    vol.Optional(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): cv.string,
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
 })
-
-# Return cached results if last scan was less then this time ago.
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
 
 
 # pylint: disable=too-many-locals
@@ -44,10 +43,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                               UdpTransportTarget, ContextData, ObjectType,
                               ObjectIdentity)
 
+    name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT, DEFAULT_PORT)
-    community = config.get(CONF_COMMUNITY, DEFAULT_COMMUNITY)
+    port = config.get(CONF_PORT)
+    community = config.get(CONF_COMMUNITY)
     baseoid = config.get(CONF_BASEOID)
+    unit = config.get(CONF_UNIT_OF_MEASUREMENT)
 
     errindication, _, _, _ = next(
         getCmd(SnmpEngine(),
@@ -61,9 +62,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
     else:
         data = SnmpData(host, port, community, baseoid)
-        add_devices([SnmpSensor(data,
-                                config.get('name', DEFAULT_NAME),
-                                config.get('unit_of_measurement'))])
+        add_devices([SnmpSensor(data, name, unit)])
 
 
 class SnmpSensor(Entity):

--- a/homeassistant/components/sensor/swiss_hydrological_data.py
+++ b/homeassistant/components/sensor/swiss_hydrological_data.py
@@ -10,20 +10,19 @@ from datetime import timedelta
 import voluptuous as vol
 import requests
 
-from homeassistant.const import (TEMP_CELSIUS, CONF_PLATFORM, CONF_NAME,
-                                 STATE_UNKNOWN)
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (TEMP_CELSIUS, CONF_NAME, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['xmltodict==0.10.2']
-
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = 'http://www.hydrodata.ch/xml/SMS.xml'
 
-DEFAULT_NAME = 'Water temperature'
 CONF_STATION = 'station'
+DEFAULT_NAME = 'Water temperature'
 ICON = 'mdi:cup-water'
+REQUIREMENTS = ['xmltodict==0.10.2']
 
 ATTR_LOCATION = 'Location'
 ATTR_UPDATE = 'Update'
@@ -36,10 +35,9 @@ ATTR_DISCHARGE_MAX = 'Discharge max'
 ATTR_WATERLEVEL_MAX = 'Level max'
 ATTR_TEMPERATURE_MAX = 'Temperature max'
 
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_PLATFORM): 'swiss_hydrological_data',
-    vol.Optional(CONF_NAME): cv.string,
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_STATION): vol.Coerce(int),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
 # Return cached results if last scan was less then this time ago.
@@ -50,8 +48,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Swiss hydrological sensor."""
     import xmltodict
 
+    name = config.get(CONF_NAME)
     station = config.get(CONF_STATION)
-    name = config.get(CONF_NAME, DEFAULT_NAME)
 
     try:
         response = requests.get(_RESOURCE, timeout=5)

--- a/homeassistant/components/sensor/swiss_hydrological_data.py
+++ b/homeassistant/components/sensor/swiss_hydrological_data.py
@@ -16,13 +16,14 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
+REQUIREMENTS = ['xmltodict==0.10.2']
+
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = 'http://www.hydrodata.ch/xml/SMS.xml'
 
 CONF_STATION = 'station'
 DEFAULT_NAME = 'Water temperature'
 ICON = 'mdi:cup-water'
-REQUIREMENTS = ['xmltodict==0.10.2']
 
 ATTR_LOCATION = 'Location'
 ATTR_UPDATE = 'Update'

--- a/homeassistant/components/sensor/swiss_public_transport.py
+++ b/homeassistant/components/sensor/swiss_public_transport.py
@@ -19,15 +19,19 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = 'http://transport.opendata.ch/v1/'
+
 ATTR_DEPARTURE_TIME1 = 'Next departure'
 ATTR_DEPARTURE_TIME2 = 'Next on departure'
 ATTR_REMAINING_TIME = 'Remaining time'
 ATTR_START = 'Start'
 ATTR_TARGET = 'Destination'
+
 CONF_DESTINATION = 'to'
 CONF_START = 'from'
+
 DEFAULT_NAME = 'Next Departure'
 ICON = 'mdi:bus'
+
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 TIME_STR_FORMAT = "%H:%M"
 

--- a/homeassistant/components/sensor/swiss_public_transport.py
+++ b/homeassistant/components/sensor/swiss_public_transport.py
@@ -17,18 +17,18 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
+_LOGGER = logging.getLogger(__name__)
 _RESOURCE = 'http://transport.opendata.ch/v1/'
-DEFAULT_NAME = 'Next Departure'
-
 ATTR_DEPARTURE_TIME1 = 'Next departure'
 ATTR_DEPARTURE_TIME2 = 'Next on departure'
+ATTR_REMAINING_TIME = 'Remaining time'
 ATTR_START = 'Start'
 ATTR_TARGET = 'Destination'
-ATTR_REMAINING_TIME = 'Remaining time'
-CONF_START = 'from'
 CONF_DESTINATION = 'to'
+CONF_START = 'from'
+DEFAULT_NAME = 'Next Departure'
 ICON = 'mdi:bus'
-
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 TIME_STR_FORMAT = "%H:%M"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -36,11 +36,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_START): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
-
-_LOGGER = logging.getLogger(__name__)
-
-# Return cached results if last scan was less then this time ago.
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -17,6 +17,8 @@ import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['psutil==4.3.0']
 
+_LOGGER = logging.getLogger(__name__)
+
 SENSOR_TYPES = {
     'disk_use_percent': ['Disk Use', '%', 'mdi:harddisk'],
     'disk_use': ['Disk Use', 'GiB', 'mdi:harddisk'],
@@ -46,8 +48,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
             vol.Optional('arg'): cv.string,
         })])
 })
-
-_LOGGER = logging.getLogger(__name__)
 
 
 # pylint: disable=unused-argument

--- a/homeassistant/components/sensor/time_date.py
+++ b/homeassistant/components/sensor/time_date.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
+
 TIME_STR_FORMAT = "%H:%M"
 
 OPTION_TYPES = {

--- a/homeassistant/components/sensor/time_date.py
+++ b/homeassistant/components/sensor/time_date.py
@@ -15,6 +15,7 @@ import homeassistant.util.dt as dt_util
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
+_LOGGER = logging.getLogger(__name__)
 TIME_STR_FORMAT = "%H:%M"
 
 OPTION_TYPES = {
@@ -30,8 +31,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DISPLAY_OPTIONS, default=['time']):
         vol.All(cv.ensure_list, [vol.In(OPTION_TYPES)]),
 })
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/transmission.py
+++ b/homeassistant/components/sensor/transmission.py
@@ -19,6 +19,9 @@ import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['transmissionrpc==0.11']
 
+_LOGGER = logging.getLogger(__name__)
+_THROTTLED_REFRESH = None
+
 DEFAULT_NAME = 'Transmission'
 DEFAULT_PORT = 9091
 
@@ -37,10 +40,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_USERNAME): cv.string,
 })
-
-_LOGGER = logging.getLogger(__name__)
-
-_THROTTLED_REFRESH = None
 
 
 # pylint: disable=unused-argument

--- a/homeassistant/components/sensor/twitch.py
+++ b/homeassistant/components/sensor/twitch.py
@@ -12,12 +12,16 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
+REQUIREMENTS = ['python-twitch==1.3.0']
+
 _LOGGER = logging.getLogger(__name__)
+
 ATTR_GAME = 'game'
 ATTR_TITLE = 'title'
+
 CONF_CHANNELS = 'channels'
 ICON = 'mdi:twitch'
-REQUIREMENTS = ['python-twitch==1.3.0']
+
 STATE_OFFLINE = 'offline'
 STATE_STREAMING = 'streaming'
 

--- a/homeassistant/components/sensor/twitch.py
+++ b/homeassistant/components/sensor/twitch.py
@@ -12,21 +12,19 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-CONF_CHANNELS = 'channels'
-STATE_STREAMING = 'streaming'
-STATE_OFFLINE = 'offline'
+_LOGGER = logging.getLogger(__name__)
 ATTR_GAME = 'game'
 ATTR_TITLE = 'title'
+CONF_CHANNELS = 'channels'
 ICON = 'mdi:twitch'
-
 REQUIREMENTS = ['python-twitch==1.3.0']
+STATE_OFFLINE = 'offline'
+STATE_STREAMING = 'streaming'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_CHANNELS, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
 })
-
-_LOGGER = logging.getLogger(__name__)
 
 
 # pylint: disable=unused-argument

--- a/homeassistant/components/sensor/worldclock.py
+++ b/homeassistant/components/sensor/worldclock.py
@@ -15,7 +15,8 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
-DEFAULT_NAME = "Worldclock Sensor"
+
+DEFAULT_NAME = 'Worldclock Sensor'
 ICON = 'mdi:clock'
 TIME_STR_FORMAT = "%H:%M"
 

--- a/homeassistant/components/sensor/worldclock.py
+++ b/homeassistant/components/sensor/worldclock.py
@@ -14,6 +14,7 @@ import homeassistant.util.dt as dt_util
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
+_LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME = "Worldclock Sensor"
 ICON = 'mdi:clock'
 TIME_STR_FORMAT = "%H:%M"
@@ -22,8 +23,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_TIME_ZONE): cv.time_zone,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -6,23 +6,23 @@ https://home-assistant.io/components/sensor.wunderground/
 """
 from datetime import timedelta
 import logging
-import requests
 
+import requests
 import voluptuous as vol
 
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_PLATFORM, CONF_MONITORED_CONDITIONS,
-                                 CONF_API_KEY, TEMP_FAHRENHEIT, TEMP_CELSIUS,
-                                 STATE_UNKNOWN)
+from homeassistant.const import (
+    CONF_MONITORED_CONDITIONS, CONF_API_KEY, TEMP_FAHRENHEIT, TEMP_CELSIUS,
+    STATE_UNKNOWN)
 
-CONF_PWS_ID = 'pws_id'
 _RESOURCE = 'http://api.wunderground.com/api/{}/conditions/q/'
 _LOGGER = logging.getLogger(__name__)
 
-# Return cached results if last scan was less then this time ago.
+CONF_PWS_ID = 'pws_id'
+
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=300)
 
 # Sensor types are defined like: Name, units
@@ -57,11 +57,10 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_PLATFORM): "wunderground",
     vol.Required(CONF_API_KEY): cv.string,
     vol.Optional(CONF_PWS_ID): cv.string,
-    vol.Required(CONF_MONITORED_CONDITIONS,
-                 default=[]): vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+    vol.Required(CONF_MONITORED_CONDITIONS, default=[]):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 
 

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -9,16 +9,15 @@ import requests
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_PLATFORM, CONF_LATITUDE, CONF_LONGITUDE, CONF_ELEVATION,
-    CONF_MONITORED_CONDITIONS
-)
+    CONF_LATITUDE, CONF_LONGITUDE, CONF_ELEVATION, CONF_MONITORED_CONDITIONS)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import dt as dt_util
 
-_LOGGER = logging.getLogger(__name__)
-
 REQUIREMENTS = ['xmltodict==0.10.2']
+
+_LOGGER = logging.getLogger(__name__)
 
 # Sensor types are defined like so:
 SENSOR_TYPES = {
@@ -38,8 +37,7 @@ SENSOR_TYPES = {
     'dewpointTemperature': ['Dewpoint temperature', '°C'],
 }
 
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_PLATFORM): 'yr',
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MONITORED_CONDITIONS, default=[]):
         [vol.In(SENSOR_TYPES.keys())],
     vol.Optional(CONF_LATITUDE): cv.latitude,
@@ -58,9 +56,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error("Latitude or longitude not set in Home Assistant config")
         return False
 
-    coordinates = dict(lat=latitude,
-                       lon=longitude,
-                       msl=elevation)
+    coordinates = dict(lat=latitude, lon=longitude, msl=elevation)
 
     weather = YrData(coordinates)
 

--- a/homeassistant/components/sensor/yweather.py
+++ b/homeassistant/components/sensor/yweather.py
@@ -6,14 +6,24 @@ https://home-assistant.io/components/sensor.yweather/
 """
 import logging
 from datetime import timedelta
+
 import voluptuous as vol
 
-from homeassistant.const import (CONF_PLATFORM, TEMP_CELSIUS,
-                                 CONF_MONITORED_CONDITIONS, STATE_UNKNOWN)
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    TEMP_CELSIUS, CONF_MONITORED_CONDITIONS, STATE_UNKNOWN)
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
 REQUIREMENTS = ["yahooweather==0.7"]
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_FORECAST = 'forecast'
+CONF_WOEID = 'woeid'
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=120)
 
 SENSOR_TYPES = {
     'weather_current': ['Current', None],
@@ -27,18 +37,13 @@ SENSOR_TYPES = {
     'visibility': ['Visibility', "distance"],
 }
 
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_PLATFORM): "yweather",
-    vol.Optional("woeid"): vol.Coerce(str),
-    vol.Optional("forecast"): vol.Coerce(int),
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_WOEID, default=None): cv.string,
+    vol.Optional(CONF_FORECAST, default=0):
+        vol.All(vol.Coerce(int), vol.Range(min=0, max=5)),
     vol.Required(CONF_MONITORED_CONDITIONS, default=[]):
-        [vol.In(SENSOR_TYPES.keys())],
+        [vol.In(SENSOR_TYPES)],
 })
-
-# Return cached results if last scan was less then this time ago.
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=120)
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -46,8 +51,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     from yahooweather import get_woeid, UNIT_C, UNIT_F
 
     unit = hass.config.units.temperature_unit
-    woeid = config.get("woeid", None)
-    forecast = config.get("forecast", 0)
+    woeid = config.get(CONF_WOEID)
+    forecast = config.get(CONF_FORECAST)
 
     # convert unit
     yunit = UNIT_C if unit == TEMP_CELSIUS else UNIT_F

--- a/homeassistant/components/switch/mystrom.py
+++ b/homeassistant/components/switch/mystrom.py
@@ -8,9 +8,9 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import (CONF_PLATFORM, CONF_NAME, CONF_HOST)
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_NAME, CONF_HOST)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.switch import SwitchDevice
 
 REQUIREMENTS = ['python-mystrom==0.3.6']
 
@@ -18,10 +18,9 @@ DEFAULT_NAME = 'myStrom Switch'
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_PLATFORM): 'mystrom',
-    vol.Optional(CONF_NAME): cv.string,
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
 
@@ -29,6 +28,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return myStrom switch."""
     from pymystrom import MyStromPlug, exceptions
 
+    name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
 
     try:
@@ -37,7 +37,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error("No route to device '%s'", host)
         return False
 
-    add_devices([MyStromSwitch(config.get('name', DEFAULT_NAME), host)])
+    add_devices([MyStromSwitch(name, host)])
 
 
 class MyStromSwitch(SwitchDevice):

--- a/homeassistant/components/switch/transmission.py
+++ b/homeassistant/components/switch/transmission.py
@@ -17,6 +17,8 @@ import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['transmissionrpc==0.11']
 
+_LOGGING = logging.getLogger(__name__)
+
 DEFAULT_NAME = 'Transmission Turtle Mode'
 DEFAULT_PORT = 9091
 
@@ -27,8 +29,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_USERNAME): cv.string,
 })
-
-_LOGGING = logging.getLogger(__name__)
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
**Description:**
This PR updates existing platforms which where already using `voluptuous` to `extend`. Also are the constants now alphabetically ordered where it makes sense, and new constants where used.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
