### PR TITLE
Fix issue #3419. Load nodes in config with leading zeros as string

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -6,6 +6,7 @@ import sys
 from collections import OrderedDict
 from typing import Union, List, Dict
 
+import re
 import yaml
 try:
     import keyring
@@ -221,3 +222,16 @@ yaml.SafeLoader.add_constructor('!include_dir_merge_list',
 yaml.SafeLoader.add_constructor('!include_dir_named', _include_dir_named_yaml)
 yaml.SafeLoader.add_constructor('!include_dir_merge_named',
                                 _include_dir_merge_named_yaml)
+
+
+for (idx, val) in enumerate(yaml.Loader.yaml_implicit_resolvers['0']):
+    (tag, regexp) = val
+    if tag == 'tag:yaml.org,2002:int':
+        _regexp_int = regexp
+        yaml.Loader.yaml_implicit_resolvers['0'][idx] =\
+            (tag, re.compile(r'^(?:0)$', re.X))
+        break
+yaml.add_implicit_resolver(
+    'tag:yaml.org,2002:string',
+    _regexp_int,
+    [0])

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -147,6 +147,26 @@ class TestYaml(unittest.TestCase):
                     "key3": "three"
                 }
 
+    def test_numeric_values(self):
+        """Test simple dict."""
+        conf = "key1: 0710000041030160 \nkey2: 10710000041030160"
+        conf += "\nkey3: 0.0710000041030160"
+        conf += "\nkey4: 04:05"
+        conf += "\nkey5: 0"
+        with io.StringIO(conf) as file:
+            doc = yaml.yaml.safe_load(file)
+        assert type(doc["key1"]) == str
+        assert type(doc["key2"]) == int
+        assert type(doc["key3"]) == float
+        assert type(doc["key4"]) == str
+        assert type(doc["key5"]) == int
+
+        assert doc["key1"] == "0710000041030160"
+        assert doc["key2"] == 10710000041030160
+        assert doc["key3"] == 0.0710000041030160
+        assert doc["key4"] == "04:05"
+        assert doc["key5"] == 0
+
 FILES = {}
 
 


### PR DESCRIPTION
**Description:**
Before the yaml loader parsed numbers starting with zero as octal.
Now all integers starting with zero will be loaded as strings.

It will no longer be required too have quotes around times. (04:12 will be loaded as a string, "04:12" )

I have tested it with my setup. Hope someone else can test it too, since it has potential of breaking something.

**Related issue (if applicable):** fixes #3419

**Checklist:**
If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
