### PR TITLE
Apparently, doesn't load the root config secret

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -170,8 +170,7 @@ def _secret_yaml(loader: SafeLineLoader,
                  node: yaml.nodes.Node):
     """Load secrets and embed it into the configuration YAML."""
     secret_path = os.path.dirname(loader.name)
-    while os.path.exists(secret_path) and not secret_path == os.path.dirname(
-            sys.path[0]):
+    while os.path.exists(secret_path):
         secrets = __SECRET_CACHE.get(secret_path,
                                      _load_secret_yaml(secret_path))
         if node.value in secrets:
@@ -180,7 +179,8 @@ def _secret_yaml(loader: SafeLineLoader,
             return secrets[node.value]
         next_path = os.path.dirname(secret_path)
 
-        if not next_path or next_path == secret_path:
+        if not next_path or next_path == secret_path \
+                or secret_path == os.path.dirname(sys.path[0]):
             # Somehow we got past the .homeassistant configuration folder...
             break
 


### PR DESCRIPTION
**Description:**
I found a bug - needs to attempt to load the root directory secret before breaking loop.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
