### PR TITLE
Change notify target property to be a dictionary

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -112,8 +112,8 @@ def setup(hass, config):
 
         if hasattr(notify_service, 'targets'):
             platform_name = (p_config.get(CONF_NAME) or platform)
-            for target in notify_service.targets:
-                target_name = slugify("{}_{}".format(platform_name, target))
+            for name, target in notify_service.targets.items():
+                target_name = slugify("{}_{}".format(platform_name, name))
                 targets[target_name] = target
                 hass.services.register(DOMAIN, target_name,
                                        service_call_handler,

--- a/homeassistant/components/notify/demo.py
+++ b/homeassistant/components/notify/demo.py
@@ -25,7 +25,7 @@ class DemoNotificationService(BaseNotificationService):
     @property
     def targets(self):
         """Return a dictionary of registered targets."""
-        return ["test target"]
+        return {"test target": "test target"}
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""

--- a/homeassistant/components/notify/demo.py
+++ b/homeassistant/components/notify/demo.py
@@ -25,7 +25,7 @@ class DemoNotificationService(BaseNotificationService):
     @property
     def targets(self):
         """Return a dictionary of registered targets."""
-        return {"test target": "test target"}
+        return {"test target name": "test target id"}
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -314,7 +314,10 @@ class HTML5NotificationService(BaseNotificationService):
     @property
     def targets(self):
         """Return a dictionary of registered targets."""
-        return self.registrations.keys()
+        targets = {}
+        for registration in self.registrations:
+            targets[registration] = registration
+        return targets
 
     # pylint: disable=too-many-locals
     def send_message(self, message="", **kwargs):

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -133,14 +133,14 @@ data_template:
     def test_targets_are_services(self):
         """Test that all targets are exposed as individual services."""
         self.assertIsNotNone(self.hass.services.has_service("notify", "demo"))
-        service = "demo_test_target"
+        service = "demo_test_target_name"
         self.assertIsNotNone(self.hass.services.has_service("notify", service))
 
     def test_messages_to_targets_route(self):
         """Test message routing to specific target services."""
         self.hass.bus.listen_once("notify", self.record_calls)
 
-        self.hass.services.call("notify", "demo_test_target",
+        self.hass.services.call("notify", "demo_test_target_name",
                                 {'message': 'my message',
                                  'title': 'my title',
                                  'data': {'hello': 'world'}})
@@ -151,7 +151,7 @@ data_template:
 
         assert {
             'message': 'my message',
-            'target': 'test target',
+            'target': 'test target id',
             'title': 'my title',
             'data': {'hello': 'world'}
         } == data


### PR DESCRIPTION
**Description:**
A dictionary is needed for platforms which don't use the target name as the target identifier (like the upcoming iOS platform).

**Checklist:**

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
