### PR TITLE
Allow user to configure server id to perform speed test against

### DIFF
--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -148,8 +148,7 @@ class SpeedtestData(object):
         try:
             args = [sys.executable, speedtest_cli.__file__, '--simple']
             if self._server_id:
-                args = args.append('--server')
-                args = args.append(self._server_id)
+                args = args + ['--server', self._server_id]
 
             re_output = _SPEEDTEST_REGEX.split(
                 check_output(args).decode("utf-8"))

--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -29,6 +29,7 @@ CONF_SECOND = 'second'
 CONF_MINUTE = 'minute'
 CONF_HOUR = 'hour'
 CONF_DAY = 'day'
+CONF_SERVER_ID = 'server_id'
 SENSOR_TYPES = {
     'ping': ['Ping', 'ms'],
     'download': ['Download', 'Mbit/s'],
@@ -38,6 +39,7 @@ SENSOR_TYPES = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_MONITORED_CONDITIONS):
         vol.All(cv.ensure_list, [vol.In(list(SENSOR_TYPES.keys()))]),
+    vol.Optional(CONF_SERVER_ID): cv.positive_int,
     vol.Optional(CONF_SECOND, default=[0]):
         vol.All(cv.ensure_list, [vol.All(vol.Coerce(int), vol.Range(0, 59))]),
     vol.Optional(CONF_MINUTE, default=[0]):
@@ -131,6 +133,7 @@ class SpeedtestData(object):
     def __init__(self, hass, config):
         """Initialize the data object."""
         self.data = None
+        self._server_id = config.get(CONF_SERVER_ID)
         track_time_change(hass, self.update,
                           second=config.get(CONF_SECOND),
                           minute=config.get(CONF_MINUTE),
@@ -143,9 +146,12 @@ class SpeedtestData(object):
 
         _LOGGER.info('Executing speedtest')
         try:
+            args = [sys.executable, speedtest_cli.__file__, '--simple']
+            if self._server_id:
+                args = ['--server', self._server_id]
+
             re_output = _SPEEDTEST_REGEX.split(
-                check_output([sys.executable, speedtest_cli.__file__,
-                              '--simple']).decode("utf-8"))
+                check_output(args).decode("utf-8"))
         except CalledProcessError as process_error:
             _LOGGER.error('Error executing speedtest: %s', process_error)
             return

--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -133,7 +133,7 @@ class SpeedtestData(object):
     def __init__(self, hass, config):
         """Initialize the data object."""
         self.data = None
-        self._server_id = config.get(CONF_SERVER_ID)
+        self._server_id = str(config.get(CONF_SERVER_ID))
         track_time_change(hass, self.update,
                           second=config.get(CONF_SECOND),
                           minute=config.get(CONF_MINUTE),

--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -133,7 +133,7 @@ class SpeedtestData(object):
     def __init__(self, hass, config):
         """Initialize the data object."""
         self.data = None
-        self._server_id = str(config.get(CONF_SERVER_ID))
+        self._server_id = config.get(CONF_SERVER_ID)
         track_time_change(hass, self.update,
                           second=config.get(CONF_SECOND),
                           minute=config.get(CONF_MINUTE),
@@ -148,7 +148,7 @@ class SpeedtestData(object):
         try:
             args = [sys.executable, speedtest_cli.__file__, '--simple']
             if self._server_id:
-                args = args + ['--server', self._server_id]
+                args = args + ['--server', str(self._server_id)]
 
             re_output = _SPEEDTEST_REGEX.split(
                 check_output(args).decode("utf-8"))

--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -149,7 +149,7 @@ class SpeedtestData(object):
             args = [sys.executable, speedtest_cli.__file__, '--simple']
             if self._server_id:
                 args = args.append('--server')
-                args = args.apped(self._server_id)
+                args = args.append(self._server_id)
 
             re_output = _SPEEDTEST_REGEX.split(
                 check_output(args).decode("utf-8"))

--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -148,7 +148,8 @@ class SpeedtestData(object):
         try:
             args = [sys.executable, speedtest_cli.__file__, '--simple']
             if self._server_id:
-                args = ['--server', self._server_id]
+                args = args.append('--server')
+                args = args.apped(self._server_id)
 
             re_output = _SPEEDTEST_REGEX.split(
                 check_output(args).decode("utf-8"))


### PR DESCRIPTION
**Description:**
Some speedtest servers are more reliable than others, the CLI allows you to specify a server id - let's let the users do that too!

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#847

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: speedtest
  server_id: 1234
  monitored_conditions:
    - ping
    - download
    - upload
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
