### PR TITLE
WIP: async awesomeness

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     REQUIRED_PYTHON_VER,
     RESTART_EXIT_CODE,
 )
+from homeassistant.helpers.async import run_callback_threadsafe
 
 
 def validate_python() -> None:
@@ -256,12 +257,14 @@ def setup_and_run_hass(config_dir: str,
                 import webbrowser
                 webbrowser.open(hass.config.api.base_url)
 
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_START, open_browser)
+        run_callback_threadsafe(
+            hass.loop,
+            hass.bus.async_listen_once,
+            EVENT_HOMEASSISTANT_START, open_browser
+        )
 
     hass.start()
-    exit_code = int(hass.block_till_stopped())
-
-    return exit_code
+    return hass.exit_code
 
 
 def try_to_restart() -> None:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -5,14 +5,15 @@ Home Assistant is a Home Automation framework for observing the state
 of entities and react to changes.
 """
 
+import asyncio
 import enum
 import functools as ft
 import logging
 import os
 import re
 import signal
-import threading
-import time
+from concurrent.futures import ThreadPoolExecutor
+
 from types import MappingProxyType
 
 # pylint: disable=unused-import
@@ -30,6 +31,9 @@ from homeassistant.const import (
     SERVICE_HOMEASSISTANT_RESTART, SERVICE_HOMEASSISTANT_STOP, __version__)
 from homeassistant.exceptions import (
     HomeAssistantError, InvalidEntityFormatError)
+from homeassistant.helpers.async import (
+    run_coroutine_threadsafe, run_callback_threadsafe,
+    fire_coroutine_threadsafe)
 import homeassistant.util as util
 import homeassistant.util.dt as dt_util
 import homeassistant.util.location as location
@@ -105,12 +109,16 @@ class HomeAssistant(object):
 
     def __init__(self):
         """Initialize new Home Assistant object."""
+        self.loop = asyncio.get_event_loop()
+        self.executer = ThreadPoolExecutor(max_workers=5)
+        self.loop.set_default_executor(self.executer)
         self.pool = pool = create_worker_pool()
-        self.bus = EventBus(pool)
-        self.services = ServiceRegistry(self.bus, self.add_job)
-        self.states = StateMachine(self.bus)
+        self.bus = EventBus(pool, self.loop)
+        self.services = ServiceRegistry(self.bus, self.add_job, self.loop)
+        self.states = StateMachine(self.bus, self.loop)
         self.config = Config()  # type: Config
         self.state = CoreState.not_running
+        self.exit_code = None
 
     @property
     def is_running(self) -> bool:
@@ -123,42 +131,30 @@ class HomeAssistant(object):
             "Starting Home Assistant (%d threads)", self.pool.worker_count)
         self.state = CoreState.starting
 
-        create_timer(self)
-        self.bus.fire(EVENT_HOMEASSISTANT_START)
-        self.pool.block_till_done()
-        self.state = CoreState.running
+        # Register the async start
+        self.loop.create_task(self.async_start())
 
-    def add_job(self,
-                target: Callable[..., None],
-                *args: Any,
-                priority: JobPriority=JobPriority.EVENT_DEFAULT) -> None:
-        """Add job to the worker pool.
-
-        target: target to call.
-        args: parameters for method to call.
-        """
-        self.pool.add_job(priority, (target,) + args)
-
-    def block_till_stopped(self) -> int:
-        """Register service homeassistant/stop and will block until called."""
-        request_shutdown = threading.Event()
-        request_restart = threading.Event()
-
+        @asyncio.coroutine
         def stop_homeassistant(*args):
-            """Stop Home Assistant."""
-            request_shutdown.set()
+            self.exit_code = 0
+            yield from self.stop()
 
+        @asyncio.coroutine
         def restart_homeassistant(*args):
-            """Reset Home Assistant."""
-            _LOGGER.warning('Home Assistant requested a restart.')
-            request_restart.set()
-            request_shutdown.set()
+            self.exit_code = RESTART_EXIT_CODE
+            yield from self.stop()
 
-        self.services.register(
-            DOMAIN, SERVICE_HOMEASSISTANT_STOP, stop_homeassistant)
-        self.services.register(
-            DOMAIN, SERVICE_HOMEASSISTANT_RESTART, restart_homeassistant)
+        # Register the restart/stop event
+        self.loop.call_soon(
+            self.services.async_register,
+            DOMAIN, SERVICE_HOMEASSISTANT_STOP, stop_homeassistant
+        )
+        self.loop.call_soon(
+            self.services.async_register,
+            DOMAIN, SERVICE_HOMEASSISTANT_RESTART, restart_homeassistant
+        )
 
+        # Setup signal handling
         try:
             signal.signal(signal.SIGTERM, stop_homeassistant)
         except ValueError:
@@ -171,23 +167,48 @@ class HomeAssistant(object):
                 'Could not bind to SIGHUP. Are you running in a thread?')
         except AttributeError:
             pass
+
+        # Run forever and catch keyboard interrupt
         try:
-            while not request_shutdown.is_set():
-                time.sleep(1)
+            # Block until stopped
+            _LOGGER.info("Starting Home Assistant core loop")
+            self.loop.run_forever()
         except KeyboardInterrupt:
             pass
         finally:
-            self.stop()
+            self.loop.create_task(stop_homeassistant())
+            self.loop.run_forever()
 
-        return RESTART_EXIT_CODE if request_restart.is_set() else 0
+    @asyncio.coroutine
+    def async_start(self):
+        """Finalizes startup from inside the event loop"""
+        create_timer(self)
+        self.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        yield from self.loop.run_in_executor(None, self.pool.block_till_done)
+        self.state = CoreState.running
 
+    def add_job(self,
+                target: Callable[..., None],
+                *args: Any,
+                priority: JobPriority=JobPriority.EVENT_DEFAULT) -> None:
+        """Add job to the worker pool.
+
+        target: target to call.
+        args: parameters for method to call.
+        """
+
+        self.pool.add_job(priority, (target,) + args)
+
+    @asyncio.coroutine
     def stop(self) -> None:
         """Stop Home Assistant and shuts down all threads."""
         _LOGGER.info("Stopping")
         self.state = CoreState.stopping
-        self.bus.fire(EVENT_HOMEASSISTANT_STOP)
-        self.pool.stop()
+        self.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        yield from self.loop.run_in_executor(None, self.pool.block_till_done)
+        yield from self.loop.run_in_executor(None, self.pool.stop)
         self.state = CoreState.not_running
+        self.loop.stop()
 
 
 class EventOrigin(enum.Enum):
@@ -247,43 +268,70 @@ class Event(object):
 class EventBus(object):
     """Allows firing of and listening for events."""
 
-    def __init__(self, pool: util.ThreadPool) -> None:
+    def __init__(self, pool: util.ThreadPool,
+                 loop: asyncio.AbstractEventLoop) -> None:
         """Initialize a new event bus."""
         self._listeners = {}
-        self._lock = threading.Lock()
         self._pool = pool
+        self._loop = loop
+
+    def async_listeners(self):
+        """Dict with events and the number of listeners.
+
+
+        """
+        return {key: len(self._listeners[key])
+                for key in self._listeners}
 
     @property
     def listeners(self):
         """Dict with events and the number of listeners."""
-        with self._lock:
-            return {key: len(self._listeners[key])
-                    for key in self._listeners}
+        return run_callback_threadsafe(
+            self._loop, self.async_listeners
+        ).result()
 
     def fire(self, event_type: str, event_data=None, origin=EventOrigin.local):
         """Fire an event."""
         if not self._pool.running:
             raise HomeAssistantError('Home Assistant has shut down.')
 
-        with self._lock:
-            # Copy the list of the current listeners because some listeners
-            # remove themselves as a listener while being executed which
-            # causes the iterator to be confused.
-            get = self._listeners.get
-            listeners = get(MATCH_ALL, []) + get(event_type, [])
+        self._loop.call_soon_threadsafe(self.async_fire, event_type,
+                                        event_data, origin)
+        return
 
-            event = Event(event_type, event_data, origin)
+    def async_fire(self, event_type: str, event_data=None,
+                         origin=EventOrigin.local, wait=False):
+        """Fire an event."""
+        # Copy the list of the current listeners because some listeners
+        # remove themselves as a listener while being executed which
+        # causes the iterator to be confused.
+        get = self._listeners.get
+        listeners = get(MATCH_ALL, []) + get(event_type, [])
 
-            if event_type != EVENT_TIME_CHANGED:
-                _LOGGER.info("Bus:Handling %s", event)
+        event = Event(event_type, event_data, origin)
 
-            if not listeners:
-                return
+        if event_type != EVENT_TIME_CHANGED:
+            _LOGGER.info("Bus:Handling %s", event)
 
-            job_priority = JobPriority.from_event_type(event_type)
+        if not listeners:
+            return
 
-            for func in listeners:
-                self._pool.add_job(job_priority, (func, event))
+        job_priority = JobPriority.from_event_type(event_type)
+
+        sync_jobs = []
+        for func in listeners:
+            if asyncio.iscoroutinefunction(func):
+                self._loop.create_task(func(event))
+            else:
+                sync_jobs.append((job_priority, (func, event)))
+
+        # Send all the sync jobs at once, since there's a lock involved we
+        # fire this off to a thread as well
+        try:
+            self._pool.add_many_jobs(sync_jobs)
+        except:
+            _LOGGER.info("Unable to queue: %s" % sync_jobs)
+            raise
 
     def listen(self, event_type, listener):
         """Listen for all events or events of a specific type.
@@ -291,15 +339,30 @@ class EventBus(object):
         To listen to all events specify the constant ``MATCH_ALL``
         as event_type.
         """
-        with self._lock:
-            if event_type in self._listeners:
-                self._listeners[event_type].append(listener)
-            else:
-                self._listeners[event_type] = [listener]
+        future = run_callback_threadsafe(
+            self._loop, self.async_listen, event_type, listener)
+        future.result()
 
         def remove_listener():
             """Remove the listener."""
             self.remove_listener(event_type, listener)
+
+        return remove_listener
+
+    def async_listen(self, event_type, listener):
+        """Listen for all events or events of a specific type.
+
+        To listen to all events specify the constant ``MATCH_ALL``
+        as event_type.
+        """
+        if event_type in self._listeners:
+            self._listeners[event_type].append(listener)
+        else:
+            self._listeners[event_type] = [listener]
+
+        def remove_listener():
+            """Remove the listener."""
+            self.async_remove_listener(event_type, listener)
 
         return remove_listener
 
@@ -331,20 +394,58 @@ class EventBus(object):
 
         return onetime_listener
 
+    def async_listen_once(self, event_type, listener):
+        """Listen once for event of a specific type.
+
+        To listen to all events specify the constant ``MATCH_ALL``
+        as event_type.
+
+        Returns registered listener that can be used with remove_listener.
+        """
+        @ft.wraps(listener)
+        @asyncio.coroutine
+        def onetime_listener(event):
+            """Remove listener from eventbus and then fire listener."""
+            if hasattr(onetime_listener, 'run'):
+                return
+            # Set variable so that we will never run twice.
+            # Because the event bus might have to wait till a thread comes
+            # available to execute this listener it might occur that the
+            # listener gets lined up twice to be executed.
+            # This will make sure the second time it does nothing.
+            setattr(onetime_listener, 'run', True)
+
+            self.async_remove_listener(event_type, onetime_listener)
+
+            if asyncio.iscoroutinefunction(listener):
+                self._loop.create_task(listener(event))
+            else:
+                listener(event)
+
+        self.async_listen(event_type, onetime_listener)
+
+        return onetime_listener
+
     def remove_listener(self, event_type, listener):
         """Remove a listener of a specific event_type."""
-        with self._lock:
-            try:
-                self._listeners[event_type].remove(listener)
+        future = run_callback_threadsafe(self._loop,
+            self.async_remove_listener, event_type, listener
+        )
+        future.result()
 
-                # delete event_type list if empty
-                if not self._listeners[event_type]:
-                    self._listeners.pop(event_type)
+    def async_remove_listener(self, event_type, listener):
+        """Remove a listener of a specific event_type."""
+        try:
+            self._listeners[event_type].remove(listener)
 
-            except (KeyError, ValueError):
-                # KeyError is key event_type listener did not exist
-                # ValueError if listener did not exist within event_type
-                pass
+            # delete event_type list if empty
+            if not self._listeners[event_type]:
+                self._listeners.pop(event_type)
+
+        except (KeyError, ValueError):
+            # KeyError is key event_type listener did not exist
+            # ValueError if listener did not exist within event_type
+            pass
 
 
 class State(object):
@@ -448,27 +549,36 @@ class State(object):
 class StateMachine(object):
     """Helper class that tracks the state of different entities."""
 
-    def __init__(self, bus):
+    def __init__(self, bus, loop):
         """Initialize state machine."""
         self._states = {}
         self._bus = bus
-        self._lock = threading.Lock()
+        self._loop = loop
 
     def entity_ids(self, domain_filter=None):
+        """List of entity ids that are being tracked."""
+        future = run_callback_threadsafe(
+            self._loop, self.async_entity_ids, domain_filter
+        )
+        return future.result()
+
+    def async_entity_ids(self, domain_filter=None):
         """List of entity ids that are being tracked."""
         if domain_filter is None:
             return list(self._states.keys())
 
         domain_filter = domain_filter.lower()
 
-        with self._lock:
-            return [state.entity_id for state in self._states.values()
-                    if state.domain == domain_filter]
+        return [state.entity_id for state in self._states.values()
+                if state.domain == domain_filter]
 
     def all(self):
         """Create a list of all states."""
-        with self._lock:
-            return list(self._states.values())
+        return run_callback_threadsafe(self._loop, self.async_all).result()
+
+    def async_all(self):
+        """Create a list of all states."""
+        return list(self._states.values())
 
     def get(self, entity_id):
         """Retrieve state of entity_id or None if not found."""
@@ -476,12 +586,24 @@ class StateMachine(object):
 
     def is_state(self, entity_id, state):
         """Test if entity exists and is specified state."""
+        return run_callback_threadsafe(
+            self._loop, self.async_is_state, entity_id, state
+        ).result()
+
+    def async_is_state(self, entity_id, state):
+        """Test if entity exists and is specified state."""
         entity_id = entity_id.lower()
 
         return (entity_id in self._states and
                 self._states[entity_id].state == state)
 
     def is_state_attr(self, entity_id, name, value):
+        """Test if entity exists and has a state attribute set to value."""
+        return run_callback_threadsafe(
+            self._loop, self.async_is_state_attr, entity_id, name, value
+        ).result()
+
+    def async_is_state_attr(self, entity_id, name, value):
         """Test if entity exists and has a state attribute set to value."""
         entity_id = entity_id.lower()
 
@@ -493,25 +615,46 @@ class StateMachine(object):
 
         Returns boolean to indicate if an entity was removed.
         """
+        return run_callback_threadsafe(
+            self._loop, self.async_remove, entity_id).result()
+
+    def async_remove(self, entity_id):
+        """Remove the state of an entity.
+
+        Returns boolean to indicate if an entity was removed.
+        """
         entity_id = entity_id.lower()
 
-        with self._lock:
-            old_state = self._states.pop(entity_id, None)
+        old_state = self._states.pop(entity_id, None)
 
-            if old_state is None:
-                return False
+        if old_state is None:
+            return False
 
-            event_data = {
-                'entity_id': entity_id,
-                'old_state': old_state,
-                'new_state': None,
-            }
+        event_data = {
+            'entity_id': entity_id,
+            'old_state': old_state,
+            'new_state': None,
+        }
 
-            self._bus.fire(EVENT_STATE_CHANGED, event_data)
+        self._bus.async_fire(EVENT_STATE_CHANGED, event_data)
 
-            return True
+        return True
 
     def set(self, entity_id, new_state, attributes=None, force_update=False):
+        """Set the state of an entity, add entity if it does not exist.
+
+        Attributes is an optional dict to specify attributes of this state.
+
+        If you just update the attributes and not the state, last changed will
+        not be affected.
+        """
+        run_callback_threadsafe(
+            self._loop,
+            self.async_set, entity_id, new_state, attributes, force_update,
+        )
+
+    def async_set(self, entity_id, new_state, attributes=None,
+                        force_update=False):
         """Set the state of an entity, add entity if it does not exist.
 
         Attributes is an optional dict to specify attributes of this state.
@@ -523,30 +666,29 @@ class StateMachine(object):
         new_state = str(new_state)
         attributes = attributes or {}
 
-        with self._lock:
-            old_state = self._states.get(entity_id)
+        old_state = self._states.get(entity_id)
 
-            is_existing = old_state is not None
-            same_state = (is_existing and old_state.state == new_state and
-                          not force_update)
-            same_attr = is_existing and old_state.attributes == attributes
+        is_existing = old_state is not None
+        same_state = (is_existing and old_state.state == new_state and
+                      not force_update)
+        same_attr = is_existing and old_state.attributes == attributes
 
-            if same_state and same_attr:
-                return
+        if same_state and same_attr:
+            return
 
-            # If state did not exist or is different, set it
-            last_changed = old_state.last_changed if same_state else None
+        # If state did not exist or is different, set it
+        last_changed = old_state.last_changed if same_state else None
 
-            state = State(entity_id, new_state, attributes, last_changed)
-            self._states[entity_id] = state
+        state = State(entity_id, new_state, attributes, last_changed)
+        self._states[entity_id] = state
 
-            event_data = {
-                'entity_id': entity_id,
-                'old_state': old_state,
-                'new_state': state,
-            }
+        event_data = {
+            'entity_id': entity_id,
+            'old_state': old_state,
+            'new_state': state,
+        }
 
-            self._bus.fire(EVENT_STATE_CHANGED, event_data)
+        self._bus.async_fire(EVENT_STATE_CHANGED, event_data)
 
 
 # pylint: disable=too-few-public-methods
@@ -607,22 +749,30 @@ class ServiceCall(object):
 class ServiceRegistry(object):
     """Offers services over the eventbus."""
 
-    def __init__(self, bus, add_job):
+    def __init__(self, bus, add_job, loop):
         """Initialize a service registry."""
         self._services = {}
-        self._lock = threading.Lock()
         self._add_job = add_job
         self._bus = bus
+        self._loop = loop
         self._cur_id = 0
-        bus.listen(EVENT_CALL_SERVICE, self._event_to_service_call)
+        run_callback_threadsafe(
+            loop,
+            bus.async_listen, EVENT_CALL_SERVICE, self._event_to_service_call,
+        )
 
     @property
     def services(self):
         """Dict with per domain a list of available services."""
-        with self._lock:
-            return {domain: {key: value.as_dict() for key, value
-                             in self._services[domain].items()}
-                    for domain in self._services}
+        return run_callback_threadsafe(
+            self._loop, self.async_services,
+        ).result()
+
+    def async_services(self):
+        """Dict with per domain a list of available services."""
+        return {domain: {key: value.as_dict() for key, value
+                         in self._services[domain].items()}
+                for domain in self._services}
 
     def has_service(self, domain, service):
         """Test if specified service exists."""
@@ -639,22 +789,67 @@ class ServiceRegistry(object):
 
         Schema is called to coerce and validate the service data.
         """
+        run_callback_threadsafe(
+            self._loop,
+            self.async_register, domain, service, service_func, description,
+            schema
+        )
+
+    def async_register(self, domain, service, service_func, description=None,
+                       schema=None):
+        """
+        Register a service.
+
+        Description is a dict containing key 'description' to describe
+        the service and a key 'fields' to describe the fields.
+
+        Schema is called to coerce and validate the service data.
+        """
         domain = domain.lower()
         service = service.lower()
         description = description or {}
         service_obj = Service(service_func, description.get('description'),
                               description.get('fields', {}), schema)
-        with self._lock:
-            if domain in self._services:
-                self._services[domain][service] = service_obj
-            else:
-                self._services[domain] = {service: service_obj}
 
-            self._bus.fire(
-                EVENT_SERVICE_REGISTERED,
-                {ATTR_DOMAIN: domain, ATTR_SERVICE: service})
+        if domain in self._services:
+            self._services[domain][service] = service_obj
+        else:
+            self._services[domain] = {service: service_obj}
+
+        self._bus.async_fire(EVENT_SERVICE_REGISTERED,
+                             {ATTR_DOMAIN: domain, ATTR_SERVICE: service}
+        )
 
     def call(self, domain, service, service_data=None, blocking=False):
+        """
+        Call a service.
+
+        Specify blocking=True to wait till service is executed.
+        Waits a maximum of SERVICE_CALL_LIMIT.
+
+        If blocking = True, will return boolean if service executed
+        succesfully within SERVICE_CALL_LIMIT.
+
+        This method will fire an event to call the service.
+        This event will be picked up by this ServiceRegistry and any
+        other ServiceRegistry that is listening on the EventBus.
+
+        Because the service is sent as an event you are not allowed to use
+        the keys ATTR_DOMAIN and ATTR_SERVICE in your service_data.
+        """
+        if blocking:
+            return run_coroutine_threadsafe(
+                self.async_call(domain, service, service_data, blocking),
+                self._loop
+            ).result()
+        else:
+            fire_coroutine_threadsafe(
+                self.async_call(domain, service, service_data, blocking),
+                self._loop
+            )
+
+    @asyncio.coroutine
+    def async_call(self, domain, service, service_data=None, blocking=False):
         """
         Call a service.
 
@@ -681,21 +876,24 @@ class ServiceRegistry(object):
         }
 
         if blocking:
-            executed_event = threading.Event()
+            fut = asyncio.Future(loop=self._loop)
 
+            @asyncio.coroutine
             def service_executed(call):
                 """Callback method that is called when service is executed."""
                 if call.data[ATTR_SERVICE_CALL_ID] == call_id:
-                    executed_event.set()
+                    fut.set_result(True)
 
-            self._bus.listen(EVENT_SERVICE_EXECUTED, service_executed)
+            self._bus.async_listen(EVENT_SERVICE_EXECUTED, service_executed)
 
-        self._bus.fire(EVENT_CALL_SERVICE, event_data)
+        self._bus.async_fire(EVENT_CALL_SERVICE, event_data)
 
         if blocking:
-            success = executed_event.wait(SERVICE_CALL_LIMIT)
-            self._bus.remove_listener(
-                EVENT_SERVICE_EXECUTED, service_executed)
+            done, _ = yield from asyncio.wait([fut], loop=self._loop,
+                                              timeout=SERVICE_CALL_LIMIT)
+            success = bool(done)
+            self._bus.async_remove_listener(EVENT_SERVICE_EXECUTED,
+                                            service_executed)
             return success
 
     def _event_to_service_call(self, event):
@@ -790,16 +988,17 @@ def create_timer(hass, interval=TIMER_INTERVAL):
     # every minute.
     assert 60 % interval == 0, "60 % TIMER_INTERVAL should be 0!"
 
-    def timer():
-        """Send an EVENT_TIME_CHANGED on interval."""
-        stop_event = threading.Event()
+    stop_event = asyncio.Event(loop=hass.loop)
 
-        def stop_timer(event):
-            """Stop the timer."""
-            stop_event.set()
+    # Setting the Event inside the loop by marking it as a coroutine
+    @asyncio.coroutine
+    def stop_timer(event):
+        stop_event.set()
 
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_timer)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_timer)
 
+    @asyncio.coroutine
+    def timer(interval, stop_event):
         _LOGGER.info("Timer:starting")
 
         last_fired_on_second = -1
@@ -823,7 +1022,7 @@ def create_timer(hass, interval=TIMER_INTERVAL):
                 slp_seconds = interval - now.second % interval + \
                     .5 - now.microsecond/1000000.0
 
-                time.sleep(slp_seconds)
+                yield from asyncio.sleep(slp_seconds)
 
                 now = calc_now()
 
@@ -832,18 +1031,21 @@ def create_timer(hass, interval=TIMER_INTERVAL):
             # Event might have been set while sleeping
             if not stop_event.is_set():
                 try:
-                    hass.bus.fire(EVENT_TIME_CHANGED, {ATTR_NOW: now})
+                    # Schedule the bus event
+                    hass.loop.call_soon(
+                        hass.bus.async_fire,
+                        EVENT_TIME_CHANGED,
+                        {ATTR_NOW: now}
+                    )
                 except HomeAssistantError:
                     # HA raises error if firing event after it has shut down
                     break
 
+    @asyncio.coroutine
     def start_timer(event):
-        """Start the timer."""
-        thread = threading.Thread(target=timer, name='Timer')
-        thread.daemon = True
-        thread.start()
+        hass.loop.create_task(timer(interval, stop_event))
 
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_timer)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, start_timer)
 
 
 def create_worker_pool(worker_count=None):

--- a/homeassistant/helpers/async.py
+++ b/homeassistant/helpers/async.py
@@ -1,0 +1,147 @@
+"""
+Asyncio backports for Python 3.4.3 compatibility
+"""
+import concurrent.futures
+from asyncio import coroutines
+from asyncio.futures import Future
+
+try:
+    from asyncio import ensure_future
+except ImportError:
+    # Python 3.4.3 and earlier has this as async
+    # pylint: disable=unused-import
+    from asyncio import async
+    ensure_future = async
+
+
+
+def _set_result_unless_cancelled(fut, result):
+    """Helper setting the result only if the future was not cancelled."""
+    if fut.cancelled():
+        return
+    fut.set_result(result)
+
+
+def _set_concurrent_future_state(concurrent, source):
+    """Copy state from a future to a concurrent.futures.Future."""
+    assert source.done()
+    if source.cancelled():
+        concurrent.cancel()
+    if not concurrent.set_running_or_notify_cancel():
+        return
+    exception = source.exception()
+    if exception is not None:
+        concurrent.set_exception(exception)
+    else:
+        result = source.result()
+        concurrent.set_result(result)
+
+
+def _copy_future_state(source, dest):
+    """Internal helper to copy state from another Future.
+    The other Future may be a concurrent.futures.Future.
+    """
+    assert source.done()
+    if dest.cancelled():
+        return
+    assert not dest.done()
+    if source.cancelled():
+        dest.cancel()
+    else:
+        exception = source.exception()
+        if exception is not None:
+            dest.set_exception(exception)
+        else:
+            result = source.result()
+            dest.set_result(result)
+
+
+def _chain_future(source, destination):
+    """Chain two futures so that when one completes, so does the other.
+    The result (or exception) of source will be copied to destination.
+    If destination is cancelled, source gets cancelled too.
+    Compatible with both asyncio.Future and concurrent.futures.Future.
+    """
+    if not isinstance(source, (Future, concurrent.futures.Future)):
+        raise TypeError('A future is required for source argument')
+    if not isinstance(destination, (Future, concurrent.futures.Future)):
+        raise TypeError('A future is required for destination argument')
+    source_loop = source._loop if isinstance(source, Future) else None
+    dest_loop = destination._loop if isinstance(destination, Future) else None
+
+    def _set_state(future, other):
+        if isinstance(future, Future):
+            _copy_future_state(other, future)
+        else:
+            _set_concurrent_future_state(future, other)
+
+    def _call_check_cancel(destination):
+        if destination.cancelled():
+            if source_loop is None or source_loop is dest_loop:
+                source.cancel()
+            else:
+                source_loop.call_soon_threadsafe(source.cancel)
+
+    def _call_set_state(source):
+        if dest_loop is None or dest_loop is source_loop:
+            _set_state(destination, source)
+        else:
+            dest_loop.call_soon_threadsafe(_set_state, destination, source)
+
+    destination.add_done_callback(_call_check_cancel)
+    source.add_done_callback(_call_set_state)
+
+
+def run_coroutine_threadsafe(coro, loop):
+    """Submit a coroutine object to a given event loop.
+    Return a concurrent.futures.Future to access the result.
+    """
+    if not coroutines.iscoroutine(coro):
+        raise TypeError('A coroutine object is required')
+    future = concurrent.futures.Future()
+
+    def callback():
+        try:
+            _chain_future(ensure_future(coro, loop=loop), future)
+        except Exception as exc:
+            if future.set_running_or_notify_cancel():
+                future.set_exception(exc)
+            raise
+
+    loop.call_soon_threadsafe(callback)
+    return future
+
+
+def fire_coroutine_threadsafe(coro, loop):
+    """Submit a coroutine object to a given event loop.
+
+    This method does not provide a way to retrieve the result and
+    is intended for fire-and-forget use. This reduces the
+    work involved to fire the function on the loop.
+    """
+    if not coroutines.iscoroutine(coro):
+        raise TypeError('A coroutine object is required: %s' % coro)
+
+    def callback():
+        ensure_future(coro, loop=loop)
+
+    loop.call_soon_threadsafe(callback)
+    return
+
+
+def run_callback_threadsafe(loop, callback, *args):
+    """Submit a callback object to a given event loop.
+    Return a concurrent.futures.Future to access the result.
+    """
+    future = concurrent.futures.Future()
+
+    def cb():
+        try:
+            future.set_result(callback(*args))
+        except Exception as exc:
+            if future.set_running_or_notify_cancel():
+                future.set_exception(exc)
+            raise
+
+    loop.call_soon_threadsafe(cb)
+    return future


### PR DESCRIPTION
**Description:**

WIP: NOT READY FOR MERGE YET

This replaces the primary mechanism by which HASS runs. 

The existing architecture exposes 3 core.py API objects, EventBus, StateMachine, and ServiceRegistry. These are called from a variety of threads and are all blocking calls that attempt to acquire per-object locks to fully execute.

This change retains the existing thread-safe blocking API for use by all components, as well as the blocking nature of component setup. However, it starts up an asyncio event loop on start, which is where the actual work is done. The thread-safe API calls schedule the async API variant version into the event loop, then blocks waiting until it has run to completion.

EventBus registrations that are marked as coroutines run on the event loop and may directly run async versions of the appropriate API's. To retain similar call characteristics as before, EventBus's async_fire schedules coroutines to run later on the event loop while sending non-coroutines to the thread-pool as before. This does mean that coroutine listeners are guaranteed to run _after_ all listeners were located, while non-coroutines may start executing immediately in the other thread.

This WIP uses Python 3.4.4 functionality as a proving ground for the approach, using earlier 3.4 should be fine with a backported function or two for asyncio features needed (such as run_coroutine_threadsafe).
