### PR TITLE
Use voluptuous for Foursquare

### DIFF
--- a/homeassistant/components/foursquare.py
+++ b/homeassistant/components/foursquare.py
@@ -7,42 +7,51 @@ https://home-assistant.io/components/foursquare/
 import logging
 import os
 import json
-import requests
 
+import requests
 import voluptuous as vol
 
+from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.config import load_yaml_config_file
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.http import HomeAssistantView
 
-DOMAIN = "foursquare"
-
-SERVICE_CHECKIN = "checkin"
-
-EVENT_PUSH = "foursquare.push"
-EVENT_CHECKIN = "foursquare.checkin"
-
-CHECKIN_SERVICE_SCHEMA = vol.Schema({
-    vol.Required("venueId"): cv.string,
-    vol.Optional("eventId"): cv.string,
-    vol.Optional("shout"): cv.string,
-    vol.Optional("mentions"): cv.string,
-    vol.Optional("broadcast"): cv.string,
-    vol.Optional("ll"): cv.string,
-    vol.Optional("llAcc"): cv.string,
-    vol.Optional("alt"): cv.string,
-    vol.Optional("altAcc"): cv.string,
-})
-
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ["http"]
+CONF_PUSH_SECRET = 'push_secret'
+
+DEPENDENCIES = ['http']
+DOMAIN = 'foursquare'
+
+EVENT_CHECKIN = 'foursquare.checkin'
+EVENT_PUSH = 'foursquare.push'
+
+SERVICE_CHECKIN = 'checkin'
+
+CHECKIN_SERVICE_SCHEMA = vol.Schema({
+    vol.Optional('alt'): cv.string,
+    vol.Optional('altAcc'): cv.string,
+    vol.Optional('broadcast'): cv.string,
+    vol.Optional('eventId'): cv.string,
+    vol.Optional('ll'): cv.string,
+    vol.Optional('llAcc'): cv.string,
+    vol.Optional('mentions'): cv.string,
+    vol.Optional('shout'): cv.string,
+    vol.Required('venueId'): cv.string,
+})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_ACCESS_TOKEN): cv.string,
+        vol.Required(CONF_PUSH_SECRET): cv.string,
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
     """Setup the Foursquare component."""
     descriptions = load_yaml_config_file(
-        os.path.join(os.path.dirname(__file__), "services.yaml"))
+        os.path.join(os.path.dirname(__file__), 'services.yaml'))
 
     config = config[DOMAIN]
 
@@ -51,7 +60,7 @@ def setup(hass, config):
         url = ("https://api.foursquare.com/v2/checkins/add"
                "?oauth_token={}"
                "&v=20160802"
-               "&m=swarm").format(config["access_token"])
+               "&m=swarm").format(config[CONF_ACCESS_TOKEN])
         response = requests.post(url, data=call.data, timeout=10)
 
         if response.status_code not in (200, 201):
@@ -62,12 +71,12 @@ def setup(hass, config):
         hass.bus.fire(EVENT_CHECKIN, response.text)
 
     # Register our service with Home Assistant.
-    hass.services.register(DOMAIN, "checkin", checkin_user,
+    hass.services.register(DOMAIN, 'checkin', checkin_user,
                            descriptions[DOMAIN][SERVICE_CHECKIN],
                            schema=CHECKIN_SERVICE_SCHEMA)
 
-    hass.wsgi.register_view(FoursquarePushReceiver(hass,
-                                                   config["push_secret"]))
+    hass.wsgi.register_view(FoursquarePushReceiver(
+        hass, config[CONF_PUSH_SECRET]))
 
     return True
 


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
foursquare:
  access_token: foursquare access token
  push_secret: foursquare push secret
```

@robbiet480, would be nice if you could take a look at the changes and run a quick test. Thanks.
