### PR TITLE
Allow script to send notify only with data

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -41,7 +41,7 @@ PLATFORM_SCHEMA = vol.Schema({
 
 NOTIFY_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_MESSAGE): cv.template,
-    vol.Optional(ATTR_TITLE): cv.string,
+    vol.Optional(ATTR_TITLE): cv.template,
     vol.Optional(ATTR_TARGET): cv.string,
     vol.Optional(ATTR_DATA): dict,
 })

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -40,7 +40,7 @@ PLATFORM_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 NOTIFY_SERVICE_SCHEMA = vol.Schema({
-    vol.Required(ATTR_MESSAGE): cv.template,
+    vol.Optional(ATTR_MESSAGE): cv.template,
     vol.Optional(ATTR_TITLE): cv.string,
     vol.Optional(ATTR_TARGET): cv.string,
     vol.Optional(ATTR_DATA): dict,
@@ -92,7 +92,7 @@ def setup(hass, config):
         def notify_message(notify_service, call):
             """Handle sending notification message service calls."""
             kwargs = {}
-            message = call.data[ATTR_MESSAGE]
+            message = call.data.get(ATTR_MESSAGE)
             title = call.data.get(ATTR_TITLE)
 
             if title:
@@ -103,7 +103,11 @@ def setup(hass, config):
             else:
                 kwargs[ATTR_TARGET] = call.data.get(ATTR_TARGET)
 
-            kwargs[ATTR_MESSAGE] = template.render(hass, message)
+            if message:
+                kwargs[ATTR_MESSAGE] = template.render(hass, message)
+            else:
+                kwargs[ATTR_MESSAGE] = ""
+
             kwargs[ATTR_DATA] = call.data.get(ATTR_DATA)
 
             notify_service.send_message(**kwargs)

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -97,16 +97,18 @@ class TelegramNotificationService(BaseNotificationService):
         data = kwargs.get(ATTR_DATA)
 
         # exists data for send a photo/location
-        if data is not None and ATTR_PHOTO in data:
+        if data is None:
+            pass
+        if ATTR_PHOTO in data:
             photos = data.get(ATTR_PHOTO, None)
             photos = photos if isinstance(photos, list) else [photos]
 
             for photo_data in photos:
                 self.send_photo(photo_data)
             return
-        elif data is not None and ATTR_LOCATION in data:
+        elif ATTR_LOCATION in data:
             return self.send_location(data.get(ATTR_LOCATION))
-        elif data is not None and ATTR_DOCUMENT in data:
+        elif ATTR_DOCUMENT in data:
             return self.send_document(data.get(ATTR_DOCUMENT))
 
         if title:

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -99,7 +99,7 @@ class TelegramNotificationService(BaseNotificationService):
         # exists data for send a photo/location
         if data is None:
             pass
-        if ATTR_PHOTO in data:
+        elif ATTR_PHOTO in data:
             photos = data.get(ATTR_PHOTO, None)
             photos = photos if isinstance(photos, list) else [photos]
 

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -131,6 +131,32 @@ data_template:
                     'US-EN-Morgan-Freeman-Roommate-Is-Arriving.wav'}}
         } == self.events[0].data
 
+    def test_calling_notify_from_script_loaded_from_yaml_with_only_data(self):
+        """Test if we can call a notify from a script."""
+        yaml_conf = """
+service: notify.notify
+data:
+  data:
+    photo:
+      file: /tmp/photo_cam.png
+"""
+
+        with tempfile.NamedTemporaryFile() as fp:
+            fp.write(yaml_conf.encode('utf-8'))
+            fp.flush()
+            conf = yaml.load_yaml(fp.name)
+
+        script.call_from_config(self.hass, conf)
+        self.hass.pool.block_till_done()
+        self.assertTrue(len(self.events) == 1)
+        assert {
+            'message': '',
+            'target': None,
+            'data': {
+                'photo': {
+                    'file': '/tmp/photo_cam.png'}}
+        } == self.events[0].data
+
     def test_targets_are_services(self):
         """Test that all targets are exposed as individual services."""
         self.assertIsNotNone(self.hass.services.has_service("notify", "demo"))


### PR DESCRIPTION
**Description:**
Allow to send a notify only with data from a Action. So it more cleaner to send photo/Location usw.

old:

``` yaml
...
Service: notify.notify
data:
  message: stupit ding they not needed and never send
  data:
     photo:
       file: /tmp/bla.png
```

now

``` yaml
...
Service: notify.notify
data:
  data:
     photo:
       file: /tmp/bla.png
```

That is now clear that is need to call for sending a photo and a message.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
