### PR TITLE
Use voluptuous for logger

### DIFF
--- a/homeassistant/components/logger.py
+++ b/homeassistant/components/logger.py
@@ -27,14 +27,9 @@ LOGSEVERITY = {
 LOGGER_DEFAULT = 'default'
 LOGGER_LOGS = 'logs'
 
-_LOGS_SCHEMA = vol.All(
-    cv.ensure_list,
-    [
-        vol.Schema({
-            cv.string: vol.In(vol.Lower(list(LOGSEVERITY))),
-        })
-    ]
-)
+_LOGS_SCHEMA = vol.Schema({
+    cv.string: vol.In(vol.Lower(list(LOGSEVERITY))),
+})
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/logger.py
+++ b/homeassistant/components/logger.py
@@ -7,6 +7,10 @@ https://home-assistant.io/components/logger/
 import logging
 from collections import OrderedDict
 
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+
 DOMAIN = 'logger'
 
 LOGSEVERITY = {
@@ -22,6 +26,22 @@ LOGSEVERITY = {
 
 LOGGER_DEFAULT = 'default'
 LOGGER_LOGS = 'logs'
+
+_LOGS_SCHEMA = vol.All(
+    cv.ensure_list,
+    [
+        vol.Schema({
+            cv.string: vol.In(vol.Lower(list(LOGSEVERITY))),
+        })
+    ]
+)
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(LOGGER_DEFAULT): vol.In(vol.Lower(list(LOGSEVERITY))),
+        vol.Required(LOGGER_LOGS): _LOGS_SCHEMA,
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 class HomeAssistantLogFilter(logging.Filter):


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
logger:
  default: critical
  logs:
    homeassistant.components: info
    homeassistant.components.mqtt: debug
    homeassistant.components.biary_sensor: critical
```

It would be nice if somebody could take a look at the changes and run a quick test. Thanks.
