### PR TITLE
Use warning instead of error (sensor.bitcoin)

### DIFF
--- a/homeassistant/components/sensor/bitcoin.py
+++ b/homeassistant/components/sensor/bitcoin.py
@@ -17,6 +17,16 @@ from homeassistant.util import Throttle
 
 REQUIREMENTS = ['blockchain==1.3.3']
 
+_LOGGER = logging.getLogger(__name__)
+
+CONF_CURRENCY = 'currency'
+
+DEFAULT_CURRENCY = 'USD'
+
+ICON = 'mdi:currency-btc'
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
+
 OPTION_TYPES = {
     'exchangerate': ['Exchange rate (1 BTC)', None],
     'trade_volume_btc': ['Trade volume', 'BTC'],
@@ -41,19 +51,11 @@ OPTION_TYPES = {
     'market_price_usd': ['Market price', 'USD']
 }
 
-ICON = 'mdi:currency-btc'
-CONF_CURRENCY = 'currency'
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DISPLAY_OPTIONS, default=[]):
-        [vol.In(OPTION_TYPES)],
-    vol.Optional(CONF_CURRENCY, default='USD'): cv.string,
+        vol.All(cv.ensure_list, [vol.In(OPTION_TYPES)]),
+    vol.Optional(CONF_CURRENCY, default=DEFAULT_CURRENCY): cv.string,
 })
-
-_LOGGER = logging.getLogger(__name__)
-
-# Return cached results if last scan was less then this time ago.
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -63,8 +65,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     currency = config.get(CONF_CURRENCY)
 
     if currency not in exchangerates.get_ticker():
-        _LOGGER.error('Currency "%s" is not available. Using "USD"', currency)
-        currency = 'USD'
+        _LOGGER.warning('Currency "%s" is not available. Using "USD"',
+                        currency)
+        currency = DEFAULT_CURRENCY
 
     data = BitcoinData()
     dev = []


### PR DESCRIPTION
**Description:**
Display a warning instead of an error when the given currency is not found in the output.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: bitcoin
  currency: CHF
  display_options:
    - exchangerate
    - trade_volume_btc
    - miners_revenue_usd
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
