### PR TITLE
Fix bloomsky platform discovery

### DIFF
--- a/homeassistant/components/binary_sensor/bloomsky.py
+++ b/homeassistant/components/binary_sensor/bloomsky.py
@@ -33,7 +33,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the available BloomSky weather binary sensors."""
     bloomsky = get_component('bloomsky')
-    sensors = config.get(CONF_MONITORED_CONDITIONS)
+    # Default needed in case of discovery
+    sensors = config.get(CONF_MONITORED_CONDITIONS, SENSOR_TYPES)
 
     for device in bloomsky.BLOOMSKY.devices.values():
         for variable in sensors:

--- a/homeassistant/components/sensor/bloomsky.py
+++ b/homeassistant/components/sensor/bloomsky.py
@@ -46,7 +46,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the available BloomSky weather sensors."""
     bloomsky = get_component('bloomsky')
-    sensors = config.get(CONF_MONITORED_CONDITIONS)
+    # Default needed in case of discovery
+    sensors = config.get(CONF_MONITORED_CONDITIONS, SENSOR_TYPES)
 
     for device in bloomsky.BLOOMSKY.devices.values():
         for variable in sensors:


### PR DESCRIPTION
**Description:**
Bloomsky sensor and binary sensor platforms were broken after the voluptuous upgrade.

We made the wrong assumption that the config passed into the `setup_platform` method has always been run through `PLATFORM_SCHEMA`. This is not the case if the platform is loaded because of discovery.

In the case of bloomsky this resulted in the wrong assumption that the config always contains the default values.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
bloomsky:
  api_key: 'ABCDEFGH'
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
