### PR TITLE
Use voluptuous for Simplisafe

### DIFF
--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -6,32 +6,39 @@ https://home-assistant.io/components/alarm_control_panel.simplisafe/
 """
 import logging
 
+import voluptuous as vol
+
 import homeassistant.components.alarm_control_panel as alarm
-
+from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_PASSWORD, CONF_USERNAME, STATE_UNKNOWN,
+    CONF_PASSWORD, CONF_USERNAME, STATE_UNKNOWN, CONF_CODE, CONF_NAME,
     STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_AWAY)
+import homeassistant.helpers.config_validation as cv
 
-_LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = ['https://github.com/w1ll1am23/simplisafe-python/archive/'
                 '586fede0e85fd69e56e516aaa8e97eb644ca8866.zip#'
                 'simplisafe-python==0.0.1']
 
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'SimpliSafe'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_CODE): cv.positive_int,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the SimpliSafe platform."""
+    name = config.get(CONF_NAME)
+    code = config.get(CONF_CODE)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    if username is None or password is None:
-        _LOGGER.error('Must specify username and password!')
-        return False
-
-    add_devices([SimpliSafeAlarm(
-        config.get('name', "SimpliSafe"),
-        username,
-        password,
-        config.get('code'))])
+    add_devices([SimpliSafeAlarm(name, username, password, code)])
 
 
 # pylint: disable=abstract-method


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
alarm_control_panel:
  platform: simplisafe
  name: "HA Alarm"
  code: PASSCODE
  username: YOUR_USERNAME
  password: YOUR_PASSWORD
```

@w1ll1am23, would be nice if you could take a look at the changes and run a quick test. Thanks.
