### PR TITLE
Increase Zwave light update delay

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -125,7 +125,7 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
                 if self._timer is not None and self._timer.isAlive():
                     self._timer.cancel()
 
-                self._timer = Timer(2, _refresh_value)
+                self._timer = Timer(5, _refresh_value)
                 self._timer.start()
 
             self.update_ha_state()


### PR DESCRIPTION
**Description:**

Increases the timer for a refresh after zwave light state changes.  The current 2s is often too short to allow a dimmer to complete it's transition from on to off or off to on so HA updates with the wrong value.

**Related issue (if applicable):** fixes #
#3389

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
