### PR TITLE
Add additional state fields to influx

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -112,6 +112,10 @@ def setup(hass, config):
             }
         ]
 
+        for key, value in state.attributes.items():
+            if key != 'unit_of_measurement':
+                json_body[0]['fields'][key] = value
+
         json_body[0]['tags'].update(tags)
 
         try:

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -101,7 +101,11 @@ class TestInfluxDB(unittest.TestCase):
                  STATE_OFF: 0,
                  'foo': 'foo'}
         for in_, out in valid.items():
-            attrs = {'unit_of_measurement': 'foobars'}
+            attrs = {
+                        'unit_of_measurement': 'foobars',
+                        'longitude': '1.1',
+                        'latitude': '2.2'
+                    }
             state = mock.MagicMock(state=in_,
                                    domain='fake',
                                    object_id='entity',
@@ -117,6 +121,8 @@ class TestInfluxDB(unittest.TestCase):
                 'time': 12345,
                 'fields': {
                     'value': out,
+                    'longitude': '1.1',
+                    'latitude': '2.2'
                 },
             }]
             self.handler_method(event)


### PR DESCRIPTION
**Description:**

Add additional state fields for events to InfluxDB

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
