### PR TITLE
Bugfix zwave climate: Revert only add 1 device

### DIFF
--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -70,8 +70,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     node = zwave.NETWORK.nodes[discovery_info[ATTR_NODE_ID]]
     value = node.values[discovery_info[ATTR_VALUE_ID]]
     value.set_change_verified(False)
-    if value.index != 1:  # Only add 1 device
-        return
     add_devices([ZWaveClimate(value, temp_unit)])
     _LOGGER.debug("discovery_info=%s and zwave.NETWORK=%s",
                   discovery_info, zwave.NETWORK)


### PR DESCRIPTION
**Description:**
It seems that no thermostat uses standard values for their setpoint indexes.
Therefore I revert the only add 1 device.
The user can pick any of the discovered device, and hide the others with customize.
There seems to be no way to only add 1 of the indexes.

**Related issue (if applicable):** fixes #
https://github.com/home-assistant/home-assistant/pull/3205/files/80a82ef7ce1245e8bf9e42c6f2e567e4f2d95f9d#r78295642
