### PR TITLE
Fix slow tests

### DIFF
--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -153,13 +153,15 @@ def setup(hass, config):
 
     if dummy_connection:
         RFXOBJECT =\
-            rfxtrxmod.Core(device, handle_receive, debug=debug,
-                           transport_protocol=rfxtrxmod.DummyTransport2)
+            rfxtrxmod.Connect(device, handle_receive, debug=debug,
+                              transport_protocol=rfxtrxmod.DummyTransport2)
     else:
-        RFXOBJECT = rfxtrxmod.Core(device, handle_receive, debug=debug)
+        RFXOBJECT = rfxtrxmod.Connect(device, handle_receive, debug=debug)
 
     def _shutdown_rfxtrx(event):
+        """Close connection with RFXtrx."""
         RFXOBJECT.close_connection()
+
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown_rfxtrx)
 
     return True

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -1,7 +1,7 @@
 """Th tests for the Rfxtrx component."""
 # pylint: disable=too-many-public-methods,protected-access
 import unittest
-import time
+from unittest.mock import patch
 
 from homeassistant.bootstrap import _setup_component
 from homeassistant.components import rfxtrx as rfxtrx
@@ -23,7 +23,8 @@ class TestRFXTRX(unittest.TestCase):
             rfxtrx.RFXOBJECT.close_connection()
         self.hass.stop()
 
-    def test_default_config(self):
+    @patch('RFXtrx.sleep')
+    def test_default_config(self, mock_sleep):
         """Test configuration."""
         self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
@@ -37,12 +38,10 @@ class TestRFXTRX(unittest.TestCase):
                        'automatic_add': True,
                        'devices': {}}}))
 
-        while len(rfxtrx.RFX_DEVICES) < 2:
-            time.sleep(0.1)
-
         self.assertEqual(len(rfxtrx.RFXOBJECT.sensors()), 2)
 
-    def test_valid_config(self):
+    @patch('RFXtrx.sleep')
+    def test_valid_config(self, mock_sleep):
         """Test configuration."""
         self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
@@ -69,9 +68,9 @@ class TestRFXTRX(unittest.TestCase):
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
                 'invalid_key': True}}))
 
-    def test_fire_event(self):
+    @patch('RFXtrx.sleep')
+    def test_fire_event(self, mock_sleep):
         """Test fire event."""
-
         self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
                 'device': '/dev/serial/by-id/usb' +
@@ -110,12 +109,12 @@ class TestRFXTRX(unittest.TestCase):
         self.assertEqual(event.values['Command'], "On")
         self.assertEqual('on', entity.state)
         self.assertEqual(self.hass.states.get('switch.test').state, 'on')
-        self.assertEqual(1, len(rfxtrx.RFX_DEVICES))
         self.assertEqual(1, len(calls))
         self.assertEqual(calls[0].data,
                          {'entity_id': 'switch.test', 'state': 'on'})
 
-    def test_fire_event_sensor(self):
+    @patch('RFXtrx.sleep')
+    def test_fire_event_sensor(self, mock_sleep):
         """Test fire event."""
         self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
@@ -145,7 +144,6 @@ class TestRFXTRX(unittest.TestCase):
         rfxtrx.RECEIVED_EVT_SUBSCRIBERS[0](event)
 
         self.hass.block_till_done()
-        self.assertEqual(1, len(rfxtrx.RFX_DEVICES))
         self.assertEqual(1, len(calls))
         self.assertEqual(calls[0].data,
                          {'entity_id': 'sensor.test'})

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -19,8 +19,6 @@ class TestRFXTRX(unittest.TestCase):
         """Stop everything that was started."""
         rfxtrx.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx.RFX_DEVICES = {}
-        if rfxtrx.RFXOBJECT:
-            rfxtrx.RFXOBJECT.close_connection()
         self.hass.stop()
 
     @patch('RFXtrx.sleep')

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -13,7 +13,7 @@ class TestRFXTRX(unittest.TestCase):
 
     def setUp(self):
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(0)
+        self.hass = get_test_home_assistant()
 
     def tearDown(self):
         """Stop everything that was started."""
@@ -46,6 +46,8 @@ class TestRFXTRX(unittest.TestCase):
                 'device': '/dev/serial/by-id/usb' +
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
                 'dummy': True}}))
+
+        self.hass.config.components.remove('rfxtrx')
 
         self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv =
     LANG=en_US.UTF-8
     PYTHONPATH = {toxinidir}:{toxinidir}/homeassistant
 commands =
-     py.test -v --timeout=30 --cov --cov-report= {posargs}
+     py.test -v --timeout=30 --duration=10 --cov --cov-report= {posargs}
 deps =
      -r{toxinidir}/requirements_all.txt
      -r{toxinidir}/requirements_test.txt


### PR DESCRIPTION
**Description:**
Branch to try to fix a bunch of RFXtrx tests that are unreasonably slow. It's partly because they contain sleeps or that they just do too much.

To find 10 slowest tests locally, run: `py.test --duration=10`. This has also now been added to the output on travis.

CC @Danielhiversen 

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
