### PR TITLE
Use voluptuous for RPi GPIO

### DIFF
--- a/homeassistant/components/binary_sensor/rpi_gpio.py
+++ b/homeassistant/components/binary_sensor/rpi_gpio.py
@@ -27,14 +27,9 @@ DEFAULT_PULL_MODE = 'UP'
 
 DEPENDENCIES = ['rpi_gpio']
 
-_SENSORS_SCHEMA = vol.All(
-    cv.ensure_list,
-    [
-        vol.Schema({
-            cv.positive_int: cv.string,
-        })
-    ]
-)
+_SENSORS_SCHEMA = vol.Schema({
+    cv.positive_int: cv.string,
+})
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PORTS): _SENSORS_SCHEMA,

--- a/homeassistant/components/binary_sensor/rpi_gpio.py
+++ b/homeassistant/components/binary_sensor/rpi_gpio.py
@@ -6,16 +6,42 @@ https://home-assistant.io/components/binary_sensor.rpi_gpio/
 """
 import logging
 
-import homeassistant.components.rpi_gpio as rpi_gpio
-from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.const import DEVICE_DEFAULT_NAME
+import voluptuous as vol
 
-DEFAULT_PULL_MODE = "UP"
+import homeassistant.components.rpi_gpio as rpi_gpio
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
+from homeassistant.const import DEVICE_DEFAULT_NAME
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_BOUNCETIME = 'bouncetime'
+CONF_INVERT_LOGIC = 'invert_logic'
+CONF_PORTS = 'ports'
+CONF_PULL_MODE = 'pull_mode'
+
 DEFAULT_BOUNCETIME = 50
 DEFAULT_INVERT_LOGIC = False
+DEFAULT_PULL_MODE = 'UP'
 
 DEPENDENCIES = ['rpi_gpio']
-_LOGGER = logging.getLogger(__name__)
+
+_SENSORS_SCHEMA = vol.All(
+    cv.ensure_list,
+    [
+        vol.Schema({
+            cv.positive_int: cv.string,
+        })
+    ]
+)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_PORTS): _SENSORS_SCHEMA,
+    vol.Optional(CONF_BOUNCETIME, default=DEFAULT_BOUNCETIME): cv.positive_int,
+    vol.Optional(CONF_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
+    vol.Optional(CONF_PULL_MODE, default=DEFAULT_PULL_MODE): cv.string,
+})
 
 
 # pylint: disable=unused-argument

--- a/homeassistant/components/cover/rpi_gpio.py
+++ b/homeassistant/components/cover/rpi_gpio.py
@@ -7,64 +7,69 @@ https://github.com/andrewshilliday/garage-door-controller
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.rpi_gpio/
 """
-
 import logging
 from time import sleep
+
 import voluptuous as vol
 
-from homeassistant.components.cover import CoverDevice
+from homeassistant.components.cover import CoverDevice, PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
 import homeassistant.components.rpi_gpio as rpi_gpio
 import homeassistant.helpers.config_validation as cv
 
-RELAY_TIME = 'relay_time'
-STATE_PULL_MODE = 'state_pull_mode'
-DEFAULT_PULL_MODE = 'UP'
-DEFAULT_RELAY_TIME = .2
-DEPENDENCIES = ['rpi_gpio']
-
 _LOGGER = logging.getLogger(__name__)
+
+CONF_COVERS = 'covers'
+CONF_RELAY_PIN = 'relay_pin'
+CONF_RELAY_TIME = 'relay_time'
+CONF_STATE_PIN = 'state_pin'
+CONF_STATE_PULL_MODE = 'state_pull_mode'
+
+DEFAULT_RELAY_TIME = .2
+DEFAULT_STATE_PULL_MODE = 'UP'
+DEPENDENCIES = ['rpi_gpio']
 
 _COVERS_SCHEMA = vol.All(
     cv.ensure_list,
     [
         vol.Schema({
-            'name': str,
-            'relay_pin': int,
-            'state_pin': int,
+            CONF_NAME: cv.string,
+            CONF_RELAY_PIN: cv.positive_int,
+            CONF_STATE_PIN: cv.positive_int,
         })
     ]
 )
-PLATFORM_SCHEMA = vol.Schema({
-    'platform': str,
-    vol.Required('covers'): _COVERS_SCHEMA,
-    vol.Optional(STATE_PULL_MODE, default=DEFAULT_PULL_MODE): cv.string,
-    vol.Optional(RELAY_TIME, default=DEFAULT_RELAY_TIME): vol.Coerce(int),
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_COVERS): _COVERS_SCHEMA,
+    vol.Optional(CONF_STATE_PULL_MODE, default=DEFAULT_STATE_PULL_MODE):
+        cv.string,
+    vol.Optional(CONF_RELAY_TIME, default=DEFAULT_RELAY_TIME): cv.positive_int,
 })
 
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the cover platform."""
-    relay_time = config.get(RELAY_TIME)
-    state_pull_mode = config.get(STATE_PULL_MODE)
+    """Setup the RPi cover platform."""
+    relay_time = config.get(CONF_RELAY_TIME)
+    state_pull_mode = config.get(CONF_STATE_PULL_MODE)
     covers = []
-    covers_conf = config.get('covers')
+    covers_conf = config.get(CONF_COVERS)
 
     for cover in covers_conf:
-        covers.append(RPiGPIOCover(cover['name'], cover['relay_pin'],
-                                   cover['state_pin'],
-                                   state_pull_mode,
-                                   relay_time))
+        covers.append(RPiGPIOCover(
+            cover[CONF_NAME], cover[CONF_RELAY_PIN], cover[CONF_STATE_PIN],
+            state_pull_mode, relay_time))
     add_devices(covers)
 
 
 # pylint: disable=abstract-method
 class RPiGPIOCover(CoverDevice):
-    """Representation of a Raspberry cover."""
+    """Representation of a Raspberry GPIO cover."""
 
     # pylint: disable=too-many-arguments
-    def __init__(self, name, relay_pin, state_pin,
-                 state_pull_mode, relay_time):
+    def __init__(self, name, relay_pin, state_pin, state_pull_mode,
+                 relay_time):
         """Initialize the cover."""
         self._name = name
         self._state = False
@@ -79,7 +84,7 @@ class RPiGPIOCover(CoverDevice):
     @property
     def unique_id(self):
         """Return the ID of this cover."""
-        return "{}.{}".format(self.__class__, self._name)
+        return '{}.{}'.format(self.__class__, self._name)
 
     @property
     def name(self):

--- a/homeassistant/components/rpi_gpio.py
+++ b/homeassistant/components/rpi_gpio.py
@@ -1,7 +1,7 @@
 """
 Support for controlling GPIO pins of a Raspberry Pi.
 
-For more details about this platform, please refer to the documentation at
+For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/rpi_gpio/
 """
 # pylint: disable=import-error
@@ -11,8 +11,10 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 
 REQUIREMENTS = ['RPi.GPIO==0.6.1']
-DOMAIN = "rpi_gpio"
+
 _LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'rpi_gpio'
 
 
 # pylint: disable=no-member

--- a/homeassistant/components/switch/rpi_gpio.py
+++ b/homeassistant/components/switch/rpi_gpio.py
@@ -24,14 +24,9 @@ CONF_INVERT_LOGIC = 'invert_logic'
 
 DEFAULT_INVERT_LOGIC = False
 
-_SWITCHES_SCHEMA = vol.All(
-    cv.ensure_list,
-    [
-        vol.Schema({
-            cv.positive_int: cv.string,
-        })
-    ]
-)
+_SWITCHES_SCHEMA = vol.Schema({
+    cv.positive_int: cv.string,
+})
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PORTS): _SWITCHES_SCHEMA,

--- a/homeassistant/components/switch/rpi_gpio.py
+++ b/homeassistant/components/switch/rpi_gpio.py
@@ -4,26 +4,48 @@ Allows to configure a switch using RPi GPIO.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.rpi_gpio/
 """
-
 import logging
 
+import voluptuous as vol
+
+from homeassistant.components.switch import PLATFORM_SCHEMA
 import homeassistant.components.rpi_gpio as rpi_gpio
 from homeassistant.const import DEVICE_DEFAULT_NAME
 from homeassistant.helpers.entity import ToggleEntity
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['rpi_gpio']
+
+CONF_PULL_MODE = 'pull_mode'
+CONF_PORTS = 'ports'
+CONF_INVERT_LOGIC = 'invert_logic'
 
 DEFAULT_INVERT_LOGIC = False
 
-DEPENDENCIES = ['rpi_gpio']
-_LOGGER = logging.getLogger(__name__)
+_SWITCHES_SCHEMA = vol.All(
+    cv.ensure_list,
+    [
+        vol.Schema({
+            cv.positive_int: cv.string,
+        })
+    ]
+)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_PORTS): _SWITCHES_SCHEMA,
+    vol.Optional(CONF_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
+})
 
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Raspberry PI GPIO devices."""
-    invert_logic = config.get('invert_logic', DEFAULT_INVERT_LOGIC)
+    invert_logic = config.get(CONF_INVERT_LOGIC)
 
     switches = []
-    ports = config.get('ports')
+    ports = config.get(CONF_PORTS)
     for port, name in ports.items():
         switches.append(RPiGPIOSwitch(name, port, invert_logic))
     add_devices(switches)


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
binary_sensor:
  platform: rpi_gpio
  ports:
    11: PIR Office
    12: PIR Bedroom
  pull_mode: "UP"
  bouncetime: 50
  invert_logic: false

switch:
  platform: rpi_gpio
  ports:
    11: Fan Office
    12: Light Desk
  invert_logic: false
```

It would be nice if somebody could take a look at the changes and run a quick test. Thanks.
