### PR TITLE
Fix nmap config

### DIFF
--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -30,7 +30,7 @@ CONF_EXCLUDE = 'exclude'
 REQUIREMENTS = ['python-nmap==0.6.1']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOSTS): vol.All(cv.ensure_list, [cv.string]),
+    vol.Required(CONF_HOSTS): cv.string,
     vol.Required(CONF_HOME_INTERVAL, default=0): cv.positive_int,
     vol.Optional(CONF_EXCLUDE, default=[]):
         vol.All(cv.ensure_list, vol.Length(min=1))


### PR DESCRIPTION
**Description:**
Fix NMAP voluptuous issue reported by @Bart274 in #3481.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
device_tracker:
  platform: nmap_tracker
  hosts: 192.168.1.1/24
  home_interval: 10
```
