### PR TITLE
Allow platform components without config

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -218,9 +218,18 @@ def setup_scanner(hass, config, see):
             lat = wayp[WAYPOINT_LAT_KEY]
             lon = wayp[WAYPOINT_LON_KEY]
             rad = wayp['rad']
+
+            # check zone exists
+            entity_id = zone_comp.ENTITY_ID_FORMAT.format(slugify(pretty_name))
+
+            # Check if state already exists
+            if hass.states.get(entity_id) is not None:
+                continue
+
             zone = zone_comp.Zone(hass, pretty_name, lat, lon, rad,
-                                  zone_comp.ICON_IMPORT, False, True)
-            zone_comp.add_zone(hass, pretty_name, zone)
+                                  zone_comp.ICON_IMPORT, False)
+            zone.entity_id = entity_id
+            zone.update_ha_state()
 
     def see_beacons(dev_id, kwargs_param):
         """Set active beacons to the current location."""

--- a/homeassistant/helpers/__init__.py
+++ b/homeassistant/helpers/__init__.py
@@ -22,7 +22,10 @@ def config_per_platform(config: ConfigType,
     """
     for config_key in extract_domain_configs(config, domain):
         platform_config = config[config_key]
-        if not isinstance(platform_config, list):
+
+        if not platform_config:
+            continue
+        elif not isinstance(platform_config, list):
             platform_config = [platform_config]
 
         for item in platform_config:

--- a/tests/components/test_zone.py
+++ b/tests/components/test_zone.py
@@ -18,6 +18,18 @@ class TestComponentZone(unittest.TestCase):
         """Stop down everything that was started."""
         self.hass.stop()
 
+    def test_setup_no_zones_still_adds_home_zone(self):
+        """Test if no config is passed in we still get the home zone."""
+        assert bootstrap.setup_component(self.hass, zone.DOMAIN,
+                                         {'zone': None})
+
+        assert len(self.hass.states.entity_ids('zone')) == 1
+        state = self.hass.states.get('zone.home')
+        assert self.hass.config.location_name == state.name
+        assert self.hass.config.latitude == state.attributes['latitude']
+        assert self.hass.config.longitude == state.attributes['longitude']
+        assert not state.attributes.get('passive', False)
+
     def test_setup(self):
         """Test setup."""
         info = {

--- a/tests/helpers/test_init.py
+++ b/tests/helpers/test_init.py
@@ -45,5 +45,4 @@ class TestHelpers(unittest.TestCase):
             ('hello', config['zone']),
             (None, 1),
             ('hello 2', config['zone Hallo'][1]),
-            (None, None)
         ] == list(helpers.config_per_platform(config, 'zone'))

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -111,14 +111,6 @@ class TestBootstrap:
             'platform_conf.whatever', MockPlatform('whatever'))
 
         assert not bootstrap._setup_component(self.hass, 'platform_conf', {
-            'platform_conf': None
-        })
-
-        assert not bootstrap._setup_component(self.hass, 'platform_conf', {
-            'platform_conf': {}
-        })
-
-        assert not bootstrap._setup_component(self.hass, 'platform_conf', {
             'platform_conf': {
                 'hello': 'world',
                 'invalid': 'extra',
@@ -150,11 +142,26 @@ class TestBootstrap:
             }
         })
 
+        self.hass.config.components.remove('platform_conf')
+
         assert bootstrap._setup_component(self.hass, 'platform_conf', {
             'platform_conf': [{
                 'platform': 'whatever',
                 'hello': 'world',
             }]
+        })
+
+        self.hass.config.components.remove('platform_conf')
+
+        # Any falsey paltform config will be ignored (None, {}, etc)
+        assert bootstrap._setup_component(self.hass, 'platform_conf', {
+            'platform_conf': None
+        })
+
+        self.hass.config.components.remove('platform_conf')
+
+        assert bootstrap._setup_component(self.hass, 'platform_conf', {
+            'platform_conf': {}
         })
 
     def test_component_not_found(self):


### PR DESCRIPTION
**Description:**
This will allow components that have a platform based config to still be setup even if no config is given. This was required by for example `zone:`.

Apologies to @kellerza, I now understand what you wanted to do when trying to change `ensure_list` to handle `None` values.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
zone:
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
