### PR TITLE
Use voluptuous for ZigBee

### DIFF
--- a/homeassistant/components/binary_sensor/zigbee.py
+++ b/homeassistant/components/binary_sensor/zigbee.py
@@ -4,18 +4,27 @@ Contains functionality to use a ZigBee device as a binary sensor.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.zigbee/
 """
+import voluptuous as vol
+
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.zigbee import (
-    ZigBeeDigitalIn, ZigBeeDigitalInConfig)
+    ZigBeeDigitalIn, ZigBeeDigitalInConfig, PLATFORM_SCHEMA)
 
-DEPENDENCIES = ["zigbee"]
+CONF_ON_STATE = 'on_state'
+
+DEFAULT_ON_STATE = 'high'
+DEPENDENCIES = ['zigbee']
+
+STATES = ['high', 'low']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_ON_STATE): vol.In(STATES),
+})
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the ZigBee binary sensor platform."""
-    add_entities([
-        ZigBeeBinarySensor(hass, ZigBeeDigitalInConfig(config))
-    ])
+    add_devices([ZigBeeBinarySensor(hass, ZigBeeDigitalInConfig(config))])
 
 
 class ZigBeeBinarySensor(ZigBeeDigitalIn, BinarySensorDevice):

--- a/homeassistant/components/light/zigbee.py
+++ b/homeassistant/components/light/zigbee.py
@@ -4,18 +4,27 @@ Functionality to use a ZigBee device as a light.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.zigbee/
 """
+import voluptuous as vol
+
 from homeassistant.components.light import Light
 from homeassistant.components.zigbee import (
-    ZigBeeDigitalOut, ZigBeeDigitalOutConfig)
+    ZigBeeDigitalOut, ZigBeeDigitalOutConfig, PLATFORM_SCHEMA)
 
-DEPENDENCIES = ["zigbee"]
+CONF_ON_STATE = 'on_state'
+
+DEFAULT_ON_STATE = 'high'
+DEPENDENCIES = ['zigbee']
+
+STATES = ['high', 'low']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_ON_STATE, default=DEFAULT_ON_STATE): vol.In(STATES),
+})
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Create and add an entity based on the configuration."""
-    add_entities([
-        ZigBeeLight(hass, ZigBeeDigitalOutConfig(config))
-    ])
+    add_devices([ZigBeeLight(hass, ZigBeeDigitalOutConfig(config))])
 
 
 class ZigBeeLight(ZigBeeDigitalOut, Light):

--- a/homeassistant/components/sensor/zigbee.py
+++ b/homeassistant/components/sensor/zigbee.py
@@ -7,32 +7,45 @@ https://home-assistant.io/components/sensor.zigbee/
 import logging
 from binascii import hexlify
 
+import voluptuous as vol
+
 from homeassistant.components import zigbee
+from homeassistant.components.zigbee import PLATFORM_SCHEMA
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.core import JobPriority
 from homeassistant.helpers.entity import Entity
 
-DEPENDENCIES = ["zigbee"]
 _LOGGER = logging.getLogger(__name__)
 
+CONF_TYPE = 'type'
+CONF_MAX_VOLTS = 'max_volts'
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Setup the Z-Wave platform.
+DEFAULT_VOLTS = 1.2
+DEPENDENCIES = ['zigbee']
+
+TYPES = ['analog', 'temperature']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_TYPE): vol.In(TYPES),
+    vol.Optional(CONF_MAX_VOLTS, default=DEFAULT_VOLTS): vol.Coerce(float),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the ZigBee platform.
 
     Uses the 'type' config value to work out which type of ZigBee sensor we're
     dealing with and instantiates the relevant classes to handle it.
     """
-    typ = config.get("type", "").lower()
-    if not typ:
-        _LOGGER.exception(
-            "Must include 'type' when configuring a ZigBee sensor.")
-        return
+    typ = config.get(CONF_TYPE)
+
     try:
         sensor_class, config_class = TYPE_CLASSES[typ]
     except KeyError:
         _LOGGER.exception("Unknown ZigBee sensor type: %s", typ)
         return
-    add_entities([sensor_class(hass, config_class(config))])
+
+    add_devices([sensor_class(hass, config_class(config))])
 
 
 class ZigBeeTemperatureSensor(Entity):

--- a/homeassistant/components/switch/zigbee.py
+++ b/homeassistant/components/switch/zigbee.py
@@ -4,18 +4,29 @@ Contains functionality to use a ZigBee device as a switch.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.zigbee/
 """
+import voluptuous as vol
+
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.components.zigbee import (
-    ZigBeeDigitalOut, ZigBeeDigitalOutConfig)
+    ZigBeeDigitalOut, ZigBeeDigitalOutConfig, PLATFORM_SCHEMA)
 
-DEPENDENCIES = ["zigbee"]
+DEPENDENCIES = ['zigbee']
+
+CONF_ON_STATE = 'on_state'
+
+DEFAULT_ON_STATE = 'high'
+DEPENDENCIES = ['zigbee']
+
+STATES = ['high', 'low']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_ON_STATE): vol.In(STATES),
+})
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the ZigBee switch platform."""
-    add_entities([
-        ZigBeeSwitch(hass, ZigBeeDigitalOutConfig(config))
-    ])
+    add_devices([ZigBeeSwitch(hass, ZigBeeDigitalOutConfig(config))])
 
 
 class ZigBeeSwitch(ZigBeeDigitalOut, SwitchDevice):

--- a/homeassistant/components/zigbee.py
+++ b/homeassistant/components/zigbee.py
@@ -9,19 +9,26 @@ import pickle
 from binascii import hexlify, unhexlify
 from base64 import b64encode, b64decode
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+import voluptuous as vol
+
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STOP, CONF_DEVICE, CONF_NAME, CONF_PIN)
 from homeassistant.core import JobPriority
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers import config_validation as cv
 
-DOMAIN = "zigbee"
-REQUIREMENTS = ("xbee-helper==0.0.7",)
+REQUIREMENTS = ['xbee-helper==0.0.7']
 
-EVENT_ZIGBEE_FRAME_RECEIVED = "zigbee_frame_received"
+_LOGGER = logging.getLogger(__name__)
 
-CONF_DEVICE = "device"
-CONF_BAUD = "baud"
+DOMAIN = 'zigbee'
 
-DEFAULT_DEVICE = "/dev/ttyUSB0"
+EVENT_ZIGBEE_FRAME_RECEIVED = 'zigbee_frame_received'
+
+CONF_ADDRESS = 'address'
+CONF_BAUD = 'baud'
+
+DEFAULT_DEVICE = '/dev/ttyUSB0'
 DEFAULT_BAUD = 9600
 DEFAULT_ADC_MAX_VOLTS = 1.2
 
@@ -35,11 +42,22 @@ CONVERT_ADC = None
 ZIGBEE_EXCEPTION = None
 ZIGBEE_TX_FAILURE = None
 
-ATTR_FRAME = "frame"
+ATTR_FRAME = 'frame'
 
 DEVICE = None
 
-_LOGGER = logging.getLogger(__name__)
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_BAUD, default=DEFAULT_BAUD): cv.string,
+        vol.Optional(CONF_DEVICE, default=DEFAULT_DEVICE): cv.string,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_PIN): cv.positive_int,
+    vol.Optional(CONF_ADDRESS): cv.string,
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
@@ -101,9 +119,9 @@ def close_serial_port(*args):
 
 def frame_is_relevant(entity, frame):
     """Test whether the frame is relevant to the entity."""
-    if frame.get("source_addr_long") != entity.config.address:
+    if frame.get('source_addr_long') != entity.config.address:
         return False
-    if "samples" not in frame:
+    if 'samples' not in frame:
         return False
     return True
 
@@ -279,7 +297,7 @@ class ZigBeeDigitalIn(Entity):
             """
             if not frame_is_relevant(self, frame):
                 return
-            sample = frame["samples"].pop()
+            sample = frame['samples'].pop()
             pin_name = DIGITAL_PINS[self._config.pin]
             if pin_name not in sample:
                 # Doesn't contain information about our pin
@@ -402,7 +420,7 @@ class ZigBeeAnalogIn(Entity):
             """
             if not frame_is_relevant(self, frame):
                 return
-            sample = frame["samples"].pop()
+            sample = frame['samples'].pop()
             pin_name = ANALOG_PINS[self._config.pin]
             if pin_name not in sample:
                 # Doesn't contain information about our pin


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
zigbee:
  device: /dev/ttyUSB0
  baud: 115200

sensor:
  - platform: zigbee
    name: My Analog ZigBee Input
    type: analog
    pin: 0
    address: 0013A2004233D138
```

@flyte, would be nice if you could take a look at the changes and run a quick test. Thanks.
