### PR TITLE
Point to master till archive is back (netatmo)

### DIFF
--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -12,16 +12,14 @@ from homeassistant.helpers import validate_config, discovery
 
 REQUIREMENTS = [
     'https://github.com/jabesq/netatmo-api-python/archive/'
-    'v0.5.0.zip#lnetatmo==0.5.0']
+    'master.zip#lnetatmo==0.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_SECRET_KEY = 'secret_key'
 
-DOMAIN = "netatmo"
+DOMAIN = 'netatmo'
 NETATMO_AUTH = None
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def setup(hass, config):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -164,7 +164,7 @@ https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.
 https://github.com/gadgetreactor/pyHS100/archive/master.zip#pyHS100==0.1.2
 
 # homeassistant.components.netatmo
-https://github.com/jabesq/netatmo-api-python/archive/v0.5.0.zip#lnetatmo==0.5.0
+https://github.com/jabesq/netatmo-api-python/archive/master.zip#lnetatmo==0.5.0
 
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1


### PR DESCRIPTION
**Description:**
It seems that at the moment the `lnetatmo` archive is not available. This makes the tests fail.

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
