### PR TITLE
Check config script: various fixes

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -21,13 +21,14 @@ _LOGGER = logging.getLogger(__name__)
 # pylint: disable=protected-access
 MOCKS = {
     'load': ("homeassistant.util.yaml.load_yaml", yaml.load_yaml),
+    'load*': ("homeassistant.config.load_yaml", yaml.load_yaml),
     'get': ("homeassistant.loader.get_component", loader.get_component),
     'secrets': ("homeassistant.util.yaml._secret_yaml", yaml._secret_yaml),
     'except': ("homeassistant.bootstrap.log_exception",
                bootstrap.log_exception)
 }
 SILENCE = (
-    'homeassistant.util.yaml.clear_secret_cache',
+    'homeassistant.bootstrap.clear_secret_cache',
     'homeassistant.core._LOGGER.info',
     'homeassistant.loader._LOGGER.info',
     'homeassistant.bootstrap._LOGGER.info',
@@ -114,7 +115,7 @@ def run(script_args: List) -> int:
     if domain_info:
         if 'all' in domain_info:
             print(color('bold_white', 'Successful config (all)'))
-            for domain, config in res['components']:
+            for domain, config in res['components'].items():
                 print(color(C_HEAD, domain + ':'))
                 dump_dict(config, indent_count=3)
         else:
@@ -207,7 +208,9 @@ def check(config_path):
 
     # Patches with local mock functions
     for key, val in MOCKS.items():
-        mock_function = locals()['mock_'+key]
+        # The * in the key is removed to find the mock_function (side_effect)
+        # This allows us to use one side_effect to patch multiple locations
+        mock_function = locals()['mock_' + key.replace('*', '')]
         PATCHES[key] = patch(val[0], side_effect=mock_function)
 
     # Start all patches

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -166,7 +166,6 @@ def _load_secret_yaml(secret_path: str) -> Dict:
             del secrets['logger']
     except FileNotFoundError:
         secrets = {}
-        return {}
     __SECRET_CACHE[secret_path] = secrets
     return secrets
 

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -149,9 +149,13 @@ def _env_var_yaml(loader: SafeLineLoader,
 
 def _load_secret_yaml(secret_path: str) -> Dict:
     """Load the secrets yaml from path."""
-    _LOGGER.debug('Loading %s', os.path.join(secret_path, _SECRET_YAML))
+    secret_path = os.path.join(secret_path, _SECRET_YAML)
+    if secret_path in __SECRET_CACHE:
+        return __SECRET_CACHE[secret_path]
+
+    _LOGGER.debug('Loading %s', secret_path)
     try:
-        secrets = load_yaml(os.path.join(secret_path, _SECRET_YAML))
+        secrets = load_yaml(secret_path)
         if 'logger' in secrets:
             logger = str(secrets['logger']).lower()
             if logger == 'debug':
@@ -160,9 +164,11 @@ def _load_secret_yaml(secret_path: str) -> Dict:
                 _LOGGER.error("secrets.yaml: 'logger: debug' expected,"
                               " but 'logger: %s' found", logger)
             del secrets['logger']
-        return secrets
     except FileNotFoundError:
+        secrets = {}
         return {}
+    __SECRET_CACHE[secret_path] = secrets
+    return secrets
 
 
 # pylint: disable=protected-access
@@ -171,8 +177,8 @@ def _secret_yaml(loader: SafeLineLoader,
     """Load secrets and embed it into the configuration YAML."""
     secret_path = os.path.dirname(loader.name)
     while True:
-        secrets = __SECRET_CACHE.get(secret_path,
-                                     _load_secret_yaml(secret_path))
+        secrets = _load_secret_yaml(secret_path)
+
         if node.value in secrets:
             _LOGGER.debug('Secret %s retrieved from secrets.yaml in '
                           'folder %s', node.value, secret_path)


### PR DESCRIPTION
**Description:**
Various fixes to the check_config script:
- `--secrets` Secrets never cached 
- `--files` patching files at config_util
- `--info all` was broken

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
