### PR TITLE
Add zwave.rename_node service

### DIFF
--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -100,3 +100,13 @@ zwave:
 
   test_network:
     description: This will send test to nodes in the zwave network. This will greatly slow down the zwave network while it is being processed. Refer to OZW.log for details.
+
+  rename_node:
+    description: Set the name of a node.
+    fields:
+      entity_id:
+        description: Name(s) of entities to to rename
+        example: 'light.leviton_vrmx11lz_multilevel_scene_switch_level_40'
+      name:
+        description: New Name
+        example: 'kitchen'

--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers.event import track_time_change
 from homeassistant.util import convert, slugify
+import homeassistant.config as conf_util
 
 DOMAIN = "zwave"
 REQUIREMENTS = ['pydispatcher==2.0.5']
@@ -40,6 +41,7 @@ SERVICE_SOFT_RESET = "soft_reset"
 SERVICE_TEST_NETWORK = "test_network"
 SERVICE_STOP_NETWORK = "stop_network"
 SERVICE_START_NETWORK = "start_network"
+SERVICE_RENAME_NODE = "rename_node"
 
 EVENT_SCENE_ACTIVATED = "zwave.scene_activated"
 EVENT_NODE_EVENT = "zwave.node_event"
@@ -187,7 +189,7 @@ DISCOVERY_COMPONENTS = [
 ATTR_NODE_ID = "node_id"
 ATTR_VALUE_ID = "value_id"
 ATTR_OBJECT_ID = "object_id"
-
+ATTR_NAME = "name"
 ATTR_SCENE_ID = "scene_id"
 ATTR_BASIC_LEVEL = "basic_level"
 
@@ -271,6 +273,9 @@ def setup(hass, config):
     """
     # pylint: disable=global-statement, import-error
     global NETWORK
+
+    descriptions = conf_util.load_yaml_config_file(
+        os.path.join(os.path.dirname(__file__), "services.yaml"))
 
     try:
         import libopenzwave
@@ -461,6 +466,18 @@ def setup(hass, config):
         NETWORK.stop()
         hass.bus.fire(EVENT_NETWORK_STOP)
 
+    def rename_node(service):
+        """Rename a node."""
+        if ATTR_ENTITY_ID in service.data:
+            if ATTR_NAME in service.data:
+                state = hass.states.get(service.data.get(ATTR_ENTITY_ID))
+                node_id = state.attributes.get(ATTR_NODE_ID)
+                node = NETWORK.nodes[node_id]
+                name = service.data.get(ATTR_NAME)
+                node.name = name
+                _LOGGER.info(
+                    "Renamed ZWave node %d to %s", node_id, name)
+
     def start_zwave(_service_or_event):
         """Startup Z-Wave network."""
         _LOGGER.info("Starting ZWave network.")
@@ -505,6 +522,8 @@ def setup(hass, config):
         hass.services.register(DOMAIN, SERVICE_TEST_NETWORK, test_network)
         hass.services.register(DOMAIN, SERVICE_STOP_NETWORK, stop_zwave)
         hass.services.register(DOMAIN, SERVICE_START_NETWORK, start_zwave)
+        hass.services.register(DOMAIN, SERVICE_RENAME_NODE, rename_node,
+                               descriptions[DOMAIN][SERVICE_RENAME_NODE])
 
     # Setup autoheal
     if autoheal:

--- a/homeassistant/components/zwave.py
+++ b/homeassistant/components/zwave.py
@@ -45,11 +45,6 @@ SERVICE_STOP_NETWORK = "stop_network"
 SERVICE_START_NETWORK = "start_network"
 SERVICE_RENAME_NODE = "rename_node"
 
-RENAME_NODE_SCHEMA = vol.Schema({
-    vol.Required("entityId"): cv.string,
-    vol.Required("name"): cv.string,
-})
-
 EVENT_SCENE_ACTIVATED = "zwave.scene_activated"
 EVENT_NODE_EVENT = "zwave.node_event"
 EVENT_NETWORK_READY = "zwave.network_ready"
@@ -199,6 +194,11 @@ ATTR_OBJECT_ID = "object_id"
 ATTR_NAME = "name"
 ATTR_SCENE_ID = "scene_id"
 ATTR_BASIC_LEVEL = "basic_level"
+
+RENAME_NODE_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+    vol.Required(ATTR_NAME): cv.string,
+})
 
 NETWORK = None
 


### PR DESCRIPTION
**Description:**

Adds a `zwave.rename_node` service to allow users to rename their nodes from Home Assistant. 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/818

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
