### PR TITLE
Bugfix ecobee: inverted high and low temps and enforce int to temps

### DIFF
--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -113,22 +113,19 @@ class Thermostat(ClimateDevice):
         """Return the temperature we try to reach."""
         if (self.operation_mode == 'heat' or
                 self.operation_mode == 'auxHeatOnly'):
-            return self.target_temperature_high
-        elif self.operation_mode == 'cool':
             return self.target_temperature_low
-        else:
-            return (self.target_temperature_low +
-                    self.target_temperature_high) / 2
+        elif self.operation_mode == 'cool':
+            return self.target_temperature_high
 
     @property
     def target_temperature_low(self):
         """Return the lower bound temperature we try to reach."""
-        return int(self.thermostat['runtime']['desiredCool'] / 10)
+        return int(self.thermostat['runtime']['desiredHeat'] / 10)
 
     @property
     def target_temperature_high(self):
         """Return the upper bound temperature we try to reach."""
-        return int(self.thermostat['runtime']['desiredHeat'] / 10)
+        return int(self.thermostat['runtime']['desiredCool'] / 10)
 
     @property
     def desired_fan_mode(self):
@@ -227,8 +224,8 @@ class Thermostat(ClimateDevice):
             high_temp = temperature + 1
         if kwargs.get(ATTR_TARGET_TEMP_LOW) is not None and \
            kwargs.get(ATTR_TARGET_TEMP_HIGH) is not None:
-            low_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
-            high_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
+            high_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
+            low_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
 
         if self.hold_temp:
             self.data.ecobee.set_hold_temp(self.thermostat_index, low_temp,

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -220,12 +220,12 @@ class Thermostat(ClimateDevice):
         """Set new target temperature."""
         if kwargs.get(ATTR_TEMPERATURE) is not None:
             temperature = kwargs.get(ATTR_TEMPERATURE)
-            low_temp = temperature
-            high_temp = temperature
+            low_temp = int(temperature)
+            high_temp = int(temperature)
         if kwargs.get(ATTR_TARGET_TEMP_LOW) is not None and \
            kwargs.get(ATTR_TARGET_TEMP_HIGH) is not None:
-            high_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
-            low_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
+            high_temp = int(kwargs.get(ATTR_TARGET_TEMP_LOW))
+            low_temp = int(kwargs.get(ATTR_TARGET_TEMP_HIGH))
 
         if self.hold_temp:
             self.data.ecobee.set_hold_temp(self.thermostat_index, low_temp,

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -230,13 +230,17 @@ class Thermostat(ClimateDevice):
         if self.hold_temp:
             self.data.ecobee.set_hold_temp(self.thermostat_index, low_temp,
                                            high_temp, "indefinite")
-            _LOGGER.debug("Setting ecobee temp to: low=%s, is=%s, high=%s, "
-                          "is=%s", low_temp, isinstance(
+            _LOGGER.debug("Setting ecobee hold_temp to: low=%s, is=%s, "
+                          "high=%s, is=%s", low_temp, isinstance(
                               low_temp, (int, float)), high_temp,
                           isinstance(high_temp, (int, float)))
         else:
             self.data.ecobee.set_hold_temp(self.thermostat_index, low_temp,
                                            high_temp)
+            _LOGGER.debug("Setting ecobee temp to: low=%s, is=%s, "
+                          "high=%s, is=%s", low_temp, isinstance(
+                              low_temp, (int, float)), high_temp,
+                          isinstance(high_temp, (int, float)))
 
     def set_operation_mode(self, operation_mode):
         """Set HVAC mode (auto, auxHeatOnly, cool, heat, off)."""

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -220,8 +220,8 @@ class Thermostat(ClimateDevice):
         """Set new target temperature."""
         if kwargs.get(ATTR_TEMPERATURE) is not None:
             temperature = kwargs.get(ATTR_TEMPERATURE)
-            low_temp = temperature - 1
-            high_temp = temperature + 1
+            low_temp = temperature
+            high_temp = temperature
         if kwargs.get(ATTR_TARGET_TEMP_LOW) is not None and \
            kwargs.get(ATTR_TARGET_TEMP_HIGH) is not None:
             high_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
@@ -230,6 +230,10 @@ class Thermostat(ClimateDevice):
         if self.hold_temp:
             self.data.ecobee.set_hold_temp(self.thermostat_index, low_temp,
                                            high_temp, "indefinite")
+            _LOGGER.debug("Setting ecobee temp to: low=%s, is=%s, high=%s, "
+                          "is=%s", low_temp, isinstance(
+                              low_temp, (int, float)), high_temp,
+                          isinstance(high_temp, (int, float)))
         else:
             self.data.ecobee.set_hold_temp(self.thermostat_index, low_temp,
                                            high_temp)

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -113,9 +113,9 @@ class Thermostat(ClimateDevice):
         """Return the temperature we try to reach."""
         if (self.operation_mode == 'heat' or
                 self.operation_mode == 'auxHeatOnly'):
-            return self.target_temperature_low
-        elif self.operation_mode == 'cool':
             return self.target_temperature_high
+        elif self.operation_mode == 'cool':
+            return self.target_temperature_low
         else:
             return (self.target_temperature_low +
                     self.target_temperature_high) / 2
@@ -123,12 +123,12 @@ class Thermostat(ClimateDevice):
     @property
     def target_temperature_low(self):
         """Return the lower bound temperature we try to reach."""
-        return int(self.thermostat['runtime']['desiredHeat'] / 10)
+        return int(self.thermostat['runtime']['desiredCool'] / 10)
 
     @property
     def target_temperature_high(self):
         """Return the upper bound temperature we try to reach."""
-        return int(self.thermostat['runtime']['desiredCool'] / 10)
+        return int(self.thermostat['runtime']['desiredHeat'] / 10)
 
     @property
     def desired_fan_mode(self):


### PR DESCRIPTION
**Description:**
It seems like the temperatures are inverted in ecobee.
Tested and found working with the help of @sgauche
**Related issue (if applicable):** fixes #
#3315
