### PR TITLE
Use voluptuous for Acer projector switch

### DIFF
--- a/homeassistant/components/switch/acer_projector.py
+++ b/homeassistant/components/switch/acer_projector.py
@@ -46,12 +46,11 @@ CMD_DICT = {LAMP: '* 0 Lamp ?\r',
             STATE_OFF: '* 0 IR 002\r'}
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_FILENAME): cv.string,
+    vol.Required(CONF_FILENAME): cv.isfile,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT):
-        vol.All(vol.Coerce(int), vol.Range(min=1)),
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     vol.Optional(CONF_WRITE_TIMEOUT, default=DEFAULT_WRITE_TIMEOUT):
-        vol.All(vol.Coerce(int), vol.Range(min=1)),
+        cv.positive_int,
 })
 
 

--- a/homeassistant/components/switch/acer_projector.py
+++ b/homeassistant/components/switch/acer_projector.py
@@ -1,21 +1,40 @@
 """
-Use serial protocol of acer projector to obtain state of the projector.
+Use serial protocol of Acer projector to obtain state of the projector.
 
-This component allows to control almost all projectors from acer using
-their RS232 serial communication protocol.
+For more details about this component, please refer to the documentation
+at https://home-assistant.io/components/switch.acer_projector/
 """
 import logging
 import re
 
-from homeassistant.components.switch import SwitchDevice
-from homeassistant.const import (STATE_ON, STATE_OFF, STATE_UNKNOWN,
-                                 CONF_NAME, CONF_FILENAME)
+import voluptuous as vol
 
-LAMP_HOURS = 'Lamp Hours'
-INPUT_SOURCE = 'Input Source'
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (
+    STATE_ON, STATE_OFF, STATE_UNKNOWN, CONF_NAME, CONF_FILENAME)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['pyserial==3.1.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_TIMEOUT = 'timeout'
+CONF_WRITE_TIMEOUT = 'write_timeout'
+
+DEFAULT_NAME = 'Acer Projector'
+DEFAULT_TIMEOUT = 1
+DEFAULT_WRITE_TIMEOUT = 1
+
 ECO_MODE = 'ECO Mode'
-MODEL = 'Model'
+
+ICON = 'mdi:projector'
+
+INPUT_SOURCE = 'Input Source'
+
 LAMP = 'Lamp'
+LAMP_HOURS = 'Lamp Hours'
+
+MODEL = 'Model'
 
 # Commands known to the projector
 CMD_DICT = {LAMP: '* 0 Lamp ?\r',
@@ -26,38 +45,35 @@ CMD_DICT = {LAMP: '* 0 Lamp ?\r',
             STATE_ON: '* 0 IR 001\r',
             STATE_OFF: '* 0 IR 002\r'}
 
-_LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ['pyserial<=3.1']
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_FILENAME): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT):
+        vol.All(vol.Coerce(int), vol.Range(min=1)),
+    vol.Optional(CONF_WRITE_TIMEOUT, default=DEFAULT_WRITE_TIMEOUT):
+        vol.All(vol.Coerce(int), vol.Range(min=1)),
+})
 
-ICON = 'mdi:projector'
 
-
-# pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Connect with serial port and return Acer Projector."""
-    serial_port = config.get(CONF_FILENAME, None)
-    name = config.get(CONF_NAME, 'Projector')
-    timeout = config.get('timeout', 1)
-    write_timeout = config.get('write_timeout', 1)
+    serial_port = config.get(CONF_FILENAME)
+    name = config.get(CONF_NAME)
+    timeout = config.get(CONF_TIMEOUT)
+    write_timeout = config.get(CONF_WRITE_TIMEOUT)
 
-    if not serial_port:
-        _LOGGER.error('Missing path of serial device')
-        return
-
-    devices = []
-    devices.append(AcerSwitch(serial_port, name, timeout, write_timeout))
-    add_devices_callback(devices)
+    add_devices([AcerSwitch(serial_port, name, timeout, write_timeout)])
 
 
 class AcerSwitch(SwitchDevice):
     """Represents an Acer Projector as an switch."""
 
-    def __init__(self, serial_port, name='Projector',
-                 timeout=1, write_timeout=1, **kwargs):
+    def __init__(self, serial_port, name, timeout, write_timeout, **kwargs):
         """Init of the Acer projector."""
         import serial
-        self.ser = serial.Serial(port=serial_port, timeout=timeout,
-                                 write_timeout=write_timeout, **kwargs)
+        self.ser = serial.Serial(
+            port=serial_port, timeout=timeout, write_timeout=write_timeout,
+            **kwargs)
         self._serial_port = serial_port
         self._name = name
         self._state = False
@@ -73,18 +89,17 @@ class AcerSwitch(SwitchDevice):
         """Write to the projector and read the return."""
         import serial
         ret = ""
-        # Sometimes the projector won't answer for no reason,
-        # or the projector was disconnected during runtime.
-        # Thisway the projector can be reconnected and will still
-        # work
+        # Sometimes the projector won't answer for no reason or the projector
+        # was disconnected during runtime.
+        # This way the projector can be reconnected and will still work
         try:
             if not self.ser.is_open:
                 self.ser.open()
             msg = msg.encode('utf-8')
             self.ser.write(msg)
-            # size is an experience value there is no real limit.
-            # AFAIK there is no limit and no end character so
-            # we will usually need to wait for timeout
+            # Size is an experience value there is no real limit.
+            # AFAIK there is no limit and no end character so we will usually
+            # need to wait for timeout
             ret = self.ser.read_until(size=20).decode('utf-8')
         except serial.SerialException:
             _LOGGER.error('Problem comunicating with %s', self._serial_port)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -346,7 +346,7 @@ pynx584==0.2
 pyowm==2.3.2
 
 # homeassistant.components.switch.acer_projector
-pyserial<=3.1
+pyserial==3.1.1
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
  platform: acer_projector
  filename: /dev/ttyUSB0
  name: Projector
  timeout: 1
  write_timeout: 1
```

@deisi, would be nice if you could take a look at the changes and run a quick test. Thanks.
