### PR TITLE
WIP: Load validated groups from config

### DIFF
--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -51,7 +51,7 @@ CONFIG_SCHEMA = vol.Schema({
         CONF_VIEW: cv.boolean,
         CONF_NAME: cv.string,
         CONF_ICON: cv.icon,
-    }, cv.match_all))
+    }), cv.match_all, DOMAIN)
 }, extra=vol.ALLOW_EXTRA)
 
 # List of ON/OFF state tuples for groupable states

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from datetime import timedelta
 import os
 import tempfile
+from unittest.mock import patch
 
 import pytest
 import voluptuous as vol
@@ -389,15 +390,17 @@ def test_ordered_dict_key_validator():
     """Test ordered_dict key validator."""
     schema = vol.Schema(cv.ordered_dict(cv.match_all, cv.string))
 
-    with pytest.raises(vol.Invalid):
+    with patch('homeassistant.bootstrap.log_exception') as loge:
         schema({None: 1})
+        assert loge.call_count == 1
 
     schema({'hello': 'world'})
 
     schema = vol.Schema(cv.ordered_dict(cv.match_all, int))
 
-    with pytest.raises(vol.Invalid):
+    with patch('homeassistant.bootstrap.log_exception') as loge:
         schema({'hello': 1})
+        assert loge.call_count == 1
 
     schema({1: 'works'})
 
@@ -406,14 +409,16 @@ def test_ordered_dict_value_validator():
     """Test ordered_dict validator."""
     schema = vol.Schema(cv.ordered_dict(cv.string))
 
-    with pytest.raises(vol.Invalid):
+    with patch('homeassistant.bootstrap.log_exception') as loge:
         schema({'hello': None})
+        assert loge.call_count == 1
 
     schema({'hello': 'world'})
 
     schema = vol.Schema(cv.ordered_dict(int))
 
-    with pytest.raises(vol.Invalid):
+    with patch('homeassistant.bootstrap.log_exception') as loge:
         schema({'hello': 'world'})
+        assert loge.call_count == 1
 
     schema({'hello': 5})


### PR DESCRIPTION
**Description:**
Following the [story](https://www.pivotaltracker.com/n/projects/1250084/stories/118811931) of loading platforms with valid config. This PR is the first step in that direction.

To be considered:
- Move `bootstrap.log_exception` to `helpers.log_exception` or `cv.log_exception` to prevent circular imports
- Same validator approach for platforms. Log the error inside the validator function and pass only correct config back. Probably need to add a test helper for log_exception patching, since it will impact many unit tests

Comments would be appreciated.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
group:
  i_will_fail:
    xname: Johann Travel Time
    entities:
      - sensor.google_travel_time
      - sensor.destination_johann

  i_will_load: 
    name: Home
    entities:
      - group.living_room
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
