### PR TITLE
Upgrade sqlalchemy to 1.0.15

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -26,7 +26,7 @@ import homeassistant.util.dt as dt_util
 
 DOMAIN = "recorder"
 
-REQUIREMENTS = ['sqlalchemy==1.0.14']
+REQUIREMENTS = ['sqlalchemy==1.0.15']
 
 DEFAULT_URL = "sqlite:///{hass_config_path}"
 DEFAULT_DB_FILE = "home-assistant_v2.db"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -445,7 +445,7 @@ speedtest-cli==0.3.4
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator
-sqlalchemy==1.0.14
+sqlalchemy==1.0.15
 
 # homeassistant.components.http
 static3==0.7.0


### PR DESCRIPTION
## 1.0.15
- Fixed bug in subquery eager loading where a subqueryload of an “of_type()” object linked to a second subqueryload of a plain mapped class, or a longer chain of several “of_type()” attributes, would fail to link the joins correctly.
- Fixed bug in Table where the internal method _reset_exported() would corrupt the state of the object. This method is intended for selectable objects and is called by the ORM in some cases; an erroneous mapper configuration would could lead the ORM to call this on on a Table object.
- Added support for parsing MySQL/Connector boolean and integer arguments within the URL query string: connection_timeout, connect_timeout, pool_size, get_warnings, raise_on_warnings, raw, consume_results, ssl_verify_cert, force_ipv6, pool_reset_session, compress, allow_local_infile, use_pure.
- Fixed bug in sqlalchemy.ext.baked where the unbaking of a subquery eager loader query would fail due to a variable scoping issue, when multiple subquery loaders were involved.

As this is a critical component, feedback is needed. Please feel free to check your OS off the list if it works or leave a comment. Thanks.
### Setup
- [x] Installation on Fedora/CentOS
- [ ] Installation on Debian/Ubuntu/Rasbian/Armbian
- [ ] Installation on OS X
- [ ] Installation on Windows
### Runtime
- [x] Runing on Fedora/CentOS
- [ ] Running on Debian/Ubuntu/Rasbian/Armbian
- [ ] Running on OS X
- [ ] Running on Windows
