### PR TITLE
Use uvloop for asyncio policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN script/build_python_openzwave && \
 COPY requirements_all.txt requirements_all.txt
 # certifi breaks Debian based installs
 RUN pip3 install --no-cache-dir -r requirements_all.txt && pip3 uninstall -y certifi && \
-    pip3 install mysqlclient psycopg2
+    pip3 install mysqlclient psycopg2 uvloop
 
 # Copy source
 COPY . .

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -40,6 +40,12 @@ import homeassistant.util.dt as dt_util
 import homeassistant.util.location as location
 from homeassistant.util.unit_system import UnitSystem, METRIC_SYSTEM  # NOQA
 
+try:
+    import uvloop
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+except ImportError:
+    pass
+
 DOMAIN = "homeassistant"
 
 # How often time_changed event should fire


### PR DESCRIPTION
uvloop is a drop-in replacement policy for asyncio, and provides huge performance benefits. This PR loads uvloop if it's present, and adds it for Docker users as we recently moved to the Dockerfile to 3.5.
