### PR TITLE
Fix TP-Link Archer C7 long passwords

### DIFF
--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -277,8 +277,9 @@ class Tplink4DeviceScanner(TplinkDeviceScanner):
         _LOGGER.info("Retrieving auth tokens...")
         url = 'http://{}/userRpm/LoginRpm.htm?Save=Save'.format(self.host)
 
-        # Generate md5 hash of password. The C7 appears to only use the first 15 characters
-        # of a password, so we truncate to remove additional characters.
+        # Generate md5 hash of password. The C7 appears to only use the first 15
+        # characters of the password, so we truncate to remove additional
+        # characters from being hashed.
         password = hashlib.md5(self.password.encode('utf')[:15]).hexdigest()
         credentials = '{}:{}'.format(self.username, password).encode('utf')
 

--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -278,8 +278,8 @@ class Tplink4DeviceScanner(TplinkDeviceScanner):
         url = 'http://{}/userRpm/LoginRpm.htm?Save=Save'.format(self.host)
 
         # Generate md5 hash of password
-        password = hashlib.md5(self.password.encode('utf')).hexdigest()
-        credentials = '{}:{}'.format(self.username, password[:15]).encode('utf')
+        password = hashlib.md5(self.password.encode('utf')[:15]).hexdigest()
+        credentials = '{}:{}'.format(self.username, password).encode('utf')
 
         # Encode the credentials to be sent as a cookie.
         self.credentials = base64.b64encode(credentials).decode('utf')

--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -277,7 +277,8 @@ class Tplink4DeviceScanner(TplinkDeviceScanner):
         _LOGGER.info("Retrieving auth tokens...")
         url = 'http://{}/userRpm/LoginRpm.htm?Save=Save'.format(self.host)
 
-        # Generate md5 hash of password
+        # Generate md5 hash of password. The C7 appears to only use the first 15 characters
+        # of a password, so we truncate to remove additional characters.
         password = hashlib.md5(self.password.encode('utf')[:15]).hexdigest()
         credentials = '{}:{}'.format(self.username, password).encode('utf')
 

--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -277,8 +277,8 @@ class Tplink4DeviceScanner(TplinkDeviceScanner):
         _LOGGER.info("Retrieving auth tokens...")
         url = 'http://{}/userRpm/LoginRpm.htm?Save=Save'.format(self.host)
 
-        # Generate md5 hash of password. The C7 appears to only use the first 15
-        # characters of the password, so we truncate to remove additional
+        # Generate md5 hash of password. The C7 appears to use the first 15
+        # characters of the password only, so we truncate to remove additional
         # characters from being hashed.
         password = hashlib.md5(self.password.encode('utf')[:15]).hexdigest()
         credentials = '{}:{}'.format(self.username, password).encode('utf')

--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -279,7 +279,7 @@ class Tplink4DeviceScanner(TplinkDeviceScanner):
 
         # Generate md5 hash of password
         password = hashlib.md5(self.password.encode('utf')).hexdigest()
-        credentials = '{}:{}'.format(self.username, password).encode('utf')
+        credentials = '{}:{}'.format(self.username, password[:15]).encode('utf')
 
         # Encode the credentials to be sent as a cookie.
         self.credentials = base64.b64encode(credentials).decode('utf')


### PR DESCRIPTION
Description:

Passwords longer than 15 chars appear to be truncated when authenticating with the TP-Link Archer C7, and possibly other devices. With a password longer than 15 characters, the MD5 in the cookie will be the md5 of the first 15 chars.
