### PR TITLE
fastdotcom from pypi

### DIFF
--- a/homeassistant/components/sensor/fastdotcom.py
+++ b/homeassistant/components/sensor/fastdotcom.py
@@ -14,8 +14,7 @@ from homeassistant.components.sensor import (DOMAIN, PLATFORM_SCHEMA)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_change
 
-REQUIREMENTS = ['https://github.com/nkgilley/fast.com/archive/'
-                'master.zip#fastdotcom==0.0.1']
+REQUIREMENTS = ['fastdotcom==0.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -81,6 +81,9 @@ enocean==0.31
 # homeassistant.components.thermostat.honeywell
 evohomeclient==0.2.5
 
+# homeassistant.components.sensor.fastdotcom
+fastdotcom==0.0.1
+
 # homeassistant.components.feedreader
 feedparser==5.2.1
 
@@ -171,9 +174,6 @@ https://github.com/kellerza/pyqwikswitch/archive/v0.4.zip#pyqwikswitch==0.4
 
 # homeassistant.components.media_player.russound_rnet
 https://github.com/laf/russound/archive/0.1.6.zip#russound==0.1.6
-
-# homeassistant.components.sensor.fastdotcom
-https://github.com/nkgilley/fast.com/archive/master.zip#fastdotcom==0.0.1
 
 # homeassistant.components.ecobee
 https://github.com/nkgilley/python-ecobee-api/archive/4856a704670c53afe1882178a89c209b5f98533d.zip#python-ecobee==0.0.6


### PR DESCRIPTION
**Description:**
install fastdotcom from pypi instead of github

**Related issue (if applicable):** fixes #3239
