### PR TITLE
Fix reference to wrong components in tests for cameras

### DIFF
--- a/tests/components/camera/test_generic.py
+++ b/tests/components/camera/test_generic.py
@@ -1,4 +1,4 @@
-"""The tests for generic camera platform."""
+"""The tests for generic camera component."""
 import unittest
 from unittest import mock
 

--- a/tests/components/camera/test_generic.py
+++ b/tests/components/camera/test_generic.py
@@ -1,4 +1,4 @@
-"""The tests for UVC camera module."""
+"""The tests for generic camera platform."""
 import unittest
 from unittest import mock
 

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -1,4 +1,4 @@
-"""The tests for UVC camera module."""
+"""The tests for local file camera component."""
 from tempfile import NamedTemporaryFile
 import unittest
 from unittest import mock
@@ -12,7 +12,7 @@ from tests.common import get_test_home_assistant
 
 
 class TestLocalCamera(unittest.TestCase):
-    """Test the generic camera platform."""
+    """Test the local file camera platform."""
 
     def setUp(self):
         """Setup things to be run when tests are started."""

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -12,7 +12,7 @@ from tests.common import get_test_home_assistant
 
 
 class TestLocalCamera(unittest.TestCase):
-    """Test the local file camera platform."""
+    """Test the local file camera component."""
 
     def setUp(self):
         """Setup things to be run when tests are started."""


### PR DESCRIPTION
**Description:**
Fix reference to wrong components in tests for generic and local file camera components.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
