### PR TITLE
Use voluptuous for Bravia TV

### DIFF
--- a/homeassistant/components/media_player/braviatv.py
+++ b/homeassistant/components/media_player/braviatv.py
@@ -122,8 +122,6 @@ def setup_bravia(config, pin, hass, add_devices):
     """Setup a Sony Bravia TV based on host parameter."""
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
-    if name is None:
-        name = DEFAULT_NAME
 
     if pin is None:
         request_configuration(config, hass, add_devices)
@@ -148,13 +146,10 @@ def setup_bravia(config, pin, hass, add_devices):
         add_devices([BraviaTVDevice(host, mac, name, pin)])
 
 
-def request_configuration(config, hass, add_devices_callback):
+def request_configuration(config, hass, add_devices):
     """Request configuration steps from the user."""
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
-
-    if name is None:
-        name = DEFAULT_NAME
 
     configurator = get_component('configurator')
 
@@ -172,9 +167,9 @@ def request_configuration(config, hass, add_devices_callback):
         braviarc = braviarc.BraviaRC(host)
         braviarc.connect(pin, CLIENTID_PREFIX, NICKNAME)
         if braviarc.is_connected():
-            setup_bravia(config, pin, hass, add_devices_callback)
+            setup_bravia(config, pin, hass, add_devices)
         else:
-            request_configuration(config, hass, add_devices_callback)
+            request_configuration(config, hass, add_devices)
 
     _CONFIGURING[host] = configurator.request_config(
         hass, name, bravia_configuration_callback,

--- a/homeassistant/components/media_player/braviatv.py
+++ b/homeassistant/components/media_player/braviatv.py
@@ -8,20 +8,28 @@ import logging
 import os
 import json
 import re
+
+import voluptuous as vol
+
 from homeassistant.loader import get_component
 from homeassistant.components.media_player import (
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
     SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP,
-    SUPPORT_VOLUME_SET, SUPPORT_SELECT_SOURCE, MediaPlayerDevice)
-from homeassistant.const import (
-    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON)
+    SUPPORT_VOLUME_SET, SUPPORT_SELECT_SOURCE, MediaPlayerDevice,
+    PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON)
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = [
     'https://github.com/aparraga/braviarc/archive/0.3.4.zip'
     '#braviarc==0.3.4']
 
 BRAVIA_CONFIG_FILE = 'bravia.conf'
+
 CLIENTID_PREFIX = 'HomeAssistant'
+
+DEFAULT_NAME = 'Sony Bravia TV'
+
 NICKNAME = 'Home Assistant'
 
 # Map ip to request id for configuring
@@ -33,6 +41,11 @@ SUPPORT_BRAVIA = SUPPORT_PAUSE | SUPPORT_VOLUME_STEP | \
                  SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET | \
                  SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK | \
                  SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
 
 
 def _get_mac_address(ip_address):
@@ -82,7 +95,7 @@ def _config_from_file(filename, config=None):
 
 
 # pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Sony Bravia TV platform."""
     host = config.get(CONF_HOST)
 
@@ -98,22 +111,22 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             pin = host_config['pin']
             mac = host_config['mac']
             name = config.get(CONF_NAME)
-            add_devices_callback([BraviaTVDevice(host, mac, name, pin)])
+            add_devices([BraviaTVDevice(host, mac, name, pin)])
             return
 
-    setup_bravia(config, pin, hass, add_devices_callback)
+    setup_bravia(config, pin, hass, add_devices)
 
 
 # pylint: disable=too-many-branches
-def setup_bravia(config, pin, hass, add_devices_callback):
+def setup_bravia(config, pin, hass, add_devices):
     """Setup a Sony Bravia TV based on host parameter."""
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
     if name is None:
-        name = "Sony Bravia TV"
+        name = DEFAULT_NAME
 
     if pin is None:
-        request_configuration(config, hass, add_devices_callback)
+        request_configuration(config, hass, add_devices)
         return
     else:
         mac = _get_mac_address(host)
@@ -132,15 +145,16 @@ def setup_bravia(config, pin, hass, add_devices_callback):
                 {host: {'pin': pin, 'host': host, 'mac': mac}}):
             _LOGGER.error('failed to save config file')
 
-        add_devices_callback([BraviaTVDevice(host, mac, name, pin)])
+        add_devices([BraviaTVDevice(host, mac, name, pin)])
 
 
 def request_configuration(config, hass, add_devices_callback):
     """Request configuration steps from the user."""
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
+
     if name is None:
-        name = "Sony Bravia"
+        name = DEFAULT_NAME
 
     configurator = get_component('configurator')
 


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
media_player:
  platform: braviatv
  host: 192.168.0.10
  name: Living Room TV
```

@aparraga, @ttu , would be nice if one of you guys could take a look at the changes and run a quick test. Thanks.
