### PR TITLE
Improve 1-Wire device family detection and error checking. Use volupt…

### DIFF
--- a/homeassistant/components/sensor/onewire.py
+++ b/homeassistant/components/sensor/onewire.py
@@ -1,16 +1,28 @@
 """
-Support for DS18B20 One Wire Sensors.
+Support for 1-Wire temperature sensors.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.onewire/
 """
-import logging
 import os
 import time
+import logging
 from glob import glob
-
-from homeassistant.const import STATE_UNKNOWN, TEMP_CELSIUS
+import voluptuous as vol
 from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import STATE_UNKNOWN, TEMP_CELSIUS
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+
+CONF_MOUNT_DIR = 'mount_dir'
+CONF_NAMES = 'names'
+DEFAULT_MOUNT_DIR = '/sys/bus/w1/devices/'
+DEVICE_FAMILIES = ('10', '22', '28', '3B', '42')
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAMES): {cv.string: cv.string},
+    vol.Optional(CONF_MOUNT_DIR, default=DEFAULT_MOUNT_DIR): cv.string,
+})
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,22 +30,22 @@ _LOGGER = logging.getLogger(__name__)
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the one wire Sensors."""
-    base_dir = config.get('mount_dir', '/sys/bus/w1/devices/')
-    device_folders = glob(os.path.join(base_dir, '[10,22,28,3B,42]*'))
+    base_dir = config.get(CONF_MOUNT_DIR)
     sensor_ids = []
     device_files = []
-    for device_folder in device_folders:
-        sensor_ids.append(os.path.split(device_folder)[1])
-        if base_dir.startswith('/sys/bus/w1/devices'):
-            device_files.append(os.path.join(device_folder, 'w1_slave'))
-        else:
-            device_files.append(os.path.join(device_folder, 'temperature'))
+    for device_family in DEVICE_FAMILIES:
+        for device_folder in glob(os.path.join(base_dir, device_family +
+                                               '.*')):
+            sensor_ids.append(os.path.split(device_folder)[1])
+            if base_dir == DEFAULT_MOUNT_DIR:
+                device_files.append(os.path.join(device_folder, 'w1_slave'))
+            else:
+                device_files.append(os.path.join(device_folder, 'temperature'))
 
     if device_files == []:
-        _LOGGER.error('No onewire sensor found.')
-        _LOGGER.error('Check if dtoverlay=w1-gpio,gpiopin=4.')
-        _LOGGER.error('is in your /boot/config.txt and')
-        _LOGGER.error('the correct gpiopin number is set.')
+        _LOGGER.error('No onewire sensor found. Check if '
+                      'dtoverlay=w1-gpio is in your /boot/config.txt. '
+                      'Check the mount_dir parameter if it\'s defined.')
         return
 
     devs = []
@@ -92,7 +104,7 @@ class OneWire(Entity):
     def update(self):
         """Get the latest data from the device."""
         temp = -99
-        if self._device_file.startswith('/sys/bus/w1/devices'):
+        if self._device_file.startswith(DEFAULT_MOUNT_DIR):
             lines = self._read_temp_raw()
             while lines[0].strip()[-3:] != 'YES':
                 time.sleep(0.2)
@@ -102,15 +114,18 @@ class OneWire(Entity):
                 temp_string = lines[1][equals_pos+2:]
                 temp = round(float(temp_string) / 1000.0, 1)
         else:
-            ds_device_file = open(self._device_file, 'r')
-            temp_read = ds_device_file.readlines()
-            ds_device_file.close()
-            if len(temp_read) == 1:
-                try:
+            try:
+                ds_device_file = open(self._device_file, 'r')
+                temp_read = ds_device_file.readlines()
+                ds_device_file.close()
+                if len(temp_read) == 1:
                     temp = round(float(temp_read[0]), 1)
-                except ValueError:
-                    _LOGGER.warning('Invalid temperature value read from ' +
-                                    self._device_file)
+            except ValueError:
+                _LOGGER.warning('Invalid temperature value read from ' +
+                                self._device_file)
+            except FileNotFoundError:
+                _LOGGER.warning('Cannot read from sensor: ' +
+                                self._device_file)
 
         if temp < -55 or temp > 125:
             return

--- a/homeassistant/components/sensor/onewire.py
+++ b/homeassistant/components/sensor/onewire.py
@@ -35,7 +35,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     device_files = []
     for device_family in DEVICE_FAMILIES:
         for device_folder in glob(os.path.join(base_dir, device_family +
-                                               '.*')):
+                                               '[.-]*')):
             sensor_ids.append(os.path.split(device_folder)[1])
             if base_dir == DEFAULT_MOUNT_DIR:
                 device_files.append(os.path.join(device_folder, 'w1_slave'))


### PR DESCRIPTION
**Description:**
Improve 1-Wire device family detection and error checking. Added voluptuous checking.
This PR replaces messed PR #3137 

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
