### PR TITLE
UOM is a list - not a string.

### DIFF
--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -35,7 +35,7 @@ def setup_platform(hass, config: ConfigType,
 
     for node in isy.filter_nodes(isy.NODES, units=UOM,
                                  states=STATES):
-        if node.dimmable or node.uom == '51':
+        if node.dimmable or '51' in node.uom:
             devices.append(ISYLightDevice(node))
 
     add_devices(devices)


### PR DESCRIPTION
**Description:**
`node.uom` is a list, not a string.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/pull/3457#issuecomment-248512526

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
