### PR TITLE
Owntracks waypoint import

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -35,6 +35,7 @@ CONF_WAYPOINT_WHITELIST = 'waypoint_whitelist'
 
 VALIDATE_LOCATION = 'location'
 VALIDATE_TRANSITION = 'transition'
+VALIDATE_WAYPOINTS = 'waypoints'
 
 WAYPOINT_LAT_KEY = 'lat'
 WAYPOINT_LON_KEY = 'lon'
@@ -59,7 +60,7 @@ def setup_scanner(hass, config, see):
                           'because of missing or malformatted data: %s',
                           data_type, data)
             return None
-        if data_type == VALIDATE_TRANSITION or data_type == 'waypoints':
+        if data_type == VALIDATE_TRANSITION or data_type == VALIDATE_WAYPOINTS:
             return data
         if max_gps_accuracy is not None and \
                 convert(data.get('acc'), float, 0.0) > max_gps_accuracy:
@@ -195,7 +196,7 @@ def setup_scanner(hass, config, see):
         """List of waypoints published by a user."""
         # Docs on available data:
         # http://owntracks.org/booklet/tech/json/#_typewaypoints
-        data = validate_payload(payload, 'waypoints')
+        data = validate_payload(payload, VALIDATE_WAYPOINTS)
         if not data:
             return
 

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -35,8 +35,6 @@ CONF_WAYPOINT_IMPORT_USER = 'waypoint_import_user'
 VALIDATE_LOCATION = 'location'
 VALIDATE_TRANSITION = 'transition'
 
-CONF_WAYPOINT_IMPORT_USER = 'waypoint_import_user'
-
 
 def setup_scanner(hass, config, see):
     """Setup an OwnTracks tracker."""

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 import homeassistant.components.mqtt as mqtt
 from homeassistant.const import STATE_HOME
 from homeassistant.util import convert, slugify
-from homeassistant.components import zone
+from homeassistant.components import zone as zone_comp
 
 DEPENDENCIES = ['mqtt']
 
@@ -114,9 +114,9 @@ def setup_scanner(hass, config, see):
 
         def enter_event():
             """Execute enter event."""
-            _zone = hass.states.get("zone.{}".format(location))
+            zone = hass.states.get("zone.{}".format(location))
             with LOCK:
-                if _zone is None and data.get('t') == 'b':
+                if zone is None and data.get('t') == 'b':
                     # Not a HA zone, and a beacon so assume mobile
                     beacons = MOBILE_BEACONS_ACTIVE[dev_id]
                     if location not in beacons:
@@ -128,7 +128,7 @@ def setup_scanner(hass, config, see):
                     if location not in regions:
                         regions.append(location)
                     _LOGGER.info("Enter region %s", location)
-                    _set_gps_from_zone(kwargs, location, _zone)
+                    _set_gps_from_zone(kwargs, location, zone)
 
                 see(**kwargs)
                 see_beacons(dev_id, kwargs)
@@ -143,8 +143,8 @@ def setup_scanner(hass, config, see):
 
                 if new_region:
                     # Exit to previous region
-                    _zone = hass.states.get("zone.{}".format(new_region))
-                    _set_gps_from_zone(kwargs, new_region, _zone)
+                    zone = hass.states.get("zone.{}".format(new_region))
+                    _set_gps_from_zone(kwargs, new_region, zone)
                     _LOGGER.info("Exit to %s", new_region)
                     see(**kwargs)
                     see_beacons(dev_id, kwargs)
@@ -201,7 +201,7 @@ def setup_scanner(hass, config, see):
             lat = wayp['lat']
             lon = wayp['lon']
             rad = wayp['rad']
-            zone.add_zone(hass, name, lat, lon, rad)
+            zone_comp.add_zone(hass, name, lat, lon, rad)
 
     def see_beacons(dev_id, kwargs_param):
         """Set active beacons to the current location."""
@@ -240,12 +240,12 @@ def _parse_see_args(topic, data):
     return dev_id, kwargs
 
 
-def _set_gps_from_zone(kwargs, location, _zone):
+def _set_gps_from_zone(kwargs, location, zone):
     """Set the see parameters from the zone parameters."""
-    if _zone is not None:
+    if zone is not None:
         kwargs['gps'] = (
-            _zone.attributes['latitude'],
-            _zone.attributes['longitude'])
-        kwargs['gps_accuracy'] = _zone.attributes['radius']
+            zone.attributes['latitude'],
+            zone.attributes['longitude'])
+        kwargs['gps_accuracy'] = zone.attributes['radius']
         kwargs['location_name'] = location
     return kwargs

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 import homeassistant.components.mqtt as mqtt
 from homeassistant.const import STATE_HOME
 from homeassistant.util import convert, slugify
+from homeassistant.components import zone
 
 DEPENDENCIES = ['mqtt']
 
@@ -22,6 +23,7 @@ BEACON_DEV_ID = 'beacon'
 
 LOCATION_TOPIC = 'owntracks/+/+'
 EVENT_TOPIC = 'owntracks/+/+/event'
+WAYPOINT_TOPIC = 'owntracks/{}/+/waypoint'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,10 +34,12 @@ CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
 VALIDATE_LOCATION = 'location'
 VALIDATE_TRANSITION = 'transition'
 
+CONF_WAYPOINT_IMPORT_USER = 'waypoint_import_user'
 
 def setup_scanner(hass, config, see):
     """Setup an OwnTracks tracker."""
     max_gps_accuracy = config.get(CONF_MAX_GPS_ACCURACY)
+    waypoint_import_user = config.get(CONF_WAYPOINT_IMPORT_USER)
 
     def validate_payload(payload, data_type):
         """Validate OwnTracks payload."""
@@ -50,7 +54,7 @@ def setup_scanner(hass, config, see):
                           'because of missing or malformatted data: %s',
                           data_type, data)
             return None
-        if data_type == VALIDATE_TRANSITION:
+        if data_type == VALIDATE_TRANSITION or data_type == 'waypoints':
             return data
         if max_gps_accuracy is not None and \
                 convert(data.get('acc'), float, 0.0) > max_gps_accuracy:
@@ -110,9 +114,9 @@ def setup_scanner(hass, config, see):
 
         def enter_event():
             """Execute enter event."""
-            zone = hass.states.get("zone.{}".format(location))
+            _zone = hass.states.get("zone.{}".format(location))
             with LOCK:
-                if zone is None and data.get('t') == 'b':
+                if _zone is None and data.get('t') == 'b':
                     # Not a HA zone, and a beacon so assume mobile
                     beacons = MOBILE_BEACONS_ACTIVE[dev_id]
                     if location not in beacons:
@@ -124,7 +128,7 @@ def setup_scanner(hass, config, see):
                     if location not in regions:
                         regions.append(location)
                     _LOGGER.info("Enter region %s", location)
-                    _set_gps_from_zone(kwargs, location, zone)
+                    _set_gps_from_zone(kwargs, location, _zone)
 
                 see(**kwargs)
                 see_beacons(dev_id, kwargs)
@@ -139,8 +143,8 @@ def setup_scanner(hass, config, see):
 
                 if new_region:
                     # Exit to previous region
-                    zone = hass.states.get("zone.{}".format(new_region))
-                    _set_gps_from_zone(kwargs, new_region, zone)
+                    _zone = hass.states.get("zone.{}".format(new_region))
+                    _set_gps_from_zone(kwargs, new_region, _zone)
                     _LOGGER.info("Exit to %s", new_region)
                     see(**kwargs)
                     see_beacons(dev_id, kwargs)
@@ -182,6 +186,23 @@ def setup_scanner(hass, config, see):
                 data['event'])
             return
 
+    def owntracks_waypoint_update(topic, payload, qos):
+        """List of waypoints published by a user."""
+        # Docs on available data:
+        # http://owntracks.org/booklet/tech/json/#_typewaypoints
+        data = validate_payload(payload, 'waypoints')
+        if not data:
+            return
+
+        wayps = data['waypoints']
+        _LOGGER.info("Got %d waypoints from %s", len(wayps), topic)
+        for wayp in wayps:
+            name = wayp['desc']
+            lat = wayp['lat']
+            lon = wayp['lon']
+            rad = wayp['rad']
+            zone.add_zone(hass, name, lat, lon, rad)
+
     def see_beacons(dev_id, kwargs_param):
         """Set active beacons to the current location."""
         kwargs = kwargs_param.copy()
@@ -194,6 +215,10 @@ def setup_scanner(hass, config, see):
 
     mqtt.subscribe(hass, LOCATION_TOPIC, owntracks_location_update, 1)
     mqtt.subscribe(hass, EVENT_TOPIC, owntracks_event_update, 1)
+
+    if waypoint_import_user is not None:
+        mqtt.subscribe(hass, WAYPOINT_TOPIC.format(waypoint_import_user),
+                        owntracks_waypoint_update, 1)
 
     return True
 
@@ -215,12 +240,12 @@ def _parse_see_args(topic, data):
     return dev_id, kwargs
 
 
-def _set_gps_from_zone(kwargs, location, zone):
+def _set_gps_from_zone(kwargs, location, _zone):
     """Set the see parameters from the zone parameters."""
-    if zone is not None:
+    if _zone is not None:
         kwargs['gps'] = (
-            zone.attributes['latitude'],
-            zone.attributes['longitude'])
-        kwargs['gps_accuracy'] = zone.attributes['radius']
+            _zone.attributes['latitude'],
+            _zone.attributes['longitude'])
+        kwargs['gps_accuracy'] = _zone.attributes['radius']
         kwargs['location_name'] = location
     return kwargs

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -36,6 +36,7 @@ VALIDATE_TRANSITION = 'transition'
 
 CONF_WAYPOINT_IMPORT_USER = 'waypoint_import_user'
 
+
 def setup_scanner(hass, config, see):
     """Setup an OwnTracks tracker."""
     max_gps_accuracy = config.get(CONF_MAX_GPS_ACCURACY)
@@ -218,7 +219,7 @@ def setup_scanner(hass, config, see):
 
     if waypoint_import_user is not None:
         mqtt.subscribe(hass, WAYPOINT_TOPIC.format(waypoint_import_user),
-                        owntracks_waypoint_update, 1)
+                       owntracks_waypoint_update, 1)
 
     return True
 

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -32,6 +32,7 @@ LOCK = threading.Lock()
 CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
 CONF_WAYPOINT_IMPORT_USER = 'waypoint_import_user'
 
+
 def setup_scanner(hass, config, see):
     """Setup an OwnTracks tracker."""
     max_gps_accuracy = config.get(CONF_MAX_GPS_ACCURACY)
@@ -203,7 +204,7 @@ def setup_scanner(hass, config, see):
 
     if waypoint_import_user is not None:
         mqtt.subscribe(hass, WAYPOINT_TOPIC.format(waypoint_import_user),
-                        owntracks_waypoint_update, 1)
+                       owntracks_waypoint_update, 1)
 
     return True
 

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -203,12 +203,13 @@ def setup_scanner(hass, config, see):
         _LOGGER.info("Got %d waypoints from %s", len(wayps), topic)
         for wayp in wayps:
             name = wayp['desc']
+            pretty_name = parse_topic(topic, True)[1] + ' - ' + name
             lat = wayp[WAYPOINT_LAT_KEY]
             lon = wayp[WAYPOINT_LON_KEY]
             rad = wayp['rad']
-            zone = zone_comp.Zone(hass, name, lat, lon, rad,
+            zone = zone_comp.Zone(hass, pretty_name, lat, lon, rad,
                                   zone_comp.ICON_IMPORT, False, True)
-            zone_comp.add_zone(hass, name, zone)
+            zone_comp.add_zone(hass, pretty_name, zone)
 
     def see_beacons(dev_id, kwargs_param):
         """Set active beacons to the current location."""
@@ -236,11 +237,22 @@ def setup_scanner(hass, config, see):
     return True
 
 
+def parse_topic(topic, pretty=False):
+    """Parse an MQTT topic owntracks/user/dev, return (user, dev) tuple."""
+    parts = topic.split('/')
+    dev_id_format = ''
+    if pretty:
+        dev_id_format = '{} {}'
+    else:
+        dev_id_format = '{}_{}'
+    dev_id = slugify(dev_id_format.format(parts[1], parts[2]))
+    host_name = parts[1]
+    return (host_name, dev_id)
+
+
 def _parse_see_args(topic, data):
     """Parse the OwnTracks location parameters, into the format see expects."""
-    parts = topic.split('/')
-    dev_id = slugify('{}_{}'.format(parts[1], parts[2]))
-    host_name = parts[1]
+    (host_name, dev_id) = parse_topic(topic, False)
     kwargs = {
         'dev_id': dev_id,
         'host_name': host_name,

--- a/homeassistant/components/zone.py
+++ b/homeassistant/components/zone.py
@@ -92,17 +92,16 @@ def setup(hass, config):
                     'Each zone needs a latitude and longitude.')
                 continue
 
-            zone = Zone(hass, name, latitude, longitude, radius, icon,
-                        passive, False)
-            zone.entity_id = generate_entity_id(ENTITY_ID_FORMAT, name,
-                                                entities)
-            zone.update_ha_state()
+            zone = Zone(hass, name, latitude, longitude, radius,
+                        icon, passive, False)
+            add_zone(hass, name, zone, entities)
             entities.add(zone.entity_id)
 
     if ENTITY_ID_HOME not in entities:
-        zone = Zone(hass, hass.config.location_name, hass.config.latitude,
-                    hass.config.longitude, DEFAULT_RADIUS, ICON_HOME,
-                    False, False)
+        zone = Zone(hass, hass.config.location_name,
+                    hass.config.latitude, hass.config.longitude,
+                    DEFAULT_RADIUS, ICON_HOME, False, False)
+        add_zone(hass, hass.config.location_name, zone, entities)
         zone.entity_id = ENTITY_ID_HOME
         zone.update_ha_state()
 
@@ -110,20 +109,24 @@ def setup(hass, config):
 
 
 # Add a zone to the existing set
-def add_zone(hass, name, latitude, longitude, radius):
+def add_zone(hass, name, zone, entities=None):
     """Add a zone from other components."""
     _LOGGER.info("Adding new zone %s", name)
-    entities = set()
+    if entities is None:
+        _entities = set()
+    else:
+        _entities = entities
 
-    if hass.states.get('zone.' + name) is None:
-        zone = Zone(hass, name, latitude, longitude, radius, ICON_IMPORT,
-                    False, True)
+    zone_exists = hass.states.get('zone.' + str(name))
+    if zone_exists is None:
         zone.entity_id = generate_entity_id(ENTITY_ID_FORMAT, name,
-                                            entities)
+                                            _entities)
         zone.update_ha_state()
-        entities.add(zone.entity_id)
+        _entities.add(zone.entity_id)
+        return zone
     else:
         _LOGGER.info("Zone already exists")
+        return zone_exists
 
 
 class Zone(Entity):

--- a/homeassistant/components/zone.py
+++ b/homeassistant/components/zone.py
@@ -29,7 +29,6 @@ DEFAULT_PASSIVE = False
 ICON_HOME = 'mdi:home'
 ICON_IMPORT = 'mdi:import'
 
-entities = set()
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -112,9 +111,11 @@ def setup(hass, config):
 
 # Add a zone to the existing set
 def add_zone(hass, name, latitude, longitude, radius):
-    """Add a zone from other components"""
+    """Add a zone from other components."""
     _LOGGER.info("Adding new zone %s", name)
-    if name not in entities:
+    entities = set()
+
+    if hass.states.get('zone.' + name) is None:
         zone = Zone(hass, name, latitude, longitude, radius, ICON_IMPORT,
                     False, True)
         zone.entity_id = generate_entity_id(ENTITY_ID_FORMAT, name,
@@ -123,7 +124,6 @@ def add_zone(hass, name, latitude, longitude, radius):
         entities.add(zone.entity_id)
     else:
         _LOGGER.info("Zone already exists")
-
 
 class Zone(Entity):
     """Representation of a Zone."""

--- a/homeassistant/components/zone.py
+++ b/homeassistant/components/zone.py
@@ -116,11 +116,10 @@ def add_zone(hass, name, zone, entities=None):
         _entities = set()
     else:
         _entities = entities
-
-    zone_exists = hass.states.get('zone.' + str(name))
+    zone.entity_id = generate_entity_id(ENTITY_ID_FORMAT, name,
+                                        _entities)
+    zone_exists = hass.states.get(zone.entity_id)
     if zone_exists is None:
-        zone.entity_id = generate_entity_id(ENTITY_ID_FORMAT, name,
-                                            _entities)
         zone.update_ha_state()
         _entities.add(zone.entity_id)
         return zone

--- a/homeassistant/components/zone.py
+++ b/homeassistant/components/zone.py
@@ -73,7 +73,7 @@ def in_zone(zone, latitude, longitude, radius=0):
 
 def setup(hass, config):
     """Setup zone."""
-
+    entities = set()
     for key in extract_domain_configs(config, DOMAIN):
         entries = config[key]
         if not isinstance(entries, list):
@@ -92,7 +92,8 @@ def setup(hass, config):
                     'Each zone needs a latitude and longitude.')
                 continue
 
-            zone = Zone(hass, name, latitude, longitude, radius, icon, passive, False)
+            zone = Zone(hass, name, latitude, longitude, radius, icon,
+                        passive, False)
             zone.entity_id = generate_entity_id(ENTITY_ID_FORMAT, name,
                                                 entities)
             zone.update_ha_state()
@@ -100,7 +101,8 @@ def setup(hass, config):
 
     if ENTITY_ID_HOME not in entities:
         zone = Zone(hass, hass.config.location_name, hass.config.latitude,
-                    hass.config.longitude, DEFAULT_RADIUS, ICON_HOME, False, False)
+                    hass.config.longitude, DEFAULT_RADIUS, ICON_HOME,
+                    False, False)
         zone.entity_id = ENTITY_ID_HOME
         zone.update_ha_state()
 
@@ -108,12 +110,13 @@ def setup(hass, config):
 
 # Add a zone to the existing set
 def add_zone(hass, name, latitude, longitude, radius):
+    """Add a zone from other components"""
     _LOGGER.info("Adding new zone %s", name)
     if name not in entities:
         zone = Zone(hass, name, latitude, longitude, radius, ICON_IMPORT,
                     False, True)
         zone.entity_id = generate_entity_id(ENTITY_ID_FORMAT, name,
-                            entities)
+                                            entities)
         zone.update_ha_state()
         entities.add(zone.entity_id)
     else:
@@ -123,7 +126,8 @@ class Zone(Entity):
     """Representation of a Zone."""
 
     # pylint: disable=too-many-arguments, too-many-instance-attributes
-    def __init__(self, hass, name, latitude, longitude, radius, icon, passive, imported):
+    def __init__(self, hass, name, latitude, longitude, radius, icon, passive,
+                 imported):
         """Initialize the zone."""
         self.hass = hass
         self._name = name

--- a/homeassistant/components/zone.py
+++ b/homeassistant/components/zone.py
@@ -125,6 +125,7 @@ def add_zone(hass, name, latitude, longitude, radius):
     else:
         _LOGGER.info("Zone already exists")
 
+
 class Zone(Entity):
     """Representation of a Zone."""
 

--- a/homeassistant/components/zone.py
+++ b/homeassistant/components/zone.py
@@ -32,6 +32,7 @@ ICON_IMPORT = 'mdi:import'
 entities = set()
 _LOGGER = logging.getLogger(__name__)
 
+
 def active_zone(hass, latitude, longitude, radius=0):
     """Find the active zone for given latitude, longitude."""
     # Sort entity IDs so that we are deterministic if equal distance to 2 zones
@@ -108,6 +109,7 @@ def setup(hass, config):
 
     return True
 
+
 # Add a zone to the existing set
 def add_zone(hass, name, latitude, longitude, radius):
     """Add a zone from other components"""
@@ -121,6 +123,7 @@ def add_zone(hass, name, latitude, longitude, radius):
         entities.add(zone.entity_id)
     else:
         _LOGGER.info("Zone already exists")
+
 
 class Zone(Entity):
     """Representation of a Zone."""

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -17,6 +17,7 @@ DEVICE = 'phone'
 
 LOCATION_TOPIC = "owntracks/{}/{}".format(USER, DEVICE)
 EVENT_TOPIC = "owntracks/{}/{}/event".format(USER, DEVICE)
+WAYPOINT_TOPIC = 'owntracks/{}/{}/waypoint'.format(USER, DEVICE)
 
 DEVICE_TRACKER_STATE = "device_tracker.{}_{}".format(USER, DEVICE)
 
@@ -24,6 +25,7 @@ IBEACON_DEVICE = 'keys'
 REGION_TRACKER_STATE = "device_tracker.beacon_{}".format(IBEACON_DEVICE)
 
 CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
+CONF_WAYPOINT_IMPORT_USER = 'waypoint_import_user'
 
 LOCATION_MESSAGE = {
     'batt': 92,
@@ -107,6 +109,28 @@ REGION_LEAVE_INACCURATE_MESSAGE = {
     'lat': 20.0,
     '_type': 'transition'}
 
+WAYPOINTS_EXPORTED_MESSAGE = {
+    "_type": "waypoints",
+    "_creator": "test",
+    "waypoints": [
+        {
+            "_type": "waypoint",
+            "tst": 3,
+            "lat": 47,
+            "lon": 9,
+            "rad": 10,
+            "desc": "exp_wayp1"
+        },
+        {
+            "_type": "waypoint",
+            "tst": 4,
+            "lat": 3,
+            "lon": 9,
+            "rad": 500,
+            "desc": "exp_wayp2"
+        }
+    ]
+}
 
 REGION_ENTER_ZERO_MESSAGE = {
     'lon': 1.0,
@@ -143,7 +167,8 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         self.assertTrue(device_tracker.setup(self.hass, {
             device_tracker.DOMAIN: {
                 CONF_PLATFORM: 'owntracks',
-                CONF_MAX_GPS_ACCURACY: 200
+                CONF_MAX_GPS_ACCURACY: 200,
+                CONF_WAYPOINT_IMPORT_USER: USER
             }}))
 
         self.hass.states.set(
@@ -530,3 +555,13 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         self.send_message(EVENT_TOPIC, exit_message)
 
         self.assertEqual(owntracks.MOBILE_BEACONS_ACTIVE['greg_phone'], [])
+
+    def test_waypoint_import_simple(self):
+        """Test a simple import of list of waypoints."""
+        waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
+        self.send_message(WAYPOINT_TOPIC, waypoints_message)
+        # Check if it made it into states
+        wayp = self.hass.states.get('zone.exp_wayp1')
+        self.assertTrue(wayp != None)
+        wayp = self.hass.states.get('zone.exp_wayp2')
+        self.assertTrue(wayp != None)

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -217,6 +217,10 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         except FileNotFoundError:
             pass
 
+    def mock_see(**kwargs):
+        """Fake see method for owntracks."""
+        return
+
     def send_message(self, topic, message):
         """Test the sending of a message."""
         fire_mqtt_message(
@@ -580,3 +584,19 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         self.assertTrue(wayp is None)
         wayp = self.hass.states.get('zone.exp_wayp2')
         self.assertTrue(wayp is None)
+
+    def test_waypoint_import_no_whitelist(self):
+        """Test import of list of waypoints with no whitelist set."""
+        test_config = {
+            CONF_PLATFORM: 'owntracks',
+            CONF_MAX_GPS_ACCURACY: 200,
+            CONF_WAYPOINT_IMPORT: True
+        }
+        owntracks.setup_scanner(self.hass, test_config, self.mock_see)
+        waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
+        self.send_message(WAYPOINT_TOPIC_BLOCKED, waypoints_message)
+        # Check if it made it into states
+        wayp = self.hass.states.get('zone.exp_wayp1')
+        self.assertTrue(wayp is not None)
+        wayp = self.hass.states.get('zone.exp_wayp2')
+        self.assertTrue(wayp is not None)

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -17,6 +17,7 @@ DEVICE = 'phone'
 
 LOCATION_TOPIC = "owntracks/{}/{}".format(USER, DEVICE)
 EVENT_TOPIC = "owntracks/{}/{}/event".format(USER, DEVICE)
+WAYPOINT_TOPIC = 'owntracks/{}/{}/waypoint'.format(USER, DEVICE)
 
 DEVICE_TRACKER_STATE = "device_tracker.{}_{}".format(USER, DEVICE)
 
@@ -24,6 +25,7 @@ IBEACON_DEVICE = 'keys'
 REGION_TRACKER_STATE = "device_tracker.beacon_{}".format(IBEACON_DEVICE)
 
 CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
+CONF_WAYPOINT_IMPORT_USER = 'waypoint_import_user'
 
 LOCATION_MESSAGE = {
     'batt': 92,
@@ -107,6 +109,28 @@ REGION_LEAVE_INACCURATE_MESSAGE = {
     'lat': 20.0,
     '_type': 'transition'}
 
+WAYPOINTS_EXPORTED_MESSAGE = {
+    "_type": "waypoints",
+    "_creator": "test",
+    "waypoints": [
+        {
+            "_type": "waypoint",
+            "tst": 3,
+            "lat": 47,
+            "lon": 9,
+            "rad": 10,
+            "desc": "exp_wayp1"
+        },
+        {
+            "_type": "waypoint",
+            "tst": 4,
+            "lat": 3,
+            "lon": 9,
+            "rad": 500,
+            "desc": "exp_wayp2"
+        }
+    ]
+}
 
 class TestDeviceTrackerOwnTracks(unittest.TestCase):
     """Test the OwnTrack sensor."""
@@ -118,7 +142,8 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         self.assertTrue(device_tracker.setup(self.hass, {
             device_tracker.DOMAIN: {
                 CONF_PLATFORM: 'owntracks',
-                CONF_MAX_GPS_ACCURACY: 200
+                CONF_MAX_GPS_ACCURACY: 200,
+                CONF_WAYPOINT_IMPORT_USER: USER
             }}))
 
         self.hass.states.set(
@@ -486,3 +511,13 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         self.send_message(EVENT_TOPIC, exit_message)
 
         self.assertEqual(owntracks.MOBILE_BEACONS_ACTIVE['greg_phone'], [])
+
+    def test_waypoint_import_simple(self):
+        """Test a simple import of list of waypoints."""
+        waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
+        self.send_message(WAYPOINT_TOPIC, waypoints_message)
+        # Check if it made it into states
+        wayp = self.hass.states.get('zone.exp_wayp1')
+        self.assertTrue(wayp != None)
+        wayp = self.hass.states.get('zone.exp_wayp2')
+        self.assertTrue(wayp != None)


### PR DESCRIPTION
**Description:**
Allow importing Owntracks waypoints into Homeassistant as zone definitions. If the configuration variable `waypoint_import_user` is defined, the Owntracks user matching user name specified here can export waypoints from the device and Home Assistant will import them as zone definitions.

**Related issue (if applicable):** N.A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/837

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
 device_tracker:
    platform: owntracks
    max_gps_accuracy: 200
    waypoint_import_user: jon
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a: _NO_
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
