### PR TITLE
Added Xbox Live component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -250,6 +250,7 @@ omit =
     homeassistant/components/sensor/twitch.py
     homeassistant/components/sensor/uber.py
     homeassistant/components/sensor/worldclock.py
+    homeassistant/components/sensor/xbox_live.py
     homeassistant/components/sensor/yweather.py
     homeassistant/components/switch/acer_projector.py
     homeassistant/components/switch/arest.py

--- a/homeassistant/components/sensor/xbox_live.py
+++ b/homeassistant/components/sensor/xbox_live.py
@@ -44,6 +44,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
 
+# pylint: disable=too-many-instance-attributes
 class XboxSensor(Entity):
     """A class for the Xbox account."""
 
@@ -70,6 +71,11 @@ class XboxSensor(Entity):
     def name(self):
         """Return the name of the sensor."""
         return self._gamertag
+
+    @property
+    def entity_id(self):
+        """Return the entity ID."""
+        return 'sensor.xbox_' + self._gamertag
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/xbox_live.py
+++ b/homeassistant/components/sensor/xbox_live.py
@@ -1,0 +1,94 @@
+"""
+Sensor for Xbox Live account status.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.xbox_live/
+"""
+import logging
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (CONF_API_KEY, STATE_UNKNOWN)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+ICON = 'mdi:xbox'
+
+REQUIREMENTS = ['xboxapi==0.1.1']
+
+CONF_XUID = 'xuid'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Required(CONF_XUID): vol.All(cv.ensure_list, [cv.string])
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Xbox platform."""
+    from xboxapi import xbox_api
+    api = xbox_api.XboxApi(config.get(CONF_API_KEY))
+
+    add_devices([XboxSensor(hass,
+                            api,
+                            xuid)
+                 for xuid in config.get(CONF_XUID)])
+
+
+class XboxSensor(Entity):
+    """A class for the Xbox account."""
+
+    def __init__(self, hass, api, xuid):
+        """Initialize the sensor."""
+        self._hass = hass
+        self._state = STATE_UNKNOWN
+        self._presence = {}
+        self._xuid = xuid
+        self._api = api
+
+        # get profile info
+        profile = self._api.get_user_profile(self._xuid)
+        self._gamertag = profile.get('Gamertag')
+        self._picture = profile.get('GameDisplayPicRaw')
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._gamertag
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attributes = {}
+        for device in self._presence:
+            for title in device.get('titles'):
+                attributes[
+                    '{} {}'.format(device.get('type'),
+                                   title.get('placement'))
+                ] = title.get('name')
+
+        return attributes
+
+    @property
+    def entity_picture(self):
+        """Avatar of the account."""
+        return self._picture
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return ICON
+
+    def update(self):
+        """Update state data from Xbox API."""
+        presence = self._api.get_user_presence(self._xuid)
+        self._state = presence.get('state', STATE_UNKNOWN)
+        self._presence = presence.get('devices', {})

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -491,6 +491,9 @@ websocket-client==0.37.0
 # homeassistant.components.zigbee
 xbee-helper==0.0.7
 
+# homeassistant.components.sensor.xbox_live
+xboxapi==0.1.1
+
 # homeassistant.components.sensor.swiss_hydrological_data
 # homeassistant.components.sensor.yr
 xmltodict==0.10.2


### PR DESCRIPTION
**Description:**
This is a new component to track Xbox Live profiles via [XboxAPI.com](http://xboxapi.com). It shows the current online/offline state and the current open apps for each connected device.

I used the official Python wrapper of the site, however it was packaged poorly and incompatible with HASS so I had to fork it and do some minor changes. I then published my version to PyPi. Since the library itself is not very complex or actively developed this shouldn't cause any issues.

**Related issue (if applicable):** none

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#851

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
# Example configuration.yaml entry
sensor:
  platform: xbox_live
  api_key: YOUR_API_KEY
  xuid:
    - account1
    - account2
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
