### PR TITLE
Use voluptuous for weblink

### DIFF
--- a/homeassistant/components/weblink.py
+++ b/homeassistant/components/weblink.py
@@ -6,30 +6,39 @@ https://home-assistant.io/components/weblink/
 """
 import logging
 
+import voluptuous as vol
+
+from homeassistant.const import (CONF_NAME, CONF_ICON, CONF_URL)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
-
-DOMAIN = "weblink"
-DEPENDENCIES = []
-
-ATTR_NAME = 'name'
-ATTR_URL = 'url'
-ATTR_ICON = 'icon'
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
+
+CONF_ENTITIES = 'entities'
+
+DOMAIN = 'weblink'
+
+ENTITIES_SCHEMA = vol.Schema({
+    vol.Required(CONF_URL): cv.url,
+    vol.Required(CONF_NAME): cv.string,
+    vol.Optional(CONF_ICON): cv.icon,
+})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_ENTITIES): [ENTITIES_SCHEMA],
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
     """Setup weblink component."""
     links = config.get(DOMAIN)
 
-    for link in links.get('entities'):
-        if ATTR_NAME not in link or ATTR_URL not in link:
-            _LOGGER.error("You need to set both %s and %s to add a %s",
-                          ATTR_NAME, ATTR_URL, DOMAIN)
-            continue
-        Link(hass, link.get(ATTR_NAME), link.get(ATTR_URL),
-             link.get(ATTR_ICON))
+    for link in links.get(CONF_ENTITIES):
+        Link(hass, link.get(CONF_NAME), link.get(CONF_URL),
+             link.get(CONF_URL))
 
     return True
 

--- a/tests/components/test_weblink.py
+++ b/tests/components/test_weblink.py
@@ -2,6 +2,7 @@
 import unittest
 
 from homeassistant.components import weblink
+from homeassistant import bootstrap
 
 from tests.common import get_test_home_assistant
 
@@ -17,16 +18,23 @@ class TestComponentWeblink(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
+    def test_bad_config(self):
+        """Test if new entity is created."""
+        self.assertFalse(bootstrap.setup_component(self.hass, 'weblink', {
+            'weblink': {
+                'entities': [{}],
+            }
+        }))
+
     def test_entities_get_created(self):
         """Test if new entity is created."""
         self.assertTrue(weblink.setup(self.hass, {
             weblink.DOMAIN: {
                 'entities': [
                     {
-                        weblink.ATTR_NAME: 'My router',
-                        weblink.ATTR_URL: 'http://127.0.0.1/'
+                        weblink.CONF_NAME: 'My router',
+                        weblink.CONF_URL: 'http://127.0.0.1/'
                     },
-                    {}
                 ]
             }
         }))


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
weblink:
  entities:
    - name: Router
      url: http://192.168.1.1/
      icon: mdi:router-wireless
    - name: Home Assistant
      url: https://home-assistant.io
```
