### PR TITLE
Wink oAuth and relay sensors

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -20,7 +20,8 @@ SENSOR_TYPES = {
     "vibration": "vibration",
     "loudness": "sound",
     "liquid_detected": "moisture",
-    "motion": "motion"
+    "motion": "motion",
+    "presence": "occupancy"
 }
 
 
@@ -58,17 +59,21 @@ class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
     def is_on(self):
         """Return true if the binary sensor is on."""
         if self.capability == "loudness":
-            return self.wink.loudness_boolean()
+            state = self.wink.loudness_boolean()
         elif self.capability == "vibration":
-            return self.wink.vibration_boolean()
+            state = self.wink.vibration_boolean()
         elif self.capability == "brightness":
-            return self.wink.brightness_boolean()
+            state = self.wink.brightness_boolean()
         elif self.capability == "liquid_detected":
-            return self.wink.liquid_boolean()
+            state = self.wink.liquid_boolean()
         elif self.capability == "motion":
-            return self.wink.motion_boolean()
+            state = self.wink.motion_boolean()
+        elif self.capability == "presence":
+            state = self.wink.presence_boolean()
         else:
-            return self.wink.state()
+            state = self.wink.state()
+
+        return state
 
     @property
     def sensor_class(self):

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -14,7 +14,7 @@ from homeassistant.loader import get_component
 
 DEPENDENCIES = ['wink']
 
-SENSOR_TYPES = ['temperature', 'humidity', 'balance']
+SENSOR_TYPES = ['temperature', 'humidity', 'balance', 'proximity']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -58,6 +58,8 @@ class WinkSensorDevice(WinkDevice, Entity):
             return round(self.wink.temperature_float(), 1)
         elif self.capability == "balance":
             return round(self.wink.balance() / 100, 2)
+        elif self.capability == "proximity":
+            return self.wink.proximity_float()
         else:
             return STATE_OPEN if self.is_open else STATE_CLOSED
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -393,7 +393,7 @@ python-telegram-bot==5.1.0
 python-twitch==1.3.0
 
 # homeassistant.components.wink
-python-wink==0.7.15
+python-wink==0.8.0
 
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11


### PR DESCRIPTION
**Description:**
Currently we are using tokens obtained from home-assistant.io this works, but after some time that token expires and you have to get another one. With these changes you will be able to provide your Wink username and password, along with client_id and client_secret to create a new token at each start of home-assistant. To obtain a client_id and client_secret you will need to contact Wink support. 

This also adds support for Wink relay sensor these will require a config change to access however. Wink is only sending back these values if a specific user-agent is provided in the API call. See example below on how to set this user-agent.

These changes are all optional and everyones config should continue to work with their current access_tokens.

You can't have both access_token, and oath2 credentials in the config at the same time! 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io# https://github.com/home-assistant/home-assistant.github.io/pull/980

**Example entry for `configuration.yaml` (if applicable):**
For oath2 support with relay sensor support

``` yaml
wink:
  email: email
  password: password
  client_id: 12345
  client_secret: 12345
  user_agent: Manufacturer/python-wink WinkAndroid/4
```

For relay support without oath2

``` yaml
wink:
  user_agent: Manufacturer/python-wink WinkAndroid/4
  access_token: 12345
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [X] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
