### PR TITLE
fixed link constructor to show icon again

### DIFF
--- a/homeassistant/components/weblink.py
+++ b/homeassistant/components/weblink.py
@@ -38,7 +38,7 @@ def setup(hass, config):
 
     for link in links.get(CONF_ENTITIES):
         Link(hass, link.get(CONF_NAME), link.get(CONF_URL),
-             link.get(CONF_URL))
+             link.get(CONF_ICON))
 
     return True
 


### PR DESCRIPTION
**Description:**
Weblink did not show icons for the links due to a typo in the entity creation - the URL of the weblink was also used for the icon. 
