### PR TITLE
Allow pairing Hue emulator with Harmony Hub

### DIFF
--- a/homeassistant/components/emulated_hue.py
+++ b/homeassistant/components/emulated_hue.py
@@ -191,6 +191,7 @@ class HueUsernameView(HomeAssistantView):
 
     url = '/api'
     name = 'hue:api'
+    extra_urls = ['/api/']
     requires_auth = False
 
     def __init__(self, hass):


### PR DESCRIPTION
**Description:**
The real Hue hub responds to both `/api` and `/api/`. For greater
compatibility, the view now responds to both using `extra_urls`.

Specifically, this allows Harmony to pair with the emulated Hue
bridge.

**Related issue (if applicable):** fixes #3296 

**Checklist:**
If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
