### PR TITLE
Use voluptuous for downloader

### DIFF
--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -12,9 +12,10 @@ import threading
 import requests
 import voluptuous as vol
 
-from homeassistant.helpers import validate_config
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import sanitize_filename
+
+_LOGGER = logging.getLogger(__name__)
 
 ATTR_SUBDIR = 'subdir'
 ATTR_URL = 'url'
@@ -30,15 +31,16 @@ SERVICE_DOWNLOAD_FILE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_SUBDIR): cv.string,
 })
 
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_DOWNLOAD_DIR): cv.string,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
 
 # pylint: disable=too-many-branches
 def setup(hass, config):
     """Listen for download events to download files."""
-    logger = logging.getLogger(__name__)
-
-    if not validate_config(config, {DOMAIN: [CONF_DOWNLOAD_DIR]}, logger):
-        return False
-
     download_path = config[DOMAIN][CONF_DOWNLOAD_DIR]
 
     # If path is relative, we assume relative to HASS config dir
@@ -46,8 +48,7 @@ def setup(hass, config):
         download_path = hass.config.path(download_path)
 
     if not os.path.isdir(download_path):
-
-        logger.error(
+        _LOGGER.error(
             "Download path %s does not exist. File Downloader not active.",
             download_path)
 
@@ -113,16 +114,16 @@ def setup(hass, config):
 
                         final_path = "{}_{}.{}".format(path, tries, ext)
 
-                    logger.info("%s -> %s", url, final_path)
+                    _LOGGER.info("%s -> %s", url, final_path)
 
                     with open(final_path, 'wb') as fil:
                         for chunk in req.iter_content(1024):
                             fil.write(chunk)
 
-                    logger.info("Downloading of %s done", url)
+                    _LOGGER.info("Downloading of %s done", url)
 
             except requests.exceptions.ConnectionError:
-                logger.exception("ConnectionError occured for %s", url)
+                _LOGGER.exception("ConnectionError occured for %s", url)
 
                 # Remove file if we started downloading but failed
                 if final_path and os.path.isfile(final_path):


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
downloader:
  download_dir: downloads
```
