### PR TITLE
Occupancy sensor_class

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -27,6 +27,7 @@ SENSOR_CLASSES = [
     'moisture',      # Specifically a wetness sensor
     'motion',        # Motion sensor
     'moving',        # On means moving, Off means stopped
+    'occupancy',     # On means occupied, Off means not occupied
     'opening',       # Door, window, etc.
     'power',         # Power, over-current, etc
     'safety',        # Generic on=unsafe, off=safe


### PR DESCRIPTION
Adds a new `sensor_class`: occupancy. On means occupied, Off means not occupied.

https://github.com/home-assistant/home-assistant-polymer/pull/103
https://github.com/home-assistant/home-assistant.github.io/pull/894
