### PR TITLE
Updated Ecobee to use occupancy sensor_class

### DIFF
--- a/homeassistant/components/binary_sensor/ecobee.py
+++ b/homeassistant/components/binary_sensor/ecobee.py
@@ -38,7 +38,7 @@ class EcobeeBinarySensor(BinarySensorDevice):
         self.sensor_name = sensor_name
         self.index = sensor_index
         self._state = None
-        self._sensor_class = 'motion'
+        self._sensor_class = 'occupancy'
         self.update()
 
     @property


### PR DESCRIPTION
**Description:** Now that @robbiet480 has created the new `occupancy` `sensor class` (#3176), it may be better to use the same for the Ecobee occupancy sensors instead of `motion` that it currently uses. 
