### PR TITLE
Modbus sensor refactoring

### DIFF
--- a/homeassistant/components/binary_sensor/modbus.py
+++ b/homeassistant/components/binary_sensor/modbus.py
@@ -1,15 +1,15 @@
 """
-Support for Modbus switches.
+Support for Modbus Coil sensors.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/switch.modbus/
+https://home-assistant.io/components/binary_sensor.modbus/
 """
 import logging
 import voluptuous as vol
 
 import homeassistant.components.modbus as modbus
 from homeassistant.const import CONF_NAME
-from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.helpers import config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 
@@ -24,52 +24,38 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COILS): [{
         vol.Required(CONF_COIL): cv.positive_int,
         vol.Required(CONF_NAME): cv.string,
-        vol.Optional(CONF_SLAVE): cv.positive_int,
+        vol.Optional(CONF_SLAVE): cv.positive_int
     }]
 })
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Read configuration and create Modbus devices."""
-    switches = []
-    for coil in config.get("coils"):
-        switches.append(ModbusCoilSwitch(
+    """Setup Modbus binary sensors."""
+    sensors = []
+    for coil in config.get(CONF_COILS):
+        sensors.append(ModbusCoilSensor(
             coil.get(CONF_NAME),
             coil.get(CONF_SLAVE),
             coil.get(CONF_COIL)))
-    add_devices(switches)
+    add_devices(sensors)
 
 
-class ModbusCoilSwitch(ToggleEntity):
-    """Representation of a Modbus switch."""
+class ModbusCoilSensor(BinarySensorDevice):
+    """Modbus coil sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, name, slave, coil):
-        """Initialize the switch."""
+        """Initialize the modbus coil sensor."""
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)
-        self._is_on = None
+        self._value = None
 
     @property
     def is_on(self):
-        """Return true if switch is on."""
-        return self._is_on
-
-    @property
-    def name(self):
-        """Return the name of the switch."""
-        return self._name
-
-    def turn_on(self, **kwargs):
-        """Set switch on."""
-        modbus.HUB.write_coil(self._slave, self._coil, True)
-
-    def turn_off(self, **kwargs):
-        """Set switch off."""
-        modbus.HUB.write_coil(self._slave, self._coil, False)
+        """Return the state of the sensor."""
+        return self._value
 
     def update(self):
-        """Update the state of the switch."""
+        """Update the state of the sensor."""
         result = modbus.HUB.read_coils(self._slave, self._coil, 1)
-        self._is_on = bool(result.bits[0])
+        self._value = result.bits[0]

--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -7,8 +7,12 @@ https://home-assistant.io/components/modbus/
 import logging
 import threading
 
+import voluptuous as vol
+
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
+    CONF_HOST, CONF_METHOD, CONF_PORT)
+import homeassistant.helpers.config_validation as cv
 
 DOMAIN = "modbus"
 
@@ -16,19 +20,33 @@ REQUIREMENTS = ['https://github.com/bashwork/pymodbus/archive/'
                 'd7fc4f1cc975631e0a9011390e8017f64b612661.zip#pymodbus==1.2.0']
 
 # Type of network
-MEDIUM = "type"
+CONF_BAUDRATE = "baudrate"
+CONF_BYTESIZE = "bytesize"
+CONF_STOPBITS = "stopbits"
+CONF_TYPE = "type"
+CONF_PARITY = "parity"
 
-# if MEDIUM == "serial"
-METHOD = "method"
-SERIAL_PORT = "port"
-BAUDRATE = "baudrate"
-STOPBITS = "stopbits"
-BYTESIZE = "bytesize"
-PARITY = "parity"
+SERIAL_SCHEMA = {
+    vol.Required(CONF_BAUDRATE): cv.positive_int,
+    vol.Required(CONF_BYTESIZE): vol.Any(5, 6, 7, 8),
+    vol.Required(CONF_METHOD): vol.Any('rtu', 'ascii'),
+    vol.Required(CONF_PORT): cv.string,
+    vol.Required(CONF_PARITY): vol.Any('E', 'O', 'N'),
+    vol.Required(CONF_STOPBITS): vol.Any(1, 2),
+    vol.Required(CONF_TYPE): 'serial',
+}
 
-# if MEDIUM == "tcp" or "udp"
-HOST = "host"
-IP_PORT = "port"
+ETHERNET_SCHEMA = {
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PORT): cv.positive_int,
+    vol.Required(CONF_TYPE): vol.Any('tcp', 'udp'),
+}
+
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)
+}, extra=vol.ALLOW_EXTRA)
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,36 +56,41 @@ ATTR_ADDRESS = "address"
 ATTR_UNIT = "unit"
 ATTR_VALUE = "value"
 
+SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema({
+    vol.Required(ATTR_UNIT): cv.positive_int,
+    vol.Required(ATTR_ADDRESS): cv.positive_int,
+    vol.Required(ATTR_VALUE): cv.positive_int
+})
+
+
 HUB = None
-TYPE = None
 
 
 def setup(hass, config):
     """Setup Modbus component."""
     # Modbus connection type
     # pylint: disable=global-statement, import-error
-    global TYPE
-    TYPE = config[DOMAIN][MEDIUM]
+    client_type = config[DOMAIN][CONF_TYPE]
 
     # Connect to Modbus network
     # pylint: disable=global-statement, import-error
 
-    if TYPE == "serial":
+    if client_type == "serial":
         from pymodbus.client.sync import ModbusSerialClient as ModbusClient
-        client = ModbusClient(method=config[DOMAIN][METHOD],
-                              port=config[DOMAIN][SERIAL_PORT],
-                              baudrate=config[DOMAIN][BAUDRATE],
-                              stopbits=config[DOMAIN][STOPBITS],
-                              bytesize=config[DOMAIN][BYTESIZE],
-                              parity=config[DOMAIN][PARITY])
-    elif TYPE == "tcp":
+        client = ModbusClient(method=config[DOMAIN][CONF_METHOD],
+                              port=config[DOMAIN][CONF_PORT],
+                              baudrate=config[DOMAIN][CONF_BAUDRATE],
+                              stopbits=config[DOMAIN][CONF_STOPBITS],
+                              bytesize=config[DOMAIN][CONF_BYTESIZE],
+                              parity=config[DOMAIN][CONF_PARITY])
+    elif client_type == "tcp":
         from pymodbus.client.sync import ModbusTcpClient as ModbusClient
-        client = ModbusClient(host=config[DOMAIN][HOST],
-                              port=config[DOMAIN][IP_PORT])
-    elif TYPE == "udp":
+        client = ModbusClient(host=config[DOMAIN][CONF_HOST],
+                              port=config[DOMAIN][CONF_PORT])
+    elif client_type == "udp":
         from pymodbus.client.sync import ModbusUdpClient as ModbusClient
-        client = ModbusClient(host=config[DOMAIN][HOST],
-                              port=config[DOMAIN][IP_PORT])
+        client = ModbusClient(host=config[DOMAIN][CONF_HOST],
+                              port=config[DOMAIN][CONF_PORT])
     else:
         return False
 
@@ -84,7 +107,8 @@ def setup(hass, config):
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_modbus)
 
         # Register services for modbus
-        hass.services.register(DOMAIN, SERVICE_WRITE_REGISTER, write_register)
+        hass.services.register(DOMAIN, SERVICE_WRITE_REGISTER, write_register,
+                               schema=SERVICE_WRITE_REGISTER_SCHEMA)
 
     def write_register(service):
         """Write modbus registers."""
@@ -128,39 +152,44 @@ class ModbusHub(object):
     def read_coils(self, unit, address, count):
         """Read coils."""
         with self._lock:
+            kwargs = {'unit': unit} if unit else {}
             return self._client.read_coils(
                 address,
                 count,
-                unit=unit)
+                **kwargs)
 
     def read_holding_registers(self, unit, address, count):
         """Read holding registers."""
         with self._lock:
+            kwargs = {'unit': unit} if unit else {}
             return self._client.read_holding_registers(
                 address,
                 count,
-                unit=unit)
+                **kwargs)
 
     def write_coil(self, unit, address, value):
         """Write coil."""
         with self._lock:
+            kwargs = {'unit': unit} if unit else {}
             self._client.write_coil(
                 address,
                 value,
-                unit=unit)
+                **kwargs)
 
     def write_register(self, unit, address, value):
         """Write register."""
         with self._lock:
+            kwargs = {'unit': unit} if unit else {}
             self._client.write_register(
                 address,
                 value,
-                unit=unit)
+                **kwargs)
 
     def write_registers(self, unit, address, values):
         """Write registers."""
         with self._lock:
+            kwargs = {'unit': unit} if unit else {}
             self._client.write_registers(
                 address,
                 values,
-                unit=unit)
+                **kwargs)


### PR DESCRIPTION
**Description:**
The modbus sensor needed some love.

I have: 
- Moved the coil support to binary_sensor, since it is a 1-bit value.
- Removed the bits part of the sensor register config, since this can be done more efficient with a template_sensor.
- Removed the register support from the switch since it can be done with template_switch.
- Removed unused functions and unnecessary overrides. 
- Moved the slave attribute to each register so that it's easier to communicate with several slaves.
- Changed the registers and coils attributes from a dicts to lists.
- Added a length attribute to the register sensor. 
- Changed from unit attribute to the more commonly used unit_of_measurement
- Added voluptuous to all modbus components

I will add voluptuous in the next PR

I have not been able to test the binary_sensor or switch since my unit lacks coils, if anyone has a unit with coils I would appreciate some help!

**Related issue (if applicable):** fixes #
#3038

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#
https://github.com/home-assistant/home-assistant.github.io/pull/933

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
modbus:                                                                                                         
  type: serial                                                                                                  
  method: rtu                                                                                                   
  port: /dev/ttyUSB0                                                                                            
  baudrate: 9600                                                                                                
  stopbits: 1                                                                                                   
  bytesize: 8                                                                                                   
  parity: N   

sensor:                                                                                                                        
  - platform: modbus                                                             
    registers:                                                                   
      - name: Fan Speed                                                          
        slave: 1                                                                 
        register: 100                                                            
      - name: Temperature set                                                    
        slave: 1                                                                 
        register: 206                                                            
      - name: Supply air                                                         
        unit_of_measurement: °C                                                  
        slave: 1                                                                 
        register: 213                                                            
        scale: 0.1                                                               
        precision: 1                                                             
      - name: Extract air                                                        
        unit_of_measurement: °C                                                  
        slave: 1                                                                 
        register: 214                                                            
        scale: 0.1                                                               
        precision: 1

binary_sensor:
  - platform: modbus
    coils:
      - name: Alarm 1
        slave: 2
        coil: 15

switch:
  - platform: modbus
    coils:
      - name: Heater
        slave: 1
        coil: 2
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
