### PR TITLE
Use COMMAND_CLASS_THERMOSTAT_SETPOINT to get unit_of_measurement inst…

### DIFF
--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -110,6 +110,7 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
         temps = []
         for value in self._node.get_values(
                 class_id=COMMAND_CLASS_THERMOSTAT_SETPOINT).values():
+            self._unit = value.units
             temps.append(int(value.data))
             if value.index == self._index:
                 self._target_temperature = int(value.data)
@@ -128,7 +129,6 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
                 class_id=COMMAND_CLASS_SENSOR_MULTILEVEL).values():
             if value.label == 'Temperature':
                 self._current_temperature = int(value.data)
-                self._unit = value.units
         # Fan Mode
         for value in self._node.get_values(
                 class_id=COMMAND_CLASS_THERMOSTAT_FAN_MODE).values():


### PR DESCRIPTION
**Description:**
@MarkoMarjamaa 's fix needed a little different approach.
Now we use COMMAND_COMMAND_CLASS_THERMOSTAT SETPOINT to catch unit_of_measurement instead of COMMAND_CLASS_SENSOR_MULTILEVEL, because not all devices provide this commandclass.

**Related issue (if applicable):** fixes #
#2982
