### PR TITLE
Stop other sensors from failing if printer not connected to Octoprint server

### DIFF
--- a/homeassistant/components/octoprint.py
+++ b/homeassistant/components/octoprint.py
@@ -40,9 +40,9 @@ def setup(hass, config):
         OCTOPRINT = OctoPrintAPI(base_url, api_key)
         OCTOPRINT.get('printer')
         OCTOPRINT.get('job')
-    except requests.exceptions.RequestException as conn_err:
-        _LOGGER.error("Error setting up OctoPrint API: %r", conn_err)
-        return False
+    except (requests.exceptions.HTTPError,
+            requests.exceptions.ConnectionError) as conn_exc:
+        _LOGGER.error("Error setting up OctoPrint API: %r", conn_exc)
 
     for component, discovery_service in (
             ('sensor', DISCOVER_SENSORS),
@@ -95,7 +95,8 @@ class OctoPrintAPI(object):
                 self.printer_last_reading[0] = response.json()
                 self.printer_last_reading[1] = time.time()
             return response.json()
-        except requests.exceptions.ConnectionError as conn_exc:
+        except (requests.exceptions.HTTPError,
+                requests.exceptions.ConnectionError) as conn_exc:
             _LOGGER.error("Failed to update OctoPrint status.  Error: %s",
                           conn_exc)
             raise


### PR DESCRIPTION
**Description:**
The main octoprint component was returning False during setup if the initial call to the octoprint API was bad. This was causing the octoprint sensors to not load, but also caused all other sensors to fail as well. This change just logs that the attempt was bad, and still returns True after setup. In this case the octoprint sensors will not load, but it wont block other sensors from loading.

@Diaoul If you can, could you check this please?

**Related issue (if applicable):** fixes #2722 

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
