### PR TITLE
Update Ecobee state after making changes to climate

### DIFF
--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -86,10 +86,16 @@ class Thermostat(ClimateDevice):
         self.hold_temp = hold_temp
         self._operation_list = ['auto', 'auxHeatOnly', 'cool',
                                 'heat', 'off']
+        self.update_without_throttle = False
 
     def update(self):
         """Get the latest state from the thermostat."""
-        self.data.update()
+        if self.update_without_throttle:
+            self.data.update(no_throttle=True)
+            self.update_without_throttle = False
+        else:
+            self.data.update()
+
         self.thermostat = self.data.ecobee.get_thermostat(
             self.thermostat_index)
 
@@ -211,12 +217,12 @@ class Thermostat(ClimateDevice):
                                               "away", "indefinite")
         else:
             self.data.ecobee.set_climate_hold(self.thermostat_index, "away")
-        self.data.update(no_throttle=True)
+        self.update_without_throttle = True
 
     def turn_away_mode_off(self):
         """Turn away off."""
         self.data.ecobee.resume_program(self.thermostat_index)
-        self.data.update(no_throttle=True)
+        self.update_without_throttle = True
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""
@@ -243,18 +249,18 @@ class Thermostat(ClimateDevice):
                           "high=%s, is=%s", low_temp, isinstance(
                               low_temp, (int, float)), high_temp,
                           isinstance(high_temp, (int, float)))
-        self.data.update(no_throttle=True)
+        self.update_without_throttle = True
 
     def set_operation_mode(self, operation_mode):
         """Set HVAC mode (auto, auxHeatOnly, cool, heat, off)."""
         self.data.ecobee.set_hvac_mode(self.thermostat_index, operation_mode)
-        self.data.update(no_throttle=True)
+        self.update_without_throttle = True
 
     def set_fan_min_on_time(self, fan_min_on_time):
         """Set the minimum fan on time."""
         self.data.ecobee.set_fan_min_on_time(self.thermostat_index,
                                              fan_min_on_time)
-        self.data.update(no_throttle=True)
+        self.update_without_throttle = True
 
     # Home and Sleep mode aren't used in UI yet:
 

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -211,10 +211,12 @@ class Thermostat(ClimateDevice):
                                               "away", "indefinite")
         else:
             self.data.ecobee.set_climate_hold(self.thermostat_index, "away")
+        self.data.update(no_throttle=True)
 
     def turn_away_mode_off(self):
         """Turn away off."""
         self.data.ecobee.resume_program(self.thermostat_index)
+        self.data.update(no_throttle=True)
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""
@@ -241,15 +243,18 @@ class Thermostat(ClimateDevice):
                           "high=%s, is=%s", low_temp, isinstance(
                               low_temp, (int, float)), high_temp,
                           isinstance(high_temp, (int, float)))
+        self.data.update(no_throttle=True)
 
     def set_operation_mode(self, operation_mode):
         """Set HVAC mode (auto, auxHeatOnly, cool, heat, off)."""
         self.data.ecobee.set_hvac_mode(self.thermostat_index, operation_mode)
+        self.data.update(no_throttle=True)
 
     def set_fan_min_on_time(self, fan_min_on_time):
         """Set the minimum fan on time."""
         self.data.ecobee.set_fan_min_on_time(self.thermostat_index,
                                              fan_min_on_time)
+        self.data.update(no_throttle=True)
 
     # Home and Sleep mode aren't used in UI yet:
 


### PR DESCRIPTION
**Description:**

Without this, climate and sensor state will take up to 3 minutes
(the MIN_TIME_BETWEEN_UPDATES on its update throttle) to update in
the interface, which makes it more difficult to do automation around the
state.

This can be confirmed by configuring the `ecobee` component, and then changing the operation mode. Without this change, it immediately changes back to the previous operation mode in the interface, and when the throttle time ends (~3 min), it is correctly updated.

**Related issue (if applicable):** 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
ecboee:
  api_key: !secret ecobee_api_key
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
