### PR TITLE
Use voluptuous for Wink

### DIFF
--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -7,30 +7,38 @@ https://home-assistant.io/components/wink/
 import logging
 import json
 
-from homeassistant.helpers import validate_config, discovery
+import voluptuous as vol
+
+from homeassistant.helpers import discovery
 from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL
 from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
 
-DOMAIN = "wink"
 REQUIREMENTS = ['python-wink==0.7.13', 'pubnub==3.8.2']
 
-SUBSCRIPTION_HANDLER = None
+_LOGGER = logging.getLogger(__name__)
+
 CHANNELS = []
+
+DOMAIN = 'wink'
+
+SUBSCRIPTION_HANDLER = None
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_ACCESS_TOKEN): cv.string,
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
     """Setup the Wink component."""
-    logger = logging.getLogger(__name__)
-
-    if not validate_config(config, {DOMAIN: [CONF_ACCESS_TOKEN]}, logger):
-        return False
-
     import pywink
     from pubnub import Pubnub
     pywink.set_bearer_token(config[DOMAIN][CONF_ACCESS_TOKEN])
     global SUBSCRIPTION_HANDLER
-    SUBSCRIPTION_HANDLER = Pubnub("N/A", pywink.get_subscription_key(),
-                                  ssl_on=True)
+    SUBSCRIPTION_HANDLER = Pubnub(
+        'N/A', pywink.get_subscription_key(), ssl_on=True)
     SUBSCRIPTION_HANDLER.set_heartbeat(120)
 
     # Load components for the devices in the Wink that we support
@@ -51,7 +59,7 @@ def setup(hass, config):
 
 
 class WinkDevice(Entity):
-    """Represents a base Wink device."""
+    """Representation a base Wink device."""
 
     def __init__(self, wink):
         """Initialize the Wink device."""
@@ -59,7 +67,7 @@ class WinkDevice(Entity):
         self.wink = wink
         self._battery = self.wink.battery_level
         if self.wink.pubnub_channel in CHANNELS:
-            pubnub = Pubnub("N/A", self.wink.pubnub_key, ssl_on=True)
+            pubnub = Pubnub('N/A', self.wink.pubnub_key, ssl_on=True)
             pubnub.set_heartbeat(120)
             pubnub.subscribe(self.wink.pubnub_channel,
                              self._pubnub_update,
@@ -75,13 +83,12 @@ class WinkDevice(Entity):
         self.update_ha_state()
 
     def _pubnub_error(self, message):
-        logging.getLogger(__name__).error(
-            "Error on pubnub update for " + self.wink.name())
+        _LOGGER.error("Error on pubnub update for " + self.wink.name())
 
     @property
     def unique_id(self):
         """Return the ID of this Wink device."""
-        return "{}.{}".format(self.__class__, self.wink.device_id())
+        return '{}.{}'.format(self.__class__, self.wink.device_id())
 
     @property
     def name(self):


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
wink:
  access_token: YOUR_ACCESS_TOKEN
```

@w1ll1am23, would be nice if you could take a look at the changes and run a quick test. Thanks.
