### PR TITLE
Added support to Yahoo Finance to track the stock market within Home Assistant

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -260,6 +260,7 @@ omit =
     homeassistant/components/sensor/uber.py
     homeassistant/components/sensor/worldclock.py
     homeassistant/components/sensor/xbox_live.py
+    homeassistant/components/sensor/yahoo_finance.py
     homeassistant/components/sensor/yweather.py
     homeassistant/components/switch/acer_projector.py
     homeassistant/components/switch/arest.py

--- a/homeassistant/components/sensor/yahoo_finance.py
+++ b/homeassistant/components/sensor/yahoo_finance.py
@@ -30,7 +30,7 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 STATE_ATTR_PRICE_SALES = 'Price/Sales (ttm)'
 STATE_ATTR_CHANGE = 'Change'
 STATE_ATTR_OPEN = 'Open'
-STATE_ATTR_PREV_CLOSE  = 'Prev. Close'
+STATE_ATTR_PREV_CLOSE = 'Prev. Close'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SYMBOL, default=DEFAULT_SYMBOL): cv.string,
@@ -110,7 +110,7 @@ class YahooFinanceData(object):
         self._name = name
         self._symbol = symbol
         self.state = None
-        self.stock =  Share(symbol)
+        self.stock = Share(symbol)
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/sensor/yahoo_finance.py
+++ b/homeassistant/components/sensor/yahoo_finance.py
@@ -40,7 +40,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Yahoo Finance sensor."""
-
     name = config.get(CONF_NAME)
     symbol = config.get(CONF_SYMBOL)
 
@@ -99,7 +98,7 @@ class YahooFinanceSensor(Entity):
         self._state = self.data.state
 
 class YahooFinanceData(object):
-    """Get data from Yahoo Finance"""
+    """Get data from Yahoo Finance."""
 
     def __init__(self, name, symbol):
         """Initialize the data object."""

--- a/homeassistant/components/sensor/yahoo_finance.py
+++ b/homeassistant/components/sensor/yahoo_finance.py
@@ -27,7 +27,6 @@ ICON = 'mdi:currency-usd'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
-ATTR_PRICE_SALES = 'Price/Sales (ttm)'
 ATTR_CHANGE = 'Change'
 ATTR_OPEN = 'Open'
 ATTR_PREV_CLOSE = 'Prev. Close'

--- a/homeassistant/components/sensor/yahoo_finance.py
+++ b/homeassistant/components/sensor/yahoo_finance.py
@@ -79,9 +79,13 @@ class YahooFinanceSensor(Entity):
         """Return the state attributes."""
         if self._state is not None:
             return {
-                ATTR_CHANGE: self.data._price_change,
-                ATTR_OPEN: self.data._price_open,
-                ATTR_PREV_CLOSE: self.data._prev_close,
+                ATTR_CHANGE: self.data.price_change,
+                ATTR_OPEN: self.data.price_open,
+                ATTR_PREV_CLOSE: self.data.prev_close,
+                'About': "Stock market information delivered by Yahoo!"
+                         " Inc. are provided free of charge for use"
+                         " by individuals and non-profit organizations"
+                         " for personal, non-commercial uses."
             }
 
     @property
@@ -95,6 +99,7 @@ class YahooFinanceSensor(Entity):
         self.data.update()
         self._state = self.data.state
 
+
 class YahooFinanceData(object):
     """Get data from Yahoo Finance."""
 
@@ -105,9 +110,9 @@ class YahooFinanceData(object):
         self._name = name
         self._symbol = symbol
         self.state = None
-        self._price_change = None
-        self._price_open = None
-        self._prev_close = None
+        self.price_change = None
+        self.price_open = None
+        self.prev_close = None
         self.stock = Share(symbol)
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
@@ -115,6 +120,6 @@ class YahooFinanceData(object):
         """Get the latest data and updates the states."""
         self.stock.refresh()
         self.state = self.stock.get_price()
-        self._price_change = self.stock.get_change()
-        self._price_open = self.stock.get_open()
-        self._prev_close = self.stock.get_prev_close()
+        self.price_change = self.stock.get_change()
+        self.price_open = self.stock.get_open()
+        self.prev_close = self.stock.get_prev_close()

--- a/homeassistant/components/sensor/yahoo_finance.py
+++ b/homeassistant/components/sensor/yahoo_finance.py
@@ -1,0 +1,120 @@
+"""
+Currency exchange rate support that comes from Yahoo Finance.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.yahoo-finance/
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['yahoo-finance==1.2.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_SYMBOL = 'symbol'
+DEFAULT_SYMBOL = 'YHOO'
+DEFAULT_NAME = 'Yahoo Stock'
+
+ICON = 'mdi:currency-usd'
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
+
+STATE_ATTR_PRICE_SALES = 'Price/Sales (ttm)'
+STATE_ATTR_CHANGE = 'Change'
+STATE_ATTR_OPEN = 'Open'
+STATE_ATTR_PREV_CLOSE  = 'Prev. Close'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_SYMBOL, default=DEFAULT_SYMBOL): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Yahoo Finance sensor."""
+    from yahoo_finance import Share
+
+    name = config.get(CONF_NAME)
+    symbol = config.get(CONF_SYMBOL)
+
+    data = YahooFinanceData(name, symbol)
+    add_devices([YahooFinanceSensor(name, data, symbol)])
+
+
+# pylint: disable=too-few-public-methods
+class YahooFinanceSensor(Entity):
+    """Representation of a Yahoo Finance sensor."""
+
+    def __init__(self, name, data, symbol):
+        """Initialize the sensor."""
+        self._name = name
+        self.data = data
+        self._symbol = symbol
+        self._state = None
+        self._unit_of_measurement = None
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._symbol
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        #self.update()
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        if self._state is not None:
+            return {
+                STATE_ATTR_CHANGE: self.data.stock.get_change(),
+                STATE_ATTR_PRICE_SALES: self.data.stock.get_price_sales(),
+                STATE_ATTR_OPEN: self.data.stock.get_open(),
+                STATE_ATTR_PREV_CLOSE: self.data.stock.get_prev_close(),
+            }
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return ICON
+
+    def update(self):
+        """Get the latest data and updates the states."""
+        _LOGGER.debug('Updating sensor %s - %s', self._name, self._state)
+        self.data.update()
+        self._state = self.data.state
+
+class YahooFinanceData(object):
+    """Get data from Yahoo Finance"""
+
+    def __init__(self, name, symbol):
+        """Initialize the data object."""
+        from yahoo_finance import Share
+
+        self._name = name
+        self._symbol = symbol
+        self.state = None
+        self.stock =  Share(symbol)
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Get the latest data and updates the states."""
+        self.stock.refresh()
+        self.state = self.stock.get_price()
+

--- a/homeassistant/components/sensor/yahoo_finance.py
+++ b/homeassistant/components/sensor/yahoo_finance.py
@@ -40,7 +40,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Yahoo Finance sensor."""
-    from yahoo_finance import Share
 
     name = config.get(CONF_NAME)
     symbol = config.get(CONF_SYMBOL)
@@ -75,7 +74,6 @@ class YahooFinanceSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        #self.update()
         return self._state
 
     @property
@@ -117,4 +115,3 @@ class YahooFinanceData(object):
         """Get the latest data and updates the states."""
         self.stock.refresh()
         self.state = self.stock.get_price()
-

--- a/homeassistant/components/sensor/yahoo_finance.py
+++ b/homeassistant/components/sensor/yahoo_finance.py
@@ -2,7 +2,7 @@
 Currency exchange rate support that comes from Yahoo Finance.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/sensor.yahoo-finance/
+https://home-assistant.io/components/sensor.yahoo_finance/
 """
 import logging
 from datetime import timedelta
@@ -27,10 +27,10 @@ ICON = 'mdi:currency-usd'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
-STATE_ATTR_PRICE_SALES = 'Price/Sales (ttm)'
-STATE_ATTR_CHANGE = 'Change'
-STATE_ATTR_OPEN = 'Open'
-STATE_ATTR_PREV_CLOSE = 'Prev. Close'
+ATTR_PRICE_SALES = 'Price/Sales (ttm)'
+ATTR_CHANGE = 'Change'
+ATTR_OPEN = 'Open'
+ATTR_PREV_CLOSE = 'Prev. Close'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SYMBOL, default=DEFAULT_SYMBOL): cv.string,
@@ -80,10 +80,9 @@ class YahooFinanceSensor(Entity):
         """Return the state attributes."""
         if self._state is not None:
             return {
-                STATE_ATTR_CHANGE: self.data.stock.get_change(),
-                STATE_ATTR_PRICE_SALES: self.data.stock.get_price_sales(),
-                STATE_ATTR_OPEN: self.data.stock.get_open(),
-                STATE_ATTR_PREV_CLOSE: self.data.stock.get_prev_close(),
+                ATTR_CHANGE: self.data._price_change,
+                ATTR_OPEN: self.data._price_open,
+                ATTR_PREV_CLOSE: self.data._prev_close,
             }
 
     @property
@@ -107,6 +106,9 @@ class YahooFinanceData(object):
         self._name = name
         self._symbol = symbol
         self.state = None
+        self._price_change = None
+        self._price_open = None
+        self._prev_close = None
         self.stock = Share(symbol)
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
@@ -114,3 +116,6 @@ class YahooFinanceData(object):
         """Get the latest data and updates the states."""
         self.stock.refresh()
         self.state = self.stock.get_price()
+        self._price_change = self.stock.get_change()
+        self._price_open = self.stock.get_open()
+        self._prev_close = self.stock.get_prev_close()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -516,6 +516,9 @@ xboxapi==0.1.1
 # homeassistant.components.sensor.yr
 xmltodict==0.10.2
 
+# homeassistant.components.sensor.yahoo_finance
+yahoo-finance==1.2.1
+
 # homeassistant.components.sensor.yweather
 yahooweather==0.8
 


### PR DESCRIPTION
**Description:**
This patch introduces a new platform to track and monitor the stock market via Yahoo Finance

**Pull request in [home-assistant.io]**
https://github.com/home-assistant/home-assistant.github.io/pull/957

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
# Example configuration.yaml entry
sensor:
  - platform: yahoo_finance
    name: Red Hat Inc.
    symbol: RHT

  - platform: yahoo_finance
    name: Google
    symbol: GOOGL
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
