### PR TITLE
Bump pyhomematic to 0.1.13; Add support for WeatherSensor

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -45,7 +45,7 @@ HM_DEVICE_TYPES = {
     DISCOVER_SWITCHES: ['Switch', 'SwitchPowermeter'],
     DISCOVER_LIGHTS: ['Dimmer'],
     DISCOVER_SENSORS: ['SwitchPowermeter', 'Motion', 'MotionV2',
-                       'RemoteMotion', 'ThermostatWall', 'AreaThermostat', 
+                       'RemoteMotion', 'ThermostatWall', 'AreaThermostat',
                        'RotaryHandleSensor', 'WaterSensor', 'PowermeterGas',
                        'LuxSensor', 'WeatherSensor'],
     DISCOVER_THERMOSTATS: ['Thermostat', 'ThermostatWall', 'MAXThermostat'],

--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import discovery
 from homeassistant.config import load_yaml_config_file
 
 DOMAIN = 'homematic'
-REQUIREMENTS = ["pyhomematic==0.1.11"]
+REQUIREMENTS = ["pyhomematic==0.1.13"]
 
 HOMEMATIC = None
 HOMEMATIC_LINK_DELAY = 0.5
@@ -45,12 +45,12 @@ HM_DEVICE_TYPES = {
     DISCOVER_SWITCHES: ['Switch', 'SwitchPowermeter'],
     DISCOVER_LIGHTS: ['Dimmer'],
     DISCOVER_SENSORS: ['SwitchPowermeter', 'Motion', 'MotionV2',
-                       'RemoteMotion', 'ThermostatWall', 'AreaThermostat',
+                       'RemoteMotion', 'ThermostatWall', 'AreaThermostat', 
                        'RotaryHandleSensor', 'WaterSensor', 'PowermeterGas',
-                       'LuxSensor'],
+                       'LuxSensor', 'WeatherSensor'],
     DISCOVER_THERMOSTATS: ['Thermostat', 'ThermostatWall', 'MAXThermostat'],
     DISCOVER_BINARY_SENSORS: ['ShutterContact', 'Smoke', 'SmokeV2', 'Motion',
-                              'MotionV2', 'RemoteMotion'],
+                              'MotionV2', 'RemoteMotion', 'WeatherSensor'],
     DISCOVER_ROLLERSHUTTER: ['Blind']
 }
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -312,7 +312,7 @@ pyenvisalink==1.0
 pyfttt==0.3
 
 # homeassistant.components.homematic
-pyhomematic==0.1.11
+pyhomematic==0.1.13
 
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.9.1


### PR DESCRIPTION
**Description:**
Pyhomematic 0.1.13 is not out yet, but once that get's released (@danielperna84, maybe you want to comment :))  this PR adds support for the Homematic OC-3 combi sensor.

**Related issue (if applicable):** None

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):**None

**Example entry for `configuration.yaml` (if applicable):**
No changes - see existing HomeMatic config

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
