### PR TITLE
Use voluptuous for Zone

### DIFF
--- a/homeassistant/components/zone.py
+++ b/homeassistant/components/zone.py
@@ -6,30 +6,47 @@ https://home-assistant.io/components/zone/
 """
 import logging
 
+import voluptuous as vol
+
 from homeassistant.const import (
-    ATTR_HIDDEN, ATTR_ICON, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_NAME)
+    ATTR_HIDDEN, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_NAME, CONF_LATITUDE,
+    CONF_LONGITUDE, CONF_ICON)
 from homeassistant.helpers import extract_domain_configs
 from homeassistant.helpers.entity import Entity, generate_entity_id
 from homeassistant.util.location import distance
-from homeassistant.util import convert
+import homeassistant.helpers.config_validation as cv
 
-DOMAIN = "zone"
-ENTITY_ID_FORMAT = 'zone.{}'
-ENTITY_ID_HOME = ENTITY_ID_FORMAT.format('home')
-STATE = 'zoning'
-
-DEFAULT_NAME = 'Unnamed zone'
-
-ATTR_RADIUS = 'radius'
-DEFAULT_RADIUS = 100
+_LOGGER = logging.getLogger(__name__)
 
 ATTR_PASSIVE = 'passive'
+ATTR_RADIUS = 'radius'
+
+CONF_PASSIVE = 'passive'
+CONF_RADIUS = 'radius'
+
+DEFAULT_NAME = 'Unnamed zone'
 DEFAULT_PASSIVE = False
+DEFAULT_RADIUS = 100
+DOMAIN = 'zone'
+
+ENTITY_ID_FORMAT = 'zone.{}'
+ENTITY_ID_HOME = ENTITY_ID_FORMAT.format('home')
 
 ICON_HOME = 'mdi:home'
 ICON_IMPORT = 'mdi:import'
 
-_LOGGER = logging.getLogger(__name__)
+STATE = 'zoning'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Required(CONF_LATITUDE): cv.latitude,
+        vol.Required(CONF_LONGITUDE): cv.longitude,
+        vol.Optional(CONF_RADIUS, default=DEFAULT_RADIUS): vol.Coerce(float),
+        vol.Optional(CONF_PASSIVE, default=DEFAULT_PASSIVE): cv.boolean,
+        vol.Optional(CONF_ICON): cv.icon,
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def active_zone(hass, latitude, longitude, radius=0):
@@ -80,20 +97,20 @@ def setup(hass, config):
             entries = entries,
 
         for entry in entries:
-            name = entry.get(CONF_NAME, DEFAULT_NAME)
-            latitude = convert(entry.get(ATTR_LATITUDE), float)
-            longitude = convert(entry.get(ATTR_LONGITUDE), float)
-            radius = convert(entry.get(ATTR_RADIUS, DEFAULT_RADIUS), float)
-            icon = entry.get(ATTR_ICON)
-            passive = entry.get(ATTR_PASSIVE, DEFAULT_PASSIVE)
+            name = entry.get(CONF_NAME)
+            latitude = entry.get(CONF_LATITUDE)
+            longitude = entry.get(CONF_LONGITUDE)
+            radius = entry.get(CONF_RADIUS)
+            icon = entry.get(CONF_ICON)
+            passive = entry.get(CONF_PASSIVE)
 
             if None in (latitude, longitude):
                 logging.getLogger(__name__).error(
                     'Each zone needs a latitude and longitude.')
                 continue
 
-            zone = Zone(hass, name, latitude, longitude, radius,
-                        icon, passive, False)
+            zone = Zone(
+                hass, name, latitude, longitude, radius, icon, passive, False)
             add_zone(hass, name, zone, entities)
             entities.add(zone.entity_id)
 
@@ -116,8 +133,7 @@ def add_zone(hass, name, zone, entities=None):
         _entities = set()
     else:
         _entities = entities
-    zone.entity_id = generate_entity_id(ENTITY_ID_FORMAT, name,
-                                        _entities)
+    zone.entity_id = generate_entity_id(ENTITY_ID_FORMAT, name, _entities)
     zone_exists = hass.states.get(zone.entity_id)
     if zone_exists is None:
         zone.update_ha_state()

--- a/homeassistant/components/zone.py
+++ b/homeassistant/components/zone.py
@@ -104,11 +104,6 @@ def setup(hass, config):
             icon = entry.get(CONF_ICON)
             passive = entry.get(CONF_PASSIVE)
 
-            if None in (latitude, longitude):
-                logging.getLogger(__name__).error(
-                    'Each zone needs a latitude and longitude.')
-                continue
-
             zone = Zone(
                 hass, name, latitude, longitude, radius, icon, passive, False)
             add_zone(hass, name, zone, entities)


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
zone:
  name: School
  latitude: 32.8773367
  longitude: -117.2494053
  radius: 250
  icon: mdi:school

zone 2:
  name: Work
  latitude: 32.8753367
  longitude: -117.2474053
```

It would be nice if somebody could take a look at the changes and run a quick test. Thanks.
