### PR TITLE
Bluetooth: keep looking for new devices

### DIFF
--- a/homeassistant/components/device_tracker/bluetooth_le_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_le_tracker.py
@@ -11,6 +11,7 @@ from homeassistant.components.device_tracker import (
     DEFAULT_SCAN_INTERVAL,
     PLATFORM_SCHEMA,
     load_config,
+    DEFAULT_TRACK_NEW
 )
 import homeassistant.util as util
 import homeassistant.util.dt as dt_util
@@ -88,7 +89,7 @@ def setup_scanner(hass, config, see):
     # if track new devices is true discover new devices
     # on every scan.
     track_new = util.convert(config.get(CONF_TRACK_NEW), bool,
-                             len(devs_to_track) == 0)
+                             DEFAULT_TRACK_NEW)
     if not devs_to_track and not track_new:
         _LOGGER.warning("No Bluetooth LE devices to track!")
         return False

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -64,15 +64,20 @@ def setup_scanner(hass, config, see):
                 devs_to_track.append(dev[0])
                 see_device(dev)
 
-    if not devs_to_track:
-        _LOGGER.warning("No bluetooth devices to track!")
-        return False
+    # if not devs_to_track:
+    #     _LOGGER.warning("No bluetooth devices to track!")
+    #     return False
 
     interval = config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
 
     def update_bluetooth(now):
         """Lookup bluetooth device and update status."""
         try:
+            if track_new:
+                for dev in discover_devices():
+                    if dev[0] not in devs_to_track and \
+                        dev[0] not in devs_donot_track:
+                        devs_to_track.append(dev[0])
             for mac in devs_to_track:
                 _LOGGER.debug("Scanning " + mac)
                 result = bluetooth.lookup_name(mac, timeout=5)

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -8,7 +8,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_point_in_utc_time
 from homeassistant.components.device_tracker import (
     YAML_DEVICES, CONF_TRACK_NEW, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
-    load_config, PLATFORM_SCHEMA)
+    load_config, PLATFORM_SCHEMA, DEFAULT_TRACK_NEW)
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ def setup_scanner(hass, config, see):
                 devs_donot_track.append(device.mac[3:])
 
     # if track new devices is true discover new devices on startup.
-    track_new = config.get(CONF_TRACK_NEW, len(devs_to_track) == 0)
+    track_new = config.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
     if track_new:
         for dev in discover_devices():
             if dev[0] not in devs_to_track and \
@@ -76,7 +76,7 @@ def setup_scanner(hass, config, see):
             if track_new:
                 for dev in discover_devices():
                     if dev[0] not in devs_to_track and \
-                        dev[0] not in devs_donot_track:
+                       dev[0] not in devs_donot_track:
                         devs_to_track.append(dev[0])
             for mac in devs_to_track:
                 _LOGGER.debug("Scanning " + mac)

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -64,10 +64,6 @@ def setup_scanner(hass, config, see):
                 devs_to_track.append(dev[0])
                 see_device(dev)
 
-    # if not devs_to_track:
-    #     _LOGGER.warning("No bluetooth devices to track!")
-    #     return False
-
     interval = config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
 
     def update_bluetooth(now):


### PR DESCRIPTION
**Description:**
This enables the Bluetooth Tracker to keep finding new devices, like the NMAP tracker.
Now it only looks for new devices at startup and it fails if there aren't any at startup.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
