### PR TITLE
protect service data for changes in calls

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -574,6 +574,7 @@ class Service(object):
         try:
             if self.schema:
                 call.data = self.schema(call.data)
+            call.data = MappingProxyType(call.data)
 
             self.func(call)
         except vol.MultipleInvalid as ex:
@@ -592,7 +593,7 @@ class ServiceCall(object):
         """Initialize a service call."""
         self.domain = domain.lower()
         self.service = service.lower()
-        self.data = MappingProxyType(data or {})
+        self.data = data or {}
         self.call_id = call_id
 
     def __repr__(self):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -5,7 +5,6 @@ Home Assistant is a Home Automation framework for observing the state
 of entities and react to changes.
 """
 
-from copy import deepcopy
 import enum
 import functools as ft
 import logging
@@ -593,7 +592,7 @@ class ServiceCall(object):
         """Initialize a service call."""
         self.domain = domain.lower()
         self.service = service.lower()
-        self.data = deepcopy(data) if data else {}
+        self.data = MappingProxyType(data or {})
         self.call_id = call_id
 
     def __repr__(self):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -5,6 +5,7 @@ Home Assistant is a Home Automation framework for observing the state
 of entities and react to changes.
 """
 
+from copy import deepcopy
 import enum
 import functools as ft
 import logging
@@ -592,7 +593,7 @@ class ServiceCall(object):
         """Initialize a service call."""
         self.domain = domain.lower()
         self.service = service.lower()
-        self.data = data or {}
+        self.data = deepcopy(data) if data else {}
         self.call_id = call_id
 
     def __repr__(self):


### PR DESCRIPTION
**Description:**

That solve the issue that service data are not protected and can change across all instance of handler.

I have make some experiments with MappingProxyType but that not solve the issue. We could create a own recursive MappingProxyType but that make new possible error-prone and is not so performant as deepcopy they is working on C. I think that is the fastest and fail-save variant to solve this issue.

If that should okay, I can make unit test for that.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
