### PR TITLE
Fix JSON serialization error html5 push config

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -144,7 +144,7 @@ def _save_config(filename, config):
     """Save configuration."""
     try:
         with open(filename, 'w') as fdesc:
-            fdesc.write(json.dumps(config, indent=4, sort_keys=True))
+            fdesc.write(json.dumps(config))
     except (IOError, TypeError) as error:
         _LOGGER.error('Saving config file failed: %s', error)
         return False


### PR DESCRIPTION
@robbiet480 suggested this fix in [https://github.com/home-assistant/home-assistant/issues/3028#issuecomment-244472690](https://github.com/home-assistant/home-assistant/issues/3028#issuecomment-244472690), and it fixed the issue https://github.com/home-assistant/home-assistant/issues/3154 for me. 

This has the side-effect of making the conf file less readable, but IMO that's better than the alternative of failed registrations that people are reporting in https://github.com/home-assistant/home-assistant/issues/3154 and https://github.com/home-assistant/home-assistant/issues/3028
