### PR TITLE
Improve voluptuous and login errors for Asus device tracker

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -70,7 +70,7 @@ def isfile(value: Any) -> str:
     """Validate that the value is an existing file."""
     if value is None:
         raise vol.Invalid('None is not file')
-    file_in = str(value)
+    file_in = os.path.expanduser(str(value))
 
     if not os.path.isfile(file_in):
         raise vol.Invalid('not a file')

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -138,7 +138,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         asuswrt = device_tracker.asuswrt.AsusWrtDeviceScanner(conf_dict)
         asuswrt.ssh_connection()
         ssh.login.assert_called_once_with('fake_host', 'fake_user',
-                                          'fake_pass')
+                                          password='fake_pass')
 
     def test_ssh_login_without_password_or_pubkey(self):  \
             # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:**

**Related issue (if applicable):** fixes #2978 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
  - platform: asuswrt
    host: 192.168.88.1
    protocol: ssh
    username: !secret asus_un
    password: !secret asus_pw
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
