### PR TITLE
Add the ability to manually specify a Yamaha AVR via it's IP address

### DIFF
--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -45,15 +45,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     source_names = config.get(CONF_SOURCE_NAMES)
 
     if host is None:
-        add_devices(
-            YamahaDevice(name, receiver, source_ignore, source_names)
-            for receiver in rxv.find())
+    	receivers = rxv.find()
     else:
         receivers = \
             [rxv.RXV("http://{}:80/YamahaRemoteControl/ctrl".format(host), name)]
-        add_devices(
-            YamahaDevice(name, receiver, source_ignore, source_names)
-            for receiver in receivers)
+            
+    add_devices(
+        YamahaDevice(name, receiver, source_ignore, source_names)
+        for receiver in receivers)
 
 
 class YamahaDevice(MediaPlayerDevice):

--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.components.media_player import (
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_SELECT_SOURCE, MediaPlayerDevice, PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_NAME, STATE_OFF, STATE_ON)
+from homeassistant.const import (CONF_NAME, CONF_HOST, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['rxv==0.1.11']
@@ -25,9 +25,11 @@ CONF_SOURCE_NAMES = 'source_names'
 CONF_SOURCE_IGNORE = 'source_ignore'
 
 DEFAULT_NAME = 'Yamaha Receiver'
+DEFAULT_HOST = 'DISCO'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_SOURCE_IGNORE, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_SOURCE_NAMES, default={}): {cv.string: cv.string},
@@ -39,12 +41,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import rxv
 
     name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
     source_ignore = config.get(CONF_SOURCE_IGNORE)
     source_names = config.get(CONF_SOURCE_NAMES)
 
-    add_devices(
-        YamahaDevice(name, receiver, source_ignore, source_names)
-        for receiver in rxv.find())
+    if host == 'DISCO':
+        add_devices(
+            YamahaDevice(name, receiver, source_ignore, source_names)
+            for receiver in rxv.find())
+    else:
+        receivers = [rxv.RXV("http://"+host+":80/YamahaRemoteControl/ctrl", name)]
+        add_devices(YamahaDevice(name, receiver, source_ignore, source_names) for receiver in receivers)
 
 
 class YamahaDevice(MediaPlayerDevice):

--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -51,7 +51,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             for receiver in rxv.find())
     else:
         receivers = \
-            [rxv.RXV("http://"+host+":80/YamahaRemoteControl/ctrl", name)]
+            [rxv.RXV("http://{}:80/YamahaRemoteControl/ctrl".format(host), name)]
         add_devices(
             YamahaDevice(name, receiver, source_ignore, source_names)
             for receiver in receivers)

--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -50,8 +50,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             YamahaDevice(name, receiver, source_ignore, source_names)
             for receiver in rxv.find())
     else:
-        receivers = [rxv.RXV("http://"+host+":80/YamahaRemoteControl/ctrl", name)]
-        add_devices(YamahaDevice(name, receiver, source_ignore, source_names) for receiver in receivers)
+        receivers = \
+            [rxv.RXV("http://"+host+":80/YamahaRemoteControl/ctrl", name)]
+        add_devices(
+            YamahaDevice(name, receiver, source_ignore, source_names)
+            for receiver in receivers)
 
 
 class YamahaDevice(MediaPlayerDevice):

--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -25,11 +25,10 @@ CONF_SOURCE_NAMES = 'source_names'
 CONF_SOURCE_IGNORE = 'source_ignore'
 
 DEFAULT_NAME = 'Yamaha Receiver'
-DEFAULT_HOST = 'DISCO'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_SOURCE_IGNORE, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_SOURCE_NAMES, default={}): {cv.string: cv.string},
@@ -45,7 +44,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     source_ignore = config.get(CONF_SOURCE_IGNORE)
     source_names = config.get(CONF_SOURCE_NAMES)
 
-    if host == 'DISCO':
+    if host is None:
         add_devices(
             YamahaDevice(name, receiver, source_ignore, source_names)
             for receiver in rxv.find())

--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -45,11 +45,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     source_names = config.get(CONF_SOURCE_NAMES)
 
     if host is None:
-    	receivers = rxv.find()
+        receivers = rxv.find()
     else:
         receivers = \
-            [rxv.RXV("http://{}:80/YamahaRemoteControl/ctrl".format(host), name)]
-            
+            [rxv.RXV("http://{}:80/YamahaRemoteControl/ctrl".format(host),
+                     name)]
+
     add_devices(
         YamahaDevice(name, receiver, source_ignore, source_names)
         for receiver in receivers)


### PR DESCRIPTION
**Description:**
I have added a feature so that you can manually specify the IP address of a Yamaha receiver if the autodiscovery won't work (due to a bug in Yamaha's firmware). The underlying rxv library did already support manually specifying the address, so it was mostly reading the config and providing a second `add_devices` function

**Related issue (if applicable):**
No related issue, but a feature request by myself [in the forums](https://community.home-assistant.io/t/possibility-to-add-yamaha-av-receivery-explicitly-via-their-ip/3922)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** 
https://github.com/home-assistant/home-assistant.github.io/pull/959

**Example entry for `configuration.yaml` (if applicable):**

```
 media_player:
    platform: yamaha
    host: 192.168.1.100
    name: 'Basement Receiver'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
