### PR TITLE
Use voluptuous for DirecTV

### DIFF
--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -1,14 +1,22 @@
-"""Support for the DirecTV recievers."""
+"""
+Support for the DirecTV recievers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.directv/
+"""
+import voluptuous as vol
 
 from homeassistant.components.media_player import (
     MEDIA_TYPE_TVSHOW, MEDIA_TYPE_VIDEO, SUPPORT_PAUSE, SUPPORT_PLAY_MEDIA,
-    SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_STOP,
+    SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_STOP, PLATFORM_SCHEMA,
     SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK, MediaPlayerDevice)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, STATE_OFF, STATE_PLAYING)
+    CONF_HOST, CONF_NAME, STATE_OFF, STATE_PLAYING, CONF_PORT)
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['directpy==0.1']
 
+DEFAULT_NAME = 'DirecTV Receiver'
 DEFAULT_PORT = 8080
 
 SUPPORT_DTV = SUPPORT_PAUSE | SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
@@ -16,6 +24,12 @@ SUPPORT_DTV = SUPPORT_PAUSE | SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
     SUPPORT_PREVIOUS_TRACK
 
 KNOWN_HOSTS = []
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -34,8 +48,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     elif CONF_HOST in config:
         hosts.append([
-            config.get(CONF_NAME, 'DirecTV Receiver'),
-            config[CONF_HOST], DEFAULT_PORT
+            config.get(CONF_NAME), config.get(CONF_HOST), config.get(CONF_PORT)
         ])
 
     dtvs = []


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.
**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
  platform: directv
  host: 192.168.1.10
  name: DirecTV Living Room
```

@cbulock, would be nice if you could take a look at the changes and run a quick test. Thanks.
