### PR TITLE
Use voluptuous for SCSGate

### DIFF
--- a/homeassistant/components/cover/scsgate.py
+++ b/homeassistant/components/cover/scsgate.py
@@ -6,15 +6,20 @@ https://home-assistant.io/components/cover.scsgate/
 """
 import logging
 
+import voluptuous as vol
+
 import homeassistant.components.scsgate as scsgate
-from homeassistant.components.cover import CoverDevice
+from homeassistant.components.cover import (CoverDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_DEVICES, CONF_NAME)
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['scsgate']
 
-PLATFORM_SCHEMA = scsgate.PLATFORM_SCHEMA
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_DEVICES): vol.Schema({cv.slug: scsgate.SCSGATE_SCHEMA}),
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -92,5 +97,5 @@ class SCSGateCover(CoverDevice):
 
     def process_event(self, message):
         """Handle a SCSGate message related with this cover."""
-        self._logger.debug("Rollershutter %s, got message %s",
+        self._logger.debug("Cover %s, got message %s",
                            self._scs_id, message.toggled)

--- a/homeassistant/components/cover/scsgate.py
+++ b/homeassistant/components/cover/scsgate.py
@@ -8,35 +8,36 @@ import logging
 
 import homeassistant.components.scsgate as scsgate
 from homeassistant.components.cover import CoverDevice
-from homeassistant.const import CONF_NAME
+from homeassistant.const import (CONF_DEVICES, CONF_NAME)
+
+_LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['scsgate']
-SCS_ID = 'scs_id'
+
+PLATFORM_SCHEMA = scsgate.PLATFORM_SCHEMA
 
 
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the SCSGate cover."""
-    devices = config.get('devices')
+    devices = config.get(CONF_DEVICES)
     covers = []
     logger = logging.getLogger(__name__)
 
     if devices:
         for _, entity_info in devices.items():
-            if entity_info[SCS_ID] in scsgate.SCSGATE.devices:
+            if entity_info[scsgate.CONF_SCS_ID] in scsgate.SCSGATE.devices:
                 continue
 
-            logger.info("Adding %s scsgate.cover", entity_info[CONF_NAME])
-
             name = entity_info[CONF_NAME]
-            scs_id = entity_info[SCS_ID]
-            cover = SCSGateCover(
-                name=name,
-                scs_id=scs_id,
-                logger=logger)
+            scs_id = entity_info[scsgate.CONF_SCS_ID]
+
+            logger.info("Adding %s scsgate.cover", name)
+
+            cover = SCSGateCover(name=name, scs_id=scs_id, logger=logger)
             scsgate.SCSGATE.add_device(cover)
             covers.append(cover)
 
-    add_devices_callback(covers)
+    add_devices(covers)
 
 
 # pylint: disable=too-many-arguments, too-many-instance-attributes
@@ -91,6 +92,5 @@ class SCSGateCover(CoverDevice):
 
     def process_event(self, message):
         """Handle a SCSGate message related with this cover."""
-        self._logger.debug(
-            "Rollershutter %s, got message %s",
-            self._scs_id, message.toggled)
+        self._logger.debug("Rollershutter %s, got message %s",
+                           self._scs_id, message.toggled)

--- a/homeassistant/components/light/scsgate.py
+++ b/homeassistant/components/light/scsgate.py
@@ -6,16 +6,21 @@ https://home-assistant.io/components/light.scsgate/
 """
 import logging
 
+import voluptuous as vol
+
 import homeassistant.components.scsgate as scsgate
-from homeassistant.components.light import Light
+from homeassistant.components.light import (Light, PLATFORM_SCHEMA)
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_STATE, CONF_DEVICES, CONF_NAME)
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['scsgate']
 
-PLATFORM_SCHEMA = scsgate.PLATFORM_SCHEMA
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_DEVICES): vol.Schema({cv.slug: scsgate.SCSGATE_SCHEMA}),
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/light/scsgate.py
+++ b/homeassistant/components/light/scsgate.py
@@ -8,33 +8,36 @@ import logging
 
 import homeassistant.components.scsgate as scsgate
 from homeassistant.components.light import Light
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import (
+    ATTR_ENTITY_ID, ATTR_STATE, CONF_DEVICES, CONF_NAME)
+
+_LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['scsgate']
 
+PLATFORM_SCHEMA = scsgate.PLATFORM_SCHEMA
 
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
-    """Add the SCSGate swiches defined inside of the configuration file."""
-    devices = config.get('devices')
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the SCSGate switches."""
+    devices = config.get(CONF_DEVICES)
     lights = []
     logger = logging.getLogger(__name__)
 
     if devices:
         for _, entity_info in devices.items():
-            if entity_info['scs_id'] in scsgate.SCSGATE.devices:
+            if entity_info[scsgate.CONF_SCS_ID] in scsgate.SCSGATE.devices:
                 continue
 
-            logger.info("Adding %s scsgate.light", entity_info['name'])
+            name = entity_info[CONF_NAME]
+            scs_id = entity_info[scsgate.CONF_SCS_ID]
 
-            name = entity_info['name']
-            scs_id = entity_info['scs_id']
-            light = SCSGateLight(
-                name=name,
-                scs_id=scs_id,
-                logger=logger)
+            logger.info("Adding %s scsgate.light", name)
+
+            light = SCSGateLight(name=name, scs_id=scs_id, logger=logger)
             lights.append(light)
 
-    add_devices_callback(lights)
+    add_devices(lights)
     scsgate.SCSGATE.add_devices_to_register(lights)
 
 
@@ -73,9 +76,7 @@ class SCSGateLight(Light):
         from scsgate.tasks import ToggleStatusTask
 
         scsgate.SCSGATE.append_task(
-            ToggleStatusTask(
-                target=self._scs_id,
-                toggled=True))
+            ToggleStatusTask(target=self._scs_id, toggled=True))
 
         self._toggled = True
         self.update_ha_state()
@@ -85,9 +86,7 @@ class SCSGateLight(Light):
         from scsgate.tasks import ToggleStatusTask
 
         scsgate.SCSGATE.append_task(
-            ToggleStatusTask(
-                target=self._scs_id,
-                toggled=False))
+            ToggleStatusTask(target=self._scs_id, toggled=False))
 
         self._toggled = False
         self.update_ha_state()
@@ -111,6 +110,6 @@ class SCSGateLight(Light):
         self.hass.bus.fire(
             'button_pressed', {
                 ATTR_ENTITY_ID: self._scs_id,
-                'state': command
+                ATTR_STATE: command,
             }
         )

--- a/homeassistant/components/scsgate.py
+++ b/homeassistant/components/scsgate.py
@@ -7,15 +7,64 @@ https://home-assistant.io/components/scsgate/
 import logging
 from threading import Lock
 
+import voluptuous as vol
+
+from homeassistant.const import (CONF_DEVICE, CONF_DEVICES, CONF_NAME)
 from homeassistant.core import EVENT_HOMEASSISTANT_STOP
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['scsgate==0.1.0']
-DOMAIN = "scsgate"
-SCSGATE = None
+
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_STATE = 'state'
 
-class SCSGate:
+CONF_SCS_ID = 'scs_id'
+
+DOMAIN = 'scsgate'
+
+SCSGATE = None
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_DEVICE): cv.string,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+SCSGATE_SCHEMA = vol.Schema({
+    vol.Required(CONF_SCS_ID): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+})
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_DEVICES): vol.Schema({cv.slug: SCSGATE_SCHEMA}),
+})
+
+
+def setup(hass, config):
+    """Setup the SCSGate component."""
+    device = config[DOMAIN][CONF_DEVICE]
+    global SCSGATE
+
+    # pylint: disable=broad-except
+    try:
+        SCSGATE = SCSGate(device=device, logger=_LOGGER)
+        SCSGATE.start()
+    except Exception as exception:
+        _LOGGER.error("Cannot setup SCSGate component: %s", exception)
+        return False
+
+    def stop_monitor(event):
+        """Stop the SCSGate."""
+        _LOGGER.info("Stopping SCSGate monitor thread")
+        SCSGATE.stop()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_monitor)
+
+    return True
+
+
+class SCSGate(object):
     """The class  for dealing with the SCSGate device via scsgate.Reactor."""
 
     def __init__(self, device, logger):
@@ -32,8 +81,7 @@ class SCSGate:
 
         from scsgate.reactor import Reactor
         self._reactor = Reactor(
-            connection=connection,
-            logger=self._logger,
+            connection=connection, logger=self._logger,
             handle_message=self.handle_message)
 
     def handle_message(self, message):
@@ -61,8 +109,7 @@ class SCSGate:
             try:
                 self._devices[message.entity].process_event(message)
             except Exception as exception:
-                msg = "Exception while processing event: {}".format(
-                    exception)
+                msg = "Exception while processing event: {}".format(exception)
                 self._logger.error(msg)
         else:
             self._logger.info(
@@ -127,26 +174,3 @@ class SCSGate:
     def append_task(self, task):
         """Register a new task to be executed."""
         self._reactor.append_task(task)
-
-
-def setup(hass, config):
-    """Setup the SCSGate component."""
-    device = config['scsgate']['device']
-    global SCSGATE
-
-    # pylint: disable=broad-except
-    try:
-        SCSGATE = SCSGate(device=device, logger=_LOGGER)
-        SCSGATE.start()
-    except Exception as exception:
-        _LOGGER.error("Cannot setup SCSGate component: %s", exception)
-        return False
-
-    def stop_monitor(event):
-        """Stop the SCSGate."""
-        _LOGGER.info("Stopping SCSGate monitor thread")
-        SCSGATE.stop()
-
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_monitor)
-
-    return True

--- a/homeassistant/components/scsgate.py
+++ b/homeassistant/components/scsgate.py
@@ -9,7 +9,7 @@ from threading import Lock
 
 import voluptuous as vol
 
-from homeassistant.const import (CONF_DEVICE, CONF_DEVICES, CONF_NAME)
+from homeassistant.const import (CONF_DEVICE, CONF_NAME)
 from homeassistant.core import EVENT_HOMEASSISTANT_STOP
 import homeassistant.helpers.config_validation as cv
 
@@ -34,10 +34,6 @@ CONFIG_SCHEMA = vol.Schema({
 SCSGATE_SCHEMA = vol.Schema({
     vol.Required(CONF_SCS_ID): cv.string,
     vol.Optional(CONF_NAME): cv.string,
-})
-
-PLATFORM_SCHEMA = vol.Schema({
-    vol.Required(CONF_DEVICES): vol.Schema({cv.slug: SCSGATE_SCHEMA}),
 })
 
 

--- a/homeassistant/components/switch/scsgate.py
+++ b/homeassistant/components/switch/scsgate.py
@@ -6,9 +6,13 @@ https://home-assistant.io/components/switch.scsgate/
 """
 import logging
 
+import voluptuous as vol
+
 import homeassistant.components.scsgate as scsgate
-from homeassistant.components.switch import SwitchDevice
-from homeassistant.const import (ATTR_ENTITY_ID, ATTR_STATE, CONF_NAME)
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (
+    ATTR_ENTITY_ID, ATTR_STATE, CONF_NAME, CONF_DEVICES)
+import homeassistant.helpers.config_validation as cv
 
 ATTR_SCENARIO_ID = 'scenario_id'
 
@@ -17,7 +21,13 @@ DEPENDENCIES = ['scsgate']
 CONF_TRADITIONAL = 'traditional'
 CONF_SCENARIO = 'scenario'
 
-PLATFORM_SCHEMA = scsgate.PLATFORM_SCHEMA
+CONF_SCS_ID = 'scs_id'
+
+DOMAIN = 'scsgate'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_DEVICES): vol.Schema({cv.slug: scsgate.SCSGATE_SCHEMA}),
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/switch/scsgate.py
+++ b/homeassistant/components/switch/scsgate.py
@@ -8,46 +8,44 @@ import logging
 
 import homeassistant.components.scsgate as scsgate
 from homeassistant.components.switch import SwitchDevice
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import (ATTR_ENTITY_ID, ATTR_STATE, CONF_NAME)
+
+ATTR_SCENARIO_ID = 'scenario_id'
 
 DEPENDENCIES = ['scsgate']
 
+CONF_TRADITIONAL = 'traditional'
+CONF_SCENARIO = 'scenario'
 
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+PLATFORM_SCHEMA = scsgate.PLATFORM_SCHEMA
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the SCSGate switches."""
     logger = logging.getLogger(__name__)
 
     _setup_traditional_switches(
-        logger=logger,
-        config=config,
-        add_devices_callback=add_devices_callback)
+        logger=logger, config=config, add_devices_callback=add_devices)
 
-    _setup_scenario_switches(
-        logger=logger,
-        config=config,
-        hass=hass)
+    _setup_scenario_switches(logger=logger, config=config, hass=hass)
 
 
 def _setup_traditional_switches(logger, config, add_devices_callback):
     """Add traditional SCSGate switches."""
-    traditional = config.get('traditional')
+    traditional = config.get(CONF_TRADITIONAL)
     switches = []
 
     if traditional:
         for _, entity_info in traditional.items():
-            if entity_info['scs_id'] in scsgate.SCSGATE.devices:
+            if entity_info[scsgate.CONF_SCS_ID] in scsgate.SCSGATE.devices:
                 continue
 
-            logger.info(
-                "Adding %s scsgate.traditional_switch", entity_info['name'])
+            name = entity_info[CONF_NAME]
+            scs_id = entity_info[scsgate.CONF_SCS_ID]
 
-            name = entity_info['name']
-            scs_id = entity_info['scs_id']
+            logger.info("Adding %s scsgate.traditional_switch", name)
 
-            switch = SCSGateSwitch(
-                name=name,
-                scs_id=scs_id,
-                logger=logger)
+            switch = SCSGateSwitch(name=name, scs_id=scs_id, logger=logger)
             switches.append(switch)
 
     add_devices_callback(switches)
@@ -56,24 +54,20 @@ def _setup_traditional_switches(logger, config, add_devices_callback):
 
 def _setup_scenario_switches(logger, config, hass):
     """Add only SCSGate scenario switches."""
-    scenario = config.get("scenario")
+    scenario = config.get(CONF_SCENARIO)
 
     if scenario:
         for _, entity_info in scenario.items():
-            if entity_info['scs_id'] in scsgate.SCSGATE.devices:
+            if entity_info[scsgate.CONF_SCS_ID] in scsgate.SCSGATE.devices:
                 continue
 
-            logger.info(
-                "Adding %s scsgate.scenario_switch", entity_info['name'])
+            name = entity_info[CONF_NAME]
+            scs_id = entity_info[scsgate.CONF_SCS_ID]
 
-            name = entity_info['name']
-            scs_id = entity_info['scs_id']
+            logger.info("Adding %s scsgate.scenario_switch", name)
 
             switch = SCSGateScenarioSwitch(
-                name=name,
-                scs_id=scs_id,
-                logger=logger,
-                hass=hass)
+                name=name, scs_id=scs_id, logger=logger, hass=hass)
             scsgate.SCSGATE.add_device(switch)
 
 
@@ -112,9 +106,7 @@ class SCSGateSwitch(SwitchDevice):
         from scsgate.tasks import ToggleStatusTask
 
         scsgate.SCSGATE.append_task(
-            ToggleStatusTask(
-                target=self._scs_id,
-                toggled=True))
+            ToggleStatusTask(target=self._scs_id, toggled=True))
 
         self._toggled = True
         self.update_ha_state()
@@ -124,9 +116,7 @@ class SCSGateSwitch(SwitchDevice):
         from scsgate.tasks import ToggleStatusTask
 
         scsgate.SCSGATE.append_task(
-            ToggleStatusTask(
-                target=self._scs_id,
-                toggled=False))
+            ToggleStatusTask(target=self._scs_id, toggled=False))
 
         self._toggled = False
         self.update_ha_state()
@@ -150,12 +140,11 @@ class SCSGateSwitch(SwitchDevice):
         self.hass.bus.fire(
             'button_pressed', {
                 ATTR_ENTITY_ID: self._scs_id,
-                'state': command
-            }
+                ATTR_STATE: command}
         )
 
 
-class SCSGateScenarioSwitch:
+class SCSGateScenarioSwitch(object):
     """Provides a SCSGate scenario switch.
 
     This switch is always in a 'off" state, when toggled it's used to trigger
@@ -188,14 +177,13 @@ class SCSGateScenarioSwitch:
         elif isinstance(message, ScenarioTriggeredMessage):
             scenario_id = message.scenario
         else:
-            self._logger.warn(
-                "Scenario switch: received unknown message %s",
-                message)
+            self._logger.warn("Scenario switch: received unknown message %s",
+                              message)
             return
 
         self._hass.bus.fire(
             'scenario_switch_triggered', {
                 ATTR_ENTITY_ID: int(self._scs_id),
-                'scenario_id': int(scenario_id, 16)
+                ATTR_SCENARIO_ID: int(scenario_id, 16)
             }
         )

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -260,6 +260,7 @@ ATTR_GPS_ACCURACY = 'gps_accuracy'
 
 # If state is assumed
 ATTR_ASSUMED_STATE = 'assumed_state'
+ATTR_STATE = 'state'
 
 # #### SERVICES ####
 SERVICE_HOMEASSISTANT_STOP = 'stop'


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
scsgate:
  device: PATH_TO_DEVICE

switch:
  platform: scsgate
  devices:
    living_room:
      name: Living Room
      scs_id: XXXXX
```

@flavio @icovada , would be nice if you could take a look at the changes and run a quick test. Thanks.
