### PR TITLE
Use voluptuous for Hikvisioncam switch

### DIFF
--- a/homeassistant/components/switch/hikvisioncam.py
+++ b/homeassistant/components/switch/hikvisioncam.py
@@ -6,31 +6,50 @@ https://home-assistant.io/components/switch.hikvision/
 """
 import logging
 
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, STATE_OFF, STATE_ON)
+    CONF_NAME, CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT, STATE_OFF,
+    STATE_ON)
 from homeassistant.helpers.entity import ToggleEntity
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['hikvision==0.4']
 
 _LOGGING = logging.getLogger(__name__)
-REQUIREMENTS = ['hikvision==0.4']
+
+DEFAULT_NAME = 'Hikvision Camera Motion Detection'
+DEFAULT_PASSWORD = '12345'
+DEFAULT_PORT = 80
+DEFAULT_USERNAME = 'admin'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+    vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PORT): cv.port,
+})
+
+
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-instance-attributes
-
-
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup Hikvision camera."""
     import hikvision.api
     from hikvision.error import HikvisionError, MissingParamError
 
-    host = config.get(CONF_HOST, None)
-    port = config.get('port', "80")
-    name = config.get('name', "Hikvision Camera Motion Detection")
-    username = config.get(CONF_USERNAME, "admin")
-    password = config.get(CONF_PASSWORD, "12345")
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    name = config.get(CONF_NAME)
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
 
     try:
         hikvision_cam = hikvision.api.CreateDevice(
-            host, port=port, username=username,
-            password=password, is_https=False)
+            host, port=port, username=username, password=password,
+            is_https=False)
     except MissingParamError as param_err:
         _LOGGING.error("Missing required param: %s", param_err)
         return False
@@ -38,9 +57,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         _LOGGING.error("Unable to connect: %s", conn_err)
         return False
 
-    add_devices_callback([
-        HikvisionMotionSwitch(name, hikvision_cam)
-    ])
+    add_devices([HikvisionMotionSwitch(name, hikvision_cam)])
 
 
 class HikvisionMotionSwitch(ToggleEntity):
@@ -85,6 +102,6 @@ class HikvisionMotionSwitch(ToggleEntity):
     def update(self):
         """Update Motion Detection state."""
         enabled = self._hikvision_cam.is_motion_detection_enabled()
-        _LOGGING.info('enabled: %s', enabled)
+        _LOGGING.info("enabled: %s", enabled)
 
         self._state = STATE_ON if enabled else STATE_OFF

--- a/homeassistant/components/switch/hikvisioncam.py
+++ b/homeassistant/components/switch/hikvisioncam.py
@@ -26,10 +26,10 @@ DEFAULT_USERNAME = 'admin'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
-    vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
     vol.Optional(CONF_PORT): cv.port,
+    vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
 })
 
 


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
    platform: hikvisioncam
    host: 192.168.1.32
    port: 80
    name: Hikvision Cam 1 Motion Detection
    username: USERNAME
    password: PASSWORD
```

@rmkraus, would be nice if you could take a look at the changes and run a quick test. Thanks.
