### PR TITLE
Fix input_boolean voluptuous Schema

### DIFF
--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -27,12 +27,12 @@ SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
 })
 
-CONFIG_SCHEMA = vol.Schema({
-    cv.slug: {
+CONFIG_SCHEMA = vol.Schema({DOMAIN: {
+    cv.slug: vol.Any({
         vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_INITIAL): cv.boolean,
+        vol.Optional(CONF_INITIAL, default=False): cv.boolean,
         vol.Optional(CONF_ICON): cv.icon,
-    }}, extra=vol.ALLOW_EXTRA)
+    }, None)}}, extra=vol.ALLOW_EXTRA)
 
 
 def is_on(hass, entity_id):


### PR DESCRIPTION
**Description:**
- Did not have {DOMAIN: } in the voluptuous scheama.
- input_boolean can also support no configurtaion

**Related issue (if applicable):** fixes #3498 

``` yaml
input_boolean:
  toggle_me:
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
