### PR TITLE
Use voluptuous for Radiotherm

### DIFF
--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -8,14 +8,27 @@ import datetime
 import logging
 from urllib.error import URLError
 
+import voluptuous as vol
+
 from homeassistant.components.climate import (
     STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_IDLE, STATE_OFF,
-    ClimateDevice)
+    ClimateDevice, PLATFORM_SCHEMA)
 from homeassistant.const import CONF_HOST, TEMP_FAHRENHEIT, ATTR_TEMPERATURE
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['radiotherm==1.2']
-HOLD_TEMP = 'hold_temp'
+
 _LOGGER = logging.getLogger(__name__)
+
+ATTR_FAN = 'fan'
+ATTR_MODE = 'mode'
+
+CONF_HOLD_TEMP = 'hold_temp'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_HOLD_TEMP, default=False): cv.boolean,
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -29,10 +42,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         hosts.append(radiotherm.discover.discover_address())
 
     if hosts is None:
-        _LOGGER.error("No radiotherm thermostats detected.")
+        _LOGGER.error("No Radiotherm Thermostats detected")
         return False
 
-    hold_temp = config.get(HOLD_TEMP, False)
+    hold_temp = config.get(CONF_HOLD_TEMP)
     tstats = []
 
     for host in hosts:
@@ -75,8 +88,8 @@ class RadioThermostat(ClimateDevice):
     def device_state_attributes(self):
         """Return the device specific state attributes."""
         return {
-            "fan": self.device.fmode['human'],
-            "mode": self.device.tmode['human']
+            ATTR_FAN: self.device.fmode['human'],
+            ATTR_MODE: self.device.tmode['human']
         }
 
     @property
@@ -124,8 +137,11 @@ class RadioThermostat(ClimateDevice):
     def set_time(self):
         """Set device time."""
         now = datetime.datetime.now()
-        self.device.time = {'day': now.weekday(),
-                            'hour': now.hour, 'minute': now.minute}
+        self.device.time = {
+            'day': now.weekday(),
+            'hour': now.hour,
+            'minute': now.minute
+        }
 
     def set_operation_mode(self, operation_mode):
         """Set operation mode (auto, cool, heat, off)."""


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
climate:
  platform: radiotherm
  host:
    - 192.168.99.137
    - 192.168.99.202
  hold_temp: True
```

@toddeye, would be nice if you could take a look at the changes and run a quick test. Thanks.
