### PR TITLE
Add operation_list to radiotherm

### DIFF
--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -73,8 +73,7 @@ class RadioThermostat(ClimateDevice):
         self._name = None
         self.hold_temp = hold_temp
         self.update()
-        self._operation_list = ['auto', 'cool', 'heat', 'off']
-
+        self._operation_list = [STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_OFF]
 
     @property
     def name(self):

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -73,6 +73,8 @@ class RadioThermostat(ClimateDevice):
         self._name = None
         self.hold_temp = hold_temp
         self.update()
+        self._operation_list = ['auto', 'cool', 'heat', 'off']
+
 
     @property
     def name(self):
@@ -101,6 +103,11 @@ class RadioThermostat(ClimateDevice):
     def current_operation(self):
         """Return the current operation. head, cool idle."""
         return self._current_operation
+
+    @property
+    def operation_list(self):
+        """Return the operation modes list."""
+        return self._operation_list
 
     @property
     def target_temperature(self):


### PR DESCRIPTION
**Description:**
Add operation_list to radiotherm platform so the mode selector UI populates options.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

climate:
  - platform: radiotherm
    host:
      - 10.0.1.204
    hold_temp: True

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
