### PR TITLE
Allow None MAC to be loaded from known_devices

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -388,7 +388,8 @@ def load_config(path: str, hass: HomeAssistantType, consider_home: timedelta):
     try:
         return [
             Device(hass, consider_home, device.get('track', False),
-                   str(dev_id).lower(), str(device.get('mac')).upper(),
+                   str(dev_id).lower(), None if device.get('mac') is None
+                   else str(device.get('mac')).upper(),
                    device.get('name'), device.get('picture'),
                    device.get('gravatar'),
                    device.get(CONF_AWAY_HIDE, DEFAULT_AWAY_HIDE))


### PR DESCRIPTION
**Description:**
Warnings for duplicates introduced in #2908 shows that while loading `known_devices.yaml`, devices with no MAC addresses are loaded with a MAC of "NONE" 

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
