### PR TITLE
Climate and cover bugfix

### DIFF
--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -12,7 +12,6 @@ from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.zwave import (
     ATTR_NODE_ID, ATTR_VALUE_ID, ZWaveDeviceEntity)
 from homeassistant.components import zwave
-from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -155,7 +155,6 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
                 if SET_TEMP_TO_INDEX.get(self._current_operation) \
                    != value.index:
                     continue
-                self._unit = value.units
                 if self._zxt_120:
                     continue
             self._target_temperature = int(value.data)
@@ -188,13 +187,7 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        unit = self._unit
-        if unit == 'C':
-            return TEMP_CELSIUS
-        elif unit == 'F':
-            return TEMP_FAHRENHEIT
-        else:
-            return self._unit
+        return self._unit
 
     @property
     def current_temperature(self):

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -61,6 +61,7 @@ SERVICE_TO_METHOD = {
     SERVICE_STOP_COVER: {'method': 'stop_cover'},
     SERVICE_OPEN_COVER_TILT: {'method': 'open_cover_tilt'},
     SERVICE_CLOSE_COVER_TILT: {'method': 'close_cover_tilt'},
+    SERVICE_STOP_COVER_TILT: {'method': 'stop_cover_tilt'},
     SERVICE_SET_COVER_TILT_POSITION: {
         'method': 'set_cover_tilt_position',
         'schema': COVER_SET_COVER_TILT_POSITION_SCHEMA},

--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -96,10 +96,10 @@ class MqttCover(CoverDevice):
                 payload = template.render_with_possible_json_value(
                     hass, value_template, payload)
             if payload == self._state_open:
-                self._state = False
+                self._state = True
                 self.update_ha_state()
             elif payload == self._state_closed:
-                self._state = True
+                self._state = False
                 self.update_ha_state()
             elif payload.isnumeric() and 0 <= int(payload) <= 100:
                 self._state = int(payload)

--- a/homeassistant/components/cover/zwave.py
+++ b/homeassistant/components/cover/zwave.py
@@ -97,7 +97,7 @@ class ZwaveRollershutter(zwave.ZWaveDeviceEntity, CoverDevice):
     def is_closed(self):
         """Return if the cover is closed."""
         if self.current_cover_position is None:
-            return
+            return None
         if self.current_cover_position > 0:
             return False
         else:

--- a/homeassistant/components/cover/zwave.py
+++ b/homeassistant/components/cover/zwave.py
@@ -96,6 +96,8 @@ class ZwaveRollershutter(zwave.ZWaveDeviceEntity, CoverDevice):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
+        if self.current_cover_position is None:
+            return
         if self.current_cover_position > 0:
             return False
         else:

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -244,7 +244,7 @@ SERVICE_OPEN_COVER = 'open_cover'
 SERVICE_OPEN_COVER_TILT = 'open_cover_tilt'
 SERVICE_SET_COVER_POSITION = 'set_cover_position'
 SERVICE_SET_COVER_TILT_POSITION = 'set_cover_tilt_position'
-SERVICE_STOP_COVER = 'stop'
+SERVICE_STOP_COVER = 'stop_cover'
 SERVICE_STOP_COVER_TILT = 'stop_cover_tilt'
 
 SERVICE_MOVE_UP = 'move_up'


### PR DESCRIPTION
**Description:**
Zwave Cover: Avoid comparing None in is_closed function.
mqtt cover: payload states was inverted, and never triggering a state change.
Cover: Wrong service name was defined for stop_cover, and missing service in service_to_methods
Zwave Climate: Fetch unit_of_measurement from config instead of device. Fetching from device only made conflicts and unwanted conversions.

**Related issue (if applicable):** fixes #
#3093
#3090
#3052
