### PR TITLE
Update voluptuous for nest

### DIFF
--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -6,12 +6,12 @@ https://home-assistant.io/components/binary_sensor.nest/
 """
 import voluptuous as vol
 
-import homeassistant.components.nest as nest
-from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
 from homeassistant.components.sensor.nest import NestSensor
-from homeassistant.const import (
-    CONF_PLATFORM, CONF_SCAN_INTERVAL, CONF_MONITORED_CONDITIONS
-)
+from homeassistant.const import (CONF_SCAN_INTERVAL, CONF_MONITORED_CONDITIONS)
+import homeassistant.components.nest as nest
+import homeassistant.helpers.config_validation as cv
 
 DEPENDENCIES = ['nest']
 BINARY_TYPES = ['fan',
@@ -25,11 +25,11 @@ BINARY_TYPES = ['fan',
                 'hvac_emer_heat_state',
                 'online']
 
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_PLATFORM): nest.DOMAIN,
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SCAN_INTERVAL):
         vol.All(vol.Coerce(int), vol.Range(min=1)),
-    vol.Required(CONF_MONITORED_CONDITIONS): [vol.In(BINARY_TYPES)],
+    vol.Required(CONF_MONITORED_CONDITIONS):
+        vol.All(cv.ensure_list, [vol.In(BINARY_TYPES)]),
 })
 
 

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -8,13 +8,12 @@ import voluptuous as vol
 
 import homeassistant.components.nest as nest
 from homeassistant.components.climate import (
-    STATE_COOL, STATE_HEAT, STATE_IDLE, ClimateDevice)
-from homeassistant.const import TEMP_CELSIUS, CONF_PLATFORM, CONF_SCAN_INTERVAL
+    STATE_COOL, STATE_HEAT, STATE_IDLE, ClimateDevice, PLATFORM_SCHEMA)
+from homeassistant.const import TEMP_CELSIUS, CONF_SCAN_INTERVAL
 
 DEPENDENCIES = ['nest']
 
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_PLATFORM): nest.DOMAIN,
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SCAN_INTERVAL):
         vol.All(vol.Coerce(int), vol.Range(min=1)),
 })

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -1,18 +1,21 @@
 """
-Support for Nest thermostats and protect smoke alarms.
+Support for Nest devices.
 
-For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/climate.nest/
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/nest/
 """
 import logging
 import socket
 
 import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_STRUCTURE
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (CONF_PASSWORD, CONF_USERNAME, CONF_STRUCTURE)
+
+_LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = ['python-nest==2.9.2']
+
 DOMAIN = 'nest'
 
 NEST = None
@@ -21,13 +24,11 @@ STRUCTURES_TO_INCLUDE = None
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_USERNAME): str,
-        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_STRUCTURE): vol.All(cv.ensure_list, cv.string)
     })
 }, extra=vol.ALLOW_EXTRA)
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def devices():


### PR DESCRIPTION
**Description:**
Update configuration check (extend platform)

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
