### PR TITLE
Add unit to comment (config)

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -35,7 +35,8 @@ DEFAULT_CORE_CONFIG = (
     (CONF_LATITUDE, 0, 'latitude', 'Location required to calculate the time'
      ' the sun rises and sets'),
     (CONF_LONGITUDE, 0, 'longitude', None),
-    (CONF_ELEVATION, 0, None, 'Impacts weather/sunrise data'),
+    (CONF_ELEVATION, 0, None, 'Impacts weather/sunrise data'
+                              ' (altitude above sea level in meters)'),
     (CONF_UNIT_SYSTEM, CONF_UNIT_SYSTEM_METRIC, None,
      '{} for Metric, {} for Imperial'.format(CONF_UNIT_SYSTEM_METRIC,
                                              CONF_UNIT_SYSTEM_IMPERIAL)),


### PR DESCRIPTION
**Description:**
Extend the comment about the unit to use for the altitude above sea level. Docs were [update](https://github.com/home-assistant/home-assistant.github.io/pull/946).

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
