### PR TITLE
Use voluptuous for aREST

### DIFF
--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -1,5 +1,5 @@
 """
-The arest sensor will consume an exposed aREST API of a device.
+Support for an exposed aREST RESTful API of a device.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.arest/
@@ -8,30 +8,48 @@ import logging
 from datetime import timedelta
 
 import requests
+import voluptuous as vol
 
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE, DEVICE_DEFAULT_NAME,
-    CONF_RESOURCE, CONF_MONITORED_VARIABLES)
+    CONF_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE, CONF_RESOURCE,
+    CONF_MONITORED_VARIABLES, CONF_NAME, STATE_UNKNOWN)
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers import template
 from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
+
+CONF_FUNCTIONS = 'functions'
+CONF_PINS = 'pins'
+
+DEFAULT_NAME = 'aREST sensor'
+
+PIN_VARIABLE_SCHEMA = vol.Schema({
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+    vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_RESOURCE): cv.url,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PINS, default={}):
+        vol.Schema({cv.string: PIN_VARIABLE_SCHEMA}),
+    vol.Optional(CONF_MONITORED_VARIABLES, default={}):
+        vol.Schema({cv.string: PIN_VARIABLE_SCHEMA}),
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the aREST sensor."""
     resource = config.get(CONF_RESOURCE)
     var_conf = config.get(CONF_MONITORED_VARIABLES)
-    pins = config.get('pins', None)
-
-    if resource is None:
-        _LOGGER.error('Not all required config keys present: %s',
-                      CONF_RESOURCE)
-        return False
+    pins = config.get(CONF_PINS)
 
     try:
         response = requests.get(resource, timeout=10).json()
@@ -65,32 +83,26 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if var_conf is not None:
         for variable in var_conf:
-            if variable['name'] not in response['variables']:
+            if variable[CONF_NAME] not in response['variables']:
                 _LOGGER.error('Variable: "%s" does not exist',
-                              variable['name'])
+                              variable[CONF_NAME])
                 continue
 
             renderer = make_renderer(variable.get(CONF_VALUE_TEMPLATE))
-            dev.append(ArestSensor(arest,
-                                   resource,
-                                   config.get('name', response['name']),
-                                   variable['name'],
-                                   variable=variable['name'],
-                                   unit_of_measurement=variable.get(
-                                       ATTR_UNIT_OF_MEASUREMENT),
-                                   renderer=renderer))
+            dev.append(ArestSensor(
+                arest, resource, config.get(CONF_NAME, response[CONF_NAME]),
+                variable[CONF_NAME], variable=variable[CONF_NAME],
+                unit_of_measurement=variable.get(CONF_UNIT_OF_MEASUREMENT),
+                renderer=renderer))
 
     if pins is not None:
         for pinnum, pin in pins.items():
             renderer = make_renderer(pin.get(CONF_VALUE_TEMPLATE))
-            dev.append(ArestSensor(ArestData(resource, pinnum),
-                                   resource,
-                                   config.get('name', response['name']),
-                                   pin.get('name'),
-                                   pin=pinnum,
-                                   unit_of_measurement=pin.get(
-                                       ATTR_UNIT_OF_MEASUREMENT),
-                                   renderer=renderer))
+            dev.append(ArestSensor(
+                ArestData(resource, pinnum), resource,
+                config.get(CONF_NAME, response[CONF_NAME]), pin.get(CONF_NAME),
+                pin=pinnum, unit_of_measurement=pin.get(
+                    CONF_UNIT_OF_MEASUREMENT), renderer=renderer))
 
     add_devices(dev)
 
@@ -104,18 +116,17 @@ class ArestSensor(Entity):
         """Initialize the sensor."""
         self.arest = arest
         self._resource = resource
-        self._name = '{} {}'.format(location.title(), name.title()) \
-                     or DEVICE_DEFAULT_NAME
+        self._name = '{} {}'.format(location.title(), name.title())
         self._variable = variable
         self._pin = pin
-        self._state = 'n/a'
+        self._state = STATE_UNKNOWN
         self._unit_of_measurement = unit_of_measurement
         self._renderer = renderer
         self.update()
 
         if self._pin is not None:
-            request = requests.get('{}/mode/{}/i'.format
-                                   (self._resource, self._pin), timeout=10)
+            request = requests.get(
+                '{}/mode/{}/i'.format(self._resource, self._pin), timeout=10)
             if request.status_code is not 200:
                 _LOGGER.error("Can't set mode. Is device offline?")
 
@@ -137,9 +148,8 @@ class ArestSensor(Entity):
         if 'error' in values:
             return values['error']
 
-        value = self._renderer(values.get('value',
-                                          values.get(self._variable,
-                                                     'N/A')))
+        value = self._renderer(
+            values.get('value', values.get(self._variable, STATE_UNKNOWN)))
         return value
 
     def update(self):


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: arest
  resource: http://IP_ADDRESS
  name: Office
  monitored_variables:
    temperature:
      name: temperature
      unit_of_measurement: '°C'
      value_template: '{{ value | round(1) }}'
   humidity:
      name: humidity
      unit_of_measurement: '%'
  pins:
    A0:
      name: Pin 0 analog
      unit_of_measurement: "ca"
      value_template: '{{ value_json.light }}'
    3:
      name: Pin 3 digital
```
