### PR TITLE
Remove validate_config

### DIFF
--- a/homeassistant/helpers/__init__.py
+++ b/homeassistant/helpers/__init__.py
@@ -14,31 +14,6 @@ if False:
 ConfigType = Dict[str, Any]
 
 
-def validate_config(config: ConfigType, items: Dict, logger: 'Logger') -> bool:
-    """Validate if all items are available in the configuration.
-
-    config is the general dictionary with all the configurations.
-    items is a dict with per domain which attributes we require.
-    logger is the logger from the caller to log the errors to.
-
-    Return True if all required items were found.
-    """
-    errors_found = False
-    for domain in items.keys():
-        config.setdefault(domain, {})
-
-        errors = [item for item in items[domain] if item not in config[domain]]
-
-        if errors:
-            logger.error(
-                "Missing required configuration items in {}: {}".format(
-                    domain, ", ".join(errors)))
-
-            errors_found = True
-
-    return not errors_found
-
-
 def config_per_platform(config: ConfigType,
                         domain: str) -> Iterable[Tuple[Any, Any]]:
     """Generator to break a component config into different platforms.


### PR DESCRIPTION
**Description:**
This is it. The magical moment has been achieved where we officially no longer use `validate_config`.

CC @fabaff ❤️ 

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
