### PR TITLE
Use constants and update configuration check for REST binary sensor/sensor

### DIFF
--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -13,12 +13,15 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.components.sensor.rest import RestData
 from homeassistant.const import (
     CONF_PAYLOAD, CONF_NAME, CONF_VALUE_TEMPLATE, CONF_METHOD, CONF_RESOURCE,
-    CONF_SENSOR_CLASS)
+    CONF_SENSOR_CLASS, CONF_VERIFY_SSL)
 from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
 
+_LOGGER = logging.getLogger(__name__)
+
 DEFAULT_METHOD = 'GET'
 DEFAULT_NAME = 'REST Binary Sensor'
+DEFAULT_VERIFY_SSL = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.url,
@@ -27,9 +30,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PAYLOAD): cv.string,
     vol.Optional(CONF_SENSOR_CLASS): SENSOR_CLASSES_SCHEMA,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
 })
-
-_LOGGER = logging.getLogger(__name__)
 
 
 # pylint: disable=unused-variable
@@ -39,7 +41,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     resource = config.get(CONF_RESOURCE)
     method = config.get(CONF_METHOD)
     payload = config.get(CONF_PAYLOAD)
-    verify_ssl = config.get('verify_ssl', True)
+    verify_ssl = config.get(CONF_VERIFY_SSL)
     sensor_class = config.get(CONF_SENSOR_CLASS)
     value_template = config.get(CONF_VALUE_TEMPLATE)
 

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -12,13 +12,16 @@ import requests
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_PAYLOAD, CONF_NAME, CONF_VALUE_TEMPLATE, CONF_METHOD, CONF_RESOURCE,
-    CONF_UNIT_OF_MEASUREMENT, STATE_UNKNOWN)
+    CONF_UNIT_OF_MEASUREMENT, STATE_UNKNOWN, CONF_VERIFY_SSL)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
 
+_LOGGER = logging.getLogger(__name__)
+
 DEFAULT_METHOD = 'GET'
 DEFAULT_NAME = 'REST Sensor'
+DEFAULT_VERIFY_SSL = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.url,
@@ -27,9 +30,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PAYLOAD): cv.string,
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
 })
-
-_LOGGER = logging.getLogger(__name__)
 
 
 # pylint: disable=unused-variable
@@ -39,7 +41,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     resource = config.get(CONF_RESOURCE)
     method = config.get(CONF_METHOD)
     payload = config.get(CONF_PAYLOAD)
-    verify_ssl = config.get('verify_ssl', True)
+    verify_ssl = config.get(CONF_VERIFY_SSL)
     unit = config.get(CONF_UNIT_OF_MEASUREMENT)
     value_template = config.get(CONF_VALUE_TEMPLATE)
 
@@ -58,7 +60,7 @@ class RestSensor(Entity):
     """Implementation of a REST sensor."""
 
     def __init__(self, hass, rest, name, unit_of_measurement, value_template):
-        """Initialize the sensor."""
+        """Initialize the REST sensor."""
         self._hass = hass
         self.rest = rest
         self._name = name


### PR DESCRIPTION
**Description:**
Use some more constants and add the option for the verification of the SSL/TLS certificate to the configuration check.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#889

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
binary_sensor:
  platform: rest
  resource: http://IP_ADDRESS/ENDPOINT
  method: GET
  name: REST GET binary sensor
  sensor_class: opening
  verify_ssl: False
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
