### PR TITLE
Make isy amaze balls

### DIFF
--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.isy994/
 """
 import logging
+from typing import Callable  # noqa
 
 from homeassistant.components.binary_sensor import BinarySensorDevice, DOMAIN
 from homeassistant.components.isy994 import (ISYDevice, SENSOR_NODES, PROGRAMS,
@@ -24,7 +25,8 @@ UOM = ['2', '78']
 STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
-def setup_platform(hass, config: ConfigType, add_devices: Callable[[list], None], discovery_info=None):
+def setup_platform(hass, config: ConfigType,
+                   add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 binary sensor platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -24,7 +24,7 @@ UOM = ['2', '78']
 STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
-def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
+def setup_platform(hass, config: ConfigType, add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 binary sensor platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
@@ -50,7 +50,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
     """Representation of an ISY994 binary sensor device."""
 
-    def __init__(self, node):
+    def __init__(self, node) -> None:
         """Initialize the ISY994 binary sensor device."""
         ISYDevice.__init__(self, node)
 
@@ -68,7 +68,7 @@ class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
 class ISYBinarySensorProgram(ISYBinarySensorDevice):
     """Representation of an ISY994 binary sensor program."""
 
-    def __init__(self, name, node):
+    def __init__(self, name, node) -> None:
         """Initialize the ISY994 binary sensor program."""
         ISYBinarySensorDevice.__init__(self, node)
         self._name = name

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -60,12 +60,7 @@ class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
     @property
     def is_on(self) -> bool:
         """Get whether the ISY994 binary sensor device is on."""
-        return self.state == STATE_ON
-
-    @property
-    def state(self) -> str:
-        """Get the state of the ISY994 binary sensor device."""
-        return VALUE_TO_STATE.get(bool(self.value), STATE_UNKNOWN)
+        return bool(self.state)
 
 
 class ISYBinarySensorProgram(ISYBinarySensorDevice):
@@ -77,6 +72,6 @@ class ISYBinarySensorProgram(ISYBinarySensorDevice):
         self._name = name
 
     @property
-    def state(self) -> bool:
-        """Get state of the ISY994 binary sensor program."""
-        return STATE_ON if bool(self.value) else STATE_OFF
+    def is_on(self):
+        """Get whether the ISY994 binary sensor program is on."""
+        return bool(self.value)

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -8,8 +8,7 @@ import logging
 from typing import Callable  # noqa
 
 from homeassistant.components.binary_sensor import BinarySensorDevice, DOMAIN
-from homeassistant.components.isy994 import (ISYDevice, SENSOR_NODES, PROGRAMS,
-                                             ISY, KEY_STATUS, filter_nodes)
+import homeassistant.components.isy994 as isy
 from homeassistant.const import STATE_ON, STATE_OFF
 from homeassistant.helpers.typing import ConfigType
 
@@ -29,19 +28,19 @@ STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 binary sensor platform."""
-    if ISY is None or not ISY.connected:
+    if isy.ISY is None or not isy.ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
 
     devices = []
 
-    for node in filter_nodes(SENSOR_NODES, units=UOM,
-                             states=STATES):
+    for node in isy.filter_nodes(isy.SENSOR_NODES, units=UOM,
+                                 states=STATES):
         devices.append(ISYBinarySensorDevice(node))
 
-    for program in PROGRAMS.get(DOMAIN, []):
+    for program in isy.PROGRAMS.get(DOMAIN, []):
         try:
-            status = program[KEY_STATUS]
+            status = program[isy.KEY_STATUS]
         except (KeyError, AssertionError):
             pass
         else:
@@ -50,12 +49,12 @@ def setup_platform(hass, config: ConfigType,
     add_devices(devices)
 
 
-class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
+class ISYBinarySensorDevice(isy.ISYDevice, BinarySensorDevice):
     """Representation of an ISY994 binary sensor device."""
 
     def __init__(self, node) -> None:
         """Initialize the ISY994 binary sensor device."""
-        ISYDevice.__init__(self, node)
+        isy.ISYDevice.__init__(self, node)
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -35,9 +35,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
     devices = []
 
     for node in (HIDDEN_NODES + SENSOR_NODES):
-        if not hasattr(node, 'uom'):
-            _LOGGER.error('WTF %s', node.name)
-        elif node.uom in UOM or (STATE_ON in node.uom and STATE_OFF in node.uom):
+        if node.uom in UOM or (STATE_ON in node.uom and STATE_OFF in node.uom):
             devices.append(ISYBinarySensorDevice(node))
 
     for program in PROGRAMS.get(DOMAIN, []):
@@ -66,7 +64,6 @@ class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
     @property
     def state(self) -> str:
         """Return the state of the device."""
-        _LOGGER.debug('GETTING STATE %s %s %s', self.name, self.value, VALUE_TO_STATE.get(self.value))
         return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
 
 

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -1,0 +1,89 @@
+"""
+Support for ISY994 binary sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.isy994/
+"""
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorDevice, DOMAIN
+from homeassistant.components.isy994 import (ISYDevice, HIDDEN_NODES,
+                                             SENSOR_NODES, PROGRAMS, ISY,
+                                             KEY_ACTIONS, KEY_STATUS)
+from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN
+from homeassistant.helpers.typing import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
+
+VALUE_TO_STATE = {
+    0: STATE_OFF,
+    100: STATE_ON,
+    False: STATE_OFF,
+    True: STATE_ON,
+}
+
+UOM = ['2', '78']
+
+
+def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
+    """Setup the ISY platform."""
+
+    if ISY is None or not ISY.connected:
+        _LOGGER.error('A connection has not been made to the ISY controller.')
+        return False
+
+    devices = []
+
+    for node in (HIDDEN_NODES + SENSOR_NODES):
+        if not hasattr(node, 'uom'):
+            _LOGGER.error('WTF %s', node.name)
+        elif node.uom in UOM or (STATE_ON in node.uom and STATE_OFF in node.uom):
+            devices.append(ISYBinarySensorDevice(node))
+
+    for program in PROGRAMS.get(DOMAIN, []):
+        try:
+            status = program[KEY_STATUS]
+        except (KeyError, AssertionError):
+            pass
+        else:
+            devices.append(ISYBinarySensorProgram(program.name, status))
+
+    add_devices(devices)
+
+
+class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
+    """Representation of a ISY binary sensor."""
+
+    def __init__(self, node):
+        """Initialize the binary sensor."""
+        ISYDevice.__init__(self, node)
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if device is locked."""
+        return self.state == STATE_ON
+
+    @property
+    def state(self) -> str:
+        """Return the state of the device."""
+        _LOGGER.debug('GETTING STATE %s %s %s', self.name, self.value, VALUE_TO_STATE.get(self.value))
+        return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
+
+
+class ISYBinarySensorProgram(ISYBinarySensorDevice):
+    """Representation of a ISY lock program."""
+
+    def __init__(self, name, node):
+        """Initialize the lock."""
+        ISYDevice.__init__(self, node)
+        self._name = name
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the device is locked."""
+        return bool(self.value)
+
+    @property
+    def unit_of_measurement(self) -> None:
+        """No unit of measurement for lock programs."""
+        return None

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/binary_sensor.isy994/
 """
 import logging
 
+from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.binary_sensor import BinarySensorDevice, DOMAIN
 from homeassistant.components.isy994 import (ISYDevice, HIDDEN_NODES,
                                              SENSOR_NODES, PROGRAMS, ISY,
@@ -23,6 +24,7 @@ VALUE_TO_STATE = {
 }
 
 UOM = ['2', '78']
+STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
@@ -34,9 +36,9 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
     devices = []
 
-    for node in (HIDDEN_NODES + SENSOR_NODES):
-        if node.uom in UOM or (STATE_ON in node.uom and STATE_OFF in node.uom):
-            devices.append(ISYBinarySensorDevice(node))
+    for node in filter_nodes(HIDDEN_NODES + SENSOR_NODES, units=UOM,
+                             states=STATES):
+        devices.append(ISYBinarySensorDevice(node))
 
     for program in PROGRAMS.get(DOMAIN, []):
         try:
@@ -79,8 +81,3 @@ class ISYBinarySensorProgram(ISYBinarySensorDevice):
     def is_on(self) -> bool:
         """Return true if the device is locked."""
         return bool(self.value)
-
-    @property
-    def unit_of_measurement(self) -> None:
-        """No unit of measurement for lock programs."""
-        return None

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -8,8 +8,7 @@ import logging
 
 from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.binary_sensor import BinarySensorDevice, DOMAIN
-from homeassistant.components.isy994 import (ISYDevice, HIDDEN_NODES,
-                                             SENSOR_NODES, PROGRAMS, ISY,
+from homeassistant.components.isy994 import (ISYDevice, SENSOR_NODES, PROGRAMS, ISY,
                                              KEY_ACTIONS, KEY_STATUS)
 from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType
@@ -36,7 +35,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
     devices = []
 
-    for node in filter_nodes(HIDDEN_NODES + SENSOR_NODES, units=UOM,
+    for node in filter_nodes(SENSOR_NODES, units=UOM,
                              states=STATES):
         devices.append(ISYBinarySensorDevice(node))
 

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -10,7 +10,7 @@ from typing import Callable  # noqa
 from homeassistant.components.binary_sensor import BinarySensorDevice, DOMAIN
 from homeassistant.components.isy994 import (ISYDevice, SENSOR_NODES, PROGRAMS,
                                              ISY, KEY_STATUS, filter_nodes)
-from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN
+from homeassistant.const import STATE_ON, STATE_OFF
 from homeassistant.helpers.typing import ConfigType
 
 

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -25,6 +25,7 @@ UOM = ['2', '78']
 STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
+# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 binary sensor platform."""

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -6,18 +6,16 @@ https://home-assistant.io/components/binary_sensor.isy994/
 """
 import logging
 
-from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.binary_sensor import BinarySensorDevice, DOMAIN
-from homeassistant.components.isy994 import (ISYDevice, SENSOR_NODES, PROGRAMS, ISY,
-                                             KEY_ACTIONS, KEY_STATUS)
+from homeassistant.components.isy994 import (ISYDevice, SENSOR_NODES, PROGRAMS,
+                                             ISY, KEY_STATUS, filter_nodes)
 from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType
+
 
 _LOGGER = logging.getLogger(__name__)
 
 VALUE_TO_STATE = {
-    0: STATE_OFF,
-    100: STATE_ON,
     False: STATE_OFF,
     True: STATE_ON,
 }
@@ -58,9 +56,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
-    """
-    Representation of an ISY994 binary sensor device.
-    """
+    """Representation of an ISY994 binary sensor device."""
 
     def __init__(self, node):
         """
@@ -86,13 +82,11 @@ class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
 
         :return: The state of the ISY994 binary sensor device.
         """
-        return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
+        return VALUE_TO_STATE.get(bool(self.value), STATE_UNKNOWN)
 
 
 class ISYBinarySensorProgram(ISYBinarySensorDevice):
-    """
-    Representation of an ISY994 binary sensor program.
-    """
+    """Representation of an ISY994 binary sensor program."""
 
     def __init__(self, name, node):
         """
@@ -101,7 +95,7 @@ class ISYBinarySensorProgram(ISYBinarySensorDevice):
         :param name: The name of the ISY994 binary sensor.
         :param node: The ISY994 program to get the sensor status.
         """
-        ISYDevice.__init__(self, node)
+        ISYBinarySensorDevice.__init__(self, node)
         self._name = name
 
     @property

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -27,8 +27,15 @@ STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """Setup the ISY platform."""
+    """
+    Setup the ISY994 binary sensor platform.
 
+    :param hass: HomeAssistant
+    :param config: The platform configuration.
+    :param add_devices: The add device callback method.
+    :param discovery_info: The discovery information.
+    :return: Whether the platform was setup properly.
+    """
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -51,32 +58,57 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
-    """Representation of a ISY binary sensor."""
+    """
+    Representation of an ISY994 binary sensor device.
+    """
 
     def __init__(self, node):
-        """Initialize the binary sensor."""
+        """
+        Initialize the ISY994 binary sensor device.
+
+        :param node: The ISY994 node.
+        """
         ISYDevice.__init__(self, node)
 
     @property
     def is_on(self) -> bool:
-        """Return true if device is locked."""
+        """
+        Get whether the ISY994 binary sensor device is on.
+
+        :return: Whether the ISY994 binary sensor device is in the 'on' state.
+        """
         return self.state == STATE_ON
 
     @property
     def state(self) -> str:
-        """Return the state of the device."""
+        """
+        Get the state of the ISY994 binary sensor device.
+
+        :return: The state of the ISY994 binary sensor device.
+        """
         return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
 
 
 class ISYBinarySensorProgram(ISYBinarySensorDevice):
-    """Representation of a ISY lock program."""
+    """
+    Representation of an ISY994 binary sensor program.
+    """
 
     def __init__(self, name, node):
-        """Initialize the lock."""
+        """
+        Initialize the ISY994 binary sensor program.
+
+        :param name: The name of the ISY994 binary sensor.
+        :param node: The ISY994 program to get the sensor status.
+        """
         ISYDevice.__init__(self, node)
         self._name = name
 
     @property
-    def is_on(self) -> bool:
-        """Return true if the device is locked."""
-        return bool(self.value)
+    def state(self) -> bool:
+        """
+        Get state of the ISY994 binary sensor program.
+
+        :return: The state of the ISY994 binary sensor program.
+        """
+        return STATE_ON if bool(self.value) else STATE_OFF

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -25,15 +25,7 @@ STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """
-    Setup the ISY994 binary sensor platform.
-
-    :param hass: HomeAssistant
-    :param config: The platform configuration.
-    :param add_devices: The add device callback method.
-    :param discovery_info: The discovery information.
-    :return: Whether the platform was setup properly.
-    """
+    """Setup the ISY994 binary sensor platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -59,29 +51,17 @@ class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
     """Representation of an ISY994 binary sensor device."""
 
     def __init__(self, node):
-        """
-        Initialize the ISY994 binary sensor device.
-
-        :param node: The ISY994 node.
-        """
+        """Initialize the ISY994 binary sensor device."""
         ISYDevice.__init__(self, node)
 
     @property
     def is_on(self) -> bool:
-        """
-        Get whether the ISY994 binary sensor device is on.
-
-        :return: Whether the ISY994 binary sensor device is in the 'on' state.
-        """
+        """Get whether the ISY994 binary sensor device is on."""
         return self.state == STATE_ON
 
     @property
     def state(self) -> str:
-        """
-        Get the state of the ISY994 binary sensor device.
-
-        :return: The state of the ISY994 binary sensor device.
-        """
+        """Get the state of the ISY994 binary sensor device."""
         return VALUE_TO_STATE.get(bool(self.value), STATE_UNKNOWN)
 
 
@@ -89,20 +69,11 @@ class ISYBinarySensorProgram(ISYBinarySensorDevice):
     """Representation of an ISY994 binary sensor program."""
 
     def __init__(self, name, node):
-        """
-        Initialize the ISY994 binary sensor program.
-
-        :param name: The name of the ISY994 binary sensor.
-        :param node: The ISY994 program to get the sensor status.
-        """
+        """Initialize the ISY994 binary sensor program."""
         ISYBinarySensorDevice.__init__(self, node)
         self._name = name
 
     @property
     def state(self) -> bool:
-        """
-        Get state of the ISY994 binary sensor program.
-
-        :return: The state of the ISY994 binary sensor program.
-        """
+        """Get state of the ISY994 binary sensor program."""
         return STATE_ON if bool(self.value) else STATE_OFF

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -100,6 +100,11 @@ class ISYCoverProgram(ISYCoverDevice):
         return bool(self.value)
 
     @property
+    def state(self):
+        """Return cover state."""
+        return STATE_CLOSED if self.is_closed else STATE_OPEN
+
+    @property
     def unit_of_measurement(self) -> None:
         """No unit of measurement for lock programs."""
         return None

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -8,8 +8,7 @@ import logging
 
 from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.cover import CoverDevice, DOMAIN, ATTR_POSITION
-from homeassistant.components.isy994 import (ISYDevice, HIDDEN_NODES,
-                                             VISIBLE_NODES, PROGRAMS, ISY,
+from homeassistant.components.isy994 import (ISYDevice, NODES, PROGRAMS, ISY,
                                              KEY_ACTIONS, KEY_STATUS)
 from homeassistant.const import STATE_OPEN, STATE_CLOSED, STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType
@@ -34,7 +33,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
     devices = []
 
-    for node in filter_nodes((HIDDEN_NODES + VISIBLE_NODES), units=UOM,
+    for node in filter_nodes(NODES, units=UOM,
                              states=STATES):
         devices.append(ISYCoverDevice(node))
 

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -139,7 +139,7 @@ class ISYCoverProgram(ISYCoverDevice):
 
         :return: Whether the ISY994 is closed.
         """
-        return not bool(self.value)
+        return bool(self.value)
 
     @property
     def state(self):

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -26,6 +26,7 @@ UOM = ['97']
 STATES = [STATE_OPEN, STATE_CLOSED, 'closing', 'opening']
 
 
+# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 cover platform."""

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/cover.isy994/
 """
 import logging
 
+from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.cover import CoverDevice, DOMAIN, ATTR_POSITION
 from homeassistant.components.isy994 import (ISYDevice, HIDDEN_NODES,
                                              VISIBLE_NODES, PROGRAMS, ISY,
@@ -21,6 +22,7 @@ VALUE_TO_STATE = {
 }
 
 UOM = ['97']
+STATES = [STATE_OPEN, STATE_CLOSED, 'closing', 'opening']
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
@@ -32,13 +34,9 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
     devices = []
 
-    for node in (HIDDEN_NODES + VISIBLE_NODES):
-        if node.uom in UOM or (
-                        STATE_OPEN in node.uom and
-                        STATE_CLOSED in node.uom and
-                        'closing' in node.uom and
-                        'opening' in node.uom):
-            devices.append(ISYCoverDevice(node))
+    for node in filter_nodes((HIDDEN_NODES + VISIBLE_NODES), units=UOM,
+                             states=STATES):
+        devices.append(ISYCoverDevice(node))
 
     for program in PROGRAMS.get(DOMAIN, []):
         try:

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -6,12 +6,13 @@ https://home-assistant.io/components/cover.isy994/
 """
 import logging
 
-from homeassistant.components.isy994 import filter_nodes
-from homeassistant.components.cover import CoverDevice, DOMAIN, ATTR_POSITION
+from homeassistant.components.cover import CoverDevice, DOMAIN
 from homeassistant.components.isy994 import (ISYDevice, NODES, PROGRAMS, ISY,
-                                             KEY_ACTIONS, KEY_STATUS)
+                                             KEY_ACTIONS, KEY_STATUS,
+                                             filter_nodes)
 from homeassistant.const import STATE_OPEN, STATE_CLOSED, STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,9 +59,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYCoverDevice(ISYDevice, CoverDevice):
-    """
-    Representation of an ISY994 cover device.
-    """
+    """Representation of an ISY994 cover device."""
 
     def __init__(self, node):
         """
@@ -119,9 +118,7 @@ class ISYCoverDevice(ISYDevice, CoverDevice):
 
 
 class ISYCoverProgram(ISYCoverDevice):
-    """
-    Representation of an ISY994 cover program.
-    """
+    """Representation of an ISY994 cover program."""
 
     def __init__(self, name, node, actions):
         """
@@ -131,7 +128,7 @@ class ISYCoverProgram(ISYCoverDevice):
         :param node: The status program to get the device status.
         :param actions: The actions program for the device.
         """
-        ISYDevice.__init__(self, node)
+        ISYCoverDevice.__init__(self, node)
         self._name = name
         self._actions = actions
 

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -8,9 +8,7 @@ import logging
 from typing import Callable  # noqa
 
 from homeassistant.components.cover import CoverDevice, DOMAIN
-from homeassistant.components.isy994 import (ISYDevice, NODES, PROGRAMS, ISY,
-                                             KEY_ACTIONS, KEY_STATUS,
-                                             filter_nodes)
+import homeassistant.components.isy994 as isy
 from homeassistant.const import STATE_OPEN, STATE_CLOSED, STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType
 
@@ -30,20 +28,20 @@ STATES = [STATE_OPEN, STATE_CLOSED, 'closing', 'opening']
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 cover platform."""
-    if ISY is None or not ISY.connected:
+    if isy.ISY is None or not isy.ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
 
     devices = []
 
-    for node in filter_nodes(NODES, units=UOM,
-                             states=STATES):
+    for node in isy.filter_nodes(isy.NODES, units=UOM,
+                                 states=STATES):
         devices.append(ISYCoverDevice(node))
 
-    for program in PROGRAMS.get(DOMAIN, []):
+    for program in isy.PROGRAMS.get(DOMAIN, []):
         try:
-            status = program[KEY_STATUS]
-            actions = program[KEY_ACTIONS]
+            status = program[isy.KEY_STATUS]
+            actions = program[isy.KEY_ACTIONS]
             assert actions.dtype == 'program', 'Not a program'
         except (KeyError, AssertionError):
             pass
@@ -53,12 +51,12 @@ def setup_platform(hass, config: ConfigType,
     add_devices(devices)
 
 
-class ISYCoverDevice(ISYDevice, CoverDevice):
+class ISYCoverDevice(isy.ISYDevice, CoverDevice):
     """Representation of an ISY994 cover device."""
 
     def __init__(self, node: object):
         """Initialize the ISY994 cover device."""
-        ISYDevice.__init__(self, node)
+        isy.ISYDevice.__init__(self, node)
 
     @property
     def current_cover_position(self) -> int:

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.isy994/
 """
 import logging
+from typing import Callable  # noqa
 
 from homeassistant.components.cover import CoverDevice, DOMAIN
 from homeassistant.components.isy994 import (ISYDevice, NODES, PROGRAMS, ISY,
@@ -25,7 +26,7 @@ UOM = ['97']
 STATES = [STATE_OPEN, STATE_CLOSED, 'closing', 'opening']
 
 
-def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
+def setup_platform(hass, config: ConfigType, add_devices: Callable([[list], None]), discovery_info=None):
     """Setup the ISY994 cover platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
@@ -53,12 +54,12 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 class ISYCoverDevice(ISYDevice, CoverDevice):
     """Representation of an ISY994 cover device."""
 
-    def __init__(self, node):
+    def __init__(self, node: object):
         """Initialize the ISY994 cover device."""
         ISYDevice.__init__(self, node)
 
     @property
-    def current_cover_position(self):
+    def current_cover_position(self) -> int:
         """Get the current cover position."""
         return sorted((0, self.value, 100))[1]
 
@@ -72,12 +73,12 @@ class ISYCoverDevice(ISYDevice, CoverDevice):
         """Get the state of the ISY994 cover device."""
         return VALUE_TO_STATE.get(self.value, STATE_OPEN)
 
-    def open_cover(self, **kwargs):
+    def open_cover(self, **kwargs) -> None:
         """Send the open cover command to the ISY994 cover device."""
         if not self._node.on(val=100):
             _LOGGER.error('Unable to open the cover')
 
-    def close_cover(self, **kwargs):
+    def close_cover(self, **kwargs) -> None:
         """Send the close cover command to the ISY994 cover device."""
         if not self._node.off():
             _LOGGER.error('Unable to close the cover')
@@ -86,7 +87,7 @@ class ISYCoverDevice(ISYDevice, CoverDevice):
 class ISYCoverProgram(ISYCoverDevice):
     """Representation of an ISY994 cover program."""
 
-    def __init__(self, name, node, actions):
+    def __init__(self, name: str, node: object, actions: object) -> None:
         """Initialize the ISY994 cover program."""
         ISYCoverDevice.__init__(self, node)
         self._name = name
@@ -98,16 +99,16 @@ class ISYCoverProgram(ISYCoverDevice):
         return bool(self.value)
 
     @property
-    def state(self):
+    def state(self) -> str:
         """Get the state of the ISY994 cover program."""
         return STATE_CLOSED if self.is_closed else STATE_OPEN
 
-    def open_cover(self, **kwargs):
+    def open_cover(self, **kwargs) -> None:
         """Send the open cover command to the ISY994 cover program."""
         if not self._actions.runThen():
             _LOGGER.error('Unable to open the cover')
 
-    def close_cover(self, **kwargs):
+    def close_cover(self, **kwargs) -> None:
         """Send the close cover command to the ISY994 cover program."""
         if not self._actions.runElse():
             _LOGGER.error('Unable to close the cover')

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -1,0 +1,117 @@
+"""
+Support for ISY994 covers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/cover.isy994/
+"""
+import logging
+
+from homeassistant.components.cover import CoverDevice, DOMAIN, ATTR_POSITION
+from homeassistant.components.isy994 import (ISYDevice, HIDDEN_NODES,
+                                             VISIBLE_NODES, PROGRAMS, ISY,
+                                             KEY_ACTIONS, KEY_STATUS)
+from homeassistant.const import STATE_OPEN, STATE_CLOSED, STATE_UNKNOWN
+from homeassistant.helpers.typing import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
+
+VALUE_TO_STATE = {
+    0: STATE_CLOSED,
+    101: STATE_UNKNOWN,
+}
+
+UOM = ['97']
+
+
+def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
+    """Setup the ISY platform."""
+
+    if ISY is None or not ISY.connected:
+        _LOGGER.error('A connection has not been made to the ISY controller.')
+        return False
+
+    devices = []
+
+    for node in (HIDDEN_NODES + VISIBLE_NODES):
+        if node.uom in UOM or (
+                        STATE_OPEN in node.uom and
+                        STATE_CLOSED in node.uom and
+                        'closing' in node.uom and
+                        'opening' in node.uom):
+            devices.append(ISYCoverDevice(node))
+
+    for program in PROGRAMS.get(DOMAIN, []):
+        try:
+            status = program[KEY_STATUS]
+            actions = program[KEY_ACTIONS]
+            assert actions.dtype == 'program', 'Not a program'
+        except (KeyError, AssertionError):
+            pass
+        else:
+            devices.append(ISYCoverProgram(program.name, status, actions))
+
+    add_devices(devices)
+
+
+class ISYCoverDevice(ISYDevice, CoverDevice):
+    """Representation of a ISY cover device."""
+
+    def __init__(self, node):
+        """Initialize the binary sensor."""
+        ISYDevice.__init__(self, node)
+
+    @property
+    def current_cover_position(self):
+        """Return the current cover position."""
+        return sorted((0, self.value, 100))[1]
+
+    @property
+    def is_closed(self) -> bool:
+        """Return true if device is locked."""
+        return self.state == STATE_CLOSED
+
+    @property
+    def state(self) -> str:
+        """Return the state of the device."""
+        _LOGGER.error('STATE %s %s %s', self.name, self.value, VALUE_TO_STATE.get(self.value, STATE_OPEN))
+        return VALUE_TO_STATE.get(self.value, STATE_OPEN)
+
+    def open_cover(self, **kwargs):
+        """Open the cover."""
+        if not self._node.on(val=100):
+            _LOGGER.error('Unable to open the cover')
+
+    def close_cover(self, **kwargs):
+        """Close cover."""
+        if not self._node.off():
+            _LOGGER.error('Unable to close the cover')
+
+
+class ISYCoverProgram(ISYCoverDevice):
+    """Representation of a ISY cover program."""
+
+    def __init__(self, name, node, actions):
+        """Initialize the cover."""
+        ISYDevice.__init__(self, node)
+        self._name = name
+        self._actions = actions
+
+    @property
+    def is_closed(self) -> bool:
+        """Return true if the device is locked."""
+        return bool(self.value)
+
+    @property
+    def unit_of_measurement(self) -> None:
+        """No unit of measurement for lock programs."""
+        return None
+
+    def open_cover(self, **kwargs):
+        """Open the cover."""
+        if not self._actions.runThen():
+            _LOGGER.error('Unable to open the cover')
+
+    def close_cover(self, **kwargs):
+        """Close the cover."""
+        if not self._actions.runElse():
+            _LOGGER.error('Unable to close the cover')

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -96,14 +96,9 @@ class ISYCoverProgram(ISYCoverDevice):
         self._actions = actions
 
     @property
-    def is_closed(self) -> bool:
-        """Get whether the ISY994 cover program is closed."""
-        return bool(self.value)
-
-    @property
     def state(self) -> str:
         """Get the state of the ISY994 cover program."""
-        return STATE_CLOSED if self.is_closed else STATE_OPEN
+        return STATE_CLOSED if bool(self.value) else STATE_OPEN
 
     def open_cover(self, **kwargs) -> None:
         """Send the open cover command to the ISY994 cover program."""

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -25,8 +25,15 @@ STATES = [STATE_OPEN, STATE_CLOSED, 'closing', 'opening']
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """Setup the ISY platform."""
+    """
+    Setup the ISY994 cover platform.
 
+    :param hass: HomeAssistant.
+    :param config: Platform configuration.
+    :param add_devices: The add devices callback method.
+    :param discovery_info: The discovery information.
+    :return: Whether the platform was setup properly.
+    """
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -51,69 +58,117 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYCoverDevice(ISYDevice, CoverDevice):
-    """Representation of a ISY cover device."""
+    """
+    Representation of an ISY994 cover device.
+    """
 
     def __init__(self, node):
-        """Initialize the binary sensor."""
+        """
+        Initialize the ISY994 cover device.
+
+        :param node: The ISY994 node.
+        """
         ISYDevice.__init__(self, node)
 
     @property
     def current_cover_position(self):
-        """Return the current cover position."""
+        """
+        Get the current cover position.
+
+        :return: The percentage value representing how closed the cover is.
+        """
         return sorted((0, self.value, 100))[1]
 
     @property
     def is_closed(self) -> bool:
-        """Return true if device is locked."""
+        """
+        Get whether the ISY994 cover device is closed.
+
+        :return: Whether the ISY994 cover device is in the 'closed' status.
+        """
         return self.state == STATE_CLOSED
 
     @property
     def state(self) -> str:
-        """Return the state of the device."""
-        _LOGGER.error('STATE %s %s %s', self.name, self.value, VALUE_TO_STATE.get(self.value, STATE_OPEN))
+        """
+        Get the state of the ISY994 cover device.
+
+        :return: The state of the ISY994 cover device.
+        """
         return VALUE_TO_STATE.get(self.value, STATE_OPEN)
 
     def open_cover(self, **kwargs):
-        """Open the cover."""
+        """
+        Send the open cover command to the ISY994 cover device.
+
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         if not self._node.on(val=100):
             _LOGGER.error('Unable to open the cover')
 
     def close_cover(self, **kwargs):
-        """Close cover."""
+        """
+        Send the close cover command to the ISY994 cover device.
+
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         if not self._node.off():
             _LOGGER.error('Unable to close the cover')
 
 
 class ISYCoverProgram(ISYCoverDevice):
-    """Representation of a ISY cover program."""
+    """
+    Representation of an ISY994 cover program.
+    """
 
     def __init__(self, name, node, actions):
-        """Initialize the cover."""
+        """
+        Initialize the ISY994 cover program.
+
+        :param name: The name of the cover device.
+        :param node: The status program to get the device status.
+        :param actions: The actions program for the device.
+        """
         ISYDevice.__init__(self, node)
         self._name = name
         self._actions = actions
 
     @property
     def is_closed(self) -> bool:
-        """Return true if the device is locked."""
-        return bool(self.value)
+        """
+        Get whether the ISY994 cover program is closed.
+
+        :return: Whether the ISY994 is closed.
+        """
+        return not bool(self.value)
 
     @property
     def state(self):
-        """Return cover state."""
+        """
+        Get the state of the ISY994 cover program.
+
+        :return: The program state.
+        """
         return STATE_CLOSED if self.is_closed else STATE_OPEN
 
-    @property
-    def unit_of_measurement(self) -> None:
-        """No unit of measurement for lock programs."""
-        return None
-
     def open_cover(self, **kwargs):
-        """Open the cover."""
+        """
+        Send the open cover command to the ISY994 cover program.
+
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         if not self._actions.runThen():
             _LOGGER.error('Unable to open the cover')
 
     def close_cover(self, **kwargs):
-        """Close the cover."""
+        """
+        Send the close cover command to the ISY994 cover program.
+
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         if not self._actions.runElse():
             _LOGGER.error('Unable to close the cover')

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -26,15 +26,7 @@ STATES = [STATE_OPEN, STATE_CLOSED, 'closing', 'opening']
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """
-    Setup the ISY994 cover platform.
-
-    :param hass: HomeAssistant.
-    :param config: Platform configuration.
-    :param add_devices: The add devices callback method.
-    :param discovery_info: The discovery information.
-    :return: Whether the platform was setup properly.
-    """
+    """Setup the ISY994 cover platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -62,57 +54,31 @@ class ISYCoverDevice(ISYDevice, CoverDevice):
     """Representation of an ISY994 cover device."""
 
     def __init__(self, node):
-        """
-        Initialize the ISY994 cover device.
-
-        :param node: The ISY994 node.
-        """
+        """Initialize the ISY994 cover device."""
         ISYDevice.__init__(self, node)
 
     @property
     def current_cover_position(self):
-        """
-        Get the current cover position.
-
-        :return: The percentage value representing how closed the cover is.
-        """
+        """Get the current cover position."""
         return sorted((0, self.value, 100))[1]
 
     @property
     def is_closed(self) -> bool:
-        """
-        Get whether the ISY994 cover device is closed.
-
-        :return: Whether the ISY994 cover device is in the 'closed' status.
-        """
+        """Get whether the ISY994 cover device is closed."""
         return self.state == STATE_CLOSED
 
     @property
     def state(self) -> str:
-        """
-        Get the state of the ISY994 cover device.
-
-        :return: The state of the ISY994 cover device.
-        """
+        """Get the state of the ISY994 cover device."""
         return VALUE_TO_STATE.get(self.value, STATE_OPEN)
 
     def open_cover(self, **kwargs):
-        """
-        Send the open cover command to the ISY994 cover device.
-
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+        """Send the open cover command to the ISY994 cover device."""
         if not self._node.on(val=100):
             _LOGGER.error('Unable to open the cover')
 
     def close_cover(self, **kwargs):
-        """
-        Send the close cover command to the ISY994 cover device.
-
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+        """Send the close cover command to the ISY994 cover device."""
         if not self._node.off():
             _LOGGER.error('Unable to close the cover')
 
@@ -121,51 +87,27 @@ class ISYCoverProgram(ISYCoverDevice):
     """Representation of an ISY994 cover program."""
 
     def __init__(self, name, node, actions):
-        """
-        Initialize the ISY994 cover program.
-
-        :param name: The name of the cover device.
-        :param node: The status program to get the device status.
-        :param actions: The actions program for the device.
-        """
+        """Initialize the ISY994 cover program."""
         ISYCoverDevice.__init__(self, node)
         self._name = name
         self._actions = actions
 
     @property
     def is_closed(self) -> bool:
-        """
-        Get whether the ISY994 cover program is closed.
-
-        :return: Whether the ISY994 is closed.
-        """
+        """Get whether the ISY994 cover program is closed."""
         return bool(self.value)
 
     @property
     def state(self):
-        """
-        Get the state of the ISY994 cover program.
-
-        :return: The program state.
-        """
+        """Get the state of the ISY994 cover program."""
         return STATE_CLOSED if self.is_closed else STATE_OPEN
 
     def open_cover(self, **kwargs):
-        """
-        Send the open cover command to the ISY994 cover program.
-
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+        """Send the open cover command to the ISY994 cover program."""
         if not self._actions.runThen():
             _LOGGER.error('Unable to open the cover')
 
     def close_cover(self, **kwargs):
-        """
-        Send the close cover command to the ISY994 cover program.
-
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+        """Send the close cover command to the ISY994 cover program."""
         if not self._actions.runElse():
             _LOGGER.error('Unable to close the cover')

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -26,7 +26,8 @@ UOM = ['97']
 STATES = [STATE_OPEN, STATE_CLOSED, 'closing', 'opening']
 
 
-def setup_platform(hass, config: ConfigType, add_devices: Callable([[list], None]), discovery_info=None):
+def setup_platform(hass, config: ConfigType,
+                   add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 cover platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -34,6 +34,7 @@ for key in VALUE_TO_STATE:
 STATES = [SPEED_OFF, SPEED_LOW, SPEED_MED, SPEED_HIGH]
 
 
+# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 fan platform."""

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/fan.isy994/
 """
 import logging
+from typing import Callable
 
 from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.fan import (FanEntity, DOMAIN, SPEED_OFF,
@@ -33,16 +34,8 @@ for key in VALUE_TO_STATE:
 STATES = [SPEED_OFF, SPEED_LOW, SPEED_MED, SPEED_HIGH]
 
 
-def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """
-    Setup the ISY994 fan platform.
-
-    :param hass: HomeAsistant.
-    :param config: The platform configuration.
-    :param add_devices: The add devices callback method.
-    :param discovery_info: The discovery information.
-    :return: Whether the platform was setup properly.
-    """
+def setup_platform(hass, config: ConfigType, add_devices: Callable[[list], None], discovery_info=None):
+    """Setup the ISY994 fan platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -68,53 +61,29 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 class ISYFanDevice(ISYDevice, FanEntity):
     """Representation of an ISY994 fan device."""
 
-    def __init__(self, node):
-        """
-        Initialize the ISY994 fan device.
-
-        :param node: The ISY994 node.
-        """
+    def __init__(self, node) -> None:
+        """Initialize the ISY994 fan device."""
         ISYDevice.__init__(self, node)
         self.speed = self.state
 
     @property
     def state(self) -> str:
-        """
-        Get the state of the ISY994 fan device.
-
-        :return: The state of the ISY994 fan device.
-        """
+        """Get the state of the ISY994 fan device."""
         return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
 
     def set_speed(self, speed: str) -> None:
-        """
-        Send the set speed command to the ISY994 fan device.
-
-        :param speed: The speed to send to the device.
-        :return: None.
-        """
+        """Send the set speed command to the ISY994 fan device."""
         if not self._node.on(val=STATE_TO_VALUE.get(speed, 0)):
             _LOGGER.debug('Unable to set fan speed')
         else:
             self.speed = self.state
 
     def turn_on(self, speed: str=None, **kwargs) -> None:
-        """
-        Send the turn on command to the ISY994 fan device.
-
-        :param speed: The speed to set it to.
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+        """Send the turn on command to the ISY994 fan device."""
         self.set_speed(speed)
 
     def turn_off(self, **kwargs) -> None:
-        """
-        Send the turn off command to the ISY994 fan device.
-
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+        """Send the turn off command to the ISY994 fan device."""
         if not self._node.off():
             _LOGGER.debug('Unable to set fan speed')
         else:
@@ -124,14 +93,8 @@ class ISYFanDevice(ISYDevice, FanEntity):
 class ISYFanProgram(ISYFanDevice):
     """Representation of an ISY994 fan program."""
 
-    def __init__(self, name, node, actions):
-        """
-        Initialize the ISY994 fan program.
-
-        :param name: The name of the ISY994 fan.
-        :param node: The ISY994 program to get the status.
-        :param actions: The ISY994 program to send commands.
-        """
+    def __init__(self, name: str, node, actions) -> None:
+        """Initialize the ISY994 fan program."""
         ISYFanDevice.__init__(self, node)
         self._name = name
         self._actions = actions
@@ -139,41 +102,23 @@ class ISYFanProgram(ISYFanDevice):
 
     @property
     def is_on(self) -> bool:
-        """
-        Get whether the ISY994 fan program is on.
-
-        :return: Whether the ISY994 fan program is in the 'on' state.
-        """
+        """Get whether the ISY994 fan program is on."""
         return bool(self.value)
 
     @property
-    def state(self):
-        """
-        Get the state of the ISY994 fan program.
-
-        :return: The state of the ISY994 fan program.
-        """
+    def state(self) -> str:
+        """Get the state of the ISY994 fan program."""
         return STATE_ON if self.is_on else STATE_OFF
 
-    def turn_off(self, **kwargs):
-        """
-        Send the turn on command to ISY994 fan program.
-
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+    def turn_off(self, **kwargs) -> None:
+        """Send the turn on command to ISY994 fan program."""
         if not self._actions.runThen():
             _LOGGER.error('Unable to open the cover')
         else:
             self.speed = STATE_ON if self.is_on else STATE_OFF
 
-    def turn_on(self, **kwargs):
-        """
-        Send the turn off command to ISY994 fan program.
-
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+    def turn_on(self, **kwargs) -> None:
+        """Send the turn off command to ISY994 fan program."""
         if not self._actions.runElse():
             _LOGGER.error('Unable to close the cover')
         else:

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -103,6 +103,11 @@ class ISYFanProgram(ISYFanDevice):
         """Return true if the device is locked."""
         return bool(self.value)
 
+    @property
+    def state(self):
+        """Return state of the fan."""
+        return STATE_ON if self.is_on else STATE_OFF
+
     def turn_off(self, **kwargs):
         """Turn fan on."""
         if not self._actions.runThen():

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -34,7 +34,8 @@ for key in VALUE_TO_STATE:
 STATES = [SPEED_OFF, SPEED_LOW, SPEED_MED, SPEED_HIGH]
 
 
-def setup_platform(hass, config: ConfigType, add_devices: Callable[[list], None], discovery_info=None):
+def setup_platform(hass, config: ConfigType,
+                   add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 fan platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -7,8 +7,8 @@ https://home-assistant.io/components/fan.isy994/
 import logging
 
 from homeassistant.components.isy994 import filter_nodes
-from homeassistant.components.fan import (FanEntity, DOMAIN, ATTR_SPEED,
-                                          SPEED_OFF, SPEED_LOW, SPEED_MED,
+from homeassistant.components.fan import (FanEntity, DOMAIN, SPEED_OFF,
+                                          SPEED_LOW, SPEED_MED,
                                           SPEED_HIGH)
 from homeassistant.components.isy994 import (ISYDevice, NODES, PROGRAMS, ISY,
                                              KEY_ACTIONS, KEY_STATUS)
@@ -66,9 +66,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYFanDevice(ISYDevice, FanEntity):
-    """
-    Representation of an ISY994 fan device.
-    """
+    """Representation of an ISY994 fan device."""
 
     def __init__(self, node):
         """
@@ -100,7 +98,7 @@ class ISYFanDevice(ISYDevice, FanEntity):
         else:
             self.speed = self.state
 
-    def turn_on(self, speed: str = None, **kwargs) -> None:
+    def turn_on(self, speed: str=None, **kwargs) -> None:
         """
         Send the turn on command to the ISY994 fan device.
 
@@ -124,9 +122,7 @@ class ISYFanDevice(ISYDevice, FanEntity):
 
 
 class ISYFanProgram(ISYFanDevice):
-    """
-    Representation of an ISY994 fan program.
-    """
+    """Representation of an ISY994 fan program."""
 
     def __init__(self, name, node, actions):
         """
@@ -136,10 +132,10 @@ class ISYFanProgram(ISYFanDevice):
         :param node: The ISY994 program to get the status.
         :param actions: The ISY994 program to send commands.
         """
-        ISYDevice.__init__(self, node)
+        ISYFanDevice.__init__(self, node)
         self._name = name
         self._actions = actions
-        self.speed = STATE_ON if self.is_on() else STATE_OFF
+        self.speed = STATE_ON if self.is_on else STATE_OFF
 
     @property
     def is_on(self) -> bool:
@@ -169,7 +165,7 @@ class ISYFanProgram(ISYFanDevice):
         if not self._actions.runThen():
             _LOGGER.error('Unable to open the cover')
         else:
-            self.speed = STATE_ON if self.is_on() else STATE_OFF
+            self.speed = STATE_ON if self.is_on else STATE_OFF
 
     def turn_on(self, **kwargs):
         """
@@ -181,4 +177,4 @@ class ISYFanProgram(ISYFanDevice):
         if not self._actions.runElse():
             _LOGGER.error('Unable to close the cover')
         else:
-            self.speed = STATE_ON if self.is_on() else STATE_OFF
+            self.speed = STATE_ON if self.is_on else STATE_OFF

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -103,14 +103,9 @@ class ISYFanProgram(ISYFanDevice):
         self.speed = STATE_ON if self.is_on else STATE_OFF
 
     @property
-    def is_on(self) -> bool:
-        """Get whether the ISY994 fan program is on."""
-        return bool(self.value)
-
-    @property
     def state(self) -> str:
         """Get the state of the ISY994 fan program."""
-        return STATE_ON if self.is_on else STATE_OFF
+        return STATE_ON if bool(self.value) else STATE_OFF
 
     def turn_off(self, **kwargs) -> None:
         """Send the turn on command to ISY994 fan program."""

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -7,12 +7,10 @@ https://home-assistant.io/components/fan.isy994/
 import logging
 from typing import Callable
 
-from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.fan import (FanEntity, DOMAIN, SPEED_OFF,
                                           SPEED_LOW, SPEED_MED,
                                           SPEED_HIGH)
-from homeassistant.components.isy994 import (ISYDevice, NODES, PROGRAMS, ISY,
-                                             KEY_ACTIONS, KEY_STATUS)
+import homeassistant.components.isy994 as isy
 from homeassistant.const import STATE_UNKNOWN, STATE_ON, STATE_OFF
 from homeassistant.helpers.typing import ConfigType
 
@@ -38,19 +36,19 @@ STATES = [SPEED_OFF, SPEED_LOW, SPEED_MED, SPEED_HIGH]
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 fan platform."""
-    if ISY is None or not ISY.connected:
+    if isy.ISY is None or not isy.ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
 
     devices = []
 
-    for node in filter_nodes(NODES, states=STATES):
+    for node in isy.filter_nodes(isy.NODES, states=STATES):
         devices.append(ISYFanDevice(node))
 
-    for program in PROGRAMS.get(DOMAIN, []):
+    for program in isy.PROGRAMS.get(DOMAIN, []):
         try:
-            status = program[KEY_STATUS]
-            actions = program[KEY_ACTIONS]
+            status = program[isy.KEY_STATUS]
+            actions = program[isy.KEY_ACTIONS]
             assert actions.dtype == 'program', 'Not a program'
         except (KeyError, AssertionError):
             pass
@@ -60,12 +58,12 @@ def setup_platform(hass, config: ConfigType,
     add_devices(devices)
 
 
-class ISYFanDevice(ISYDevice, FanEntity):
+class ISYFanDevice(isy.ISYDevice, FanEntity):
     """Representation of an ISY994 fan device."""
 
     def __init__(self, node) -> None:
         """Initialize the ISY994 fan device."""
-        ISYDevice.__init__(self, node)
+        isy.ISYDevice.__init__(self, node)
         self.speed = self.state
 
     @property

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -32,9 +32,17 @@ for key in VALUE_TO_STATE:
 
 STATES = [SPEED_OFF, SPEED_LOW, SPEED_MED, SPEED_HIGH]
 
-def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """Setup the ISY platform."""
 
+def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
+    """
+    Setup the ISY994 fan platform.
+
+    :param hass: HomeAsistant.
+    :param config: The platform configuration.
+    :param add_devices: The add devices callback method.
+    :param discovery_info: The discovery information.
+    :return: Whether the platform was setup properly.
+    """
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -58,31 +66,57 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYFanDevice(ISYDevice, FanEntity):
-    """Representation of a ISY fan device."""
+    """
+    Representation of an ISY994 fan device.
+    """
 
     def __init__(self, node):
-        """Initialize the binary sensor."""
+        """
+        Initialize the ISY994 fan device.
+
+        :param node: The ISY994 node.
+        """
         ISYDevice.__init__(self, node)
         self.speed = self.state
 
     @property
     def state(self) -> str:
-        """Return the state of the device."""
+        """
+        Get the state of the ISY994 fan device.
+
+        :return: The state of the ISY994 fan device.
+        """
         return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
 
     def set_speed(self, speed: str) -> None:
-        """Set the speed of the fan."""
+        """
+        Send the set speed command to the ISY994 fan device.
+
+        :param speed: The speed to send to the device.
+        :return: None.
+        """
         if not self._node.on(val=STATE_TO_VALUE.get(speed, 0)):
             _LOGGER.debug('Unable to set fan speed')
         else:
             self.speed = self.state
 
     def turn_on(self, speed: str = None, **kwargs) -> None:
-        """Turn on the fan."""
+        """
+        Send the turn on command to the ISY994 fan device.
+
+        :param speed: The speed to set it to.
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         self.set_speed(speed)
 
     def turn_off(self, **kwargs) -> None:
-        """Turn off the fan."""
+        """
+        Send the turn off command to the ISY994 fan device.
+
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         if not self._node.off():
             _LOGGER.debug('Unable to set fan speed')
         else:
@@ -90,10 +124,18 @@ class ISYFanDevice(ISYDevice, FanEntity):
 
 
 class ISYFanProgram(ISYFanDevice):
-    """Representation of a ISY cover program."""
+    """
+    Representation of an ISY994 fan program.
+    """
 
     def __init__(self, name, node, actions):
-        """Initialize the cover."""
+        """
+        Initialize the ISY994 fan program.
+
+        :param name: The name of the ISY994 fan.
+        :param node: The ISY994 program to get the status.
+        :param actions: The ISY994 program to send commands.
+        """
         ISYDevice.__init__(self, node)
         self._name = name
         self._actions = actions
@@ -101,23 +143,41 @@ class ISYFanProgram(ISYFanDevice):
 
     @property
     def is_on(self) -> bool:
-        """Return true if the device is locked."""
+        """
+        Get whether the ISY994 fan program is on.
+
+        :return: Whether the ISY994 fan program is in the 'on' state.
+        """
         return bool(self.value)
 
     @property
     def state(self):
-        """Return state of the fan."""
+        """
+        Get the state of the ISY994 fan program.
+
+        :return: The state of the ISY994 fan program.
+        """
         return STATE_ON if self.is_on else STATE_OFF
 
     def turn_off(self, **kwargs):
-        """Turn fan on."""
+        """
+        Send the turn on command to ISY994 fan program.
+
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         if not self._actions.runThen():
             _LOGGER.error('Unable to open the cover')
         else:
             self.speed = STATE_ON if self.is_on() else STATE_OFF
 
     def turn_on(self, **kwargs):
-        """Turn fan off."""
+        """
+        Send the turn off command to ISY994 fan program.
+
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         if not self._actions.runElse():
             _LOGGER.error('Unable to close the cover')
         else:

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -68,7 +68,6 @@ class ISYFanDevice(ISYDevice, FanEntity):
     @property
     def state(self) -> str:
         """Return the state of the device."""
-        _LOGGER.error('STATE %s %s %s', self.name, self.value, VALUE_TO_STATE.get(self.value, STATE_UNKNOWN))
         return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
 
     def set_speed(self, speed: str) -> None:

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -10,8 +10,7 @@ from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.fan import (FanEntity, DOMAIN, ATTR_SPEED,
                                           SPEED_OFF, SPEED_LOW, SPEED_MED,
                                           SPEED_HIGH)
-from homeassistant.components.isy994 import (ISYDevice, HIDDEN_NODES,
-                                             VISIBLE_NODES, PROGRAMS, ISY,
+from homeassistant.components.isy994 import (ISYDevice, NODES, PROGRAMS, ISY,
                                              KEY_ACTIONS, KEY_STATUS)
 from homeassistant.const import STATE_UNKNOWN, STATE_ON, STATE_OFF
 from homeassistant.helpers.typing import ConfigType
@@ -21,6 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 VALUE_TO_STATE = {
     0: SPEED_OFF,
     63: SPEED_LOW,
+    64: SPEED_LOW,
+    190: SPEED_MED,
     191: SPEED_MED,
     255: SPEED_HIGH,
 }
@@ -40,7 +41,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
     devices = []
 
-    for node in filter_nodes(HIDDEN_NODES + VISIBLE_NODES, states=STATES):
+    for node in filter_nodes(NODES, states=STATES):
         devices.append(ISYFanDevice(node))
 
     for program in PROGRAMS.get(DOMAIN, []):

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/fan.isy994/
 """
 import logging
 
+from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.fan import (FanEntity, DOMAIN, ATTR_SPEED,
                                           SPEED_OFF, SPEED_LOW, SPEED_MED,
                                           SPEED_HIGH)
@@ -28,6 +29,8 @@ STATE_TO_VALUE = {}
 for key in VALUE_TO_STATE:
     STATE_TO_VALUE[VALUE_TO_STATE[key]] = key
 
+STATES = [SPEED_OFF, SPEED_LOW, SPEED_MED, SPEED_HIGH]
+
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
     """Setup the ISY platform."""
 
@@ -37,12 +40,8 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
     devices = []
 
-    for node in (HIDDEN_NODES + VISIBLE_NODES):
-        if (SPEED_OFF in node.uom and
-                SPEED_LOW in node.uom and
-                SPEED_MED in node.uom and
-                SPEED_HIGH in node.uom):
-            devices.append(ISYFanDevice(node))
+    for node in filter_nodes(HIDDEN_NODES + VISIBLE_NODES, states=STATES):
+        devices.append(ISYFanDevice(node))
 
     for program in PROGRAMS.get(DOMAIN, []):
         try:
@@ -103,11 +102,6 @@ class ISYFanProgram(ISYFanDevice):
     def is_on(self) -> bool:
         """Return true if the device is locked."""
         return bool(self.value)
-
-    @property
-    def unit_of_measurement(self) -> None:
-        """No unit of measurement for lock programs."""
-        return None
 
     def turn_off(self, **kwargs):
         """Turn fan on."""

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -1,0 +1,125 @@
+"""
+Support for ISY994 fans.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/fan.isy994/
+"""
+import logging
+
+from homeassistant.components.fan import (FanEntity, DOMAIN, ATTR_SPEED,
+                                          SPEED_OFF, SPEED_LOW, SPEED_MED,
+                                          SPEED_HIGH)
+from homeassistant.components.isy994 import (ISYDevice, HIDDEN_NODES,
+                                             VISIBLE_NODES, PROGRAMS, ISY,
+                                             KEY_ACTIONS, KEY_STATUS)
+from homeassistant.const import STATE_UNKNOWN, STATE_ON, STATE_OFF
+from homeassistant.helpers.typing import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
+
+VALUE_TO_STATE = {
+    0: SPEED_OFF,
+    63: SPEED_LOW,
+    191: SPEED_MED,
+    255: SPEED_HIGH,
+}
+
+STATE_TO_VALUE = {}
+for key in VALUE_TO_STATE:
+    STATE_TO_VALUE[VALUE_TO_STATE[key]] = key
+
+def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
+    """Setup the ISY platform."""
+
+    if ISY is None or not ISY.connected:
+        _LOGGER.error('A connection has not been made to the ISY controller.')
+        return False
+
+    devices = []
+
+    for node in (HIDDEN_NODES + VISIBLE_NODES):
+        if (SPEED_OFF in node.uom and
+                SPEED_LOW in node.uom and
+                SPEED_MED in node.uom and
+                SPEED_HIGH in node.uom):
+            devices.append(ISYFanDevice(node))
+
+    for program in PROGRAMS.get(DOMAIN, []):
+        try:
+            status = program[KEY_STATUS]
+            actions = program[KEY_ACTIONS]
+            assert actions.dtype == 'program', 'Not a program'
+        except (KeyError, AssertionError):
+            pass
+        else:
+            devices.append(ISYFanProgram(program.name, status, actions))
+
+    add_devices(devices)
+
+
+class ISYFanDevice(ISYDevice, FanEntity):
+    """Representation of a ISY fan device."""
+
+    def __init__(self, node):
+        """Initialize the binary sensor."""
+        ISYDevice.__init__(self, node)
+        self.speed = self.state
+
+    @property
+    def state(self) -> str:
+        """Return the state of the device."""
+        _LOGGER.error('STATE %s %s %s', self.name, self.value, VALUE_TO_STATE.get(self.value, STATE_UNKNOWN))
+        return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
+
+    def set_speed(self, speed: str) -> None:
+        """Set the speed of the fan."""
+        if not self._node.on(val=STATE_TO_VALUE.get(speed, 0)):
+            _LOGGER.debug('Unable to set fan speed')
+        else:
+            self.speed = self.state
+
+    def turn_on(self, speed: str = None, **kwargs) -> None:
+        """Turn on the fan."""
+        self.set_speed(speed)
+
+    def turn_off(self, **kwargs) -> None:
+        """Turn off the fan."""
+        if not self._node.off():
+            _LOGGER.debug('Unable to set fan speed')
+        else:
+            self.speed = self.state
+
+
+class ISYFanProgram(ISYFanDevice):
+    """Representation of a ISY cover program."""
+
+    def __init__(self, name, node, actions):
+        """Initialize the cover."""
+        ISYDevice.__init__(self, node)
+        self._name = name
+        self._actions = actions
+        self.speed = STATE_ON if self.is_on() else STATE_OFF
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the device is locked."""
+        return bool(self.value)
+
+    @property
+    def unit_of_measurement(self) -> None:
+        """No unit of measurement for lock programs."""
+        return None
+
+    def turn_off(self, **kwargs):
+        """Turn fan on."""
+        if not self._actions.runThen():
+            _LOGGER.error('Unable to open the cover')
+        else:
+            self.speed = STATE_ON if self.is_on() else STATE_OFF
+
+    def turn_on(self, **kwargs):
+        """Turn fan off."""
+        if not self._actions.runElse():
+            _LOGGER.error('Unable to close the cover')
+        else:
+            self.speed = STATE_ON if self.is_on() else STATE_OFF

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -49,7 +49,7 @@ PROGRAMS = {}
 
 HIDDEN_STRING = DEFAULT_HIDDEN_STRING
 
-COMPONENTS = ['lock', 'binary_sensor']
+COMPONENTS = ['lock', 'binary_sensor', 'cover']
 # '('binary_sensor', 'climate', 'cover', 'fan', 'light',
 #                       'lock', 'sensor')
 

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -19,7 +19,7 @@ DOMAIN = "isy994"
 REQUIREMENTS = ['PyISY==1.0.7']
 
 ISY = None
-DEFAULT_SENSOR_STRING = 'Sensor'
+DEFAULT_SENSOR_STRING = 'sensor'
 DEFAULT_HIDDEN_STRING = '{HIDE ME}'
 CONF_TLS_VER = 'tls'
 CONF_HIDDEN_STRING = 'hidden_string'
@@ -49,7 +49,7 @@ PROGRAMS = {}
 
 HIDDEN_STRING = DEFAULT_HIDDEN_STRING
 
-COMPONENTS = ['lock', 'binary_sensor', 'cover', 'fan']
+COMPONENTS = ['lock', 'binary_sensor', 'cover', 'fan', 'sensor']
 # '('binary_sensor', 'climate', 'cover', 'fan', 'light',
 #                       'lock', 'sensor')
 

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -43,13 +43,13 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 SENSOR_NODES = []
-HIDDEN_NODES = []
-VISIBLE_NODES = []
+NODES = []
+GROUPS = []
 PROGRAMS = {}
 
 HIDDEN_STRING = DEFAULT_HIDDEN_STRING
 
-COMPONENTS = ['lock', 'binary_sensor', 'cover', 'fan', 'sensor']
+COMPONENTS = ['lock', 'binary_sensor', 'cover', 'fan', 'sensor', 'light', 'switch']
 # '('binary_sensor', 'climate', 'cover', 'fan', 'light',
 #                       'lock', 'sensor')
 
@@ -119,24 +119,25 @@ def setup(hass, config: ConfigType) -> bool:
         return False
 
     global SENSOR_NODES
-    global HIDDEN_NODES
-    global VISIBLE_NODES
+    global NODES
+    global GROUPS
     global PROGRAMS
 
     SENSOR_NODES = []
-    HIDDEN_NODES = []
-    VISIBLE_NODES = []
+    NODES = []
+    GROUPS = []
     PROGRAMS = {}
 
     for (path, node) in ISY.nodes:
-        if not isinstance(node, PyISY.Nodes.Node):
-            continue
+        hidden = hidden_identifier in path or hidden_identifier in node.name
+        if hidden:
+            node.name += hidden_identifier
         if sensor_identifier in path or sensor_identifier in node.name:
             SENSOR_NODES.append(node)
-        elif hidden_identifier in path or hidden_identifier in node.name:
-            HIDDEN_NODES.append(node)
-        else:
-            VISIBLE_NODES.append(node)
+        elif isinstance(node, PyISY.Nodes.Node):
+            NODES.append(node)
+        elif isinstance(node, PyISY.Nodes.Group):
+            GROUPS.append(node)
 
     for component in COMPONENTS:
         try:

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -38,9 +38,9 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_HOST): cv.url,
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_TLS_VER, None): vol.Coerce(float),
-        vol.Optional(CONF_HIDDEN_STRING, DEFAULT_HIDDEN_STRING): cv.string,
-        vol.Optional(CONF_SENSOR_STRING, DEFAULT_SENSOR_STRING): cv.string
+        vol.Optional(CONF_TLS_VER): vol.Coerce(float),
+        vol.Optional(CONF_HIDDEN_STRING, default=DEFAULT_HIDDEN_STRING): cv.string,
+        vol.Optional(CONF_SENSOR_STRING, default=DEFAULT_SENSOR_STRING): cv.string
     })
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -53,8 +53,8 @@ PYISY = None
 
 HIDDEN_STRING = DEFAULT_HIDDEN_STRING
 
-COMPONENTS = ['lock', 'binary_sensor', 'cover', 'fan', 'sensor', 'light',
-              'switch']
+SUPPORTED_DOMAINS = ['lock', 'binary_sensor', 'cover', 'fan', 'sensor', 'light',
+                     'switch']
 
 
 def filter_nodes(nodes: list, units: list=None, states: list=None) -> list:
@@ -109,7 +109,7 @@ def _categorize_programs() -> None:
 
     PROGRAMS = {}
 
-    for component in COMPONENTS:
+    for component in SUPPORTED_DOMAINS:
         try:
             folder = ISY.programs[KEY_MY_PROGRAMS]['HA.' + component]
         except KeyError:
@@ -180,7 +180,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop)
 
     # Load platforms for the devices in the ISY controller that we support.
-    for component in COMPONENTS:
+    for component in SUPPORTED_DOMAINS:
         discovery.load_platform(hass, component, DOMAIN, {}, config)
 
     ISY.auto_update = True

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -128,7 +128,7 @@ def _categorize_programs() -> None:
 
     for component in COMPONENTS:
         try:
-            folder = ISY.programs[KEY_MY_PROGRAMS][component]
+            folder = ISY.programs[KEY_MY_PROGRAMS]['HA.' + component]
         except KeyError:
             pass
         else:

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -49,8 +49,6 @@ NODES = []
 GROUPS = []
 PROGRAMS = {}
 
-PYISY = None
-
 HIDDEN_STRING = DEFAULT_HIDDEN_STRING
 
 COMPONENTS = ['lock', 'binary_sensor', 'cover', 'fan', 'sensor', 'light',
@@ -185,9 +183,6 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     import PyISY
 
-    global PYISY
-    PYISY = PyISY
-
     # Connect to ISY controller.
     global ISY
     ISY = PyISY.ISY(addr, port, username=user, password=password,
@@ -228,7 +223,7 @@ class ISYDevice(Entity):
     _domain = None
     _name = None
 
-    def __init__(self, node: PYISY.Nodes.node) -> None:
+    def __init__(self, node) -> None:
         """
         Initialize the insteon device.
 

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -108,9 +108,9 @@ def _categorize_nodes(hidden_identifier: str, sensor_identifier: str) -> None:
             node.name += hidden_identifier
         if sensor_identifier in path or sensor_identifier in node.name:
             SENSOR_NODES.append(node)
-        elif isinstance(node, PyISY.Nodes.Node):
+        elif isinstance(node, ISY.Nodes.Node):
             NODES.append(node)
-        elif isinstance(node, PyISY.Nodes.Group):
+        elif isinstance(node, ISY.Nodes.Group):
             GROUPS.append(node)
 
 

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -50,12 +50,17 @@ PROGRAMS = {}
 HIDDEN_STRING = DEFAULT_HIDDEN_STRING
 
 COMPONENTS = ['lock', 'binary_sensor', 'cover', 'fan', 'sensor', 'light', 'switch']
-# '('binary_sensor', 'climate', 'cover', 'fan', 'light',
-#                       'lock', 'sensor')
 
 
 def filter_nodes(nodes: list, units: list=[], states: list=[]) -> list:
-    """Filter nodes for the specified units or states."""
+    """
+    Filter a list of ISY nodes based on the units and states provided.
+
+    :param nodes: List of nodes to filter.
+    :param units: List of units the node should meet.
+    :param states: List of states the node should meet.
+    :return: List of filtered Nodes.
+    """
     filtered_nodes = []
     for node in nodes:
         match_unit = False
@@ -77,9 +82,12 @@ def filter_nodes(nodes: list, units: list=[], states: list=[]) -> list:
 
 
 def setup(hass, config: ConfigType) -> bool:
-    """Setup ISY994 component.
+    """
+    Set up the ISY 994 platform.
 
-    This will automatically import associated lights, switches, and sensors.
+    :param hass: HomeAssistant.
+    :param config: Platform configuration.
+    :return: Whether the platform was setup correctly.
     """
     isy_config = config.get(DOMAIN)
 
@@ -171,12 +179,19 @@ def setup(hass, config: ConfigType) -> bool:
 
 # pylint: disable=unused-argument
 def stop(event: object) -> None:
-    """Cleanup the ISY subscription."""
+    """
+    Stop ISY auto updates.
+
+    :param event: The event being watched.
+    :return: None.
+    """
     ISY.auto_update = False
 
 
 class ISYDevice(Entity):
-    """Base class for all isy994 devices."""
+    """
+    Representation of an ISY994 device.
+    """
 
     import PyISY.Nodes.node  # noqa
 
@@ -185,58 +200,98 @@ class ISYDevice(Entity):
     _name = None
 
     def __init__(self, node: PyISY.Nodes.node) -> None:
-        """Initialize the isy device."""
+        """
+        Initialize the insteon device.
+
+        :param node: The ISY994 node object.
+        """
         self._node = node
 
         self._change_handler = self._node.status.subscribe('changed',
                                                            self.on_update)
 
     def __del__(self) -> None:
-        """Cleanup subscriptions."""
+        """
+        Cleanup the subscriptions.
+
+        :return: None.
+        """
         self._change_handler.unsubscribe()
 
     # pylint: disable=unused-argument
     def on_update(self, event: object) -> None:
-        """Handle the update received event."""
+        """
+        Handle the update event from the ISY994 Node.
+        :param event: The event being subscribed to.
+        :return: None.
+        """
         self.update_ha_state()
 
     @property
     def domain(self) -> str:
-        """Return the domain of the device."""
+        """
+        Get the domain of the device.
+
+        :return: The domain of the device.
+        """
         return self._domain
 
     @property
     def unique_id(self):
-        """Return the node id."""
+        """
+        Get the unique identifier of the device.
+
+        :return: The ISY994 Node Id.
+        """
         # pylint: disable=protected-access
         return self._node._id
 
     @property
     def raw_name(self):
-        """Return the raw node name."""
+        """
+        Get the raw name of the device.
+
+        :return: The raw name of the ISY994 Node.
+        """
         return str(self._name) \
             if self._name is not None else str(self._node.name)
 
     @property
     def name(self):
-        """Return the cleaned name of the node."""
+        """
+        Get the name of the device.
+
+        :return: The device name.
+        """
         return self.raw_name.replace(HIDDEN_STRING, '').strip() \
             .replace('_', ' ')
 
     @property
     def should_poll(self) -> bool:
-        """No polling required."""
+        """
+        No polling required since we're using the subscription.
+
+        :return: False.
+        """
         return False
 
     @property
     def value(self) -> object:
-        """Return the raw value from the controller"""
+        """
+        Get the current value of the device.
+
+        :return: The ISY994 Node's value.
+        """
         # pylint: disable=protected-access
         return self._node.status._val
 
     @property
     def state_attributes(self) -> Dict:
-        """Return the state attributes for the node."""
+        """
+        Get the state attributes for the device.
+
+        :return: The state attributes associated with the device.
+        """
         attr = {}
         if hasattr(self._node, 'aux_properties'):
             for name, val in self._node.aux_properties.items():
@@ -245,19 +300,36 @@ class ISYDevice(Entity):
 
     @property
     def hidden(self):
-        """Flag to hide entity from UI."""
+        """
+        Get whether the device should be hidden from the UI.
+
+        :return: Whether the device should be hidden.
+        """
         return HIDDEN_STRING in self.raw_name
 
     @property
     def unit_of_measurement(self):
-        """Default to no unit of measure."""
+        """
+        Get the device unit of measure.
+
+        :return: None.
+        """
         return None
 
     def _attr_filter(self, attr):
-        """A Placeholder for attribute filters."""
+        """
+        Filter the attribute.
+
+        :param attr: Attribute to filter.
+        :return: The attribute.
+        """
         # pylint: disable=no-self-use
         return attr
 
     def update(self):
-        """Update the state of the device."""
+        """
+        Perform an update for the device.
+
+        :return: None
+        """
         pass

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -39,8 +39,10 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_TLS_VER): vol.Coerce(float),
-        vol.Optional(CONF_HIDDEN_STRING, default=DEFAULT_HIDDEN_STRING): cv.string,
-        vol.Optional(CONF_SENSOR_STRING, default=DEFAULT_SENSOR_STRING): cv.string
+        vol.Optional(CONF_HIDDEN_STRING,
+                     default=DEFAULT_HIDDEN_STRING): cv.string,
+        vol.Optional(CONF_SENSOR_STRING,
+                     default=DEFAULT_SENSOR_STRING): cv.string
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -53,8 +55,8 @@ PYISY = None
 
 HIDDEN_STRING = DEFAULT_HIDDEN_STRING
 
-SUPPORTED_DOMAINS = ['lock', 'binary_sensor', 'cover', 'fan', 'sensor', 'light',
-                     'switch']
+SUPPORTED_DOMAINS = ['binary_sensor', 'cover', 'fan', 'light', 'lock',
+                     'sensor', 'switch']
 
 
 def filter_nodes(nodes: list, units: list=None, states: list=None) -> list:

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -49,6 +49,8 @@ NODES = []
 GROUPS = []
 PROGRAMS = {}
 
+PYISY = None
+
 HIDDEN_STRING = DEFAULT_HIDDEN_STRING
 
 COMPONENTS = ['lock', 'binary_sensor', 'cover', 'fan', 'sensor', 'light',
@@ -94,8 +96,6 @@ def _categorize_nodes(hidden_identifier: str, sensor_identifier: str) -> None:
     :param sensor_identifier: String to denote teh node is a sensor.
     :return: None.
     """
-    import PyISY
-
     global SENSOR_NODES
     global NODES
     global GROUPS
@@ -185,6 +185,9 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     import PyISY
 
+    global PYISY
+    PYISY = PyISY
+
     # Connect to ISY controller.
     global ISY
     ISY = PyISY.ISY(addr, port, username=user, password=password,
@@ -221,13 +224,11 @@ def stop(event: object) -> None:
 class ISYDevice(Entity):
     """Representation of an ISY994 device."""
 
-    import PyISY.Nodes.node  # noqa
-
     _attrs = {}
     _domain = None
     _name = None
 
-    def __init__(self, node: PyISY.Nodes.node) -> None:
+    def __init__(self, node: PYISY.Nodes.node) -> None:
         """
         Initialize the insteon device.
 

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -49,6 +49,8 @@ NODES = []
 GROUPS = []
 PROGRAMS = {}
 
+PYISY = None
+
 HIDDEN_STRING = DEFAULT_HIDDEN_STRING
 
 COMPONENTS = ['lock', 'binary_sensor', 'cover', 'fan', 'sensor', 'light',
@@ -108,9 +110,9 @@ def _categorize_nodes(hidden_identifier: str, sensor_identifier: str) -> None:
             node.name += hidden_identifier
         if sensor_identifier in path or sensor_identifier in node.name:
             SENSOR_NODES.append(node)
-        elif isinstance(node, ISY.Nodes.Node):
+        elif isinstance(node, PYISY.Nodes.Node):
             NODES.append(node)
-        elif isinstance(node, ISY.Nodes.Group):
+        elif isinstance(node, PYISY.Nodes.Group):
             GROUPS.append(node)
 
 
@@ -182,6 +184,9 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     addr = addr.replace(':{}'.format(port), '')
 
     import PyISY
+
+    global PYISY
+    PYISY = PyISY
 
     # Connect to ISY controller.
     global ISY

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -54,6 +54,28 @@ COMPONENTS = ['lock', 'binary_sensor', 'cover', 'fan', 'sensor']
 #                       'lock', 'sensor')
 
 
+def filter_nodes(nodes: list, units: list=[], states: list=[]) -> list:
+    """Filter nodes for the specified units or states."""
+    filtered_nodes = []
+    for node in nodes:
+        match_unit = False
+        match_state = True
+        for uom in node.uom:
+            if uom in units:
+                match_unit = True
+                continue
+            elif uom not in states:
+                match_state = False
+
+            if match_unit:
+                continue
+
+        if match_unit or match_state:
+            filtered_nodes.append(node)
+
+    return filtered_nodes
+
+
 def setup(hass, config: ConfigType) -> bool:
     """Setup ISY994 component.
 
@@ -227,12 +249,8 @@ class ISYDevice(Entity):
 
     @property
     def unit_of_measurement(self):
-        """Return the defined units of measurement or None."""
-        # More than one uom = enumerated states
-        if len(self._node.uom) < 2:
-            return self._node.uom
-        else:
-            return None
+        """Default to no unit of measure."""
+        return None
 
     def _attr_filter(self, attr):
         """A Placeholder for attribute filters."""

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -215,9 +215,9 @@ class ISYDevice(Entity):
     def state_attributes(self) -> Dict:
         """Return the state attributes for the node."""
         attr = {}
-        for name, prop in self._attrs.items():
-            attr[name] = getattr(self, prop)
-            attr = self._attr_filter(attr)
+        if hasattr(self._node, 'aux_properties'):
+            for name, val in self._node.aux_properties.items():
+                attr[name] = '{} {}'.format(val.get('value'), val.get('uom'))
         return attr
 
     @property

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -110,9 +110,9 @@ def _categorize_nodes(hidden_identifier: str, sensor_identifier: str) -> None:
             node.name += hidden_identifier
         if sensor_identifier in path or sensor_identifier in node.name:
             SENSOR_NODES.append(node)
-        elif isinstance(node, PYISY.Nodes.Node):
+        elif isinstance(node, PYISY.Nodes.Node):  # pylint: disable=no-member
             NODES.append(node)
-        elif isinstance(node, PYISY.Nodes.Group):
+        elif isinstance(node, PYISY.Nodes.Group):  # pylint: disable=no-member
             GROUPS.append(node)
 
 

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -58,14 +58,7 @@ COMPONENTS = ['lock', 'binary_sensor', 'cover', 'fan', 'sensor', 'light',
 
 
 def filter_nodes(nodes: list, units: list=None, states: list=None) -> list:
-    """
-    Filter a list of ISY nodes based on the units and states provided.
-
-    :param nodes: List of nodes to filter.
-    :param units: List of units the node should meet.
-    :param states: List of states the node should meet.
-    :return: List of filtered Nodes.
-    """
+    """Filter a list of ISY nodes based on the units and states provided."""
     filtered_nodes = []
     units = units if units else []
     states = states if states else []
@@ -89,13 +82,7 @@ def filter_nodes(nodes: list, units: list=None, states: list=None) -> list:
 
 
 def _categorize_nodes(hidden_identifier: str, sensor_identifier: str) -> None:
-    """
-    Categorize the ISY994 nodes.
-
-    :param hidden_identifier: String to denote the node should be hidden.
-    :param sensor_identifier: String to denote teh node is a sensor.
-    :return: None.
-    """
+    """Categorize the ISY994 nodes."""
     global SENSOR_NODES
     global NODES
     global GROUPS
@@ -117,11 +104,7 @@ def _categorize_nodes(hidden_identifier: str, sensor_identifier: str) -> None:
 
 
 def _categorize_programs() -> None:
-    """
-    Categorize the ISY994 programs.
-
-    :return: None.
-    """
+    """Categorize the ISY994 programs."""
     global PROGRAMS
 
     PROGRAMS = {}
@@ -148,13 +131,7 @@ def _categorize_programs() -> None:
 
 # pylint: disable=too-many-locals
 def setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """
-    Set up the ISY 994 platform.
-
-    :param hass: HomeAssistant.
-    :param config: Platform configuration.
-    :return: Whether the platform was setup correctly.
-    """
+    """Set up the ISY 994 platform."""
     isy_config = config.get(DOMAIN)
 
     user = isy_config.get(CONF_USERNAME)
@@ -212,12 +189,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 # pylint: disable=unused-argument
 def stop(event: object) -> None:
-    """
-    Stop ISY auto updates.
-
-    :param event: The event being watched.
-    :return: None.
-    """
+    """Stop ISY auto updates."""
     ISY.auto_update = False
 
 
@@ -229,99 +201,58 @@ class ISYDevice(Entity):
     _name = None
 
     def __init__(self, node) -> None:
-        """
-        Initialize the insteon device.
-
-        :param node: The ISY994 node object.
-        """
+        """Initialize the insteon device."""
         self._node = node
 
         self._change_handler = self._node.status.subscribe('changed',
                                                            self.on_update)
 
     def __del__(self) -> None:
-        """
-        Cleanup the subscriptions.
-
-        :return: None.
-        """
+        """Cleanup the subscriptions."""
         self._change_handler.unsubscribe()
 
     # pylint: disable=unused-argument
     def on_update(self, event: object) -> None:
-        """
-        Handle the update event from the ISY994 Node.
-
-        :param event: The event being subscribed to.
-        :return: None.
-        """
+        """Handle the update event from the ISY994 Node."""
         self.update_ha_state()
 
     @property
     def domain(self) -> str:
-        """
-        Get the domain of the device.
-
-        :return: The domain of the device.
-        """
+        """Get the domain of the device."""
         return self._domain
 
     @property
     def unique_id(self):
-        """
-        Get the unique identifier of the device.
-
-        :return: The ISY994 Node Id.
-        """
+        """Get the unique identifier of the device."""
         # pylint: disable=protected-access
         return self._node._id
 
     @property
     def raw_name(self):
-        """
-        Get the raw name of the device.
-
-        :return: The raw name of the ISY994 Node.
-        """
+        """Get the raw name of the device."""
         return str(self._name) \
             if self._name is not None else str(self._node.name)
 
     @property
     def name(self):
-        """
-        Get the name of the device.
-
-        :return: The device name.
-        """
+        """Get the name of the device."""
         return self.raw_name.replace(HIDDEN_STRING, '').strip() \
             .replace('_', ' ')
 
     @property
     def should_poll(self) -> bool:
-        """
-        No polling required since we're using the subscription.
-
-        :return: False.
-        """
+        """No polling required since we're using the subscription."""
         return False
 
     @property
     def value(self) -> object:
-        """
-        Get the current value of the device.
-
-        :return: The ISY994 Node's value.
-        """
+        """Get the current value of the device."""
         # pylint: disable=protected-access
         return self._node.status._val
 
     @property
     def state_attributes(self) -> Dict:
-        """
-        Get the state attributes for the device.
-
-        :return: The state attributes associated with the device.
-        """
+        """Get the state attributes for the device."""
         attr = {}
         if hasattr(self._node, 'aux_properties'):
             for name, val in self._node.aux_properties.items():
@@ -330,36 +261,19 @@ class ISYDevice(Entity):
 
     @property
     def hidden(self):
-        """
-        Get whether the device should be hidden from the UI.
-
-        :return: Whether the device should be hidden.
-        """
+        """Get whether the device should be hidden from the UI."""
         return HIDDEN_STRING in self.raw_name
 
     @property
     def unit_of_measurement(self):
-        """
-        Get the device unit of measure.
-
-        :return: None.
-        """
+        """Get the device unit of measure."""
         return None
 
     def _attr_filter(self, attr):
-        """
-        Filter the attribute.
-
-        :param attr: Attribute to filter.
-        :return: The attribute.
-        """
+        """Filter the attribute."""
         # pylint: disable=no-self-use
         return attr
 
     def update(self):
-        """
-        Perform an update for the device.
-
-        :return: None
-        """
+        """Perform an update for the device."""
         pass

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -197,8 +197,8 @@ class ISYDevice(Entity):
     """Representation of an ISY994 device."""
 
     _attrs = {}
-    _domain = None
-    _name = None
+    _domain = None  # type: str
+    _name = None  # type: str
 
     def __init__(self, node) -> None:
         """Initialize the insteon device."""
@@ -222,19 +222,19 @@ class ISYDevice(Entity):
         return self._domain
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Get the unique identifier of the device."""
         # pylint: disable=protected-access
         return self._node._id
 
     @property
-    def raw_name(self):
+    def raw_name(self) -> str:
         """Get the raw name of the device."""
         return str(self._name) \
             if self._name is not None else str(self._node.name)
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Get the name of the device."""
         return self.raw_name.replace(HIDDEN_STRING, '').strip() \
             .replace('_', ' ')
@@ -260,20 +260,20 @@ class ISYDevice(Entity):
         return attr
 
     @property
-    def hidden(self):
+    def hidden(self) -> bool:
         """Get whether the device should be hidden from the UI."""
         return HIDDEN_STRING in self.raw_name
 
     @property
-    def unit_of_measurement(self):
+    def unit_of_measurement(self) -> str:
         """Get the device unit of measure."""
         return None
 
-    def _attr_filter(self, attr):
+    def _attr_filter(self, attr: str) -> str:
         """Filter the attribute."""
         # pylint: disable=no-self-use
         return attr
 
-    def update(self):
+    def update(self) -> None:
         """Perform an update for the device."""
         pass

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -49,7 +49,7 @@ PROGRAMS = {}
 
 HIDDEN_STRING = DEFAULT_HIDDEN_STRING
 
-COMPONENTS = ['lock', 'binary_sensor', 'cover']
+COMPONENTS = ['lock', 'binary_sensor', 'cover', 'fan']
 # '('binary_sensor', 'climate', 'cover', 'fan', 'light',
 #                       'lock', 'sensor')
 

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -24,7 +24,8 @@ UOM = ['2', '78']
 STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
-def setup_platform(hass, config: ConfigType, add_devices: Callable[[list, None]], discovery_info=None):
+def setup_platform(hass, config: ConfigType,
+                   add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 light platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -7,17 +7,14 @@ https://home-assistant.io/components/switch.isy994/
 import logging
 
 from homeassistant.components.isy994 import filter_nodes
-from homeassistant.components.light import Light, DOMAIN
-from homeassistant.components.isy994 import (ISYDevice, NODES, PROGRAMS, ISY,
-                                             KEY_ACTIONS, KEY_STATUS)
+from homeassistant.components.light import Light
+from homeassistant.components.isy994 import ISYDevice, NODES, ISY
 from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
 VALUE_TO_STATE = {
-    0: STATE_OFF,
-    100: STATE_ON,
     False: STATE_OFF,
     True: STATE_ON,
 }
@@ -51,9 +48,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYLightDevice(ISYDevice, Light):
-    """
-    Representation of an ISY994 light devie.
-    """
+    """Representation of an ISY994 light devie."""
 
     def __init__(self, node):
         """
@@ -79,7 +74,7 @@ class ISYLightDevice(ISYDevice, Light):
 
         :return: The state of the ISY994 light device.
         """
-        return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
+        return VALUE_TO_STATE.get(bool(self.value), STATE_UNKNOWN)
 
     def turn_off(self, **kwargs):
         """

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -7,9 +7,8 @@ https://home-assistant.io/components/light.isy994/
 import logging
 from typing import Callable
 
-from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.light import Light
-from homeassistant.components.isy994 import ISYDevice, NODES, ISY
+import homeassistant.components.isy994 as isy
 from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType
 
@@ -28,26 +27,26 @@ STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 light platform."""
-    if ISY is None or not ISY.connected:
+    if isy.ISY is None or not isy.ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
 
     devices = []
 
-    for node in filter_nodes(NODES, units=UOM,
-                             states=STATES):
+    for node in isy.filter_nodes(isy.NODES, units=UOM,
+                                 states=STATES):
         if node.dimmable:
             devices.append(ISYLightDevice(node))
 
     add_devices(devices)
 
 
-class ISYLightDevice(ISYDevice, Light):
+class ISYLightDevice(isy.ISYDevice, Light):
     """Representation of an ISY994 light devie."""
 
     def __init__(self, node: object) -> None:
         """Initialize the ISY994 light device."""
-        ISYDevice.__init__(self, node)
+        isy.ISYDevice.__init__(self, node)
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -1,8 +1,8 @@
 """
-Support for ISY994 switches.
+Support for ISY994 lights.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/switch.isy994/
+https://home-assistant.io/components/light.isy994/
 """
 import logging
 from typing import Callable
@@ -62,9 +62,9 @@ class ISYLightDevice(ISYDevice, Light):
     def turn_off(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 light device."""
         if not self._node.fastOff():
-            _LOGGER.debug('Unable to turn on switch.')
+            _LOGGER.debug('Unable to turn on light.')
 
     def turn_on(self, brightness=100, **kwargs) -> None:
         """Send the turn on command to the ISY994 light device."""
         if not self._node.on(val=brightness):
-            _LOGGER.debug('Unable to turn on switch.')
+            _LOGGER.debug('Unable to turn on light.')

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.isy994/
 """
 import logging
+from typing import Callable
 
 from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.light import Light
@@ -23,7 +24,7 @@ UOM = ['2', '78']
 STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
-def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
+def setup_platform(hass, config: ConfigType, add_devices: Callable[[list, None]], discovery_info=None):
     """Set up the ISY994 light platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
@@ -42,7 +43,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 class ISYLightDevice(ISYDevice, Light):
     """Representation of an ISY994 light devie."""
 
-    def __init__(self, node):
+    def __init__(self, node: object) -> None:
         """Initialize the ISY994 light device."""
         ISYDevice.__init__(self, node)
 
@@ -56,12 +57,12 @@ class ISYLightDevice(ISYDevice, Light):
         """Get the state of the ISY994 light."""
         return VALUE_TO_STATE.get(bool(self.value), STATE_UNKNOWN)
 
-    def turn_off(self, **kwargs):
+    def turn_off(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 light device."""
         if not self._node.fastOff():
             _LOGGER.debug('Unable to turn on switch.')
 
-    def turn_on(self, brightness=100, **kwargs):
+    def turn_on(self, brightness=100, **kwargs) -> None:
         """Send the turn on command to the ISY994 light device."""
         if not self._node.on(val=brightness):
             _LOGGER.debug('Unable to turn on switch.')

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -24,15 +24,7 @@ STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """
-    Set up the ISY994 light platform.
-
-    :param hass: HomeAssistant.
-    :param config: Platform configuration.
-    :param add_devices: The add devices callback method.
-    :param discovery_info: The discovery information.
-    :return: Whether the platform was set up properly.
-    """
+    """Set up the ISY994 light platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -51,47 +43,25 @@ class ISYLightDevice(ISYDevice, Light):
     """Representation of an ISY994 light devie."""
 
     def __init__(self, node):
-        """
-        Initialize the ISY994 light device.
-
-        :param node: The ISY994 node.
-        """
+        """Initialize the ISY994 light device."""
         ISYDevice.__init__(self, node)
 
     @property
     def is_on(self) -> bool:
-        """
-        Get whether the ISY994 light is on.
-
-        :return: Whether the ISY994 light is in the 'on' state
-        """
+        """Get whether the ISY994 light is on."""
         return self.state == STATE_ON
 
     @property
     def state(self) -> str:
-        """
-        Get the state of the ISY994 light.
-
-        :return: The state of the ISY994 light device.
-        """
+        """Get the state of the ISY994 light."""
         return VALUE_TO_STATE.get(bool(self.value), STATE_UNKNOWN)
 
     def turn_off(self, **kwargs):
-        """
-        Send the turn off command to the ISY994 light device.
-
-        :param kwargs: Keyword Arguments.
-        :return: None.
-        """
+        """Send the turn off command to the ISY994 light device."""
         if not self._node.fastOff():
             _LOGGER.debug('Unable to turn on switch.')
 
     def turn_on(self, brightness=100, **kwargs):
-        """
-        Send the turn on command to the ISY994 light device.
-
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+        """Send the turn on command to the ISY994 light device."""
         if not self._node.on(val=brightness):
             _LOGGER.debug('Unable to turn on switch.')

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -27,8 +27,15 @@ STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """Setup the ISY platform."""
+    """
+    Set up the ISY994 light platform.
 
+    :param hass: HomeAssistant.
+    :param config: Platform configuration.
+    :param add_devices: The add devices callback method.
+    :param discovery_info: The discovery information.
+    :return: Whether the platform was set up properly.
+    """
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -44,29 +51,52 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYLightDevice(ISYDevice, Light):
-    """Representation of a ISY switch."""
+    """
+    Representation of an ISY994 light devie.
+    """
 
     def __init__(self, node):
-        """Initialize the binary sensor."""
+        """
+        Initialize the ISY994 light device.
+
+        :param node: The ISY994 node.
+        """
         ISYDevice.__init__(self, node)
 
     @property
     def is_on(self) -> bool:
-        """Return true if device is locked."""
+        """
+        Get whether the ISY994 light is on.
+
+        :return: Whether the ISY994 light is in the 'on' state
+        """
         return self.state == STATE_ON
 
     @property
     def state(self) -> str:
-        """Return the state of the device."""
+        """
+        Get the state of the ISY994 light.
+
+        :return: The state of the ISY994 light device.
+        """
         return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
 
     def turn_off(self, **kwargs):
-        """Turn off the switch."""
+        """
+        Send the turn off command to the ISY994 light device.
+
+        :param kwargs: Keyword Arguments.
+        :return: None.
+        """
         if not self._node.fastOff():
             _LOGGER.debug('Unable to turn on switch.')
 
-    def turn_on(self, **kwargs):
-        """Turn on the switch."""
-        brightness = kwargs.get('brightness', 100)
+    def turn_on(self, brightness=100, **kwargs):
+        """
+        Send the turn on command to the ISY994 light device.
+
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         if not self._node.on(val=brightness):
             _LOGGER.debug('Unable to turn on switch.')

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -24,6 +24,7 @@ UOM = ['2', '78']
 STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
+# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 light platform."""

--- a/homeassistant/components/lock/isy994.py
+++ b/homeassistant/components/lock/isy994.py
@@ -59,9 +59,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYLockDevice(ISYDevice, LockDevice):
-    """
-    Representation of an ISY994 lock device.
-    """
+    """Representation of an ISY994 lock device."""
 
     def __init__(self, node):
         """

--- a/homeassistant/components/lock/isy994.py
+++ b/homeassistant/components/lock/isy994.py
@@ -108,6 +108,11 @@ class ISYLockProgram(ISYLockDevice):
         """Return true if the device is locked."""
         return bool(self.value)
 
+    @property
+    def state(self):
+        """Return the state of the lock."""
+        return STATE_LOCKED if self.is_locked else STATE_UNLOCKED
+
     def lock(self, **kwargs) -> None:
         """Lock the device."""
         if not self._actions.runThen():

--- a/homeassistant/components/lock/isy994.py
+++ b/homeassistant/components/lock/isy994.py
@@ -26,8 +26,15 @@ STATES = [STATE_LOCKED, STATE_UNLOCKED]
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """Setup the ISY platform."""
+    """
+    Set up the ISY994 lock platform.
 
+    :param hass: HomeAssistant.
+    :param config: The configuration dictionary.
+    :param add_devices: Add device callback function.
+    :param discovery_info: Discovery information
+    :return: Whether the platform was setup properly.
+    """
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -52,25 +59,44 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYLockDevice(ISYDevice, LockDevice):
-    """Representation of a ISY lock."""
+    """
+    Representation of an ISY994 lock device.
+    """
 
     def __init__(self, node):
-        """Initialize the lock."""
+        """
+        Initialize the ISY994 lock device.
+
+        :param node: The ISY994 Node
+        """
         ISYDevice.__init__(self, node)
         self._conn = node.parent.parent.conn
 
     @property
     def is_locked(self) -> bool:
-        """Return true if device is locked."""
+        """
+        Get whether the lock is in locked state.
+
+        :return: Whether the lock is in locked state.
+        """
         return self.state == STATE_LOCKED
 
     @property
     def state(self) -> str:
-        """Return the state of the device."""
+        """
+        Get the state of the lock.
+
+        :return: The state of the device.
+        """
         return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
 
     def lock(self, **kwargs) -> None:
-        """Lock the device."""
+        """
+        Send the lock command to the ISY994 device.
+
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         # Hack until PyISY is updated
         req_url = self._conn.compileURL(['nodes', self.unique_id, 'cmd',
                                          'SECMD', '1'])
@@ -82,7 +108,12 @@ class ISYLockDevice(ISYDevice, LockDevice):
         self._node.update(0.5)
 
     def unlock(self, **kwargs) -> None:
-        """Unlock the device."""
+        """
+        Send the unlock command to the ISY994 device.
+
+        :param kwargs: Keyword arguments.
+        :return: None
+        """
         # Hack until PyISY is updated
         req_url = self._conn.compileURL(['nodes', self.unique_id, 'cmd',
                                          'SECMD', '0'])

--- a/homeassistant/components/lock/isy994.py
+++ b/homeassistant/components/lock/isy994.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/lock.isy994/
 """
 import logging
 
+from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.lock import LockDevice, DOMAIN
 from homeassistant.components.isy994 import (ISYDevice, HIDDEN_NODES,
                                              VISIBLE_NODES, PROGRAMS, ISY,
@@ -20,7 +21,8 @@ VALUE_TO_STATE = {
     100: STATE_LOCKED
 }
 
-UOM = '11'
+UOM = ['11']
+STATES = [STATE_LOCKED, STATE_UNLOCKED]
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
@@ -32,9 +34,9 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
     devices = []
 
-    for node in (HIDDEN_NODES + VISIBLE_NODES):
-        if node.uom == UOM or STATE_LOCKED in node.uom:
-            devices.append(ISYLockDevice(node))
+    for node in filter_nodes(HIDDEN_NODES + VISIBLE_NODES, units=UOM,
+                             states=STATES):
+        devices.append(ISYLockDevice(node))
 
     for program in PROGRAMS.get(DOMAIN, []):
         try:
@@ -105,11 +107,6 @@ class ISYLockProgram(ISYLockDevice):
     def is_locked(self) -> bool:
         """Return true if the device is locked."""
         return bool(self.value)
-
-    @property
-    def unit_of_measurement(self) -> None:
-        """No unit of measurement for lock programs."""
-        return None
 
     def lock(self, **kwargs) -> None:
         """Lock the device."""

--- a/homeassistant/components/lock/isy994.py
+++ b/homeassistant/components/lock/isy994.py
@@ -26,6 +26,7 @@ UOM = ['11']
 STATES = [STATE_LOCKED, STATE_UNLOCKED]
 
 
+# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 lock platform."""

--- a/homeassistant/components/lock/isy994.py
+++ b/homeassistant/components/lock/isy994.py
@@ -7,11 +7,8 @@ https://home-assistant.io/components/lock.isy994/
 import logging
 from typing import Callable  # noqa
 
-from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.lock import LockDevice, DOMAIN
-from homeassistant.components.isy994 import (ISYDevice, NODES,
-                                             PROGRAMS, ISY,
-                                             KEY_ACTIONS, KEY_STATUS)
+import homeassistant.components.isy994 as isy
 from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED, STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType
 
@@ -30,20 +27,20 @@ STATES = [STATE_LOCKED, STATE_UNLOCKED]
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 lock platform."""
-    if ISY is None or not ISY.connected:
+    if isy.ISY is None or not isy.ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
 
     devices = []
 
-    for node in filter_nodes(NODES, units=UOM,
-                             states=STATES):
+    for node in isy.filter_nodes(isy.NODES, units=UOM,
+                                 states=STATES):
         devices.append(ISYLockDevice(node))
 
-    for program in PROGRAMS.get(DOMAIN, []):
+    for program in isy.PROGRAMS.get(DOMAIN, []):
         try:
-            status = program[KEY_STATUS]
-            actions = program[KEY_ACTIONS]
+            status = program[isy.KEY_STATUS]
+            actions = program[isy.KEY_ACTIONS]
             assert actions.dtype == 'program', 'Not a program'
         except (KeyError, AssertionError):
             pass
@@ -53,12 +50,12 @@ def setup_platform(hass, config: ConfigType,
     add_devices(devices)
 
 
-class ISYLockDevice(ISYDevice, LockDevice):
+class ISYLockDevice(isy.ISYDevice, LockDevice):
     """Representation of an ISY994 lock device."""
 
     def __init__(self, node) -> None:
         """Initialize the ISY994 lock device."""
-        ISYDevice.__init__(self, node)
+        isy.ISYDevice.__init__(self, node)
         self._conn = node.parent.parent.conn
 
     @property

--- a/homeassistant/components/lock/isy994.py
+++ b/homeassistant/components/lock/isy994.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/lock.isy994/
 """
 import logging
+from typing import Callable  # noqa
 
 from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.lock import LockDevice, DOMAIN
@@ -25,7 +26,7 @@ UOM = ['11']
 STATES = [STATE_LOCKED, STATE_UNLOCKED]
 
 
-def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
+def setup_platform(hass, config: ConfigType, add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 lock platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
@@ -53,7 +54,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 class ISYLockDevice(ISYDevice, LockDevice):
     """Representation of an ISY994 lock device."""
 
-    def __init__(self, node):
+    def __init__(self, node) -> None:
         """Initialize the ISY994 lock device."""
         ISYDevice.__init__(self, node)
         self._conn = node.parent.parent.conn
@@ -96,7 +97,7 @@ class ISYLockDevice(ISYDevice, LockDevice):
 class ISYLockProgram(ISYLockDevice):
     """Representation of a ISY lock program."""
 
-    def __init__(self, name, node, actions):
+    def __init__(self, name: str, node, actions) -> None:
         """Initialize the lock."""
         ISYLockDevice.__init__(self, node)
         self._name = name
@@ -108,7 +109,7 @@ class ISYLockProgram(ISYLockDevice):
         return bool(self.value)
 
     @property
-    def state(self):
+    def state(self) -> str:
         """Return the state of the lock."""
         return STATE_LOCKED if self.is_locked else STATE_UNLOCKED
 

--- a/homeassistant/components/lock/isy994.py
+++ b/homeassistant/components/lock/isy994.py
@@ -26,15 +26,7 @@ STATES = [STATE_LOCKED, STATE_UNLOCKED]
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """
-    Set up the ISY994 lock platform.
-
-    :param hass: HomeAssistant.
-    :param config: The configuration dictionary.
-    :param add_devices: Add device callback function.
-    :param discovery_info: Discovery information
-    :return: Whether the platform was setup properly.
-    """
+    """Set up the ISY994 lock platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -62,39 +54,22 @@ class ISYLockDevice(ISYDevice, LockDevice):
     """Representation of an ISY994 lock device."""
 
     def __init__(self, node):
-        """
-        Initialize the ISY994 lock device.
-
-        :param node: The ISY994 Node
-        """
+        """Initialize the ISY994 lock device."""
         ISYDevice.__init__(self, node)
         self._conn = node.parent.parent.conn
 
     @property
     def is_locked(self) -> bool:
-        """
-        Get whether the lock is in locked state.
-
-        :return: Whether the lock is in locked state.
-        """
+        """Get whether the lock is in locked state."""
         return self.state == STATE_LOCKED
 
     @property
     def state(self) -> str:
-        """
-        Get the state of the lock.
-
-        :return: The state of the device.
-        """
+        """Get the state of the lock."""
         return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
 
     def lock(self, **kwargs) -> None:
-        """
-        Send the lock command to the ISY994 device.
-
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+        """Send the lock command to the ISY994 device."""
         # Hack until PyISY is updated
         req_url = self._conn.compileURL(['nodes', self.unique_id, 'cmd',
                                          'SECMD', '1'])
@@ -106,12 +81,7 @@ class ISYLockDevice(ISYDevice, LockDevice):
         self._node.update(0.5)
 
     def unlock(self, **kwargs) -> None:
-        """
-        Send the unlock command to the ISY994 device.
-
-        :param kwargs: Keyword arguments.
-        :return: None
-        """
+        """Send the unlock command to the ISY994 device."""
         # Hack until PyISY is updated
         req_url = self._conn.compileURL(['nodes', self.unique_id, 'cmd',
                                          'SECMD', '0'])

--- a/homeassistant/components/lock/isy994.py
+++ b/homeassistant/components/lock/isy994.py
@@ -8,8 +8,8 @@ import logging
 
 from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.lock import LockDevice, DOMAIN
-from homeassistant.components.isy994 import (ISYDevice, HIDDEN_NODES,
-                                             VISIBLE_NODES, PROGRAMS, ISY,
+from homeassistant.components.isy994 import (ISYDevice, NODES,
+                                             PROGRAMS, ISY,
                                              KEY_ACTIONS, KEY_STATUS)
 from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED, STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType
@@ -34,7 +34,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
     devices = []
 
-    for node in filter_nodes(HIDDEN_NODES + VISIBLE_NODES, units=UOM,
+    for node in filter_nodes(NODES, units=UOM,
                              states=STATES):
         devices.append(ISYLockDevice(node))
 

--- a/homeassistant/components/lock/isy994.py
+++ b/homeassistant/components/lock/isy994.py
@@ -26,7 +26,8 @@ UOM = ['11']
 STATES = [STATE_LOCKED, STATE_UNLOCKED]
 
 
-def setup_platform(hass, config: ConfigType, add_devices: Callable[[list], None], discovery_info=None):
+def setup_platform(hass, config: ConfigType,
+                   add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 lock platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')

--- a/homeassistant/components/sensor/isy994.py
+++ b/homeassistant/components/sensor/isy994.py
@@ -235,6 +235,7 @@ UOM_TO_STATES = {
 BINARY_UOM = ['2', '78']
 
 
+# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 sensor platform."""

--- a/homeassistant/components/sensor/isy994.py
+++ b/homeassistant/components/sensor/isy994.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.isy994/
 """
 import logging
+from typing import Callable  # noqa
 
 from homeassistant.components.isy994 import (ISYDevice, SENSOR_NODES, ISY)
 from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT, STATE_OFF,
@@ -234,7 +235,7 @@ UOM_TO_STATES = {
 BINARY_UOM = ['2', '78']
 
 
-def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
+def setup_platform(hass, config: ConfigType, add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 sensor platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
@@ -254,7 +255,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 class ISYSensorDevice(ISYDevice):
     """Representation of an ISY994 sensor device."""
 
-    def __init__(self, node):
+    def __init__(self, node) -> None:
         """Initialize the ISY994 sensor device."""
         ISYDevice.__init__(self, node)
 
@@ -278,7 +279,7 @@ class ISYSensorDevice(ISYDevice):
         return None
 
     @property
-    def unit_of_measurement(self):
+    def unit_of_measurement(self) -> str:
         """Get the unit of measurement for the ISY994 sensor device."""
         if len(self._node.uom) == 1:
             if self._node.uom[0] in UOM_FRIENDLY_NAME:

--- a/homeassistant/components/sensor/isy994.py
+++ b/homeassistant/components/sensor/isy994.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/binary_sensor.isy994/
 import logging
 from typing import Callable  # noqa
 
-from homeassistant.components.isy994 import (ISYDevice, SENSOR_NODES, ISY)
+import homeassistant.components.isy994 as isy
 from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT, STATE_OFF,
                                  STATE_ON)
 from homeassistant.helpers.typing import ConfigType
@@ -239,13 +239,13 @@ BINARY_UOM = ['2', '78']
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 sensor platform."""
-    if ISY is None or not ISY.connected:
+    if isy.ISY is None or not isy.ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
 
     devices = []
 
-    for node in SENSOR_NODES:
+    for node in isy.SENSOR_NODES:
         if (len(node.uom) == 0 or node.uom[0] not in BINARY_UOM) and \
                 STATE_OFF not in node.uom and STATE_ON not in node.uom:
             _LOGGER.debug('LOADING %s', node.name)
@@ -254,12 +254,12 @@ def setup_platform(hass, config: ConfigType,
     add_devices(devices)
 
 
-class ISYSensorDevice(ISYDevice):
+class ISYSensorDevice(isy.ISYDevice):
     """Representation of an ISY994 sensor device."""
 
     def __init__(self, node) -> None:
         """Initialize the ISY994 sensor device."""
-        ISYDevice.__init__(self, node)
+        isy.ISYDevice.__init__(self, node)
 
     @property
     def raw_unit_of_measurement(self) -> str:

--- a/homeassistant/components/sensor/isy994.py
+++ b/homeassistant/components/sensor/isy994.py
@@ -235,7 +235,8 @@ UOM_TO_STATES = {
 BINARY_UOM = ['2', '78']
 
 
-def setup_platform(hass, config: ConfigType, add_devices: Callable[[list], None], discovery_info=None):
+def setup_platform(hass, config: ConfigType,
+                   add_devices: Callable[[list], None], discovery_info=None):
     """Setup the ISY994 sensor platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
@@ -265,7 +266,8 @@ class ISYSensorDevice(ISYDevice):
         if len(self._node.uom) == 1:
             if self._node.uom[0] in UOM_FRIENDLY_NAME:
                 friendly_name = UOM_FRIENDLY_NAME.get(self._node.uom[0])
-                if friendly_name == TEMP_CELSIUS or friendly_name == TEMP_FAHRENHEIT:
+                if friendly_name == TEMP_CELSIUS or \
+                        friendly_name == TEMP_FAHRENHEIT:
                     friendly_name = self.hass.config.units.temperature_unit
                 return friendly_name
             else:
@@ -287,8 +289,10 @@ class ISYSensorDevice(ISYDevice):
                 decimal_part = str_val[-int_prec:]
                 whole_part = str_val[:len(str_val) - int_prec]
                 val = float('{}.{}'.format(whole_part, decimal_part))
-                if self.raw_unit_of_measurement in (TEMP_CELSIUS, TEMP_FAHRENHEIT):
-                    val = self.hass.config.units.temperature(val, self.raw_unit_of_measurement)
+                raw_units = self.raw_unit_of_measurement
+                if raw_units in (
+                        TEMP_CELSIUS, TEMP_FAHRENHEIT):
+                    val = self.hass.config.units.temperature(val, raw_units)
 
                 return str(val)
             else:

--- a/homeassistant/components/sensor/isy994.py
+++ b/homeassistant/components/sensor/isy994.py
@@ -6,9 +6,9 @@ https://home-assistant.io/components/binary_sensor.isy994/
 """
 import logging
 
-from homeassistant.components.isy994 import (ISYDevice, HIDDEN_NODES,
-                                             SENSOR_NODES, ISY)
-from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT)
+from homeassistant.components.isy994 import (ISYDevice, SENSOR_NODES, ISY)
+from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT, STATE_OFF,
+                                 STATE_ON)
 from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
@@ -231,6 +231,8 @@ UOM_TO_STATES = {
     }
 }
 
+BINARY_UOM = ['2', '78']
+
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
     """Setup the ISY platform."""
@@ -241,8 +243,10 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
     devices = []
 
-    for node in (HIDDEN_NODES + SENSOR_NODES):
-        devices.append(ISYSensorDevice(node))
+    for node in SENSOR_NODES:
+        if node.uom not in BINARY_UOM and \
+                STATE_OFF not in node.uom and STATE_ON not in node.uom:
+            devices.append(ISYSensorDevice(node))
 
     add_devices(devices)
 
@@ -251,7 +255,7 @@ class ISYSensorDevice(ISYDevice):
     """Representation of a ISY sensor."""
 
     def __init__(self, node):
-        """Initialize the binary sensor."""
+        """Initialize the sensor."""
         ISYDevice.__init__(self, node)
 
     @property

--- a/homeassistant/components/sensor/isy994.py
+++ b/homeassistant/components/sensor/isy994.py
@@ -244,7 +244,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
     devices = []
 
     for node in SENSOR_NODES:
-        if node.uom[0] not in BINARY_UOM and \
+        if (len(node.uom) == 0 or node.uom[0] not in BINARY_UOM) and \
                 STATE_OFF not in node.uom and STATE_ON not in node.uom:
             _LOGGER.debug('LOADING %s', node.name)
             devices.append(ISYSensorDevice(node))

--- a/homeassistant/components/sensor/isy994.py
+++ b/homeassistant/components/sensor/isy994.py
@@ -235,15 +235,7 @@ BINARY_UOM = ['2', '78']
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """
-    Setup the ISY994 sensor platform.
-
-    :param hass: HomeAssistant.
-    :param config: The platform configuration dictionary.
-    :param add_devices: The add device callback method.
-    :param discovery_info: The discovery information.
-    :return: Whether the platform was setup properly.
-    """
+    """Setup the ISY994 sensor platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -263,20 +255,12 @@ class ISYSensorDevice(ISYDevice):
     """Representation of an ISY994 sensor device."""
 
     def __init__(self, node):
-        """
-        Initialize the ISY994 sensor device.
-
-        :param node: The ISY994 node.
-        """
+        """Initialize the ISY994 sensor device."""
         ISYDevice.__init__(self, node)
 
     @property
     def state(self) -> str:
-        """
-        Get the state of the ISY994 sensor device.
-
-        :return: The state of the ISY994 sensor device.
-        """
+        """Get the state of the ISY994 sensor device."""
         if len(self._node.uom) == 1:
             if self._node.uom[0] in UOM_TO_STATES:
                 states = UOM_TO_STATES.get(self._node.uom[0])
@@ -295,11 +279,7 @@ class ISYSensorDevice(ISYDevice):
 
     @property
     def unit_of_measurement(self):
-        """
-        Get the unit of measurement for the ISY994 sensor device.
-
-        :return: The unit of measurment for the ISY994 sensor device.
-        """
+        """Get the unit of measurement for the ISY994 sensor device."""
         if len(self._node.uom) == 1:
             if self._node.uom[0] in UOM_FRIENDLY_NAME:
                 return UOM_FRIENDLY_NAME.get(self._node.uom[0])

--- a/homeassistant/components/sensor/isy994.py
+++ b/homeassistant/components/sensor/isy994.py
@@ -1,95 +1,294 @@
 """
-Support for ISY994 sensors.
+Support for ISY994 binary sensors.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/isy994/
+https://home-assistant.io/components/binary_sensor.isy994/
 """
 import logging
 
-from homeassistant.components.isy994 import (
-    HIDDEN_STRING, ISY, SENSOR_STRING, ISYDeviceABC)
-from homeassistant.const import (
-    STATE_CLOSED, STATE_HOME, STATE_NOT_HOME, STATE_OFF, STATE_ON, STATE_OPEN)
+from homeassistant.components.sensor import DOMAIN
+from homeassistant.components.isy994 import (ISYDevice, HIDDEN_NODES,
+                                             SENSOR_NODES, PROGRAMS, ISY,
+                                             KEY_ACTIONS, KEY_STATUS)
+from homeassistant.const import (STATE_UNKNOWN, TEMP_CELSIUS, TEMP_FAHRENHEIT)
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.typing import ConfigType
 
-DEFAULT_HIDDEN_WEATHER = ['Temperature_High', 'Temperature_Low', 'Feels_Like',
-                          'Temperature_Average', 'Pressure', 'Dew_Point',
-                          'Gust_Speed', 'Evapotranspiration',
-                          'Irrigation_Requirement', 'Water_Deficit_Yesterday',
-                          'Elevation', 'Average_Temperature_Tomorrow',
-                          'High_Temperature_Tomorrow',
-                          'Low_Temperature_Tomorrow', 'Humidity_Tomorrow',
-                          'Wind_Speed_Tomorrow', 'Gust_Speed_Tomorrow',
-                          'Rain_Tomorrow', 'Snow_Tomorrow',
-                          'Forecast_Average_Temperature',
-                          'Forecast_High_Temperature',
-                          'Forecast_Low_Temperature', 'Forecast_Humidity',
-                          'Forecast_Rain', 'Forecast_Snow']
+_LOGGER = logging.getLogger(__name__)
+
+UOM_FRIENDLY_NAME = {
+    '1': 'amp',
+    '3': 'btu/h',
+    '4': TEMP_CELSIUS,
+    '5': 'cm',
+    '6': 'ft³',
+    '7': 'ft³/min',
+    '8': 'm³',
+    '9': 'day',
+    '10': 'days',
+    '12': 'dB',
+    '13': 'dB A',
+    '14': '°',
+    '16': 'macroseismic',
+    '17': TEMP_FAHRENHEIT,
+    '18': 'ft',
+    '19': 'hour',
+    '20': 'hours',
+    '21': 'abs. humidity (%)',
+    '22': 'rel. humidity (%)',
+    '23': 'inHg',
+    '24': 'in/hr',
+    '25': 'index',
+    '26': 'K',
+    '27': 'keyword',
+    '28': 'kg',
+    '29': 'kV',
+    '30': 'kW',
+    '31': 'kPa',
+    '32': 'KPH',
+    '33': 'kWH',
+    '34': 'liedu',
+    '35': 'l',
+    '36': 'lux',
+    '37': 'mercalli',
+    '38': 'm',
+    '39': 'm³/hr',
+    '40': 'm/s',
+    '41': 'mA',
+    '42': 'ms',
+    '43': 'mV',
+    '44': 'min',
+    '45': 'min',
+    '46': 'mm/hr',
+    '47': 'month',
+    '48': 'MPH',
+    '49': 'm/s',
+    '50': 'ohm',
+    '51': '%',
+    '52': 'lb',
+    '53': 'power factor',
+    '54': 'ppm',
+    '55': 'pulse count',
+    '57': 's',
+    '58': 's',
+    '59': 'seimens/m',
+    '60': 'body wave magnitude scale',
+    '61': 'Ricter scale',
+    '62': 'moment magnitude scale',
+    '63': 'surface wave magnitude scale',
+    '64': 'shindo',
+    '65': 'SML',
+    '69': 'gal',
+    '71': 'UV index',
+    '72': 'V',
+    '73': 'W',
+    '74': 'W/m²',
+    '75': 'weekday',
+    '76': 'Wind Direction (°)',
+    '77': 'year',
+    '82': 'mm',
+    '83': 'km',
+    '85': 'ohm',
+    '86': 'kOhm',
+    '87': 'm³/m³',
+    '88': 'Water activity',
+    '89': 'RPM',
+    '90': 'Hz',
+    '91': '° (Relative to North)',
+    '92': '° (Relative to South)',
+}
+
+UOM_TO_STATES = {
+    '11': {
+        '0': 'unlocked',
+        '100': 'locked',
+        '102': 'jammed',
+    },
+    '15': {
+        '1': 'master code changed',
+        '2': 'tamper code entry limit',
+        '3': 'escutcheon removed',
+        '4': 'key/manually locked',
+        '5': 'locked by touch',
+        '6': 'key/manually unlocked',
+        '7': 'remote locking jammed bolt',
+        '8': 'remotely locked',
+        '9': 'remotely unlocked',
+        '10': 'deadbolt jammed',
+        '11': 'battery too low to operate',
+        '12': 'critical low battery',
+        '13': 'low battery',
+        '14': 'automatically locked',
+        '15': 'automatic locking jammed bolt',
+        '16': 'remotely power cycled',
+        '17': 'lock handling complete',
+        '19': 'user deleted',
+        '20': 'user added',
+        '21': 'duplicate pin',
+        '22': 'jammed bolt by locking with keypad',
+        '23': 'locked by keypad',
+        '24': 'unlocked by keypad',
+        '25': 'keypad attempt outside schedule',
+        '26': 'hardware failure',
+        '27': 'factory reset'
+    },
+    '66': {
+        '0': 'idle',
+        '1': 'heating',
+        '2': 'cooling',
+        '3': 'fan only',
+        '4': 'pending heat',
+        '5': 'pending cool',
+        '6': 'vent',
+        '7': 'aux heat',
+        '8': '2nd stage heating',
+        '9': '2nd stage cooling',
+        '10': '2nd stage aux heat',
+        '11': '3rd stage aux heat'
+    },
+    '67': {
+        '0': 'off',
+        '1': 'heat',
+        '2': 'cool',
+        '3': 'auto',
+        '4': 'aux/emergency heat',
+        '5': 'resume',
+        '6': 'fan only',
+        '7': 'furnace',
+        '8': 'dry air',
+        '9': 'moist air',
+        '10': 'auto changeover',
+        '11': 'energy save heat',
+        '12': 'energy save cool',
+        '13': 'away'
+    },
+    '68': {
+        '0': 'auto',
+        '1': 'on',
+        '2': 'auto high',
+        '3': 'high',
+        '4': 'auto medium',
+        '5': 'medium',
+        '6': 'circulation',
+        '7': 'humidity circulation'
+    },
+    '93': {
+        '1': 'power applied',
+        '2': 'ac mains disconnected',
+        '3': 'ac mains reconnected',
+        '4': 'surge detection',
+        '5': 'volt drop or drift',
+        '6': 'over current detected',
+        '7': 'over voltage detected',
+        '8': 'over load detected',
+        '9': 'load error',
+        '10': 'replace battery soon',
+        '11': 'replace battery now',
+        '12': 'battery is charging',
+        '13': 'battery is fully charged',
+        '14': 'charge battery soon',
+        '15': 'charge battery now'
+    },
+    '94': {
+        '1': 'program started',
+        '2': 'program in progress',
+        '3': 'program completed',
+        '4': 'replace main filter',
+        '5': 'failure to set target temperature',
+        '6': 'supplying water',
+        '7': 'water supply failure',
+        '8': 'boiling',
+        '9': 'boiling failure',
+        '10': 'washing',
+        '11': 'washing failure',
+        '12': 'rinsing',
+        '13': 'rinsing failure',
+        '14': 'draining',
+        '15': 'draining failure',
+        '16': 'spinning',
+        '17': 'spinning failure',
+        '18': 'drying',
+        '19': 'drying failure',
+        '20': 'fan failure',
+        '21': 'compressor failure'
+    },
+    '95': {
+        '1': 'leaving bed',
+        '2': 'sitting on bed',
+        '3': 'lying on bed',
+        '4': 'posture changed',
+        '5': 'sitting on edge of bed'
+    },
+    '96': {
+        '1': 'clean',
+        '2': 'slightly polluted',
+        '3': 'moderately polluted',
+        '4': 'highly polluted'
+    },
+    '97': {
+        '0': 'closed',
+        '100': 'open',
+        '102': 'stopped',
+        '103': 'closing',
+        '104': 'opening'
+    }
+}
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the ISY994 platform."""
-    # pylint: disable=protected-access
-    logger = logging.getLogger(__name__)
-    devs = []
-    # Verify connection
+def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
+    """Setup the ISY platform."""
+
     if ISY is None or not ISY.connected:
-        logger.error('A connection has not been made to the ISY controller.')
+        _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
 
-    # Import weather
-    if ISY.climate is not None:
-        for prop in ISY.climate._id2name:
-            if prop is not None:
-                prefix = HIDDEN_STRING \
-                    if prop in DEFAULT_HIDDEN_WEATHER else ''
-                node = WeatherPseudoNode('ISY.weather.' + prop, prefix + prop,
-                                         getattr(ISY.climate, prop),
-                                         getattr(ISY.climate, prop + '_units'))
-                devs.append(ISYSensorDevice(node))
+    devices = []
 
-    # Import sensor nodes
-    for (path, node) in ISY.nodes:
-        if SENSOR_STRING in node.name:
-            if HIDDEN_STRING in path:
-                node.name += HIDDEN_STRING
-            devs.append(ISYSensorDevice(node, [STATE_ON, STATE_OFF]))
+    for node in (HIDDEN_NODES + SENSOR_NODES):
+        if (STATE_ON not in node.uom and STATE_OFF not in node.uom):
+            devices.append(ISYSensorDevice(node))
 
-    # Import sensor programs
-    for (folder_name, states) in (
-            ('HA.locations', [STATE_HOME, STATE_NOT_HOME]),
-            ('HA.sensors', [STATE_OPEN, STATE_CLOSED]),
-            ('HA.states', [STATE_ON, STATE_OFF])):
-        try:
-            folder = ISY.programs['My Programs'][folder_name]
-        except KeyError:
-            # folder does not exist
-            pass
+    add_devices(devices)
+
+
+class ISYSensorDevice(ISYDevice):
+    """Representation of a ISY sensor."""
+
+    def __init__(self, node):
+        """Initialize the binary sensor."""
+        ISYDevice.__init__(self, node)
+
+    @property
+    def state(self) -> str:
+        """Return the state of the device."""
+        if len(self._node.uom) == 1:
+            return self.value
         else:
-            for _, _, node_id in folder.children:
-                node = folder[node_id].leaf
-                devs.append(ISYSensorDevice(node, states))
+            return None
 
-    add_devices(devs)
-
-
-class WeatherPseudoNode(object):
-    """This class allows weather variable to act as regular nodes."""
-
-    # pylint: disable=too-few-public-methods
-    def __init__(self, device_id, name, status, units=None):
-        """Initialize the sensor."""
-        self._id = device_id
-        self.name = name
-        self.status = status
-        self.units = units
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement for the device."""
+        if len(self._node.uom) == 1:
+            return self._node.uom[0]
+        else:
+            return None
 
 
-class ISYSensorDevice(ISYDeviceABC):
-    """Representation of an ISY sensor."""
+class ISYBinarySensorProgram(ISYBinarySensorDevice):
+    """Representation of a ISY lock program."""
 
-    _domain = 'sensor'
+    def __init__(self, name, node):
+        """Initialize the lock."""
+        ISYDevice.__init__(self, node)
+        self._name = name
 
-    def __init__(self, node, states=None):
-        """Initialize the device."""
-        super().__init__(node)
-        self._states = states or []
+    @property
+    def is_on(self) -> bool:
+        """Return true if the device is locked."""
+        return bool(self.value)
+
+    @property
+    def unit_of_measurement(self) -> None:
+        """No unit of measurement for lock programs."""
+        return None

--- a/homeassistant/components/sensor/isy994.py
+++ b/homeassistant/components/sensor/isy994.py
@@ -235,8 +235,15 @@ BINARY_UOM = ['2', '78']
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """Setup the ISY platform."""
+    """
+    Setup the ISY994 sensor platform.
 
+    :param hass: HomeAssistant.
+    :param config: The platform configuration dictionary.
+    :param add_devices: The add device callback method.
+    :param discovery_info: The discovery information.
+    :return: Whether the platform was setup properly.
+    """
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -253,15 +260,25 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYSensorDevice(ISYDevice):
-    """Representation of a ISY sensor."""
+    """
+    Representation of an ISY994 sensor device.
+    """
 
     def __init__(self, node):
-        """Initialize the sensor."""
+        """
+        Initialize the ISY994 sensor device.
+
+        :param node: The ISY994 node.
+        """
         ISYDevice.__init__(self, node)
 
     @property
     def state(self) -> str:
-        """Return the state of the device."""
+        """
+        Get the state of the ISY994 sensor device.
+
+        :return: The state of the ISY994 sensor device.
+        """
         if len(self._node.uom) == 1:
             if self._node.uom[0] in UOM_TO_STATES:
                 states = UOM_TO_STATES.get(self._node.uom[0])
@@ -280,7 +297,11 @@ class ISYSensorDevice(ISYDevice):
 
     @property
     def unit_of_measurement(self):
-        """Return the unit of measurement for the device."""
+        """
+        Get the unit of measurement for the ISY994 sensor device.
+
+        :return: The unit of measurment for the ISY994 sensor device.
+        """
         if len(self._node.uom) == 1:
             if self._node.uom[0] in UOM_FRIENDLY_NAME:
                 return UOM_FRIENDLY_NAME.get(self._node.uom[0])

--- a/homeassistant/components/sensor/isy994.py
+++ b/homeassistant/components/sensor/isy994.py
@@ -260,9 +260,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYSensorDevice(ISYDevice):
-    """
-    Representation of an ISY994 sensor device.
-    """
+    """Representation of an ISY994 sensor device."""
 
     def __init__(self, node):
         """
@@ -287,7 +285,7 @@ class ISYSensorDevice(ISYDevice):
             elif self._node.prec and self._node.prec != [0]:
                 str_val = str(self.value)
                 int_prec = int(self._node.prec)
-                decimal_part =str_val[-int_prec:]
+                decimal_part = str_val[-int_prec:]
                 whole_part = str_val[:len(str_val) - int_prec]
                 return '{}.{}'.format(whole_part, decimal_part)
             else:

--- a/homeassistant/components/switch/isy994.py
+++ b/homeassistant/components/switch/isy994.py
@@ -26,15 +26,7 @@ STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """
-    Set up the ISY994 switch platform.
-
-    :param hass: HomeAssistant.
-    :param config: The platform configuration.
-    :param add_devices: The add devices callback function.
-    :param discovery_info: Discovery information
-    :return: Whether the platform was set up correctly.
-    """
+    """Set up the ISY994 switch platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -66,48 +58,26 @@ class ISYSwitchDevice(ISYDevice, SwitchDevice):
     """Representation of an ISY994 switch device."""
 
     def __init__(self, node):
-        """
-        Initialize the ISY994 switch device.
-
-        :param node: The ISY994 Node.
-        """
+        """Initialize the ISY994 switch device."""
         ISYDevice.__init__(self, node)
 
     @property
     def is_on(self) -> bool:
-        """
-        Get whether the ISY994 device is in the on state.
-
-        :return: Whether the switch is in the on state.
-        """
+        """Get whether the ISY994 device is in the on state."""
         return self.state == STATE_ON
 
     @property
     def state(self) -> str:
-        """
-        Get the state of the ISY994 device.
-
-        :return: The state of the ISY994 switch.
-        """
+        """Get the state of the ISY994 device."""
         return VALUE_TO_STATE.get(bool(self.value), STATE_UNKNOWN)
 
     def turn_off(self, **kwargs):
-        """
-        Send the turn on command to the ISY994 switch.
-
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+        """Send the turn on command to the ISY994 switch."""
         if not self._node.off():
             _LOGGER.debug('Unable to turn on switch.')
 
     def turn_on(self, **kwargs):
-        """
-        Send the turn off command to the ISY994 switch.
-
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+        """Send the turn off command to the ISY994 switch."""
         if not self._node.on():
             _LOGGER.debug('Unable to turn on switch.')
 
@@ -116,42 +86,22 @@ class ISYSwitchProgram(ISYSwitchDevice):
     """A representation of an ISY994 program switch."""
 
     def __init__(self, name, node, actions):
-        """
-        Initialize the ISY994 switch program.
-
-        :param name: The device name.
-        :param node: The status program node.
-        :param actions: The actions program node.
-        """
+        """Initialize the ISY994 switch program."""
         ISYSwitchDevice.__init__(self, node)
         self._name = name
         self._actions = actions
 
     @property
     def is_on(self) -> bool:
-        """
-        Get whether the ISY994 switch program is on.
-
-        :return: Whether the ISY994 switch program is on.
-        """
+        """Get whether the ISY994 switch program is on."""
         return bool(self.value)
 
     def turn_on(self, **kwargs):
-        """
-        Send the turn on command to the ISY994 switch program.
-
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+        """Send the turn on command to the ISY994 switch program."""
         if not self._actions.runThen():
             _LOGGER.error('Unable to turn on switch')
 
     def turn_off(self, **kwargs):
-        """
-        Send the turn off command to the ISY994 switch program.
-
-        :param kwargs: Keyword arguments.
-        :return: None.
-        """
+        """Send the turn off command to the ISY994 switch program."""
         if not self._actions.runElse():
             _LOGGER.error('Unable to turn off switch')

--- a/homeassistant/components/switch/isy994.py
+++ b/homeassistant/components/switch/isy994.py
@@ -26,6 +26,7 @@ UOM = ['2', '78']
 STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
+# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 switch platform."""

--- a/homeassistant/components/switch/isy994.py
+++ b/homeassistant/components/switch/isy994.py
@@ -28,8 +28,15 @@ STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
 def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
-    """Setup the ISY platform."""
+    """
+    Set up the ISY994 switch platform.
 
+    :param hass: HomeAssistant.
+    :param config: The platform configuration.
+    :param add_devices: The add devices callback function.
+    :param discovery_info: Discovery information
+    :return: Whether the platform was set up correctly.
+    """
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
@@ -58,53 +65,99 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYSwitchDevice(ISYDevice, SwitchDevice):
-    """Representation of a ISY switch."""
+    """
+    Representation of an ISY994 switch device.
+    """
 
     def __init__(self, node):
-        """Initialize the binary sensor."""
+        """
+        Initialize the ISY994 switch device.
+
+        :param node: The ISY994 Node.
+        """
         ISYDevice.__init__(self, node)
 
     @property
     def is_on(self) -> bool:
-        """Return true if device is locked."""
+        """
+        Get whether the ISY994 device is in the on state.
+
+        :return: Whether the switch is in the on state.
+        """
         return self.state == STATE_ON
 
     @property
     def state(self) -> str:
-        """Return the state of the device."""
+        """
+        Get the state of the ISY994 device.
+
+        :return: The state of the ISY994 switch.
+        """
         return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
 
     def turn_off(self, **kwargs):
-        """Turn off the switch."""
+        """
+        Send the turn on command to the ISY994 switch.
+
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         if not self._node.off():
             _LOGGER.debug('Unable to turn on switch.')
 
     def turn_on(self, **kwargs):
-        """Turn on the switch."""
+        """
+        Send the turn off command to the ISY994 switch.
+
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         if not self._node.on():
             _LOGGER.debug('Unable to turn on switch.')
 
 
 class ISYSwitchProgram(ISYSwitchDevice):
-    """Representation of a ISY lock program."""
+    """
+    A representation of an ISY994 program switch.
+    """
 
     def __init__(self, name, node, actions):
-        """Initialize the lock."""
+        """
+        Initialize the ISY994 switch program
+
+        :param name: The device name.
+        :param node: The status program node.
+        :param actions: The actions program node.
+        """
         ISYDevice.__init__(self, node)
         self._name = name
         self._actions = actions
 
     @property
     def is_on(self) -> bool:
-        """Return true if the device is locked."""
+        """
+        Get whether the ISY994 switch program is on.
+
+        :return: Whether the ISY994 switch program is on.
+        """
         return bool(self.value)
 
     def turn_on(self, **kwargs):
-        """Turn on the switch."""
+        """
+        Send the turn on command to the ISY994 switch program.
+
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         if not self._actions.runThen():
             _LOGGER.error('Unable to turn on switch')
 
     def turn_off(self, **kwargs):
-        """Turn off the switch."""
+        """
+        Send the turn off command to the ISY994 switch program.
+
+        :param kwargs: Keyword arguments.
+        :return: None.
+        """
         if not self._actions.runElse():
             _LOGGER.error('Unable to turn off switch')

--- a/homeassistant/components/switch/isy994.py
+++ b/homeassistant/components/switch/isy994.py
@@ -117,7 +117,7 @@ class ISYSwitchProgram(ISYSwitchDevice):
 
     def __init__(self, name, node, actions):
         """
-        Initialize the ISY994 switch program
+        Initialize the ISY994 switch program.
 
         :param name: The device name.
         :param node: The status program node.

--- a/homeassistant/components/switch/isy994.py
+++ b/homeassistant/components/switch/isy994.py
@@ -7,11 +7,8 @@ https://home-assistant.io/components/switch.isy994/
 import logging
 from typing import Callable  # noqa
 
-from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.switch import SwitchDevice, DOMAIN
-from homeassistant.components.isy994 import (ISYDevice, NODES, PROGRAMS, ISY,
-                                             KEY_ACTIONS, KEY_STATUS,
-                                             GROUPS)
+import homeassistant.components.isy994 as isy
 from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType  # noqa
 
@@ -30,24 +27,24 @@ STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 switch platform."""
-    if ISY is None or not ISY.connected:
+    if isy.ISY is None or not isy.ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
         return False
 
     devices = []
 
-    for node in filter_nodes(NODES, units=UOM,
-                             states=STATES):
+    for node in isy.filter_nodes(isy.NODES, units=UOM,
+                                 states=STATES):
         if not node.dimmable:
             devices.append(ISYSwitchDevice(node))
 
-    for node in GROUPS:
+    for node in isy.GROUPS:
         devices.append(ISYSwitchDevice(node))
 
-    for program in PROGRAMS.get(DOMAIN, []):
+    for program in isy.PROGRAMS.get(DOMAIN, []):
         try:
-            status = program[KEY_STATUS]
-            actions = program[KEY_ACTIONS]
+            status = program[isy.KEY_STATUS]
+            actions = program[isy.KEY_ACTIONS]
             assert actions.dtype == 'program', 'Not a program'
         except (KeyError, AssertionError):
             pass
@@ -57,12 +54,12 @@ def setup_platform(hass, config: ConfigType,
     add_devices(devices)
 
 
-class ISYSwitchDevice(ISYDevice, SwitchDevice):
+class ISYSwitchDevice(isy.ISYDevice, SwitchDevice):
     """Representation of an ISY994 switch device."""
 
     def __init__(self, node) -> None:
         """Initialize the ISY994 switch device."""
-        ISYDevice.__init__(self, node)
+        isy.ISYDevice.__init__(self, node)
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/switch/isy994.py
+++ b/homeassistant/components/switch/isy994.py
@@ -17,8 +17,6 @@ from homeassistant.helpers.typing import ConfigType
 _LOGGER = logging.getLogger(__name__)
 
 VALUE_TO_STATE = {
-    0: STATE_OFF,
-    100: STATE_ON,
     False: STATE_OFF,
     True: STATE_ON,
 }
@@ -48,7 +46,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
         if not node.dimmable:
             devices.append(ISYSwitchDevice(node))
 
-    for node in (GROUPS):
+    for node in GROUPS:
         devices.append(ISYSwitchDevice(node))
 
     for program in PROGRAMS.get(DOMAIN, []):
@@ -65,9 +63,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 
 
 class ISYSwitchDevice(ISYDevice, SwitchDevice):
-    """
-    Representation of an ISY994 switch device.
-    """
+    """Representation of an ISY994 switch device."""
 
     def __init__(self, node):
         """
@@ -93,7 +89,7 @@ class ISYSwitchDevice(ISYDevice, SwitchDevice):
 
         :return: The state of the ISY994 switch.
         """
-        return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
+        return VALUE_TO_STATE.get(bool(self.value), STATE_UNKNOWN)
 
     def turn_off(self, **kwargs):
         """
@@ -117,9 +113,7 @@ class ISYSwitchDevice(ISYDevice, SwitchDevice):
 
 
 class ISYSwitchProgram(ISYSwitchDevice):
-    """
-    A representation of an ISY994 program switch.
-    """
+    """A representation of an ISY994 program switch."""
 
     def __init__(self, name, node, actions):
         """
@@ -129,7 +123,7 @@ class ISYSwitchProgram(ISYSwitchDevice):
         :param node: The status program node.
         :param actions: The actions program node.
         """
-        ISYDevice.__init__(self, node)
+        ISYSwitchDevice.__init__(self, node)
         self._name = name
         self._actions = actions
 

--- a/homeassistant/components/switch/isy994.py
+++ b/homeassistant/components/switch/isy994.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.isy994/
 """
 import logging
+from typing import Callable  # noqa
 
 from homeassistant.components.isy994 import filter_nodes
 from homeassistant.components.switch import SwitchDevice, DOMAIN
@@ -12,7 +13,7 @@ from homeassistant.components.isy994 import (ISYDevice, NODES, PROGRAMS, ISY,
                                              KEY_ACTIONS, KEY_STATUS,
                                              GROUPS)
 from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType  # noqa
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ UOM = ['2', '78']
 STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
-def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
+def setup_platform(hass, config: ConfigType, add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 switch platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')
@@ -57,7 +58,7 @@ def setup_platform(hass, config: ConfigType, add_devices, discovery_info=None):
 class ISYSwitchDevice(ISYDevice, SwitchDevice):
     """Representation of an ISY994 switch device."""
 
-    def __init__(self, node):
+    def __init__(self, node) -> None:
         """Initialize the ISY994 switch device."""
         ISYDevice.__init__(self, node)
 
@@ -71,12 +72,12 @@ class ISYSwitchDevice(ISYDevice, SwitchDevice):
         """Get the state of the ISY994 device."""
         return VALUE_TO_STATE.get(bool(self.value), STATE_UNKNOWN)
 
-    def turn_off(self, **kwargs):
+    def turn_off(self, **kwargs) -> None:
         """Send the turn on command to the ISY994 switch."""
         if not self._node.off():
             _LOGGER.debug('Unable to turn on switch.')
 
-    def turn_on(self, **kwargs):
+    def turn_on(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 switch."""
         if not self._node.on():
             _LOGGER.debug('Unable to turn on switch.')
@@ -85,7 +86,7 @@ class ISYSwitchDevice(ISYDevice, SwitchDevice):
 class ISYSwitchProgram(ISYSwitchDevice):
     """A representation of an ISY994 program switch."""
 
-    def __init__(self, name, node, actions):
+    def __init__(self, name: str, node, actions) -> None:
         """Initialize the ISY994 switch program."""
         ISYSwitchDevice.__init__(self, node)
         self._name = name
@@ -96,12 +97,12 @@ class ISYSwitchProgram(ISYSwitchDevice):
         """Get whether the ISY994 switch program is on."""
         return bool(self.value)
 
-    def turn_on(self, **kwargs):
+    def turn_on(self, **kwargs) -> None:
         """Send the turn on command to the ISY994 switch program."""
         if not self._actions.runThen():
             _LOGGER.error('Unable to turn on switch')
 
-    def turn_off(self, **kwargs):
+    def turn_off(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 switch program."""
         if not self._actions.runElse():
             _LOGGER.error('Unable to turn off switch')

--- a/homeassistant/components/switch/isy994.py
+++ b/homeassistant/components/switch/isy994.py
@@ -26,7 +26,8 @@ UOM = ['2', '78']
 STATES = [STATE_OFF, STATE_ON, 'true', 'false']
 
 
-def setup_platform(hass, config: ConfigType, add_devices: Callable[[list], None], discovery_info=None):
+def setup_platform(hass, config: ConfigType,
+                   add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 switch platform."""
     if ISY is None or not ISY.connected:
         _LOGGER.error('A connection has not been made to the ISY controller.')

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -8,7 +8,7 @@ voluptuous==0.9.2
 typing>=3,<4
 
 # homeassistant.components.isy994
-PyISY==1.0.6
+PyISY==1.0.7
 
 # homeassistant.components.notify.html5
 PyJWT==1.4.2


### PR DESCRIPTION
**Description:**
The ISY994 platform is woefully incomplete. Update the platform to automatically discover covers, binary sensors, sensors, switches, lights, locks, etc. The PyISY library was updated to return the unit of measurement for devices, this allows sensors to display their value with unites or as a state.

Unit tests incoming - if I have time.

**Related issue (if applicable):** fixes #3037 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#893

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
isy994:
    host: 192.168.1.129
    username: admin
    password: admin
    tls: 1.2
    hidden_string: hidden
    sensor_string: sensor
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
