### PR TITLE
Use voluptuous for Hyperion

### DIFF
--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -8,24 +8,41 @@ import json
 import logging
 import socket
 
-from homeassistant.components.light import (ATTR_RGB_COLOR, SUPPORT_RGB_COLOR,
-                                            Light)
-from homeassistant.const import CONF_HOST
+import voluptuous as vol
+
+from homeassistant.components.light import (
+    ATTR_RGB_COLOR, SUPPORT_RGB_COLOR, Light, PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_NAME)
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = []
+
+CONF_DEFAULT_COLOR = 'default_color'
+
+DEFAULT_COLOR = [255, 255, 255]
+DEFAULT_NAME = 'Hyperion'
+DEFAULT_PORT = 19444
 
 SUPPORT_HYPERION = SUPPORT_RGB_COLOR
 
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_DEFAULT_COLOR, default=DEFAULT_COLOR): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
 
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup a Hyperion server remote."""
-    host = config.get(CONF_HOST, None)
-    port = config.get("port", 19444)
-    default_color = config.get("default_color", [255, 255, 255])
-    device = Hyperion(config.get('name', host), host, port, default_color)
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    default_color = config.get(CONF_DEFAULT_COLOR)
+
+    device = Hyperion(config.get(CONF_NAME), host, port, default_color)
+
     if device.setup():
-        add_devices_callback([device])
+        add_devices([device])
         return True
     return False
 
@@ -68,34 +85,34 @@ class Hyperion(Light):
         else:
             self._rgb_color = self._default_color
 
-        self.json_request({"command": "color", "priority": 128,
-                           "color": self._rgb_color})
+        self.json_request(
+            {'command': 'color', 'priority': 128, 'color': self._rgb_color})
 
     def turn_off(self, **kwargs):
         """Disconnect all remotes."""
-        self.json_request({"command": "clearall"})
+        self.json_request({'command': 'clearall'})
         self._rgb_color = [0, 0, 0]
 
     def update(self):
         """Get the remote's active color."""
-        response = self.json_request({"command": "serverinfo"})
+        response = self.json_request({'command': 'serverinfo'})
         if response:
             # workaround for outdated Hyperion
-            if "activeLedColor" not in response["info"]:
+            if 'activeLedColor' not in response['info']:
                 self._rgb_color = self._default_color
                 return
 
-            if response["info"]["activeLedColor"] == []:
+            if response['info']['activeLedColor'] == []:
                 self._rgb_color = [0, 0, 0]
             else:
                 self._rgb_color =\
-                    response["info"]["activeLedColor"][0]["RGB Value"]
+                    response['info']['activeLedColor'][0]['RGB Value']
 
     def setup(self):
         """Get the hostname of the remote."""
-        response = self.json_request({"command": "serverinfo"})
+        response = self.json_request({'command': 'serverinfo'})
         if response:
-            self._name = response["info"]["hostname"]
+            self._name = response['info']['hostname']
             return True
         return False
 
@@ -110,7 +127,7 @@ class Hyperion(Light):
             sock.close()
             return False
 
-        sock.send(bytearray(json.dumps(request) + "\n", "utf-8"))
+        sock.send(bytearray(json.dumps(request) + '\n', 'utf-8'))
         try:
             buf = sock.recv(4096)
         except socket.timeout:
@@ -121,8 +138,8 @@ class Hyperion(Light):
         # Read until a newline or timeout
         buffering = True
         while buffering:
-            if "\n" in str(buf, "utf-8"):
-                response = str(buf, "utf-8").split("\n")[0]
+            if '\n' in str(buf, 'utf-8'):
+                response = str(buf, 'utf-8').split('\n')[0]
                 buffering = False
             else:
                 try:
@@ -131,7 +148,7 @@ class Hyperion(Light):
                     more = None
                 if not more:
                     buffering = False
-                    response = str(buf, "utf-8")
+                    response = str(buf, 'utf-8')
                 else:
                     buf += more
 


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
light:
  platform: hyperion
  host: 192.168.1.98
  # Optional
  port: 19444
```

Would be nice if somebody could take a look at the changes and run a quick test. Thanks.
