### PR TITLE
Add support for Vera covers.

### DIFF
--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -1,0 +1,70 @@
+"""
+Support for Vera cover - curtains, rollershutters etc.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/cover.vera/
+"""
+import logging
+
+from homeassistant.components.cover import CoverDevice
+from homeassistant.components.vera import (
+    VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
+
+DEPENDENCIES = ['vera']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Find and return Vera covers."""
+    add_devices_callback(
+        VeraCover(device, VERA_CONTROLLER) for
+        device in VERA_DEVICES['cover'])
+
+
+# pylint: disable=abstract-method
+class VeraCover(VeraDevice, CoverDevice):
+    """Represents a Vera Cover in Home Assistant."""
+
+    def __init__(self, vera_device, controller):
+        """Initialize the Vera device."""
+        VeraDevice.__init__(self, vera_device, controller)
+
+    @property
+    def current_cover_position(self):
+        """
+        Return current position of cover.
+
+        0 is closed, 100 is fully open.
+        """
+        position = self.vera_device.get_level()
+        if position <= 5:
+            return 0
+        if position >= 95:
+            return 100
+        return position
+
+    def set_cover_position(self, position, **kwargs):
+        """Move the cover to a specific position."""
+        self.vera_device.set_level(position)
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        if self.current_cover_position is not None:
+            if self.current_cover_position > 0:
+                return False
+            else:
+                return True
+
+    def open_cover(self, **kwargs):
+        """Open the cover."""
+        self.vera_device.open()
+
+    def close_cover(self, **kwargs):
+        """Close the cover."""
+        self.vera_device.close()
+
+    def stop_cover(self, **kwargs):
+        """Stop the cover."""
+        self.vera_device.stop()

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyvera==0.2.16']
+REQUIREMENTS = ['pyvera==0.2.20']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 VERA_COMPONENTS = [
-    'binary_sensor', 'sensor', 'light', 'switch', 'lock', 'climate'
+    'binary_sensor', 'sensor', 'light', 'switch', 'lock', 'climate', 'cover'
 ]
 
 
@@ -109,12 +109,13 @@ def map_vera_device(vera_device, remap):
         return 'lock'
     if isinstance(vera_device, veraApi.VeraThermostat):
         return 'climate'
+    if isinstance(vera_device, veraApi.VeraCurtain):
+        return 'cover'
     if isinstance(vera_device, veraApi.VeraSwitch):
         if vera_device.device_id in remap:
             return 'light'
         else:
             return 'switch'
-    # VeraCurtain: NOT SUPPORTED YET
     return None
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -407,7 +407,7 @@ python-wink==0.7.14
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.2.16
+pyvera==0.2.20
 
 # homeassistant.components.wemo
 pywemo==0.4.6


### PR DESCRIPTION
**Description:**
This PR adds support for Vera covers (roller shutters / blinds / curtains).

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**
no changes to config

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
