### PR TITLE
Consider user defined scan_interval for command_line sensor.

### DIFF
--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/sensor.command_line/
 """
 import logging
 import subprocess
-from datetime import timedelta
 
 import voluptuous as vol
 

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -95,7 +95,6 @@ class CommandSensorData(object):
         self.command = command
         self.value = None
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data with a shell command."""
         _LOGGER.info('Running command: %s', self.command)


### PR DESCRIPTION
**Description:**
Remove hard coded scan_interval of 60s so the command_line sensor considers either the default value of 30s or a user defined value, as expected according to https://home-assistant.io/topics/platform_options/#scan-interval.
