### PR TITLE
Automatic polling

### DIFF
--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -165,4 +165,4 @@ class AutomaticDeviceScanner(object):
             self.see(**kwargs)
 
         track_point_in_utc_time(self.hass, self._update_info,
-                                dt_util.now() + MIN_TIME_BETWEEN_SCANS);
+                                dt_util.now() + MIN_TIME_BETWEEN_SCANS)

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -61,6 +61,7 @@ def setup_scanner(hass, config: dict, see):
 
 
 # pylint: disable=too-many-instance-attributes
+# pylint: disable=too-few-public-methods
 class AutomaticDeviceScanner(object):
     """A class representing an Automatic device."""
 

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -86,7 +86,7 @@ class AutomaticDeviceScanner(object):
 
         self.scan_devices()
 
-        track_point_in_utc_time(self.hass, self._update_info(),
+        track_point_in_utc_time(self.hass, self._update_info,
                                 dt_util.now() + MIN_TIME_BETWEEN_SCANS);
 
     def scan_devices(self):

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -118,7 +118,7 @@ class AutomaticDeviceScanner(object):
             }
 
     @Throttle(MIN_TIME_BETWEEN_SCANS)
-    def _update_info(self, now) -> None:
+    def _update_info(self, now=None) -> None:
         """Update the device info."""
         _LOGGER.info('Updating devices %s', now)
         self._update_headers()

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -62,6 +62,7 @@ def setup_scanner(hass, config: dict, see):
     return True
 
 
+# pylint: disable=too-many-instance-attributes
 class AutomaticDeviceScanner(object):
     """A class representing an Automatic device."""
 

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -12,8 +12,7 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (PLATFORM_SCHEMA,
-                                                     ATTR_ATTRIBUTES,
-                                                     DEFAULT_SCAN_INTERVAL)
+                                                     ATTR_ATTRIBUTES)
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_point_in_utc_time

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -55,7 +55,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_scanner(hass, config: dict, see):
     """Validate the configuration and return an Automatic scanner."""
     try:
-        AutomaticDeviceScanner(config, see)
+        AutomaticDeviceScanner(hass, config, see)
     except requests.HTTPError as err:
         _LOGGER.error(str(err))
         return False
@@ -66,8 +66,9 @@ def setup_scanner(hass, config: dict, see):
 class AutomaticDeviceScanner(object):
     """A class representing an Automatic device."""
 
-    def __init__(self, config: dict, see) -> None:
+    def __init__(self, hass, config: dict, see) -> None:
         """Initialize the automatic device scanner."""
+        self.hass = hass
         self._devices = config.get(CONF_DEVICES, None)
         self._access_token_payload = {
             'username': config.get(CONF_USERNAME),

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -86,12 +86,12 @@ class AutomaticDeviceScanner(object):
 
         self.scan_devices()
 
+        track_point_in_utc_time(self.hass, self._update_info(),
+                                dt_util.now + MIN_TIME_BETWEEN_SCANS);
+
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()
-
-        track_point_in_utc_time(self.hass, self.scan_devices(),
-                                dt_util.now + MIN_TIME_BETWEEN_SCANS);
 
         return [item['id'] for item in self.last_results]
 

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -86,9 +86,6 @@ class AutomaticDeviceScanner(object):
 
         self.scan_devices()
 
-        track_point_in_utc_time(self.hass, self._update_info,
-                                dt_util.now() + MIN_TIME_BETWEEN_SCANS);
-
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()
@@ -121,9 +118,9 @@ class AutomaticDeviceScanner(object):
             }
 
     @Throttle(MIN_TIME_BETWEEN_SCANS)
-    def _update_info(self) -> None:
+    def _update_info(self, now) -> None:
         """Update the device info."""
-        _LOGGER.info('Updating devices')
+        _LOGGER.info('Updating devices %s', now)
         self._update_headers()
 
         response = requests.get(URL_VEHICLES, headers=self._headers)
@@ -167,3 +164,6 @@ class AutomaticDeviceScanner(object):
                 kwargs['gps_accuracy'] = end_location['accuracy_m']
 
             self.see(**kwargs)
+
+        track_point_in_utc_time(self.hass, self._update_info,
+                                dt_util.now() + MIN_TIME_BETWEEN_SCANS);

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -108,7 +108,7 @@ class AutomaticDeviceScanner(object):
 
     def _update_info(self, now=None) -> None:
         """Update the device info."""
-        _LOGGER.info('Updating devices %s', now)
+        _LOGGER.debug('Updating devices %s', now)
         self._update_headers()
 
         response = requests.get(URL_VEHICLES, headers=self._headers)

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -117,7 +117,6 @@ class AutomaticDeviceScanner(object):
                 'Authorization': 'Bearer {}'.format(access_token)
             }
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self, now=None) -> None:
         """Update the device info."""
         _LOGGER.info('Updating devices %s', now)

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -87,7 +87,7 @@ class AutomaticDeviceScanner(object):
         self.scan_devices()
 
         track_point_in_utc_time(self.hass, self._update_info(),
-                                dt_util.now + MIN_TIME_BETWEEN_SCANS);
+                                dt_util.now() + MIN_TIME_BETWEEN_SCANS);
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -15,6 +15,7 @@ from homeassistant.components.device_tracker import (PLATFORM_SCHEMA,
                                                      ATTR_ATTRIBUTES)
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import track_utc_time_change
 from homeassistant.util import Throttle, datetime as dt_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,10 +54,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_scanner(hass, config: dict, see):
     """Validate the configuration and return an Automatic scanner."""
     try:
-        AutomaticDeviceScanner(config, see)
+        scanner = AutomaticDeviceScanner(config, see)
     except requests.HTTPError as err:
         _LOGGER.error(str(err))
         return False
+
+    track_utc_time_change(hass, scanner.scan_devices(),
+                          second=MIN_TIME_BETWEEN_SCANS)
 
     return True
 

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -12,7 +12,8 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (PLATFORM_SCHEMA,
-                                                     ATTR_ATTRIBUTES)
+                                                     ATTR_ATTRIBUTES,
+                                                     DEFAULT_SCAN_INTERVAL)
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_utc_time_change
@@ -60,7 +61,7 @@ def setup_scanner(hass, config: dict, see):
         return False
 
     track_utc_time_change(hass, scanner.scan_devices(),
-                          second=MIN_TIME_BETWEEN_SCANS)
+                          second=range(0, 6, DEFAULT_SCAN_INTERVAL))
 
     return True
 

--- a/tests/components/device_tracker/test_automatic.py
+++ b/tests/components/device_tracker/test_automatic.py
@@ -239,19 +239,3 @@ class TestAutomatic(unittest.TestCase):
         }
 
         self.assertTrue(setup_scanner(self.hass, config, self.see_mock))
-
-    @patch('requests.get', side_effect=mocked_requests)
-    @patch('requests.post', side_effect=mocked_requests)
-    def test_device_attributes(self, mock_get, mock_post):
-        """Test device attributes are set on load."""
-        config = {
-            'platform': 'automatic',
-            'username': VALID_USERNAME,
-            'password': PASSWORD,
-            'client_id': CLIENT_ID,
-            'secret': CLIENT_SECRET
-        }
-
-        scanner = AutomaticDeviceScanner(self.hass, config, self.see_mock)
-
-        self.assertEqual(DISPLAY_NAME, scanner.get_device_name('vid'))

--- a/tests/components/device_tracker/test_automatic.py
+++ b/tests/components/device_tracker/test_automatic.py
@@ -6,8 +6,7 @@ import unittest
 from unittest.mock import patch
 
 from homeassistant.components.device_tracker.automatic import (
-    URL_AUTHORIZE, URL_VEHICLES, URL_TRIPS, setup_scanner,
-    AutomaticDeviceScanner)
+    URL_AUTHORIZE, URL_VEHICLES, URL_TRIPS, setup_scanner)
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/device_tracker/test_automatic.py
+++ b/tests/components/device_tracker/test_automatic.py
@@ -9,6 +9,8 @@ from homeassistant.components.device_tracker.automatic import (
     URL_AUTHORIZE, URL_VEHICLES, URL_TRIPS, setup_scanner,
     AutomaticDeviceScanner)
 
+from tests.common import get_test_home_assistant
+
 _LOGGER = logging.getLogger(__name__)
 
 INVALID_USERNAME = 'bob'
@@ -205,6 +207,7 @@ class TestAutomatic(unittest.TestCase):
 
     def setUp(self):
         """Set up test data."""
+        self.hass = get_test_home_assistant()
 
     def tearDown(self):
         """Tear down test data."""
@@ -221,7 +224,7 @@ class TestAutomatic(unittest.TestCase):
             'secret': CLIENT_SECRET
         }
 
-        self.assertFalse(setup_scanner(None, config, self.see_mock))
+        self.assertFalse(setup_scanner(self.hass, config, self.see_mock))
 
     @patch('requests.get', side_effect=mocked_requests)
     @patch('requests.post', side_effect=mocked_requests)
@@ -235,7 +238,7 @@ class TestAutomatic(unittest.TestCase):
             'secret': CLIENT_SECRET
         }
 
-        self.assertTrue(setup_scanner(None, config, self.see_mock))
+        self.assertTrue(setup_scanner(self.hass, config, self.see_mock))
 
     @patch('requests.get', side_effect=mocked_requests)
     @patch('requests.post', side_effect=mocked_requests)
@@ -249,6 +252,6 @@ class TestAutomatic(unittest.TestCase):
             'secret': CLIENT_SECRET
         }
 
-        scanner = AutomaticDeviceScanner(config, self.see_mock)
+        scanner = AutomaticDeviceScanner(self.hass, config, self.see_mock)
 
         self.assertEqual(DISPLAY_NAME, scanner.get_device_name('vid'))


### PR DESCRIPTION
**Description:**
Bug reported to me that Automatic is not polling correctly. Added track_point_in_time event listener to requery the automatic service every so often.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
