### PR TITLE
Adds Dockerfile for aarch64

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,28 @@
+FROM aarch64/python:3.4
+
+VOLUME /config
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+RUN pip3 install --no-cache-dir colorlog cython
+
+# For the nmap tracker, bluetooth tracker, Z-Wave
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends nmap net-tools cython3 libudev-dev sudo libglib2.0-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY script/build_python_openzwave script/build_python_openzwave
+RUN script/build_python_openzwave && \
+  mkdir -p /usr/local/share/python-openzwave && \
+  ln -sf /usr/src/app/build/python-openzwave/openzwave/config /usr/local/share/python-openzwave/config
+
+COPY requirements_all.txt requirements_all.txt
+# certifi breaks Debian based installs
+RUN pip3 install --no-cache-dir -r requirements_all.txt && pip3 uninstall -y certifi && \
+    pip3 install mysqlclient psycopg2
+
+# Copy source
+COPY . .
+
+CMD [ "python", "-m", "homeassistant", "--config", "/config" ]


### PR DESCRIPTION
Adds a `Dockerfile.aarch64`[1] file to use for building a Docker image for the `aarch64` (or arm64) cpu.  The `Dockerfile.aarch64` only change is using the official `python:3.4` to `aarch64/python3.4`. 

I am using this to run Home Assistant in Docker on my Pine64.

[1] [Docker uses this naming scheme within their own repository](https://github.com/docker/docker)
