### PR TITLE
Automatic Device Tracker Bug Fix

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -338,7 +338,7 @@ class Device(Entity):
             attr[ATTR_BATTERY] = self.battery
 
         if self.attributes:
-            for key, value in self.attributes:
+            for key, value in self.attributes.items():
                 attr[key] = value
 
         return attr

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -142,6 +142,7 @@ class AutomaticDeviceScanner(object):
 
         for vehicle in self.last_results:
             dev_id = vehicle.get('id')
+            host_name = vehicle.get('display_name')
 
             attrs = {
                 'fuel_level': vehicle.get('fuel_level_percent')
@@ -149,6 +150,7 @@ class AutomaticDeviceScanner(object):
 
             kwargs = {
                 'dev_id': dev_id,
+                'host_name': host_name,
                 'mac': dev_id,
                 ATTR_ATTRIBUTES: attrs
             }


### PR DESCRIPTION
**Description:**
Not sure how, but worked during testing, release gave me an issue iterating over state_attributes. Fixed that and passed the display name as the host name for device tracker known devices.

**Related issue (if applicable):** fixes #3331

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
