### PR TITLE
Use voluptuous for KNX

### DIFF
--- a/homeassistant/components/binary_sensor/knx.py
+++ b/homeassistant/components/binary_sensor/knx.py
@@ -5,17 +5,14 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.knx/
 """
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.components.knx import (
-    KNXConfig, KNXGroupAddress)
+from homeassistant.components.knx import (KNXConfig, KNXGroupAddress)
 
-DEPENDENCIES = ["knx"]
+DEPENDENCIES = ['knx']
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the KNX binary sensor platform."""
-    add_entities([
-        KNXSwitch(hass, KNXConfig(config))
-    ])
+    add_devices([KNXSwitch(hass, KNXConfig(config))])
 
 
 class KNXSwitch(KNXGroupAddress, BinarySensorDevice):

--- a/homeassistant/components/switch/knx.py
+++ b/homeassistant/components/switch/knx.py
@@ -4,18 +4,29 @@ Support KNX switching actuators.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.knx/
 """
-from homeassistant.components.switch import SwitchDevice
-from homeassistant.components.knx import (
-    KNXConfig, KNXGroupAddress)
+import voluptuous as vol
 
-DEPENDENCIES = ["knx"]
+from homeassistant.components.knx import (KNXConfig, KNXGroupAddress)
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
+
+CONF_ADDRESS = 'address'
+CONF_STATE_ADDRESS = 'state_address'
+
+DEFAULT_NAME = 'KNX Switch'
+DEPENDENCIES = ['knx']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ADDRESS): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_STATE_ADDRESS): cv.string,
+})
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the KNX switch platform."""
-    add_entities([
-        KNXSwitch(hass, KNXConfig(config))
-    ])
+    add_devices([KNXSwitch(hass, KNXConfig(config))])
 
 
 class KNXSwitch(KNXGroupAddress, SwitchDevice):


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`. This is a breaking change as `http://` will no longer be needed for the `host:` configuration variable. Not sure if `itunes-api` supports SSL/TLS.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
knx:
  host: IP_ADDRESS
  port: PORT

switch:
  - platform: knx
    name: KNX Switch
    address: 0/0/1
    state_address: 0/0/3
```

@usul27 @open-homeautomation 
, would be nice if you could take a look at the changes and run a quick test. Thanks.
