### PR TITLE
Bugfix pilight component

### DIFF
--- a/homeassistant/components/pilight.py
+++ b/homeassistant/components/pilight.py
@@ -10,7 +10,6 @@ import socket
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import ensure_list
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, CONF_HOST, CONF_PORT,
     CONF_WHITELIST)
@@ -31,7 +30,7 @@ EVENT = 'pilight_received'
 # Thus only require to have the protocol information
 # Ensure that protocol is in a list otherwise segfault in pilight-daemon
 # https://github.com/pilight/pilight/issues/296
-RF_CODE_SCHEMA = vol.Schema({vol.Required(ATTR_PROTOCOL): vol.All(cv.string, cv.ensure_list)},
+RF_CODE_SCHEMA = vol.Schema({vol.Required(ATTR_PROTOCOL): vol.All(cv.ensure_list, [cv.string])},
                             extra=vol.ALLOW_EXTRA)
 SERVICE_NAME = 'send'
 

--- a/homeassistant/components/pilight.py
+++ b/homeassistant/components/pilight.py
@@ -30,7 +30,8 @@ EVENT = 'pilight_received'
 # Thus only require to have the protocol information
 # Ensure that protocol is in a list otherwise segfault in pilight-daemon
 # https://github.com/pilight/pilight/issues/296
-RF_CODE_SCHEMA = vol.Schema({vol.Required(ATTR_PROTOCOL): vol.All(cv.ensure_list, [cv.string])},
+RF_CODE_SCHEMA = vol.Schema({vol.Required(ATTR_PROTOCOL):
+                             vol.All(cv.ensure_list, [cv.string])},
                             extra=vol.ALLOW_EXTRA)
 SERVICE_NAME = 'send'
 
@@ -75,7 +76,7 @@ def setup(hass, config):
         # Change type to dict from mappingproxy
         # since data has to be JSON serializable
         message_data = dict(call.data)
-        
+
         try:
             pilight_client.send_code(message_data)
         except IOError:

--- a/homeassistant/components/pilight.py
+++ b/homeassistant/components/pilight.py
@@ -73,7 +73,7 @@ def setup(hass, config):
 
     def send_code(call):
         """Send RF code to the pilight-daemon."""
-        message_data = call.data
+        message_data = dict(call.data)
 
         try:
             pilight_client.send_code(message_data)

--- a/homeassistant/components/pilight.py
+++ b/homeassistant/components/pilight.py
@@ -73,8 +73,10 @@ def setup(hass, config):
 
     def send_code(call):
         """Send RF code to the pilight-daemon."""
+        # Change type to dict from mappingproxy
+        # since data has to be JSON serializable
         message_data = dict(call.data)
-
+        
         try:
             pilight_client.send_code(message_data)
         except IOError:

--- a/homeassistant/components/pilight.py
+++ b/homeassistant/components/pilight.py
@@ -29,7 +29,9 @@ EVENT = 'pilight_received'
 
 # The pilight code schema depends on the protocol
 # Thus only require to have the protocol information
-RF_CODE_SCHEMA = vol.Schema({vol.Required(ATTR_PROTOCOL): cv.string},
+# Ensure that protocol is in a list otherwise segfault in pilight-daemon
+# https://github.com/pilight/pilight/issues/296
+RF_CODE_SCHEMA = vol.Schema({vol.Required(ATTR_PROTOCOL): vol.All(cv.string, cv.ensure_list)},
                             extra=vol.ALLOW_EXTRA)
 SERVICE_NAME = 'send'
 
@@ -72,11 +74,6 @@ def setup(hass, config):
     def send_code(call):
         """Send RF code to the pilight-daemon."""
         message_data = call.data
-
-        # Patch data because of bug:
-        # https://github.com/pilight/pilight/issues/296
-        # Protocol has to be in a list otherwise segfault in pilight-daemon
-        message_data['protocol'] = ensure_list(message_data['protocol'])
 
         try:
             pilight_client.send_code(message_data)


### PR DESCRIPTION
**Description:**
The service data is a read-only [mapping proxy](http://stackoverflow.com/questions/32720492/why-is-a-class-dict-a-mappingproxy) now. This introduced a bug in the pilight component where
data had to be to be patched on the fly and has to be JSON serializable. 
Service data is not a dict anymore since HA release 0.28. Therefore this PR is needed as a bug fix.

**Related issue (if applicable):** fixes #3351

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
pilight:
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
