### PR TITLE
Update yahooweather 0.8 / change request time

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -505,7 +505,7 @@ xboxapi==0.1.1
 xmltodict==0.10.2
 
 # homeassistant.components.sensor.yweather
-yahooweather==0.7
+yahooweather==0.8
 
 # homeassistant.components.zeroconf
 zeroconf==0.17.6


### PR DESCRIPTION
**Description:**
- Update yahooweather to 0.8 to reduce error in logs
- Add CONF_NAME support
- Rename min/max temperature value
- Change update time to 10 minute, so 2 minute are to small and give a lot of false request

**Bad change:**
- Min/Max temperature change name from `Temperature` to `Temperature min` and `Temperature max` for better understand.
- Default name change from `weather` -> `yweather`

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** This version is official in docu bot not supported at the moment from platform... This PR change that

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
