### PR TITLE
Use voluptuous for mysensors

### DIFF
--- a/homeassistant/components/binary_sensor/mysensors.py
+++ b/homeassistant/components/binary_sensor/mysensors.py
@@ -32,7 +32,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             pres.S_MOTION: [set_req.V_TRIPPED],
             pres.S_SMOKE: [set_req.V_TRIPPED],
         }
-        if float(gateway.version) >= 1.5:
+        if float(gateway.protocol_version) >= 1.5:
             map_sv_types.update({
                 pres.S_SPRINKLER: [set_req.V_TRIPPED],
                 pres.S_WATER_LEAK: [set_req.V_TRIPPED],
@@ -66,7 +66,7 @@ class MySensorsBinarySensor(
             pres.S_MOTION: 'motion',
             pres.S_SMOKE: 'smoke',
         }
-        if float(self.gateway.version) >= 1.5:
+        if float(self.gateway.protocol_version) >= 1.5:
             class_map.update({
                 pres.S_SPRINKLER: 'sprinkler',
                 pres.S_WATER_LEAK: 'leak',

--- a/homeassistant/components/light/mysensors.py
+++ b/homeassistant/components/light/mysensors.py
@@ -40,7 +40,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         device_class_map = {
             pres.S_DIMMER: MySensorsLightDimmer,
         }
-        if float(gateway.version) >= 1.5:
+        if float(gateway.protocol_version) >= 1.5:
             # Add V_RGBW when rgb_white is implemented in the frontend
             map_sv_types.update({
                 pres.S_RGB_LIGHT: [set_req.V_RGB],
@@ -169,7 +169,7 @@ class MySensorsLight(mysensors.MySensorsDeviceEntity, Light):
 
     def _turn_off_rgb_or_w(self, value_type=None, value=None):
         """Turn off RGB or RGBW child device."""
-        if float(self.gateway.version) >= 1.5:
+        if float(self.gateway.protocol_version) >= 1.5:
             set_req = self.gateway.const.SetReq
             if self.value_type == set_req.V_RGB:
                 value = '000000'
@@ -227,7 +227,6 @@ class MySensorsLight(mysensors.MySensorsDeviceEntity, Light):
         """Update the controller with the latest value from a sensor."""
         node = self.gateway.sensors[self.node_id]
         child = node.children[self.child_id]
-        self.battery_level = node.battery_level
         for value_type, value in child.values.items():
             _LOGGER.debug(
                 '%s: value_type %s, value = %s', self._name, value_type, value)

--- a/homeassistant/components/sensor/mysensors.py
+++ b/homeassistant/components/sensor/mysensors.py
@@ -47,12 +47,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             pres.S_SCENE_CONTROLLER: [set_req.V_SCENE_ON,
                                       set_req.V_SCENE_OFF],
         }
-        if float(gateway.version) < 1.5:
+        if float(gateway.protocol_version) < 1.5:
             map_sv_types.update({
                 pres.S_AIR_QUALITY: [set_req.V_DUST_LEVEL],
                 pres.S_DUST: [set_req.V_DUST_LEVEL],
             })
-        if float(gateway.version) >= 1.5:
+        if float(gateway.protocol_version) >= 1.5:
             map_sv_types.update({
                 pres.S_COLOR_SENSOR: [set_req.V_RGB],
                 pres.S_MULTIMETER: [set_req.V_VOLTAGE,
@@ -99,7 +99,7 @@ class MySensorsSensor(mysensors.MySensorsDeviceEntity, Entity):
             set_req.V_VOLTAGE: 'V',
             set_req.V_CURRENT: 'A',
         }
-        if float(self.gateway.version) >= 1.5:
+        if float(self.gateway.protocol_version) >= 1.5:
             if set_req.V_UNIT_PREFIX in self._values:
                 return self._values[
                     set_req.V_UNIT_PREFIX]

--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -55,7 +55,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             pres.S_LOCK: MySensorsSwitch,
             pres.S_IR: MySensorsIRSwitch,
         }
-        if float(gateway.version) >= 1.5:
+        if float(gateway.protocol_version) >= 1.5:
             map_sv_types.update({
                 pres.S_BINARY: [set_req.V_STATUS, set_req.V_LIGHT],
                 pres.S_SPRINKLER: [set_req.V_STATUS],


### PR DESCRIPTION
**Description:**
- Add voluptuous config validation for mysensors
- Remove and clean up parts that are not needed for pymysensors 0.7.

**Question**:
@fabaff Do we need to add something to mysensors platforms that are not configured individually? All configuration for mysensors is done through the component.

**Related issue (if applicable):**
https://github.com/home-assistant/home-assistant/issues/2800

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
mysensors:
  gateways:
    - device: '/dev/ttyUSB0'
      persistence_file: 'path/mysensors.json'
      baud_rate: 38400
    - device: '/dev/ttyACM0'
      persistence_file: 'path/mysensors2.json'
      baud_rate: 115200
    - device: '192.168.1.18'
      persistence_file: 'path/mysensors3.json'
      tcp_port: 5003
    - device: mqtt
      persistence_file: 'path/mysensors4.json'
      topic_in_prefix: 'mygateway1-out'
      topic_out_prefix: 'mygateway1-in'
  debug: true
  optimistic: false
  persistence: true
  retain: true
  version: 2.0
```

**Checklist:**
If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
