### PR TITLE
Adding link_names to post.message call

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -58,14 +58,12 @@ class SlackNotificationService(BaseNotificationService):
 
         channel = kwargs.get('target') or self._default_channel
         data = kwargs.get('data')
-        if data:
-            attachments = data.get('attachments')
-        else:
-            attachments = None
+        attachments = data.get('attachments') if data else None
 
         try:
             self.slack.chat.post_message(channel, message,
                                          as_user=True,
-                                         attachments=attachments)
+                                         attachments=attachments,
+                                         link_names=True)
         except slacker.Error as err:
             _LOGGER.error("Could not send slack notification. Error: %s", err)


### PR DESCRIPTION
**Description:**
If you do not turn link_names on, Slack will not highlight @channel and @username messages.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
