### PR TITLE
Add full color support for Osram Lightify bulbs with Wink

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.entity import Entity
 from homeassistant.loader import get_component
 
-REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.14', 'pubnub==3.8.2']
 
 # These are the available sensors mapped to binary_sensor class
 SENSOR_TYPES = {

--- a/homeassistant/components/cover/wink.py
+++ b/homeassistant/components/cover/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.cover import CoverDevice
 from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.14', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/garage_door/wink.py
+++ b/homeassistant/components/garage_door/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.garage_door import GarageDoorDevice
 from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.14', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.wink/
 """
 import logging
+import colorsys
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, \
     ATTR_RGB_COLOR, SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, \
@@ -15,7 +16,7 @@ from homeassistant.util import color as color_util
 from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
 
-REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.14', 'pubnub==3.8.2']
 
 SUPPORT_WINK = SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_RGB_COLOR
 
@@ -57,6 +58,21 @@ class WinkLight(WinkDevice, Light):
         return int(self.wink.brightness() * 255)
 
     @property
+    def rgb_color(self):
+        """Current bulb color in RGB."""
+        if not self.wink.supports_hue_saturation():
+            return None
+        else:
+            hue = self.wink.color_hue()
+            saturation = self.wink.color_saturation()
+            value = int(self.wink.brightness() * 255)
+            rgb = colorsys.hsv_to_rgb(hue, saturation, value)
+            r_value = int(round(rgb[0]))
+            g_value = int(round(rgb[1]))
+            b_value = int(round(rgb[2]))
+            return r_value, g_value, b_value
+
+    @property
     def xy_color(self):
         """Current bulb color in CIE 1931 (XY) color space."""
         if not self.wink.supports_xy_color():
@@ -87,9 +103,14 @@ class WinkLight(WinkDevice, Light):
         }
 
         if rgb_color:
-            xyb = color_util.color_RGB_to_xy(*rgb_color)
-            state_kwargs['color_xy'] = xyb[0], xyb[1]
-            state_kwargs['brightness'] = xyb[2]
+            if self.wink.supports_xy_color():
+                xyb = color_util.color_RGB_to_xy(*rgb_color)
+                state_kwargs['color_xy'] = xyb[0], xyb[1]
+                state_kwargs['brightness'] = xyb[2]
+            elif self.wink.supports_hue_saturation():
+                hsv = colorsys.rgb_to_hsv(rgb_color[0],
+                                          rgb_color[1], rgb_color[2])
+                state_kwargs['color_hue_saturation'] = hsv[0], hsv[1]
 
         if color_temp_mired:
             state_kwargs['color_kelvin'] = mired_to_kelvin(color_temp_mired)

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.lock import LockDevice
 from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.14', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/rollershutter/wink.py
+++ b/homeassistant/components/rollershutter/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.rollershutter import RollershutterDevice
 from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.14', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.components.wink import WinkDevice
 from homeassistant.loader import get_component
 
-REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.14', 'pubnub==3.8.2']
 
 SENSOR_TYPES = ['temperature', 'humidity']
 

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -10,7 +10,7 @@ from homeassistant.components.wink import WinkDevice
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.entity import ToggleEntity
 
-REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.14', 'pubnub==3.8.2']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.7.14', 'pubnub==3.8.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -394,7 +394,7 @@ python-twitch==1.3.0
 # homeassistant.components.rollershutter.wink
 # homeassistant.components.sensor.wink
 # homeassistant.components.switch.wink
-python-wink==0.7.13
+python-wink==0.7.14
 
 # homeassistant.components.keyboard
 pyuserinput==0.1.11


### PR DESCRIPTION
**Description:**
Currently the Osram Lightify RGB bulbs are only showing as temperature adjustable. This will add support for full color. 

@TDWhbp @cbulock if either of you could test this that would be awesome.

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
