### PR TITLE
Use voluptuous for Foscam and FFMpeg cameras

### DIFF
--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -9,31 +9,33 @@ from contextlib import closing
 
 import voluptuous as vol
 
-from homeassistant.components.camera import Camera
+from homeassistant.components.camera import (Camera, PLATFORM_SCHEMA)
 from homeassistant.components.camera.mjpeg import extract_image_from_mjpeg
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_NAME, CONF_PLATFORM
+from homeassistant.const import CONF_NAME
 
-REQUIREMENTS = ["ha-ffmpeg==0.8"]
+REQUIREMENTS = ['ha-ffmpeg==0.8']
+
+_LOGGER = logging.getLogger(__name__)
 
 CONF_INPUT = 'input'
 CONF_FFMPEG_BIN = 'ffmpeg_bin'
 CONF_EXTRA_ARGUMENTS = 'extra_arguments'
 
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_PLATFORM): "ffmpeg",
-    vol.Optional(CONF_NAME, default="FFmpeg"): cv.string,
+DEFAULT_BINARY = 'ffmpeg'
+DEFAULT_NAME = 'FFmpeg'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_INPUT): cv.string,
-    vol.Optional(CONF_FFMPEG_BIN, default="ffmpeg"): cv.string,
     vol.Optional(CONF_EXTRA_ARGUMENTS): cv.string,
+    vol.Optional(CONF_FFMPEG_BIN, default=DEFAULT_BINARY): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-_LOGGER = logging.getLogger(__name__)
 
-
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup a FFmpeg Camera."""
-    add_devices_callback([FFmpegCamera(config)])
+    add_devices([FFmpegCamera(config)])
 
 
 class FFmpegCamera(Camera):

--- a/homeassistant/components/camera/foscam.py
+++ b/homeassistant/components/camera/foscam.py
@@ -7,21 +7,33 @@ https://home-assistant.io/components/camera.foscam/
 import logging
 
 import requests
+import voluptuous as vol
 
-from homeassistant.components.camera import DOMAIN, Camera
-from homeassistant.helpers import validate_config
+from homeassistant.components.camera import (Camera, PLATFORM_SCHEMA)
+from homeassistant.const import (
+    CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_PORT)
+from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_IP = 'ip'
+
+DEFAULT_NAME = 'Foscam Camera'
+DEFAULT_PORT = 88
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_IP): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+})
+
 
 # pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup a Foscam IP Camera."""
-    if not validate_config({DOMAIN: config},
-                           {DOMAIN: ['username', 'password', 'ip']}, _LOGGER):
-        return None
-
-    add_devices_callback([FoscamCamera(config)])
+    add_devices([FoscamCamera(config)])
 
 
 # pylint: disable=too-many-instance-attributes
@@ -32,16 +44,16 @@ class FoscamCamera(Camera):
         """Initialize a Foscam camera."""
         super(FoscamCamera, self).__init__()
 
-        ip_address = device_info.get('ip')
-        port = device_info.get('port', 88)
+        ip_address = device_info.get(CONF_IP)
+        port = device_info.get(CONF_PORT)
 
-        self._base_url = 'http://' + ip_address + ':' + str(port) + '/'
-        self._username = device_info.get('username')
-        self._password = device_info.get('password')
+        self._base_url = 'http://{}:{}/'.format(ip_address, port)
+        self._username = device_info.get(CONF_USERNAME)
+        self._password = device_info.get(CONF_PASSWORD)
         self._snap_picture_url = self._base_url \
             + 'cgi-bin/CGIProxy.fcgi?cmd=snapPicture2&usr=' \
             + self._username + '&pwd=' + self._password
-        self._name = device_info.get('name', 'Foscam Camera')
+        self._name = device_info.get(CONF_NAME)
 
         _LOGGER.info('Using the following URL for %s: %s',
                      self._name, self._snap_picture_url)


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
camera:
  platform: foscam
  ip: IP_ADDRESS
  name: Door Camera
  port: 88
  username: USERNAME
  password: PASSWORD
```
