### PR TITLE
Updated python-wink version to fix color/temp detection

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.entity import Entity
 from homeassistant.loader import get_component
 
-REQUIREMENTS = ['python-wink==0.7.11', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
 
 # These are the available sensors mapped to binary_sensor class
 SENSOR_TYPES = {

--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.garage_door import GarageDoorDevice
 from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.11', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -15,7 +15,7 @@ from homeassistant.util import color as color_util
 from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
 
-REQUIREMENTS = ['python-wink==0.7.11', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
 
 SUPPORT_WINK = SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_RGB_COLOR
 

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.lock import LockDevice
 from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.11', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/rollershutter/wink.py
+++ b/homeassistant/components/rollershutter/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.rollershutter import RollershutterDevice
 from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.11', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.components.wink import WinkDevice
 from homeassistant.loader import get_component
 
-REQUIREMENTS = ['python-wink==0.7.11', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
 
 SENSOR_TYPES = ['temperature', 'humidity']
 

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.entity import ToggleEntity
 
-REQUIREMENTS = ['python-wink==0.7.11', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
 from homeassistant.helpers.entity import Entity
 
 DOMAIN = "wink"
-REQUIREMENTS = ['python-wink==0.7.11', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
 
 SUBSCRIPTION_HANDLER = None
 CHANNELS = []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -382,7 +382,7 @@ python-twitch==1.3.0
 # homeassistant.components.rollershutter.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.7.11
+python-wink==0.7.13
 
 # homeassistant.components.keyboard
 pyuserinput==0.1.9


### PR DESCRIPTION
**Description:**
Some Wink lights that support color and temperature weren't returning an API response that python-wink was expecting. This update changes the way color and temperature support is detected to correct this issue.

**Checklist:**
If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
