### PR TITLE
Use voluptuous for Octoprint

### DIFF
--- a/homeassistant/components/binary_sensor/octoprint.py
+++ b/homeassistant/components/binary_sensor/octoprint.py
@@ -9,8 +9,10 @@ import logging
 import requests
 import voluptuous as vol
 
-from homeassistant.const import CONF_NAME, STATE_ON, STATE_OFF, CONF_MONITORED_CONDITIONS
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_NAME, STATE_ON, STATE_OFF, CONF_MONITORED_CONDITIONS)
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
 from homeassistant.loader import get_component
 import homeassistant.helpers.config_validation as cv
 
@@ -32,6 +34,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
+
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/binary_sensor/octoprint.py
+++ b/homeassistant/components/binary_sensor/octoprint.py
@@ -5,45 +5,53 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.octoprint/
 """
 import logging
+
 import requests
+import voluptuous as vol
 
-from homeassistant.const import CONF_NAME, STATE_ON, STATE_OFF
-from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.const import CONF_NAME, STATE_ON, STATE_OFF, CONF_MONITORED_CONDITIONS
+from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
 from homeassistant.loader import get_component
+import homeassistant.helpers.config_validation as cv
 
-DEPENDENCIES = ["octoprint"]
-
-SENSOR_TYPES = {
-    # API Endpoint, Group, Key, unit
-    "Printing": ["printer", "state", "printing", None],
-    "Printing Error": ["printer", "state", "error", None]
-}
 
 _LOGGER = logging.getLogger(__name__)
 
+DEPENDENCIES = ['octoprint']
+
+DEFAULT_NAME = 'OctoPrint'
+
+SENSOR_TYPES = {
+    # API Endpoint, Group, Key, unit
+    'Printing': ['printer', 'state', 'printing', None],
+    'Printing Error': ['printer', 'state', 'error', None]
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=SENSOR_TYPES):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the available OctoPrint binary sensors."""
     octoprint = get_component('octoprint')
-    name = config.get(CONF_NAME, "OctoPrint")
-    monitored_conditions = config.get("monitored_conditions",
+    name = config.get(CONF_NAME)
+    monitored_conditions = config.get(CONF_MONITORED_CONDITIONS,
                                       SENSOR_TYPES.keys())
 
     devices = []
     for octo_type in monitored_conditions:
-        if octo_type in SENSOR_TYPES:
-            new_sensor = OctoPrintBinarySensor(octoprint.OCTOPRINT,
-                                               octo_type,
-                                               SENSOR_TYPES[octo_type][2],
-                                               name,
-                                               SENSOR_TYPES[octo_type][3],
-                                               SENSOR_TYPES[octo_type][0],
-                                               SENSOR_TYPES[octo_type][1],
-                                               "flags")
-            devices.append(new_sensor)
-        else:
-            _LOGGER.error("Unknown OctoPrint sensor type: %s", octo_type)
+        new_sensor = OctoPrintBinarySensor(octoprint.OCTOPRINT,
+                                           octo_type,
+                                           SENSOR_TYPES[octo_type][2],
+                                           name,
+                                           SENSOR_TYPES[octo_type][3],
+                                           SENSOR_TYPES[octo_type][0],
+                                           SENSOR_TYPES[octo_type][1],
+                                           'flags')
+        devices.append(new_sensor)
     add_devices(devices)
 
 
@@ -52,14 +60,14 @@ class OctoPrintBinarySensor(BinarySensorDevice):
     """Representation an OctoPrint binary sensor."""
 
     # pylint: disable=too-many-arguments
-    def __init__(self, api, condition, sensor_type, sensor_name,
-                 unit, endpoint, group, tool=None):
+    def __init__(self, api, condition, sensor_type, sensor_name, unit,
+                 endpoint, group, tool=None):
         """Initialize a new OctoPrint sensor."""
         self.sensor_name = sensor_name
         if tool is None:
-            self._name = sensor_name + ' ' + condition
+            self._name = '{} {}'.format(sensor_name, condition)
         else:
-            self._name = sensor_name + ' ' + condition
+            self._name = '{} {}'.format(sensor_name, condition)
         self.sensor_type = sensor_type
         self.api = api
         self._state = False

--- a/homeassistant/components/octoprint.py
+++ b/homeassistant/components/octoprint.py
@@ -5,37 +5,41 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/octoprint/
 """
 import logging
-
 import time
+
 import requests
+import voluptuous as vol
 
-from homeassistant.const import CONF_API_KEY, CONF_HOST
-from homeassistant.helpers import validate_config, discovery
-
-DOMAIN = "octoprint"
-OCTOPRINT = None
+from homeassistant.const import CONF_API_KEY, CONF_HOST, CONTENT_TYPE_JSON
+from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-DISCOVER_SENSORS = 'octoprint.sensors'
 DISCOVER_BINARY_SENSORS = 'octoprint.binary_sensor'
+DISCOVER_SENSORS = 'octoprint.sensors'
+DOMAIN = 'octoprint'
+
+OCTOPRINT = None
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_API_KEY): cv.string,
+        vol.Required(CONF_HOST): cv.string,
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
     """Set up OctoPrint API."""
-    if not validate_config(config, {DOMAIN: [CONF_API_KEY],
-                                    DOMAIN: [CONF_HOST]},
-                           _LOGGER):
-        return False
-
-    base_url = config[DOMAIN][CONF_HOST] + "/api/"
+    base_url = 'http://{}/api/'.format(config[DOMAIN][CONF_HOST])
     api_key = config[DOMAIN][CONF_API_KEY]
 
     global OCTOPRINT
     try:
         OCTOPRINT = OctoPrintAPI(base_url, api_key)
-        OCTOPRINT.get("printer")
-        OCTOPRINT.get("job")
+        OCTOPRINT.get('printer')
+        OCTOPRINT.get('job')
     except requests.exceptions.RequestException as conn_err:
         _LOGGER.error("Error setting up OctoPrint API: %r", conn_err)
         return False
@@ -55,7 +59,7 @@ class OctoPrintAPI(object):
     def __init__(self, api_url, key):
         """Initialize OctoPrint API and set headers needed later."""
         self.api_url = api_url
-        self.headers = {'content-type': 'application/json',
+        self.headers = {'content-type': CONTENT_TYPE_JSON,
                         'X-Api-Key': key}
         self.printer_last_reading = [{}, None]
         self.job_last_reading = [{}, None]

--- a/homeassistant/components/sensor/octoprint.py
+++ b/homeassistant/components/sensor/octoprint.py
@@ -5,31 +5,44 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.octoprint/
 """
 import logging
-import requests
 
-from homeassistant.const import TEMP_CELSIUS, CONF_NAME
+import requests
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    TEMP_CELSIUS, CONF_NAME, CONF_MONITORED_CONDITIONS)
 from homeassistant.helpers.entity import Entity
 from homeassistant.loader import get_component
+import homeassistant.helpers.config_validation as cv
 
-DEPENDENCIES = ["octoprint"]
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['octoprint']
+
+DEFAULT_NAME = 'OctoPrint'
 
 SENSOR_TYPES = {
     # API Endpoint, Group, Key, unit
-    "Temperatures": ["printer", "temperature", "*", TEMP_CELSIUS],
-    "Current State": ["printer", "state", "text", None],
-    "Job Percentage": ["job", "progress", "completion", "%"],
+    'Temperatures': ['printer', 'temperature', '*', TEMP_CELSIUS],
+    'Current State': ['printer', 'state', 'text', None],
+    'Job Percentage': ['job', 'progress', 'completion', '%'],
 }
 
-_LOGGER = logging.getLogger(__name__)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=SENSOR_TYPES):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
 
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the available OctoPrint sensors."""
     octoprint = get_component('octoprint')
-    name = config.get(CONF_NAME, "OctoPrint")
-    monitored_conditions = config.get("monitored_conditions",
-                                      SENSOR_TYPES.keys())
+    name = config.get(CONF_NAME)
+    monitored_conditions = config.get(CONF_MONITORED_CONDITIONS)
 
     devices = []
     types = ["actual", "target"]
@@ -46,19 +59,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                                  SENSOR_TYPES[octo_type][1],
                                                  tool)
                     devices.append(new_sensor)
-        elif octo_type in SENSOR_TYPES:
-            new_sensor = OctoPrintSensor(octoprint.OCTOPRINT,
-                                         octo_type,
-                                         SENSOR_TYPES[octo_type][2],
-                                         name,
-                                         SENSOR_TYPES[octo_type][3],
-                                         SENSOR_TYPES[octo_type][0],
-                                         SENSOR_TYPES[octo_type][1])
-            devices.append(new_sensor)
         else:
             _LOGGER.error("Unknown OctoPrint sensor type: %s", octo_type)
 
-        add_devices(devices)
+        new_sensor = OctoPrintSensor(octoprint.OCTOPRINT,
+                                     octo_type,
+                                     SENSOR_TYPES[octo_type][2],
+                                     name,
+                                     SENSOR_TYPES[octo_type][3],
+                                     SENSOR_TYPES[octo_type][0],
+                                     SENSOR_TYPES[octo_type][1])
+        devices.append(new_sensor)
+
+    add_devices(devices)
 
 
 # pylint: disable=too-many-instance-attributes
@@ -66,14 +79,15 @@ class OctoPrintSensor(Entity):
     """Representation of an OctoPrint sensor."""
 
     # pylint: disable=too-many-arguments
-    def __init__(self, api, condition, sensor_type, sensor_name,
-                 unit, endpoint, group, tool=None):
+    def __init__(self, api, condition, sensor_type, sensor_name, unit,
+                 endpoint, group, tool=None):
         """Initialize a new OctoPrint sensor."""
         self.sensor_name = sensor_name
         if tool is None:
-            self._name = sensor_name + ' ' + condition
+            self._name = '{} {}'.format(sensor_name, condition)
         else:
-            self._name = sensor_name + ' ' + condition + ' ' + tool + ' temp'
+            self._name = '{} {} {} {}'.format(
+                sensor_name, condition, tool, ' temp')
         self.sensor_type = sensor_type
         self.api = api
         self._state = None


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
octoprint:
  host: YOUR_OCTOPRINT_HOST
  api_key: YOUR_API_KEY

binary_sensor:
  platform: octoprint
  monitored_conditions:
    - Printing
    - Printing Error
```

@w1ll1am23, would be nice if you could take a look at the changes and run a quick test. Thanks.
