### PR TITLE
Use voluptuous for netio

### DIFF
--- a/homeassistant/components/switch/netio.py
+++ b/homeassistant/components/switch/netio.py
@@ -7,59 +7,75 @@ https://home-assistant.io/components/switch.netio/
 import logging
 from collections import namedtuple
 from datetime import timedelta
+
+import voluptuous as vol
+
 from homeassistant import util
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_USERNAME, \
-    CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP, STATE_ON
-from homeassistant.helpers import validate_config
-from homeassistant.components.switch import SwitchDevice
+from homeassistant.const import (
+    CONF_HOST, CONF_PORT, CONF_USERNAME, CONF_PASSWORD,
+    EVENT_HOMEASSISTANT_STOP, STATE_ON)
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['pynetio==0.1.6']
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ['http']
-REQUIREMENTS = ['pynetio==0.1.6']
-DEFAULT_USERNAME = 'admin'
+ATTR_CURRENT_POWER_MWH = 'current_power_mwh'
+ATTR_CURRENT_POWER_W = 'current_power_w'
+ATTR_START_DATE = 'start_date'
+ATTR_TODAY_MWH = 'today_mwh'
+ATTR_TOTAL_CONSUMPTION_KWH = 'total_energy_kwh'
+
+CONF_OUTLETS = 'outlets'
+
 DEFAULT_PORT = 1234
-URL_API_NETIO_EP = "/api/netio/<host>"
-
-CONF_OUTLETS = "outlets"
-REQ_CONF = [CONF_HOST, CONF_OUTLETS]
-ATTR_TODAY_MWH = "today_mwh"
-ATTR_TOTAL_CONSUMPTION_KWH = "total_energy_kwh"
-ATTR_CURRENT_POWER_MWH = "current_power_mwh"
-ATTR_CURRENT_POWER_W = "current_power_w"
-
+DEFAULT_USERNAME = 'admin'
+DEPENDENCIES = ['http']
 Device = namedtuple('device', ['netio', 'entities'])
 DEVICES = {}
-ATTR_START_DATE = 'start_date'
+
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
+REQ_CONF = [CONF_HOST, CONF_OUTLETS]
 
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
-    """Configure the netio platform."""
+URL_API_NETIO_EP = '/api/netio/<host>'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_OUTLETS): {cv.string: cv.string},
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Configure the Netio platform."""
     from pynetio import Netio
 
-    if validate_config({"conf": config}, {"conf": [CONF_OUTLETS,
-                                                   CONF_HOST]}, _LOGGER):
-        if len(DEVICES) == 0:
-            hass.wsgi.register_view(NetioApiView)
+    host = config.get(CONF_HOST)
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    port = config.get(CONF_PORT)
 
-        dev = Netio(config[CONF_HOST],
-                    config.get(CONF_PORT, DEFAULT_PORT),
-                    config.get(CONF_USERNAME, DEFAULT_USERNAME),
-                    config.get(CONF_PASSWORD, DEFAULT_USERNAME))
+    if len(DEVICES) == 0:
+        hass.wsgi.register_view(NetioApiView)
 
-        DEVICES[config[CONF_HOST]] = Device(dev, [])
+    dev = Netio(host, port, username, password)
 
-        # Throttle the update for all NetioSwitches of one Netio
-        dev.update = util.Throttle(MIN_TIME_BETWEEN_SCANS)(dev.update)
+    DEVICES[host] = Device(dev, [])
 
-        for key in config[CONF_OUTLETS]:
-            switch = NetioSwitch(DEVICES[config[CONF_HOST]].netio, key,
-                                 config[CONF_OUTLETS][key])
-            DEVICES[config[CONF_HOST]].entities.append(switch)
+    # Throttle the update for all NetioSwitches of one Netio
+    dev.update = util.Throttle(MIN_TIME_BETWEEN_SCANS)(dev.update)
 
-        add_devices_callback(DEVICES[config[CONF_HOST]].entities)
+    for key in config[CONF_OUTLETS]:
+        switch = NetioSwitch(
+            DEVICES[host].netio, key, config[CONF_OUTLETS][key])
+        DEVICES[host].entities.append(switch)
+
+    add_devices(DEVICES[host].entities)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, dispose)
     return True
@@ -75,7 +91,7 @@ class NetioApiView(HomeAssistantView):
     """WSGI handler class."""
 
     url = URL_API_NETIO_EP
-    name = "api:netio"
+    name = 'api:netio'
 
     def get(self, request, host):
         """Request handler."""
@@ -135,7 +151,7 @@ class NetioSwitch(SwitchDevice):
 
     def _set(self, value):
         val = list('uuuu')
-        val[self.outlet - 1] = "1" if value else "0"
+        val[self.outlet - 1] = '1' if value else '0'
         self.netio.get('port list %s' % ''.join(val))
         self.netio.states[self.outlet - 1] = value
         self.update_ha_state()
@@ -146,15 +162,17 @@ class NetioSwitch(SwitchDevice):
         return self.netio.states[self.outlet - 1]
 
     def update(self):
-        """Called by HA."""
+        """Called by Home Assistant."""
         self.netio.update()
 
     @property
     def state_attributes(self):
         """Return optional state attributes."""
-        return {ATTR_CURRENT_POWER_W: self.current_power_w,
-                ATTR_TOTAL_CONSUMPTION_KWH: self.cumulated_consumption_kwh,
-                ATTR_START_DATE: self.start_date.split('|')[0]}
+        return {
+            ATTR_CURRENT_POWER_W: self.current_power_w,
+            ATTR_TOTAL_CONSUMPTION_KWH: self.cumulated_consumption_kwh,
+            ATTR_START_DATE: self.start_date.split('|')[0]
+        }
 
     @property
     def current_power_w(self):


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
  - platform: netio
    host: 192.168.1.43
    port: 1234
    username: user
    password: pwd
    outlets:
      1: Free
      2: TV
      4: Lamp
```

@eagleamon, would be nice if you could take a look at the changes and run a quick test. Thanks.
