### PR TITLE
Use voluptuous for APCUPSd

### DIFF
--- a/homeassistant/components/apcupsd.py
+++ b/homeassistant/components/apcupsd.py
@@ -7,35 +7,43 @@ https://home-assistant.io/components/apcupsd/
 import logging
 from datetime import timedelta
 
+import voluptuous as vol
+
+from homeassistant.const import (CONF_HOST, CONF_PORT)
+import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-DOMAIN = "apcupsd"
-REQUIREMENTS = ("apcaccess==0.0.4",)
+REQUIREMENTS = ['apcaccess==0.0.4']
 
-CONF_HOST = "host"
-CONF_PORT = "port"
-CONF_TYPE = "type"
+_LOGGER = logging.getLogger(__name__)
 
-DEFAULT_HOST = "localhost"
+CONF_TYPE = 'type'
+
+DATA = None
+DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 3551
+DOMAIN = 'apcupsd'
 
-KEY_STATUS = "STATUS"
-
-VALUE_ONLINE = "ONLINE"
+KEY_STATUS = 'STATUS'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
-DATA = None
+VALUE_ONLINE = 'ONLINE'
 
-_LOGGER = logging.getLogger(__name__)
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_HOST, default=DEFAULT_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
     """Use config values to set up a function enabling status retrieval."""
     global DATA
-
-    host = config[DOMAIN].get(CONF_HOST, DEFAULT_HOST)
-    port = config[DOMAIN].get(CONF_PORT, DEFAULT_PORT)
+    conf = config[DOMAIN]
+    host = conf.get(CONF_HOST)
+    port = conf.get(CONF_PORT)
 
     DATA = APCUPSdData(host, port)
 

--- a/homeassistant/components/binary_sensor/apcupsd.py
+++ b/homeassistant/components/binary_sensor/apcupsd.py
@@ -4,23 +4,32 @@ Support for tracking the online status of a UPS.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.apcupsd/
 """
-from homeassistant.components import apcupsd
-from homeassistant.components.binary_sensor import BinarySensorDevice
+import voluptuous as vol
 
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
+from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components import apcupsd
+
+DEFAULT_NAME = 'UPS Online Status'
 DEPENDENCIES = [apcupsd.DOMAIN]
-DEFAULT_NAME = "UPS Online Status"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Instantiate an OnlineStatus binary sensor entity."""
+    """Setup an Online Status binary sensor."""
     add_entities((OnlineStatus(config, apcupsd.DATA),))
 
 
 class OnlineStatus(BinarySensorDevice):
-    """Represent UPS online status."""
+    """Representation of an UPS online status."""
 
     def __init__(self, config, data):
-        """Initialize the APCUPSd device."""
+        """Initialize the APCUPSd binary device."""
         self._config = config
         self._data = data
         self._state = None
@@ -29,7 +38,7 @@ class OnlineStatus(BinarySensorDevice):
     @property
     def name(self):
         """Return the name of the UPS online status sensor."""
-        return self._config.get("name", DEFAULT_NAME)
+        return self._config.get(CONF_NAME)
 
     @property
     def is_on(self):

--- a/homeassistant/components/sensor/apcupsd.py
+++ b/homeassistant/components/sensor/apcupsd.py
@@ -6,9 +6,15 @@ https://home-assistant.io/components/sensor.apcupsd/
 """
 import logging
 
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components import apcupsd
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import (TEMP_CELSIUS, CONF_RESOURCES)
 from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = [apcupsd.DOMAIN]
 
@@ -92,14 +98,17 @@ INFERRED_UNITS = {
     ' C': TEMP_CELSIUS,
 }
 
-_LOGGER = logging.getLogger(__name__)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_RESOURCES, default=[]):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Setup the APCUPSd sensors."""
     entities = []
 
-    for resource in config['resources']:
+    for resource in config[CONF_RESOURCES]:
         sensor_type = resource.lower()
 
         if sensor_type not in SENSOR_TYPES:
@@ -109,7 +118,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if sensor_type.upper() not in apcupsd.DATA.status:
             _LOGGER.warning(
                 'Sensor type: "%s" does not appear in the APCUPSd status '
-                'output.', sensor_type)
+                'output', sensor_type)
 
         entities.append(APCUPSdSensor(apcupsd.DATA, sensor_type))
 


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
apcupsd:
  host: IP_ADDRESS
  port: PORT
```

@flyte @dale3h , would be nice if you could take a look at the changes and run a quick test. Thanks.
