### PR TITLE
Fix temp conversion for nest setpoint

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -4,8 +4,8 @@ Support for Nest thermostats.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.nest/
 """
+import logging
 import voluptuous as vol
-
 import homeassistant.components.nest as nest
 from homeassistant.components.climate import (
     STATE_COOL, STATE_HEAT, STATE_IDLE, ClimateDevice, PLATFORM_SCHEMA)
@@ -14,6 +14,7 @@ from homeassistant.const import (
 from homeassistant.util.temperature import convert as convert_temperature
 
 DEPENDENCIES = ['nest']
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SCAN_INTERVAL):
@@ -138,7 +139,8 @@ class NestThermostat(ClimateDevice):
     def set_temperature(self, **kwargs):
         """Set new target temperature."""
         temperature = convert_temperature(kwargs.get(ATTR_TEMPERATURE),
-                                          TEMP_CELSIUS, self._unit)
+                                          self._unit, TEMP_CELSIUS)
+        _LOGGER.debug("Nest set_temperature-input-value=%s", temperature)
         if temperature is None:
             return
         if self.device.mode == 'range':
@@ -146,6 +148,7 @@ class NestThermostat(ClimateDevice):
                 temperature = (temperature, self.target_temperature_high)
             elif self.target_temperature == self.target_temperature_high:
                 temperature = (self.target_temperature_low, temperature)
+        _LOGGER.debug("Nest set_temperature-output-value=%s", temperature)
         self.device.target = temperature
 
     def set_operation_mode(self, operation_mode):


### PR DESCRIPTION
**Description:**
Bugfix for nest:
python-nest only communicates with celsuis temperatures.

**Related issue (if applicable):** fixes #
#3361
