### PR TITLE
fix play/pause delay in gpmdp

### DIFF
--- a/homeassistant/components/media_player/gpmdp.py
+++ b/homeassistant/components/media_player/gpmdp.py
@@ -8,6 +8,7 @@ import logging
 import json
 import os
 import socket
+import time
 
 from homeassistant.components.media_player import (
     MEDIA_TYPE_MUSIC, SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK,
@@ -214,6 +215,7 @@ class GPMDP(MediaPlayerDevice):
 
     def update(self):
         """Get the latest details from the player."""
+        time.sleep(1)
         playstate = self.send_gpmdp_msg('playback', 'getPlaybackState')
         if playstate is None:
             return


### PR DESCRIPTION
**Description:**
gpmdp used to be slow to update in the frontend when you pushed play/pause.  Previously it seemed to poll the application for play state before it was actually playing.  This little wait time fixes it and every appears instant in the frontend.
