### PR TITLE
Add voluptuous to template switch

### DIFF
--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -47,9 +47,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for device, device_config in config[CONF_SWITCHES].items():
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
-        state_template = device_config.get(CONF_VALUE_TEMPLATE)
-        on_action = device_config.get(ON_ACTION)
-        off_action = device_config.get(OFF_ACTION)
+        state_template = device_config[CONF_VALUE_TEMPLATE]
+        on_action = device_config[ON_ACTION]
+        off_action = device_config[OFF_ACTION]
         entity_ids = device_config.get(ATTR_ENTITY_ID, MATCH_ALL)
 
         switches.append(

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -5,8 +5,11 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.template/
 """
 import logging
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
 
-from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchDevice
+from homeassistant.components.switch import (
+    ENTITY_ID_FORMAT, SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, CONF_VALUE_TEMPLATE, STATE_OFF, STATE_ON,
     ATTR_ENTITY_ID, MATCH_ALL)
@@ -15,7 +18,6 @@ from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.script import Script
 from homeassistant.helpers import template
 from homeassistant.helpers.event import track_state_change
-from homeassistant.util import slugify
 
 CONF_SWITCHES = 'switches'
 
@@ -25,40 +27,29 @@ OFF_ACTION = 'turn_off'
 _LOGGER = logging.getLogger(__name__)
 _VALID_STATES = [STATE_ON, STATE_OFF, 'true', 'false']
 
+SWITCH_SCHEMA = vol.Schema({
+    vol.Required(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Required(ON_ACTION): cv.SCRIPT_SCHEMA,
+    vol.Required(OFF_ACTION): cv.SCRIPT_SCHEMA,
+    vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SWITCHES): vol.Schema({cv.slug: SWITCH_SCHEMA}),
+})
+
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Template switch."""
     switches = []
-    if config.get(CONF_SWITCHES) is None:
-        _LOGGER.error("Missing configuration data for switch platform")
-        return False
 
     for device, device_config in config[CONF_SWITCHES].items():
-
-        if device != slugify(device):
-            _LOGGER.error("Found invalid key for switch.template: %s. "
-                          "Use %s instead", device, slugify(device))
-            continue
-
-        if not isinstance(device_config, dict):
-            _LOGGER.error("Missing configuration data for switch %s", device)
-            continue
-
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         state_template = device_config.get(CONF_VALUE_TEMPLATE)
         on_action = device_config.get(ON_ACTION)
         off_action = device_config.get(OFF_ACTION)
-        if state_template is None:
-            _LOGGER.error(
-                "Missing %s for switch %s", CONF_VALUE_TEMPLATE, device)
-            continue
-
-        if on_action is None or off_action is None:
-            _LOGGER.error(
-                "Missing action for switch %s", device)
-            continue
-
         entity_ids = device_config.get(ATTR_ENTITY_ID, MATCH_ALL)
 
         switches.append(

--- a/tests/components/switch/test_template.py
+++ b/tests/components/switch/test_template.py
@@ -1,6 +1,6 @@
 """The tests for the  Template switch platform."""
+import homeassistant.bootstrap as bootstrap
 import homeassistant.components as core
-import homeassistant.components.switch as switch
 
 from homeassistant.const import (
     STATE_ON,
@@ -18,6 +18,7 @@ class TestTemplateSwitch:
         self.calls = []
 
         def record_call(service):
+            """Track function calls.."""
             self.calls.append(service)
 
         self.hass.services.register('test', 'automation', record_call)
@@ -28,7 +29,7 @@ class TestTemplateSwitch:
 
     def test_template_state_text(self):
         """"Test the state text of a template."""
-        assert switch.setup(self.hass, {
+        assert bootstrap.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template',
                 'switches': {
@@ -62,7 +63,7 @@ class TestTemplateSwitch:
 
     def test_template_state_boolean_on(self):
         """Test the setting of the state with boolean on."""
-        assert switch.setup(self.hass, {
+        assert bootstrap.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template',
                 'switches': {
@@ -87,7 +88,7 @@ class TestTemplateSwitch:
 
     def test_template_state_boolean_off(self):
         """Test the setting of the state with off."""
-        assert switch.setup(self.hass, {
+        assert bootstrap.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template',
                 'switches': {
@@ -112,7 +113,7 @@ class TestTemplateSwitch:
 
     def test_template_syntax_error(self):
         """Test templating syntax error."""
-        assert switch.setup(self.hass, {
+        assert not bootstrap.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template',
                 'switches': {
@@ -131,15 +132,11 @@ class TestTemplateSwitch:
                 }
             }
         })
-
-        state = self.hass.states.set('switch.test_state', STATE_ON)
-        self.hass.pool.block_till_done()
-        state = self.hass.states.get('switch.test_template_switch')
-        assert state.state == 'unavailable'
+        assert self.hass.states.all() == []
 
     def test_invalid_name_does_not_create(self):
         """Test invalid name."""
-        assert switch.setup(self.hass, {
+        assert not bootstrap.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template',
                 'switches': {
@@ -161,8 +158,8 @@ class TestTemplateSwitch:
         assert self.hass.states.all() == []
 
     def test_invalid_switch_does_not_create(self):
-        """Test invalid name."""
-        assert switch.setup(self.hass, {
+        """Test invalid switch."""
+        assert not bootstrap.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template',
                 'switches': {
@@ -174,7 +171,7 @@ class TestTemplateSwitch:
 
     def test_no_switches_does_not_create(self):
         """Test if there are no switches no creation."""
-        assert switch.setup(self.hass, {
+        assert not bootstrap.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template'
             }
@@ -183,7 +180,7 @@ class TestTemplateSwitch:
 
     def test_missing_template_does_not_create(self):
         """Test missing template."""
-        assert switch.setup(self.hass, {
+        assert not bootstrap.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template',
                 'switches': {
@@ -206,7 +203,7 @@ class TestTemplateSwitch:
 
     def test_missing_on_does_not_create(self):
         """Test missing on."""
-        assert switch.setup(self.hass, {
+        assert not bootstrap.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template',
                 'switches': {
@@ -229,7 +226,7 @@ class TestTemplateSwitch:
 
     def test_missing_off_does_not_create(self):
         """Test missing off."""
-        assert switch.setup(self.hass, {
+        assert not bootstrap.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template',
                 'switches': {
@@ -252,7 +249,7 @@ class TestTemplateSwitch:
 
     def test_on_action(self):
         """Test on action."""
-        assert switch.setup(self.hass, {
+        assert bootstrap.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template',
                 'switches': {
@@ -279,11 +276,11 @@ class TestTemplateSwitch:
         core.switch.turn_on(self.hass, 'switch.test_template_switch')
         self.hass.pool.block_till_done()
 
-        assert 1 == len(self.calls)
+        assert len(self.calls) == 1
 
     def test_off_action(self):
         """Test off action."""
-        assert switch.setup(self.hass, {
+        assert bootstrap.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template',
                 'switches': {
@@ -311,4 +308,4 @@ class TestTemplateSwitch:
         core.switch.turn_off(self.hass, 'switch.test_template_switch')
         self.hass.pool.block_till_done()
 
-        assert 1 == len(self.calls)
+        assert len(self.calls) == 1


### PR DESCRIPTION
**Description:**
Add voluptuous to template switch / revise tests.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
