### PR TITLE
Use voluptuous for nx584 alarm

### DIFF
--- a/homeassistant/components/alarm_control_panel/nx584.py
+++ b/homeassistant/components/alarm_control_panel/nx584.py
@@ -7,22 +7,40 @@ https://home-assistant.io/components/alarm_control_panel.nx584/
 import logging
 
 import requests
+import voluptuous as vol
 
 import homeassistant.components.alarm_control_panel as alarm
+from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED,
-    STATE_UNKNOWN)
+    STATE_UNKNOWN, CONF_NAME, CONF_HOST, CONF_PORT)
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pynx584==0.2']
+
 _LOGGER = logging.getLogger(__name__)
+
+DEFAULT_HOST = 'localhost'
+DEFAULT_NAME = 'NX584'
+DEFAULT_PORT = 5007
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup nx584 platform."""
-    host = config.get('host', 'localhost:5007')
+    name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+
+    url = 'http://{}:{}'.format(host, port)
 
     try:
-        add_devices([NX584Alarm(hass, host, config.get('name', 'NX584'))])
+        add_devices([NX584Alarm(hass, url, name)])
     except requests.exceptions.ConnectionError as ex:
         _LOGGER.error('Unable to connect to NX584: %s', str(ex))
         return False
@@ -31,13 +49,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class NX584Alarm(alarm.AlarmControlPanel):
     """Represents the NX584-based alarm panel."""
 
-    def __init__(self, hass, host, name):
+    def __init__(self, hass, url, name):
         """Initalize the nx584 alarm panel."""
         from nx584 import client
         self._hass = hass
-        self._host = host
         self._name = name
-        self._alarm = client.Client('http://%s' % host)
+        self._alarm = client.Client(url)
         # Do an initial list operation so that we will try to actually
         # talk to the API and trigger a requests exception for setup_platform()
         # to catch
@@ -66,7 +83,7 @@ class NX584Alarm(alarm.AlarmControlPanel):
             zones = self._alarm.list_zones()
         except requests.exceptions.ConnectionError as ex:
             _LOGGER.error('Unable to connect to %(host)s: %(reason)s',
-                          dict(host=self._host, reason=ex))
+                          dict(host=self._url, reason=ex))
             return STATE_UNKNOWN
         except IndexError:
             _LOGGER.error('nx584 reports no partitions')

--- a/homeassistant/components/alarm_control_panel/nx584.py
+++ b/homeassistant/components/alarm_control_panel/nx584.py
@@ -54,7 +54,8 @@ class NX584Alarm(alarm.AlarmControlPanel):
         from nx584 import client
         self._hass = hass
         self._name = name
-        self._alarm = client.Client(url)
+        self._url = url
+        self._alarm = client.Client(self._url)
         # Do an initial list operation so that we will try to actually
         # talk to the API and trigger a requests exception for setup_platform()
         # to catch


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

This is a breaking change.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
alarm_control_panel:
alarm_control_panel:
  platform: nx584
  host: IP_ADDRESS
  port: 5007
```

@kk7ds , would be nice if you could take a look at the changes and run a quick test. Thanks.
