### PR TITLE
Update Docker to use Python 3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4
+FROM python:3.5
 MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
 
 VOLUME /config


### PR DESCRIPTION
This updates the Docker image to default to Python 3.5.
