### PR TITLE
Use voluptuous for roku

### DIFF
--- a/homeassistant/components/media_player/roku.py
+++ b/homeassistant/components/media_player/roku.py
@@ -6,13 +6,15 @@ https://home-assistant.io/components/media_player.roku/
 """
 import logging
 
+import voluptuous as vol
+
 from homeassistant.components.media_player import (
     MEDIA_TYPE_VIDEO, SUPPORT_NEXT_TRACK, SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
-    SUPPORT_SELECT_SOURCE, MediaPlayerDevice)
-
+    SUPPORT_SELECT_SOURCE, MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_HOST, STATE_IDLE, STATE_PLAYING, STATE_UNKNOWN, STATE_HOME)
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = [
     'https://github.com/bah2830/python-roku/archive/3.1.2.zip'
@@ -26,6 +28,10 @@ _LOGGER = logging.getLogger(__name__)
 SUPPORT_ROKU = SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK |\
     SUPPORT_PLAY_MEDIA | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE |\
     SUPPORT_SELECT_SOURCE
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST): cv.string,
+})
 
 
 # pylint: disable=abstract-method
@@ -41,7 +47,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         hosts.append(discovery_info[0])
 
     elif CONF_HOST in config:
-        hosts.append(config[CONF_HOST])
+        hosts.append(config.get(CONF_HOST))
 
     rokus = []
     for host in hosts:


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.
**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
media_player:
  platform: pioneer
  host: 192.168.0.10
  name: Living receiver
```

@bah2830, would be nice if you could take a look at the changes and run a quick test. Thanks.
