### PR TITLE
update ffmpeg version to 0.10 add get image to camera

### DIFF
--- a/homeassistant/components/binary_sensor/ffmpeg.py
+++ b/homeassistant/components/binary_sensor/ffmpeg.py
@@ -16,7 +16,7 @@ from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (EVENT_HOMEASSISTANT_STOP, CONF_NAME,
                                  ATTR_ENTITY_ID)
 
-REQUIREMENTS = ["ha-ffmpeg==0.9"]
+REQUIREMENTS = ["ha-ffmpeg==0.10"]
 
 SERVICE_RESTART = 'ffmpeg_restart'
 

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -5,16 +5,14 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/camera.ffmpeg/
 """
 import logging
-from contextlib import closing
 
 import voluptuous as vol
 
 from homeassistant.components.camera import (Camera, PLATFORM_SCHEMA)
-from homeassistant.components.camera.mjpeg import extract_image_from_mjpeg
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_NAME
 
-REQUIREMENTS = ['ha-ffmpeg==0.9']
+REQUIREMENTS = ['ha-ffmpeg==0.10']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,22 +47,20 @@ class FFmpegCamera(Camera):
         self._extra_arguments = config.get(CONF_EXTRA_ARGUMENTS)
         self._ffmpeg_bin = config.get(CONF_FFMPEG_BIN)
 
-    def _ffmpeg_stream(self):
-        """Return a FFmpeg process object."""
-        from haffmpeg import CameraMjpeg
-
-        ffmpeg = CameraMjpeg(self._ffmpeg_bin)
-        ffmpeg.open_camera(self._input, extra_cmd=self._extra_arguments)
-        return ffmpeg
-
     def camera_image(self):
         """Return a still image response from the camera."""
-        with closing(self._ffmpeg_stream()) as stream:
-            return extract_image_from_mjpeg(stream)
+        from haffmpeg import ImageSingle, IMAGE_JPEG
+        ffmpeg = ImageSingle(self._ffmpeg_bin)
+
+        return ffmpeg.get_image(self._input, output_format=IMAGE_JPEG,
+                                extra_cmd=self._extra_arguments)
 
     def mjpeg_stream(self, response):
         """Generate an HTTP MJPEG stream from the camera."""
-        stream = self._ffmpeg_stream()
+        from haffmpeg import CameraMjpeg
+
+        stream = CameraMjpeg(self._ffmpeg_bin)
+        stream.open_camera(self._input, extra_cmd=self._extra_arguments)
         return response(
             stream,
             mimetype='multipart/x-mixed-replace;boundary=ffserver',

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -107,7 +107,7 @@ gps3==0.33.3
 
 # homeassistant.components.binary_sensor.ffmpeg
 # homeassistant.components.camera.ffmpeg
-ha-ffmpeg==0.9
+ha-ffmpeg==0.10
 
 # homeassistant.components.mqtt.server
 hbmqtt==0.7.1


### PR DESCRIPTION
**Description:**
- Update ha-ffmpeg to version 0.10
- Change camera image to ha-ffmpeg image capture (new in 0.10). This minimize the foodprint for preview image capture and reduce resource.

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
