### PR TITLE
Ignore desktop.ini (Windows Explorer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ virtualization/vagrant/config
 
 # Built docs
 docs/build
+
+# Windows Explorer
+desktop.ini


### PR DESCRIPTION
**Description:**
Add 'desktop.ini' to .gitignore. When developing on Windows, Explorer drops these files in many (every?) folder.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
