### PR TITLE
Use constants (*.arest)

### DIFF
--- a/homeassistant/components/binary_sensor/arest.py
+++ b/homeassistant/components/binary_sensor/arest.py
@@ -9,17 +9,14 @@ from datetime import timedelta
 
 import requests
 
-from homeassistant.components.binary_sensor import (BinarySensorDevice,
-                                                    SENSOR_CLASSES)
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, SENSOR_CLASSES)
+from homeassistant.const import CONF_RESOURCE, CONF_PIN
 from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-# Return cached results if last scan was less then this time ago
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
-
-CONF_RESOURCE = 'resource'
-CONF_PIN = 'pin'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -10,7 +10,8 @@ from datetime import timedelta
 import requests
 
 from homeassistant.const import (
-    ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE, DEVICE_DEFAULT_NAME)
+    ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE, DEVICE_DEFAULT_NAME,
+    CONF_RESOURCE, CONF_MONITORED_VARIABLES)
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers import template
@@ -18,11 +19,7 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-# Return cached results if last scan was less then this time ago.
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
-
-CONF_RESOURCE = 'resource'
-CONF_MONITORED_VARIABLES = 'monitored_variables'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/switch/arest.py
+++ b/homeassistant/components/switch/arest.py
@@ -10,14 +10,15 @@ import logging
 import requests
 
 from homeassistant.components.switch import SwitchDevice
-from homeassistant.const import DEVICE_DEFAULT_NAME
+from homeassistant.const import (
+    DEVICE_DEFAULT_NAME, CONF_NAME, CONF_RESOURCE)
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the aREST switches."""
-    resource = config.get('resource', None)
+    resource = config.get(CONF_RESOURCE, None)
 
     try:
         response = requests.get(resource, timeout=10)
@@ -34,18 +35,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     dev = []
     pins = config.get('pins', {})
     for pinnum, pin in pins.items():
-        dev.append(ArestSwitchPin(resource,
-                                  config.get('name', response.json()['name']),
-                                  pin.get('name'),
-                                  pinnum))
+        dev.append(ArestSwitchPin(
+            resource, config.get(CONF_NAME, response.json()['name']),
+            pin.get('name'), pinnum))
 
     functions = config.get('functions', {})
     for funcname, func in functions.items():
-        dev.append(ArestSwitchFunction(resource,
-                                       config.get('name',
-                                                  response.json()['name']),
-                                       func.get('name'),
-                                       funcname))
+        dev.append(ArestSwitchFunction(
+            resource, config.get(CONF_NAME, response.json()['name']),
+            func.get('name'), funcname))
 
     add_devices(dev)
 


### PR DESCRIPTION
**Description:**
Use constants.

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
