### PR TITLE
Use voluptuous for netatmo

### DIFF
--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -16,8 +16,7 @@ import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = [
     'https://github.com/jabesq/netatmo-api-python/archive/'
-    'master.zip#lnetatmo==0.5.0']
-# 'v0.5.0.zip#lnetatmo==0.5.0']
+    'v0.5.0.zip#lnetatmo==0.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +28,7 @@ NETATMO_AUTH = None
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Optional(CONF_API_KEY): cv.string,
+        vol.Required(CONF_API_KEY): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Required(CONF_SECRET_KEY): cv.string,
         vol.Required(CONF_USERNAME): cv.string,

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -6,46 +6,49 @@ https://home-assistant.io/components/netatmo/
 """
 import logging
 from urllib.error import HTTPError
+
+import voluptuous as vol
+
 from homeassistant.const import (
     CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME)
-from homeassistant.helpers import validate_config, discovery
+from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = [
     'https://github.com/jabesq/netatmo-api-python/archive/'
     'master.zip#lnetatmo==0.5.0']
+# 'v0.5.0.zip#lnetatmo==0.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_SECRET_KEY = 'secret_key'
 
 DOMAIN = 'netatmo'
+
 NETATMO_AUTH = None
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_API_KEY): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_SECRET_KEY): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+    })
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
     """Setup the Netatmo devices."""
-    if not validate_config(config,
-                           {DOMAIN: [CONF_API_KEY,
-                                     CONF_USERNAME,
-                                     CONF_PASSWORD,
-                                     CONF_SECRET_KEY]},
-                           _LOGGER):
-        return None
-
     import lnetatmo
 
     global NETATMO_AUTH
     try:
-        NETATMO_AUTH = lnetatmo.ClientAuth(config[DOMAIN][CONF_API_KEY],
-                                           config[DOMAIN][CONF_SECRET_KEY],
-                                           config[DOMAIN][CONF_USERNAME],
-                                           config[DOMAIN][CONF_PASSWORD],
-                                           "read_station read_camera "
-                                           "access_camera")
+        NETATMO_AUTH = lnetatmo.ClientAuth(
+            config[DOMAIN][CONF_API_KEY], config[DOMAIN][CONF_SECRET_KEY],
+            config[DOMAIN][CONF_USERNAME], config[DOMAIN][CONF_PASSWORD],
+            'read_station read_camera access_camera')
     except HTTPError:
-        _LOGGER.error(
-            "Connection error "
-            "Please check your settings for NatAtmo API.")
+        _LOGGER.error("Unable to connect to NatAtmo API")
         return False
 
     for component in 'camera', 'sensor':

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -6,43 +6,58 @@ https://home-assistant.io/components/sensor.netatmo/
 """
 import logging
 from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.loader import get_component
-
-
-DEPENDENCIES = ["netatmo"]
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-SENSOR_TYPES = {
-    'temperature':  ['Temperature', TEMP_CELSIUS, 'mdi:thermometer'],
-    'co2':          ['CO2', 'ppm', 'mdi:cloud'],
-    'pressure':     ['Pressure', 'mbar', 'mdi:gauge'],
-    'noise':        ['Noise', 'dB', 'mdi:volume-high'],
-    'humidity':     ['Humidity', '%', 'mdi:water-percent'],
-    'rain':         ['Rain', 'mm', 'mdi:weather-rainy'],
-    'sum_rain_1':   ['sum_rain_1', 'mm', 'mdi:weather-rainy'],
-    'sum_rain_24':  ['sum_rain_24', 'mm', 'mdi:weather-rainy'],
-    'battery_vp':   ['Battery', '', 'mdi:battery'],
-    'min_temp':     ['Min Temp.', TEMP_CELSIUS, 'mdi:thermometer'],
-    'max_temp':     ['Max Temp.', TEMP_CELSIUS, 'mdi:thermometer'],
-    'WindAngle':    ['Angle', '', 'mdi:compass'],
-    'WindStrength': ['Strength', 'km/h', 'mdi:weather-windy'],
-    'GustAngle':    ['Gust Angle', '', 'mdi:compass'],
-    'GustStrength': ['Gust Strength', 'km/h', 'mdi:weather-windy'],
-    'rf_status':    ['Radio', '', 'mdi:signal'],
-    'wifi_status':  ['Wifi', '', 'mdi:wifi']
-}
-
-CONF_STATION = 'station'
 ATTR_MODULE = 'modules'
 
-# Return cached results if last scan was less then this time ago
-# NetAtmo Data is uploaded to server every 10mn
-# so this time should not be under
+CONF_MODULES = 'modules'
+CONF_MODULE_NAME = 'module_name'
+CONF_STATION = 'station'
+
+DEPENDENCIES = ['netatmo']
+
+# NetAtmo Data is uploaded to server every 10 minutes
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=600)
+
+SENSOR_TYPES = {
+    'temperature': ['Temperature', TEMP_CELSIUS, 'mdi:thermometer'],
+    'co2': ['CO2', 'ppm', 'mdi:cloud'],
+    'pressure': ['Pressure', 'mbar', 'mdi:gauge'],
+    'noise': ['Noise', 'dB', 'mdi:volume-high'],
+    'humidity': ['Humidity', '%', 'mdi:water-percent'],
+    'rain': ['Rain', 'mm', 'mdi:weather-rainy'],
+    'sum_rain_1': ['sum_rain_1', 'mm', 'mdi:weather-rainy'],
+    'sum_rain_24': ['sum_rain_24', 'mm', 'mdi:weather-rainy'],
+    'battery_vp': ['Battery', '', 'mdi:battery'],
+    'min_temp': ['Min Temp.', TEMP_CELSIUS, 'mdi:thermometer'],
+    'max_temp': ['Max Temp.', TEMP_CELSIUS, 'mdi:thermometer'],
+    'WindAngle': ['Angle', '', 'mdi:compass'],
+    'WindStrength': ['Strength', 'km/h', 'mdi:weather-windy'],
+    'GustAngle': ['Gust Angle', '', 'mdi:compass'],
+    'GustStrength': ['Gust Strength', 'km/h', 'mdi:weather-windy'],
+    'rf_status': ['Radio', '', 'mdi:signal'],
+    'wifi_status': ['Wifi', '', 'mdi:wifi']
+}
+
+MODULE_SCHEMA = vol.Schema({
+    vol.Required(CONF_MODULE_NAME, default=[]):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_STATION): cv.string,
+    vol.Required(CONF_MODULES): MODULE_SCHEMA,
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -53,18 +68,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     dev = []
     try:
         # Iterate each module
-        for module_name, monitored_conditions in config[ATTR_MODULE].items():
+        for module_name, monitored_conditions in config[CONF_MODULES].items():
             # Test if module exist """
             if module_name not in data.get_module_names():
                 _LOGGER.error('Module name: "%s" not found', module_name)
                 continue
             # Only create sensor for monitored """
             for variable in monitored_conditions:
-                if variable not in SENSOR_TYPES:
-                    _LOGGER.error('Sensor type: "%s" does not exist', variable)
-                else:
-                    dev.append(
-                        NetAtmoSensor(data, module_name, variable))
+                dev.append(NetAtmoSensor(data, module_name, variable))
     except KeyError:
         pass
 
@@ -77,7 +88,7 @@ class NetAtmoSensor(Entity):
 
     def __init__(self, netatmo_data, module_name, sensor_type):
         """Initialize the sensor."""
-        self._name = "NetAtmo {} {}".format(module_name,
+        self._name = 'NetAtmo {} {}'.format(module_name,
                                             SENSOR_TYPES[sensor_type][0])
         self.netatmo_data = netatmo_data
         self.module_name = module_name

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -164,7 +164,7 @@ https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.
 https://github.com/gadgetreactor/pyHS100/archive/master.zip#pyHS100==0.1.2
 
 # homeassistant.components.netatmo
-https://github.com/jabesq/netatmo-api-python/archive/master.zip#lnetatmo==0.5.0
+https://github.com/jabesq/netatmo-api-python/archive/v0.5.0.zip#lnetatmo==0.5.0
 
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
netatmo:
  api_key: YOUR_API_KEY
  secret_key: YOUR_SECRET_KEY
  username: YOUR_USERNAME
  password: YOUR_PASSWORD

sensor:
  platform: netatmo
  station: STATION_NAME
  modules:
    module_name1:
      - temperature
    module_name2:
      - temperature
```

@jabesq, would be nice if you could take a look at the changes and run a quick test. Thanks.
