### PR TITLE
Minor naming fix for the Xbox component

### DIFF
--- a/homeassistant/components/sensor/xbox_live.py
+++ b/homeassistant/components/sensor/xbox_live.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_API_KEY, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
+from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,7 +76,7 @@ class XboxSensor(Entity):
     @property
     def entity_id(self):
         """Return the entity ID."""
-        return 'sensor.xbox_' + self._gamertag
+        return 'sensor.xbox_' + slugify(self._gamertag)
 
     @property
     def state(self):


### PR DESCRIPTION
**Description:**
This is a minor naming fix for the Xbox component to prevent special characters in Xbox gamertags from casuing errors in Home Assistant - sorry for missing this on the component submission.

**Related issue (if applicable):** none

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** none

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
