### PR TITLE
Update telegram.py add send_document

### DIFF
--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -137,7 +137,7 @@ class TelegramNotificationService(BaseNotificationService):
         try:
             document = load_data(**data)
             self.bot.sendDocument(chat_id=self._chat_id,
-                               document=document, caption=caption)
+                                  document=document, caption=caption)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending document.")
             return

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -21,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = ['python-telegram-bot==5.0.0']
 
 ATTR_PHOTO = "photo"
+ATTR_DOCUMENT = "document"
 ATTR_CAPTION = "caption"
 
 CONF_CHAT_ID = 'chat_id'
@@ -102,6 +103,8 @@ class TelegramNotificationService(BaseNotificationService):
             return
         elif data is not None and ATTR_LOCATION in data:
             return self.send_location(data.get(ATTR_LOCATION))
+        elif data is not None and ATTR_DOCUMENT in data:
+            return self.send_document(data.get(ATTR_DOCUMENT, None)[0])
 
         # send message
         try:
@@ -123,6 +126,20 @@ class TelegramNotificationService(BaseNotificationService):
                                photo=photo, caption=caption)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending photo.")
+            return
+
+    def send_document(self, data):
+        """Send a document."""
+        import telegram
+        caption = data.pop(ATTR_CAPTION, None)
+
+        # send photo
+        try:
+            document = load_data(**data)
+            self.bot.sendDocument(chat_id=self._chat_id,
+                               document=document, caption=caption)
+        except telegram.error.TelegramError:
+            _LOGGER.exception("Error sending document.")
             return
 
     def send_location(self, gps):

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -104,7 +104,7 @@ class TelegramNotificationService(BaseNotificationService):
         elif data is not None and ATTR_LOCATION in data:
             return self.send_location(data.get(ATTR_LOCATION))
         elif data is not None and ATTR_DOCUMENT in data:
-            return self.send_document(data.get(ATTR_DOCUMENT, None))
+            return self.send_document(data.get(ATTR_DOCUMENT))
 
         # send message
         try:

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -104,7 +104,7 @@ class TelegramNotificationService(BaseNotificationService):
         elif data is not None and ATTR_LOCATION in data:
             return self.send_location(data.get(ATTR_LOCATION))
         elif data is not None and ATTR_DOCUMENT in data:
-            return self.send_document(data.get(ATTR_DOCUMENT, None)[0])
+            return self.send_document(data.get(ATTR_DOCUMENT, None))
 
         # send message
         try:


### PR DESCRIPTION
**Description:**
Add Telegram capability to send documents

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#821

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
      - service: notify.something
        data:
          message: "This is a message"
          data:
            document:
              - file: /tmp/gif2.gif
                caption: "This is a caption"

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Add Telegram notify capability to send documents

Useful to send GIFs
