### PR TITLE
Fix mFi sensors in uninitialized state

### DIFF
--- a/homeassistant/components/sensor/mfi.py
+++ b/homeassistant/components/sensor/mfi.py
@@ -91,7 +91,13 @@ class MfiSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        if self._port.model == 'Input Digital':
+        try:
+            tag = self._port.tag
+        except ValueError:
+            tag = None
+        if tag is None:
+            return STATE_OFF
+        elif self._port.model == 'Input Digital':
             return self._port.value > 0 and STATE_ON or STATE_OFF
         else:
             digits = DIGITS.get(self._port.tag, 0)
@@ -100,13 +106,18 @@ class MfiSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        if self._port.tag == 'temperature':
+        try:
+            tag = self._port.tag
+        except ValueError:
+            return 'State'
+
+        if tag == 'temperature':
             return TEMP_CELSIUS
-        elif self._port.tag == 'active_pwr':
+        elif tag == 'active_pwr':
             return 'Watts'
         elif self._port.model == 'Input Digital':
             return 'State'
-        return self._port.tag
+        return tag
 
     def update(self):
         """Get the latest data."""

--- a/tests/components/sensor/test_mfi.py
+++ b/tests/components/sensor/test_mfi.py
@@ -147,6 +147,11 @@ class TestMfiSensor(unittest.TestCase):
         self.port.tag = 'balloons'
         self.assertEqual('balloons', self.sensor.unit_of_measurement)
 
+    def test_uom_uninitialized(self):
+        """Test that the UOM defaults if not initialized."""
+        type(self.port).tag = mock.PropertyMock(side_effect=ValueError)
+        self.assertEqual('State', self.sensor.unit_of_measurement)
+
     def test_state_digital(self):
         """Test the digital input."""
         self.port.model = 'Input Digital'
@@ -165,6 +170,11 @@ class TestMfiSensor(unittest.TestCase):
             self.assertEqual(1.2, self.sensor.state)
         with mock.patch.dict(mfi.DIGITS, {}):
             self.assertEqual(1.0, self.sensor.state)
+
+    def test_state_uninitialized(self):
+        """Test the state of uninitialized sensors."""
+        type(self.port).tag = mock.PropertyMock(side_effect=ValueError)
+        self.assertEqual(mfi.STATE_OFF, self.sensor.state)
 
     def test_update(self):
         """Test the update."""


### PR DESCRIPTION
**Description:**

If mFi sensors are identified but not fully assigned they can
have no tag value, and mficlient throws a ValueError to signal this.
This patch handles that case by considering such devices to always
be STATE_OFF.

**Checklist:**
- [X ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X ] Tests have been added to verify that the new code works.
