### PR TITLE
modbus write register service

### DIFF
--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -31,6 +31,12 @@ IP_PORT = "port"
 
 _LOGGER = logging.getLogger(__name__)
 
+SERVICE_WRITE_REGISTER = "write_register"
+
+ATTR_ADDRESS = "address"
+ATTR_UNIT = "unit"
+ATTR_VALUE = "value"
+
 NETWORK = None
 TYPE = None
 
@@ -73,6 +79,16 @@ def setup(hass, config):
         """Start Modbus service."""
         NETWORK.connect()
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_modbus)
+
+        # Register services for modbus
+        hass.services.register(DOMAIN, SERVICE_WRITE_REGISTER, write_register)
+
+    def write_register(service):
+        """Write modbus register."""
+        unit = int(float(service.data.get(ATTR_UNIT)))
+        address = int(float(service.data.get(ATTR_ADDRESS)))
+        value = int(float(service.data.get(ATTR_VALUE)))
+        NETWORK.write_register(address, value, unit=unit)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_modbus)
 


### PR DESCRIPTION
**Description:**
New service to write modbus register.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#834

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
automation:
  - alias: Set fan speed                                                         
    trigger:                                                                     
      platform: state                                                            
      entity_id: input_slider.fan_speed                                                                         
    action:                                                                                                     
      service: modbus.write_register                                                                            
      data_template:                                                                                            
        unit: 1                                                                                                 
        address: 100                                                             
        value: '{{ states.input_slider.fan_speed.state }}'  
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
