### PR TITLE
Add new component for licence plates processing (OpenAlpr)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -206,6 +206,7 @@ omit =
     homeassistant/components/notify/twitter.py
     homeassistant/components/notify/xmpp.py
     homeassistant/components/nuimo_controller.py
+    homeassistant/components/openalpr.py
     homeassistant/components/scene/hunterdouglas_powerview.py
     homeassistant/components/sensor/arest.py
     homeassistant/components/sensor/bitcoin.py

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -61,7 +61,7 @@ CONF_REGION = 'region'
 CONF_RUNTIME = 'runtime'
 CONF_INTERVAL = 'interval'
 CONF_ENTITIES = 'entities'
-CONF_CONFIDENCE = 'CONF_CONFIDENCE'
+CONF_CONFIDENCE = 'confidence'
 
 DEFAULT_NAME = 'OpenAlpr'
 DEFAULT_ENGINE = ENGINE_LOCAL
@@ -405,7 +405,7 @@ class OpenalprDeviceImage(OpenalprDevice):
 class OpenalprApi(object):
     """OpenAlpr api class."""
 
-    def __init__(region, confidence):
+    def __init__(self, region, confidence):
         """Init basic api processing."""
         self._region = region
         self._confidence = confidence

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -25,8 +25,8 @@ from homeassistant.helpers.entity_component import EntityComponent
 DOMAIN = 'openalpr'
 DEPENDENCIES = ['ffmpeg']
 REQUIREMENTS = [
-    'https://github.com/pvizeli/cloudapi/archive/1.0.1.zip'
-    '#cloud_api==1.0.1']
+    'https://github.com/pvizeli/cloudapi/releases/download/1.0.1/'
+    'python-1.0.1.zip#cloud_api==1.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -401,7 +401,7 @@ class OpenalprApiCloud(OpenalprApi):
             self._api_key,
             'plate',
             image="",
-            image_bytes=b64encode(image),
+            image_bytes=str(b64encode(image), 'utf-8'),
             country=self._region
         )
 

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -1,0 +1,395 @@
+"""
+Component that will help set the openalpr for video streams.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/openalpr/
+"""
+from base64 import b64encode
+import logging
+import os
+from time import time
+
+import requests
+import voluptuous as vol
+
+from homeassistant.config import load_yaml_config_file
+from homeassistant.const import (
+    CONF_API_KEY, CONF_NAME, CONF_USERNAME, CONF_PASSWORD, ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_STOP)
+from homeassistant.components.ffmpeg import (
+    get_binary, run_test, CONF_INPUT, CONF_EXTRA_ARGUMENTS)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+
+DOMAIN = 'openalpr'
+DEPENDENCIES = ['ffmpeg']
+REQUIREMENTS = [
+    'git+https://github.com/pvizeli/cloudapi.git'
+    '#egg=openalpr_api&subdirectory=python']
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_SCAN = 'scan'
+SERVICE_RESTART = 'restart'
+
+EVENT_FOUND = 'openalpr.found'
+
+ATTR_PLATE = 'plate'
+
+
+ENGINE_LOCAL = 'local'
+ENGINE_CLOUD = 'cloud'
+
+RENDER_IMAGE = 'image'
+RENDER_FFMPEG = 'ffmpeg'
+
+OPENALPR_REGIONS = [
+    'us',
+    'eu',
+    'au',
+    'auwide',
+    'gb',
+    'kr',
+    'mx',
+    'sg',
+]
+
+CONF_RENDER = 'render'
+CONF_ENGINE = 'engine'
+CONF_REGION = 'region'
+CONF_RUNTIME = 'runtime'
+CONF_INTERVAL = 'interval'
+CONF_ENTITIES = 'entities'
+
+DEFAULT_NAME = 'OpenAlpr'
+DEFAULT_ENGINE = ENGINE_LOCAL
+DEFAULT_RENDER = RENDER_FFMPEG
+DEFAULT_INTERVAL = 2
+
+DEVICE_SCHEMA = vol.Schema({
+    vol.Required(CONF_INPUT): cv.string,
+    vol.Optional(CONF_INTERVAL, default=DEFAULT_INTERVAL): cv.positive_int,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_RENDER, default=DEFAULT_RENDER):
+        vol.In([RENDER_IMAGE, RENDER_FFMPEG]),
+    vol.Optional(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_RUNTIME): vol.IsDir,
+    vol.Optional(CONF_EXTRA_ARGUMENTS): cv.string,
+    vol.Optional(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_PASSWORD): cv.string,
+})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_ENGINE): vol.In([ENGINE_LOCAL, ENGINE_CLOUD]),
+        vol.Required(CONF_REGION): vol.In(OPENALPR_REGIONS),
+        vol.Required(CONF_ENTITIES): vol.All(cv.ensure_list, [DEVICE_SCHEMA]),
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+SERVICE_RESTART_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+})
+
+SERVICE_SCAN_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+})
+
+
+def scan(hass, entity_id=None):
+    """Scan a image immediately."""
+    data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
+    hass.services.call(DOMAIN, SERVICE_SCAN, data)
+
+
+def restart(hass, entity_id=None):
+    """Restart a ffmpeg process."""
+    data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
+    hass.services.call(DOMAIN, SERVICE_RESTART, data)
+
+
+def setup(hass, config):
+    """Setup the OpenAlpr component."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+    openalpr_device = []
+
+    descriptions = load_yaml_config_file(
+        os.path.join(os.path.dirname(__file__), 'services.yaml'))
+
+    engine = config[DOMAIN].get(CONF_ENGINE)
+    region = config[DOMAIN].get(CONF_REGION)
+    use_render_fffmpeg = False
+    for device in config[DOMAIN].get(CONF_ENTITIES):
+        input_source = device.get(CONF_INPUT)
+        render = device.get(CONF_RENDER)
+
+        # if render ffmpeg, test input
+        if render == RENDER_FFMPEG:
+            use_render_fffmpeg = True
+            if not run_test(input_source):
+                _LOGGER.error("'%s' is not valid ffmpeg input", input_source)
+                continue
+
+        # if local openalpr engine, check if exists
+        if engine == ENGINE_LOCAL:
+            try:
+                # pylint: disable=unused-variable
+                from openalpr import Alpr # NOQA
+            except ImportError:
+                _LOGGER.error("Local openalpr instalation not exists")
+                continue
+
+            alpr_dev = OpenalprDeviceLocal(
+                name=device.get(CONF_NAME),
+                render=render,
+                interval=device.get(CONF_INTERVAL),
+                input_source=input_source,
+                runtime=device.get(CONF_RUNTIME),
+                region=region,
+                extra_arguments=device.get(CONF_EXTRA_ARGUMENTS),
+                username=device.get(CONF_USERNAME),
+                password=device.get(CONF_PASSWORD),
+            )
+
+        else:
+            alpr_dev = OpenalprDeviceCloud(
+                name=device.get(CONF_NAME),
+                render=render,
+                interval=device.get(CONF_INTERVAL),
+                input_source=input_source,
+                api_key=device.get(CONF_RUNTIME),
+                region=region,
+                extra_arguments=device.get(CONF_EXTRA_ARGUMENTS),
+                username=device.get(CONF_USERNAME),
+                password=device.get(CONF_PASSWORD),
+            )
+
+        # register shutdown event
+        openalpr_device.append(alpr_dev)
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, alpr_dev.shutdown)
+
+    component.add_entities(openalpr_device)
+
+    def _handle_service_scan(service):
+        """Handle service for immediately scan."""
+        device_list = component.extract_from_service(service)
+
+        for device in device_list:
+            device.scan()
+
+    hass.services.register(DOMAIN, SERVICE_SCAN,
+                           _handle_service_scan,
+                           descriptions[DOMAIN][SERVICE_SCAN],
+                           schema=SERVICE_SCAN_SCHEMA)
+
+    # Add restart service only if a device use ffmpeg as render
+    if not use_render_fffmpeg:
+        return True
+
+    def _handle_service_restart(service):
+        """Handle service for restart ffmpeg process."""
+        device_list = component.extract_from_service(service)
+
+        for device in device_list:
+            device.restart()
+
+    hass.services.register(DOMAIN, SERVICE_RESTART,
+                           _handle_service_restart,
+                           descriptions[DOMAIN][SERVICE_RESTART],
+                           schema=SERVICE_RESTART_SCHEMA)
+
+    return True
+
+
+# pylint: disable=too-many-instance-attributes
+class OpenalprDevice(Entity):
+    """Represent a openalpr device object for processing stream/images."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, name, render, interval, input_source,
+                 extra_arguments=None, username=None, password=None):
+        """Init image processing."""
+        from haffmpeg import ImageStream
+
+        self._name = name
+        self._render = render
+        self._interval = interval
+        self._last = set()
+
+        # generade input source
+        if self._render == RENDER_FFMPEG:
+            self._ffmpeg = ImageStream(get_binary(), self._process_image)
+            self._input_source = input_source
+            self._extra_arguments = extra_arguments
+            self._start_ffmpeg()
+        else:
+            self._ffmpeg = None
+            self._next = time()
+            self._username = username
+            self._password = password
+            self._url = input_source
+
+    def shutdown(self, event):
+        """Close ffmpeg stream."""
+        if self._render == RENDER_FFMPEG:
+            self._ffmpeg.close()
+
+    def restart(self):
+        """Restart ffmpeg stream."""
+        if self._render == RENDER_FFMPEG:
+            self._ffmpeg.close()
+            self._start_ffmpeg()
+
+    def _process_image(self, image):
+        """Callback for processing image."""
+        raise NotImplementedError
+
+    def _process_event(self, plates):
+        """Send event with new plates."""
+        new_plates = plates - self._last
+
+        # send events
+        for i_plate in new_plates:
+            self.hass.buss.fire(EVENT_FOUND, {
+                ATTR_PLATE: i_plate,
+                ATTR_ENTITY_ID: self.entity_id
+            })
+        self._last = plates.copy()
+
+    def scan(self):
+        """Immediately scan a image."""
+        if self._render == RENDER_FFMPEG:
+            self._ffmpeg.push_image()
+        else:
+            self._next = time()
+            self.update()
+
+    def _start_ffmpeg(self):
+        """Start a ffmpeg image stream."""
+        from haffmpeg import IMAGE_PNG
+
+        if self._render == RENDER_FFMPEG:
+            self._ffmpeg.open_stream(
+                input_source=self._input_source,
+                interval=self._interval,
+                output_format=IMAGE_PNG,
+                extra_cmd=self._extra_arguments,
+            )
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return self._name
+
+    @property
+    def hidden(self):
+        """Return True if the entity should be hidden from UIs."""
+        return True
+
+    @property
+    def should_poll(self):
+        """Return True if render is be 'image' or False if 'ffmpeg'."""
+        if self._render == RENDER_IMAGE:
+            return True
+        return False
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        if self._render == RENDER_IMAGE:
+            return True
+
+        # ffmpeg process
+        return self._ffmpeg.is_running
+
+    def update(self):
+        """Retrieve latest state."""
+        if self._render != RENDER_IMAGE or self._next > time():
+            return
+
+        # send request
+        if self._username is not None and self._password is not None:
+            req = requests.get(
+                self._url, auth=(self._username, self._password), timeout=15)
+        else:
+            req = requests.get(self._url, timeout=15)
+
+        # process image
+        image = req.content
+        self._next = time() + self._interval
+        self._process_image(image)
+
+
+class OpenalprDeviceCloud(OpenalprDevice):
+    """Use local openalpr library to parse licences plate."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, name, render, interval, input_source, api_key, region,
+                 extra_arguments=None, username=None, password=None):
+        """Init image processing."""
+        import openalpr_api
+
+        self._api = openalpr_api.DefaultApi()
+        self._api_key = api_key
+        self._region = region
+
+        # init render
+        super().__init__(
+            name=name, render=render, interval=interval,
+            input_source=input_source, extra_arguments=extra_arguments,
+            username=username, password=password)
+
+    def _process_image(self, image):
+        """Callback for processing image."""
+        result = self._api.recognize_post(
+            self._api_key,
+            'plate',
+            image="",
+            image_bytes=b64encode(image),
+            country=self._region
+        )
+
+        # process result
+        f_plates = set()
+        # pylint: disable=no-member
+        for object_plate in result.plate.results:
+            f_plates.add(object_plate.plate)
+        self._process_event(f_plates)
+
+
+class OpenalprDeviceLocal(OpenalprDevice):
+    """Use the cloud openalpr api to parse licences plate."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, name, render, interval, input_source, runtime, region,
+                 extra_arguments=None, username=None, password=None):
+        """Init image processing."""
+        # pylint: disable=import-error
+        from openalpr import Alpr
+
+        self._api = Alpr(region, "", runtime)
+
+        # init render
+        super().__init__(
+            name=name, render=render, interval=interval,
+            input_source=input_source, extra_arguments=extra_arguments,
+            username=username, password=password)
+
+    def shutdown(self, event):
+        """Close api stuff."""
+        super().shutdown(event)
+        self._api.unload()
+
+    def _process_image(self, image):
+        """Callback for processing image."""
+        result = self._api.recognize_array(image)
+
+        # process result
+        f_plates = set()
+        for plate in result.get('results'):
+            for candidate in plate.get('candidates'):
+                f_plates.add(candidate.get('plate'))
+                break
+        self._process_event(f_plates)

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -244,7 +244,7 @@ class OpenalprDevice(Entity):
 
     def restart(self):
         """Restart stream."""
-        pass
+        raise NotImplementedError()
 
     def _process_image(self, image):
         """Callback for processing image."""
@@ -280,17 +280,12 @@ class OpenalprDevice(Entity):
 
     def scan(self):
         """Immediately scan a image."""
-        pass
+        raise NotImplementedError()
 
     @property
     def name(self):
         """Return the name of the entity."""
         return self._name
-
-    @property
-    def hidden(self):
-        """Return True if the entity should be hidden from UIs."""
-        return True
 
 
 class OpenalprDeviceFFmpeg(OpenalprDevice):
@@ -361,9 +356,7 @@ class OpenalprDeviceFFmpeg(OpenalprDevice):
     @property
     def available(self):
         """Return True if entity is available."""
-        if self._interval == 0:
-            return True
-        return self._ffmpeg.is_running
+        return self._interval == 0 or self._ffmpeg.is_running:
 
 
 class OpenalprDeviceImage(OpenalprDevice):
@@ -381,7 +374,7 @@ class OpenalprDeviceImage(OpenalprDevice):
         self._url = input_source
 
     def restart(self):
-        """Restart ffmpeg stream."""
+        """Fake restart with scan a picture."""
         self.scan()
 
     def scan(self):
@@ -400,14 +393,7 @@ class OpenalprDeviceImage(OpenalprDevice):
     @property
     def should_poll(self):
         """Return True if render is be 'image' or False if 'ffmpeg'."""
-        if self._interval > 0:
-            return True
-        return False
-
-    @property
-    def available(self):
-        """Return True if entity is available."""
-        return True
+        return self._interval > 0:
 
     def update(self):
         """Retrieve latest state."""
@@ -428,7 +414,7 @@ class OpenalprApi(object):
 
     def process_image(self, image, event_callback):
         """Callback for processing image."""
-        raise NotImplementedError
+        raise NotImplementedError()
 
 
 # pylint: disable=too-few-public-methods

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -90,7 +90,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_CONFIDENCE, default=DEFAULT_CONFIDENCE):
             vol.Coerce(float),
         vol.Optional(CONF_API_KEY): cv.string,
-        vol.Optional(CONF_ALPR_BINARY, default=DEFAULT_BINARY), cv.string,
+        vol.Optional(CONF_ALPR_BINARY, default=DEFAULT_BINARY): cv.string,
         vol.Required(CONF_ENTITIES):
             vol.All(cv.ensure_list, [DEVICE_SCHEMA]),
     })

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -27,7 +27,7 @@ DEPENDENCIES = ['ffmpeg']
 REQUIREMENTS = [
     'https://github.com/pvizeli/cloudapi/releases/download/1.0.2/'
     'python-1.0.2.zip#cloud_api==1.0.2',
-    'ha-alpr==0.1']
+    'ha-alpr==0.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -455,7 +455,7 @@ class OpenalprApiLocal(OpenalprApi):
 
     def process_image(self, image, event_callback):
         """Callback for processing image."""
-        result = yield from self._api.recognize_byte(image)
+        result = self._api.recognize_byte(image)
 
         # process result
         f_plates = {}

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -73,8 +73,6 @@ DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_RENDER, default=DEFAULT_RENDER):
         vol.In([RENDER_IMAGE, RENDER_FFMPEG]),
-    vol.Optional(CONF_API_KEY): cv.string,
-    vol.Optional(CONF_RUNTIME): vol.IsDir,
     vol.Optional(CONF_EXTRA_ARGUMENTS): cv.string,
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
@@ -84,6 +82,8 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_ENGINE): vol.In([ENGINE_LOCAL, ENGINE_CLOUD]),
         vol.Required(CONF_REGION): vol.In(OPENALPR_REGIONS),
+        vol.Optional(CONF_API_KEY): cv.string,
+        vol.Optional(CONF_RUNTIME): vol.IsDir,
         vol.Required(CONF_ENTITIES): vol.All(cv.ensure_list, [DEVICE_SCHEMA]),
     })
 }, extra=vol.ALLOW_EXTRA)
@@ -120,6 +120,8 @@ def setup(hass, config):
 
     engine = config[DOMAIN].get(CONF_ENGINE)
     region = config[DOMAIN].get(CONF_REGION)
+    api_key = config[DOMAIN].get(CONF_API_KEY)
+    runtime = config[DOMAIN].get(CONF_RUNTIME)
     use_render_fffmpeg = False
     for device in config[DOMAIN].get(CONF_ENTITIES):
         input_source = device.get(CONF_INPUT)
@@ -146,7 +148,7 @@ def setup(hass, config):
                 render=render,
                 interval=device.get(CONF_INTERVAL),
                 input_source=input_source,
-                runtime=device.get(CONF_RUNTIME),
+                runtime=runtime,
                 region=region,
                 extra_arguments=device.get(CONF_EXTRA_ARGUMENTS),
                 username=device.get(CONF_USERNAME),
@@ -159,7 +161,7 @@ def setup(hass, config):
                 render=render,
                 interval=device.get(CONF_INTERVAL),
                 input_source=input_source,
-                api_key=device.get(CONF_RUNTIME),
+                api_key=api_key,
                 region=region,
                 extra_arguments=device.get(CONF_EXTRA_ARGUMENTS),
                 username=device.get(CONF_USERNAME),

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -455,7 +455,7 @@ class OpenalprApiLocal(OpenalprApi):
 
     def process_image(self, image, event_callback):
         """Callback for processing image."""
-        result = yield from self._api.recognize(image)
+        result = yield from self._api.recognize_byte(image)
 
         # process result
         f_plates = {}

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -110,6 +110,7 @@ def restart(hass, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_RESTART, data)
 
 
+# pylint: disable=too-many-locals
 def setup(hass, config):
     """Setup the OpenAlpr component."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -136,7 +136,7 @@ def setup(hass, config):
         if engine == ENGINE_LOCAL:
             try:
                 # pylint: disable=unused-variable
-                from openalpr import Alpr # NOQA
+                from openalpr import Alpr  # NOQA
             except ImportError:
                 _LOGGER.error("Local openalpr instalation not exists")
                 continue

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -275,7 +275,7 @@ class OpenalprDevice(Entity):
 
         # send events
         for i_plate in new_plates:
-            self.hass.buss.fire(EVENT_FOUND, {
+            self.hass.bus.fire(EVENT_FOUND, {
                 ATTR_PLATE: i_plate,
                 ATTR_ENTITY_ID: self.entity_id
             })
@@ -443,7 +443,7 @@ class OpenalprApiCloud(OpenalprApi):
             self._api_key,
             'plate',
             image="",
-            image_bytes=b64encode(image),
+            image_bytes=str(b64encode(image), 'utf-8'),
             country=self._region
         )
 

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -165,7 +165,7 @@ def setup(hass, config):
                 _LOGGER.error("'%s' is not valid ffmpeg input", input_source)
                 continue
 
-            alp_dev = OpenalprDeviceFFmpeg(
+            alpr_dev = OpenalprDeviceFFmpeg(
                 name=device.get(CONF_NAME),
                 interval=device.get(CONF_INTERVAL),
                 api=alpr_api,
@@ -173,7 +173,7 @@ def setup(hass, config):
                 extra_arguments=device.get(CONF_EXTRA_ARGUMENTS),
             )
         else:
-            alp_dev = OpenalprDeviceImage(
+            alpr_dev = OpenalprDeviceImage(
                 name=device.get(CONF_NAME),
                 interval=device.get(CONF_INTERVAL),
                 api=alpr_api,
@@ -272,7 +272,7 @@ class OpenalprDevice(Entity):
         return True
 
 
-class OpenalprDeviceFFmpeg(Entity):
+class OpenalprDeviceFFmpeg(OpenalprDevice):
     """Represent a openalpr device object for processing stream/images."""
 
     # pylint: disable=too-many-arguments
@@ -323,7 +323,7 @@ class OpenalprDeviceFFmpeg(Entity):
         return self._ffmpeg.is_running
 
 
-class OpenalprDeviceImage(Entity):
+class OpenalprDeviceImage(OpenalprDevice):
     """Represent a openalpr device object for processing stream/images."""
 
     # pylint: disable=too-many-arguments
@@ -374,6 +374,7 @@ class OpenalprDeviceImage(Entity):
         self._process_image(image)
 
 
+# pylint: disable=too-few-public-methods
 class OpenalprApi(object):
     """OpenAlpr api class."""
 
@@ -382,6 +383,7 @@ class OpenalprApi(object):
         raise NotImplementedError
 
 
+# pylint: disable=too-few-public-methods
 class OpenalprApiCloud(OpenalprApi):
     """Use local openalpr library to parse licences plate."""
 

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -393,7 +393,7 @@ class OpenalprDeviceImage(OpenalprDevice):
     @property
     def should_poll(self):
         """Return True if render is be 'image' or False if 'ffmpeg'."""
-        return self._interval > 0:
+        return self._interval > 0
 
     def update(self):
         """Retrieve latest state."""

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -356,7 +356,7 @@ class OpenalprDeviceFFmpeg(OpenalprDevice):
     @property
     def available(self):
         """Return True if entity is available."""
-        return self._interval == 0 or self._ffmpeg.is_running:
+        return self._interval == 0 or self._ffmpeg.is_running
 
 
 class OpenalprDeviceImage(OpenalprDevice):

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -82,6 +82,7 @@ def check_api(engine):
     try:
         # pylint: disable=unused-variable
         from openalpr import Alpr  # NOQA
+        return engine
     except ImportError:
         raise vol.Invalid("Local openalpr instalation not exists")
 

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -4,7 +4,6 @@ Component that will help set the openalpr for video streams.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/openalpr/
 """
-import asyncio
 from base64 import b64encode
 import logging
 import os

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -374,7 +374,7 @@ class OpenalprDeviceImage(Entity):
         self._process_image(image)
 
 
-class OpenalprApi(Object):
+class OpenalprApi(object):
     """OpenAlpr api class."""
 
     def process_image(self, image, event_callback):

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -90,6 +90,18 @@ homematic:
         description: New value
         example: 1
 
+openalpr:
+  scan:
+    description: Scan immediately a device.
+
+    fields:
+      entity_id:
+        description: Name(s) of entities to scan
+        example: 'openalpr.garage'
+
+  restart:
+    description: Restart ffmpeg process of device.
+
 zwave:
   add_node:
     description: Add a new node to the zwave network. Refer to OZW.log for details.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -188,7 +188,7 @@ https://github.com/nkgilley/python-ecobee-api/archive/4856a704670c53afe1882178a8
 https://github.com/nkgilley/python-join-api/archive/3e1e849f1af0b4080f551b62270c6d244d5fbcbd.zip#python-join-api==0.0.1
 
 # homeassistant.components.openalpr
-https://github.com/pvizeli/cloudapi/archive/1.0.1.zip#cloud_api==1.0.1
+https://github.com/pvizeli/cloudapi/releases/download/1.0.1/python-1.0.1.zip#cloud_api==1.0.1
 
 # homeassistant.components.switch.edimax
 https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f3700.zip#pyedimax==0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -117,6 +117,9 @@ googlemaps==2.4.4
 # homeassistant.components.sensor.gpsd
 gps3==0.33.3
 
+# homeassistant.components.openalpr
+ha-alpr==0.1
+
 # homeassistant.components.ffmpeg
 ha-ffmpeg==0.13
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -118,7 +118,7 @@ googlemaps==2.4.4
 gps3==0.33.3
 
 # homeassistant.components.openalpr
-ha-alpr==0.1
+ha-alpr==0.2
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==0.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -108,9 +108,6 @@ fuzzywuzzy==0.11.1
 # homeassistant.components.device_tracker.bluetooth_le_tracker
 # gattlib==0.20150805
 
-# homeassistant.components.openalpr
-git+https://github.com/pvizeli/cloudapi.git#egg=openalpr_api&subdirectory=python
-
 # homeassistant.components.notify.gntp
 gntp==1.0.3
 
@@ -189,6 +186,9 @@ https://github.com/nkgilley/python-ecobee-api/archive/4856a704670c53afe1882178a8
 # homeassistant.components.joaoapps_join
 # homeassistant.components.notify.joaoapps_join
 https://github.com/nkgilley/python-join-api/archive/3e1e849f1af0b4080f551b62270c6d244d5fbcbd.zip#python-join-api==0.0.1
+
+# homeassistant.components.openalpr
+https://github.com/pvizeli/cloudapi/archive/1.0.1.zip#cloud_api==1.0.1
 
 # homeassistant.components.switch.edimax
 https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f3700.zip#pyedimax==0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -188,7 +188,7 @@ https://github.com/nkgilley/python-ecobee-api/archive/4856a704670c53afe1882178a8
 https://github.com/nkgilley/python-join-api/archive/3e1e849f1af0b4080f551b62270c6d244d5fbcbd.zip#python-join-api==0.0.1
 
 # homeassistant.components.openalpr
-https://github.com/pvizeli/cloudapi/releases/download/1.0.1/python-1.0.1.zip#cloud_api==1.0.1
+https://github.com/pvizeli/cloudapi/releases/download/1.0.2/python-1.0.2.zip#cloud_api==1.0.2
 
 # homeassistant.components.switch.edimax
 https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f3700.zip#pyedimax==0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -108,6 +108,9 @@ fuzzywuzzy==0.11.1
 # homeassistant.components.device_tracker.bluetooth_le_tracker
 # gattlib==0.20150805
 
+# homeassistant.components.openalpr
+git+https://github.com/pvizeli/cloudapi.git#egg=openalpr_api&subdirectory=python
+
 # homeassistant.components.notify.gntp
 gntp==1.0.3
 


### PR DESCRIPTION
I need tester for helping to finisch this component. Please don't add stack trace or some things from testing on this PR. That could make this PR confuse. Please use Gitter for that @pvizeli.

Test and work correct:
[x] cloud api
[x] local api

**Description:**
Scan licence plates from a image or video stream. It is passed on OpenAlpr and support local installation or the cloud api to process image data. For video streams it is requered to have ffmpeg.

If it detect a new licence plate it send a event to Home-Assistant. This allow to do some things if you drive by on your outdor camera to open your garage or other stuff.

Not all camera have a high quallity video stream it could be that a still image from camera with a low video Bitrate stream are better.

If is interval equal 0, it don't poll anymore. It only scan a picture/stream with Service `openalpr.scan`.

For local api, it need the command line tool 'alpr' in the system path. Local API Installation instruction: https://github.com/openalpr/openalpr/wiki
On Debian I use follow cmake Option for build:

```
cmake -DWITH_TEST=FALSE -DWITH_BINDING_JAVA=FALSE --DWITH_BINDING_PYTHON=FALSE --DWITH_BINDING_GO=FALSE -DWITH_DAEMON=FALSE -DCMAKE_INSTALL_PREFIX:PATH=/usr
```

Event

``` yaml
trigger:
  platform: event
  Event_type: openalpr.found
  Event_data:
    entity_id: openalpr.camera_garage_1
    plate: BE2183423
...
```

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#975 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
openalpr:
  engine: local # local or cloud
  region: eu
  confidence: 80.0
  api_key: JKDJW3423423KJKDD # for cloud api
  alpr_binary: alpr # for local api
  entities:
    - name: Camera garage 1
      interval: 5 # second
      render: ffmpeg
      input: INPUT_STREAM
      extra_arguments: SOME OTHER FFMPEG STUFF
    - name: Camera Garage 2
      interval: 5 # second
      render: image # still image!
      input: https://camera_ip/still_image.jpg
      username: admin
      password: bla
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
