### PR TITLE
bump vsure version

### DIFF
--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -15,7 +15,7 @@ from homeassistant.util import Throttle
 
 DOMAIN = "verisure"
 
-REQUIREMENTS = ['vsure==0.10.1']
+REQUIREMENTS = ['vsure==0.10.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -480,7 +480,7 @@ urllib3
 uvcclient==0.9.0
 
 # homeassistant.components.verisure
-vsure==0.10.1
+vsure==0.10.2
 
 # homeassistant.components.switch.wake_on_lan
 wakeonlan==0.2.2


### PR DESCRIPTION
**Description:**
Longer timeouts when communicating with verisure mypages.

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
