### PR TITLE
Use voluptuous for Neurio

### DIFF
--- a/homeassistant/components/sensor/neurio_energy.py
+++ b/homeassistant/components/sensor/neurio_energy.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_API_SECRET = 'api_secret'
 CONF_SENSOR_ID = 'sensor_id'
 
-DEFAULT_NAME =
+DEFAULT_NAME = 'Energy Usage'
 
 ICON = 'mdi:flash'
 

--- a/homeassistant/components/sensor/neurio_energy.py
+++ b/homeassistant/components/sensor/neurio_energy.py
@@ -1,5 +1,5 @@
 """
-Support for monitoring  an neurio hub.
+Support for monitoring  an Neurio hub.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.neurio_energy/
@@ -7,26 +7,39 @@ https://home-assistant.io/components/sensor.neurio_energy/
 import logging
 
 import requests.exceptions
+import voluptuous as vol
 
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (CONF_API_KEY, CONF_NAME)
 from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['neurio==0.2.10']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_API_SECRET = 'api_secret'
+CONF_SENSOR_ID = 'sensor_id'
+
+DEFAULT_NAME =
+
 ICON = 'mdi:flash'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Required(CONF_API_SECRET): cv.string,
+    vol.Optional(CONF_SENSOR_ID): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Neurio sensor."""
-    api_key = config.get("api_key")
-    api_secret = config.get("api_secret")
-    sensor_id = config.get("sensor_id")
-    if not api_key and not api_secret:
-        _LOGGER.error(
-            "Configuration Error"
-            "Please make sure you have configured your api key and api secret")
-        return None
+    name = config.get(CONF_NAME)
+    api_key = config.get(CONF_API_KEY)
+    api_secret = config.get(CONF_API_SECRET)
+    sensor_id = config.get(CONF_SENSOR_ID)
+
     if not sensor_id:
         import neurio
         neurio_tp = neurio.TokenProvider(key=api_key, secret=api_secret)
@@ -35,9 +48,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.warning('Sensor ID auto-detected, set api_sensor_id: "%s"',
                         user_info["locations"][0]["sensors"][0]["sensorId"])
         sensor_id = user_info["locations"][0]["sensors"][0]["sensorId"]
-    dev = []
-    dev.append(NeurioEnergy(api_key, api_secret, sensor_id))
-    add_devices(dev)
+
+    add_devices([NeurioEnergy(api_key, api_secret, name, sensor_id)])
 
 
 # pylint: disable=too-many-instance-attributes
@@ -45,14 +57,14 @@ class NeurioEnergy(Entity):
     """Implementation of an Neurio energy."""
 
     # pylint: disable=too-many-arguments
-    def __init__(self, api_key, api_secret, sensor_id):
+    def __init__(self, api_key, api_secret, name, sensor_id):
         """Initialize the sensor."""
-        self._name = "Energy Usage"
+        self._name = name
         self.api_key = api_key
         self.api_secret = api_secret
         self.sensor_id = sensor_id
         self._state = None
-        self._unit_of_measurement = "W"
+        self._unit_of_measurement = 'W'
 
     @property
     def name(self):
@@ -78,8 +90,8 @@ class NeurioEnergy(Entity):
         """Get the Neurio monitor data from the web service."""
         import neurio
         try:
-            neurio_tp = neurio.TokenProvider(key=self.api_key,
-                                             secret=self.api_secret)
+            neurio_tp = neurio.TokenProvider(
+                key=self.api_key, secret=self.api_secret)
             neurio_client = neurio.Client(token_provider=neurio_tp)
             sample = neurio_client.get_samples_live_last(
                 sensor_id=self.sensor_id)


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: neurio_energy
  api_key: API_KEY
  api_secret: API_SECRET
  sensor_id: "SENSOR_ID"
```

@infamy, would be nice if you could take a look at the changes and run a quick test. Thanks.
