### PR TITLE
Allow hiding automation entities from UIs

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -306,7 +306,8 @@ def _process_config(hass, config, component):
 
             attach_triggers = partial(_process_trigger, hass, config,
                                       config_block.get(CONF_TRIGGER, []), name)
-            entity = AutomationEntity(name, attach_triggers, cond_func, action, hidden)
+            entity = AutomationEntity(name, attach_triggers, cond_func, action,
+                                      hidden)
             component.add_entities((entity,))
             success = True
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -30,7 +30,7 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 DEPENDENCIES = ['group']
 
 CONF_ALIAS = 'alias'
-CONF_HIDDEN = 'hidden'
+CONF_HIDE_ENTITY = 'hide_entity'
 
 CONF_CONDITION = 'condition'
 CONF_ACTION = 'action'
@@ -42,6 +42,7 @@ CONDITION_TYPE_AND = 'and'
 CONDITION_TYPE_OR = 'or'
 
 DEFAULT_CONDITION_TYPE = CONDITION_TYPE_AND
+DEFAULT_HIDE_ENTITY = False
 
 METHOD_TRIGGER = 'trigger'
 METHOD_IF_ACTION = 'if_action'
@@ -100,7 +101,7 @@ _CONDITION_SCHEMA = vol.Any(
 
 PLATFORM_SCHEMA = vol.Schema({
     CONF_ALIAS: cv.string,
-    CONF_HIDDEN: cv.boolean,
+    vol.Optional(CONF_HIDE_ENTITY, default=DEFAULT_HIDE_ENTITY): cv.boolean,
     vol.Required(CONF_TRIGGER): _TRIGGER_SCHEMA,
     vol.Required(CONF_CONDITION_TYPE, default=DEFAULT_CONDITION_TYPE):
         vol.All(vol.Lower, vol.Any(CONDITION_TYPE_AND, CONDITION_TYPE_OR)),
@@ -290,7 +291,7 @@ def _process_config(hass, config, component):
             name = config_block.get(CONF_ALIAS) or "{} {}".format(config_key,
                                                                   list_no)
 
-            hidden = config_block.get(CONF_HIDDEN) or False
+            hidden = config_block[CONF_HIDE_ENTITY]
 
             action = _get_action(hass, config_block.get(CONF_ACTION, {}), name)
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -30,6 +30,7 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 DEPENDENCIES = ['group']
 
 CONF_ALIAS = 'alias'
+CONF_HIDDEN = 'hidden'
 
 CONF_CONDITION = 'condition'
 CONF_ACTION = 'action'
@@ -99,6 +100,7 @@ _CONDITION_SCHEMA = vol.Any(
 
 PLATFORM_SCHEMA = vol.Schema({
     CONF_ALIAS: cv.string,
+    CONF_HIDDEN: cv.boolean,
     vol.Required(CONF_TRIGGER): _TRIGGER_SCHEMA,
     vol.Required(CONF_CONDITION_TYPE, default=DEFAULT_CONDITION_TYPE):
         vol.All(vol.Lower, vol.Any(CONDITION_TYPE_AND, CONDITION_TYPE_OR)),
@@ -206,7 +208,8 @@ def setup(hass, config):
 class AutomationEntity(ToggleEntity):
     """Entity to show status of entity."""
 
-    def __init__(self, name, attach_triggers, cond_func, action):
+    # pylint: disable=too-many-arguments, too-many-instance-attributes
+    def __init__(self, name, attach_triggers, cond_func, action, hidden):
         """Initialize an automation entity."""
         self._name = name
         self._attach_triggers = attach_triggers
@@ -215,6 +218,7 @@ class AutomationEntity(ToggleEntity):
         self._action = action
         self._enabled = True
         self._last_triggered = None
+        self._hidden = hidden
 
     @property
     def name(self):
@@ -232,6 +236,11 @@ class AutomationEntity(ToggleEntity):
         return {
             ATTR_LAST_TRIGGERED: self._last_triggered
         }
+
+    @property
+    def hidden(self) -> bool:
+        """Return True if the automation entity should be hidden from UIs."""
+        return self._hidden
 
     @property
     def is_on(self) -> bool:
@@ -281,6 +290,8 @@ def _process_config(hass, config, component):
             name = config_block.get(CONF_ALIAS) or "{} {}".format(config_key,
                                                                   list_no)
 
+            hidden = config_block.get(CONF_HIDDEN) or False
+
             action = _get_action(hass, config_block.get(CONF_ACTION, {}), name)
 
             if CONF_CONDITION in config_block:
@@ -295,7 +306,7 @@ def _process_config(hass, config, component):
 
             attach_triggers = partial(_process_trigger, hass, config,
                                       config_block.get(CONF_TRIGGER, []), name)
-            entity = AutomationEntity(name, attach_triggers, cond_func, action)
+            entity = AutomationEntity(name, attach_triggers, cond_func, action, hidden)
             component.add_entities((entity,))
             success = True
 


### PR DESCRIPTION
**Description:**
Allow hiding automation entities from the UI via configuration switch to avoid cluttering and/or exposing sensitive automations (e.g. alarm states, as any user could simply disable the automation for triggering the alarm).

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#956

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
- alias: Door alarm
  hide_entity: True
  trigger:
    - platform: state
      entity_id: binary_sensor.contact_door
      to: 'on'
  condition:
    - condition: state
      entity_id: alarm_control_panel.alarm
      state: 'armed_away'
  action:
    service: alarm_control_panel.alarm_trigger
    entity_id: alarm_control_panel.alarm
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
