### PR TITLE
Add exclude option to nmap device tracker

### DIFF
--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -61,8 +61,10 @@ class NmapDeviceScanner(object):
         self.last_results = []
 
         self.hosts = config[CONF_HOSTS]
-        if config[CONF_EXCLUDE]:
+        if CONF_EXCLUDE in config:
             self.exclude = config[CONF_EXCLUDE]
+        else:
+            self.exclude = []
         minutes = convert(config.get(CONF_HOME_INTERVAL), int, 0)
         self.home_interval = timedelta(minutes=minutes)
 
@@ -112,8 +114,10 @@ class NmapDeviceScanner(object):
                 exclude_hosts = self.exclude
         else:
             last_results = []
-        exclude = " --exclude {}".format(",".join(exclude_hosts))
-        options += exclude
+            exclude_hosts = self.exclude
+        if exclude_hosts:
+            exclude = " --exclude {}".format(",".join(exclude_hosts))
+            options += exclude
 
         try:
             result = scanner.scan(hosts=self.hosts, arguments=options)

--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -22,8 +22,8 @@ MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 _LOGGER = logging.getLogger(__name__)
 
 # Interval in minutes to exclude devices from a scan while they are home
-CONF_HOME_INTERVAL = "home_interval"
-CONF_EXCLUDE = "exclude"
+CONF_HOME_INTERVAL = 'home_interval'
+CONF_EXCLUDE = 'exclude'
 
 REQUIREMENTS = ['python-nmap==0.6.1']
 
@@ -61,10 +61,7 @@ class NmapDeviceScanner(object):
         self.last_results = []
 
         self.hosts = config[CONF_HOSTS]
-        if CONF_EXCLUDE in config:
-            self.exclude = config[CONF_EXCLUDE]
-        else:
-            self.exclude = []
+        self.exclude = config.get(CONF_EXCLUDE, [])
         minutes = convert(config.get(CONF_HOME_INTERVAL), int, 0)
         self.home_interval = timedelta(minutes=minutes)
 


### PR DESCRIPTION
**Description:**
Add option to exclude hosts from nmap scans. This useful when specifying a range. Scanning some applications will result in noisy, cluttered logs (such as home-assistant!).

**Related issue (if applicable):** fixes #2875

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
device_tracker:
  - platform: nmap_tracker
    hosts: 10.0.0.1/24
    home_interval: 1
    interval_seconds: 12
    consider_home: 120
    track_new_devices: yes
    exclude:
      - 10.0.0.2
      - 10.0.0.1
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Adds an optional exclude paramater to nmap device tracker.
Devices specified in the exclude list will never be scanned
by nmap. This can help to reduce log spam.

ex:

```
device_tracker:
  - platform: nmap_tracker
    hosts: 10.0.0.1/24
    home_interval: 1
    interval_seconds: 12
    consider_home: 120
    track_new_devices: yes
    exclude:
      - 10.0.0.2
      - 10.0.0.1
```
