### PR TITLE
Bugfix group order

### DIFF
--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -46,12 +46,12 @@ def _conf_preprocess(value):
 
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: {cv.match_all: vol.Schema(vol.All(_conf_preprocess, {
+    DOMAIN: cv.ordered_dict(vol.Schema(vol.All(_conf_preprocess, {
         vol.Optional(CONF_ENTITIES): vol.Any(cv.entity_ids, None),
         CONF_VIEW: cv.boolean,
         CONF_NAME: cv.string,
         CONF_ICON: cv.icon,
-    }))}
+    })), cv.match_all)
 }, extra=vol.ALLOW_EXTRA)
 
 # List of ON/OFF state tuples for groupable states

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -46,12 +46,12 @@ def _conf_preprocess(value):
 
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: cv.ordered_dict(vol.Schema(vol.All(_conf_preprocess, {
+    DOMAIN: cv.ordered_dict(vol.All(_conf_preprocess, {
         vol.Optional(CONF_ENTITIES): vol.Any(cv.entity_ids, None),
         CONF_VIEW: cv.boolean,
         CONF_NAME: cv.string,
         CONF_ICON: cv.icon,
-    })), cv.match_all)
+    }, cv.match_all))
 }, extra=vol.ALLOW_EXTRA)
 
 # List of ON/OFF state tuples for groupable states

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -297,30 +297,19 @@ def ordered_dict(value_validator, key_validator=match_all):
     value_validator will be applied to each value of the dictionary.
     key_validator (optional) will be applied to each key of the dictionary.
     """
+
+    item_validator = vol.Schema({key_validator: value_validator})
+
     def validator(value):
         """Validate ordered dict."""
         config = OrderedDict()
         errors = []
         for key, val in value.items():
             try:
-                v_key = key_validator(key)
-            except ValueError:
-                errors.append(vol.ValueInvalid('is not a valid key', [key]))
-                continue
+                v_res = item_validator({key: val})
+                config.update(v_res)
             except vol.Invalid as ex:
                 errors.append(ex)
-                continue
-
-            try:
-                val = value_validator(val)
-            except ValueError:
-                errors.append(vol.ValueInvalid('is not a valid value', [key]))
-                continue
-            except vol.Invalid as ex:
-                errors.append(ex)
-                continue
-
-            config[v_key] = val
 
         if errors:
             raise vol.MultipleInvalid(errors)

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -292,7 +292,11 @@ def url(value: Any) -> str:
 
 
 def ordered_dict(value_validator, key_validator=match_all):
-    """Generate an ordered dict validator that maintains ordering."""
+    """Validate an ordered dict validator that maintains ordering.
+
+    value_validator will be applied to each value of the dictionary.
+    key_validator (optional) will be applied to each key of the dictionary.
+    """
     def validator(value):
         """Validate ordered dict."""
         config = OrderedDict()

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -297,7 +297,6 @@ def ordered_dict(value_validator, key_validator=match_all):
     value_validator will be applied to each value of the dictionary.
     key_validator (optional) will be applied to each key of the dictionary.
     """
-
     item_validator = vol.Schema({key_validator: value_validator})
 
     def validator(value):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -302,6 +302,7 @@ def ordered_dict(value_validator, key_validator=match_all):
                 v_key = key_validator(key)
             except ValueError:
                 errors.append(vol.ValueInvalid('is not a valid key', [key]))
+                continue
             except vol.Invalid as ex:
                 errors.append(ex)
                 continue
@@ -310,6 +311,7 @@ def ordered_dict(value_validator, key_validator=match_all):
                 val = value_validator(val)
             except ValueError:
                 errors.append(vol.ValueInvalid('is not a valid value', [key]))
+                continue
             except vol.Invalid as ex:
                 errors.append(ex)
                 continue

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -303,16 +303,10 @@ def ordered_dict(value_validator, key_validator=match_all):
     def validator(value):
         """Validate ordered dict."""
         config = OrderedDict()
-        errors = []
-        for key, val in value.items():
-            try:
-                v_res = item_validator({key: val})
-                config.update(v_res)
-            except vol.Invalid as ex:
-                errors.append(ex)
 
-        if errors:
-            raise vol.MultipleInvalid(errors)
+        for key, val in value.items():
+            v_res = item_validator({key: val})
+            config.update(v_res)
 
         return config
 

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -1,5 +1,6 @@
 """The tests for the Group components."""
 # pylint: disable=protected-access,too-many-public-methods
+from collections import OrderedDict
 import unittest
 from unittest.mock import patch
 
@@ -220,16 +221,16 @@ class TestComponentsGroup(unittest.TestCase):
         test_group = group.Group(
             self.hass, 'init_group', ['light.Bowl', 'light.Ceiling'], False)
 
-        _setup_component(self.hass, 'group', {'group': {
-                    'second_group': {
+        group_conf = OrderedDict()
+        group_conf['second_group'] = {
                         'entities': 'light.Bowl, ' + test_group.entity_id,
                         'icon': 'mdi:work',
                         'view': True,
-                    },
-                    'test_group': 'hello.world,sensor.happy',
-                    'empty_group': {'name': 'Empty Group', 'entities': None},
-                }
-            })
+                    }
+        group_conf['test_group'] = 'hello.world,sensor.happy'
+        group_conf['empty_group'] = {'name': 'Empty Group', 'entities': None}
+
+        _setup_component(self.hass, 'group', {'group': group_conf})
 
         group_state = self.hass.states.get(
             group.ENTITY_ID_FORMAT.format('second_group'))
@@ -241,6 +242,7 @@ class TestComponentsGroup(unittest.TestCase):
                          group_state.attributes.get(ATTR_ICON))
         self.assertTrue(group_state.attributes.get(group.ATTR_VIEW))
         self.assertTrue(group_state.attributes.get(ATTR_HIDDEN))
+        self.assertEqual(1, group_state.attributes.get(group.ATTR_ORDER))
 
         group_state = self.hass.states.get(
             group.ENTITY_ID_FORMAT.format('test_group'))
@@ -251,6 +253,7 @@ class TestComponentsGroup(unittest.TestCase):
         self.assertIsNone(group_state.attributes.get(ATTR_ICON))
         self.assertIsNone(group_state.attributes.get(group.ATTR_VIEW))
         self.assertIsNone(group_state.attributes.get(ATTR_HIDDEN))
+        self.assertEqual(2, group_state.attributes.get(group.ATTR_ORDER))
 
     def test_groups_get_unique_names(self):
         """Two groups with same name should both have a unique entity id."""

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -371,20 +371,49 @@ def test_has_at_least_one_key():
         schema(value)
 
 
-def test_ordered_dict():
+def test_ordered_dict_order():
     """Test ordered_dict validator."""
-    schema = vol.Schema(cv.ordered_dict(int))
+    schema = vol.Schema(cv.ordered_dict(int, cv.string))
 
     val = OrderedDict()
     val['first'] = 1
-    val['second'] = 'hello'
-
-    with pytest.raises(vol.Invalid):
-        print(schema(val))
-
     val['second'] = 2
 
     validated = schema(val)
 
     assert isinstance(validated, OrderedDict)
     assert ['first', 'second'] == list(validated.keys())
+
+
+def test_ordered_dict_key_validator():
+    """Test ordered_dict key validator."""
+    schema = vol.Schema(cv.ordered_dict(cv.match_all, cv.string))
+
+    with pytest.raises(vol.Invalid):
+        schema({None: 1})
+
+    schema({'hello': 'world'})
+
+    schema = vol.Schema(cv.ordered_dict(cv.match_all, int))
+
+    with pytest.raises(vol.Invalid):
+        schema({'hello': 1})
+
+    schema({1: 'works'})
+
+
+def test_ordered_dict_value_validator():
+    """Test ordered_dict validator."""
+    schema = vol.Schema(cv.ordered_dict(cv.string))
+
+    with pytest.raises(vol.Invalid):
+        schema({'hello': None})
+
+    schema({'hello': 'world'})
+
+    schema = vol.Schema(cv.ordered_dict(int))
+
+    with pytest.raises(vol.Invalid):
+        schema({'hello': 'world'})
+
+    schema({'hello': 5})

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -1,3 +1,5 @@
+"""Test config validators."""
+from collections import OrderedDict
 from datetime import timedelta
 import os
 import tempfile
@@ -367,3 +369,22 @@ def test_has_at_least_one_key():
 
     for value in ({'beer': None}, {'soda': None}):
         schema(value)
+
+
+def test_ordered_dict():
+    """Test ordered_dict validator."""
+    schema = vol.Schema(cv.ordered_dict(int))
+
+    val = OrderedDict()
+    val['first'] = 1
+    val['second'] = 'hello'
+
+    with pytest.raises(vol.Invalid):
+        print(schema(val))
+
+    val['second'] = 2
+
+    validated = schema(val)
+
+    assert isinstance(validated, OrderedDict)
+    assert ['first', 'second'] == list(validated.keys())


### PR DESCRIPTION
**Description:**
As part of my PR #3203 to add reloading config to groups I introduced a bug when cleaning up the voluptuous schema validation that broke the group ordering based on their order in the config.

The problem is that passing an ordered dict through a voluptuous dictionary validator will convert it to a normal dictionary. The group component depends on the order from the config to calculate the order of groups so this caused an issue.

This PR adds a new config validator to validate ordered dictionaries while maintaining the order.

I think that we should release this as part of 0.28.1

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
group:
  kitchen:
    name: Kitchen
    entities:
      - switch.kitchen_pin_3
  upstairs:
    name: Kids
    icon: mdi:account-multiple
    view: yes
    entities:
      - input_boolean.notify_home
      - camera.demo_camera
      - device_tracker.demo_paulus
      - group.garden
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
