### PR TITLE
Move worker pool monitoring to be time based instead of add_job based.

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -193,8 +193,8 @@ class HomeAssistant(object):
 
         This method is a coroutine.
         """
-        create_timer(self)
-        create_worker_pool_monitor(self)
+        async_create_timer(self)
+        async_monitor_worker_pool(self)
         self.bus.async_fire(EVENT_HOMEASSISTANT_START)
         yield from self.loop.run_in_executor(None, self.pool.block_till_done)
         self.state = CoreState.running
@@ -1079,13 +1079,8 @@ class Config(object):
         }
 
 
-def create_timer(hass, interval=TIMER_INTERVAL):
+def async_create_timer(hass, interval=TIMER_INTERVAL):
     """Create a timer that will start on HOMEASSISTANT_START."""
-    # We want to be able to fire every time a minute starts (seconds=0).
-    # We want this so other modules can use that to make sure they fire
-    # every minute.
-    assert 60 % interval == 0, "60 % TIMER_INTERVAL should be 0!"
-
     stop_event = asyncio.Event(loop=hass.loop)
 
     # Setting the Event inside the loop by marking it as a coroutine
@@ -1167,7 +1162,7 @@ def create_worker_pool(worker_count=None):
     return util.ThreadPool(job_handler, worker_count)
 
 
-def create_worker_pool_monitor(hass):
+def async_monitor_worker_pool(hass):
     """Create a monitor for the thread pool to check if pool is misbehaving."""
     busy_threshold = hass.pool.worker_count * 3
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -56,6 +56,9 @@ MIN_WORKER_THREAD = 2
 # Pattern for validating entity IDs (format: <domain>.<entity>)
 ENTITY_ID_PATTERN = re.compile(r"^(\w+)\.(\w+)$")
 
+# Interval at which we check if the pool is getting busy
+MONITOR_POOL_INTERVAL = 30
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -191,6 +194,7 @@ class HomeAssistant(object):
         This method is a coroutine.
         """
         create_timer(self)
+        create_worker_pool_monitor(self)
         self.bus.async_fire(EVENT_HOMEASSISTANT_START)
         yield from self.loop.run_in_executor(None, self.pool.block_till_done)
         self.state = CoreState.running
@@ -1160,14 +1164,48 @@ def create_worker_pool(worker_count=None):
             # We do not want to crash our ThreadPool
             _LOGGER.exception("BusHandler:Exception doing job")
 
-    def busy_callback(worker_count, current_jobs, pending_jobs_count):
-        """Callback to be called when the pool queue gets too big."""
+    return util.ThreadPool(job_handler, worker_count)
+
+
+def create_worker_pool_monitor(hass):
+    """Create a monitor for the thread pool to check if pool is misbehaving."""
+    busy_threshold = hass.pool.worker_count * 3
+
+    handle = None
+
+    def schedule():
+        """Schedule the monitor."""
+        nonlocal handle
+        handle = hass.loop.call_later(MONITOR_POOL_INTERVAL,
+                                      check_pool_threshold)
+
+    def check_pool_threshold():
+        """Check pool size."""
+        nonlocal busy_threshold
+
+        pending_jobs = hass.pool.queue_size
+
+        if pending_jobs < busy_threshold:
+            schedule()
+            return
+
         _LOGGER.warning(
             "WorkerPool:All %d threads are busy and %d jobs pending",
-            worker_count, pending_jobs_count)
+            hass.pool.worker_count, pending_jobs)
 
-        for start, job in current_jobs:
-            _LOGGER.warning("WorkerPool:Current job from %s: %s",
+        for start, job in hass.pool.current_jobs:
+            _LOGGER.warning("WorkerPool:Current job started at %s: %s",
                             dt_util.as_local(start).isoformat(), job)
 
-    return util.ThreadPool(job_handler, worker_count, busy_callback)
+        busy_threshold *= 2
+
+        schedule()
+
+    schedule()
+
+    @asyncio.coroutine
+    def stop_monitor(event):
+        """Stop the monitor."""
+        handle.cancel()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_monitor)

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -143,7 +143,7 @@ class HomeAssistant(ha.HomeAssistant):
                     'Unable to setup local API to receive events')
 
         self.state = ha.CoreState.starting
-        ha.create_timer(self)
+        ha.async_create_timer(self)
 
         self.bus.fire(ha.EVENT_HOMEASSISTANT_START,
                       origin=ha.EventOrigin.remote)

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -308,7 +308,7 @@ class ThreadPool(object):
     """A priority queue-based thread pool."""
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, job_handler, worker_count=0, busy_callback=None):
+    def __init__(self, job_handler, worker_count=0):
         """Initialize the pool.
 
         job_handler: method to be called from worker thread to handle job
@@ -318,13 +318,10 @@ class ThreadPool(object):
                                    pending_jobs_count
         """
         self._job_handler = job_handler
-        self._busy_callback = busy_callback
 
         self.worker_count = 0
-        self.busy_warning_limit = 0
         self._work_queue = queue.PriorityQueue()
         self.current_jobs = []
-        self._lock = threading.RLock()
         self._quit_task = object()
 
         self.running = True
@@ -332,70 +329,45 @@ class ThreadPool(object):
         for _ in range(worker_count):
             self.add_worker()
 
+    @property
+    def queue_size(self):
+        """Return estimated number of jobs that are waiting to be processed."""
+        return self._work_queue.qsize()
+
     def add_worker(self):
         """Add worker to the thread pool and reset warning limit."""
-        with self._lock:
-            if not self.running:
-                raise RuntimeError("ThreadPool not running")
+        if not self.running:
+            raise RuntimeError("ThreadPool not running")
 
-            worker = threading.Thread(
-                target=self._worker,
-                name='ThreadPool Worker {}'.format(self.worker_count))
-            worker.daemon = True
-            worker.start()
+        threading.Thread(
+            target=self._worker, daemon=True,
+            name='ThreadPool Worker {}'.format(self.worker_count)).start()
 
-            self.worker_count += 1
-            self.busy_warning_limit = self.worker_count * 3
+        self.worker_count += 1
 
     def remove_worker(self):
         """Remove worker from the thread pool and reset warning limit."""
-        with self._lock:
-            if not self.running:
-                raise RuntimeError("ThreadPool not running")
+        if not self.running:
+            raise RuntimeError("ThreadPool not running")
 
-            self._work_queue.put(PriorityQueueItem(0, self._quit_task))
+        self._work_queue.put(PriorityQueueItem(0, self._quit_task))
 
-            self.worker_count -= 1
-            self.busy_warning_limit = self.worker_count * 3
+        self.worker_count -= 1
 
     def add_job(self, priority, job):
         """Add a job to the queue."""
-        with self._lock:
-            if not self.running:
-                raise RuntimeError("ThreadPool not running")
+        if not self.running:
+            raise RuntimeError("ThreadPool not running")
 
-            self._work_queue.put(PriorityQueueItem(priority, job))
-
-            # Check if our queue is getting too big.
-            if self._work_queue.qsize() > self.busy_warning_limit \
-               and self._busy_callback is not None:
-
-                # Increase limit we will issue next warning.
-                self.busy_warning_limit *= 2
-
-                self._busy_callback(
-                    self.worker_count, self.current_jobs,
-                    self._work_queue.qsize())
+        self._work_queue.put(PriorityQueueItem(priority, job))
 
     def add_many_jobs(self, jobs):
         """Add a list of jobs to the queue."""
-        with self._lock:
-            if not self.running:
-                raise RuntimeError("ThreadPool not running")
+        if not self.running:
+            raise RuntimeError("ThreadPool not running")
 
-            for priority, job in jobs:
-                self._work_queue.put(PriorityQueueItem(priority, job))
-
-            # Check if our queue is getting too big.
-            if self._work_queue.qsize() > self.busy_warning_limit \
-               and self._busy_callback is not None:
-
-                # Increase limit we will issue next warning.
-                self.busy_warning_limit *= 2
-
-                self._busy_callback(
-                    self.worker_count, self.current_jobs,
-                    self._work_queue.qsize())
+        for priority, job in jobs:
+            self._work_queue.put(PriorityQueueItem(priority, job))
 
     def block_till_done(self):
         """Block till current work is done."""
@@ -405,18 +377,17 @@ class ThreadPool(object):
         """Finish all the jobs and stops all the threads."""
         self.block_till_done()
 
-        with self._lock:
-            if not self.running:
-                return
+        if not self.running:
+            return
 
-            # Tell the workers to quit
-            for _ in range(self.worker_count):
-                self.remove_worker()
+        # Tell the workers to quit
+        for _ in range(self.worker_count):
+            self.remove_worker()
 
-            self.running = False
+        self.running = False
 
-            # Wait till all workers have quit
-            self.block_till_done()
+        # Wait till all workers have quit
+        self.block_till_done()
 
     def _worker(self):
         """Handle jobs for the thread pool."""

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,6 +2,7 @@ flake8>=3.0.4
 pylint>=1.5.6
 coveralls>=1.1
 pytest>=2.9.2
+pytest-asyncio>=0.5.0
 pytest-cov>=2.3.1
 pytest-timeout>=1.0.0
 pytest-catchlog>=1.2.2

--- a/tests/common.py
+++ b/tests/common.py
@@ -76,8 +76,10 @@ def get_test_home_assistant(num_threads=None):
         with patch.object(hass.loop, 'run_forever', return_value=None):
             with patch.object(hass, 'async_stop', return_value=fake_stop()):
                 with patch.object(ha, 'create_timer', return_value=None):
-                    orig_start()
-                    hass.block_till_done()
+                    with patch.object(ha, 'create_worker_pool_monitor',
+                                      return_value=None):
+                        orig_start()
+                        hass.block_till_done()
 
     def stop_hass():
         orig_stop()

--- a/tests/common.py
+++ b/tests/common.py
@@ -75,8 +75,8 @@ def get_test_home_assistant(num_threads=None):
         """Helper to start hass."""
         with patch.object(hass.loop, 'run_forever', return_value=None):
             with patch.object(hass, 'async_stop', return_value=fake_stop()):
-                with patch.object(ha, 'create_timer', return_value=None):
-                    with patch.object(ha, 'create_worker_pool_monitor',
+                with patch.object(ha, 'async_create_timer', return_value=None):
+                    with patch.object(ha, 'async_monitor_worker_pool',
                                       return_value=None):
                         orig_start()
                         hass.block_till_done()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -69,7 +69,7 @@ def setUpModule():   # pylint: disable=invalid-name
         {http.DOMAIN: {http.CONF_API_PASSWORD: API_PASSWORD,
                        http.CONF_SERVER_PORT: SLAVE_PORT}})
 
-    with patch.object(ha, 'create_timer', return_value=None):
+    with patch.object(ha, 'async_create_timer', return_value=None):
         slave.start()
 
 


### PR DESCRIPTION
**Description:**
We used to check if the worker pool was busy while adding a job. This meant it required a lock and could cause threads to wait for one another while doing simple things like adding jobs.

This is no longer the case. We now monitor the pool every 30 seconds. This scheduling is done directly on the event loop instead of on the event bus because it is a housekeeping task of the core.

Includes tests for both create_timer and monitor_worker_pool

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
