### PR TITLE
Use voluptuous for Fire-TV

### DIFF
--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -7,46 +7,55 @@ https://home-assistant.io/components/media_player.firetv/
 import logging
 
 import requests
+import voluptuous as vol
 
 from homeassistant.components.media_player import (
-    SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK, PLATFORM_SCHEMA,
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_SET, MediaPlayerDevice)
 from homeassistant.const import (
     STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING, STATE_STANDBY,
-    STATE_UNKNOWN)
+    STATE_UNKNOWN, CONF_HOST, CONF_PORT, CONF_NAME, CONF_DEVICE, CONF_DEVICES)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
 
 SUPPORT_FIRETV = SUPPORT_PAUSE | \
     SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PREVIOUS_TRACK | \
     SUPPORT_NEXT_TRACK | SUPPORT_VOLUME_SET
 
-DOMAIN = 'firetv'
-DEVICE_LIST_URL = 'http://{0}/devices/list'
-DEVICE_STATE_URL = 'http://{0}/devices/state/{1}'
-DEVICE_ACTION_URL = 'http://{0}/devices/action/{1}/{2}'
+DEFAULT_DEVICE = 'default'
+DEFAULT_HOST = 'localhost'
+DEFAULT_NAME = 'Amazon Fire TV'
+DEFAULT_PORT = 5556
+DEVICE_ACTION_URL = 'http://{0}:{1}/devices/action/{2}/{3}'
+DEVICE_LIST_URL = 'http://{0}:{1}/devices/list'
+DEVICE_STATE_URL = 'http://{0}:{1}/devices/state/{2}'
 
-_LOGGER = logging.getLogger(__name__)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICE, default=DEFAULT_DEVICE): cv.string,
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+})
 
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the FireTV platform."""
-    host = config.get('host', 'localhost:5556')
-    device_id = config.get('device', 'default')
+    name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    device_id = config.get(CONF_DEVICE)
+
     try:
-        response = requests.get(DEVICE_LIST_URL.format(host)).json()
-        if device_id in response['devices'].keys():
-            add_devices([
-                FireTVDevice(
-                    host,
-                    device_id,
-                    config.get('name', 'Amazon Fire TV')
-                )
-            ])
-            _LOGGER.info(
-                'Device %s accessible and ready for control', device_id)
+        response = requests.get(DEVICE_LIST_URL.format(host, port)).json()
+        if device_id in response[CONF_DEVICES].keys():
+            add_devices([FireTVDevice(host, port, device_id, name)])
+            _LOGGER.info('Device %s accessible and ready for control',
+                         device_id)
         else:
-            _LOGGER.warning(
-                'Device %s is not registered with firetv-server', device_id)
+            _LOGGER.warning('Device %s is not registered with firetv-server',
+                            device_id)
     except requests.exceptions.RequestException:
         _LOGGER.error('Could not connect to firetv-server at %s', host)
 
@@ -62,9 +71,10 @@ class FireTV(object):
     be running via Python 2).
     """
 
-    def __init__(self, host, device_id):
+    def __init__(self, host, port, device_id):
         """Initialize the FireTV server."""
         self.host = host
+        self.port = port
         self.device_id = device_id
 
     @property
@@ -73,10 +83,7 @@ class FireTV(object):
         try:
             response = requests.get(
                 DEVICE_STATE_URL.format(
-                    self.host,
-                    self.device_id
-                    )
-                ).json()
+                    self.host, self.port, self.device_id), timeout=10).json()
             return response.get('state', STATE_UNKNOWN)
         except requests.exceptions.RequestException:
             _LOGGER.error(
@@ -86,13 +93,8 @@ class FireTV(object):
     def action(self, action_id):
         """Perform an action on the device."""
         try:
-            requests.get(
-                DEVICE_ACTION_URL.format(
-                    self.host,
-                    self.device_id,
-                    action_id
-                    )
-                )
+            requests.get(DEVICE_ACTION_URL.format(
+                self.host, self.port, self.device_id, action_id), timeout=10)
         except requests.exceptions.RequestException:
             _LOGGER.error(
                 'Action request for %s was not accepted for device %s',
@@ -103,9 +105,9 @@ class FireTVDevice(MediaPlayerDevice):
     """Representation of an Amazon Fire TV device on the network."""
 
     # pylint: disable=abstract-method
-    def __init__(self, host, device, name):
+    def __init__(self, host, port, device, name):
         """Initialize the FireTV device."""
-        self._firetv = FireTV(host, device)
+        self._firetv = FireTV(host, port, device)
         self._name = name
         self._state = STATE_UNKNOWN
 


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.
**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
media_player:
  platform: firetv
  host: localhost
  port: 5556
  device: livingroom-firetv
  name: My Amazon Fire TV
```

@happyleavesaoc, would be nice if you could take a look at the changes and run a quick test. Thanks.
