### PR TITLE
Add current_cover_position support to wink covers

### DIFF
--- a/homeassistant/components/cover/wink.py
+++ b/homeassistant/components/cover/wink.py
@@ -46,3 +46,8 @@ class WinkCoverDevice(WinkDevice, CoverDevice):
             return False
         else:
             return None
+
+    @property
+    def current_cover_position(self):
+        """Return current position of cover."""
+        return 0 if self.is_closed else 100


### PR DESCRIPTION
**Description:**
Adds the property "current_cover_postion" to wink covers.

This allows the state icon to chanage along with the control button/icons based on open or close.

Add current_cover_postion property to be defined so that icon state changes along with open and close buttons/controls
