### PR TITLE
Try to fix Segfaults

### DIFF
--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -80,7 +80,7 @@ class BinarySensorTemplate(BinarySensorDevice):
 
         def template_bsensor_state_listener(entity, old_state, new_state):
             """Called when the target device changes state."""
-            self.update_ha_state(True)
+            self.update_ha_state(soft_update=True)
 
         track_state_change(hass, entity_ids, template_bsensor_state_listener)
 

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -78,7 +78,7 @@ class SensorTemplate(Entity):
 
         def template_sensor_state_listener(entity, old_state, new_state):
             """Called when the target device changes state."""
-            self.update_ha_state(True)
+            self.update_ha_state(soft_update=True)
 
         track_state_change(hass, entity_ids, template_sensor_state_listener)
 

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -88,7 +88,7 @@ class SwitchTemplate(SwitchDevice):
 
         def template_switch_state_listener(entity, old_state, new_state):
             """Called when the target device changes state."""
-            self.update_ha_state(True)
+            self.update_ha_state(soft_update=True)
 
         track_state_change(hass, entity_ids, template_switch_state_listener)
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -138,10 +138,11 @@ class Entity(object):
 
     hass = None  # type: Optional[HomeAssistant]
 
-    def update_ha_state(self, force_refresh=False):
+    def update_ha_state(self, force_refresh=False, soft_update=False):
         """Update Home Assistant with current state of entity.
 
         If force_refresh == True will update entity before setting state.
+        If soft_update == True will update entitiy but not force StateMachine
         """
         if self.hass is None:
             raise RuntimeError("Attribute hass is None for {}".format(self))
@@ -150,7 +151,7 @@ class Entity(object):
             raise NoEntitySpecifiedError(
                 "No entity id specified for entity {}".format(self.name))
 
-        if force_refresh:
+        if force_refresh or soft_update:
             self.update()
 
         state = STATE_UNKNOWN if self.state is None else str(self.state)


### PR DESCRIPTION
**Description:**

Template sensor run into endless Loop while it use `force_update` in a state_change callback (with MATCH_ALL):
https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/sensor/template.py#L27
https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/sensor/template.py#L81
That Trigger this in StateMachine:
https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/core.py#L776-L781
We create now a new STATE_CHANGE event and they will trigger a new force_update on entities which will create a new STATE_CHANGE event ect.

**Related issue (if applicable):** fixes #3453 
