### PR TITLE
Clean-up

### DIFF
--- a/homeassistant/components/lock/demo.py
+++ b/homeassistant/components/lock/demo.py
@@ -5,20 +5,20 @@ For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/demo/
 """
 from homeassistant.components.lock import LockDevice
-from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
+from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED)
 
 
 # pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
-    """Setup the demo lock platform."""
-    add_devices_callback([
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Demo lock platform."""
+    add_devices([
         DemoLock('Front Door', STATE_LOCKED),
         DemoLock('Kitchen Door', STATE_UNLOCKED)
     ])
 
 
 class DemoLock(LockDevice):
-    """Representation of a demo lock."""
+    """Representation of a Demo lock."""
 
     def __init__(self, name, state):
         """Initialize the lock."""

--- a/homeassistant/components/lock/mqtt.py
+++ b/homeassistant/components/lock/mqtt.py
@@ -23,9 +23,9 @@ DEPENDENCIES = ['mqtt']
 CONF_PAYLOAD_LOCK = 'payload_lock'
 CONF_PAYLOAD_UNLOCK = 'payload_unlock'
 
-DEFAULT_NAME = "MQTT Lock"
-DEFAULT_PAYLOAD_LOCK = "LOCK"
-DEFAULT_PAYLOAD_UNLOCK = "UNLOCK"
+DEFAULT_NAME = 'MQTT Lock'
+DEFAULT_PAYLOAD_LOCK = 'LOCK'
+DEFAULT_PAYLOAD_UNLOCK = 'UNLOCK'
 DEFAULT_OPTIMISTIC = False
 
 PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
@@ -39,9 +39,9 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 
 
 # pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the MQTT lock."""
-    add_devices_callback([MqttLock(
+    add_devices([MqttLock(
         hass,
         config[CONF_NAME],
         config.get(CONF_STATE_TOPIC),

--- a/homeassistant/components/lock/vera.py
+++ b/homeassistant/components/lock/vera.py
@@ -7,19 +7,18 @@ https://home-assistant.io/components/lock.vera/
 import logging
 
 from homeassistant.components.lock import LockDevice
-from homeassistant.const import (
-    STATE_LOCKED, STATE_UNLOCKED)
+from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED)
 from homeassistant.components.vera import (
     VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
 
-DEPENDENCIES = ['vera']
-
 _LOGGER = logging.getLogger(__name__)
 
+DEPENDENCIES = ['vera']
 
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return Vera locks."""
-    add_devices_callback(
+    add_devices(
         VeraLock(device, VERA_CONTROLLER) for
         device in VERA_DEVICES['lock'])
 


### PR DESCRIPTION
**Description:**
Just a little clean-up. No need for voluptuous.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
