### PR TITLE
MQTT fan platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -138,6 +138,7 @@ omit =
     homeassistant/components/device_tracker/ubus.py
     homeassistant/components/discovery.py
     homeassistant/components/downloader.py
+    homeassistant/components/fan/mqtt.py
     homeassistant/components/feedreader.py
     homeassistant/components/foursquare.py
     homeassistant/components/garage_door/rpi_gpio.py

--- a/homeassistant/components/emulated_hue.py
+++ b/homeassistant/components/emulated_hue.py
@@ -44,7 +44,7 @@ DEFAULT_LISTEN_PORT = 8300
 DEFAULT_OFF_MAPS_TO_ON_DOMAINS = ['script', 'scene']
 DEFAULT_EXPOSE_BY_DEFAULT = True
 DEFAULT_EXPOSED_DOMAINS = [
-    'switch', 'light', 'group', 'input_boolean', 'media_player'
+    'switch', 'light', 'group', 'input_boolean', 'media_player', 'fan'
 ]
 
 HUE_API_STATE_ON = 'on'

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -39,6 +39,7 @@ SERVICE_OSCILLATE = 'oscillate'
 SPEED_OFF = 'off'
 SPEED_LOW = 'low'
 SPEED_MED = 'med'
+SPEED_MEDIUM = 'medium'
 SPEED_HIGH = 'high'
 
 ATTR_SPEED = 'speed'

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -45,8 +45,6 @@ ATTR_SPEED = 'speed'
 ATTR_SPEED_LIST = 'speed_list'
 ATTR_OSCILLATING = 'oscillating'
 
-ATTR_FAKE_BRIGHTNESS = 'brightness'
-
 PROP_TO_ATTR = {
     'speed': ATTR_SPEED,
     'speed_list': ATTR_SPEED_LIST,
@@ -61,8 +59,7 @@ FAN_SET_SPEED_SCHEMA = vol.Schema({
 
 FAN_TURN_ON_SCHEMA = vol.Schema({
     vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Exclusive(ATTR_SPEED, 'speed'): cv.string,
-    vol.Exclusive(ATTR_FAKE_BRIGHTNESS, 'speed'): cv.string
+    vol.Optional(ATTR_SPEED): cv.string
 })  # type: dict
 
 FAN_TURN_OFF_SCHEMA = vol.Schema({
@@ -168,8 +165,6 @@ def setup(hass, config: dict) -> None:
 
         if service_fun:
             for fan in target_fans:
-                if params.get(ATTR_FAKE_BRIGHTNESS) is not None:
-                    params[ATTR_SPEED] = params.get(ATTR_FAKE_BRIGHTNESS)
                 getattr(fan, service_fun)(**params)
 
             for fan in target_fans:

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -45,6 +45,8 @@ ATTR_SPEED = 'speed'
 ATTR_SPEED_LIST = 'speed_list'
 ATTR_OSCILLATING = 'oscillating'
 
+ATTR_FAKE_BRIGHTNESS = 'brightness'
+
 PROP_TO_ATTR = {
     'speed': ATTR_SPEED,
     'speed_list': ATTR_SPEED_LIST,
@@ -59,7 +61,8 @@ FAN_SET_SPEED_SCHEMA = vol.Schema({
 
 FAN_TURN_ON_SCHEMA = vol.Schema({
     vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Optional(ATTR_SPEED): cv.string
+    vol.Exclusive(ATTR_SPEED, 'speed'): cv.string,
+    vol.Exclusive(ATTR_FAKE_BRIGHTNESS, 'speed'): cv.string
 })  # type: dict
 
 FAN_TURN_OFF_SCHEMA = vol.Schema({
@@ -165,6 +168,8 @@ def setup(hass, config: dict) -> None:
 
         if service_fun:
             for fan in target_fans:
+                if params.get(ATTR_FAKE_BRIGHTNESS) is not None:
+                    params[ATTR_SPEED] = params.get(ATTR_FAKE_BRIGHTNESS)
                 getattr(fan, service_fun)(**params)
 
             for fan in target_fans:

--- a/homeassistant/components/fan/demo.py
+++ b/homeassistant/components/fan/demo.py
@@ -1,5 +1,5 @@
 """
-Demo garage door platform that has a fake fan.
+Demo fan platform that has a fake fan.
 
 For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/demo/
@@ -19,7 +19,7 @@ DEMO_SUPPORT = SUPPORT_SET_SPEED | SUPPORT_OSCILLATE
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
-    """Setup demo garage door platform."""
+    """Setup demo fan platform."""
     add_devices_callback([
         DemoFan(hass, FAN_NAME, STATE_OFF),
     ])

--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -55,12 +55,16 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_OSCILLATION_VALUE_TEMPLATE): cv.template,
     vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
     vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
-    vol.Optional(CONF_PAYLOAD_OSCILLATION_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
-    vol.Optional(CONF_PAYLOAD_OSCILLATION_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
+    vol.Optional(CONF_PAYLOAD_OSCILLATION_ON,
+                 default=DEFAULT_PAYLOAD_ON): cv.string,
+    vol.Optional(CONF_PAYLOAD_OSCILLATION_OFF,
+                 default=DEFAULT_PAYLOAD_OFF): cv.string,
     vol.Optional(CONF_PAYLOAD_LOW_SPEED, default=SPEED_LOW): cv.string,
     vol.Optional(CONF_PAYLOAD_MEDIUM_SPEED, default=SPEED_MED): cv.string,
     vol.Optional(CONF_PAYLOAD_HIGH_SPEED, default=SPEED_HIGH): cv.string,
-    vol.Optional(CONF_SPEED_LIST, default=[SPEED_OFF, SPEED_LOW, SPEED_MED, SPEED_HIGH]): cv.ensure_list,
+    vol.Optional(CONF_SPEED_LIST,
+                 default=[SPEED_OFF, SPEED_LOW,
+                          SPEED_MED, SPEED_HIGH]): cv.ensure_list,
     vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
 })
 
@@ -116,8 +120,11 @@ class MqttFan(FanEntity):
         self._payload = payload
         self._speed_list = speed_list
         self._optimistic = optimistic or topic["state_topic"] is None
-        self._optimistic_oscillation = (optimistic or topic["oscillation_state_topic"] is None)
-        self._optimistic_speed = (optimistic or topic["speed_state_topic"] is None)
+        self._optimistic_oscillation = (optimistic or
+                                        topic["oscillation_state_topic"]
+                                        is None)
+        self._optimistic_speed = (optimistic or
+                                  topic["speed_state_topic"] is None)
         self._state = False
         self._supported_features = 0
         self._supported_features |= (

--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -106,9 +106,11 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     )])
 
 
+# pylint: disable=too-many-instance-attributes
 class MqttFan(FanEntity):
     """A MQTT fan component."""
 
+    # pylint: disable=too-many-arguments
     def __init__(self, hass, name, topic, templates, qos, retain, payload,
                  speed_list, optimistic):
         """Initialize MQTT fan."""

--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -10,39 +10,46 @@ from functools import partial
 import voluptuous as vol
 
 import homeassistant.components.mqtt as mqtt
-from homeassistant.const import CONF_NAME, CONF_OPTIMISTIC
+from homeassistant.const import (CONF_NAME, CONF_OPTIMISTIC, CONF_STATE,
+                                 STATE_ON, STATE_OFF)
 from homeassistant.components.mqtt import (
     CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.template import render_with_possible_json_value
-from homeassistant.components.fan import (SPEED_LOW, SPEED_MED, SPEED_HIGH,
-                                          FanEntity, SUPPORT_SET_SPEED,
-                                          SUPPORT_OSCILLATE, SPEED_OFF)
+from homeassistant.components.fan import (SPEED_LOW, SPEED_MED, SPEED_MEDIUM,
+                                          SPEED_HIGH, FanEntity,
+                                          SUPPORT_SET_SPEED, SUPPORT_OSCILLATE,
+                                          SPEED_OFF, ATTR_SPEED)
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ['mqtt']
+DEPENDENCIES = ["mqtt"]
 
-CONF_STATE_VALUE_TEMPLATE = 'state_value_template'
-CONF_SPEED_STATE_TOPIC = 'speed_state_topic'
-CONF_SPEED_COMMAND_TOPIC = 'speed_command_topic'
-CONF_SPEED_VALUE_TEMPLATE = 'speed_value_template'
-CONF_OSCILLATION_STATE_TOPIC = 'oscillation_state_topic'
-CONF_OSCILLATION_COMMAND_TOPIC = 'oscillation_command_topic'
-CONF_OSCILLATION_VALUE_TEMPLATE = 'oscillation_value_template'
-CONF_PAYLOAD_ON = 'payload_on'
-CONF_PAYLOAD_OFF = 'payload_off'
-CONF_PAYLOAD_OSCILLATION_ON = 'payload_oscillation_on'
-CONF_PAYLOAD_OSCILLATION_OFF = 'payload_oscillation_off'
-CONF_PAYLOAD_LOW_SPEED = 'payload_low_speed'
-CONF_PAYLOAD_MEDIUM_SPEED = 'payload_medium_speed'
-CONF_PAYLOAD_HIGH_SPEED = 'payload_high_speed'
-CONF_SPEED_LIST = 'speeds'
+CONF_STATE_VALUE_TEMPLATE = "state_value_template"
+CONF_SPEED_STATE_TOPIC = "speed_state_topic"
+CONF_SPEED_COMMAND_TOPIC = "speed_command_topic"
+CONF_SPEED_VALUE_TEMPLATE = "speed_value_template"
+CONF_OSCILLATION_STATE_TOPIC = "oscillation_state_topic"
+CONF_OSCILLATION_COMMAND_TOPIC = "oscillation_command_topic"
+CONF_OSCILLATION_VALUE_TEMPLATE = "oscillation_value_template"
+CONF_PAYLOAD_ON = "payload_on"
+CONF_PAYLOAD_OFF = "payload_off"
+CONF_PAYLOAD_OSCILLATION_ON = "payload_oscillation_on"
+CONF_PAYLOAD_OSCILLATION_OFF = "payload_oscillation_off"
+CONF_PAYLOAD_LOW_SPEED = "payload_low_speed"
+CONF_PAYLOAD_MEDIUM_SPEED = "payload_medium_speed"
+CONF_PAYLOAD_HIGH_SPEED = "payload_high_speed"
+CONF_SPEED_LIST = "speeds"
 
-DEFAULT_NAME = 'MQTT Fan'
-DEFAULT_PAYLOAD_ON = 'ON'
-DEFAULT_PAYLOAD_OFF = 'OFF'
+DEFAULT_NAME = "MQTT Fan"
+DEFAULT_PAYLOAD_ON = "ON"
+DEFAULT_PAYLOAD_OFF = "OFF"
 DEFAULT_OPTIMISTIC = False
+
+OSCILLATE_ON_PAYLOAD = "oscillate_on"
+OSCILLATE_OFF_PAYLOAD = "oscillate_off"
+
+OSCILLATION = "oscillation"
 
 PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -86,20 +93,20 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             )
         },
         {
-            'state': config.get(CONF_STATE_VALUE_TEMPLATE),
-            'speed': config.get(CONF_SPEED_VALUE_TEMPLATE),
-            'oscillation': config.get(CONF_OSCILLATION_VALUE_TEMPLATE)
+            CONF_STATE: config.get(CONF_STATE_VALUE_TEMPLATE),
+            ATTR_SPEED: config.get(CONF_SPEED_VALUE_TEMPLATE),
+            OSCILLATION: config.get(CONF_OSCILLATION_VALUE_TEMPLATE)
         },
         config[CONF_QOS],
         config[CONF_RETAIN],
         {
-            'on': config[CONF_PAYLOAD_ON],
-            'off': config[CONF_PAYLOAD_OFF],
-            'oscillate_on': config[CONF_PAYLOAD_OSCILLATION_ON],
-            'oscillate_off': config[CONF_PAYLOAD_OSCILLATION_OFF],
-            'low': config[CONF_PAYLOAD_LOW_SPEED],
-            'medium': config[CONF_PAYLOAD_MEDIUM_SPEED],
-            'high': config[CONF_PAYLOAD_HIGH_SPEED],
+            STATE_ON: config[CONF_PAYLOAD_ON],
+            STATE_OFF: config[CONF_PAYLOAD_OFF],
+            OSCILLATE_ON_PAYLOAD: config[CONF_PAYLOAD_OSCILLATION_ON],
+            OSCILLATE_OFF_PAYLOAD: config[CONF_PAYLOAD_OSCILLATION_OFF],
+            SPEED_LOW: config[CONF_PAYLOAD_LOW_SPEED],
+            SPEED_MEDIUM: config[CONF_PAYLOAD_MEDIUM_SPEED],
+            SPEED_HIGH: config[CONF_PAYLOAD_HIGH_SPEED],
         },
         config[CONF_SPEED_LIST],
         config[CONF_OPTIMISTIC],
@@ -121,18 +128,18 @@ class MqttFan(FanEntity):
         self._retain = retain
         self._payload = payload
         self._speed_list = speed_list
-        self._optimistic = optimistic or topic["state_topic"] is None
+        self._optimistic = optimistic or topic[CONF_STATE_TOPIC] is None
         self._optimistic_oscillation = (optimistic or
-                                        topic["oscillation_state_topic"]
+                                        topic[CONF_OSCILLATION_STATE_TOPIC]
                                         is None)
         self._optimistic_speed = (optimistic or
-                                  topic["speed_state_topic"] is None)
+                                  topic[CONF_SPEED_STATE_TOPIC] is None)
         self._state = False
         self._supported_features = 0
-        self._supported_features |= (
-            topic['oscillation_state_topic'] is not None and SUPPORT_OSCILLATE)
-        self._supported_features |= (
-            topic['speed_state_topic'] is not None and SUPPORT_SET_SPEED)
+        self._supported_features |= (topic[CONF_OSCILLATION_STATE_TOPIC]
+                                     is not None and SUPPORT_OSCILLATE)
+        self._supported_features |= (topic[CONF_SPEED_STATE_TOPIC]
+                                     is not None and SUPPORT_SET_SPEED)
 
         templates = {key: ((lambda value: value) if tpl is None else
                            partial(render_with_possible_json_value, hass, tpl))
@@ -140,52 +147,53 @@ class MqttFan(FanEntity):
 
         def state_received(topic, payload, qos):
             """A new MQTT message has been received."""
-            payload = templates['state'](payload)
-            if payload == self._payload["on"]:
+            payload = templates[CONF_STATE](payload)
+            if payload == self._payload[STATE_ON]:
                 self._state = True
-            elif payload == self._payload["off"]:
+            elif payload == self._payload[STATE_OFF]:
                 self._state = False
 
             self.update_ha_state()
 
-        if self._topic["state_topic"] is not None:
-            mqtt.subscribe(self._hass, self._topic["state_topic"],
+        if self._topic[CONF_STATE_TOPIC] is not None:
+            mqtt.subscribe(self._hass, self._topic[CONF_STATE_TOPIC],
                            state_received, self._qos)
 
         def speed_received(topic, payload, qos):
             """A new MQTT message for the speed has been received."""
-            payload = templates['speed'](payload)
-            if payload == self._payload["low"]:
+            payload = templates[ATTR_SPEED](payload)
+            if payload == self._payload[SPEED_LOW]:
                 self._speed = SPEED_LOW
-            elif payload == self._payload["medium"]:
+            elif payload == self._payload[SPEED_MEDIUM]:
                 self._speed = SPEED_MED
-            elif payload == self._payload["high"]:
+            elif payload == self._payload[SPEED_HIGH]:
                 self._speed = SPEED_HIGH
             self.update_ha_state()
 
-        if self._topic["speed_state_topic"] is not None:
-            mqtt.subscribe(self._hass, self._topic["speed_state_topic"],
+        if self._topic[CONF_SPEED_STATE_TOPIC] is not None:
+            mqtt.subscribe(self._hass, self._topic[CONF_SPEED_STATE_TOPIC],
                            speed_received, self._qos)
             self._speed = SPEED_OFF
-        elif self._topic["speed_command_topic"] is not None:
+        elif self._topic[CONF_SPEED_COMMAND_TOPIC] is not None:
             self._speed = SPEED_OFF
         else:
             self._speed = SPEED_OFF
 
         def oscillation_received(topic, payload, qos):
             """A new MQTT message has been received."""
-            payload = templates['oscillation'](payload)
-            if payload == self._payload["oscillate_on"]:
+            payload = templates[OSCILLATION](payload)
+            if payload == self._payload[OSCILLATE_ON_PAYLOAD]:
                 self._oscillation = True
-            elif payload == self._payload["oscillate_off"]:
+            elif payload == self._payload[OSCILLATE_OFF_PAYLOAD]:
                 self._oscillation = False
             self.update_ha_state()
 
-        if self._topic["oscillation_state_topic"] is not None:
-            mqtt.subscribe(self._hass, self._topic["oscillation_state_topic"],
+        if self._topic[CONF_OSCILLATION_STATE_TOPIC] is not None:
+            mqtt.subscribe(self._hass,
+                           self._topic[CONF_OSCILLATION_STATE_TOPIC],
                            oscillation_received, self._qos)
             self._oscillation = False
-        if self._topic["oscillation_command_topic"] is not None:
+        if self._topic[CONF_OSCILLATION_COMMAND_TOPIC] is not None:
             self._oscillation = False
         else:
             self._oscillation = False
@@ -232,36 +240,37 @@ class MqttFan(FanEntity):
 
     def turn_on(self, speed: str=SPEED_MED) -> None:
         """Turn on the entity."""
-        mqtt.publish(self._hass, self._topic["command_topic"],
-                     self._payload["on"], self._qos, self._retain)
+        mqtt.publish(self._hass, self._topic[CONF_COMMAND_TOPIC],
+                     self._payload[STATE_ON], self._qos, self._retain)
         self.set_speed(speed)
 
     def turn_off(self) -> None:
         """Turn off the entity."""
-        mqtt.publish(self._hass, self._topic["command_topic"],
-                     self._payload["off"], self._qos, self._retain)
+        mqtt.publish(self._hass, self._topic[CONF_COMMAND_TOPIC],
+                     self._payload[STATE_OFF], self._qos, self._retain)
 
     def set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
-        if self._topic["speed_command_topic"] is not None:
+        if self._topic[CONF_SPEED_COMMAND_TOPIC] is not None:
             mqtt_payload = SPEED_OFF
             if speed == SPEED_LOW:
-                mqtt_payload = self._payload["low"]
+                mqtt_payload = self._payload[SPEED_LOW]
             elif speed == SPEED_MED:
-                mqtt_payload = self._payload["medium"]
+                mqtt_payload = self._payload[SPEED_MEDIUM]
             elif speed == SPEED_HIGH:
-                mqtt_payload = self._payload["high"]
+                mqtt_payload = self._payload[SPEED_HIGH]
             else:
                 mqtt_payload = speed
             self._speed = speed
-            mqtt.publish(self._hass, self._topic["speed_command_topic"],
+            mqtt.publish(self._hass, self._topic[CONF_SPEED_COMMAND_TOPIC],
                          mqtt_payload, self._qos, self._retain)
             self.update_ha_state()
 
     def oscillate(self, oscillating: bool) -> None:
         """Set oscillation."""
-        if self._topic["speed_command_topic"] is not None:
+        if self._topic[CONF_SPEED_COMMAND_TOPIC] is not None:
             self._oscillation = oscillating
-            mqtt.publish(self._hass, self._topic["oscillation_command_topic"],
+            mqtt.publish(self._hass,
+                         self._topic[CONF_OSCILLATION_COMMAND_TOPIC],
                          self._oscillation, self._qos, self._retain)
             self.update_ha_state()

--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -10,7 +10,7 @@ from functools import partial
 import voluptuous as vol
 
 import homeassistant.components.mqtt as mqtt
-from homeassistant.const import CONF_NAME, CONF_OPTIMISTIC, CONF_VALUE_TEMPLATE
+from homeassistant.const import CONF_NAME, CONF_OPTIMISTIC
 from homeassistant.components.mqtt import (
     CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN)
 import homeassistant.helpers.config_validation as cv
@@ -51,6 +51,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
     vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
 })
+
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
@@ -96,10 +97,8 @@ class MqttFan(FanEntity):
         self._retain = retain
         self._payload = payload
         self._optimistic = optimistic or topic["state_topic"] is None
-        self._optimistic_oscillation = (optimistic or
-                                        topic["oscillation_state_topic"] is None)
-        self._optimistic_speed = (optimistic or
-                                  topic["speed_state_topic"] is None)
+        self._optimistic_oscillation = (optimistic or topic["oscillation_state_topic"] is None)
+        self._optimistic_speed = (optimistic or topic["speed_state_topic"] is None)
         self._state = False
         self._supported_features = 0
         self._supported_features |= (

--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -235,7 +235,7 @@ class MqttFan(FanEntity):
 
     @property
     def oscillating(self):
-        """Return the current speed."""
+        """Return the oscillation state."""
         return self._oscillation
 
     def turn_on(self, speed: str=SPEED_MED) -> None:

--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -1,0 +1,223 @@
+"""
+Support for MQTT fans.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/fan.mqtt/
+"""
+import logging
+from functools import partial
+
+import voluptuous as vol
+
+import homeassistant.components.mqtt as mqtt
+from homeassistant.const import CONF_NAME, CONF_OPTIMISTIC, CONF_VALUE_TEMPLATE
+from homeassistant.components.mqtt import (
+    CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.template import render_with_possible_json_value
+from homeassistant.components.fan import (SPEED_LOW, SPEED_MED, SPEED_HIGH,
+                                          FanEntity, SUPPORT_SET_SPEED,
+                                          SUPPORT_OSCILLATE, SPEED_OFF)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['mqtt']
+
+CONF_STATE_VALUE_TEMPLATE = 'state_value_template'
+CONF_SPEED_STATE_TOPIC = 'speed_state_topic'
+CONF_SPEED_COMMAND_TOPIC = 'speed_command_topic'
+CONF_SPEED_VALUE_TEMPLATE = 'speed_value_template'
+CONF_OSCILLATION_STATE_TOPIC = 'oscillation_state_topic'
+CONF_OSCILLATION_COMMAND_TOPIC = 'oscillation_command_topic'
+CONF_OSCILLATION_VALUE_TEMPLATE = 'oscillation_value_template'
+CONF_PAYLOAD_ON = 'payload_on'
+CONF_PAYLOAD_OFF = 'payload_off'
+
+DEFAULT_NAME = 'MQTT Fan'
+DEFAULT_PAYLOAD_ON = 'ON'
+DEFAULT_PAYLOAD_OFF = 'OFF'
+DEFAULT_OPTIMISTIC = False
+
+PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_STATE_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_SPEED_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_SPEED_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_SPEED_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_OSCILLATION_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_OSCILLATION_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_OSCILLATION_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
+    vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
+    vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
+})
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Setup MQTT fan platform."""
+    add_devices_callback([MqttFan(
+        hass,
+        config[CONF_NAME],
+        {
+            key: config.get(key) for key in (
+                CONF_STATE_TOPIC,
+                CONF_COMMAND_TOPIC,
+                CONF_SPEED_STATE_TOPIC,
+                CONF_SPEED_COMMAND_TOPIC,
+                CONF_OSCILLATION_STATE_TOPIC,
+                CONF_OSCILLATION_COMMAND_TOPIC,
+            )
+        },
+        {
+            'state': config.get(CONF_STATE_VALUE_TEMPLATE),
+            'speed': config.get(CONF_SPEED_VALUE_TEMPLATE),
+            'oscillation': config.get(CONF_OSCILLATION_VALUE_TEMPLATE)
+        },
+        config[CONF_QOS],
+        config[CONF_RETAIN],
+        {
+            'on': config[CONF_PAYLOAD_ON],
+            'off': config[CONF_PAYLOAD_OFF],
+        },
+        config[CONF_OPTIMISTIC],
+    )])
+
+
+class MqttFan(FanEntity):
+    """A MQTT fan component."""
+
+    def __init__(self, hass, name, topic, templates, qos, retain, payload,
+                 optimistic):
+        """Initialize MQTT fan."""
+        self._hass = hass
+        self._name = name
+        self._topic = topic
+        self._qos = qos
+        self._retain = retain
+        self._payload = payload
+        self._optimistic = optimistic or topic["state_topic"] is None
+        self._optimistic_oscillation = (optimistic or
+                                        topic["oscillation_state_topic"] is None)
+        self._optimistic_speed = (optimistic or
+                                  topic["speed_state_topic"] is None)
+        self._state = False
+        self._supported_features = 0
+        self._supported_features |= (
+            topic['oscillation_state_topic'] is not None and SUPPORT_OSCILLATE)
+        self._supported_features |= (
+            topic['speed_state_topic'] is not None and SUPPORT_SET_SPEED)
+
+        templates = {key: ((lambda value: value) if tpl is None else
+                           partial(render_with_possible_json_value, hass, tpl))
+                     for key, tpl in templates.items()}
+
+        def state_received(topic, payload, qos):
+            """A new MQTT message has been received."""
+            payload = templates['state'](payload)
+            if payload == self._payload["on"]:
+                self._state = True
+            elif payload == self._payload["off"]:
+                self._state = False
+
+            self.update_ha_state()
+
+        if self._topic["state_topic"] is not None:
+            mqtt.subscribe(self._hass, self._topic["state_topic"],
+                           state_received, self._qos)
+
+        def speed_received(topic, payload, qos):
+            """A new MQTT message for the speed has been received."""
+            self._speed = templates['speed'](payload)
+            self.update_ha_state()
+
+        if self._topic["speed_state_topic"] is not None:
+            mqtt.subscribe(self._hass, self._topic["speed_state_topic"],
+                           speed_received, self._qos)
+            self._speed = SPEED_OFF
+        elif self._topic["speed_command_topic"] is not None:
+            self._speed = SPEED_OFF
+        else:
+            self._speed = SPEED_OFF
+
+        def oscillation_received(topic, payload, qos):
+            """A new MQTT message has been received."""
+            self._oscillation = bool(templates['oscillation'](payload))
+            self.update_ha_state()
+
+        if self._topic["oscillation_state_topic"] is not None:
+            mqtt.subscribe(self._hass, self._topic["oscillation_state_topic"],
+                           oscillation_received, self._qos)
+            self._oscillation = False
+        if self._topic["oscillation_command_topic"] is not None:
+            self._oscillation = False
+        else:
+            self._oscillation = False
+
+    @property
+    def should_poll(self):
+        """No polling needed for a MQTT fan."""
+        return False
+
+    @property
+    def assumed_state(self):
+        """Return true if we do optimistic updates."""
+        return self._optimistic
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    @property
+    def name(self) -> str:
+        """Get entity name."""
+        return self._name
+
+    @property
+    def speed_list(self) -> list:
+        """Get the list of available speeds."""
+        return [SPEED_OFF, SPEED_LOW, SPEED_MED, SPEED_HIGH]
+
+    def turn_on(self, brightness: str, speed: str=SPEED_MED) -> None:
+        """Turn on the entity."""
+        mqtt.publish(self._hass, self._topic["command_topic"],
+                     self._payload["on"], self._qos, self._retain)
+        if brightness is not None:
+            self.set_speed(self.map_brightness_to_speed(int(brightness)))
+        else:
+            self.set_speed(speed)
+
+    def turn_off(self) -> None:
+        """Turn off the entity."""
+        mqtt.publish(self._hass, self._topic["command_topic"],
+                     self._payload["off"], self._qos, self._retain)
+
+    def set_speed(self, speed: str) -> None:
+        """Set the speed of the fan."""
+        if self._topic["speed_command_topic"] is not None:
+            self._speed = speed
+            mqtt.publish(self._hass, self._topic["speed_command_topic"],
+                         self._speed, self._qos, self._retain)
+            self.update_ha_state()
+
+    def oscillate(self, oscillating: bool) -> None:
+        """Set oscillation."""
+        if self._topic["speed_command_topic"] is not None:
+            self._oscillation = oscillating
+            mqtt.publish(self._hass, self._topic["oscillation_command_topic"],
+                         self._oscillation, self._qos, self._retain)
+            self.update_ha_state()
+
+    def map_brightness_to_speed(self, brightness: int):
+        """Map a 0-255 brightness value to speed."""
+        if brightness > 0 and brightness < 85:
+            return SPEED_LOW
+        elif brightness > 85 and brightness < 170:
+            return SPEED_MED
+        elif brightness > 170 and brightness < 255:
+            return SPEED_HIGH
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        return self._supported_features


### PR DESCRIPTION
**Description:** Adds an MQTT platform for the fan component

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
fan:
- platform: mqtt
  name: "Robbie's Fan"
  state_topic: "robbies_ac/on/state"
  command_topic: "robbies_ac/on/set"
  oscillation_state_topic: "robbies_ac/oscillation/state"
  oscillation_command_topic: "robbies_ac/oscillation/set"
  speed_state_topic: "robbies_ac/speed/state"
  speed_command_topic: "robbies_ac/speed/set"
  qos: 0
  payload_on: "true"
  payload_off: "false"
  payload_oscillation_on: "true"
  payload_oscillation_off: "false"
  payload_low_speed: "low"
  payload_medium_speed: "medium"
  payload_high_speed: "high"
  speeds:
    - low
    - medium
    - high
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
