### PR TITLE
Add PyBluez to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends nmap net-tools cython3 libudev-dev sudo libglib2.0-dev bluetooth libbluetooth-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Install pybluez for bluetooth tracker
-RUN pip install pybluez
-
 COPY script/build_python_openzwave script/build_python_openzwave
 RUN script/build_python_openzwave && \
   mkdir -p /usr/local/share/python-openzwave && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,11 @@ RUN pip3 install --no-cache-dir colorlog cython
 
 # For the nmap tracker, bluetooth tracker, Z-Wave
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends nmap net-tools cython3 libudev-dev sudo libglib2.0-dev && \
+    apt-get install -y --no-install-recommends nmap net-tools cython3 libudev-dev sudo libglib2.0-dev bluetooth libbluetooth-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install pybluez for bluetooth tracker
+RUN pip install pybluez
 
 COPY script/build_python_openzwave script/build_python_openzwave
 RUN script/build_python_openzwave && \

--- a/virtualization/Docker/Dockerfile.test
+++ b/virtualization/Docker/Dockerfile.test
@@ -10,8 +10,11 @@ RUN pip3 install --no-cache-dir colorlog cython
 
 # For the nmap tracker, bluetooth tracker, Z-Wave
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends nmap net-tools cython3 libudev-dev sudo libglib2.0-dev locales-all && \
+    apt-get install -y --no-install-recommends nmap net-tools cython3 libudev-dev sudo libglib2.0-dev locales-all bluetooth libbluetooth-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install pybluez for bluetooth tracker
+RUN pip install pybluez
 
 RUN pip3 install --no-cache-dir tox
 

--- a/virtualization/Docker/Dockerfile.test
+++ b/virtualization/Docker/Dockerfile.test
@@ -13,9 +13,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends nmap net-tools cython3 libudev-dev sudo libglib2.0-dev locales-all bluetooth libbluetooth-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Install pybluez for bluetooth tracker
-RUN pip install pybluez
-
 RUN pip3 install --no-cache-dir tox
 
 # Copy over everything required to run tox


### PR DESCRIPTION
**Description:** Installs PyBluez in Docker images so users using Docker can use the Bluetooth device tracker.

**Related issue (if applicable):** #1830

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
device_tracker:
  - platform: bluetooth_tracker
    track_new_devices: true
    interval_seconds: 5
    consider_home: 180 
```

**Checklist:**

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Adds PyBluez to Dockerfile so people using Docker can run Bluetooth
devices.
