### PR TITLE
add ffmpeg noise detection sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -101,6 +101,7 @@ omit =
     homeassistant/components/alarm_control_panel/nx584.py
     homeassistant/components/alarm_control_panel/simplisafe.py
     homeassistant/components/binary_sensor/arest.py
+    homeassistant/components/binary_sensor/ffmpeg.py
     homeassistant/components/binary_sensor/rest.py
     homeassistant/components/browser.py
     homeassistant/components/camera/bloomsky.py

--- a/homeassistant/components/binary_sensor/ffmpeg.py
+++ b/homeassistant/components/binary_sensor/ffmpeg.py
@@ -1,0 +1,109 @@
+"""
+Provides a binary sensor which is a collection of ffmpeg tools.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.ffmpeg/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.binary_sensor import (BinarySensorDevice,
+                                                    PLATFORM_SCHEMA)
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_NAME
+
+REQUIREMENTS = ["ha-ffmpeg==0.7"]
+
+MAP_FFMPEG_BIN = [
+    'noise'
+]
+
+CONF_TOOL = 'tool'
+CONF_INPUT = 'input'
+CONF_FFMPEG_BIN = 'ffmpeg_bin'
+CONF_EXTRA_ARGUMENTS = 'extra_arguments'
+CONF_OUTPUT = 'output'
+CONF_PEAK = 'peak'
+CONF_DURATION = 'duration'
+CONF_RESET = 'reset'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_TOOL): vol.In(MAP_FFMPEG_BIN),
+    vol.Required(CONF_INPUT): cv.string,
+    vol.Optional(CONF_NAME, default="FFmpeg"): cv.string,
+    vol.Optional(CONF_FFMPEG_BIN, default="ffmpeg"): cv.string,
+    vol.Optional(CONF_EXTRA_ARGUMENTS): cv.string,
+    vol.Optional(CONF_OUTPUT): cv.string,
+    vol.Optional(CONF_PEAK, default=-30): vol.Coerce(int),
+    vol.Optional(CONF_DURATION, default=1):
+        vol.All(vol.Coerce(int), vol.Range(min=1)),
+    vol.Optional(CONF_RESET, default=2):
+        vol.All(vol.Coerce(int), vol.Range(min=1)),
+})
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Create the binary sensor."""
+    if config.get(CONF_TOOL) == "noise":
+        entity = FFmpegNoise(config)
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, entity.shutdown_ffmpeg)
+    add_entities([entity])
+
+
+class FFmpegNoise(BinarySensorDevice):
+    """A binary sensor which use ffmpeg for noise detection."""
+
+    def __init__(self, config):
+        """Constructor for binary sensor noise detection."""
+        from haffmpeg import SensorNoise
+
+        self._state = False
+        self._name = config.get(CONF_NAME)
+        self._ffmpeg = SensorNoise(config.get(CONF_FFMPEG_BIN), self._callback)
+
+        # init config
+        self._ffmpeg.set_options(
+            time_duration=config.get(CONF_DURATION),
+            time_reset=config.get(CONF_RESET),
+            peak=config.get(CONF_PEAK),
+        )
+
+        # run
+        self._ffmpeg.open_sensor(
+            input_source=config.get(CONF_INPUT),
+            output_dest=config.get(CONF_OUTPUT),
+            extra_cmd=config.get(CONF_EXTRA_ARGUMENTS),
+        )
+
+    def _callback(self, state):
+        """HA-FFmpeg callback for noise detection."""
+        self._state = state
+        self.update_ha_state()
+
+    def shutdown_ffmpeg(self, event):
+        """For STOP event to shutdown ffmpeg."""
+        self._ffmpeg.close()
+
+    @property
+    def is_on(self):
+        """True if the binary sensor is on."""
+        return self._state
+
+    @property
+    def sensor_class(self):
+        """Return the class of this sensor, from SENSOR_CLASSES."""
+        return "sound"
+
+    @property
+    def should_poll(self):
+        """Return True if entity has to be polled for state."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return self._name

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -14,7 +14,7 @@ from homeassistant.components.camera.mjpeg import extract_image_from_mjpeg
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
 
-REQUIREMENTS = ["ha-ffmpeg==0.4"]
+REQUIREMENTS = ["ha-ffmpeg==0.7"]
 
 CONF_INPUT = 'input'
 CONF_FFMPEG_BIN = 'ffmpeg_bin'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -102,8 +102,9 @@ googlemaps==2.4.4
 # homeassistant.components.sensor.gpsd
 gps3==0.33.2
 
+# homeassistant.components.binary_sensor.ffmpeg
 # homeassistant.components.camera.ffmpeg
-ha-ffmpeg==0.4
+ha-ffmpeg==0.7
 
 # homeassistant.components.mqtt.server
 hbmqtt==0.7.1


### PR DESCRIPTION
**Description:**

The next of my ffmpeg series sensor is a noise detection. It is possible to detect a noise of a ffmpeg valid input (i.e. ip camera) stream. The peak is the dB for trigger the state they need 'duration' seconds over this value for detect a real noice. After 'reset' seconds without a noise it going to off state. It need only 0.7 - 1.7 % CPU on a raspberry.

I use HA now as my baby monitor. If trigger a noise alarm from my cam, it stream to a icecast server and with automation I can play that over my sonos media player.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
binary_sensor:
 - platform: ffmpeg
   tool: noise
   input: FFMPEG_VALID_INPUT
   # optional
   ffmpeg_bin: /usr/bin/ffmpeg
   peak: -30
   duration: 1
   reset: 2
   output: i.e to a icecast server for play on SONOS
   extra: argument to pass to ffmpeg (i.e. filter frequenc)
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
