### PR TITLE
Full homematic system variable support

### DIFF
--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -73,6 +73,18 @@ homematic:
         description: Event to send i.e. PRESS_LONG, PRESS_SHORT
         example: PRESS_LONG
 
+  set_value:
+    description: Set the name of a node.
+
+    fields:
+      entity_id:
+        description: Name(s) of entities to set value
+        example: 'homematic.my_variable'
+
+      value:
+        description: New value
+        example: 1
+
 zwave:
   add_node:
     description: Add a new node to the zwave network. Refer to OZW.log for details.


### PR DESCRIPTION
**Description:**
- Full homematic system variable support per entities and service.

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
