### PR TITLE
Simplepush notifications

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -196,6 +196,7 @@ omit =
     homeassistant/components/notify/pushover.py
     homeassistant/components/notify/rest.py
     homeassistant/components/notify/sendgrid.py
+    homeassistant/components/notify/simplepush.py
     homeassistant/components/notify/slack.py
     homeassistant/components/notify/smtp.py
     homeassistant/components/notify/syslog.py

--- a/homeassistant/components/notify/simplepush.py
+++ b/homeassistant/components/notify/simplepush.py
@@ -1,0 +1,55 @@
+"""
+Simplepush notification service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.simplepush/
+"""
+import logging
+
+import requests
+import voluptuous as vol
+
+from homeassistant.components.notify import (
+    ATTR_TITLE, ATTR_TITLE_DEFAULT, PLATFORM_SCHEMA, BaseNotificationService)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+_RESOURCE = 'https://api.simplepush.io/send'
+
+CONF_DEVICE_KEY = 'device_key'
+
+DEFAULT_TIMEOUT = 10
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_DEVICE_KEY): cv.string,
+})
+
+
+def get_service(hass, config):
+    """Get the Simplepush notification service."""
+    return SimplePushNotificationService(config.get(CONF_DEVICE_KEY))
+
+
+# pylint: disable=too-few-public-methods
+class SimplePushNotificationService(BaseNotificationService):
+    """Implementation of the notification service for SimplePush."""
+
+    def __init__(self, device_key):
+        """Initialize the service."""
+        self._device_key = device_key
+
+    def send_message(self, message='', **kwargs):
+        """Send a message to a user."""
+        title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
+
+        # Upstream bug will be fixed soon, but no dead-line available.
+        # payload = 'key={}&title={}&msg={}'.format(
+        #     self._device_key, title, message).replace(' ', '%')
+        # response = requests.get(
+        #     _RESOURCE, data=payload, timeout=DEFAULT_TIMEOUT)
+        response = requests.get(
+            '{}/{}/{}/{}'.format(_RESOURCE, self._device_key, title, message),
+            timeout=DEFAULT_TIMEOUT)
+
+        if response.json()['status'] != 'OK':
+            _LOGGER.error("Not possible to send notification")


### PR DESCRIPTION
**Description:**
[Simplepush](https://simplepush.io/) is a very simple notification service that is limited to sending  notifications to Android devices.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#926

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
notifiy:
 - name: simplepush
   platform: simplepush
   device_key: mxTTb
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
