### PR TITLE
Fix octoprint sensor

### DIFF
--- a/homeassistant/components/sensor/octoprint.py
+++ b/homeassistant/components/sensor/octoprint.py
@@ -84,7 +84,7 @@ class OctoPrintSensor(Entity):
             self._name = '{} {}'.format(sensor_name, condition)
         else:
             self._name = '{} {} {} {}'.format(
-                sensor_name, condition, tool, ' temp')
+                sensor_name, condition, tool, 'temp')
         self.sensor_type = sensor_type
         self.api = api
         self._state = None

--- a/homeassistant/components/sensor/octoprint.py
+++ b/homeassistant/components/sensor/octoprint.py
@@ -61,12 +61,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                     devices.append(new_sensor)
         else:
             new_sensor = OctoPrintSensor(octoprint.OCTOPRINT,
-                                        octo_type,
-                                        SENSOR_TYPES[octo_type][2],
-                                        name,
-                                        SENSOR_TYPES[octo_type][3],
-                                        SENSOR_TYPES[octo_type][0],
-                                        SENSOR_TYPES[octo_type][1])
+                                         octo_type,
+                                         SENSOR_TYPES[octo_type][2],
+                                         name,
+                                         SENSOR_TYPES[octo_type][3],
+                                         SENSOR_TYPES[octo_type][0],
+                                         SENSOR_TYPES[octo_type][1])
             devices.append(new_sensor)
     add_devices(devices)
 

--- a/homeassistant/components/sensor/octoprint.py
+++ b/homeassistant/components/sensor/octoprint.py
@@ -60,17 +60,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                                  tool)
                     devices.append(new_sensor)
         else:
-            _LOGGER.error("Unknown OctoPrint sensor type: %s", octo_type)
-
-        new_sensor = OctoPrintSensor(octoprint.OCTOPRINT,
-                                     octo_type,
-                                     SENSOR_TYPES[octo_type][2],
-                                     name,
-                                     SENSOR_TYPES[octo_type][3],
-                                     SENSOR_TYPES[octo_type][0],
-                                     SENSOR_TYPES[octo_type][1])
-        devices.append(new_sensor)
-
+            new_sensor = OctoPrintSensor(octoprint.OCTOPRINT,
+                                        octo_type,
+                                        SENSOR_TYPES[octo_type][2],
+                                        name,
+                                        SENSOR_TYPES[octo_type][3],
+                                        SENSOR_TYPES[octo_type][0],
+                                        SENSOR_TYPES[octo_type][1])
+            devices.append(new_sensor)
     add_devices(devices)
 
 


### PR DESCRIPTION
**Description:**
Octoprint sensor wasn't working for anything other than the `Temperatures` monitored conditions due to a typo in [migrating to voluptuous](https://github.com/home-assistant/home-assistant/commit/6a84b826633beeb807c5a8b8d300095c5241f0d5#diff-eaf89336510874e9afa5b768a5bbafc1R63). Temperature sensors also ended up with an extra space in their name.

**Checklist:**
None apply (no existing tests)
