### PR TITLE
D-link switch library bump and error handling for W110 devices (#3386)

### DIFF
--- a/homeassistant/components/switch/dlink.py
+++ b/homeassistant/components/switch/dlink.py
@@ -12,10 +12,10 @@ from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import TEMP_CELSIUS, STATE_UNKNOWN
 
 REQUIREMENTS = ['https://github.com/LinuxChristian/pyW215/archive/'
-                'v0.3.4.zip#pyW215==0.3.4']
+                'v0.3.5.zip#pyW215==0.3.5']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,11 +72,25 @@ class SmartPlugSwitch(SwitchDevice):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the device."""
-        ui_temp = self.units.temperature(int(self.smartplug.temperature),
-                                         TEMP_CELSIUS)
-        temperature = "{} {}".format(ui_temp, self.units.temperature_unit)
-        current_consumption = "{} W".format(self.smartplug.current_consumption)
-        total_consumption = "{} W".format(self.smartplug.total_consumption)
+        try:
+            ui_temp = self.units.temperature(int(self.smartplug.temperature),
+                                             TEMP_CELSIUS)
+            temperature = "%i %s" % \
+                          (ui_temp, self.units.temperature_unit)
+        except ValueError:
+            temperature = STATE_UNKNOWN
+
+        try:
+            current_consumption = "%.2f W" % \
+                                  float(self.smartplug.current_consumption)
+        except ValueError:
+            current_consumption = STATE_UNKNOWN
+
+        try:
+            total_consumption = "%.1f W" % \
+                                float(self.smartplug.total_consumption)
+        except ValueError:
+            total_consumption = STATE_UNKNOWN
 
         attrs = {
             ATTR_CURRENT_CONSUMPTION: current_consumption,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -134,7 +134,7 @@ hikvision==0.4
 https://github.com/Danielhiversen/flux_led/archive/0.6.zip#flux_led==0.6
 
 # homeassistant.components.switch.dlink
-https://github.com/LinuxChristian/pyW215/archive/v0.3.4.zip#pyW215==0.3.4
+https://github.com/LinuxChristian/pyW215/archive/v0.3.5.zip#pyW215==0.3.5
 
 # homeassistant.components.media_player.webostv
 # homeassistant.components.notify.webostv


### PR DESCRIPTION
**Description:** Adding device_state_attributes to the component created issues for D-Link W110 devices which does not support reading temperature and power consumption. The backend library v0.3.5 returns N/A if the switch does not support this options. To handle the possible error I have added an exception when type casting the temperature to int. Users with old devices will see N/A beside the variables which their device does not support.

The PR has been tested on my W215 and by @Shadex12 on this W110 switch.

**Related issue (if applicable):** fixes #3386 and https://github.com/LinuxChristian/pyW215/issues/6
