### PR TITLE
Upgrade pyuserinput to 0.1.11

### DIFF
--- a/homeassistant/components/keyboard.py
+++ b/homeassistant/components/keyboard.py
@@ -11,8 +11,9 @@ from homeassistant.const import (
     SERVICE_MEDIA_PREVIOUS_TRACK, SERVICE_VOLUME_DOWN, SERVICE_VOLUME_MUTE,
     SERVICE_VOLUME_UP)
 
-DOMAIN = "keyboard"
-REQUIREMENTS = ['pyuserinput==0.1.9']
+REQUIREMENTS = ['pyuserinput==0.1.11']
+
+DOMAIN = 'keyboard'
 
 TAP_KEY_SCHEMA = vol.Schema({})
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -394,7 +394,7 @@ python-twitch==1.3.0
 python-wink==0.7.13
 
 # homeassistant.components.keyboard
-pyuserinput==0.1.9
+pyuserinput==0.1.11
 
 # homeassistant.components.vera
 pyvera==0.2.15


### PR DESCRIPTION
**Description:**
No changelog details available. According to the commits most changes seems related to dependency management and MAC keys.

Tested with the following configuration:

``` yaml
keyboard:
```
