### PR TITLE
Upgrade cherrypy to 8.1.0

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -25,7 +25,7 @@ import homeassistant.util.dt as dt_util
 import homeassistant.helpers.config_validation as cv
 
 DOMAIN = 'http'
-REQUIREMENTS = ('cherrypy==7.1.0', 'static3==0.7.0', 'Werkzeug==0.11.11')
+REQUIREMENTS = ('cherrypy==8.1.0', 'static3==0.7.0', 'Werkzeug==0.11.11')
 
 CONF_API_PASSWORD = 'api_password'
 CONF_SERVER_HOST = 'server_host'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -53,7 +53,7 @@ blockchain==1.3.3
 boto3==1.3.1
 
 # homeassistant.components.http
-cherrypy==7.1.0
+cherrypy==8.1.0
 
 # homeassistant.components.sensor.coinmarketcap
 coinmarketcap==2.0.1


### PR DESCRIPTION
## 8.1.0
- `HTTPError` now also works as a context manager.
- The sessions tool now accepts a `storage_class` parameter, which supersedes the new deprecated
  `storage_type` parameter. The `storage_class` should be the actual Session subclass to be used.
- Releases now use `setuptools_scm` to track the release versions. Therefore, releases can be cut by simply tagging a commit in the repo. Versions numbers are now stored in exactly one place.

As this is a critical component, feedback is needed. Please feel free to check your OS off the list if it works or leave a comment. Thanks.
### Setup
- [x] Installation on Fedora/CentOS
- [ ] Installation on Debian/Ubuntu/Rasbian/Armbian
- [ ] Installation on OS X
- [ ] Installation on Windows
### Runtime
- [x] Runing on Fedora/CentOS
- [ ] Running on Debian/Ubuntu/Rasbian/Armbian
- [ ] Running on OS X
- [ ] Running on Windows
