### PR TITLE
Add support for notifying with Slack attachments.

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -56,6 +56,8 @@ class SlackNotificationService(BaseNotificationService):
             attachments = data.get('attachments')
 
         try:
-            self.slack.chat.post_message(channel, message, as_user=True, attachments=attachments)
+            self.slack.chat.post_message(channel, message,
+                                         as_user=True,
+                                         attachments=attachments)
         except slacker.Error:
             _LOGGER.exception("Could not send slack notification")

--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -51,7 +51,11 @@ class SlackNotificationService(BaseNotificationService):
         import slacker
 
         channel = kwargs.get('target') or self._default_channel
+        data = kwargs.get('data')
+        if data:
+            attachments = data.get('attachments')
+
         try:
-            self.slack.chat.post_message(channel, message, as_user=True)
+            self.slack.chat.post_message(channel, message, as_user=True, attachments=attachments)
         except slacker.Error:
             _LOGGER.exception("Could not send slack notification")

--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -54,6 +54,8 @@ class SlackNotificationService(BaseNotificationService):
         data = kwargs.get('data')
         if data:
             attachments = data.get('attachments')
+        else:
+            attachments = None
 
         try:
             self.slack.chat.post_message(channel, message,


### PR DESCRIPTION
**Description:**

When creating notifications, this allows you to pass in `attachments`
with the `data`. It's an array of attachments as defined in
https://api.slack.com/docs/message-attachments

When passing in attachments, message is still required, but it's okay to
be a blank string.

This requires some changes to slack to support it. I started https://github.com/os/slacker/pull/75 I'm not sure if it's possible to make a `REQUIREMENTS` on git branch in the meantime.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#TODO

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
