### PR TITLE
Make forecast.io update interval configurable

### DIFF
--- a/tests/components/sensor/test_forecast.py
+++ b/tests/components/sensor/test_forecast.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import forecastio
 from requests.exceptions import HTTPError
 import requests_mock
+from datetime import timedelta
 
 from homeassistant.components.sensor import forecast
 
@@ -21,7 +22,8 @@ class TestForecastSetup(unittest.TestCase):
         self.key = 'foo'
         self.config = {
             'api_key': 'foo',
-            'monitored_conditions': ['summary', 'icon']
+            'monitored_conditions': ['summary', 'icon'],
+            'update_interval': timedelta(seconds=120),
         }
         self.lat = 37.8267
         self.lon = -122.423


### PR DESCRIPTION
**Description:**
Adds a config parameter (`update_interval`) to the `forecast` sensor to set the minimum update interval. Handy if you don't need super-current weather data and want to conserve your API quota. The default remains 120 seconds.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#990

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
update_interval: 'HH:MM'
```

OR

``` yaml
update_interval: 'HH:MM:SS'
```

OR

``` yaml
update_interval:
  # At least one of these must be specified:
  days: 0
  hours: 0
  minutes: 3
  seconds: 30
  milliseconds: 0
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
