### PR TITLE
  Added option to use effect:random for Flux Led light bulbs

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -7,9 +7,11 @@ https://home-assistant.io/components/light.flux_led/
 
 import logging
 import socket
+import random
 import voluptuous as vol
 
 from homeassistant.components.light import (ATTR_BRIGHTNESS, ATTR_RGB_COLOR,
+                                            ATTR_EFFECT, EFFECT_RANDOM,
                                             SUPPORT_BRIGHTNESS,
                                             SUPPORT_RGB_COLOR, Light)
 import homeassistant.helpers.config_validation as cv
@@ -125,10 +127,15 @@ class FluxLight(Light):
 
         rgb = kwargs.get(ATTR_RGB_COLOR)
         brightness = kwargs.get(ATTR_BRIGHTNESS)
+        effect = kwargs.get(ATTR_EFFECT)
         if rgb:
             self._bulb.setRgb(*tuple(rgb))
         elif brightness:
             self._bulb.setWarmWhite255(brightness)
+        elif effect == EFFECT_RANDOM:
+            self._bulb.setRgb(random.randrange(0, 255),
+                              random.randrange(0, 255),
+                              random.randrange(0, 255))
 
     def turn_off(self, **kwargs):
         """Turn the specified or all lights off."""


### PR DESCRIPTION
**Description:**
This patch added the ability to define `effect: random` for a Flex Led light bulb. 

Special thanks to Daniel Høyer Iversen - @Danielhiversen

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable): https://github.com/home-assistant/home-assistant.github.io/pull/868

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
automation:
   random_flux_living_room_lamp:
   trigger:
     platform: time
     seconds: '/45'
   action:
     service: light.turn_on
     data:
       entity_id: light.flux_living_room_lamp
       effect: random
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] Tests have been added to verify that the new code works.
