### PR TITLE
Bugfix: incorrectly inverted value when setting zwave cover position

### DIFF
--- a/homeassistant/components/cover/zwave.py
+++ b/homeassistant/components/cover/zwave.py
@@ -139,7 +139,7 @@ class ZwaveRollershutter(zwave.ZWaveDeviceEntity, CoverDevice):
 
     def set_cover_position(self, position, **kwargs):
         """Move the roller shutter to a specific position."""
-        self._node.set_dimmer(self._value.value_id, 100 - position)
+        self._node.set_dimmer(self._value.value_id, position)
 
     def stop_cover(self, **kwargs):
         """Stop the roller shutter."""


### PR DESCRIPTION
**Description:**
Setting position for the zwave cover component submits the position to the open-zwave library as 100-position. This is not consistent with the rest of the code where the position is used as is. Setting the cover position to 80 sends the cover to position 20 and the state is read back correctly as 20.

This PR fixes the problem by removing the inversion in set_cover_position.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
