### PR TITLE
Bug fix in insteon hub library

### DIFF
--- a/homeassistant/components/insteon_hub.py
+++ b/homeassistant/components/insteon_hub.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import validate_config, discovery
 from homeassistant.helpers.entity import Entity
 
 DOMAIN = 'insteon_hub'  # type: str
-REQUIREMENTS = ['insteon_hub==0.5.0']  # type: list
+REQUIREMENTS = ['insteon_hub==0.5.1']  # type: list
 INSTEON = None  # type: Insteon
 DEVCAT = 'DevCat'  # type: str
 SUBCAT = 'SubCat'  # type: str

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -204,7 +204,7 @@ https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 influxdb==3.0.0
 
 # homeassistant.components.insteon_hub
-insteon_hub==0.5.0
+insteon_hub==0.5.1
 
 # homeassistant.components.media_player.kodi
 jsonrpc-requests==0.3


### PR DESCRIPTION
**Description:**
Fix in insteon hub library

**Related issue (if applicable):** fixes #3056

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
