### PR TITLE
Migrate camera.uvc to voluptuous

### DIFF
--- a/homeassistant/components/camera/uvc.py
+++ b/homeassistant/components/camera/uvc.py
@@ -8,28 +8,33 @@ import logging
 import socket
 
 import requests
+import voluptuous as vol
 
-from homeassistant.components.camera import DOMAIN, Camera
-from homeassistant.helpers import validate_config
+from homeassistant.const import CONF_PORT
+from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['uvcclient==0.9.0']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_NVR = 'nvr'
+CONF_KEY = 'key'
+
+DEFAULT_PORT = 7080
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_NVR): cv.string,
+    vol.Required(CONF_KEY): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+})
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Discover cameras on a Unifi NVR."""
-    if not validate_config({DOMAIN: config}, {DOMAIN: ['nvr', 'key']},
-                           _LOGGER):
-        return None
-
-    addr = config.get('nvr')
-    key = config.get('key')
-    try:
-        port = int(config.get('port', 7080))
-    except ValueError:
-        _LOGGER.error('Invalid port number provided')
-        return False
+    addr = config[CONF_NVR]
+    key = config[CONF_KEY]
+    port = config[CONF_PORT]
 
     from uvcclient import nvr
     nvrconn = nvr.UVCRemote(addr, port, key)


### PR DESCRIPTION
**Description:**
Migrate the UVC camera platform to use voluptuous.

**Related issue (if applicable):** #2800

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
camera:
  platform: uvc
  nvr: IP_ADDRESS
  port: PORT
  key: APIKEY
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
