### PR TITLE
Upgrade sendgrid to 3.4.0

### DIFF
--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -13,7 +13,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import (CONF_API_KEY, CONF_SENDER, CONF_RECIPIENT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['sendgrid==3.2.10']
+REQUIREMENTS = ['sendgrid==3.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -422,7 +422,7 @@ schiene==0.17
 scsgate==0.1.0
 
 # homeassistant.components.notify.sendgrid
-sendgrid==3.2.10
+sendgrid==3.4.0
 
 # homeassistant.components.notify.slack
 slacker==0.9.25


### PR DESCRIPTION
## 3.4.0
- Support larger files. Note that there is a 20MB maximum.
## 3.3.1
- Naming inconsistency, we now standardized on file_name
- Support for use of iteritems in Python 3
## 3.3.0
- Allow for custom Inbound Parse config.yml

Tested with the following configuration:

``` yaml
notify:
  - name: sendgrid
    platform: sendgrid
    api_key: !secret sendgrid_api
    sender: you@example.com
    recipient: me@example.com
```

Message sent with "Call Service" but failed (#3138)

``` json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!",
  "title": "Test message"
}
```
