### PR TITLE
Better Hue error reporting

### DIFF
--- a/homeassistant/components/emulated_hue.py
+++ b/homeassistant/components/emulated_hue.py
@@ -17,7 +17,7 @@ from homeassistant import util, core
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, SERVICE_TURN_OFF, SERVICE_TURN_ON,
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
-    STATE_ON
+    STATE_ON, HTTP_BAD_REQUEST
 )
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_SUPPORTED_FEATURES, SUPPORT_BRIGHTNESS
@@ -202,11 +202,10 @@ class HueUsernameView(HomeAssistantView):
         data = request.json
 
         if 'devicetype' not in data:
-            return self.Response("devicetype not specified", status=400)
+            return self.json_message('devicetype not specified',
+                                     HTTP_BAD_REQUEST)
 
-        json_response = [{'success': {'username': '12345678901234567890'}}]
-
-        return self.json(json_response)
+        return self.json([{'success': {'username': '12345678901234567890'}}])
 
 
 class HueLightsView(HomeAssistantView):

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -94,7 +94,7 @@ def setup_bridge(host, hass, add_devices_callback, filename,
             host,
             config_file_path=hass.config.path(filename))
     except ConnectionRefusedError:  # Wrong host was given
-        _LOGGER.exception("Error connecting to the Hue bridge at %s", host)
+        _LOGGER.error("Error connecting to the Hue bridge at %s", host)
 
         return
 


### PR DESCRIPTION
**Description:**
This will improve Hue error reporting:
- Light - Hue will no longer print a stacktrace on connection refused. It will instead just print an error.
- Emulated_hue will now return valid JSON when it returns an error message.

**Related issue (if applicable):** fixes #3085

**Checklist:**

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
