### PR TITLE
Fix wemo component without static configuration

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -81,7 +81,7 @@ def setup(hass, config):
 
     # Add static devices from the config file.
     devices.extend((address, None)
-                   for address in config.get(DOMAIN, {}).get(CONF_STATIC))
+                   for address in config.get(DOMAIN, {}).get(CONF_STATIC, []))
 
     for address, device in devices:
         port = pywemo.ouimeaux_device.probe_wemo(address)


### PR DESCRIPTION
**Description:**

This was reported in https://community.home-assistant.io/t/issue-after-update/3339/4

https://github.com/home-assistant/home-assistant/pull/2895 added
voluptuous to wemo, but in the process it removed defaulting static
to an empty array.

There isn't a test for the component, just the platform. I also don't have wemo stuff, so I can't really confirm if this works, just basing it on setting static to `[]` fixing it. It's also probably going to fail some validations.

I mostly wanted to file this to demonstrate the problem, if anyone else wants to take this on to fix it properly.

**Related issue (if applicable):** https://community.home-assistant.io/t/issue-after-update/3339

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
