### PR TITLE
Use voluptuous for mFi switch

### DIFF
--- a/homeassistant/components/switch/mfi.py
+++ b/homeassistant/components/switch/mfi.py
@@ -7,14 +7,21 @@ https://home-assistant.io/components/switch.mfi/
 import logging
 
 import requests
+import voluptuous as vol
 
-from homeassistant.components.switch import DOMAIN, SwitchDevice
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers import validate_config
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (
+    CONF_HOST, CONF_PORT, CONF_PASSWORD, CONF_USERNAME, CONF_SSL,
+    CONF_VERIFY_SSL)
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['mficlient==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
+
+DEFAULT_PORT = 6443
+DEFAULT_SSL = True
+DEFAULT_VERIFY_SSL = True
 
 SWITCH_MODELS = [
     'Outlet',
@@ -22,28 +29,27 @@ SWITCH_MODELS = [
     'Output 12v',
     'Output 24v',
 ]
-CONF_TLS = 'use_tls'
-CONF_VERIFY_TLS = 'verify_tls'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+})
 
 
 # pylint: disable=unused-variable
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup mFi sensors."""
-    if not validate_config({DOMAIN: config},
-                           {DOMAIN: ['host',
-                                     CONF_USERNAME,
-                                     CONF_PASSWORD]},
-                           _LOGGER):
-        _LOGGER.error('A host, username, and password are required')
-        return False
-
-    host = config.get('host')
-    username = config.get('username')
-    password = config.get('password')
-    use_tls = bool(config.get(CONF_TLS, True))
-    verify_tls = bool(config.get(CONF_VERIFY_TLS, True))
-    default_port = use_tls and 6443 or 6080
-    port = int(config.get('port', default_port))
+    host = config.get(CONF_HOST)
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    use_tls = config.get(CONF_SSL)
+    verify_tls = config.get(CONF_VERIFY_SSL)
+    default_port = use_tls and DEFAULT_PORT or 6080
+    port = int(config.get(CONF_PORT, default_port))
 
     from mficlient.client import FailedToLogin, MFiClient
 

--- a/tests/components/sensor/test_mfi.py
+++ b/tests/components/sensor/test_mfi.py
@@ -24,16 +24,14 @@ class TestMfiSensorSetup(unittest.TestCase):
             'port': 6123,
             'username': 'user',
             'password': 'pass',
-            'use_tls': True,
-            'verify_tls': True,
+            'ssl': True,
+            'verify_ssl': True,
         }
     }
 
     def setup_method(self, method):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.latitude = 32.87336
-        self.hass.config.longitude = 117.22743
 
     def teardown_method(self, method):
         """Stop everything that was started."""
@@ -54,9 +52,8 @@ class TestMfiSensorSetup(unittest.TestCase):
         mock_client.FailedToLogin = Exception()
         mock_client.MFiClient.side_effect = mock_client.FailedToLogin
         self.assertFalse(
-            self.PLATFORM.setup_platform(self.hass,
-                                         dict(self.GOOD_CONFIG),
-                                         None))
+            self.PLATFORM.setup_platform(
+                self.hass, dict(self.GOOD_CONFIG), None))
 
     @mock.patch('mficlient.client')
     def test_setup_failed_connect(self, mock_client):
@@ -64,9 +61,8 @@ class TestMfiSensorSetup(unittest.TestCase):
         mock_client.FailedToLogin = Exception()
         mock_client.MFiClient.side_effect = requests.exceptions.ConnectionError
         self.assertFalse(
-            self.PLATFORM.setup_platform(self.hass,
-                                         dict(self.GOOD_CONFIG),
-                                         None))
+            self.PLATFORM.setup_platform(
+                self.hass, dict(self.GOOD_CONFIG), None))
 
     @mock.patch('mficlient.client.MFiClient')
     def test_setup_minimum(self, mock_client):
@@ -74,9 +70,8 @@ class TestMfiSensorSetup(unittest.TestCase):
         config = dict(self.GOOD_CONFIG)
         del config[self.THING]['port']
         assert self.COMPONENT.setup(self.hass, config)
-        mock_client.assert_called_once_with('foo', 'user', 'pass',
-                                            port=6443, use_tls=True,
-                                            verify=True)
+        mock_client.assert_called_once_with(
+            'foo', 'user', 'pass', port=6443, use_tls=True, verify=True)
 
     @mock.patch('mficlient.client.MFiClient')
     def test_setup_with_port(self, mock_client):
@@ -84,21 +79,19 @@ class TestMfiSensorSetup(unittest.TestCase):
         config = dict(self.GOOD_CONFIG)
         config[self.THING]['port'] = 6123
         assert self.COMPONENT.setup(self.hass, config)
-        mock_client.assert_called_once_with('foo', 'user', 'pass',
-                                            port=6123, use_tls=True,
-                                            verify=True)
+        mock_client.assert_called_once_with(
+            'foo', 'user', 'pass', port=6123, use_tls=True, verify=True)
 
     @mock.patch('mficlient.client.MFiClient')
     def test_setup_with_tls_disabled(self, mock_client):
         """Test setup without TLS."""
         config = dict(self.GOOD_CONFIG)
         del config[self.THING]['port']
-        config[self.THING]['use_tls'] = False
-        config[self.THING]['verify_tls'] = False
+        config[self.THING]['ssl'] = False
+        config[self.THING]['verify_ssl'] = False
         assert self.COMPONENT.setup(self.hass, config)
-        mock_client.assert_called_once_with('foo', 'user', 'pass',
-                                            port=6080, use_tls=False,
-                                            verify=False)
+        mock_client.assert_called_once_with(
+            'foo', 'user', 'pass', port=6080, use_tls=False, verify=False)
 
     @mock.patch('mficlient.client.MFiClient')
     @mock.patch('homeassistant.components.sensor.mfi.MfiSensor')
@@ -123,8 +116,6 @@ class TestMfiSensor(unittest.TestCase):
     def setup_method(self, method):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.latitude = 32.87336
-        self.hass.config.longitude = 117.22743
         self.port = mock.MagicMock()
         self.sensor = mfi.MfiSensor(self.port, self.hass)
 

--- a/tests/components/switch/test_mfi.py
+++ b/tests/components/switch/test_mfi.py
@@ -22,6 +22,8 @@ class TestMfiSwitchSetup(test_mfi_sensor.TestMfiSensorSetup):
             'port': 6123,
             'username': 'user',
             'password': 'pass',
+            'ssl': True,
+            'verify_ssl': True,
         }
     }
 
@@ -48,8 +50,6 @@ class TestMfiSwitch(unittest.TestCase):
     def setup_method(self, method):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.latitude = 32.87336
-        self.hass.config.longitude = 117.22743
         self.port = mock.MagicMock()
         self.switch = mfi.MfiSwitch(self.port)
 


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

This is a breaking change.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Documentation change [home-assistant.io](https://github.com/home-assistant/home-assistant.io):**
https://github.com/home-assistant/home-assistant.github.io/commit/167d5632b1a9016496bf12461afd5b6d8f2d0015

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: mfi
  host: IP_ADDRESS
  port: PORT
  username: USERNAME
  password: PASSWORD
  ssl: true
  verify_ssl: true
```

@kk7ds, would be nice if you could take a look at the changes and run a quick test. Thanks.
