### PR TITLE
Bump somecomfort to 0.3.2

### DIFF
--- a/homeassistant/components/climate/honeywell.py
+++ b/homeassistant/components/climate/honeywell.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['evohomeclient==0.2.5',
-                'somecomfort==0.2.1']
+                'somecomfort==0.3.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/thermostat/honeywell.py
+++ b/homeassistant/components/thermostat/honeywell.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     CONF_PASSWORD, CONF_USERNAME, TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
 REQUIREMENTS = ['evohomeclient==0.2.5',
-                'somecomfort==0.2.1']
+                'somecomfort==0.3.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -434,7 +434,7 @@ snapcast==1.2.2
 
 # homeassistant.components.climate.honeywell
 # homeassistant.components.thermostat.honeywell
-somecomfort==0.2.1
+somecomfort==0.3.2
 
 # homeassistant.components.sensor.speedtest
 speedtest-cli==0.3.4


### PR DESCRIPTION
**Description:**

Bump the version of somecomfort used by the honeywell components.

**Related issue (if applicable):** fixes #3468

cc: @techwood111

If code communicates with devices, web services, or a:
- [X ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).

This has fixes related to #3468
