### PR TITLE
Slack notification optional username / icon

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -23,8 +23,8 @@ CONF_CHANNEL = 'default_channel'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_CHANNEL): cv.string,
-    vol.Optional(CONF_USERNAME, default=None): cv.string,
-    vol.Optional(CONF_ICON, default=None): cv.string,
+    vol.Optional(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_ICON): cv.string,
 })
 
 
@@ -37,8 +37,8 @@ def get_service(hass, config):
         return SlackNotificationService(
             config[CONF_CHANNEL],
             config[CONF_API_KEY],
-            config[CONF_USERNAME],
-            config[CONF_ICON])
+            config.get(CONF_USERNAME, None),
+            config.get(CONF_ICON, None))
 
     except slacker.Error:
         _LOGGER.exception("Slack authentication failed")

--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -56,6 +56,11 @@ class SlackNotificationService(BaseNotificationService):
         self._api_token = api_token
         self._username = username
         self._icon = icon
+        if self._username or self._icon:
+            self._as_user = False
+        else:
+            self._as_user = True
+
         self.slack = Slacker(self._api_token)
         self.slack.auth.test()
 
@@ -68,17 +73,11 @@ class SlackNotificationService(BaseNotificationService):
         attachments = data.get('attachments') if data else None
 
         try:
-            if self._username or self._icon:
-                self.slack.chat.post_message(channel, message,
-                                             as_user=False,
-                                             username=self._username,
-                                             icon_emoji=self._icon,
-                                             attachments=attachments,
-                                             link_names=True)
-            else:
-                self.slack.chat.post_message(channel, message,
-                                             as_user=True,
-                                             attachments=attachments,
-                                             link_names=True)
+            self.slack.chat.post_message(channel, message,
+                                         as_user=self._as_user,
+                                         username=self._username,
+                                         icon_emoji=self._icon,
+                                         attachments=attachments,
+                                         link_names=True)
         except slacker.Error as err:
             _LOGGER.error("Could not send slack notification. Error: %s", err)

--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -10,7 +10,8 @@ import voluptuous as vol
 
 from homeassistant.components.notify import (
     PLATFORM_SCHEMA, BaseNotificationService)
-from homeassistant.const import CONF_API_KEY
+from homeassistant.const import (
+    CONF_API_KEY, CONF_USERNAME, CONF_ICON)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['slacker==0.9.25']
@@ -22,6 +23,8 @@ CONF_CHANNEL = 'default_channel'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_CHANNEL): cv.string,
+    vol.Optional(CONF_USERNAME, default=None): cv.string,
+    vol.Optional(CONF_ICON, default=None): cv.string,
 })
 
 
@@ -33,7 +36,9 @@ def get_service(hass, config):
     try:
         return SlackNotificationService(
             config[CONF_CHANNEL],
-            config[CONF_API_KEY])
+            config[CONF_API_KEY],
+            config[CONF_USERNAME],
+            config[CONF_ICON])
 
     except slacker.Error:
         _LOGGER.exception("Slack authentication failed")
@@ -44,11 +49,13 @@ def get_service(hass, config):
 class SlackNotificationService(BaseNotificationService):
     """Implement the notification service for Slack."""
 
-    def __init__(self, default_channel, api_token):
+    def __init__(self, default_channel, api_token, username, icon):
         """Initialize the service."""
         from slacker import Slacker
         self._default_channel = default_channel
         self._api_token = api_token
+        self._username = username
+        self._icon = icon
         self.slack = Slacker(self._api_token)
         self.slack.auth.test()
 
@@ -61,9 +68,17 @@ class SlackNotificationService(BaseNotificationService):
         attachments = data.get('attachments') if data else None
 
         try:
-            self.slack.chat.post_message(channel, message,
-                                         as_user=True,
-                                         attachments=attachments,
-                                         link_names=True)
+            if self._username or self._icon:
+                self.slack.chat.post_message(channel, message,
+                                             as_user=False,
+                                             username=self._username,
+                                             icon_emoji=self._icon,
+                                             attachments=attachments,
+                                             link_names=True)
+            else:
+                self.slack.chat.post_message(channel, message,
+                                             as_user=True,
+                                             attachments=attachments,
+                                             link_names=True)
         except slacker.Error as err:
             _LOGGER.error("Could not send slack notification. Error: %s", err)


### PR DESCRIPTION
**Description:**
Slack allows an optional username and icon to be passed when you're sending messages.  This allows us to set that in the config in case posting as the created user isn't the wanted solution.  The current default stays and this just overwrites it if we set either the username or icon options.

Example:
![example](http://imgur.com/My3iHX0.jpg)

**Related issue (if applicable):** 
Possible fix for https://github.com/home-assistant/home-assistant/pull/3270

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/923

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
notify:
  - name: slack 
    platform: slack
    api_key: slackapikey
    default_channel: '#ha'
    icon: ':taco:' 
    username: Home-Assistant
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
