### PR TITLE
Fixed Homematic cover

### DIFF
--- a/homeassistant/components/cover/homematic.py
+++ b/homeassistant/components/cover/homematic.py
@@ -11,7 +11,7 @@ properly configured.
 import logging
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.components.cover import CoverDevice,\
-    ATTR_CURRENT_POSITION
+    ATTR_POSITION
 import homeassistant.components.homematic as homematic
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,16 +41,16 @@ class HMCover(homematic.HMDevice, CoverDevice):
         None is unknown, 0 is closed, 100 is fully open.
         """
         if self.available:
-            return int((1 - self._hm_get_state()) * 100)
+            return int(self._hm_get_state() * 100)
         return None
 
     def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         if self.available:
-            if ATTR_CURRENT_POSITION in kwargs:
-                position = float(kwargs[ATTR_CURRENT_POSITION])
+            if ATTR_POSITION in kwargs:
+                position = float(kwargs[ATTR_POSITION])
                 position = min(100, max(0, position))
-                level = (100 - position) / 100.0
+                level = position / 100.0
                 self._hmdevice.set_level(level, self._channel)
 
     @property


### PR DESCRIPTION
**Description:**
The Homematic cover had an inverted open/closed state. Besides that, moving to a position did not work. This PR fixes that.
Stopping the cover is fixed with #3097
