### PR TITLE
Use voluptuous for Honeywell

### DIFF
--- a/tests/components/climate/test_honeywell.py
+++ b/tests/components/climate/test_honeywell.py
@@ -3,10 +3,11 @@ import socket
 import unittest
 from unittest import mock
 
+import voluptuous as vol
 import somecomfort
 
-from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD,
-                                 TEMP_CELSIUS, TEMP_FAHRENHEIT)
+from homeassistant.const import (
+    CONF_USERNAME, CONF_PASSWORD, TEMP_CELSIUS, TEMP_FAHRENHEIT)
 import homeassistant.components.climate.honeywell as honeywell
 
 
@@ -21,17 +22,30 @@ class TestHoneywell(unittest.TestCase):
         config = {
             CONF_USERNAME: 'user',
             CONF_PASSWORD: 'pass',
-            'region': 'us',
+            honeywell.CONF_REGION: 'us',
         }
         bad_pass_config = {
             CONF_USERNAME: 'user',
-            'region': 'us',
+            honeywell.CONF_REGION: 'us',
         }
         bad_region_config = {
             CONF_USERNAME: 'user',
             CONF_PASSWORD: 'pass',
-            'region': 'un',
+            honeywell.CONF_REGION: 'un',
         }
+
+        with self.assertRaises(vol.Invalid):
+            honeywell.PLATFORM_SCHEMA(None)
+
+        with self.assertRaises(vol.Invalid):
+            honeywell.PLATFORM_SCHEMA({})
+
+        with self.assertRaises(vol.Invalid):
+            honeywell.PLATFORM_SCHEMA(bad_pass_config)
+
+        with self.assertRaises(vol.Invalid):
+            honeywell.PLATFORM_SCHEMA(bad_region_config)
+
         hass = mock.MagicMock()
         add_devices = mock.MagicMock()
 
@@ -46,10 +60,6 @@ class TestHoneywell(unittest.TestCase):
         locations[0].devices_by_id.values.return_value = devices_1
         locations[1].devices_by_id.values.return_value = devices_2
 
-        result = honeywell.setup_platform(hass, bad_pass_config, add_devices)
-        self.assertFalse(result)
-        result = honeywell.setup_platform(hass, bad_region_config, add_devices)
-        self.assertFalse(result)
         result = honeywell.setup_platform(hass, config, add_devices)
         self.assertTrue(result)
         mock_sc.assert_called_once_with('user', 'pass')
@@ -67,7 +77,7 @@ class TestHoneywell(unittest.TestCase):
         config = {
             CONF_USERNAME: 'user',
             CONF_PASSWORD: 'pass',
-            'region': 'us',
+            honeywell.CONF_REGION: 'us',
         }
 
         mock_sc.side_effect = somecomfort.AuthError
@@ -88,7 +98,7 @@ class TestHoneywell(unittest.TestCase):
         config = {
             CONF_USERNAME: 'user',
             CONF_PASSWORD: 'pass',
-            'region': 'us',
+            honeywell.CONF_REGION: 'us',
             'location': loc,
             'thermostat': dev,
         }
@@ -152,12 +162,12 @@ class TestHoneywell(unittest.TestCase):
     @mock.patch('homeassistant.components.climate.honeywell.'
                 'RoundThermostat')
     def test_eu_setup_full_config(self, mock_round, mock_evo):
-        """Test the EU setup wwith complete configuration."""
+        """Test the EU setup with complete configuration."""
         config = {
             CONF_USERNAME: 'user',
             CONF_PASSWORD: 'pass',
-            honeywell.CONF_AWAY_TEMP: 20,
-            'region': 'eu',
+            honeywell.CONF_AWAY_TEMPERATURE: 20.0,
+            honeywell.CONF_REGION: 'eu',
         }
         mock_evo.return_value.temperatures.return_value = [
             {'id': 'foo'}, {'id': 'bar'}]
@@ -168,8 +178,8 @@ class TestHoneywell(unittest.TestCase):
         mock_evo.return_value.temperatures.assert_called_once_with(
             force_refresh=True)
         mock_round.assert_has_calls([
-            mock.call(mock_evo.return_value, 'foo', True, 20),
-            mock.call(mock_evo.return_value, 'bar', False, 20),
+            mock.call(mock_evo.return_value, 'foo', True, 20.0),
+            mock.call(mock_evo.return_value, 'bar', False, 20.0),
         ])
         self.assertEqual(2, add_devices.call_count)
 
@@ -181,17 +191,20 @@ class TestHoneywell(unittest.TestCase):
         config = {
             CONF_USERNAME: 'user',
             CONF_PASSWORD: 'pass',
-            'region': 'eu',
+            honeywell.CONF_REGION: 'eu',
         }
+
         mock_evo.return_value.temperatures.return_value = [
             {'id': 'foo'}, {'id': 'bar'}]
+        config[honeywell.CONF_AWAY_TEMPERATURE] = \
+            honeywell.DEFAULT_AWAY_TEMPERATURE
+
         hass = mock.MagicMock()
         add_devices = mock.MagicMock()
         self.assertTrue(honeywell.setup_platform(hass, config, add_devices))
-        default = honeywell.DEFAULT_AWAY_TEMP
         mock_round.assert_has_calls([
-            mock.call(mock_evo.return_value, 'foo', True, default),
-            mock.call(mock_evo.return_value, 'bar', False, default),
+            mock.call(mock_evo.return_value, 'foo', True, 16),
+            mock.call(mock_evo.return_value, 'bar', False, 16),
         ])
 
     @mock.patch('evohomeclient.EvohomeClient')
@@ -202,10 +215,12 @@ class TestHoneywell(unittest.TestCase):
         config = {
             CONF_USERNAME: 'user',
             CONF_PASSWORD: 'pass',
-            honeywell.CONF_AWAY_TEMP: 'ponies',
-            'region': 'eu',
+            honeywell.CONF_AWAY_TEMPERATURE: 'ponies',
+            honeywell.CONF_REGION: 'eu',
         }
-        self.assertFalse(honeywell.setup_platform(None, config, None))
+
+        with self.assertRaises(vol.Invalid):
+            honeywell.PLATFORM_SCHEMA(config)
 
     @mock.patch('evohomeclient.EvohomeClient')
     @mock.patch('homeassistant.components.climate.honeywell.'
@@ -215,8 +230,8 @@ class TestHoneywell(unittest.TestCase):
         config = {
             CONF_USERNAME: 'user',
             CONF_PASSWORD: 'pass',
-            honeywell.CONF_AWAY_TEMP: 20,
-            'region': 'eu',
+            honeywell.CONF_AWAY_TEMPERATURE: 20,
+            honeywell.CONF_REGION: 'eu',
         }
         mock_evo.return_value.temperatures.side_effect = socket.error
         add_devices = mock.MagicMock()
@@ -356,9 +371,9 @@ class TestHoneywellUS(unittest.TestCase):
     def test_attributes(self):
         """Test the attributes."""
         expected = {
-            'fan': 'running',
-            'fanmode': 'auto',
-            'system_mode': 'heat',
+            honeywell.ATTR_FAN: 'running',
+            honeywell.ATTR_FANMODE: 'auto',
+            honeywell.ATTR_SYSTEM_MODE: 'heat',
         }
         self.assertEqual(expected, self.honeywell.device_state_attributes)
         expected['fan'] = 'idle'
@@ -370,8 +385,8 @@ class TestHoneywellUS(unittest.TestCase):
         self.device.fan_running = False
         self.device.fan_mode = None
         expected = {
-            'fan': 'idle',
-            'fanmode': None,
-            'system_mode': 'heat',
+            honeywell.ATTR_FAN: 'idle',
+            honeywell.ATTR_FANMODE: None,
+            honeywell.ATTR_SYSTEM_MODE: 'heat',
         }
         self.assertEqual(expected, self.honeywell.device_state_attributes)


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`. Also this is includes an upgrade of somecomfort to 0.3.1 as discussed on gitter.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
climate:
  platform: honeywell
  username: YOUR_USERNAME
  password:  YOUR_PASSWORD
  region: REGION
```

Would be nice if somebody could take a look at the changes and run a quick test. Thanks.
