### PR TITLE
Add toggle service to input_boolean

### DIFF
--- a/tests/components/test_input_boolean.py
+++ b/tests/components/test_input_boolean.py
@@ -63,6 +63,13 @@ class TestInputBoolean(unittest.TestCase):
         self.assertFalse(
             input_boolean.is_on(self.hass, entity_id))
 
+        input_boolean.toggle(self.hass, entity_id)
+
+        self.hass.block_till_done()
+
+        self.assertTrue(
+            input_boolean.is_on(self.hass, entity_id))
+
     def test_config_options(self):
         """Test configuration options."""
         count_start = len(self.hass.states.entity_ids())


### PR DESCRIPTION
**Description:**

Add `input_boolean.toogle` service to input_boolean. I use a lot of group stuff with `homeassistant.toggle` and input_boolean is a toggle entity but don't support that. I think that need be constistance over homeassistant, so I add this service now.

I also rename internal old service handle function (toggle in name) to a general name for better code undstanding.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
