### PR TITLE
Fixed voluptuous to accept string instead only  positive_int for CODE for Simplisafe

### DIFF
--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -26,7 +26,7 @@ DEFAULT_NAME = 'SimpliSafe'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
-    vol.Optional(CONF_CODE): cv.positive_int,
+    vol.Optional(CONF_CODE): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 


### PR DESCRIPTION
**Description:**

Changed voluptuous to accept password with number and letters

``` bash
16-09-10 23:43:55 homeassistant.bootstrap: Invalid config for [alarm_control_panel.simplisafe]: expected int for dictionary value @ data['code']. Got 's3cr4t_p4ssw0rd'
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
