### PR TITLE
Exclude www_static from pydocstyle linting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ norecursedirs = .git testing_config
 
 [flake8]
 exclude = .venv,.git,.tox,docs,www_static,venv,bin,lib,deps,build
+
+[pydocstyle]
+match_dir = ^((?!\.|www_static).)*$


### PR DESCRIPTION
**Description:**
pydocstyle was finding python modules in frontend sub-directories and
running tox was failing as a consequence.
- Avoid tox failing by excluding www_static directory from pydocstyle
  tests.

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
