### PR TITLE
Use setup_component in tests

### DIFF
--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -28,7 +28,7 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME, default=DEFAULT_ALARM_NAME): cv.string,
     vol.Optional(CONF_CODE): cv.string,
     vol.Optional(CONF_PENDING_TIME, default=DEFAULT_PENDING_TIME):
-        vol.All(vol.Coerce(int), vol.Range(min=1)),
+        vol.All(vol.Coerce(int), vol.Range(min=0)),
     vol.Optional(CONF_TRIGGER_TIME, default=DEFAULT_TRIGGER_TIME):
         vol.All(vol.Coerce(int), vol.Range(min=1)),
     vol.Optional(CONF_DISARM_AFTER_TRIGGER,

--- a/homeassistant/components/sensor/mfi.py
+++ b/homeassistant/components/sensor/mfi.py
@@ -20,7 +20,6 @@ REQUIREMENTS = ['mficlient==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_PORT = 6443
 DEFAULT_SSL = True
 DEFAULT_VERIFY_SSL = True
 
@@ -43,7 +42,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_PORT): cv.port,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
 })
@@ -57,7 +56,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     password = config.get(CONF_PASSWORD)
     use_tls = config.get(CONF_SSL)
     verify_tls = config.get(CONF_VERIFY_SSL)
-    default_port = use_tls and DEFAULT_PORT or 6080
+    default_port = use_tls and 6443 or 6080
     port = int(config.get(CONF_PORT, default_port))
 
     from mficlient.client import FailedToLogin, MFiClient

--- a/homeassistant/components/switch/mfi.py
+++ b/homeassistant/components/switch/mfi.py
@@ -19,7 +19,6 @@ REQUIREMENTS = ['mficlient==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_PORT = 6443
 DEFAULT_SSL = True
 DEFAULT_VERIFY_SSL = True
 
@@ -34,7 +33,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_PORT): cv.port,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
 })
@@ -48,7 +47,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     password = config.get(CONF_PASSWORD)
     use_tls = config.get(CONF_SSL)
     verify_tls = config.get(CONF_VERIFY_SSL)
-    default_port = use_tls and DEFAULT_PORT or 6080
+    default_port = use_tls and 6443 or 6080
     port = int(config.get(CONF_PORT, default_port))
 
     from mficlient.client import FailedToLogin, MFiClient

--- a/tests/common.py
+++ b/tests/common.py
@@ -42,6 +42,7 @@ def get_test_home_assistant(num_threads=None):
     if num_threads:
         ha.MIN_WORKER_THREAD = orig_num_threads
 
+    hass.config.location_name = 'test home'
     hass.config.config_dir = get_test_config_dir()
     hass.config.latitude = 32.87336
     hass.config.longitude = -117.22743

--- a/tests/components/alarm_control_panel/test_manual.py
+++ b/tests/components/alarm_control_panel/test_manual.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import unittest
 from unittest.mock import patch
 
+from homeassistant.bootstrap import setup_component
 from homeassistant.const import (
     STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED)
@@ -27,8 +28,9 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
     def test_arm_home_no_pending(self):
         """Test arm home method."""
-        self.assertTrue(alarm_control_panel.setup(self.hass, {
-            'alarm_control_panel': {
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
                 'platform': 'manual',
                 'name': 'test',
                 'code': CODE,
@@ -49,8 +51,9 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
     def test_arm_home_with_pending(self):
         """Test arm home method."""
-        self.assertTrue(alarm_control_panel.setup(self.hass, {
-            'alarm_control_panel': {
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
                 'platform': 'manual',
                 'name': 'test',
                 'code': CODE,
@@ -80,8 +83,9 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
     def test_arm_home_with_invalid_code(self):
         """Attempt to arm home without a valid code."""
-        self.assertTrue(alarm_control_panel.setup(self.hass, {
-            'alarm_control_panel': {
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
                 'platform': 'manual',
                 'name': 'test',
                 'code': CODE,
@@ -102,8 +106,9 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
     def test_arm_away_no_pending(self):
         """Test arm home method."""
-        self.assertTrue(alarm_control_panel.setup(self.hass, {
-            'alarm_control_panel': {
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
                 'platform': 'manual',
                 'name': 'test',
                 'code': CODE,
@@ -124,8 +129,9 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
     def test_arm_away_with_pending(self):
         """Test arm home method."""
-        self.assertTrue(alarm_control_panel.setup(self.hass, {
-            'alarm_control_panel': {
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
                 'platform': 'manual',
                 'name': 'test',
                 'code': CODE,
@@ -155,8 +161,9 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
     def test_arm_away_with_invalid_code(self):
         """Attempt to arm away without a valid code."""
-        self.assertTrue(alarm_control_panel.setup(self.hass, {
-            'alarm_control_panel': {
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
                 'platform': 'manual',
                 'name': 'test',
                 'code': CODE,
@@ -176,12 +183,13 @@ class TestAlarmControlPanelManual(unittest.TestCase):
                          self.hass.states.get(entity_id).state)
 
     def test_trigger_no_pending(self):
-        """Test arm home method."""
-        self.assertTrue(alarm_control_panel.setup(self.hass, {
-            'alarm_control_panel': {
+        """Test triggering when no pending submitted method."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
                 'platform': 'manual',
                 'name': 'test',
-                'trigger_time': 0,
+                'trigger_time': 1,
                 'disarm_after_trigger': False
             }}))
 
@@ -193,13 +201,23 @@ class TestAlarmControlPanelManual(unittest.TestCase):
         alarm_control_panel.alarm_trigger(self.hass, entity_id=entity_id)
         self.hass.block_till_done()
 
+        self.assertEqual(STATE_ALARM_PENDING,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=60)
+        with patch(('homeassistant.components.alarm_control_panel.manual.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
         self.assertEqual(STATE_ALARM_TRIGGERED,
                          self.hass.states.get(entity_id).state)
 
     def test_trigger_with_pending(self):
         """Test arm home method."""
-        self.assertTrue(alarm_control_panel.setup(self.hass, {
-            'alarm_control_panel': {
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
                 'platform': 'manual',
                 'name': 'test',
                 'pending_time': 2,
@@ -238,8 +256,9 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
     def test_trigger_with_disarm_after_trigger(self):
         """Test disarm after trigger."""
-        self.assertTrue(alarm_control_panel.setup(self.hass, {
-            'alarm_control_panel': {
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
                 'platform': 'manual',
                 'name': 'test',
                 'trigger_time': 5,
@@ -269,8 +288,9 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
     def test_disarm_while_pending_trigger(self):
         """Test disarming while pending state."""
-        self.assertTrue(alarm_control_panel.setup(self.hass, {
-            'alarm_control_panel': {
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
                 'platform': 'manual',
                 'name': 'test',
                 'trigger_time': 5,
@@ -305,8 +325,9 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
     def test_disarm_during_trigger_with_invalid_code(self):
         """Test disarming while code is invalid."""
-        self.assertTrue(alarm_control_panel.setup(self.hass, {
-            'alarm_control_panel': {
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
                 'platform': 'manual',
                 'name': 'test',
                 'pending_time': 5,

--- a/tests/components/automation/test_zone.py
+++ b/tests/components/automation/test_zone.py
@@ -1,7 +1,7 @@
 """The tests for the location automation."""
 import unittest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import automation, zone
 
 from tests.common import get_test_home_assistant
@@ -14,7 +14,7 @@ class TestAutomationZone(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.components.append('group')
-        zone.setup(self.hass, {
+        assert setup_component(self.hass, zone.DOMAIN, {
             'zone': {
                 'name': 'test',
                 'latitude': 32.880837,
@@ -42,7 +42,7 @@ class TestAutomationZone(unittest.TestCase):
         })
         self.hass.block_till_done()
 
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'zone',
@@ -100,7 +100,7 @@ class TestAutomationZone(unittest.TestCase):
         })
         self.hass.block_till_done()
 
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'zone',
@@ -130,7 +130,7 @@ class TestAutomationZone(unittest.TestCase):
         })
         self.hass.block_till_done()
 
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'zone',
@@ -160,7 +160,7 @@ class TestAutomationZone(unittest.TestCase):
         })
         self.hass.block_till_done()
 
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'zone',
@@ -190,7 +190,7 @@ class TestAutomationZone(unittest.TestCase):
         })
         self.hass.block_till_done()
 
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',

--- a/tests/components/climate/test_demo.py
+++ b/tests/components/climate/test_demo.py
@@ -4,6 +4,7 @@ import unittest
 from homeassistant.util.unit_system import (
     METRIC_SYSTEM,
 )
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import climate
 
 from tests.common import get_test_home_assistant
@@ -20,9 +21,10 @@ class TestDemoClimate(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.units = METRIC_SYSTEM
-        self.assertTrue(climate.setup(self.hass, {'climate': {
-            'platform': 'demo',
-        }}))
+        self.assertTrue(setup_component(self.hass, climate.DOMAIN, {
+            'climate': {
+                'platform': 'demo',
+            }}))
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop down everything that was started."""

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -4,7 +4,7 @@ import unittest
 from unittest import mock
 
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     SERVICE_TURN_OFF,
@@ -44,12 +44,12 @@ class TestSetupClimateGenericThermostat(unittest.TestCase):
             'name': 'test',
             'target_sensor': ENT_SENSOR
         }
-        self.assertFalse(_setup_component(self.hass, 'climate', {
+        self.assertFalse(setup_component(self.hass, 'climate', {
             'climate': config}))
 
     def test_valid_conf(self):
         """Test set up genreic_thermostat with valid config values."""
-        self.assertTrue(_setup_component(self.hass, 'climate',
+        self.assertTrue(setup_component(self.hass, 'climate',
                         {'climate': {
                             'platform': 'generic_thermostat',
                             'name': 'test',
@@ -61,7 +61,7 @@ class TestSetupClimateGenericThermostat(unittest.TestCase):
         self.hass.states.set(ENT_SENSOR, 22.0, {
             ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS
         })
-        climate.setup(self.hass, {'climate': {
+        assert setup_component(self.hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test',
             'heater': ENT_SWITCH,
@@ -80,7 +80,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.units = METRIC_SYSTEM
-        climate.setup(self.hass, {'climate': {
+        assert setup_component(self.hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test',
             'heater': ENT_SWITCH,
@@ -104,7 +104,8 @@ class TestClimateGenericThermostat(unittest.TestCase):
 
     def test_custom_setup_params(self):
         """Test the setup with custom parameters."""
-        climate.setup(self.hass, {'climate': {
+        self.hass.config.components.remove(climate.DOMAIN)
+        assert setup_component(self.hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test',
             'heater': ENT_SWITCH,
@@ -229,7 +230,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.temperature_unit = TEMP_CELSIUS
-        climate.setup(self.hass, {'climate': {
+        assert setup_component(self.hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test',
             'heater': ENT_SWITCH,
@@ -319,7 +320,7 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.temperature_unit = TEMP_CELSIUS
-        climate.setup(self.hass, {'climate': {
+        assert setup_component(self.hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test',
             'heater': ENT_SWITCH,
@@ -410,7 +411,7 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.temperature_unit = TEMP_CELSIUS
-        climate.setup(self.hass, {'climate': {
+        assert setup_component(self.hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test',
             'heater': ENT_SWITCH,

--- a/tests/components/cover/test_command_line.py
+++ b/tests/components/cover/test_command_line.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 from unittest import mock
 
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.cover as cover
 from homeassistant.components.cover import (
     command_line as cmd_rs)
@@ -52,7 +53,7 @@ class TestCommandCover(unittest.TestCase):
                 'command_stop': 'echo 0 > {}'.format(path),
                 'value_template': '{{ value }}'
             }
-            self.assertTrue(cover.setup(self.hass, {
+            self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
                 'cover': {
                     'platform': 'command_line',
                     'covers': {

--- a/tests/components/cover/test_demo.py
+++ b/tests/components/cover/test_demo.py
@@ -3,6 +3,7 @@ import unittest
 from datetime import timedelta
 import homeassistant.util.dt as dt_util
 
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import cover
 from tests.common import get_test_home_assistant, fire_time_changed
 
@@ -15,7 +16,7 @@ class TestCoverDemo(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.assertTrue(cover.setup(self.hass, {'cover': {
+        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {'cover': {
             'platform': 'demo',
         }}))
 

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from datetime import datetime, timedelta
 import os
 
+from homeassistant.bootstrap import setup_component
 from homeassistant.loader import get_component
 import homeassistant.util.dt as dt_util
 from homeassistant.const import (
@@ -76,7 +77,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
             'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
             away_hide=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
-        self.assertTrue(device_tracker.setup(self.hass, TEST_PLATFORM))
+        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
+                                        TEST_PLATFORM))
         config = device_tracker.load_config(self.yaml_devices, self.hass,
                                             device.consider_home)[0]
         self.assertEqual(device.dev_id, config.dev_id)
@@ -120,7 +122,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
     def test_setup_without_yaml_file(self):
         """Test with no YAML file."""
-        self.assertTrue(device_tracker.setup(self.hass, TEST_PLATFORM))
+        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
+                                        TEST_PLATFORM))
 
     def test_adding_unknown_device_to_config(self): \
             # pylint: disable=invalid-name
@@ -129,7 +132,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         scanner.reset()
         scanner.come_home('DEV1')
 
-        self.assertTrue(device_tracker.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN, {
             device_tracker.DOMAIN: {CONF_PLATFORM: 'test'}}))
         config = device_tracker.load_config(self.yaml_devices, self.hass,
                                             timedelta(seconds=0))
@@ -164,8 +167,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
         with patch.dict(device_tracker.DISCOVERY_PLATFORMS, {'test': 'test'}):
             with patch.object(scanner, 'scan_devices') as mock_scan:
-                self.assertTrue(device_tracker.setup(self.hass,
-                                                     TEST_PLATFORM))
+                self.assertTrue(setup_component(
+                    self.hass, device_tracker.DOMAIN, TEST_PLATFORM))
                 fire_service_discovered(self.hass, 'test', {})
                 self.assertTrue(mock_scan.called)
 
@@ -180,7 +183,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
         with patch('homeassistant.components.device_tracker.dt_util.utcnow',
                    return_value=register_time):
-            self.assertTrue(device_tracker.setup(self.hass, {
+            self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN, {
                 device_tracker.DOMAIN: {
                     CONF_PLATFORM: 'test',
                     device_tracker.CONF_CONSIDER_HOME: 59,
@@ -211,7 +214,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
             friendly_name, picture, away_hide=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
 
-        self.assertTrue(device_tracker.setup(self.hass, TEST_PLATFORM))
+        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
+                                        TEST_PLATFORM))
 
         attrs = self.hass.states.get(entity_id).attributes
 
@@ -230,7 +234,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         scanner = get_component('device_tracker.test').SCANNER
         scanner.reset()
 
-        self.assertTrue(device_tracker.setup(self.hass, TEST_PLATFORM))
+        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
+                                        TEST_PLATFORM))
 
         self.assertTrue(self.hass.states.get(entity_id)
                         .attributes.get(ATTR_HIDDEN))
@@ -247,7 +252,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         scanner = get_component('device_tracker.test').SCANNER
         scanner.reset()
 
-        self.assertTrue(device_tracker.setup(self.hass, TEST_PLATFORM))
+        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
+                                        TEST_PLATFORM))
 
         state = self.hass.states.get(device_tracker.ENTITY_ID_ALL_DEVICES)
         self.assertIsNotNone(state)
@@ -258,7 +264,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     @patch('homeassistant.components.device_tracker.DeviceTracker.see')
     def test_see_service(self, mock_see):
         """Test the see service with a unicode dev_id and NO MAC."""
-        self.assertTrue(device_tracker.setup(self.hass, TEST_PLATFORM))
+        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
+                                        TEST_PLATFORM))
         params = {
             'dev_id': 'some_device',
             'host_name': 'example.com',
@@ -281,7 +288,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     def test_not_write_duplicate_yaml_keys(self): \
             # pylint: disable=invalid-name
         """Test that the device tracker will not generate invalid YAML."""
-        self.assertTrue(device_tracker.setup(self.hass, TEST_PLATFORM))
+        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
+                                        TEST_PLATFORM))
 
         device_tracker.see(self.hass, 'mac_1', host_name='hello')
         device_tracker.see(self.hass, 'mac_2', host_name='hello')
@@ -294,7 +302,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
     def test_not_allow_invalid_dev_id(self):  # pylint: disable=invalid-name
         """Test that the device tracker will not allow invalid dev ids."""
-        self.assertTrue(device_tracker.setup(self.hass, TEST_PLATFORM))
+        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
+                                        TEST_PLATFORM))
 
         device_tracker.see(self.hass, dev_id='hello-world')
 
@@ -329,6 +338,6 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     @patch('homeassistant.components.device_tracker.log_exception')
     def test_config_failure(self, mock_ex):
         """Test that the device tracker see failures."""
-        device_tracker.setup(self.hass, {device_tracker.DOMAIN: {
-            device_tracker.CONF_CONSIDER_HOME: -1}})
-        assert mock_ex.call_count == 1
+        assert not setup_component(self.hass, device_tracker.DOMAIN,
+                                   {device_tracker.DOMAIN: {
+                                    device_tracker.CONF_CONSIDER_HOME: -1}})

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -5,6 +5,7 @@ import unittest
 
 from collections import defaultdict
 
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.const import (STATE_NOT_HOME, CONF_PLATFORM)
 import homeassistant.components.device_tracker.owntracks as owntracks
@@ -191,7 +192,7 @@ class TestDeviceTrackerOwnTracks(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         mock_mqtt_component(self.hass)
-        self.assertTrue(device_tracker.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN, {
             device_tracker.DOMAIN: {
                 CONF_PLATFORM: 'owntracks',
                 CONF_MAX_GPS_ACCURACY: 200,

--- a/tests/components/fan/test_demo.py
+++ b/tests/components/fan/test_demo.py
@@ -2,6 +2,7 @@
 
 import unittest
 
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import fan
 from homeassistant.components.fan.demo import FAN_ENTITY_ID
 from homeassistant.const import STATE_OFF, STATE_ON
@@ -19,7 +20,7 @@ class TestDemoFan(unittest.TestCase):
     def setUp(self):
         """Initialize unit test data."""
         self.hass = get_test_home_assistant()
-        self.assertTrue(fan.setup(self.hass, {'fan': {
+        self.assertTrue(setup_component(self.hass, fan.DOMAIN, {'fan': {
             'platform': 'demo',
         }}))
         self.hass.block_till_done()

--- a/tests/components/garage_door/test_demo.py
+++ b/tests/components/garage_door/test_demo.py
@@ -1,6 +1,7 @@
 """The tests for the Demo Garage door platform."""
 import unittest
 
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.garage_door as gd
 
 from tests.common import get_test_home_assistant
@@ -16,7 +17,7 @@ class TestGarageDoorDemo(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.assertTrue(gd.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, gd.DOMAIN, {
             'garage_door': {
                 'platform': 'demo'
             }

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -3,6 +3,7 @@
 import unittest
 import os
 
+from homeassistant.bootstrap import setup_component
 import homeassistant.loader as loader
 from homeassistant.const import (
     ATTR_ENTITY_ID, STATE_ON, STATE_OFF, CONF_PLATFORM,
@@ -112,7 +113,8 @@ class TestLight(unittest.TestCase):
 
         platform.init()
         self.assertTrue(
-            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+            setup_component(self.hass, light.DOMAIN,
+                            {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
 
         dev1, dev2, dev3 = platform.DEVICES
 
@@ -250,8 +252,8 @@ class TestLight(unittest.TestCase):
             user_file.write('id,x,y,brightness\n')
             user_file.write('I,WILL,NOT,WORK\n')
 
-        self.assertFalse(light.setup(
-            self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}
+        self.assertFalse(setup_component(
+            self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: 'test'}}
         ))
 
     def test_light_profiles(self):
@@ -265,8 +267,8 @@ class TestLight(unittest.TestCase):
             user_file.write('id,x,y,brightness\n')
             user_file.write('test,.4,.6,100\n')
 
-        self.assertTrue(light.setup(
-            self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}
+        self.assertTrue(setup_component(
+            self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: 'test'}}
         ))
 
         dev1, dev2, dev3 = platform.DEVICES

--- a/tests/components/lock/test_demo.py
+++ b/tests/components/lock/test_demo.py
@@ -1,6 +1,7 @@
 """The tests for the Demo lock platform."""
 import unittest
 
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import lock
 
 from tests.common import get_test_home_assistant
@@ -16,7 +17,7 @@ class TestLockDemo(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.assertTrue(lock.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, lock.DOMAIN, {
             'lock': {
                 'platform': 'demo'
             }

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -1,7 +1,8 @@
 """The tests for the Demo Media player platform."""
 import unittest
 from unittest.mock import patch
-from homeassistant import bootstrap
+
+from homeassistant.bootstrap import setup_component
 from homeassistant.const import HTTP_HEADER_HA_AUTH
 import homeassistant.components.media_player as mp
 import homeassistant.components.http as http
@@ -27,7 +28,7 @@ def setUpModule():   # pylint: disable=invalid-name
     global hass
 
     hass = get_test_home_assistant()
-    bootstrap.setup_component(hass, http.DOMAIN, {
+    setup_component(hass, http.DOMAIN, {
         http.DOMAIN: {
             http.CONF_SERVER_PORT: SERVER_PORT,
             http.CONF_API_PASSWORD: API_PASSWORD,
@@ -49,13 +50,19 @@ class TestDemoMediaPlayer(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
         self.hass = hass
+        try:
+            self.hass.config.components.remove(mp.DOMAIN)
+        except ValueError:
+            pass
 
     def test_source_select(self):
         """Test the input source service."""
 
         entity_id = 'media_player.lounge_room'
 
-        assert mp.setup(self.hass, {'media_player': {'platform': 'demo'}})
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
         state = self.hass.states.get(entity_id)
         assert 'dvd' == state.attributes.get('source')
 
@@ -71,7 +78,9 @@ class TestDemoMediaPlayer(unittest.TestCase):
 
     def test_clear_playlist(self):
         """Test clear playlist."""
-        assert mp.setup(self.hass, {'media_player': {'platform': 'demo'}})
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
         assert self.hass.states.is_state(entity_id, 'playing')
 
         mp.clear_playlist(self.hass, entity_id)
@@ -80,8 +89,11 @@ class TestDemoMediaPlayer(unittest.TestCase):
 
     def test_volume_services(self):
         """Test the volume service."""
-        assert mp.setup(self.hass, {'media_player': {'platform': 'demo'}})
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
         state = self.hass.states.get(entity_id)
+        print(state)
         assert 1.0 == state.attributes.get('volume_level')
 
         mp.set_volume_level(self.hass, None, entity_id)
@@ -118,7 +130,9 @@ class TestDemoMediaPlayer(unittest.TestCase):
 
     def test_turning_off_and_on(self):
         """Test turn_on and turn_off."""
-        assert mp.setup(self.hass, {'media_player': {'platform': 'demo'}})
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
         assert self.hass.states.is_state(entity_id, 'playing')
 
         mp.turn_off(self.hass, entity_id)
@@ -137,7 +151,9 @@ class TestDemoMediaPlayer(unittest.TestCase):
 
     def test_playing_pausing(self):
         """Test media_pause."""
-        assert mp.setup(self.hass, {'media_player': {'platform': 'demo'}})
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
         assert self.hass.states.is_state(entity_id, 'playing')
 
         mp.media_pause(self.hass, entity_id)
@@ -158,7 +174,9 @@ class TestDemoMediaPlayer(unittest.TestCase):
 
     def test_prev_next_track(self):
         """Test media_next_track and media_previous_track ."""
-        assert mp.setup(self.hass, {'media_player': {'platform': 'demo'}})
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
         state = self.hass.states.get(entity_id)
         assert 1 == state.attributes.get('media_track')
         assert 0 == (mp.SUPPORT_PREVIOUS_TRACK &
@@ -185,7 +203,9 @@ class TestDemoMediaPlayer(unittest.TestCase):
         assert 0 < (mp.SUPPORT_PREVIOUS_TRACK &
                     state.attributes.get('supported_media_commands'))
 
-        assert mp.setup(self.hass, {'media_player': {'platform': 'demo'}})
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
         ent_id = 'media_player.lounge_room'
         state = self.hass.states.get(ent_id)
         assert 1 == state.attributes.get('media_episode')
@@ -212,7 +232,9 @@ class TestDemoMediaPlayer(unittest.TestCase):
         fake_picture_data = 'test.test'
         m.get('https://graph.facebook.com/v2.5/107771475912710/'
               'picture?type=large', text=fake_picture_data)
-        assert mp.setup(self.hass, {'media_player': {'platform': 'demo'}})
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
         assert self.hass.states.is_state(entity_id, 'playing')
         state = self.hass.states.get(entity_id)
         req = requests.get(HTTP_BASE_URL +
@@ -223,7 +245,9 @@ class TestDemoMediaPlayer(unittest.TestCase):
            'media_seek')
     def test_play_media(self, mock_seek):
         """Test play_media ."""
-        assert mp.setup(self.hass, {'media_player': {'platform': 'demo'}})
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
         ent_id = 'media_player.living_room'
         state = self.hass.states.get(ent_id)
         assert 0 < (mp.SUPPORT_PLAY_MEDIA &

--- a/tests/components/notify/test_command_line.py
+++ b/tests/components/notify/test_command_line.py
@@ -4,8 +4,8 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.notify as notify
-from homeassistant import bootstrap
 from tests.common import get_test_home_assistant
 
 
@@ -22,7 +22,7 @@ class TestCommandLine(unittest.TestCase):
 
     def test_setup(self):
         """Test setup."""
-        assert bootstrap.setup_component(self.hass, 'notify', {
+        assert setup_component(self.hass, 'notify', {
             'notify': {
                 'name': 'test',
                 'platform': 'command_line',
@@ -31,7 +31,7 @@ class TestCommandLine(unittest.TestCase):
 
     def test_bad_config(self):
         """Test set up the platform with bad/missing configuration."""
-        self.assertFalse(notify.setup(self.hass, {
+        self.assertFalse(setup_component(self.hass, notify.DOMAIN, {
             'notify': {
                 'name': 'test',
                 'platform': 'bad_platform',
@@ -43,7 +43,7 @@ class TestCommandLine(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdirname:
             filename = os.path.join(tempdirname, 'message.txt')
             message = 'one, two, testing, testing'
-            self.assertTrue(notify.setup(self.hass, {
+            self.assertTrue(setup_component(self.hass, notify.DOMAIN, {
                 'notify': {
                     'name': 'test',
                     'platform': 'command_line',
@@ -63,7 +63,7 @@ class TestCommandLine(unittest.TestCase):
     @patch('homeassistant.components.notify.command_line._LOGGER.error')
     def test_error_for_none_zero_exit_code(self, mock_error):
         """Test if an error is logged for non zero exit codes."""
-        self.assertTrue(notify.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, notify.DOMAIN, {
             'notify': {
                 'name': 'test',
                 'platform': 'command_line',

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -2,6 +2,7 @@
 import tempfile
 import unittest
 
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.notify as notify
 from homeassistant.components.notify import demo
 from homeassistant.helpers import script
@@ -16,7 +17,7 @@ class TestNotifyDemo(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.assertTrue(notify.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, notify.DOMAIN, {
             'notify': {
                 'platform': 'demo'
             }

--- a/tests/components/notify/test_file.py
+++ b/tests/components/notify/test_file.py
@@ -4,6 +4,7 @@ import unittest
 import tempfile
 from unittest.mock import patch
 
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.notify as notify
 from homeassistant.components.notify import (
     ATTR_TITLE_DEFAULT)
@@ -41,7 +42,7 @@ class TestNotifyFile(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdirname:
             filename = os.path.join(tempdirname, 'notify.txt')
             message = 'one, two, testing, testing'
-            self.assertTrue(notify.setup(self.hass, {
+            self.assertTrue(setup_component(self.hass, notify.DOMAIN, {
                 'notify': {
                     'name': 'test',
                     'platform': 'file',

--- a/tests/components/notify/test_group.py
+++ b/tests/components/notify/test_group.py
@@ -1,6 +1,7 @@
 """The tests for the notify.group platform."""
 import unittest
 
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.notify as notify
 from homeassistant.components.notify import group
 
@@ -14,17 +15,14 @@ class TestNotifyGroup(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.events = []
-        self.assertTrue(notify.setup(self.hass, {
-            'notify': {
+        self.assertTrue(setup_component(self.hass, notify.DOMAIN, {
+            'notify': [{
                 'name': 'demo1',
                 'platform': 'demo'
-            }
-        }))
-        self.assertTrue(notify.setup(self.hass, {
-            'notify': {
+            }, {
                 'name': 'demo2',
                 'platform': 'demo'
-            }
+            }]
         }))
 
         self.service = group.get_service(self.hass, {'services': [

--- a/tests/components/sensor/test_mfi.py
+++ b/tests/components/sensor/test_mfi.py
@@ -4,6 +4,7 @@ import unittest.mock as mock
 
 import requests
 
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.sensor as sensor
 import homeassistant.components.sensor.mfi as mfi
 from homeassistant.const import TEMP_CELSIUS
@@ -69,7 +70,7 @@ class TestMfiSensorSetup(unittest.TestCase):
         """Test setup with minimum configuration."""
         config = dict(self.GOOD_CONFIG)
         del config[self.THING]['port']
-        assert self.COMPONENT.setup(self.hass, config)
+        assert setup_component(self.hass, self.COMPONENT.DOMAIN, config)
         mock_client.assert_called_once_with(
             'foo', 'user', 'pass', port=6443, use_tls=True, verify=True)
 
@@ -78,7 +79,7 @@ class TestMfiSensorSetup(unittest.TestCase):
         """Test setup with port."""
         config = dict(self.GOOD_CONFIG)
         config[self.THING]['port'] = 6123
-        assert self.COMPONENT.setup(self.hass, config)
+        assert setup_component(self.hass, self.COMPONENT.DOMAIN, config)
         mock_client.assert_called_once_with(
             'foo', 'user', 'pass', port=6123, use_tls=True, verify=True)
 
@@ -89,7 +90,7 @@ class TestMfiSensorSetup(unittest.TestCase):
         del config[self.THING]['port']
         config[self.THING]['ssl'] = False
         config[self.THING]['verify_ssl'] = False
-        assert self.COMPONENT.setup(self.hass, config)
+        assert setup_component(self.hass, self.COMPONENT.DOMAIN, config)
         mock_client.assert_called_once_with(
             'foo', 'user', 'pass', port=6080, use_tls=False, verify=False)
 

--- a/tests/components/sensor/test_moldindicator.py
+++ b/tests/components/sensor/test_moldindicator.py
@@ -1,6 +1,7 @@
 """The tests for the MoldIndicator sensor."""
 import unittest
 
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.sensor as sensor
 from homeassistant.components.sensor.mold_indicator import (ATTR_DEWPOINT,
                                                             ATTR_CRITICAL_TEMP)
@@ -22,7 +23,6 @@ class TestSensorMoldIndicator(unittest.TestCase):
                              {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
         self.hass.states.set('test.indoorhumidity', '50',
                              {ATTR_UNIT_OF_MEASUREMENT: '%'})
-        self.hass.block_till_done()
 
     def tearDown(self):
         """Stop down everything that was started."""
@@ -30,7 +30,7 @@ class TestSensorMoldIndicator(unittest.TestCase):
 
     def test_setup(self):
         """Test the mold indicator sensor setup."""
-        self.assertTrue(sensor.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, sensor.DOMAIN, {
             'sensor': {
                 'platform': 'mold_indicator',
                 'indoor_temp_sensor': 'test.indoortemp',
@@ -53,7 +53,7 @@ class TestSensorMoldIndicator(unittest.TestCase):
         self.hass.states.set('test.indoorhumidity', '0',
                              {ATTR_UNIT_OF_MEASUREMENT: '%'})
 
-        self.assertTrue(sensor.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, sensor.DOMAIN, {
             'sensor': {
                 'platform': 'mold_indicator',
                 'indoor_temp_sensor': 'test.indoortemp',
@@ -68,7 +68,7 @@ class TestSensorMoldIndicator(unittest.TestCase):
 
     def test_calculation(self):
         """Test the mold indicator internal calculations."""
-        self.assertTrue(sensor.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, sensor.DOMAIN, {
             'sensor': {
                 'platform': 'mold_indicator',
                 'indoor_temp_sensor': 'test.indoortemp',
@@ -100,7 +100,7 @@ class TestSensorMoldIndicator(unittest.TestCase):
 
     def test_sensor_changed(self):
         """Test the sensor_changed function."""
-        self.assertTrue(sensor.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, sensor.DOMAIN, {
             'sensor': {
                 'platform': 'mold_indicator',
                 'indoor_temp_sensor': 'test.indoortemp',

--- a/tests/components/sensor/test_mqtt_room.py
+++ b/tests/components/sensor/test_mqtt_room.py
@@ -4,6 +4,7 @@ import datetime
 import unittest
 from unittest.mock import patch
 
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.sensor as sensor
 from homeassistant.components.mqtt import (CONF_STATE_TOPIC, CONF_QOS,
                                            DEFAULT_QOS)
@@ -52,7 +53,7 @@ class TestMQTTRoomSensor(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         mock_mqtt_component(self.hass)
-        self.assertTrue(sensor.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, sensor.DOMAIN, {
             sensor.DOMAIN: {
                 CONF_PLATFORM: 'mqtt_room',
                 CONF_NAME: NAME,

--- a/tests/components/switch/test_command_line.py
+++ b/tests/components/switch/test_command_line.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import unittest
 
+from homeassistant.bootstrap import setup_component
 from homeassistant.const import STATE_ON, STATE_OFF
 import homeassistant.components.switch as switch
 import homeassistant.components.switch.command_line as command_line
@@ -30,7 +31,7 @@ class TestCommandSwitch(unittest.TestCase):
                 'command_on': 'echo 1 > {}'.format(path),
                 'command_off': 'echo 0 > {}'.format(path),
             }
-            self.assertTrue(switch.setup(self.hass, {
+            self.assertTrue(setup_component(self.hass, switch.DOMAIN, {
                 'switch': {
                     'platform': 'command_line',
                     'switches': {
@@ -64,7 +65,7 @@ class TestCommandSwitch(unittest.TestCase):
                 'command_off': 'echo 0 > {}'.format(path),
                 'value_template': '{{ value=="1" }}'
             }
-            self.assertTrue(switch.setup(self.hass, {
+            self.assertTrue(setup_component(self.hass, switch.DOMAIN, {
                 'switch': {
                     'platform': 'command_line',
                     'switches': {
@@ -100,7 +101,7 @@ class TestCommandSwitch(unittest.TestCase):
                 'command_off': 'echo \'{}\' > {}'.format(offcmd, path),
                 'value_template': '{{ value_json.status=="ok" }}'
             }
-            self.assertTrue(switch.setup(self.hass, {
+            self.assertTrue(setup_component(self.hass, switch.DOMAIN, {
                 'switch': {
                     'platform': 'command_line',
                     'switches': {
@@ -133,7 +134,7 @@ class TestCommandSwitch(unittest.TestCase):
                 'command_on': 'echo 1 > {}'.format(path),
                 'command_off': 'echo 0 > {}'.format(path),
             }
-            self.assertTrue(switch.setup(self.hass, {
+            self.assertTrue(setup_component(self.hass, switch.DOMAIN, {
                 'switch': {
                     'platform': 'command_line',
                     'switches': {

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -3,7 +3,7 @@ import unittest
 from datetime import timedelta
 from unittest.mock import patch
 
-from homeassistant.bootstrap import _setup_component, setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import switch, light
 from homeassistant.const import CONF_PLATFORM, STATE_ON, SERVICE_TURN_ON
 import homeassistant.loader as loader
@@ -25,7 +25,7 @@ class TestSwitchFlux(unittest.TestCase):
 
     def test_valid_config(self):
         """Test configuration."""
-        assert _setup_component(self.hass, 'switch', {
+        assert setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'flux',
                 'name': 'flux',
@@ -35,7 +35,7 @@ class TestSwitchFlux(unittest.TestCase):
 
     def test_valid_config_with_info(self):
         """Test configuration."""
-        assert _setup_component(self.hass, 'switch', {
+        assert setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'flux',
                 'name': 'flux',
@@ -50,7 +50,7 @@ class TestSwitchFlux(unittest.TestCase):
 
     def test_valid_config_no_name(self):
         """Test configuration."""
-        assert _setup_component(self.hass, 'switch', {
+        assert setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'flux',
                 'lights': ['light.desk', 'light.lamp']
@@ -59,7 +59,7 @@ class TestSwitchFlux(unittest.TestCase):
 
     def test_invalid_config_no_lights(self):
         """Test configuration."""
-        assert not _setup_component(self.hass, 'switch', {
+        assert not setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'flux',
                 'name': 'flux'
@@ -71,7 +71,8 @@ class TestSwitchFlux(unittest.TestCase):
         platform = loader.get_component('light.test')
         platform.init()
         self.assertTrue(
-            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+            setup_component(self.hass, light.DOMAIN,
+                            {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
 
         dev1 = platform.DEVICES[0]
 
@@ -110,7 +111,8 @@ class TestSwitchFlux(unittest.TestCase):
         platform = loader.get_component('light.test')
         platform.init()
         self.assertTrue(
-            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+            setup_component(self.hass, light.DOMAIN,
+                            {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
 
         dev1 = platform.DEVICES[0]
 
@@ -154,7 +156,8 @@ class TestSwitchFlux(unittest.TestCase):
         platform = loader.get_component('light.test')
         platform.init()
         self.assertTrue(
-            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+            setup_component(self.hass, light.DOMAIN,
+                            {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
 
         dev1 = platform.DEVICES[0]
 
@@ -198,7 +201,8 @@ class TestSwitchFlux(unittest.TestCase):
         platform = loader.get_component('light.test')
         platform.init()
         self.assertTrue(
-            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+            setup_component(self.hass, light.DOMAIN,
+                            {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
 
         dev1 = platform.DEVICES[0]
 
@@ -242,7 +246,8 @@ class TestSwitchFlux(unittest.TestCase):
         platform = loader.get_component('light.test')
         platform.init()
         self.assertTrue(
-            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+            setup_component(self.hass, light.DOMAIN,
+                            {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
 
         dev1 = platform.DEVICES[0]
 
@@ -286,7 +291,8 @@ class TestSwitchFlux(unittest.TestCase):
         platform = loader.get_component('light.test')
         platform.init()
         self.assertTrue(
-            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+            setup_component(self.hass, light.DOMAIN,
+                            {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
 
         dev1 = platform.DEVICES[0]
 
@@ -332,7 +338,8 @@ class TestSwitchFlux(unittest.TestCase):
         platform = loader.get_component('light.test')
         platform.init()
         self.assertTrue(
-            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+            setup_component(self.hass, light.DOMAIN,
+                            {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
 
         dev1 = platform.DEVICES[0]
 
@@ -378,7 +385,8 @@ class TestSwitchFlux(unittest.TestCase):
         platform = loader.get_component('light.test')
         platform.init()
         self.assertTrue(
-            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+            setup_component(self.hass, light.DOMAIN,
+                            {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
 
         dev1 = platform.DEVICES[0]
 
@@ -422,7 +430,8 @@ class TestSwitchFlux(unittest.TestCase):
         platform = loader.get_component('light.test')
         platform.init()
         self.assertTrue(
-            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+            setup_component(self.hass, light.DOMAIN,
+                            {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
 
         dev1, dev2, dev3 = platform.DEVICES
         light.turn_on(self.hass, entity_id=dev2.entity_id)
@@ -486,7 +495,8 @@ class TestSwitchFlux(unittest.TestCase):
         platform = loader.get_component('light.test')
         platform.init()
         self.assertTrue(
-            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+            setup_component(self.hass, light.DOMAIN,
+                            {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
 
         dev1 = platform.DEVICES[0]
 
@@ -528,7 +538,8 @@ class TestSwitchFlux(unittest.TestCase):
         platform = loader.get_component('light.test')
         platform.init()
         self.assertTrue(
-            light.setup(self.hass, {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
+            setup_component(self.hass, light.DOMAIN,
+                            {light.DOMAIN: {CONF_PLATFORM: 'test'}}))
 
         dev1 = platform.DEVICES[0]
 

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -2,6 +2,7 @@
 # pylint: disable=too-many-public-methods,protected-access
 import unittest
 
+from homeassistant.bootstrap import setup_component
 from homeassistant import loader
 from homeassistant.components import switch
 from homeassistant.const import STATE_ON, STATE_OFF, CONF_PLATFORM
@@ -17,10 +18,6 @@ class TestSwitch(unittest.TestCase):
         self.hass = get_test_home_assistant()
         platform = loader.get_component('switch.test')
         platform.init()
-        self.assertTrue(switch.setup(
-            self.hass, {switch.DOMAIN: {CONF_PLATFORM: 'test'}}
-        ))
-
         # Switch 1 is ON, switch 2 is OFF
         self.switch_1, self.switch_2, self.switch_3 = \
             platform.DEVICES
@@ -31,6 +28,9 @@ class TestSwitch(unittest.TestCase):
 
     def test_methods(self):
         """Test is_on, turn_on, turn_off methods."""
+        self.assertTrue(setup_component(
+            self.hass, switch.DOMAIN, {switch.DOMAIN: {CONF_PLATFORM: 'test'}}
+        ))
         self.assertTrue(switch.is_on(self.hass))
         self.assertEqual(
             STATE_ON,
@@ -83,8 +83,8 @@ class TestSwitch(unittest.TestCase):
         loader.set_component('switch.test2', test_platform)
         test_platform.init(False)
 
-        self.assertTrue(switch.setup(
-            self.hass, {
+        self.assertTrue(setup_component(
+            self.hass, switch.DOMAIN, {
                 switch.DOMAIN: {CONF_PLATFORM: 'test'},
                 '{} 2'.format(switch.DOMAIN): {CONF_PLATFORM: 'test2'},
             }

--- a/tests/components/test_scene.py
+++ b/tests/components/test_scene.py
@@ -1,6 +1,7 @@
 """The tests for the Scene component."""
 import unittest
 
+from homeassistant.bootstrap import setup_component
 from homeassistant import loader
 from homeassistant.components import light, scene
 
@@ -38,7 +39,7 @@ class TestScene(unittest.TestCase):
         test_light = loader.get_component('light.test')
         test_light.init()
 
-        self.assertTrue(light.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {'platform': 'test'}
         }))
 
@@ -52,7 +53,7 @@ class TestScene(unittest.TestCase):
             'state': 'on',
             'brightness': 100,
         }
-        self.assertTrue(scene.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, scene.DOMAIN, {
             'scene': [{
                 'name': 'test',
                 'entities': {
@@ -77,7 +78,7 @@ class TestScene(unittest.TestCase):
         test_light = loader.get_component('light.test')
         test_light.init()
 
-        self.assertTrue(light.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {'platform': 'test'}
         }))
 
@@ -87,7 +88,7 @@ class TestScene(unittest.TestCase):
 
         self.hass.block_till_done()
 
-        self.assertTrue(scene.setup(self.hass, {
+        self.assertTrue(setup_component(self.hass, scene.DOMAIN, {
             'scene': [{
                 'name': 'test',
                 'entities': {


### PR DESCRIPTION
**Description:**
We should migrate our tests to use `setup_component` instead of `platform.setup` or `component.setup` so that the validations are run. That way we can verify that the config we expect our users to use and what we accept in the platform match.

This idea was triggered after we got reports that zone config validation was broken while the tests were still passing.

This is a first pass on updating ~50% of the tests that need to be upgraded.

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
