### PR TITLE
Fix typo in http

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -24,21 +24,21 @@ from homeassistant.core import split_entity_id
 import homeassistant.util.dt as dt_util
 import homeassistant.helpers.config_validation as cv
 
-DOMAIN = "http"
-REQUIREMENTS = ("cherrypy==7.1.0", "static3==0.7.0", "Werkzeug==0.11.10")
+DOMAIN = 'http'
+REQUIREMENTS = ('cherrypy==7.1.0', 'static3==0.7.0', 'Werkzeug==0.11.10')
 
-CONF_API_PASSWORD = "api_password"
-CONF_SERVER_HOST = "server_host"
-CONF_SERVER_PORT = "server_port"
-CONF_DEVELOPMENT = "development"
+CONF_API_PASSWORD = 'api_password'
+CONF_SERVER_HOST = 'server_host'
+CONF_SERVER_PORT = 'server_port'
+CONF_DEVELOPMENT = 'development'
 CONF_SSL_CERTIFICATE = 'ssl_certificate'
 CONF_SSL_KEY = 'ssl_key'
 CONF_CORS_ORIGINS = 'cors_allowed_origins'
 
 DATA_API_PASSWORD = 'api_password'
 
-# TLS configuation follows the best-practice guidelines
-# specified here: https://wiki.mozilla.org/Security/Server_Side_TLS
+# TLS configuation follows the best-practice guidelines specified here:
+# https://wiki.mozilla.org/Security/Server_Side_TLS
 # Intermediate guidelines are followed.
 SSL_VERSION = ssl.PROTOCOL_SSLv23
 SSL_OPTS = ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3
@@ -478,7 +478,7 @@ class HomeAssistantView(object):
             authenticated = True
 
         if self.requires_auth and not authenticated:
-            _LOGGER.warning('Login attempt or request with an invalid'
+            _LOGGER.warning('Login attempt or request with an invalid '
                             'password from %s', request.remote_addr)
             raise Unauthorized()
 


### PR DESCRIPTION
**Description:**
Missing space in the error message lead to a typo in the output.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
http:
  api_password: YOUR_PASSWORD
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
