### PR TITLE
Fix test shutdown to ensure loop/threads are clean.

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -273,6 +273,7 @@ class HomeAssistant(object):
         self.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         yield from self.loop.run_in_executor(None, self.pool.block_till_done)
         yield from self.loop.run_in_executor(None, self.pool.stop)
+        self.executer.shutdown()
         self.state = CoreState.not_running
         self.loop.stop()
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -56,6 +56,7 @@ def get_test_home_assistant(num_threads=None):
 
     # FIXME should not be a daemon. Means hass.stop() not called in teardown
     stop_event = threading.Event()
+
     def run_loop():
         loop.run_forever()
         loop.close()

--- a/tests/common.py
+++ b/tests/common.py
@@ -55,10 +55,16 @@ def get_test_home_assistant(num_threads=None):
         loader.prepare(hass)
 
     # FIXME should not be a daemon. Means hass.stop() not called in teardown
-    threading.Thread(name="LoopThread", target=loop.run_forever,
-                     daemon=True).start()
+    stop_event = threading.Event()
+    def run_loop():
+        loop.run_forever()
+        loop.close()
+        stop_event.set()
+
+    threading.Thread(name="LoopThread", target=run_loop, daemon=True).start()
 
     orig_start = hass.start
+    orig_stop = hass.stop
 
     @asyncio.coroutine
     def fake_stop():
@@ -72,7 +78,12 @@ def get_test_home_assistant(num_threads=None):
                     orig_start()
                     hass.block_till_done()
 
+    def stop_hass():
+        orig_stop()
+        stop_event.wait()
+
     hass.start = start_hass
+    hass.stop = stop_hass
 
     return hass
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -29,6 +29,9 @@ class TestBootstrap:
 
     def teardown_method(self, method):
         """Clean up."""
+        if method == self.test_from_config_file:
+            return
+
         dt_util.DEFAULT_TIME_ZONE = ORIG_TIMEZONE
         self.hass.stop()
         loader._COMPONENT_CACHE = self.backup_cache


### PR DESCRIPTION
**Description:**

Ensures each test using hass.stop actually waits till the event loop has completed, then is closed. The stop command now also ensures the thread-pool executer has shut-down as well to free up those resources.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

We now ensure the loop is closed, it has completed, and the
executer has completed. This ensure all threads are freed
up with any test calling hass.stop().
