### PR TITLE
Upgrade Werkzeug to 0.11.11

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -25,7 +25,7 @@ import homeassistant.util.dt as dt_util
 import homeassistant.helpers.config_validation as cv
 
 DOMAIN = 'http'
-REQUIREMENTS = ('cherrypy==7.1.0', 'static3==0.7.0', 'Werkzeug==0.11.10')
+REQUIREMENTS = ('cherrypy==7.1.0', 'static3==0.7.0', 'Werkzeug==0.11.11')
 
 CONF_API_PASSWORD = 'api_password'
 CONF_SERVER_HOST = 'server_host'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -26,7 +26,7 @@ SoCo==0.11.1
 TwitterAPI==2.4.2
 
 # homeassistant.components.http
-Werkzeug==0.11.10
+Werkzeug==0.11.11
 
 # homeassistant.components.apcupsd
 apcaccess==0.0.4


### PR DESCRIPTION
## Version 0.11.11
- Fix JSONRequestMixin for Python3
- Fix broken string handling in test client when passing integers
- Fix a bug in `parse_options_header` where an invalid content type
  starting with comma or semi-colon would result in an invalid return value
- Fix a bug in multidicts when passing empty lists as values
- Fix a security issue that allows XSS on the Werkzeug debugger

Tested with the following configuration:

``` yaml
http:
  api_password: mypass
```
