### PR TITLE
Taking out 'as_user' (notify.slack)

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -62,7 +62,6 @@ class SlackNotificationService(BaseNotificationService):
 
         try:
             self.slack.chat.post_message(channel, message,
-                                         as_user=True,
                                          attachments=attachments,
                                          link_names=True)
         except slacker.Error as err:


### PR DESCRIPTION
**Description:**
Updating the post.message call to alert you now

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

If you use 'as_user' and try to @channel or @here, it will use username of the person that created the token and not actually alert you. 

In theory, https://github.com/os/slacker/blob/master/slacker/__init__.py#L276 all the options here should be allowed in the configuration of component.
