### PR TITLE
Device tracker component & platform validation. No more home_range.

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -385,8 +385,6 @@ class Device(Entity):
 
 def load_config(path: str, hass: HomeAssistantType, consider_home: timedelta):
     """Load devices from YAML configuration file."""
-    if not os.path.isfile(path):
-        return []
     try:
         return [
             Device(hass, consider_home, device.get('track', False),
@@ -395,7 +393,7 @@ def load_config(path: str, hass: HomeAssistantType, consider_home: timedelta):
                    device.get('gravatar'),
                    device.get(CONF_AWAY_HIDE, DEFAULT_AWAY_HIDE))
             for dev_id, device in load_yaml_config_file(path).items()]
-    except HomeAssistantError:
+    except (HomeAssistantError, FileNotFoundError):
         # When YAML file could not be loaded/did not contain a dict
         return []
 

--- a/homeassistant/components/device_tracker/bluetooth_le_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_le_tracker.py
@@ -63,7 +63,7 @@ def setup_scanner(hass, config, see):
     # Load all known devices.
     # We just need the devices so set consider_home and home range
     # to 0
-    for device in load_config(yaml_path, hass, 0, 0):
+    for device in load_config(yaml_path, hass, 0):
         # check if device is a valid bluetooth device
         if device.mac and device.mac[:3].upper() == BLE_PREFIX:
             if device.track:

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -45,7 +45,7 @@ def setup_scanner(hass, config, see):
     # Load all known devices.
     # We just need the devices so set consider_home and home range
     # to 0
-    for device in load_config(yaml_path, hass, 0, 0):
+    for device in load_config(yaml_path, hass, 0):
         # check if device is a valid bluetooth device
         if device.mac and device.mac[:3].upper() == BT_PREFIX:
             if device.track:

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -1,24 +1,13 @@
 """Typing Helpers for Home-Assistant."""
-from typing import Dict, Any
+from typing import Dict, Any, Tuple
 
-# NOTE: NewType added to typing in 3.5.2 in June, 2016; Since 3.5.2 includes
-#       security fixes everyone on 3.5 should upgrade "soon"
-try:
-    from typing import NewType
-except ImportError:
-    NewType = None
+import homeassistant.core
 
 # pylint: disable=invalid-name
-if NewType:
-    ConfigType = NewType('ConfigType', Dict[str, Any])
 
-    # Custom type for recorder Queries
-    QueryType = NewType('QueryType', Any)
+GPSType = Tuple[float, float]
+ConfigType = Dict[str, Any]
+HomeAssistantType = homeassistant.core.HomeAssistant
 
-# Duplicates for 3.5.1
-# pylint: disable=invalid-name
-else:
-    ConfigType = Dict[str, Any]  # type: ignore
-
-    # Custom type for recorder Queries
-    QueryType = Any  # type: ignore
+# Custom type for recorder Queries
+QueryType = Any

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -12,7 +12,7 @@ import string
 from functools import wraps
 from types import MappingProxyType
 
-from typing import Any, Optional, TypeVar, Callable, Sequence
+from typing import Any, Optional, TypeVar, Callable, Sequence, KeysView, Union
 
 from .dt import as_local, utcnow
 
@@ -63,8 +63,8 @@ def convert(value: T, to_type: Callable[[T], U],
         return default
 
 
-def ensure_unique_string(preferred_string: str,
-                         current_strings: Sequence[str]) -> str:
+def ensure_unique_string(preferred_string: str, current_strings:
+                         Union[Sequence[str], KeysView[str]]) -> str:
     """Return a string that is not present in current_strings.
 
     If preferred string exists will append _2, _3, ..

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,7 +7,7 @@ from io import StringIO
 import logging
 
 from homeassistant import core as ha, loader
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.util.unit_system import METRIC_SYSTEM
 import homeassistant.util.dt as date_util
@@ -137,15 +137,15 @@ def mock_http_component(hass):
     hass.config.components.append('http')
 
 
-@mock.patch('homeassistant.components.mqtt.MQTT')
-def mock_mqtt_component(hass, mock_mqtt):
+def mock_mqtt_component(hass):
     """Mock the MQTT component."""
-    _setup_component(hass, mqtt.DOMAIN, {
-        mqtt.DOMAIN: {
-            mqtt.CONF_BROKER: 'mock-broker',
-        }
-    })
-    return mock_mqtt
+    with mock.patch('homeassistant.components.mqtt.MQTT') as mock_mqtt:
+        setup_component(hass, mqtt.DOMAIN, {
+            mqtt.DOMAIN: {
+                mqtt.CONF_BROKER: 'mock-broker',
+            }
+        })
+        return mock_mqtt
 
 
 class MockModule(object):

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -321,3 +321,10 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         assert mock_warning.call_count == 3
 
         assert len(config) == 4
+
+    @patch('homeassistant.components.device_tracker.log_exception')
+    def test_config_failure(self, mock_ex):
+        """Test that the device tracker see failures."""
+        device_tracker.setup(self.hass, {device_tracker.DOMAIN: {
+            device_tracker.CONF_CONSIDER_HOME: -1}})
+        assert mock_ex.call_count == 1

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -89,9 +89,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
             device_tracker.Device(self.hass, True, True, 'your_device',
                                   'AB:01', 'Your device', None, None, False)]
         device_tracker.DeviceTracker(self.hass, False, True, devices)
-
         print(mock_warning.call_args_list)
-        mock_warning.assert_called_once()
+        assert mock_warning.call_count == 1, \
+            "The only warning call should be duplicates (check stdout)"
         args, _ = mock_warning.call_args
         assert 'Duplicate device MAC' in args[0], \
             'Duplicate MAC warning expected'
@@ -105,7 +105,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         device_tracker.DeviceTracker(self.hass, False, True, devices)
 
         print(mock_warning.call_args_list)
-        mock_warning.assert_called_once()
+        assert mock_warning.call_count == 1, \
+            "The only warning call should be duplicates (check stdout)"
         args, _ = mock_warning.call_args
         assert 'Duplicate device IDs' in args[0], \
             'Duplicate device IDs warning expected'

--- a/tests/components/device_tracker/test_locative.py
+++ b/tests/components/device_tracker/test_locative.py
@@ -8,17 +8,19 @@ import requests
 from homeassistant import bootstrap, const
 import homeassistant.components.device_tracker as device_tracker
 import homeassistant.components.http as http
+from homeassistant.const import CONF_PLATFORM
 
 from tests.common import get_test_home_assistant, get_test_instance_port
 
 SERVER_PORT = get_test_instance_port()
 HTTP_BASE_URL = "http://127.0.0.1:{}".format(SERVER_PORT)
 
-hass = None
+hass = None  # pylint: disable=invalid-name
 
 
-def _url(data={}):
+def _url(data=None):
     """Helper method to generate URLs."""
+    data = data or {}
     data = "&".join(["{}={}".format(name, value) for
                      name, value in data.items()])
     return "{}{}locative?{}".format(HTTP_BASE_URL, const.URL_API, data)
@@ -26,7 +28,7 @@ def _url(data={}):
 
 def setUpModule():   # pylint: disable=invalid-name
     """Initalize a Home Assistant server."""
-    global hass
+    global hass    # pylint: disable=invalid-name
 
     hass = get_test_home_assistant()
     bootstrap.setup_component(hass, http.DOMAIN, {
@@ -38,7 +40,7 @@ def setUpModule():   # pylint: disable=invalid-name
     # Set up device tracker
     bootstrap.setup_component(hass, device_tracker.DOMAIN, {
         device_tracker.DOMAIN: {
-            'platform': 'locative'
+            CONF_PLATFORM: 'locative'
         }
     })
 

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -48,7 +48,7 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
                     'devices': {dev_id: topic}
                 }
             })
-            mock_sp.assert_called_once()
+            assert mock_sp.call_count == 1
 
     def test_new_message(self):
         """Test new message."""

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -1,5 +1,7 @@
 """The tests for the MQTT device tracker platform."""
 import unittest
+from unittest.mock import patch
+import logging
 import os
 
 from homeassistant.bootstrap import _setup_component
@@ -8,6 +10,8 @@ from homeassistant.const import CONF_PLATFORM
 
 from tests.common import (
     get_test_home_assistant, mock_mqtt_component, fire_mqtt_message)
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
@@ -24,6 +28,27 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
             os.remove(self.hass.config.path(device_tracker.YAML_DEVICES))
         except FileNotFoundError:
             pass
+
+    def test_ensure_device_tracker_platform_validation(self): \
+            # pylint: disable=invalid-name
+        """Test if platform validation was done."""
+        def mock_setup_scanner(hass, config, see):
+            """Check that Qos was added by validation."""
+            self.assertTrue('qos' in config)
+
+        with patch('homeassistant.components.device_tracker.mqtt.'
+                   'setup_scanner', side_effect=mock_setup_scanner) as mock_sp:
+
+            dev_id = 'paulus'
+            topic = '/location/paulus'
+            self.hass.config.components = ['mqtt', 'zone']
+            assert _setup_component(self.hass, device_tracker.DOMAIN, {
+                device_tracker.DOMAIN: {
+                    CONF_PLATFORM: 'mqtt',
+                    'devices': {dev_id: topic}
+                }
+            })
+            mock_sp.assert_called_once()
 
     def test_new_message(self):
         """Test new message."""

--- a/tests/components/test_device_sun_light_trigger.py
+++ b/tests/components/test_device_sun_light_trigger.py
@@ -22,12 +22,12 @@ def setUpModule():   # pylint: disable=invalid-name
     """Write a device tracker known devices file to be used."""
     device_tracker.update_config(
         KNOWN_DEV_YAML_PATH, 'device_1', device_tracker.Device(
-            None, None, None, True, 'device_1', 'DEV1',
+            None, None, True, 'device_1', 'DEV1',
             picture='http://example.com/dev1.jpg'))
 
     device_tracker.update_config(
         KNOWN_DEV_YAML_PATH, 'device_2', device_tracker.Device(
-            None, None, None, True, 'device_2', 'DEV2',
+            None, None, True, 'device_2', 'DEV2',
             picture='http://example.com/dev2.jpg'))
 
 
@@ -83,7 +83,8 @@ class TestDeviceSunLightTrigger(unittest.TestCase):
 
         self.assertTrue(light.is_on(self.hass))
 
-    def test_lights_turn_off_when_everyone_leaves(self):
+    def test_lights_turn_off_when_everyone_leaves(self): \
+            # pylint: disable=invalid-name
         """Test lights turn off when everyone leaves the house."""
         light.turn_on(self.hass)
 
@@ -99,7 +100,8 @@ class TestDeviceSunLightTrigger(unittest.TestCase):
 
         self.assertFalse(light.is_on(self.hass))
 
-    def test_lights_turn_on_when_coming_home_after_sun_set(self):
+    def test_lights_turn_on_when_coming_home_after_sun_set(self): \
+            # pylint: disable=invalid-name
         """Test lights turn on when coming home after sun set."""
         light.turn_off(self.hass)
         ensure_sun_set(self.hass)


### PR DESCRIPTION
**Description:**
*Device tracker component & validation for platforms
*Removed home_range from device_tracker

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
device_tracker:
```

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
