### PR TITLE
 Added the ability to Weather Underground to track severe weather alerts

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -64,6 +64,7 @@ ALERTS_ATTRS = [
     'date',
     'description',
     'expires',
+    'message',
 ]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -125,6 +125,9 @@ class WUndergroundSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         attrs = {}
+
+        attrs[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+
         if not self.rest.alerts or self._condition != 'alerts':
             return
 
@@ -138,13 +141,6 @@ class WUndergroundSensor(Entity):
                         dkey = alert.capitalize()
                     attrs[dkey] = data[alert]
         return attrs
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        return {
-            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-        }
 
     @property
     def entity_picture(self):

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -129,7 +129,7 @@ class WUndergroundSensor(Entity):
         attrs[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
 
         if not self.rest.alerts or self._condition != 'alerts':
-            return
+            return attrs
 
         multiple_alerts = len(self.rest.alerts) > 1
         for data in self.rest.alerts:

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -117,11 +117,8 @@ class WUndergroundSensor(Entity):
             else:
                 return self.rest.data[self._condition]
 
-        if self._condition == 'alerts':
-            if self.rest.alerts is None:
-                self.update()
-            else:
-                return len(self.rest.alerts)
+        if self.rest.alerts and self._condition == 'alerts':
+            return len(self.rest.alerts)
         return STATE_UNKNOWN
 
     @property

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -159,7 +159,10 @@ class WUndergroundSensor(Entity):
 
     def update(self):
         """Update current conditions."""
-        self.rest.update()
+        if self._condition == 'alerts':
+            self.rest.update_alerts()
+        else:
+            self.rest.update()
 
 
 # pylint: disable=too-few-public-methods
@@ -200,6 +203,9 @@ class WUndergroundData(object):
             self.data = None
             raise
 
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update_alerts(self):
+        """Get the latest alerts data from WUnderground."""
         try:
             result = requests.get(self._build_url(_ALERTS), timeout=10).json()
             if "error" in result['response']:

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -118,7 +118,10 @@ class WUndergroundSensor(Entity):
                 return self.rest.data[self._condition]
 
         if self._condition == 'alerts':
-            return len(self.rest.alerts)
+            if self.rest.alerts is None:
+                self.update()
+            else:
+                return len(self.rest.alerts)
         return STATE_UNKNOWN
 
     @property

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -61,7 +61,15 @@ def mocked_requests_get(*args, **kwargs):
                 "feelslike_c": FEELS_LIKE,
                 "weather": WEATHER,
                 "icon_url": ICON_URL
-            }
+            }, "alerts": [
+                {
+                    "type": "FLO",
+                    "description": "Areal Flood Warning",
+                    "date": "9:36 PM CDT on September 22, 2016",
+                    "expires": "10:00 AM CDT on September 23, 2016",
+                    "message": "This is a test message",
+                }
+            ],
         }, 200)
     else:
         return MockResponse({

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -11,7 +11,7 @@ VALID_CONFIG_PWS = {
     'api_key': 'foo',
     'pws_id': 'bar',
     'monitored_conditions': [
-        'weather', 'feelslike_c'
+        'weather', 'feelslike_c', 'alerts'
     ]
 }
 
@@ -19,17 +19,19 @@ VALID_CONFIG = {
     'platform': 'wunderground',
     'api_key': 'foo',
     'monitored_conditions': [
-        'weather', 'feelslike_c'
+        'weather', 'feelslike_c', 'alerts'
     ]
 }
 
 FEELS_LIKE = '40'
 WEATHER = 'Clear'
 ICON_URL = 'http://icons.wxug.com/i/c/k/clear.gif'
+ALERT_MESSAGE = 'This is a test alert message'
 
 
 def mocked_requests_get(*args, **kwargs):
     """Mock requests.get invocations."""
+    # pylint: disable=too-few-public-methods
     class MockResponse:
         """Class to represent a mocked response."""
 
@@ -63,32 +65,34 @@ def mocked_requests_get(*args, **kwargs):
                 "icon_url": ICON_URL
             }, "alerts": [
                 {
-                    "type": "FLO",
+                    "type": 'FLO',
                     "description": "Areal Flood Warning",
                     "date": "9:36 PM CDT on September 22, 2016",
                     "expires": "10:00 AM CDT on September 23, 2016",
-                    "message": "This is a test message",
-                }
+                    "message": ALERT_MESSAGE,
+                },
+
             ],
         }, 200)
     else:
         return MockResponse({
-                "response": {
-                    "version": "0.1",
-                    "termsofService":
-                        "http://www.wunderground.com/weather/api/d/terms.html",
-                    "features": {},
-                    "error": {
-                        "type": "keynotfound",
-                        "description": "this key does not exist"
-                    }
+            "response": {
+                "version": "0.1",
+                "termsofService":
+                    "http://www.wunderground.com/weather/api/d/terms.html",
+                "features": {},
+                "error": {
+                    "type": "keynotfound",
+                    "description": "this key does not exist"
                 }
-            }, 200)
+            }
+        }, 200)
 
 
 class TestWundergroundSetup(unittest.TestCase):
     """Test the WUnderground platform."""
 
+    # pylint: disable=invalid-name
     DEVICES = []
 
     def add_devices(self, devices):
@@ -115,14 +119,13 @@ class TestWundergroundSetup(unittest.TestCase):
                                         self.add_devices, None))
         self.assertTrue(
             wunderground.setup_platform(self.hass, VALID_CONFIG,
-                                        self.add_devices,
-                                        None))
+                                        self.add_devices, None))
         invalid_config = {
             'platform': 'wunderground',
             'api_key': 'BOB',
             'pws_id': 'bar',
             'monitored_conditions': [
-                'weather', 'feelslike_c'
+                'weather', 'feelslike_c', 'alerts'
             ]
         }
 
@@ -141,6 +144,11 @@ class TestWundergroundSetup(unittest.TestCase):
                 self.assertEqual(ICON_URL, device.entity_picture)
                 self.assertEqual(WEATHER, device.state)
                 self.assertIsNone(device.unit_of_measurement)
+            elif device.name == 'PWS_alerts':
+                self.assertEqual(1, device.state)
+                self.assertEqual(ALERT_MESSAGE,
+                                 device.device_state_attributes['Message'])
+                self.assertIsNone(device.entity_picture)
             else:
                 self.assertIsNone(device.entity_picture)
                 self.assertEqual(FEELS_LIKE, device.state)

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -139,6 +139,7 @@ class TestWundergroundSetup(unittest.TestCase):
         wunderground.setup_platform(self.hass, VALID_CONFIG, self.add_devices,
                                     None)
         for device in self.DEVICES:
+            device.update()
             self.assertTrue(str(device.name).startswith('PWS_'))
             if device.name == 'PWS_weather':
                 self.assertEqual(ICON_URL, device.entity_picture)


### PR DESCRIPTION
**Description:**
This patch allows the Weather Underground sensor to report the severe weather advisories issued for the current location. 

**[home-assistant.io]https://github.com/home-assistant/home-assistant.github.io/pull/981

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
    platform: wunderground
    api_key: your_api_key
    pws_id: enter_pws_id
    monitored_conditions:
      - weather
      - temp_f
      - alerts
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
