### PR TITLE
emulated_hue: use '/api/' for API root for correctness and Harmony co…

### DIFF
--- a/homeassistant/components/emulated_hue.py
+++ b/homeassistant/components/emulated_hue.py
@@ -188,7 +188,7 @@ class DescriptionXmlView(HomeAssistantView):
 class HueUsernameView(HomeAssistantView):
     """Handle requests to create a username for the emulated hue bridge."""
 
-    url = '/api'
+    url = '/api/'
     name = 'hue:api'
     requires_auth = False
 


### PR DESCRIPTION
**Description:**
The Hue API root is "/api/", and devices seem to alternatively use "/api" (Alexa) or "/api/" (Harmony Hub).  "/api/" is the correct one and should work for both.

This allows the Harmony Hub to discover the emulated Hue bridge.
