### PR TITLE
Added play media to squeezebox

### DIFF
--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -319,7 +319,7 @@ class SqueezeBoxDevice(MediaPlayerDevice):
     def _play_uri(self, media_id):
         """
         Replace the current play list with the uri.
-        
+
         Telnet Command Strucutre:
         <playerid> playlist play <item> <title> <fadeInSecs>
 

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -28,7 +28,7 @@ KNOWN_DEVICES = []
 
 SUPPORT_SQUEEZEBOX = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | \
     SUPPORT_VOLUME_MUTE | SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK | \
-    SUPPORT_SEEK | SUPPORT_TURN_ON | SUPPORT_TURN_OFF
+    SUPPORT_SEEK | SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PLAY_MEDIA
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -304,7 +304,7 @@ class SqueezeBoxDevice(MediaPlayerDevice):
         """Turn the media player on."""
         self._lms.query(self._id, 'power', '1')
         self.update_ha_state()
-        
+
     def play_media(self, media_type, media_id, **kwargs):
         """
         Send the play_media command to the media player.
@@ -363,4 +363,3 @@ class SqueezeBoxDevice(MediaPlayerDevice):
         """
         self._lms.query(self._id, 'playlist', 'add', media_id)
         self.update_ha_state()
-        

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -312,14 +312,15 @@ class SqueezeBoxDevice(MediaPlayerDevice):
         If ATTR_MEDIA_ENQUEUE is True, add `media_id` to the current playlist.
         """
         if kwargs.get(ATTR_MEDIA_ENQUEUE):
-            self.add_uri_to_playlist(media_id)
+            self._add_uri_to_playlist(media_id)
         else:
-            self.play_uri(media_id)
+            self._play_uri(media_id)
 
-    def play_uri(self, media_id):
+    def _play_uri(self, media_id):
         """
         Replace the current play list with the uri.
-
+        
+        Telnet Command Strucutre:
         <playerid> playlist play <item> <title> <fadeInSecs>
 
         The "playlist play" command puts the specified song URL,
@@ -339,10 +340,11 @@ class SqueezeBoxDevice(MediaPlayerDevice):
         self._lms.query(self._id, 'playlist', 'play', media_id)
         self.update_ha_state()
 
-    def add_uri_to_playlist(self, media_id):
+    def _add_uri_to_playlist(self, media_id):
         """
         Add a items to the existing playlist.
 
+        Telnet Command Strucutre:
         <playerid> playlist add <item>
 
         The "playlist add" command adds the specified song URL, playlist or

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -11,6 +11,7 @@ import urllib.parse
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
+    ATTR_MEDIA_ENQUEUE, SUPPORT_PLAY_MEDIA,
     MEDIA_TYPE_MUSIC, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, PLATFORM_SCHEMA,
     SUPPORT_PREVIOUS_TRACK, SUPPORT_SEEK, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, MediaPlayerDevice)
@@ -303,3 +304,63 @@ class SqueezeBoxDevice(MediaPlayerDevice):
         """Turn the media player on."""
         self._lms.query(self._id, 'power', '1')
         self.update_ha_state()
+        
+    def play_media(self, media_type, media_id, **kwargs):
+        """
+        Send the play_media command to the media player.
+
+        If ATTR_MEDIA_ENQUEUE is True, add `media_id` to the current playlist.
+        """
+        if kwargs.get(ATTR_MEDIA_ENQUEUE):
+            self.add_uri_to_playlist(media_id)
+        else:
+            self.play_uri(media_id)
+
+    def play_uri(self, media_id):
+        """
+        Replace the current play list with the uri.
+
+        <playerid> playlist play <item> <title> <fadeInSecs>
+
+        The "playlist play" command puts the specified song URL,
+        playlist or directory contents into the current playlist
+        and plays starting at the first item. Any songs previously
+        in the playlist are discarded. An optional title value may be
+        passed to set a title. This can be useful for remote URLs.
+        The "fadeInSecs" parameter may be passed to specify fade-in period.
+
+        Examples:
+        Request: "04:20:00:12:23:45 playlist play
+                    /music/abba/01_Voulez_Vous.mp3<LF>"
+        Response: "04:20:00:12:23:45 playlist play
+            /music/abba/01_Voulez_Vous.mp3<LF>"
+
+        """
+        self._lms.query(self._id, 'playlist', 'play', media_id)
+        self.update_ha_state()
+
+    def add_uri_to_playlist(self, media_id):
+        """
+        Add a items to the existing playlist.
+
+        <playerid> playlist add <item>
+
+        The "playlist add" command adds the specified song URL, playlist or
+        directory contents to the end of the current playlist. Songs
+        currently playing or already on the playlist are not affected.
+
+        Examples:
+        Request: "04:20:00:12:23:45 playlist add
+            /music/abba/01_Voulez_Vous.mp3<LF>"
+        Response: "04:20:00:12:23:45 playlist add
+            /music/abba/01_Voulez_Vous.mp3<LF>"
+
+        Request: "04:20:00:12:23:45 playlist add
+            /playlists/abba.m3u<LF>"
+        Response: "04:20:00:12:23:45 playlist add
+            /playlists/abba.m3u<LF>"
+
+        """
+        self._lms.query(self._id, 'playlist', 'add', media_id)
+        self.update_ha_state()
+        


### PR DESCRIPTION
**Description:**
Updated the squeezebox component to handle play commands. 
- You can now specify a URI in the play and it will play it immediately. 
- You can specify enqueuer and it adds it to the end of the current play list. 

**Related issue (if applicable):** NA

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#
NA - adding support for existing features, no change in documentation.

**Example entry for `configuration.yaml` (if applicable):**
NA - No configuration changes. 

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

The squeezebox component can now add a URI to an existing playlist or just over write it to force a stream to play.
