### PR TITLE
Fix mysensors required version for HVAC

### DIFF
--- a/homeassistant/components/climate/mysensors.py
+++ b/homeassistant/components/climate/mysensors.py
@@ -25,6 +25,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if discovery_info is None:
         return
     for gateway in mysensors.GATEWAYS.values():
+        if float(gateway.protocol_version) < 1.5:
+            continue
         pres = gateway.const.Presentation
         set_req = gateway.const.SetReq
         map_sv_types = {


### PR DESCRIPTION
**Description:**
MySensors HVAC requires version 1.5 or higher of MySensors library.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
mysensors:
  gateways:
    - device: '/dev/ttyUSB0'
  version: 1.4
```

**Checklist:**
If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
