### PR TITLE
Fix bug in wemo discovery caused by voluptuous addition.

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -81,7 +81,7 @@ def setup(hass, config):
 
     # Add static devices from the config file.
     devices.extend((address, None)
-                   for address in config.get(DOMAIN, {}).get(CONF_STATIC))
+                   for address in config.get(DOMAIN, {}).get(CONF_STATIC, []))
 
     for address, device in devices:
         port = pywemo.ouimeaux_device.probe_wemo(address)


### PR DESCRIPTION
**Description:**
Fixes bug where discovery loads wemo, but `wemo:` is not specified in `configuration.yaml`

**Related issue (if applicable):** fixes #3024

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
