### PR TITLE
Fix logger config validation

### DIFF
--- a/homeassistant/components/logger.py
+++ b/homeassistant/components/logger.py
@@ -27,14 +27,12 @@ LOGSEVERITY = {
 LOGGER_DEFAULT = 'default'
 LOGGER_LOGS = 'logs'
 
-_LOGS_SCHEMA = vol.Schema({
-    cv.string: vol.In(vol.Lower(list(LOGSEVERITY))),
-})
+_VALID_LOG_LEVEL = vol.All(vol.Upper, vol.In(LOGSEVERITY))
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(LOGGER_DEFAULT): vol.In(vol.Lower(list(LOGSEVERITY))),
-        vol.Required(LOGGER_LOGS): _LOGS_SCHEMA,
+        vol.Optional(LOGGER_DEFAULT): _VALID_LOG_LEVEL,
+        vol.Optional(LOGGER_LOGS): vol.Schema({cv.string: _VALID_LOG_LEVEL}),
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -65,19 +63,19 @@ class HomeAssistantLogFilter(logging.Filter):
 
 def setup(hass, config=None):
     """Setup the logger component."""
-    logfilter = dict()
+    logfilter = {}
 
     # Set default log severity
     logfilter[LOGGER_DEFAULT] = LOGSEVERITY['DEBUG']
     if LOGGER_DEFAULT in config.get(DOMAIN):
         logfilter[LOGGER_DEFAULT] = LOGSEVERITY[
-            config.get(DOMAIN)[LOGGER_DEFAULT].upper()
+            config.get(DOMAIN)[LOGGER_DEFAULT]
         ]
 
     # Compute log severity for components
     if LOGGER_LOGS in config.get(DOMAIN):
         for key, value in config.get(DOMAIN)[LOGGER_LOGS].items():
-            config.get(DOMAIN)[LOGGER_LOGS][key] = LOGSEVERITY[value.upper()]
+            config.get(DOMAIN)[LOGGER_LOGS][key] = LOGSEVERITY[value]
 
         logs = OrderedDict(
             sorted(

--- a/tests/components/test_logger.py
+++ b/tests/components/test_logger.py
@@ -2,7 +2,9 @@
 from collections import namedtuple
 import logging
 import unittest
+from unittest.mock import MagicMock
 
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import logger
 
 RECORD = namedtuple('record', ('name', 'levelno'))
@@ -22,7 +24,7 @@ class TestUpdater(unittest.TestCase):
 
     def test_logger_setup(self):
         """Use logger to create a logging filter."""
-        logger.setup(None, self.log_config)
+        setup_component(MagicMock(), logger.DOMAIN, self.log_config)
 
         self.assertTrue(len(logging.root.handlers) > 0)
         handler = logging.root.handlers[-1]
@@ -35,7 +37,7 @@ class TestUpdater(unittest.TestCase):
 
     def test_logger_test_filters(self):
         """Test resulting filter operation."""
-        logger.setup(None, self.log_config)
+        setup_component(MagicMock(), logger.DOMAIN, self.log_config)
 
         log_filter = logging.root.handlers[-1].filters[0]
 


### PR DESCRIPTION
**Description:**
We accidentally changed the config requirements for the logger component. Thanks to @tylerstraub for reporting it in https://github.com/home-assistant/home-assistant/pull/3375#issuecomment-248161776

**Related issue (if applicable):** fixes #3375

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
