### PR TITLE
Display the error instead of the traceback (notify.slack)

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -6,12 +6,24 @@ https://home-assistant.io/components/notify.slack/
 """
 import logging
 
-from homeassistant.components.notify import DOMAIN, BaseNotificationService
-from homeassistant.const import CONF_API_KEY
-from homeassistant.helpers import validate_config
+import voluptuous as vol
+
+from homeassistant.components.notify import (
+    PLATFORM_SCHEMA, BaseNotificationService)
+from homeassistant.const import (CONF_API_KEY, CONF_NAME)
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['slacker==0.9.24']
+
 _LOGGER = logging.getLogger(__name__)
+
+CONF_CHANNEL = 'default_channel'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Required(CONF_CHANNEL): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+})
 
 
 # pylint: disable=unused-variable
@@ -19,14 +31,9 @@ def get_service(hass, config):
     """Get the Slack notification service."""
     import slacker
 
-    if not validate_config({DOMAIN: config},
-                           {DOMAIN: ['default_channel', CONF_API_KEY]},
-                           _LOGGER):
-        return None
-
     try:
         return SlackNotificationService(
-            config['default_channel'],
+            config[CONF_CHANNEL],
             config[CONF_API_KEY])
 
     except slacker.Error:
@@ -61,5 +68,5 @@ class SlackNotificationService(BaseNotificationService):
             self.slack.chat.post_message(channel, message,
                                          as_user=True,
                                          attachments=attachments)
-        except slacker.Error:
-            _LOGGER.exception("Could not send slack notification")
+        except slacker.Error as err:
+            _LOGGER.error("Could not send slack notification. Error: %s", err)

--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant.components.notify import (
     PLATFORM_SCHEMA, BaseNotificationService)
-from homeassistant.const import (CONF_API_KEY, CONF_NAME)
+from homeassistant.const import CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['slacker==0.9.24']
@@ -22,7 +22,6 @@ CONF_CHANNEL = 'default_channel'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_CHANNEL): cv.string,
-    vol.Optional(CONF_NAME): cv.string,
 })
 
 


### PR DESCRIPTION
**Description:**
- Display the output of `slacker.Error` instead of the full traceback.
- Migration of the configuration check to voluptuous.

**Related issue (if applicable):** related to #3071, fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
notify:
  - name: slack
    platform: slack
    api_key: !secret slack_bot_api
    default_channel: '#ha'
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
