### PR TITLE
Fix media_player descriptions and select_source

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -97,7 +97,6 @@ SERVICE_TO_METHOD = {
     SERVICE_MEDIA_STOP: 'media_stop',
     SERVICE_MEDIA_NEXT_TRACK: 'media_next_track',
     SERVICE_MEDIA_PREVIOUS_TRACK: 'media_previous_track',
-    SERVICE_SELECT_SOURCE: 'select_source',
     SERVICE_CLEAR_PLAYLIST: 'clear_playlist'
 }
 

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -40,25 +40,25 @@ volume_down:
       description: Name(s) of entities to turn volume down on
       example: 'media_player.living_room_sonos'
 
-mute_volume:
+volume_mute:
   description: Mute a media player's volume
 
   fields:
     entity_id:
       description: Name(s) of entities to mute
       example: 'media_player.living_room_sonos'
-    mute:
+    is_volume_muted:
       description: True/false for mute/unmute
       example: true
 
-set_volume_level:
+volume_set:
   description: Set a media player's volume level
 
   fields:
     entity_id:
       description: Name(s) of entities to set volume level on
       example: 'media_player.living_room_sonos'
-    volume:
+    volume_level:
       description: Volume level to set
       example: 60
 
@@ -117,7 +117,7 @@ media_seek:
     entity_id:
       description: Name(s) of entities to seek media on
       example: 'media_player.living_room_chromecast'
-    position:
+    seek_position:
       description: Position to seek to. The format is platform dependent.
       example: 100
 


### PR DESCRIPTION
**Description:**
- Fix names of services and attributes in yaml description.
- Remove select_source service from `SERVICE_TO_METHOD` dict. This
  service has its own service callback.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):**
https://github.com/home-assistant/home-assistant.github.io/pull/860

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
