### PR TITLE
Use voluptuous for Edimax

### DIFF
--- a/homeassistant/components/switch/edimax.py
+++ b/homeassistant/components/switch/edimax.py
@@ -24,9 +24,9 @@ DEFAULT_USERNAME = 'admin'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+    vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
 })
 
 

--- a/homeassistant/components/switch/edimax.py
+++ b/homeassistant/components/switch/edimax.py
@@ -6,39 +6,40 @@ https://home-assistant.io/components/switch.edimax/
 """
 import logging
 
-from homeassistant.components.switch import DOMAIN, SwitchDevice
+import voluptuous as vol
+
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME)
-from homeassistant.helpers import validate_config
+import homeassistant.helpers.config_validation as cv
 
-# constants
-DEFAULT_USERNAME = 'admin'
-DEFAULT_PASSWORD = '1234'
-DEVICE_DEFAULT_NAME = 'Edimax Smart Plug'
 REQUIREMENTS = ['https://github.com/rkabadi/pyedimax/archive/'
                 '365301ce3ff26129a7910c501ead09ea625f3700.zip#pyedimax==0.1']
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_NAME = 'Edimax Smart Plug'
+DEFAULT_PASSWORD = '1234'
+DEFAULT_USERNAME = 'admin'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
 
 # pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return Edimax Smart Plugs."""
     from pyedimax.smartplug import SmartPlug
 
-    # pylint: disable=global-statement
-    # check for required values in configuration file
-    if not validate_config({DOMAIN: config},
-                           {DOMAIN: [CONF_HOST]},
-                           _LOGGER):
-        return False
-
     host = config.get(CONF_HOST)
-    auth = (config.get(CONF_USERNAME, DEFAULT_USERNAME),
-            config.get(CONF_PASSWORD, DEFAULT_PASSWORD))
-    name = config.get(CONF_NAME, DEVICE_DEFAULT_NAME)
+    auth = (config.get(CONF_USERNAME), config.get(CONF_PASSWORD))
+    name = config.get(CONF_NAME)
 
-    add_devices_callback([SmartPlugSwitch(SmartPlug(host, auth), name)])
+    add_devices([SmartPlugSwitch(SmartPlug(host, auth), name)])
 
 
 class SmartPlugSwitch(SwitchDevice):


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
bloomsky:
  api_key: YOUR_API_KEY

switch:
  platform: edimax
  host: 192.168.1.32
  username: YOUR_USERNAME
  password: YOUR_PASSWORD
  name: Edimax Smart Plug
```

@rkabadi, would be nice if you could take a look at the changes and run a quick test. Thanks.
