### PR TITLE
Fix reference to wrong components in tests for cameras

### DIFF
--- a/tests/components/camera/test_generic.py
+++ b/tests/components/camera/test_generic.py
@@ -1,4 +1,4 @@
-"""The tests for UVC camera module."""
+"""The tests for generic camera component."""
 import unittest
 from unittest import mock
 

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -1,4 +1,4 @@
-"""The tests for UVC camera module."""
+"""The tests for local file camera component."""
 from tempfile import NamedTemporaryFile
 import unittest
 from unittest import mock
@@ -12,7 +12,7 @@ from tests.common import get_test_home_assistant
 
 
 class TestLocalCamera(unittest.TestCase):
-    """Test the generic camera platform."""
+    """Test the local file camera component."""
 
     def setUp(self):
         """Setup things to be run when tests are started."""


### PR DESCRIPTION
**Description:**
Fix reference to wrong components in tests for generic and local file camera components.

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
