### PR TITLE
Use voluptuous for logentries

### DIFF
--- a/homeassistant/components/logentries.py
+++ b/homeassistant/components/logentries.py
@@ -7,29 +7,31 @@ https://home-assistant.io/components/logentries/
 import json
 import logging
 import requests
-import homeassistant.util as util
-from homeassistant.const import EVENT_STATE_CHANGED
+
+import voluptuous as vol
+
+from homeassistant.const import (CONF_TOKEN, EVENT_STATE_CHANGED)
 from homeassistant.helpers import state as state_helper
-from homeassistant.helpers import validate_config
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "logentries"
-DEPENDENCIES = []
+DOMAIN = 'logentries'
 
 DEFAULT_HOST = 'https://webhook.logentries.com/noformat/logs/'
 
-CONF_TOKEN = 'token'
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_TOKEN): cv.string,
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
     """Setup the Logentries component."""
-    if not validate_config(config, {DOMAIN: ['token']}, _LOGGER):
-        _LOGGER.error("Logentries token not present")
-        return False
     conf = config[DOMAIN]
-    token = util.convert(conf.get(CONF_TOKEN), str)
-    le_wh = DEFAULT_HOST + token
+    token = conf.get(CONF_TOKEN)
+    le_wh = '{}{}'.format(DEFAULT_HOST, token)
 
     def logentries_event_listener(event):
         """Listen for new messages on the bus and sends them to Logentries."""


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
logentries:
  token: your-log-token-here
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

@omgapuppy, would be nice if you could take a look at the changes and run a quick test.
