### PR TITLE
Use voluptuous for Proliphix

### DIFF
--- a/homeassistant/components/climate/proliphix.py
+++ b/homeassistant/components/climate/proliphix.py
@@ -4,12 +4,23 @@ Support for Proliphix NT10e Thermostats.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.proliphix/
 """
+import voluptuous as vol
+
 from homeassistant.components.climate import (
-    STATE_COOL, STATE_HEAT, STATE_IDLE, ClimateDevice)
+    STATE_COOL, STATE_HEAT, STATE_IDLE, ClimateDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, TEMP_FAHRENHEIT, ATTR_TEMPERATURE)
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['proliphix==0.3.1']
+
+ATTR_FAN = 'fan'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -22,9 +33,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     pdp = proliphix.PDP(host, username, password)
 
-    add_devices([
-        ProliphixThermostat(pdp)
-    ])
+    add_devices([ProliphixThermostat(pdp)])
 
 
 # pylint: disable=abstract-method
@@ -56,7 +65,7 @@ class ProliphixThermostat(ClimateDevice):
     def device_state_attributes(self):
         """Return the device specific state attributes."""
         return {
-            "fan": self._pdp.fan_state
+            ATTR_FAN: self._pdp.fan_state
         }
 
     @property


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
climate:
  platform: proliphix
  host: IP_ADDRESS
  username: YOUR_USERNAME
  password: YOUR_PASSWORD
```

@sdague, would be nice if you could take a look at the changes and run a quick test. Thanks.
