### PR TITLE
Upgrade rfxtrx lib

### DIFF
--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -14,7 +14,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (ATTR_ENTITY_ID, TEMP_CELSIUS)
 
-REQUIREMENTS = ['pyRFXtrx==0.10.1']
+REQUIREMENTS = ['pyRFXtrx==0.11.0']
 
 DOMAIN = "rfxtrx"
 
@@ -42,7 +42,7 @@ DATA_TYPES = OrderedDict([
     ('Total usage', 'W'),
     ('Sound', ''),
     ('Sensor Status', ''),
-    ('Unknown', '')])
+    ('Counter value', '')])
 
 RECEIVED_EVT_SUBSCRIBERS = []
 RFX_DEVICES = {}

--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -84,7 +84,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
         pkt_id = "".join("{0:02x}".format(x) for x in event.data)
         _LOGGER.info("Automatic add rfxtrx.sensor: %s",
-                     device_id)
+                     pkt_id)
 
         data_type = "Unknown"
         for _data_type in DATA_TYPES:
@@ -109,10 +109,8 @@ class RfxtrxSensor(Entity):
         self.event = event
         self._name = name
         self.should_fire_event = should_fire_event
-        if data_type not in DATA_TYPES:
-            data_type = "Unknown"
         self.data_type = data_type
-        self._unit_of_measurement = DATA_TYPES[data_type]
+        self._unit_of_measurement = DATA_TYPES.get(data_type, '')
 
     def __str__(self):
         """Return the name of the sensor."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -293,7 +293,7 @@ pushetta==1.0.15
 py-cpuinfo==0.2.3
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.10.1
+pyRFXtrx==0.11.0
 
 # homeassistant.components.notify.xmpp
 pyasn1-modules==0.0.8


### PR DESCRIPTION
**Description:**
Upgrade rfxtrx lib to enable RFXMeter as a sensor: https://github.com/pyrou/x10rf/blob/master/Documents/RFXMeter%20(1).pdf

Thanks to @keigezellig for adding this functionality to the rfxtrx lib.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
