### PR TITLE
Use voluptuous for statsd

### DIFF
--- a/homeassistant/components/statsd.py
+++ b/homeassistant/components/statsd.py
@@ -6,27 +6,36 @@ https://home-assistant.io/components/statsd/
 """
 import logging
 
-import homeassistant.util as util
-from homeassistant.const import EVENT_STATE_CHANGED
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_HOST, CONF_PORT, CONF_PREFIX, EVENT_STATE_CHANGED)
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import state as state_helper
+
+REQUIREMENTS = ['statsd==3.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "statsd"
-DEPENDENCIES = []
+CONF_ATTR = 'log_attributes'
+CONF_RATE = 'rate'
 
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 8125
 DEFAULT_PREFIX = 'hass'
 DEFAULT_RATE = 1
+DOMAIN = 'statsd'
 
-REQUIREMENTS = ['statsd==3.2.1']
-
-CONF_HOST = 'host'
-CONF_PORT = 'port'
-CONF_PREFIX = 'prefix'
-CONF_RATE = 'rate'
-CONF_ATTR = 'log_attributes'
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_HOST, default=DEFAULT_HOST): cv.string,
+        vol.Optional(CONF_ATTR, default=False): cv.boolean,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_PREFIX, default=DEFAULT_PREFIX): cv.string,
+        vol.Optional(CONF_RATE, default=DEFAULT_RATE):
+            vol.All(vol.Coerce(int), vol.Range(min=1)),
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
@@ -34,18 +43,13 @@ def setup(hass, config):
     import statsd
 
     conf = config[DOMAIN]
+    host = conf.get(CONF_HOST)
+    port = conf.get(CONF_PORT)
+    sample_rate = conf.get(CONF_RATE)
+    prefix = conf.get(CONF_PREFIX)
+    show_attribute_flag = conf.get(CONF_ATTR)
 
-    host = conf[CONF_HOST]
-    port = util.convert(conf.get(CONF_PORT), int, DEFAULT_PORT)
-    sample_rate = util.convert(conf.get(CONF_RATE), int, DEFAULT_RATE)
-    prefix = util.convert(conf.get(CONF_PREFIX), str, DEFAULT_PREFIX)
-    show_attribute_flag = conf.get(CONF_ATTR, False)
-
-    statsd_client = statsd.StatsClient(
-        host=host,
-        port=port,
-        prefix=prefix
-    )
+    statsd_client = statsd.StatsClient(host=host, port=port, prefix=prefix)
 
     def statsd_event_listener(event):
         """Listen for new messages on the bus and sends them to StatsD."""


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
statsd:
  host: localhost
  port: 8125
  prefix: DB_TO_STORE_EVENTS
  rate: 1
  log_attributes: true
```

@michaelkuty, would be nice if you could take a look at the changes and run a quick test. Thanks.
