### PR TITLE
Use voluptuous for D-Link Switch

### DIFF
--- a/homeassistant/components/switch/dlink.py
+++ b/homeassistant/components/switch/dlink.py
@@ -6,42 +6,41 @@ https://home-assistant.io/components/switch.dlink/
 """
 import logging
 
-from homeassistant.components.switch import DOMAIN, SwitchDevice
+import voluptuous as vol
+
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME)
-from homeassistant.helpers import validate_config
+import homeassistant.helpers.config_validation as cv
 
-# constants
-DEFAULT_USERNAME = 'admin'
-DEFAULT_PASSWORD = ''
-DEVICE_DEFAULT_NAME = 'D-link Smart Plug W215'
 REQUIREMENTS = ['https://github.com/LinuxChristian/pyW215/archive/'
                 'v0.1.1.zip#pyW215==0.1.1']
 
-# setup logger
 _LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'D-link Smart Plug W215'
+DEFAULT_PASSWORD = ''
+DEFAULT_USERNAME = 'admin'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
 
 
 # pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
-    """Find and return D-Link Smart Plugs."""
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup a D-Link Smart Plug."""
     from pyW215.pyW215 import SmartPlug
 
-    # check for required values in configuration file
-    if not validate_config({DOMAIN: config},
-                           {DOMAIN: [CONF_HOST]},
-                           _LOGGER):
-        return False
-
     host = config.get(CONF_HOST)
-    username = config.get(CONF_USERNAME, DEFAULT_USERNAME)
-    password = str(config.get(CONF_PASSWORD, DEFAULT_PASSWORD))
-    name = config.get(CONF_NAME, DEVICE_DEFAULT_NAME)
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    name = config.get(CONF_NAME)
 
-    add_devices_callback([SmartPlugSwitch(SmartPlug(host,
-                                                    password,
-                                                    username),
-                                          name)])
+    add_devices([SmartPlugSwitch(SmartPlug(host, password, username), name)])
 
 
 class SmartPlugSwitch(SwitchDevice):


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
  platform: dlink
  host: IP_ADRRESS
  name: D-Link plug
  username: YOUR_USERNAME
  password: YOUR_PASSWORD
```

@omgapuppy, would be nice if you could take a look at the changes and run a quick test.
