### PR TITLE
Automatic odb device tracker

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -87,10 +87,11 @@ def is_on(hass: HomeAssistantType, entity_id: str=None):
     return hass.states.is_state(entity, STATE_HOME)
 
 
+# pylint: disable=too-many-arguments
 def see(hass: HomeAssistantType, mac: str=None, dev_id: str=None,
         host_name: str=None, location_name: str=None,
         gps: GPSType=None, gps_accuracy=None,
-        battery=None, attributes: dict=None):  # pylint: disable=too-many-arguments
+        battery=None, attributes: dict=None):
     """Call service to notify you see device."""
     data = {key: value for key, value in
             ((ATTR_MAC, mac),

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -62,7 +62,7 @@ ATTR_HOST_NAME = 'host_name'
 ATTR_LOCATION_NAME = 'location_name'
 ATTR_GPS = 'gps'
 ATTR_BATTERY = 'battery'
-ATTR_FUEL_LEVEL = 'fuel_level'
+ATTR_ATTRIBUTES = 'attributes'
 
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SCAN_INTERVAL): cv.positive_int,  # seconds
@@ -90,7 +90,7 @@ def is_on(hass: HomeAssistantType, entity_id: str=None):
 def see(hass: HomeAssistantType, mac: str=None, dev_id: str=None,
         host_name: str=None, location_name: str=None,
         gps: GPSType=None, gps_accuracy=None,
-        battery=None, fuel_level=None):  # pylint: disable=too-many-arguments
+        battery=None, attrs: dict=None):  # pylint: disable=too-many-arguments
     """Call service to notify you see device."""
     data = {key: value for key, value in
             ((ATTR_MAC, mac),
@@ -99,8 +99,10 @@ def see(hass: HomeAssistantType, mac: str=None, dev_id: str=None,
              (ATTR_LOCATION_NAME, location_name),
              (ATTR_GPS, gps),
              (ATTR_GPS_ACCURACY, gps_accuracy),
-             (ATTR_BATTERY, battery),
-             (ATTR_FUEL_LEVEL, fuel_level)) if value is not None}
+             (ATTR_BATTERY, battery)) if value is not None}
+    if attrs:
+        for key, value in attrs:
+            data[key] = value
     hass.services.call(DOMAIN, SERVICE_SEE, data)
 
 

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -90,7 +90,7 @@ def is_on(hass: HomeAssistantType, entity_id: str=None):
 def see(hass: HomeAssistantType, mac: str=None, dev_id: str=None,
         host_name: str=None, location_name: str=None,
         gps: GPSType=None, gps_accuracy=None,
-        battery=None, attrs: dict=None):  # pylint: disable=too-many-arguments
+        battery=None, attributes: dict=None):  # pylint: disable=too-many-arguments
     """Call service to notify you see device."""
     data = {key: value for key, value in
             ((ATTR_MAC, mac),
@@ -100,8 +100,8 @@ def see(hass: HomeAssistantType, mac: str=None, dev_id: str=None,
              (ATTR_GPS, gps),
              (ATTR_GPS_ACCURACY, gps_accuracy),
              (ATTR_BATTERY, battery)) if value is not None}
-    if attrs:
-        for key, value in attrs:
+    if attributes:
+        for key, value in attributes:
             data[key] = value
     hass.services.call(DOMAIN, SERVICE_SEE, data)
 

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/device_tracker.automatic/
 from datetime import timedelta
 import logging
 import re
-import threading
 import requests
 
 import voluptuous as vol
@@ -76,7 +75,6 @@ class AutomaticDeviceScanner(object):
             'scope': SCOPE
         }
         self._headers = None
-        self._access_token = None
         self._token_expires = dt_util.now()
         self.last_results = {}
         self.last_trips = {}
@@ -99,7 +97,7 @@ class AutomaticDeviceScanner(object):
 
     def _update_headers(self):
         """Get the access token from automatic."""
-        if self._access_token is None or self._token_expires <= dt_util.now():
+        if self._headers is None or self._token_expires <= dt_util.now():
             resp = requests.post(
                 URL_AUTHORIZE,
                 data=self._access_token_payload)

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -61,17 +61,20 @@ def setup_scanner(hass, config: dict, see):
     return True
 
 
-# pylint: disable=too-many-instance-attributes
 class AutomaticDeviceScanner(object):
     """A class representing an Automatic device."""
 
     def __init__(self, config: dict, see) -> None:
         """Initialize the automatic device scanner."""
-        self._client_id = config.get(CONF_CLIENT_ID)
-        self._secret = config.get(CONF_SECRET)
-        self._user_name = config.get(CONF_USERNAME)
-        self._password = config.get(CONF_PASSWORD)
         self._devices = config.get(CONF_DEVICES, None)
+        self._access_token_payload = {
+            'username': config.get(CONF_USERNAME),
+            'password': config.get(CONF_PASSWORD),
+            'client_id': config.get(CONF_CLIENT_ID),
+            'client_secret': config.get(CONF_SECRET),
+            'grant_type': 'password',
+            'scope': SCOPE
+        }
         self._headers = None
         self._access_token = None
         self._token_expires = dt_util.now()
@@ -98,18 +101,9 @@ class AutomaticDeviceScanner(object):
     def _get_access_token(self):
         """Get the access token from automatic."""
         if self._access_token is None or self._token_expires <= dt_util.now():
-            data = {
-                'username': self._user_name,
-                'password': self._password,
-                'client_id': self._client_id,
-                'client_secret': self._secret,
-                'grant_type': 'password',
-                'scope': SCOPE
-            }
-
             resp = requests.post(
                 URL_AUTHORIZE,
-                data=data)
+                data=self._access_token_payload)
 
             if resp.status_code != 200:
                 raise IOError(resp.content)

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -54,7 +54,7 @@ def setup_scanner(hass, config: dict, see):
     """Validate the configuration and return an Automatic scanner."""
     try:
         AutomaticDeviceScanner(config, see)
-    except IOError as err:
+    except requests.HTTPError as err:
         _LOGGER.error(str(err))
         return False
 
@@ -104,8 +104,7 @@ class AutomaticDeviceScanner(object):
                 URL_AUTHORIZE,
                 data=self._access_token_payload)
 
-            if resp.status_code != 200:
-                raise IOError(resp.content)
+            resp.raise_for_status()
 
             json = resp.json()
 
@@ -125,8 +124,7 @@ class AutomaticDeviceScanner(object):
 
         response = requests.get(URL_VEHICLES, headers=self._headers)
 
-        if response.status_code != 200:
-            raise IOError(response.content)
+        response.raise_for_status()
 
         self.last_results = [item for item in response.json()[ATTR_RESULTS]
                              if self._devices is None or item[

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -106,13 +106,12 @@ class AutomaticDeviceScanner(object):
 
             json = resp.json()
 
-            self._access_token = json[ATTR_ACCESS_TOKEN]
+            access_token = json[ATTR_ACCESS_TOKEN]
             self._token_expires = dt_util.now() + timedelta(
                 seconds=json[ATTR_EXPIRES_IN])
-
-        self._headers = {
-            'Authorization': 'Bearer {}'.format(self._access_token)
-        }
+            self._headers = {
+                'Authorization': 'Bearer {}'.format(access_token)
+            }
 
     @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self) -> None:

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -1,0 +1,170 @@
+"""
+Support for the Automatic platform.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.automatic/
+"""
+from datetime import timedelta
+import logging
+import re
+import threading
+import requests
+
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import PLATFORM_SCHEMA
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle, datetime as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=30)
+
+CONF_CLIENT_ID = 'client_id'
+CONF_SECRET = 'secret'
+CONF_DEVICES = 'devices'
+
+SCOPE = 'scope:location scope:vehicle:profile scope:user:profile scope:trip'
+
+ATTR_ACCESS_TOKEN = 'access_token'
+ATTR_EXPIRES_IN = 'expires_in'
+ATTR_RESULTS = 'results'
+ATTR_VEHICLE = 'vehicle'
+ATTR_ENDED_AT = 'ended_at'
+ATTR_END_LOCATION = 'end_location'
+
+URL_AUTHORIZE = 'https://accounts.automatic.com/oauth/access_token/'
+URL_VEHICLES = 'https://api.automatic.com/vehicle/'
+URL_TRIPS = 'https://api.automatic.com/trip/'
+
+_VEHICLE_ID_REGEX = re.compile(
+    (URL_VEHICLES + '(.*)?[/]$').replace('/', r'\/'))
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_CLIENT_ID): cv.string,
+    vol.Required(CONF_SECRET): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_DEVICES): vol.All(cv.ensure_list, [cv.string])
+})
+
+
+def setup_scanner(hass, config: dict, see):
+    """Validate the configuration and return an Automatic scanner."""
+    try:
+        AutomaticDeviceScanner(config, see)
+    except IOError:
+        return False
+
+    return True
+
+
+# pylint: disable=too-many-instance-attributes
+class AutomaticDeviceScanner(object):
+    """A class representing an Automatic device."""
+
+    def __init__(self, config: dict, see) -> None:
+        """Initialize the automatic device scanner."""
+        self._client_id = config.get(CONF_CLIENT_ID)
+        self._secret = config.get(CONF_SECRET)
+        self._user_name = config.get(CONF_USERNAME)
+        self._password = config.get(CONF_PASSWORD)
+        self._devices = config.get(CONF_DEVICES, None)
+        self._headers = None
+        self._access_token = None
+        self._token_expires = dt_util.now()
+        self.last_results = {}
+        self.last_trips = {}
+        self.lock = threading.Lock()
+        self.see = see
+
+        self.scan_devices()
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+
+        return [item['id'] for item in self.last_results]
+
+    def get_device_name(self, device):
+        """Get the device name from id."""
+        vehicle = [item['display_name'] for item in self.last_results
+                   if item['id'] == device]
+
+        return vehicle[0]
+
+    def _get_access_token(self):
+        """Get the access token from automatic."""
+        if self._access_token is None or self._token_expires <= dt_util.now():
+            data = {
+                'username': self._user_name,
+                'password': self._password,
+                'client_id': self._client_id,
+                'client_secret': self._secret,
+                'grant_type': 'password',
+                'scope': SCOPE
+            }
+
+            resp = requests.post(
+                URL_AUTHORIZE,
+                data=data)
+
+            if resp.status_code != 200:
+                raise IOError(resp.content)
+
+            json = resp.json()
+
+            self._access_token = json[ATTR_ACCESS_TOKEN]
+            self._token_expires = dt_util.now() + timedelta(
+                seconds=json[ATTR_EXPIRES_IN])
+
+        self._headers = {
+            'Authorization': 'Bearer {}'.format(self._access_token)
+        }
+
+    @Throttle(MIN_TIME_BETWEEN_SCANS)
+    def _update_info(self) -> None:
+        """Update the device info."""
+        with self.lock:
+            self._get_access_token()
+
+            _LOGGER.info('Getting device states')
+            response = requests.get(URL_VEHICLES, headers=self._headers)
+
+            if response.status_code != 200:
+                raise IOError(response.content)
+
+            self.last_results = [item for item in response.json()[ATTR_RESULTS]
+                                 if self._devices is None or item[
+                                     'display_name'] in self._devices]
+
+            _LOGGER.info('Getting device trips')
+            response = requests.get(URL_TRIPS, headers=self._headers)
+
+            if response.status_code == 200:
+                for trip in response.json()[ATTR_RESULTS]:
+                    vehicle_id = _VEHICLE_ID_REGEX.match(
+                        trip[ATTR_VEHICLE]).group(1)
+                    if vehicle_id not in self.last_trips:
+                        self.last_trips[vehicle_id] = trip
+                    elif self.last_trips[vehicle_id][ATTR_ENDED_AT] < trip[
+                            ATTR_ENDED_AT]:
+                        self.last_trips[vehicle_id] = trip
+
+            _LOGGER.info('Build device attributes')
+            for vehicle in self.last_results:
+                dev_id = vehicle.get('id')
+
+                kwargs = {
+                    'dev_id': dev_id,
+                    'mac': dev_id,
+                    'fuel_level': vehicle.get('fuel_level_percent')
+                }
+
+                if dev_id in self.last_trips:
+                    end_location = self.last_trips[dev_id][ATTR_END_LOCATION]
+                    kwargs['gps'] = (end_location['lat'], end_location['lon'])
+                    kwargs['gps_accuracy'] = end_location['accuracy_m']
+
+                self.see(**kwargs)

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -11,7 +11,8 @@ import requests
 
 import voluptuous as vol
 
-from homeassistant.components.device_tracker import PLATFORM_SCHEMA
+from homeassistant.components.device_tracker import (PLATFORM_SCHEMA,
+                                                     ATTR_ATTRIBUTES)
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle, datetime as dt_util
@@ -142,10 +143,14 @@ class AutomaticDeviceScanner(object):
         for vehicle in self.last_results:
             dev_id = vehicle.get('id')
 
+            attrs = {
+                'fuel_level': vehicle.get('fuel_level_percent')
+            }
+
             kwargs = {
                 'dev_id': dev_id,
                 'mac': dev_id,
-                'fuel_level': vehicle.get('fuel_level_percent')
+                ATTR_ATTRIBUTES: attrs
             }
 
             if dev_id in self.last_trips:

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -54,7 +54,8 @@ def setup_scanner(hass, config: dict, see):
     """Validate the configuration and return an Automatic scanner."""
     try:
         AutomaticDeviceScanner(config, see)
-    except IOError:
+    except IOError as err:
+        _LOGGER.error(str(err))
         return False
 
     return True

--- a/tests/components/device_tracker/test_automatic.py
+++ b/tests/components/device_tracker/test_automatic.py
@@ -198,7 +198,8 @@ class TestAutomatic(unittest.TestCase):
     def see_mock(self, **kwargs):
         """Mock see function."""
         self.assertEqual('vid', kwargs.get('dev_id'))
-        self.assertEqual(FUEL_LEVEL, kwargs.get('fuel_level'))
+        self.assertEqual(FUEL_LEVEL,
+                         kwargs.get('attributes', {}).get('fuel_level'))
         self.assertEqual((LATITUDE, LONGITUDE), kwargs.get('gps'))
         self.assertEqual(ACCURACY, kwargs.get('gps_accuracy'))
 

--- a/tests/components/device_tracker/test_automatic.py
+++ b/tests/components/device_tracker/test_automatic.py
@@ -1,6 +1,7 @@
 """Test the automatic device tracker platform."""
 
 import logging
+import requests
 import unittest
 from unittest.mock import patch
 
@@ -40,6 +41,11 @@ def mocked_requests(*args, **kwargs):
         def content(self):
             """Return the content of the response."""
             return self.json()
+
+        def raise_for_status(self):
+            """Raise an HTTPError if status is not 200."""
+            if self.status_code != 200:
+                raise requests.HTTPError(self.status_code)
 
     data = kwargs.get('data')
 

--- a/tests/components/device_tracker/test_automatic.py
+++ b/tests/components/device_tracker/test_automatic.py
@@ -1,0 +1,247 @@
+"""Test the automatic device tracker platform."""
+
+import logging
+import unittest
+from unittest.mock import patch
+
+from homeassistant.components.device_tracker.automatic import (
+    URL_AUTHORIZE, URL_VEHICLES, URL_TRIPS, setup_scanner,
+    AutomaticDeviceScanner)
+
+_LOGGER = logging.getLogger(__name__)
+
+INVALID_USERNAME = 'bob'
+VALID_USERNAME = 'jim'
+PASSWORD = 'password'
+CLIENT_ID = '12345'
+CLIENT_SECRET = '54321'
+FUEL_LEVEL = 77.2
+LATITUDE = 32.82336
+LONGITUDE = -117.23743
+ACCURACY = 8
+DISPLAY_NAME = 'My Vehicle'
+
+
+def mocked_requests(*args, **kwargs):
+    """Mock requests.get invocations."""
+    class MockResponse:
+        """Class to represent a mocked response."""
+
+        def __init__(self, json_data, status_code):
+            """Initialize the mock response class."""
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            """Return the json of the response."""
+            return self.json_data
+
+        @property
+        def content(self):
+            """Return the content of the response."""
+            return self.json()
+
+    data = kwargs.get('data')
+
+    if data and data.get('username', None) == INVALID_USERNAME:
+        return MockResponse({
+            "error": "invalid_credentials"
+        }, 401)
+    elif str(args[0]).startswith(URL_AUTHORIZE):
+        return MockResponse({
+            "user": {
+                "sid": "sid",
+                "id": "id"
+            },
+            "token_type": "Bearer",
+            "access_token": "accesstoken",
+            "refresh_token": "refreshtoken",
+            "expires_in": 31521669,
+            "scope": ""
+        }, 200)
+    elif str(args[0]).startswith(URL_VEHICLES):
+        return MockResponse({
+            "_metadata": {
+                "count": 2,
+                "next": None,
+                "previous": None
+            },
+            "results": [
+                {
+                    "url": "https://api.automatic.com/vehicle/vid/",
+                    "id": "vid",
+                    "created_at": "2016-03-05T20:05:16.240000Z",
+                    "updated_at": "2016-08-29T01:52:59.597898Z",
+                    "make": "Honda",
+                    "model": "Element",
+                    "year": 2007,
+                    "submodel": "EX",
+                    "display_name": DISPLAY_NAME,
+                    "fuel_grade": "regular",
+                    "fuel_level_percent": FUEL_LEVEL,
+                    "active_dtcs": []
+                }]
+        }, 200)
+    elif str(args[0]).startswith(URL_TRIPS):
+        return MockResponse({
+            "_metadata": {
+                "count": 1594,
+                "next": "https://api.automatic.com/trip/?page=2",
+                "previous": None
+            },
+            "results": [
+                {
+                    "url": "https://api.automatic.com/trip/tid1/",
+                    "id": "tid1",
+                    "driver": "https://api.automatic.com/user/uid/",
+                    "user": "https://api.automatic.com/user/uid/",
+                    "started_at": "2016-08-28T19:37:23.986000Z",
+                    "ended_at": "2016-08-28T19:43:22.500000Z",
+                    "distance_m": 3931.6,
+                    "duration_s": 358.5,
+                    "vehicle": "https://api.automatic.com/vehicle/vid/",
+                    "start_location": {
+                        "lat": 32.87336,
+                        "lon": -117.22743,
+                        "accuracy_m": 10
+                    },
+                    "start_address": {
+                        "name": "123 Fake St, Nowhere, NV 12345",
+                        "display_name": "123 Fake St, Nowhere, NV",
+                        "street_number": "Unknown",
+                        "street_name": "Fake St",
+                        "city": "Nowhere",
+                        "state": "NV",
+                        "country": "US"
+                    },
+                    "end_location": {
+                        "lat": LATITUDE,
+                        "lon": LONGITUDE,
+                        "accuracy_m": ACCURACY
+                    },
+                    "end_address": {
+                        "name": "321 Fake St, Nowhere, NV 12345",
+                        "display_name": "321 Fake St, Nowhere, NV",
+                        "street_number": "Unknown",
+                        "street_name": "Fake St",
+                        "city": "Nowhere",
+                        "state": "NV",
+                        "country": "US"
+                    },
+                    "path": "path",
+                    "vehicle_events": [],
+                    "start_timezone": "America/Denver",
+                    "end_timezone": "America/Denver",
+                    "idling_time_s": 0,
+                    "tags": []
+                },
+                {
+                    "url": "https://api.automatic.com/trip/tid2/",
+                    "id": "tid2",
+                    "driver": "https://api.automatic.com/user/uid/",
+                    "user": "https://api.automatic.com/user/uid/",
+                    "started_at": "2016-08-28T18:48:00.727000Z",
+                    "ended_at": "2016-08-28T18:55:25.800000Z",
+                    "distance_m": 3969.1,
+                    "duration_s": 445.1,
+                    "vehicle": "https://api.automatic.com/vehicle/vid/",
+                    "start_location": {
+                        "lat": 32.87336,
+                        "lon": -117.22743,
+                        "accuracy_m": 11
+                    },
+                    "start_address": {
+                        "name": "123 Fake St, Nowhere, NV, USA",
+                        "display_name": "Fake St, Nowhere, NV",
+                        "street_number": "123",
+                        "street_name": "Fake St",
+                        "city": "Nowhere",
+                        "state": "NV",
+                        "country": "US"
+                    },
+                    "end_location": {
+                        "lat": 32.82336,
+                        "lon": -117.23743,
+                        "accuracy_m": 10
+                    },
+                    "end_address": {
+                        "name": "321 Fake St, Nowhere, NV, USA",
+                        "display_name": "Fake St, Nowhere, NV",
+                        "street_number": "Unknown",
+                        "street_name": "Fake St",
+                        "city": "Nowhere",
+                        "state": "NV",
+                        "country": "US"
+                    },
+                    "path": "path",
+                    "vehicle_events": [],
+                    "start_timezone": "America/Denver",
+                    "end_timezone": "America/Denver",
+                    "idling_time_s": 0,
+                    "tags": []
+                }
+            ]
+        }, 200)
+    else:
+        _LOGGER.debug('UNKNOWN ROUTE')
+
+
+class TestAutomatic(unittest.TestCase):
+    """Test cases around the automatic device scanner."""
+
+    def see_mock(self, **kwargs):
+        """Mock see function."""
+        self.assertEqual('vid', kwargs.get('dev_id'))
+        self.assertEqual(FUEL_LEVEL, kwargs.get('fuel_level'))
+        self.assertEqual((LATITUDE, LONGITUDE), kwargs.get('gps'))
+        self.assertEqual(ACCURACY, kwargs.get('gps_accuracy'))
+
+    def setUp(self):
+        """Set up test data."""
+
+    def tearDown(self):
+        """Tear down test data."""
+
+    @patch('requests.get', side_effect=mocked_requests)
+    @patch('requests.post', side_effect=mocked_requests)
+    def test_invalid_credentials(self, mock_get, mock_post):
+        """Test error is raised with invalid credentials."""
+        config = {
+            'platform': 'automatic',
+            'username': INVALID_USERNAME,
+            'password': PASSWORD,
+            'client_id': CLIENT_ID,
+            'secret': CLIENT_SECRET
+        }
+
+        self.assertFalse(setup_scanner(None, config, self.see_mock))
+
+    @patch('requests.get', side_effect=mocked_requests)
+    @patch('requests.post', side_effect=mocked_requests)
+    def test_valid_credentials(self, mock_get, mock_post):
+        """Test error is raised with invalid credentials."""
+        config = {
+            'platform': 'automatic',
+            'username': VALID_USERNAME,
+            'password': PASSWORD,
+            'client_id': CLIENT_ID,
+            'secret': CLIENT_SECRET
+        }
+
+        self.assertTrue(setup_scanner(None, config, self.see_mock))
+
+    @patch('requests.get', side_effect=mocked_requests)
+    @patch('requests.post', side_effect=mocked_requests)
+    def test_device_attributes(self, mock_get, mock_post):
+        """Test device attributes are set on load."""
+        config = {
+            'platform': 'automatic',
+            'username': VALID_USERNAME,
+            'password': PASSWORD,
+            'client_id': CLIENT_ID,
+            'secret': CLIENT_SECRET
+        }
+
+        scanner = AutomaticDeviceScanner(config, self.see_mock)
+
+        self.assertEqual(DISPLAY_NAME, scanner.get_device_name('vid'))


### PR DESCRIPTION
**Description:**
The Automatic ODB reader tracks driving habits and locations. `Battery` attribute didn't quite fit for the `Fuel Level` so added a new attribute.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#863

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
device_tracker:
  platform: automatic
  client_id: 1234567
  secret: 0987654321
  username: your@email.com
  password: your_password
  devices:
    - 2007 Honda Element
    - 2004 Subaru Impreza
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
