### PR TITLE
Upgrade sendgrid to 3.2.10

### DIFF
--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -10,7 +10,7 @@ from homeassistant.components.notify import (
     ATTR_TITLE, DOMAIN, BaseNotificationService)
 from homeassistant.helpers import validate_config
 
-REQUIREMENTS = ['sendgrid==3.1.10']
+REQUIREMENTS = ['sendgrid==3.2.10']
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -422,7 +422,7 @@ schiene==0.17
 scsgate==0.1.0
 
 # homeassistant.components.notify.sendgrid
-sendgrid==3.1.10
+sendgrid==3.2.10
 
 # homeassistant.components.notify.slack
 slacker==0.9.24


### PR DESCRIPTION
## 3.2.10
- no changelog entry available.
## 3.2.2
- Table of Contents in the README
- Added a USE_CASES.md section, with the first use case example for transactional templates
## 3.2.1
- pep8 formatting
- include Heroku config files in PyPi
## 3.2.0
- Helper code for our Inbound Parse webhook

Tested with the following configuration:

``` yaml
notify:
  - name: sendgrid
    platform: sendgrid
    api_key: !secret sendgrid_api
    sender: you@example.com
    recipient: me@example.com
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```
