### PR TITLE
Use voluptuous for WOL

### DIFF
--- a/homeassistant/components/switch/wake_on_lan.py
+++ b/homeassistant/components/switch/wake_on_lan.py
@@ -8,27 +8,35 @@ import logging
 import platform
 import subprocess as sp
 
-from homeassistant.components.switch import SwitchDevice
+import voluptuous as vol
 
-_LOGGER = logging.getLogger(__name__)
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (CONF_HOST, CONF_NAME)
+
 REQUIREMENTS = ['wakeonlan==0.2.2']
 
-DEFAULT_NAME = "Wake on LAN"
+_LOGGER = logging.getLogger(__name__)
+
+CONF_MAC_ADDRESS = 'mac_address'
+
+DEFAULT_NAME = 'Wake on LAN'
 DEFAULT_PING_TIMEOUT = 1
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_MAC_ADDRESS): cv.string,
+    vol.Optional(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Add wake on lan switch."""
-    if config.get('mac_address') is None:
-        _LOGGER.error("Missing required variable: mac_address")
-        return False
+    name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
+    mac_address = config.get(CONF_MAC_ADDRESS)
 
-    add_devices_callback([WOLSwitch(
-        hass,
-        config.get('name', DEFAULT_NAME),
-        config.get('host'),
-        config.get('mac_address'),
-        )])
+    add_devices_callback([WOLSwitch(hass, name, host, mac_address)])
 
 
 class WOLSwitch(SwitchDevice):


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
  platform: wake_on_lan
  mac_address: "00-01-02-03-04-05"
  name: "WOL"
  host: "192.168.1.1"
```

@joopert, would be nice if you could take a look at the changes and run a quick test. Thanks.
