### PR TITLE
Fix enocean device

### DIFF
--- a/homeassistant/components/binary_sensor/enocean.py
+++ b/homeassistant/components/binary_sensor/enocean.py
@@ -80,4 +80,5 @@ class EnOceanBinarySensor(enocean.EnOceanDevice, BinarySensorDevice):
         self.hass.bus.fire('button_pressed', {"id": self.dev_id,
                                               'pushed': value,
                                               'which': self.which,
-                                              'onoff': self.onoff})
+                                              'onoff': self.onoff,
+                                              'devname': self.devname})

--- a/homeassistant/components/enocean.py
+++ b/homeassistant/components/enocean.py
@@ -58,9 +58,10 @@ class EnOceanDongle:
 
     def _combine_hex(self, data):  # pylint: disable=no-self-use
         """Combine list of integer values to one big integer."""
-        output = 0x00
+        output = 0
+        data = data.replace(' ', '').strip('[]').split(',')
         for i, j in enumerate(reversed(data)):
-            output |= (j << i * 8)
+            output |= (int(j) << i * 8)
         return output
 
     # pylint: disable=too-many-branches


### PR DESCRIPTION
**Description:**
- This will fix broken device id comparison method for enocean module
- When an event gets fired now devname is also sent along, so that you can use a pretty name in configuration.yaml

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
automation:
  - alias: Turn off some light
    trigger:
      platform: event
      event_type: button_pressed
      event_data:
        onoff: 0
        devname: someprettyname  # pretty name

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
