### PR TITLE
Upgrade PyMata to 2.13

### DIFF
--- a/homeassistant/components/arduino.py
+++ b/homeassistant/components/arduino.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
 from homeassistant.const import CONF_PORT
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['PyMata==2.12']
+REQUIREMENTS = ['PyMata==2.13']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -14,7 +14,7 @@ PyISY==1.0.7
 PyJWT==1.4.2
 
 # homeassistant.components.arduino
-PyMata==2.12
+PyMata==2.13
 
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.6.1


### PR DESCRIPTION
## 2.13

This release fixes some mismatches of constant values introduced with the latest FirmataPlus sketches. If you are not using FirmataPlus, you do not need to update to this version.

Tested with the following configuration:

``` yaml
arduino:
  port: /dev/ttyACM0

sensor:
  platform: arduino
  pins:
    1:
      name: Poti
      type: analog
```
