### PR TITLE
Use voluptuous for Verisure

### DIFF
--- a/homeassistant/components/alarm_control_panel/verisure.py
+++ b/homeassistant/components/alarm_control_panel/verisure.py
@@ -8,7 +8,7 @@ import logging
 
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.verisure import HUB as hub
-
+from homeassistant.components.verisure import (CONF_ALARM, CONF_CODE_DIGITS)
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED,
     STATE_UNKNOWN)
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Verisure platform."""
     alarms = []
-    if int(hub.config.get('alarm', '1')):
+    if int(hub.config.get(CONF_ALARM, '1')):
         hub.update_alarms()
         alarms.extend([
             VerisureAlarm(value.id)
@@ -36,7 +36,7 @@ class VerisureAlarm(alarm.AlarmControlPanel):
         """Initalize the Verisure alarm panel."""
         self._id = device_id
         self._state = STATE_UNKNOWN
-        self._digits = int(hub.config.get('code_digits', '4'))
+        self._digits = hub.config.get(CONF_CODE_DIGITS)
         self._changed_by = None
 
     @property

--- a/homeassistant/components/alarm_control_panel/verisure.py
+++ b/homeassistant/components/alarm_control_panel/verisure.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Verisure platform."""
     alarms = []
-    if int(hub.config.get(CONF_ALARM, '1')):
+    if int(hub.config.get(CONF_ALARM, 1)):
         hub.update_alarms()
         alarms.extend([
             VerisureAlarm(value.id)

--- a/homeassistant/components/lock/verisure.py
+++ b/homeassistant/components/lock/verisure.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Verisure platform."""
     locks = []
-    if int(hub.config.get(CONF_LOCKS, '1')):
+    if int(hub.config.get(CONF_LOCKS, 1)):
         hub.update_locks()
         locks.extend([
             VerisureDoorlock(device_id)

--- a/homeassistant/components/lock/verisure.py
+++ b/homeassistant/components/lock/verisure.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/verisure/
 import logging
 
 from homeassistant.components.verisure import HUB as hub
+from homeassistant.components.verisure import (CONF_LOCKS, CONF_CODE_DIGITS)
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import (
     ATTR_CODE, STATE_LOCKED, STATE_UNKNOWN, STATE_UNLOCKED)
@@ -17,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Verisure platform."""
     locks = []
-    if int(hub.config.get('locks', '1')):
+    if int(hub.config.get(CONF_LOCKS, '1')):
         hub.update_locks()
         locks.extend([
             VerisureDoorlock(device_id)
@@ -34,7 +35,7 @@ class VerisureDoorlock(LockDevice):
         """Initialize the lock."""
         self._id = device_id
         self._state = STATE_UNKNOWN
-        self._digits = int(hub.config.get('code_digits', '4'))
+        self._digits = hub.config.get(CONF_CODE_DIGITS)
         self._changed_by = None
 
     @property

--- a/homeassistant/components/sensor/verisure.py
+++ b/homeassistant/components/sensor/verisure.py
@@ -2,11 +2,13 @@
 Interfaces with Verisure sensors.
 
 For more details about this platform, please refer to the documentation at
-documentation at https://home-assistant.io/components/verisure/
+https://home-assistant.io/components/sensor.verisure/
 """
 import logging
 
 from homeassistant.components.verisure import HUB as hub
+from homeassistant.components.verisure import (
+    CONF_THERMOMETERS, CONF_HYDROMETERS, CONF_MOUSE)
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 
@@ -17,7 +19,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Verisure platform."""
     sensors = []
 
-    if int(hub.config.get('thermometers', '1')):
+    if int(hub.config.get(CONF_THERMOMETERS, '1')):
         hub.update_climate()
         sensors.extend([
             VerisureThermometer(value.id)
@@ -25,7 +27,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             if hasattr(value, 'temperature') and value.temperature
             ])
 
-    if int(hub.config.get('hygrometers', '1')):
+    if int(hub.config.get(CONF_HYDROMETERS, '1')):
         hub.update_climate()
         sensors.extend([
             VerisureHygrometer(value.id)
@@ -33,7 +35,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             if hasattr(value, 'humidity') and value.humidity
             ])
 
-    if int(hub.config.get('mouse', '1')):
+    if int(hub.config.get(CONF_MOUSE, '1')):
         hub.update_mousedetection()
         sensors.extend([
             VerisureMouseDetection(value.deviceLabel)
@@ -56,8 +58,7 @@ class VerisureThermometer(Entity):
     def name(self):
         """Return the name of the device."""
         return '{} {}'.format(
-            hub.climate_status[self._id].location,
-            "Temperature")
+            hub.climate_status[self._id].location, "Temperature")
 
     @property
     def state(self):
@@ -91,8 +92,7 @@ class VerisureHygrometer(Entity):
     def name(self):
         """Return the name of the sensor."""
         return '{} {}'.format(
-            hub.climate_status[self._id].location,
-            "Humidity")
+            hub.climate_status[self._id].location, "Humidity")
 
     @property
     def state(self):
@@ -126,8 +126,7 @@ class VerisureMouseDetection(Entity):
     def name(self):
         """Return the name of the sensor."""
         return '{} {}'.format(
-            hub.mouse_status[self._id].location,
-            "Mouse")
+            hub.mouse_status[self._id].location, "Mouse")
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/verisure.py
+++ b/homeassistant/components/sensor/verisure.py
@@ -19,7 +19,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Verisure platform."""
     sensors = []
 
-    if int(hub.config.get(CONF_THERMOMETERS, '1')):
+    if int(hub.config.get(CONF_THERMOMETERS, 1)):
         hub.update_climate()
         sensors.extend([
             VerisureThermometer(value.id)
@@ -27,7 +27,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             if hasattr(value, 'temperature') and value.temperature
             ])
 
-    if int(hub.config.get(CONF_HYDROMETERS, '1')):
+    if int(hub.config.get(CONF_HYDROMETERS, 1)):
         hub.update_climate()
         sensors.extend([
             VerisureHygrometer(value.id)
@@ -35,7 +35,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             if hasattr(value, 'humidity') and value.humidity
             ])
 
-    if int(hub.config.get(CONF_MOUSE, '1')):
+    if int(hub.config.get(CONF_MOUSE, 1)):
         hub.update_mousedetection()
         sensors.extend([
             VerisureMouseDetection(value.deviceLabel)
@@ -58,7 +58,7 @@ class VerisureThermometer(Entity):
     def name(self):
         """Return the name of the device."""
         return '{} {}'.format(
-            hub.climate_status[self._id].location, "Temperature")
+            hub.climate_status[self._id].location, 'Temperature')
 
     @property
     def state(self):
@@ -92,7 +92,7 @@ class VerisureHygrometer(Entity):
     def name(self):
         """Return the name of the sensor."""
         return '{} {}'.format(
-            hub.climate_status[self._id].location, "Humidity")
+            hub.climate_status[self._id].location, 'Humidity')
 
     @property
     def state(self):
@@ -126,7 +126,7 @@ class VerisureMouseDetection(Entity):
     def name(self):
         """Return the name of the sensor."""
         return '{} {}'.format(
-            hub.mouse_status[self._id].location, "Mouse")
+            hub.mouse_status[self._id].location, 'Mouse')
 
     @property
     def state(self):

--- a/homeassistant/components/switch/verisure.py
+++ b/homeassistant/components/switch/verisure.py
@@ -2,11 +2,12 @@
 Support for Verisure Smartplugs.
 
 For more details about this platform, please refer to the documentation at
-documentation at https://home-assistant.io/components/verisure/
+https://home-assistant.io/components/switch.verisure/
 """
 import logging
 
 from homeassistant.components.verisure import HUB as hub
+from homeassistant.components.verisure import CONF_SMARTPLUGS
 from homeassistant.components.switch import SwitchDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -14,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Verisure switch platform."""
-    if not int(hub.config.get('smartplugs', '1')):
+    if not int(hub.config.get(CONF_SMARTPLUGS, '1')):
         return False
 
     hub.update_smartplugs()

--- a/homeassistant/components/switch/verisure.py
+++ b/homeassistant/components/switch/verisure.py
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Verisure switch platform."""
-    if not int(hub.config.get(CONF_SMARTPLUGS, '1')):
+    if not int(hub.config.get(CONF_SMARTPLUGS, 1)):
         return False
 
     hub.update_smartplugs()

--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -34,14 +34,15 @@ HUB = None
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
         vol.Optional(CONF_ALARM, default=True): cv.boolean,
         vol.Optional(CONF_CODE_DIGITS, default=4): cv.positive_int,
         vol.Optional(CONF_HYDROMETERS, default=True): cv.boolean,
         vol.Optional(CONF_LOCKS, default=True): cv.boolean,
         vol.Optional(CONF_MOUSE, default=True): cv.boolean,
         vol.Optional(CONF_SMARTPLUGS, default=True): cv.boolean,
+        vol.Optional(CONF_THERMOMETERS, default=True): cv.boolean,
     }),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -9,26 +9,45 @@ import threading
 import time
 from datetime import timedelta
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers import validate_config, discovery
-from homeassistant.util import Throttle
+import voluptuous as vol
 
-DOMAIN = "verisure"
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import discovery
+from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['vsure==0.10.2']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_ALARM = 'alarm'
+CONF_CODE_DIGITS = 'code_digits'
+CONF_HYDROMETERS = 'hygrometers'
+CONF_LOCKS = 'locks'
+CONF_MOUSE = 'mouse'
+CONF_SMARTPLUGS = 'smartplugs'
+CONF_THERMOMETERS = 'thermometers'
+
+DOMAIN = 'verisure'
+
 HUB = None
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_ALARM, default=True): cv.boolean,
+        vol.Optional(CONF_CODE_DIGITS, default=4): cv.positive_int,
+        vol.Optional(CONF_HYDROMETERS, default=True): cv.boolean,
+        vol.Optional(CONF_LOCKS, default=True): cv.boolean,
+        vol.Optional(CONF_MOUSE, default=True): cv.boolean,
+        vol.Optional(CONF_SMARTPLUGS, default=True): cv.boolean,
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
     """Setup the Verisure component."""
-    if not validate_config(config,
-                           {DOMAIN: [CONF_USERNAME, CONF_PASSWORD]},
-                           _LOGGER):
-        return False
-
     import verisure
     global HUB
     HUB = VerisureHub(config[DOMAIN], verisure)


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`. Also are now constants used.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
verisure:
  username: USERNAME
  password: PASSWORD
  alarm: 1
  hygrometers: 0
  smartplugs: 1
  thermometers: 0
  locks: 0
  mouse: 1
  code_digits: 4
```

@persandstrom , would be nice if you could take a look at the changes and run a quick test. Thanks.
