### PR TITLE
Comment out pyuserinput in requirements_all

### DIFF
--- a/homeassistant/components/keyboard.py
+++ b/homeassistant/components/keyboard.py
@@ -50,6 +50,7 @@ def media_prev_track(hass):
 
 def setup(hass, config):
     """Listen for keyboard events."""
+    # pylint: disable=import-error
     import pykeyboard
 
     keyboard = pykeyboard.PyKeyboard()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -397,7 +397,7 @@ python-twitch==1.3.0
 python-wink==0.7.13
 
 # homeassistant.components.keyboard
-pyuserinput==0.1.11
+# pyuserinput==0.1.11
 
 # homeassistant.components.vera
 pyvera==0.2.15

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -14,7 +14,8 @@ COMMENT_REQUIREMENTS = (
     'pybluez',
     'bluepy',
     'python-lirc',
-    'gattlib'
+    'gattlib',
+    'pyuserinput',
 )
 
 IGNORE_PACKAGES = (


### PR DESCRIPTION
This will move pyuserinput to the requirements that are no longer installed into the test environment. This is because it has started to cause issues on OS X systems recently, preventing developers to run `tox`.

It's a dependency of the keyboard component.
