### PR TITLE
Update zwave.py

### DIFF
--- a/homeassistant/components/thermostat/zwave.py
+++ b/homeassistant/components/thermostat/zwave.py
@@ -116,6 +116,7 @@ class ZWaveThermostat(zwave.ZWaveDeviceEntity, ThermostatDevice):
             temps.append(int(value.data))
             if value.index == self._index:
                 self._target_temperature = value.data
+                self._unit = value.units
         self._target_temperature_high = max(temps)
         self._target_temperature_low = min(temps)
 

--- a/homeassistant/components/thermostat/zwave.py
+++ b/homeassistant/components/thermostat/zwave.py
@@ -116,7 +116,6 @@ class ZWaveThermostat(zwave.ZWaveDeviceEntity, ThermostatDevice):
             temps.append(int(value.data))
             if value.index == self._index:
                 self._target_temperature = value.data
-                self._unit = value.units
         self._target_temperature_high = max(temps)
         self._target_temperature_low = min(temps)
 

--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -23,6 +23,7 @@ REQUIREMENTS = ['pydispatcher==2.0.5']
 CONF_USB_STICK_PATH = "usb_path"
 DEFAULT_CONF_USB_STICK_PATH = "/zwaveusbstick"
 CONF_DEBUG = "debug"
+CONF_USE_NODEID_IN_NAMES = "use_nodeid_in_names"
 CONF_POLLING_INTERVAL = "polling_interval"
 CONF_POLLING_INTENSITY = "polling_intensity"
 CONF_AUTOHEAL = "autoheal"
@@ -192,7 +193,7 @@ ATTR_SCENE_ID = "scene_id"
 ATTR_BASIC_LEVEL = "basic_level"
 
 NETWORK = None
-
+USE_NODEID_IN_NAMES = None
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -216,8 +217,11 @@ def _value_name(value):
 
 def _node_object_id(node):
     """Return the object_id of the node."""
-    node_object_id = "{}_{}".format(slugify(_node_name(node)),
+    if USE_NODEID_IN_NAMES :
+        node_object_id = "{}_{}".format(slugify(_node_name(node)),
                                     node.node_id)
+    else :
+        node_object_id = "{}".format(slugify(_node_name(node)))
 
     return node_object_id
 
@@ -228,8 +232,11 @@ def _object_id(value):
     The object_id contains node_id and value instance id
     to not collide with other entity_ids.
     """
-    object_id = "{}_{}".format(slugify(_value_name(value)),
-                               value.node.node_id)
+    if USE_NODEID_IN_NAMES :
+        object_id = "{}_{}".format(slugify(_value_name(value)),
+                                   value.node.node_id)
+    else :
+        object_id = "{}".format(slugify(_value_name(value)))
 
     # Add the instance id if there is more than one instance for the value
     if value.instance > 1:
@@ -271,7 +278,8 @@ def setup(hass, config):
     """
     # pylint: disable=global-statement, import-error
     global NETWORK
-
+    global USE_NODEID_IN_NAMES
+    
     try:
         import libopenzwave
     except ImportError:
@@ -290,6 +298,7 @@ def setup(hass, config):
     use_debug = str(config[DOMAIN].get(CONF_DEBUG)) == '1'
     customize = config[DOMAIN].get(CONF_CUSTOMIZE, {})
     autoheal = config[DOMAIN].get(CONF_AUTOHEAL, DEFAULT_CONF_AUTOHEAL)
+    USE_NODEID_IN_NAMES = str(config[DOMAIN].get(CONF_USE_NODEID_IN_NAMES,"true")) == 'true'
 
     # Setup options
     options = ZWaveOption(


### PR DESCRIPTION
**Description:**
Added configuration option use_nodeid_in_names, default value is true that is the old style of device names. 
If it is set to false, no node ids are added to device names. This works if user can be sure the user can be sure there's no duplicate device names and if there are, renamed devices with OZWCP. 
This allows persistent zwave device names even after a device is broken and replaced.
Default value is true, and it is the same as the old behavior. If you don't use this configuration option, everything works like before. 

https://community.home-assistant.io/t/persistent-zwave-names-even-after-replacing-sensor-or-readding-to-controller/3101

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#816

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Added configuration option use_nodeid_in_names, default value is true that is the old style of device names. 
If it is set to false, no node ids are added to device names. This works if user can be sure the user can be sure there's no duplicate device names and if there are, renanamed devices with OZWCP. 
This allows persistant zwave device names even after a device is broken and replaced.
