### PR TITLE
 Upgraded fitbit to version 0.2.3 which fixed oauthlib.oauth2.rfc6749.errors.TokenExpiredError: (token_expired)

### DIFF
--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -16,7 +16,7 @@ from homeassistant.loader import get_component
 from homeassistant.components.http import HomeAssistantView
 
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ["fitbit==0.2.2"]
+REQUIREMENTS = ["fitbit==0.2.3"]
 DEPENDENCIES = ["http"]
 
 ICON = "mdi:walk"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -82,7 +82,7 @@ evohomeclient==0.2.5
 feedparser==5.2.1
 
 # homeassistant.components.sensor.fitbit
-fitbit==0.2.2
+fitbit==0.2.3
 
 # homeassistant.components.sensor.fixer
 fixerio==0.1.1


### PR DESCRIPTION
**Description:**
Upgrading to fitbit 0.2.3 which fixed the tracebacks when fitbit token is expired. 

``` python
Aug 29 16:54:00 pi hass[13584]: ERROR:homeassistant.core:BusHandler:Exception doing job
Aug 29 16:54:00 pi hass[13584]: Traceback (most recent call last):
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/core.py", line 852, in job_handler
Aug 29 16:54:00 pi hass[13584]: func(*args)
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/helpers/event.py", line 179, in pattern_time_change_listener
Aug 29 16:54:00 pi hass[13584]: action(now)
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/helpers/entity_component.py", line 180, in _update_entity_states
Aug 29 16:54:00 pi hass[13584]: entity.update_ha_state(True)
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/helpers/entity.py", line 154, in update_ha_state
Aug 29 16:54:00 pi hass[13584]: self.update()
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/util/__init__.py", line 296, in wrapper
Aug 29 16:54:00 pi hass[13584]: result = method(*args, **kwargs)
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/components/sensor/fitbit.py", line 387, in update
Aug 29 16:54:00 pi hass[13584]: response = self.client.time_series(self.resource_type, period="7d")
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.homeassistant/deps/fitbit/api.py", line 515, in time_series
Aug 29 16:54:00 pi hass[13584]: return self.make_request(url)
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.homeassistant/deps/fitbit/api.py", line 227, in make_request
Aug 29 16:54:00 pi hass[13584]: response = self.client.make_request(*args, **kwargs)
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.homeassistant/deps/fitbit/api.py", line 68, in make_request
Aug 29 16:54:00 pi hass[13584]: response = self._request(method, url, data=data, auth=auth, **kwargs)
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.homeassistant/deps/fitbit/api.py", line 55, in _request
Aug 29 16:54:00 pi hass[13584]: return self.session.request(method, url, **kwargs)
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/requests/sessions.py", line 461, in request
Aug 29 16:54:00 pi hass[13584]: prep = self.prepare_request(req)
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/requests/sessions.py", line 394, in prepare_request
Aug 29 16:54:00 pi hass[13584]: hooks=merge_hooks(request.hooks, self.hooks),
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/requests/models.py", line 298, in prepare
Aug 29 16:54:00 pi hass[13584]: self.prepare_auth(auth, url)
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/requests/models.py", line 500, in prepare_auth
Aug 29 16:54:00 pi hass[13584]: r = auth(self)
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.homeassistant/deps/requests_oauthlib/oauth2_auth.py", line 35, in __call__
Aug 29 16:54:00 pi hass[13584]: http_method=r.method, body=r.body, headers=r.headers)
Aug 29 16:54:00 pi hass[13584]: File "/home/hass/.homeassistant/deps/oauthlib/oauth2/rfc6749/clients/base.py", line 194, in add_token
Aug 29 16:54:00 pi hass[13584]: raise TokenExpiredError()
Aug 29 16:54:00 pi hass[13584]: oauthlib.oauth2.rfc6749.errors.TokenExpiredError: (token_expired)
```

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/issues/2083

**Checklist:**

If code communicates with devices, web services, or a:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.
  …
