### PR TITLE
Remove units for humidity in Wundeground sensor

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -47,7 +47,7 @@ SENSOR_TYPES = {
     'wind_string': ['Wind Summary', None],
     'temp_c': ['Temperature (°C)', TEMP_CELSIUS],
     'temp_f': ['Temperature (°F)', TEMP_FAHRENHEIT],
-    'relative_humidity': ['Relative Humidity', None],
+    'relative_humidity': ['Relative Humidity', '%'],
     'visibility_mi': ['Visibility (miles)', 'mi'],
     'visibility_km': ['Visibility (km)', 'km'],
     'precip_today_in': ['Precipation Today', 'in'],
@@ -101,7 +101,10 @@ class WUndergroundSensor(Entity):
     def state(self):
         """Return the state of the sensor."""
         if self.rest.data and self._condition in self.rest.data:
-            return self.rest.data[self._condition]
+            if self._condition == 'relative_humidity':
+                return int(self.rest.data[self._condition][:-1])
+            else:
+                return self.rest.data[self._condition]
         else:
             return STATE_UNKNOWN
 

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -47,7 +47,7 @@ SENSOR_TYPES = {
     'wind_string': ['Wind Summary', None],
     'temp_c': ['Temperature (°C)', TEMP_CELSIUS],
     'temp_f': ['Temperature (°F)', TEMP_FAHRENHEIT],
-    'relative_humidity': ['Relative Humidity', '%'],
+    'relative_humidity': ['Relative Humidity', None],
     'visibility_mi': ['Visibility (miles)', 'mi'],
     'visibility_km': ['Visibility (km)', 'km'],
     'precip_today_in': ['Precipation Today', 'in'],


### PR DESCRIPTION
**Description:** Wunderground returns the humidity with `%` so need to remove the extra `%` Otherwise, it appears as 
![image](https://cloud.githubusercontent.com/assets/18319734/18034622/879ac5cc-6d0f-11e6-91ae-3b4a4ce2ebec.png)

Here's the current entity information...note that the state already has `%`. 
![image](https://cloud.githubusercontent.com/assets/18319734/18034640/d3f34d9a-6d0f-11e6-8b42-569a8ae8a2a9.png)
