### PR TITLE
modbus update, add error log instead of AttributeError exception

### DIFF
--- a/homeassistant/components/sensor/modbus.py
+++ b/homeassistant/components/sensor/modbus.py
@@ -93,6 +93,12 @@ class ModbusRegisterSensor(Entity):
             self._register,
             self._count)
         val = 0
+        if not result:
+            _LOGGER.error(
+                'No response from modbus slave %s register %s',
+                self._slave,
+                self._register)
+            return
         for i, res in enumerate(result.registers):
             val += res * (2**(i*16))
         self._value = format(

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -72,4 +72,10 @@ class ModbusCoilSwitch(ToggleEntity):
     def update(self):
         """Update the state of the switch."""
         result = modbus.HUB.read_coils(self._slave, self._coil, 1)
+        if not result:
+            _LOGGER.error(
+                'No response from modbus slave %s coil %s',
+                self._slave,
+                self._coil)
+            return
         self._is_on = bool(result.bits[0])


### PR DESCRIPTION
**Description:**
When the modbus slave did not respond in time an AttributeError was raised and a stack trace was printed.

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
