### PR TITLE
Upgrade slacker to 0.9.25

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -13,7 +13,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['slacker==0.9.24']
+REQUIREMENTS = ['slacker==0.9.25']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -425,7 +425,7 @@ scsgate==0.1.0
 sendgrid==3.2.10
 
 # homeassistant.components.notify.slack
-slacker==0.9.24
+slacker==0.9.25
 
 # homeassistant.components.notify.xmpp
 sleekxmpp==1.3.1


### PR DESCRIPTION
## 0.9.24
- user.profile.set fix

Tested with the following configuration:

``` yaml
notify:
  - name: slack
    platform: slack
    api_key: !secret slack_api
    default_channel: '#ha'
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```
