### PR TITLE
Upgrade psutil to 4.3.1

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -8,14 +8,13 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.util.dt as dt_util
-
-from homeassistant.const import (CONF_RESOURCES, STATE_OFF, STATE_ON)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (CONF_RESOURCES, STATE_OFF, STATE_ON)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==4.3.0']
+REQUIREMENTS = ['psutil==4.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -270,7 +270,7 @@ pmsensor==0.3
 proliphix==0.3.1
 
 # homeassistant.components.sensor.systemmonitor
-psutil==4.3.0
+psutil==4.3.1
 
 # homeassistant.components.wink
 # homeassistant.components.binary_sensor.wink


### PR DESCRIPTION
## 4.3.1

**Enhancements**
-  "make install" now works also when using a virtual env.

**Bug fixes**
- Process.as_dict() raises ValueError if passed an erroneous attrs name.
- [SunOS] Process cpu_times(), cpu_percent(), threads() amd memory_maps() may raise RuntimeError if attempting to query a 64bit process with a 32bit python. "Null" values are returned as a fallback.
- Process.as_dict() should not return memory_info_ex() because it's deprecated.
- [Windows] memory_map truncates addresses above 32 bits
- [Windows] win_service_iter() and services in general are not able to handle unicode service names / descriptions.
- [Windows] Process.wait() may raise TimeoutExpired with wrong timeout unit (ms instead of sec).
- [Windows] Handle leak inside psutil_get_process_data.

Tested with the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
```
