### PR TITLE
Filter entities from logbook

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -193,10 +193,6 @@ def humanify(events):
         for event in events_batch:
             if event.event_type == EVENT_STATE_CHANGED:
 
-                # Do not report on new entities
-                if 'old_state' not in event.data:
-                    continue
-
                 to_state = State.from_dict(event.data.get('new_state'))
 
                 # If last_changed != last_updated only attributes have changed
@@ -271,8 +267,8 @@ def _exclude_events(events, config):
     filtered_events = []
     for event in events:
         if event.event_type == EVENT_STATE_CHANGED:
-            # if no new state exists exclude it anyway
             to_state = State.from_dict(event.data.get('new_state'))
+            # Do not report on new entities
             if not to_state:
                 continue
 

--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -29,7 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_EXCLUDE = 'exclude'
 CONF_ENTITIES = 'entities'
-CONF_PLATFORMS = 'platforms'
+CONF_PLATFORMS = 'domains'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -265,28 +265,29 @@ def _exclude_events(events, config):
     excluded_domains = []
     exclude = config[DOMAIN].get(CONF_EXCLUDE)
     if exclude:
-        excluded_entities = exclude.get(CONF_ENTITIES, [])
-        excluded_domains = exclude.get(CONF_DOMAINS, [])
+        excluded_entities = exclude[CONF_ENTITIES]
+        excluded_domains = exclude[CONF_DOMAINS]
 
     filtered_events = []
     for event in events:
-        # if no new state exists exclude it anyway
-        to_state = State.from_dict(event.data.get('new_state'))
-        if not to_state:
-            continue
+        if event.event_type == EVENT_STATE_CHANGED:
+            # if no new state exists exclude it anyway
+            to_state = State.from_dict(event.data.get('new_state'))
+            if not to_state:
+                continue
 
-        # exclude entities which are customized hidden
-        hidden = to_state.attributes.get(ATTR_HIDDEN, False)
-        if hidden:
-            continue
+            # exclude entities which are customized hidden
+            hidden = to_state.attributes.get(ATTR_HIDDEN, False)
+            if hidden:
+                continue
 
-        domain = to_state.domain
-        # check if logbook entry is excluded for this domain
-        if domain in excluded_domains:
-            continue
-        # check if logbook entry is excluded for this entity
-        if to_state.entity_id in excluded_entities:
-            continue
+            domain = to_state.domain
+            # check if logbook entry is excluded for this domain
+            if domain in excluded_domains:
+                continue
+            # check if logbook entry is excluded for this entity
+            if to_state.entity_id in excluded_entities:
+                continue
         filtered_events.append(event)
     return filtered_events
 


### PR DESCRIPTION
**Description:**
Added the ability to exclude logbook entries for certain entities or domains.
- exclude logbook messages from hidden entities
- exclude logbook messages for entities or domains configured in the logbook platform

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#963

**Example entry for `configuration.yaml`:**

``` yaml
logbook:
  exclude:
    entities:
      - sensor.motion_basement_temperature_5
      - sensor.last_boot
      - sensor.date
    domains:
      - sun
      - weblink
```

**Checklist:**
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
