### PR TITLE
Optimize template 2

### DIFF
--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -4,6 +4,7 @@ Support for Alexa skill service end point.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/alexa/
 """
+import copy
 import enum
 import logging
 
@@ -42,10 +43,20 @@ class AlexaView(HomeAssistantView):
         """Initialize Alexa view."""
         super().__init__(hass)
 
+        intents = copy.deepcopy(intents)
+
         for name, intent in intents.items():
             if CONF_ACTION in intent:
                 intent[CONF_ACTION] = script.Script(
                     hass, intent[CONF_ACTION], "Alexa intent {}".format(name))
+            if CONF_CARD in intent:
+                intent[CONF_CARD]['title'] = template.compile_template(
+                    hass, intent[CONF_CARD]['title'])
+                intent[CONF_CARD]['content'] = template.compile_template(
+                    hass, intent[CONF_CARD]['content'])
+            if CONF_SPEECH in intent:
+                intent[CONF_SPEECH]['text'] = template.compile_template(
+                    hass, intent[CONF_SPEECH]['text'])
 
         self.intents = intents
 
@@ -204,4 +215,4 @@ class AlexaResponse(object):
 
     def _render(self, template_string):
         """Render a response, adding data from intent if available."""
-        return template.render(self.hass, template_string, self.variables)
+        return template.render(template_string, self.variables)

--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -8,8 +8,10 @@ import copy
 import enum
 import logging
 
+import voluptuous as vol
+
 from homeassistant.const import HTTP_BAD_REQUEST
-from homeassistant.helpers import template, script
+from homeassistant.helpers import template, script, config_validation as cv
 from homeassistant.components.http import HomeAssistantView
 
 _LOGGER = logging.getLogger(__name__)
@@ -21,8 +23,47 @@ CONF_CARD = 'card'
 CONF_INTENTS = 'intents'
 CONF_SPEECH = 'speech'
 
+CONF_TYPE = 'type'
+CONF_TITLE = 'title'
+CONF_CONTENT = 'content'
+CONF_TEXT = 'text'
+
 DOMAIN = 'alexa'
 DEPENDENCIES = ['http']
+
+
+class SpeechType(enum.Enum):
+    """The Alexa speech types."""
+
+    plaintext = "PlainText"
+    ssml = "SSML"
+
+
+class CardType(enum.Enum):
+    """The Alexa card types."""
+
+    simple = "Simple"
+    link_account = "LinkAccount"
+
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: {
+        CONF_INTENTS: {
+            cv.string: {
+                vol.Optional(CONF_ACTION): cv.SCRIPT_SCHEMA,
+                vol.Optional(CONF_CARD): {
+                    vol.Required(CONF_TYPE): cv.enum(CardType),
+                    vol.Required(CONF_TITLE): cv.template,
+                    vol.Required(CONF_CONTENT): cv.template,
+                },
+                vol.Optional(CONF_SPEECH): {
+                    vol.Required(CONF_TYPE): cv.enum(SpeechType),
+                    vol.Required(CONF_TEXT): cv.template,
+                }
+            }
+        }
+    }
+})
 
 
 def setup(hass, config):
@@ -44,19 +85,12 @@ class AlexaView(HomeAssistantView):
         super().__init__(hass)
 
         intents = copy.deepcopy(intents)
+        template.attach(hass, intents)
 
         for name, intent in intents.items():
             if CONF_ACTION in intent:
                 intent[CONF_ACTION] = script.Script(
                     hass, intent[CONF_ACTION], "Alexa intent {}".format(name))
-            if CONF_CARD in intent:
-                intent[CONF_CARD]['title'] = template.compile_template(
-                    hass, intent[CONF_CARD]['title'])
-                intent[CONF_CARD]['content'] = template.compile_template(
-                    hass, intent[CONF_CARD]['content'])
-            if CONF_SPEECH in intent:
-                intent[CONF_SPEECH]['text'] = template.compile_template(
-                    hass, intent[CONF_SPEECH]['text'])
 
         self.intents = intents
 
@@ -112,27 +146,13 @@ class AlexaView(HomeAssistantView):
 
         # pylint: disable=unsubscriptable-object
         if speech is not None:
-            response.add_speech(SpeechType[speech['type']], speech['text'])
+            response.add_speech(speech[CONF_TYPE], speech[CONF_TEXT])
 
         if card is not None:
-            response.add_card(CardType[card['type']], card['title'],
-                              card['content'])
+            response.add_card(card[CONF_TYPE], card[CONF_TITLE],
+                              card[CONF_CONTENT])
 
         return self.json(response)
-
-
-class SpeechType(enum.Enum):
-    """The Alexa speech types."""
-
-    plaintext = "PlainText"
-    ssml = "SSML"
-
-
-class CardType(enum.Enum):
-    """The Alexa card types."""
-
-    simple = "Simple"
-    link_account = "LinkAccount"
 
 
 class AlexaResponse(object):
@@ -164,8 +184,8 @@ class AlexaResponse(object):
             self.card = card
             return
 
-        card["title"] = self._render(title),
-        card["content"] = self._render(content)
+        card["title"] = title.render(self.variables)
+        card["content"] = content.render(self.variables)
         self.card = card
 
     def add_speech(self, speech_type, text):
@@ -174,9 +194,12 @@ class AlexaResponse(object):
 
         key = 'ssml' if speech_type == SpeechType.ssml else 'text'
 
+        if isinstance(text, template.Template):
+            text = text.render(self.variables)
+
         self.speech = {
             'type': speech_type.value,
-            key: self._render(text)
+            key: text
         }
 
     def add_reprompt(self, speech_type, text):
@@ -187,7 +210,7 @@ class AlexaResponse(object):
 
         self.reprompt = {
             'type': speech_type.value,
-            key: self._render(text)
+            key: text.render(self.variables)
         }
 
     def as_dict(self):
@@ -212,7 +235,3 @@ class AlexaResponse(object):
             'sessionAttributes': self.session_attributes,
             'response': response,
         }
-
-    def _render(self, template_string):
-        """Render a response, adding data from intent if available."""
-        return template.render(template_string, self.variables)

--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -378,8 +378,9 @@ class APITemplateView(HomeAssistantView):
     def post(self, request):
         """Render a template."""
         try:
-            return template.render(self.hass, request.json['template'],
-                                   request.json.get('variables'))
+            tpl = template.compile_template(
+                self.hass, request.json['template'])
+            return template.render(tpl, request.json.get('variables'))
         except TemplateError as ex:
             return self.json_message('Error rendering template: {}'.format(ex),
                                      HTTP_BAD_REQUEST)

--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -378,9 +378,8 @@ class APITemplateView(HomeAssistantView):
     def post(self, request):
         """Render a template."""
         try:
-            tpl = template.compile_template(
-                self.hass, request.json['template'])
-            return template.render(tpl, request.json.get('variables'))
+            tpl = template.Template(request.json['template'], self.hass)
+            return tpl.render(request.json.get('variables'))
         except TemplateError as ex:
             return self.json_message('Error rendering template: {}'.format(ex),
                                      HTTP_BAD_REQUEST)

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     CONF_VALUE_TEMPLATE, CONF_PLATFORM, CONF_ENTITY_ID,
     CONF_BELOW, CONF_ABOVE)
 from homeassistant.helpers.event import track_state_change
-from homeassistant.helpers import condition, config_validation as cv, template
+from homeassistant.helpers import condition, config_validation as cv
 
 TRIGGER_SCHEMA = vol.All(vol.Schema({
     vol.Required(CONF_PLATFORM): 'numeric_state',
@@ -32,7 +32,7 @@ def trigger(hass, config, action):
     above = config.get(CONF_ABOVE)
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
+        value_template.hass = hass
 
     # pylint: disable=unused-argument
     def state_automation_listener(entity, from_s, to_s):

--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_VALUE_TEMPLATE, CONF_PLATFORM, MATCH_ALL)
-from homeassistant.helpers import condition, template
+from homeassistant.helpers import condition
 from homeassistant.helpers.event import track_state_change
 import homeassistant.helpers.config_validation as cv
 
@@ -25,8 +25,9 @@ TRIGGER_SCHEMA = IF_ACTION_SCHEMA = vol.Schema({
 
 def trigger(hass, config, action):
     """Listen for state changes based on configuration."""
-    value_template = template.compile_template(
-        hass, config.get(CONF_VALUE_TEMPLATE))
+    value_template = config.get(CONF_VALUE_TEMPLATE)
+    if value_template is not None:
+        value_template.hass = hass
 
     # Local variable to keep track of if the action has already been triggered
     already_triggered = False

--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -8,8 +8,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_VALUE_TEMPLATE, CONF_PLATFORM, MATCH_ALL)
+from homeassistant.const import CONF_VALUE_TEMPLATE, CONF_PLATFORM
 from homeassistant.helpers import condition
 from homeassistant.helpers.event import track_state_change
 import homeassistant.helpers.config_validation as cv
@@ -26,8 +25,7 @@ TRIGGER_SCHEMA = IF_ACTION_SCHEMA = vol.Schema({
 def trigger(hass, config, action):
     """Listen for state changes based on configuration."""
     value_template = config.get(CONF_VALUE_TEMPLATE)
-    if value_template is not None:
-        value_template.hass = hass
+    value_template.hass = hass
 
     # Local variable to keep track of if the action has already been triggered
     already_triggered = False
@@ -51,4 +49,5 @@ def trigger(hass, config, action):
         elif not template_result:
             already_triggered = False
 
-    return track_state_change(hass, MATCH_ALL, state_changed_listener)
+    return track_state_change(hass, value_template.extract_entities(),
+                              state_changed_listener)

--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -4,6 +4,7 @@ Offer template automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#template-trigger
 """
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -30,15 +31,16 @@ def trigger(hass, config, action):
     # Local variable to keep track of if the action has already been triggered
     already_triggered = False
 
+    @asyncio.coroutine
     def state_changed_listener(entity_id, from_s, to_s):
         """Listen for state changes and calls action."""
         nonlocal already_triggered
-        template_result = condition.template(hass, value_template)
+        template_result = condition.async_template(hass, value_template)
 
         # Check to see if template returns true
         if template_result and not already_triggered:
             already_triggered = True
-            action({
+            hass.async_add_job(action, {
                 'trigger': {
                     'platform': 'template',
                     'entity_id': entity_id,

--- a/homeassistant/components/binary_sensor/command_line.py
+++ b/homeassistant/components/binary_sensor/command_line.py
@@ -95,7 +95,7 @@ class CommandBinarySensor(BinarySensorDevice):
 
         if self._value_template is not None:
             value = template.render_with_possible_json_value(
-                self._hass, self._value_template, value, False)
+                self._value_template, value, False)
         if value == self._payload_on:
             self._state = True
         elif value == self._payload_off:

--- a/homeassistant/components/binary_sensor/command_line.py
+++ b/homeassistant/components/binary_sensor/command_line.py
@@ -15,7 +15,6 @@ from homeassistant.components.sensor.command_line import CommandSensorData
 from homeassistant.const import (
     CONF_PAYLOAD_OFF, CONF_PAYLOAD_ON, CONF_NAME, CONF_VALUE_TEMPLATE,
     CONF_SENSOR_CLASS, CONF_COMMAND)
-from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,10 +44,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     payload_on = config.get(CONF_PAYLOAD_ON)
     sensor_class = config.get(CONF_SENSOR_CLASS)
     value_template = config.get(CONF_VALUE_TEMPLATE)
-
     if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
-
+        value_template.hass = hass
     data = CommandSensorData(command)
 
     add_devices([CommandBinarySensor(
@@ -94,8 +91,8 @@ class CommandBinarySensor(BinarySensorDevice):
         value = self.data.value
 
         if self._value_template is not None:
-            value = template.render_with_possible_json_value(
-                self._value_template, value, False)
+            value = self._value_template.render_with_possible_json_value(
+                value, False)
         if value == self._payload_on:
             self._state = True
         elif value == self._payload_off:

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
     CONF_NAME, CONF_VALUE_TEMPLATE, CONF_PAYLOAD_ON, CONF_PAYLOAD_OFF,
     CONF_SENSOR_CLASS)
 from homeassistant.components.mqtt import (CONF_STATE_TOPIC, CONF_QOS)
-from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,10 +37,8 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the MQTT binary sensor."""
     value_template = config.get(CONF_VALUE_TEMPLATE)
-
     if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
-
+        value_template.hass = hass
     add_devices([MqttBinarySensor(
         hass,
         config.get(CONF_NAME),
@@ -73,8 +70,8 @@ class MqttBinarySensor(BinarySensorDevice):
         def message_received(topic, payload, qos):
             """A new MQTT message has been received."""
             if value_template is not None:
-                payload = template.render_with_possible_json_value(
-                    hass, value_template, payload)
+                payload = value_template.render_with_possible_json_value(
+                    payload)
             if payload == self._payload_on:
                 self._state = True
                 self.update_ha_state()

--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -92,7 +92,7 @@ class RestBinarySensor(BinarySensorDevice):
 
         if self._value_template is not None:
             response = template.render_with_possible_json_value(
-                self._hass, self._value_template, self.rest.data, False)
+                self._value_template, self.rest.data, False)
 
         try:
             return bool(int(response))

--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -14,7 +14,6 @@ from homeassistant.components.sensor.rest import RestData
 from homeassistant.const import (
     CONF_PAYLOAD, CONF_NAME, CONF_VALUE_TEMPLATE, CONF_METHOD, CONF_RESOURCE,
     CONF_SENSOR_CLASS, CONF_VERIFY_SSL)
-from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,10 +43,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     verify_ssl = config.get(CONF_VERIFY_SSL)
     sensor_class = config.get(CONF_SENSOR_CLASS)
     value_template = config.get(CONF_VALUE_TEMPLATE)
-
     if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
-
+        value_template.hass = hass
     rest = RestData(method, resource, payload, verify_ssl)
     rest.update()
 
@@ -91,8 +88,8 @@ class RestBinarySensor(BinarySensorDevice):
             return False
 
         if self._value_template is not None:
-            response = template.render_with_possible_json_value(
-                self._value_template, self.rest.data, False)
+            response = self._value_template.render_with_possible_json_value(
+                self.rest.data, False)
 
         try:
             return bool(int(response))

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -107,8 +107,7 @@ class BinarySensorTemplate(BinarySensorDevice):
     def update(self):
         """Get the latest data and update the state."""
         try:
-            self._state = template.render(
-                self.hass, self._template).lower() == 'true'
+            self._state = template.render(self._template).lower() == 'true'
         except TemplateError as ex:
             if ex.args and ex.args[0].startswith(
                     "UndefinedError: 'None' has no attribute"):

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -12,7 +12,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDevice, ENTITY_ID_FORMAT, PLATFORM_SCHEMA,
     SENSOR_CLASSES_SCHEMA)
 from homeassistant.const import (
-    ATTR_FRIENDLY_NAME, ATTR_ENTITY_ID, MATCH_ALL, CONF_VALUE_TEMPLATE,
+    ATTR_FRIENDLY_NAME, ATTR_ENTITY_ID, CONF_VALUE_TEMPLATE,
     CONF_SENSOR_CLASS, CONF_SENSORS)
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import generate_entity_id
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 SENSOR_SCHEMA = vol.Schema({
     vol.Required(CONF_VALUE_TEMPLATE): cv.template,
     vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
-    vol.Optional(ATTR_ENTITY_ID, default=MATCH_ALL): cv.entity_ids,
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Optional(CONF_SENSOR_CLASS, default=None): SENSOR_CLASSES_SCHEMA
 })
 
@@ -39,7 +39,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for device, device_config in config[CONF_SENSORS].items():
         value_template = device_config[CONF_VALUE_TEMPLATE]
-        entity_ids = device_config[ATTR_ENTITY_ID]
+        entity_ids = (device_config.get(ATTR_ENTITY_ID) or
+                      value_template.extract_entities())
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         sensor_class = device_config.get(CONF_SENSOR_CLASS)
 

--- a/homeassistant/components/binary_sensor/trend.py
+++ b/homeassistant/components/binary_sensor/trend.py
@@ -2,7 +2,7 @@
 A sensor that monitors trands in other components.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/sensor.template/
+https://home-assistant.io/components/sensor.trend/
 """
 import logging
 import voluptuous as vol
@@ -70,7 +70,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class SensorTrend(BinarySensorDevice):
-    """Representation of a Template Sensor."""
+    """Representation of a trend Sensor."""
 
     # pylint: disable=too-many-arguments, too-many-instance-attributes
     def __init__(self, hass, device_id, friendly_name,
@@ -90,14 +90,14 @@ class SensorTrend(BinarySensorDevice):
 
         self.update()
 
-        def template_sensor_state_listener(entity, old_state, new_state):
+        def trend_sensor_state_listener(entity, old_state, new_state):
             """Called when the target device changes state."""
             self.from_state = old_state
             self.to_state = new_state
             self.update_ha_state(True)
 
         track_state_change(hass, target_entity,
-                           template_sensor_state_listener)
+                           trend_sensor_state_listener)
 
     @property
     def name(self):

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -71,7 +71,7 @@ class GenericCamera(Camera):
     def camera_image(self):
         """Return a still image response from the camera."""
         try:
-            url = template.render(self.hass, self._still_image_url)
+            url = template.render(self._still_image_url)
         except TemplateError as err:
             _LOGGER.error('Error parsing template %s: %s',
                           self._still_image_url, err)

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION)
 from homeassistant.exceptions import TemplateError
 from homeassistant.components.camera import (PLATFORM_SCHEMA, Camera)
-from homeassistant.helpers import config_validation as cv, template
+from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ CONF_STILL_IMAGE_URL = 'still_image_url'
 DEFAULT_NAME = 'Generic Camera'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_STILL_IMAGE_URL): vol.Any(cv.url, cv.template),
+    vol.Required(CONF_STILL_IMAGE_URL): cv.template,
     vol.Optional(CONF_AUTHENTICATION, default=HTTP_BASIC_AUTHENTICATION):
         vol.In([HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]),
     vol.Optional(CONF_LIMIT_REFETCH_TO_URL_CHANGE, default=False): cv.boolean,
@@ -50,8 +50,8 @@ class GenericCamera(Camera):
         super().__init__()
         self.hass = hass
         self._name = device_info.get(CONF_NAME)
-        self._still_image_url = template.compile_template(
-            hass, device_info[CONF_STILL_IMAGE_URL])
+        self._still_image_url = device_info[CONF_STILL_IMAGE_URL]
+        self._still_image_url.hass = hass
         self._limit_refetch = device_info[CONF_LIMIT_REFETCH_TO_URL_CHANGE]
 
         username = device_info.get(CONF_USERNAME)
@@ -71,7 +71,7 @@ class GenericCamera(Camera):
     def camera_image(self):
         """Return a still image response from the camera."""
         try:
-            url = template.render(self._still_image_url)
+            url = self._still_image_url.render()
         except TemplateError as err:
             _LOGGER.error('Error parsing template %s: %s',
                           self._still_image_url, err)

--- a/homeassistant/components/cover/command_line.py
+++ b/homeassistant/components/cover/command_line.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     CONF_COMMAND_CLOSE, CONF_COMMAND_OPEN, CONF_COMMAND_STATE,
     CONF_COMMAND_STOP, CONF_COVERS, CONF_VALUE_TEMPLATE, CONF_FRIENDLY_NAME)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers import template
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,9 +38,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for device_name, device_config in devices.items():
         value_template = device_config.get(CONF_VALUE_TEMPLATE)
-
-        if value_template is not None:
-            value_template = template.compile_template(hass, value_template)
+        value_template.hass = hass
 
         covers.append(
             CommandCover(
@@ -141,8 +138,8 @@ class CommandCover(CoverDevice):
         if self._command_state:
             payload = str(self._query_state())
             if self._value_template:
-                payload = template.render_with_possible_json_value(
-                    self._hass, self._value_template, payload)
+                payload = self._value_template.render_with_possible_json_value(
+                    payload)
             self._state = int(payload)
 
     def open_cover(self, **kwargs):

--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/fan.mqtt/
 """
 import logging
-from functools import partial
 
 import voluptuous as vol
 
@@ -16,8 +15,6 @@ from homeassistant.const import (
 from homeassistant.components.mqtt import (
     CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.template import (render_with_possible_json_value,
-                                            compile_template)
 from homeassistant.components.fan import (SPEED_LOW, SPEED_MED, SPEED_MEDIUM,
                                           SPEED_HIGH, FanEntity,
                                           SUPPORT_SET_SPEED, SUPPORT_OSCILLATE,
@@ -144,8 +141,8 @@ class MqttFan(FanEntity):
             if tpl is None:
                 templates[key] = lambda value: value
             else:
-                templates[key] = partial(render_with_possible_json_value, hass,
-                                         compile_template(hass, tpl))
+                tpl.hass = hass
+                templates[key] = tpl.render_with_possible_json_value
 
         def state_received(topic, payload, qos):
             """A new MQTT message has been received."""

--- a/homeassistant/components/garage_door/mqtt.py
+++ b/homeassistant/components/garage_door/mqtt.py
@@ -45,6 +45,11 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Add MQTT Garage Door."""
+    value_template = config.get(CONF_VALUE_TEMPLATE)
+
+    if value_template is not None:
+        value_template = template.compile_template(hass, value_template)
+
     add_devices_callback([MqttGarageDoor(
         hass,
         config[CONF_NAME],
@@ -57,7 +62,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         config[CONF_SERVICE_OPEN],
         config[CONF_SERVICE_CLOSE],
         config[CONF_OPTIMISTIC],
-        config.get(CONF_VALUE_TEMPLATE))])
+        value_template)])
 
 
 # pylint: disable=too-many-arguments, too-many-instance-attributes

--- a/homeassistant/components/garage_door/mqtt.py
+++ b/homeassistant/components/garage_door/mqtt.py
@@ -16,7 +16,6 @@ from homeassistant.const import (
 from homeassistant.components.mqtt import (
     CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers import template
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,10 +45,8 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Add MQTT Garage Door."""
     value_template = config.get(CONF_VALUE_TEMPLATE)
-
     if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
-
+        value_template.hass = hass
     add_devices_callback([MqttGarageDoor(
         hass,
         config[CONF_NAME],
@@ -89,8 +86,8 @@ class MqttGarageDoor(GarageDoorDevice):
         def message_received(topic, payload, qos):
             """A new MQTT message has been received."""
             if value_template is not None:
-                payload = template.render_with_possible_json_value(
-                    hass, value_template, payload)
+                payload = value_template.render_with_possible_json_value(
+                    payload)
             if payload == self._state_open:
                 self._state = True
                 self.update_ha_state()

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -19,7 +19,8 @@ from homeassistant.const import (
 from homeassistant.components.mqtt import (
     CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.template import render_with_possible_json_value
+from homeassistant.helpers.template import (render_with_possible_json_value,
+                                            compile_template)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -117,9 +118,12 @@ class MqttLight(Light):
             topic[CONF_BRIGHTNESS_STATE_TOPIC] is not None and
             SUPPORT_BRIGHTNESS)
 
-        templates = {key: ((lambda value: value) if tpl is None else
-                           partial(render_with_possible_json_value, hass, tpl))
-                     for key, tpl in templates.items()}
+        for key, tpl in list(templates.items()):
+            if tpl is None:
+                templates[key] = lambda value: value
+            else:
+                templates[key] = partial(render_with_possible_json_value, hass,
+                                         compile_template(hass, tpl))
 
         def state_received(topic, payload, qos):
             """A new MQTT message has been received."""

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.mqtt/
 """
 import logging
-from functools import partial
 
 import voluptuous as vol
 
@@ -19,8 +18,6 @@ from homeassistant.const import (
 from homeassistant.components.mqtt import (
     CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.template import (render_with_possible_json_value,
-                                            compile_template)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,8 +119,8 @@ class MqttLight(Light):
             if tpl is None:
                 templates[key] = lambda value: value
             else:
-                templates[key] = partial(render_with_possible_json_value, hass,
-                                         compile_template(hass, tpl))
+                tpl.hass = hass
+                templates[key] = tpl.render_with_possible_json_value
 
         def state_received(topic, payload, qos):
             """A new MQTT message has been received."""

--- a/homeassistant/components/lock/mqtt.py
+++ b/homeassistant/components/lock/mqtt.py
@@ -42,6 +42,11 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the MQTT lock."""
+    value_template = config.get(CONF_VALUE_TEMPLATE)
+
+    if value_template is not None:
+        value_template = template.compile_template(hass, value_template)
+
     add_devices([MqttLock(
         hass,
         config.get(CONF_NAME),
@@ -52,7 +57,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         config.get(CONF_PAYLOAD_LOCK),
         config.get(CONF_PAYLOAD_UNLOCK),
         config.get(CONF_OPTIMISTIC),
-        config.get(CONF_VALUE_TEMPLATE)
+        value_template,
     )])
 
 

--- a/homeassistant/components/lock/mqtt.py
+++ b/homeassistant/components/lock/mqtt.py
@@ -13,7 +13,6 @@ from homeassistant.components.mqtt import (
     CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN)
 from homeassistant.const import (
     CONF_NAME, CONF_OPTIMISTIC, CONF_VALUE_TEMPLATE)
-from homeassistant.helpers import template
 import homeassistant.components.mqtt as mqtt
 import homeassistant.helpers.config_validation as cv
 
@@ -43,10 +42,8 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the MQTT lock."""
     value_template = config.get(CONF_VALUE_TEMPLATE)
-
     if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
-
+        value_template.hass = hass
     add_devices([MqttLock(
         hass,
         config.get(CONF_NAME),
@@ -82,8 +79,8 @@ class MqttLock(LockDevice):
         def message_received(topic, payload, qos):
             """A new MQTT message has been received."""
             if value_template is not None:
-                payload = template.render_with_possible_json_value(
-                    hass, value_template, payload)
+                payload = value_template.render_with_possible_json_value(
+                    payload)
             if payload == self._payload_lock:
                 self._state = True
                 self.update_ha_state()

--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -20,7 +20,6 @@ from homeassistant.const import (EVENT_HOMEASSISTANT_START,
                                  STATE_NOT_HOME, STATE_OFF, STATE_ON,
                                  ATTR_HIDDEN)
 from homeassistant.core import State, split_entity_id, DOMAIN as HA_DOMAIN
-from homeassistant.helpers import template
 
 DOMAIN = "logbook"
 DEPENDENCIES = ['recorder', 'frontend']
@@ -51,7 +50,7 @@ ATTR_ENTITY_ID = 'entity_id'
 
 LOG_MESSAGE_SCHEMA = vol.Schema({
     vol.Required(ATTR_NAME): cv.string,
-    vol.Required(ATTR_MESSAGE): cv.string,
+    vol.Required(ATTR_MESSAGE): cv.template,
     vol.Optional(ATTR_DOMAIN): cv.slug,
     vol.Optional(ATTR_ENTITY_ID): cv.entity_id,
 })
@@ -80,7 +79,8 @@ def setup(hass, config):
         domain = service.data.get(ATTR_DOMAIN)
         entity_id = service.data.get(ATTR_ENTITY_ID)
 
-        message = template.Template(message, hass).render()
+        message.hass = hass
+        message = message.render()
         log_entry(hass, name, message, domain, entity_id)
 
     hass.wsgi.register_view(LogbookView(hass, config))

--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -80,7 +80,7 @@ def setup(hass, config):
         domain = service.data.get(ATTR_DOMAIN)
         entity_id = service.data.get(ATTR_ENTITY_ID)
 
-        message = template.render(template.compile_template(hass, message))
+        message = template.Template(message, hass).render()
         log_entry(hass, name, message, domain, entity_id)
 
     hass.wsgi.register_view(LogbookView(hass, config))

--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -80,7 +80,7 @@ def setup(hass, config):
         domain = service.data.get(ATTR_DOMAIN)
         entity_id = service.data.get(ATTR_ENTITY_ID)
 
-        message = template.render(hass, message)
+        message = template.render(template.compile_template(hass, message))
         log_entry(hass, name, message, domain, entity_id)
 
     hass.wsgi.register_view(LogbookView(hass, config))

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -265,8 +265,7 @@ def setup(hass, config):
         retain = call.data[ATTR_RETAIN]
         try:
             if payload_template is not None:
-                payload = template.render(
-                    hass, template.compile_template(hass, payload_template))
+                payload = template.Template(payload_template, hass).render()
         except template.jinja2.TemplateError as exc:
             _LOGGER.error(
                 "Unable to publish to '%s': rendering payload template of "

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -264,8 +264,9 @@ def setup(hass, config):
         qos = call.data[ATTR_QOS]
         retain = call.data[ATTR_RETAIN]
         try:
-            payload = (payload if payload_template is None else
-                       template.render(hass, payload_template)) or ''
+            if payload_template is not None:
+                payload = template.render(
+                    hass, template.compile_template(hass, payload_template))
         except template.jinja2.TemplateError as exc:
             _LOGGER.error(
                 "Unable to publish to '%s': rendering payload template of "

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -96,14 +96,16 @@ def setup(hass, config):
             title = call.data.get(ATTR_TITLE)
 
             if title:
-                kwargs[ATTR_TITLE] = template.render(hass, title)
+                kwargs[ATTR_TITLE] = template.render(
+                    hass, template.compile_template(hass, title))
 
             if targets.get(call.service) is not None:
                 kwargs[ATTR_TARGET] = targets[call.service]
             else:
                 kwargs[ATTR_TARGET] = call.data.get(ATTR_TARGET)
 
-            kwargs[ATTR_MESSAGE] = template.render(hass, message)
+            kwargs[ATTR_MESSAGE] = template.render(
+                hass, template.compile_template(hass, message))
             kwargs[ATTR_DATA] = call.data.get(ATTR_DATA)
 
             notify_service.send_message(**kwargs)

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 
 import homeassistant.bootstrap as bootstrap
 from homeassistant.config import load_yaml_config_file
-from homeassistant.helpers import config_per_platform, template
+from homeassistant.helpers import config_per_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
 from homeassistant.util import slugify
@@ -41,7 +41,7 @@ PLATFORM_SCHEMA = vol.Schema({
 
 NOTIFY_SERVICE_SCHEMA = vol.Schema({
     vol.Required(ATTR_MESSAGE): cv.template,
-    vol.Optional(ATTR_TITLE): cv.string,
+    vol.Optional(ATTR_TITLE): cv.template,
     vol.Optional(ATTR_TARGET): cv.string,
     vol.Optional(ATTR_DATA): dict,
 })
@@ -96,16 +96,16 @@ def setup(hass, config):
             title = call.data.get(ATTR_TITLE)
 
             if title:
-                kwargs[ATTR_TITLE] = template.render(
-                    hass, template.compile_template(hass, title))
+                title.hass = hass
+                kwargs[ATTR_TITLE] = title.render()
 
             if targets.get(call.service) is not None:
                 kwargs[ATTR_TARGET] = targets[call.service]
             else:
                 kwargs[ATTR_TARGET] = call.data.get(ATTR_TARGET)
 
-            kwargs[ATTR_MESSAGE] = template.render(
-                hass, template.compile_template(hass, message))
+            message.hass = hass
+            kwargs[ATTR_MESSAGE] = message.render()
             kwargs[ATTR_DATA] = call.data.get(ATTR_DATA)
 
             notify_service.send_message(**kwargs)

--- a/homeassistant/components/persistent_notification.py
+++ b/homeassistant/components/persistent_notification.py
@@ -10,7 +10,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template, config_validation as cv
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.util import slugify
 from homeassistant.config import load_yaml_config_file
@@ -63,16 +63,20 @@ def setup(hass, config):
         attr = {}
         if title is not None:
             try:
-                title = template.render(template.compile_template(hass, title))
+                title.hass = hass
+                title = title.render()
             except TemplateError as ex:
                 _LOGGER.error('Error rendering title %s: %s', title, ex)
+                title = title.template
 
             attr[ATTR_TITLE] = title
 
         try:
-            message = template.render(template.compile_template(hass, message))
+            message.hass = hass
+            message = message.render()
         except TemplateError as ex:
             _LOGGER.error('Error rendering message %s: %s', message, ex)
+            message = message.template
 
         hass.states.set(entity_id, message, attr)
 

--- a/homeassistant/components/persistent_notification.py
+++ b/homeassistant/components/persistent_notification.py
@@ -63,14 +63,14 @@ def setup(hass, config):
         attr = {}
         if title is not None:
             try:
-                title = template.render(hass, title)
+                title = template.render(template.compile_template(hass, title))
             except TemplateError as ex:
                 _LOGGER.error('Error rendering title %s: %s', title, ex)
 
             attr[ATTR_TITLE] = title
 
         try:
-            message = template.render(hass, message)
+            message = template.render(template.compile_template(hass, message))
         except TemplateError as ex:
             _LOGGER.error('Error rendering message %s: %s', message, ex)
 

--- a/homeassistant/components/rollershutter/command_line.py
+++ b/homeassistant/components/rollershutter/command_line.py
@@ -20,6 +20,11 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     devices = []
 
     for dev_name, properties in rollershutters.items():
+        value_template = properties.get(CONF_VALUE_TEMPLATE)
+
+        if value_template is not None:
+            value_template = template.compile_template(hass, value_template)
+
         devices.append(
             CommandRollershutter(
                 hass,
@@ -28,7 +33,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                 properties.get('downcmd', 'true'),
                 properties.get('stopcmd', 'true'),
                 properties.get('statecmd', False),
-                properties.get(CONF_VALUE_TEMPLATE, '{{ value }}')))
+                value_template))
     add_devices_callback(devices)
 
 

--- a/homeassistant/components/rollershutter/command_line.py
+++ b/homeassistant/components/rollershutter/command_line.py
@@ -9,7 +9,7 @@ import subprocess
 
 from homeassistant.components.rollershutter import RollershutterDevice
 from homeassistant.const import CONF_VALUE_TEMPLATE
-from homeassistant.helpers import template
+from homeassistant.helpers.template import Template
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         value_template = properties.get(CONF_VALUE_TEMPLATE)
 
         if value_template is not None:
-            value_template = template.compile_template(hass, value_template)
+            value_template = Template(value_template, hass)
 
         devices.append(
             CommandRollershutter(
@@ -108,8 +108,8 @@ class CommandRollershutter(RollershutterDevice):
         if self._command_state:
             payload = str(self._query_state())
             if self._value_template:
-                payload = template.render_with_possible_json_value(
-                    self._hass, self._value_template, payload)
+                payload = self._value_template.render_with_possible_json_value(
+                    payload)
             self._state = int(payload)
 
     def move_up(self, **kwargs):

--- a/homeassistant/components/rollershutter/mqtt.py
+++ b/homeassistant/components/rollershutter/mqtt.py
@@ -39,6 +39,11 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Add MQTT Rollershutter."""
+    value_template = config.get(CONF_VALUE_TEMPLATE)
+
+    if value_template is not None:
+        value_template = template.compile_template(hass, value_template)
+
     add_devices_callback([MqttRollershutter(
         hass,
         config[CONF_NAME],
@@ -48,7 +53,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         config[CONF_PAYLOAD_UP],
         config[CONF_PAYLOAD_DOWN],
         config[CONF_PAYLOAD_STOP],
-        config.get(CONF_VALUE_TEMPLATE)
+        value_template,
     )])
 
 

--- a/homeassistant/components/rollershutter/mqtt.py
+++ b/homeassistant/components/rollershutter/mqtt.py
@@ -13,7 +13,6 @@ from homeassistant.components.rollershutter import RollershutterDevice
 from homeassistant.const import CONF_NAME, CONF_VALUE_TEMPLATE
 from homeassistant.components.mqtt import (
     CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_QOS)
-from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,10 +39,8 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Add MQTT Rollershutter."""
     value_template = config.get(CONF_VALUE_TEMPLATE)
-
     if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
-
+        value_template.hass = hass
     add_devices_callback([MqttRollershutter(
         hass,
         config[CONF_NAME],
@@ -81,8 +78,8 @@ class MqttRollershutter(RollershutterDevice):
         def message_received(topic, payload, qos):
             """A new MQTT message has been received."""
             if value_template is not None:
-                payload = template.render_with_possible_json_value(
-                    hass, value_template, payload)
+                payload = value_template.render_with_possible_json_value(
+                    payload)
             if payload.isnumeric() and 0 <= int(payload) <= 100:
                 self._state = int(payload)
                 self.update_ha_state()

--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -52,11 +52,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if value_template is None:
             return lambda value: value
 
-        value_template = template.compile_template(hass, value_template)
+        value_template = template.Template(value_template, hass)
 
         def _render(value):
             try:
-                return template.render(value_template, {'value': value})
+                return value_template.render({'value': value})
             except TemplateError:
                 _LOGGER.exception('Error parsing value')
                 return value

--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -52,9 +52,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if value_template is None:
             return lambda value: value
 
+        value_template = template.compile_template(hass, value_template)
+
         def _render(value):
             try:
-                return template.render(hass, value_template, {'value': value})
+                return template.render(value_template, {'value': value})
             except TemplateError:
                 _LOGGER.exception('Error parsing value')
                 return value

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -14,7 +14,6 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_NAME, CONF_VALUE_TEMPLATE, CONF_UNIT_OF_MEASUREMENT, CONF_COMMAND)
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers import template
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
@@ -39,10 +38,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     command = config.get(CONF_COMMAND)
     unit = config.get(CONF_UNIT_OF_MEASUREMENT)
     value_template = config.get(CONF_VALUE_TEMPLATE)
-
     if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
-
+        value_template.hass = hass
     data = CommandSensorData(command)
 
     add_devices([CommandSensor(hass, data, name, unit, value_template)])
@@ -83,8 +80,8 @@ class CommandSensor(Entity):
         value = self.data.value
 
         if self._value_template is not None:
-            self._state = template.render_with_possible_json_value(
-                self._value_template, value, 'N/A')
+            self._state = self._value_template.render_with_possible_json_value(
+                value, 'N/A')
         else:
             self._state = value
 

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -40,6 +40,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     unit = config.get(CONF_UNIT_OF_MEASUREMENT)
     value_template = config.get(CONF_VALUE_TEMPLATE)
 
+    if value_template is not None:
+        value_template = template.compile_template(hass, value_template)
+
     data = CommandSensorData(command)
 
     add_devices([CommandSensor(hass, data, name, unit, value_template)])
@@ -81,7 +84,7 @@ class CommandSensor(Entity):
 
         if self._value_template is not None:
             self._state = template.render_with_possible_json_value(
-                self._hass, self._value_template, value, 'N/A')
+                self._value_template, value, 'N/A')
         else:
             self._state = value
 

--- a/homeassistant/components/sensor/dweet.py
+++ b/homeassistant/components/sensor/dweet.py
@@ -46,15 +46,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     value_template = config.get(CONF_VALUE_TEMPLATE)
     unit = config.get(CONF_UNIT_OF_MEASUREMENT)
 
+    if value_template is not None:
+        value_template = template.compile_template(hass, value_template)
+
     try:
         content = json.dumps(dweepy.get_latest_dweet_for(device)[0]['content'])
     except dweepy.DweepyError:
         _LOGGER.error("Device/thing '%s' could not be found", device)
         return False
 
-    if template.render_with_possible_json_value(hass,
-                                                value_template,
-                                                content) is '':
+    if template.render_with_possible_json_value(value_template, content) == '':
         _LOGGER.error("'%s' was not found", value_template)
         return False
 
@@ -95,7 +96,7 @@ class DweetSensor(Entity):
         else:
             values = json.dumps(self.dweet.data[0]['content'])
             value = template.render_with_possible_json_value(
-                self.hass, self._value_template, values)
+                self._value_template, values)
             return value
 
     def update(self):

--- a/homeassistant/components/sensor/dweet.py
+++ b/homeassistant/components/sensor/dweet.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
     CONF_NAME, CONF_VALUE_TEMPLATE, STATE_UNKNOWN, CONF_UNIT_OF_MEASUREMENT)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers import template
 from homeassistant.util import Throttle
 
 REQUIREMENTS = ['dweepy==0.2.0']
@@ -45,17 +44,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     device = config.get(CONF_DEVICE)
     value_template = config.get(CONF_VALUE_TEMPLATE)
     unit = config.get(CONF_UNIT_OF_MEASUREMENT)
-
-    if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
-
+    value_template.hass = hass
     try:
         content = json.dumps(dweepy.get_latest_dweet_for(device)[0]['content'])
     except dweepy.DweepyError:
         _LOGGER.error("Device/thing '%s' could not be found", device)
         return False
 
-    if template.render_with_possible_json_value(value_template, content) == '':
+    if value_template.render_with_possible_json_value(content) == '':
         _LOGGER.error("'%s' was not found", value_template)
         return False
 
@@ -95,8 +91,8 @@ class DweetSensor(Entity):
             return STATE_UNKNOWN
         else:
             values = json.dumps(self.dweet.data[0]['content'])
-            value = template.render_with_possible_json_value(
-                self._value_template, values)
+            value = self._value_template.render_with_possible_json_value(
+                values)
             return value
 
     def update(self):

--- a/homeassistant/components/sensor/emoncms.py
+++ b/homeassistant/components/sensor/emoncms.py
@@ -69,7 +69,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     include_only_feeds = config.get(CONF_ONLY_INCLUDE_FEEDID)
     sensor_names = config.get(CONF_SENSOR_NAMES)
     interval = config.get(CONF_SCAN_INTERVAL)
-    value_template.hass = hass
+
+    if value_template is not None:
+        value_template.hass = hass
+
     data = EmonCmsData(hass, url, apikey, interval)
 
     data.update()

--- a/homeassistant/components/sensor/emoncms.py
+++ b/homeassistant/components/sensor/emoncms.py
@@ -69,10 +69,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     include_only_feeds = config.get(CONF_ONLY_INCLUDE_FEEDID)
     sensor_names = config.get(CONF_SENSOR_NAMES)
     interval = config.get(CONF_SCAN_INTERVAL)
-
-    if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
-
+    value_template.hass = hass
     data = EmonCmsData(hass, url, apikey, interval)
 
     data.update()
@@ -126,9 +123,8 @@ class EmonCmsSensor(Entity):
         self._elem = elem
 
         if self._value_template is not None:
-            self._state = template.render_with_possible_json_value(
-                self._value_template, elem["value"],
-                STATE_UNKNOWN)
+            self._state = self._value_template.render_with_possible_json_value(
+                elem["value"], STATE_UNKNOWN)
         else:
             self._state = round(float(elem["value"]), DECIMALS)
 
@@ -180,9 +176,8 @@ class EmonCmsSensor(Entity):
         self._elem = elem
 
         if self._value_template is not None:
-            self._state = template.render_with_possible_json_value(
-                self._value_template, elem["value"],
-                STATE_UNKNOWN)
+            self._state = self._value_template.render_with_possible_json_value(
+                elem["value"], STATE_UNKNOWN)
         else:
             self._state = round(float(elem["value"]), DECIMALS)
 

--- a/homeassistant/components/sensor/emoncms.py
+++ b/homeassistant/components/sensor/emoncms.py
@@ -70,6 +70,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     sensor_names = config.get(CONF_SENSOR_NAMES)
     interval = config.get(CONF_SCAN_INTERVAL)
 
+    if value_template is not None:
+        value_template = template.compile_template(hass, value_template)
+
     data = EmonCmsData(hass, url, apikey, interval)
 
     data.update()
@@ -124,7 +127,7 @@ class EmonCmsSensor(Entity):
 
         if self._value_template is not None:
             self._state = template.render_with_possible_json_value(
-                self._hass, self._value_template, elem["value"],
+                self._value_template, elem["value"],
                 STATE_UNKNOWN)
         else:
             self._state = round(float(elem["value"]), DECIMALS)
@@ -178,7 +181,7 @@ class EmonCmsSensor(Entity):
 
         if self._value_template is not None:
             self._state = template.render_with_possible_json_value(
-                self._hass, self._value_template, elem["value"],
+                self._value_template, elem["value"],
                 STATE_UNKNOWN)
         else:
             self._state = round(float(elem["value"]), DECIMALS)

--- a/homeassistant/components/sensor/imap_email_content.py
+++ b/homeassistant/components/sensor/imap_email_content.py
@@ -14,7 +14,6 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_NAME, CONF_PORT, CONF_USERNAME, CONF_PASSWORD, CONF_VALUE_TEMPLATE)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers import template
 import voluptuous as vol
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,10 +47,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         config.get(CONF_PORT))
 
     value_template = config.get(CONF_VALUE_TEMPLATE)
-
     if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
-
+        value_template.hass = hass
     sensor = EmailContentSensor(
         hass,
         reader,
@@ -176,7 +173,7 @@ class EmailContentSensor(Entity):
             ATTR_DATE: email_message['Date'],
             ATTR_BODY: EmailContentSensor.get_msg_text(email_message)
         }
-        return template.render(self._value_template, variables)
+        return self._value_template.render(variables)
 
     def sender_allowed(self, email_message):
         """Check if the sender is in the allowed senders list."""

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -11,7 +11,6 @@ import voluptuous as vol
 from homeassistant.components.mqtt import CONF_STATE_TOPIC, CONF_QOS
 from homeassistant.const import (
     CONF_NAME, CONF_VALUE_TEMPLATE, STATE_UNKNOWN, CONF_UNIT_OF_MEASUREMENT)
-from homeassistant.helpers import template
 from homeassistant.helpers.entity import Entity
 import homeassistant.components.mqtt as mqtt
 import homeassistant.helpers.config_validation as cv
@@ -31,10 +30,8 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup MQTT Sensor."""
     value_template = config.get(CONF_VALUE_TEMPLATE)
-
     if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
-
+        value_template.hass = hass
     add_devices([MqttSensor(
         hass,
         config.get(CONF_NAME),
@@ -62,8 +59,8 @@ class MqttSensor(Entity):
         def message_received(topic, payload, qos):
             """A new MQTT message has been received."""
             if value_template is not None:
-                payload = template.render_with_possible_json_value(
-                    hass, value_template, payload)
+                payload = value_template.render_with_possible_json_value(
+                    payload)
             self._state = payload
             self.update_ha_state()
 

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -30,13 +30,18 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup MQTT Sensor."""
+    value_template = config.get(CONF_VALUE_TEMPLATE)
+
+    if value_template is not None:
+        value_template = template.compile_template(hass, value_template)
+
     add_devices([MqttSensor(
         hass,
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_QOS),
         config.get(CONF_UNIT_OF_MEASUREMENT),
-        config.get(CONF_VALUE_TEMPLATE),
+        value_template,
     )])
 
 

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     CONF_PAYLOAD, CONF_NAME, CONF_VALUE_TEMPLATE, CONF_METHOD, CONF_RESOURCE,
     CONF_UNIT_OF_MEASUREMENT, STATE_UNKNOWN, CONF_VERIFY_SSL)
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,10 +43,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     verify_ssl = config.get(CONF_VERIFY_SSL)
     unit = config.get(CONF_UNIT_OF_MEASUREMENT)
     value_template = config.get(CONF_VALUE_TEMPLATE)
-
     if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
-
+        value_template.hass = hass
     rest = RestData(method, resource, payload, verify_ssl)
     rest.update()
 
@@ -95,8 +92,8 @@ class RestSensor(Entity):
         if value is None:
             value = STATE_UNKNOWN
         elif self._value_template is not None:
-            value = template.render_with_possible_json_value(
-                self._value_template, value, STATE_UNKNOWN)
+            value = self._value_template.render_with_possible_json_value(
+                value, STATE_UNKNOWN)
 
         self._state = value
 

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -45,6 +45,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     unit = config.get(CONF_UNIT_OF_MEASUREMENT)
     value_template = config.get(CONF_VALUE_TEMPLATE)
 
+    if value_template is not None:
+        value_template = template.compile_template(hass, value_template)
+
     rest = RestData(method, resource, payload, verify_ssl)
     rest.update()
 
@@ -93,7 +96,7 @@ class RestSensor(Entity):
             value = STATE_UNKNOWN
         elif self._value_template is not None:
             value = template.render_with_possible_json_value(
-                self._hass, self._value_template, value, STATE_UNKNOWN)
+                self._value_template, value, STATE_UNKNOWN)
 
         self._state = value
 

--- a/homeassistant/components/sensor/tcp.py
+++ b/homeassistant/components/sensor/tcp.py
@@ -41,6 +41,11 @@ class Sensor(Entity):
 
     def __init__(self, hass, config):
         """Set all the config values if they exist and get initial state."""
+        value_template = config.get(CONF_VALUE_TEMPLATE)
+
+        if value_template is not None:
+            template.compile_template(hass, value_template)
+
         self._hass = hass
         self._config = {
             CONF_NAME: config.get(CONF_NAME),
@@ -49,7 +54,7 @@ class Sensor(Entity):
             CONF_TIMEOUT: config.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
             CONF_PAYLOAD: config[CONF_PAYLOAD],
             CONF_UNIT: config.get(CONF_UNIT),
-            CONF_VALUE_TEMPLATE: config.get(CONF_VALUE_TEMPLATE),
+            CONF_VALUE_TEMPLATE: value_template,
             CONF_VALUE_ON: config.get(CONF_VALUE_ON),
             CONF_BUFFER_SIZE: config.get(
                 CONF_BUFFER_SIZE, DEFAULT_BUFFER_SIZE),

--- a/homeassistant/components/sensor/tcp.py
+++ b/homeassistant/components/sensor/tcp.py
@@ -9,9 +9,9 @@ import socket
 import select
 
 from homeassistant.const import CONF_NAME, CONF_HOST
-from homeassistant.helpers import template
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.template import Template
 
 CONF_PORT = "port"
 CONF_TIMEOUT = "timeout"
@@ -44,7 +44,7 @@ class Sensor(Entity):
         value_template = config.get(CONF_VALUE_TEMPLATE)
 
         if value_template is not None:
-            template.compile_template(hass, value_template)
+            value_template = Template(value_template, hass)
 
         self._hass = hass
         self._config = {
@@ -127,9 +127,7 @@ class Sensor(Entity):
 
         if self._config[CONF_VALUE_TEMPLATE] is not None:
             try:
-                self._state = template.render(
-                    self._hass,
-                    self._config[CONF_VALUE_TEMPLATE],
+                self._state = self._config[CONF_VALUE_TEMPLATE].render(
                     value=value)
                 return
             except TemplateError as err:

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import ENTITY_ID_FORMAT, PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE,
-    ATTR_ENTITY_ID, MATCH_ALL, CONF_SENSORS)
+    ATTR_ENTITY_ID, CONF_SENSORS)
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import Entity, generate_entity_id
 from homeassistant.helpers.event import track_state_change
@@ -23,7 +23,7 @@ SENSOR_SCHEMA = vol.Schema({
     vol.Required(CONF_VALUE_TEMPLATE): cv.template,
     vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
     vol.Optional(ATTR_UNIT_OF_MEASUREMENT): cv.string,
-    vol.Optional(ATTR_ENTITY_ID, default=MATCH_ALL): cv.entity_ids
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -38,7 +38,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for device, device_config in config[CONF_SENSORS].items():
         state_template = device_config[CONF_VALUE_TEMPLATE]
-        entity_ids = device_config[ATTR_ENTITY_ID]
+        entity_ids = (device_config.get(ATTR_ENTITY_ID) or
+                      state_template.extract_entities())
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         unit_of_measurement = device_config.get(ATTR_UNIT_OF_MEASUREMENT)
 

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -105,7 +105,7 @@ class SensorTemplate(Entity):
     def update(self):
         """Get the latest data and update the states."""
         try:
-            self._state = template.render(self.hass, self._template)
+            self._state = template.render(self._template)
         except TemplateError as ex:
             if ex.args and ex.args[0].startswith(
                     "UndefinedError: 'None' has no attribute"):

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -13,7 +13,6 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE,
     ATTR_ENTITY_ID, MATCH_ALL, CONF_SENSORS)
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template
 from homeassistant.helpers.entity import Entity, generate_entity_id
 from homeassistant.helpers.event import track_state_change
 import homeassistant.helpers.config_validation as cv
@@ -43,6 +42,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         unit_of_measurement = device_config.get(ATTR_UNIT_OF_MEASUREMENT)
 
+        state_template.hass = hass
+
         sensors.append(
             SensorTemplate(
                 hass,
@@ -71,7 +72,7 @@ class SensorTemplate(Entity):
                                             hass=hass)
         self._name = friendly_name
         self._unit_of_measurement = unit_of_measurement
-        self._template = template.compile_template(hass, state_template)
+        self._template = state_template
         self._state = None
 
         self.update()
@@ -105,7 +106,7 @@ class SensorTemplate(Entity):
     def update(self):
         """Get the latest data and update the states."""
         try:
-            self._state = template.render(self._template)
+            self._state = self._template.render()
         except TemplateError as ex:
             if ex.args and ex.args[0].startswith(
                     "UndefinedError: 'None' has no attribute"):

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -38,6 +38,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     switches = []
 
     for device_name, device_config in devices.items():
+        value_template = device_config.get(CONF_VALUE_TEMPLATE)
+
+        if value_template is not None:
+            value_template = template.compile_template(hass, value_template)
+
         switches.append(
             CommandSwitch(
                 hass,
@@ -45,7 +50,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 device_config.get(CONF_COMMAND_ON),
                 device_config.get(CONF_COMMAND_OFF),
                 device_config.get(CONF_COMMAND_STATE),
-                device_config.get(CONF_VALUE_TEMPLATE)
+                value_template,
             )
         )
 

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -13,7 +13,6 @@ from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_FRIENDLY_NAME, CONF_SWITCHES, CONF_VALUE_TEMPLATE, CONF_COMMAND_OFF,
     CONF_COMMAND_ON, CONF_COMMAND_STATE)
-from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,7 +40,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         value_template = device_config.get(CONF_VALUE_TEMPLATE)
 
         if value_template is not None:
-            value_template = template.compile_template(hass, value_template)
+            value_template.hass = hass
 
         switches.append(
             CommandSwitch(
@@ -140,8 +139,8 @@ class CommandSwitch(SwitchDevice):
         if self._command_state:
             payload = str(self._query_state())
             if self._value_template:
-                payload = template.render_with_possible_json_value(
-                    self._hass, self._value_template, payload)
+                payload = self._value_template.render_with_possible_json_value(
+                    payload)
             self._state = (payload.lower() == "true")
 
     def turn_on(self, **kwargs):

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -38,6 +38,11 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the MQTT switch."""
+    value_template = config.get(CONF_VALUE_TEMPLATE)
+
+    if value_template is not None:
+        value_template = template.compile_template(hass, value_template)
+
     add_devices([MqttSwitch(
         hass,
         config.get(CONF_NAME),
@@ -48,7 +53,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         config.get(CONF_PAYLOAD_ON),
         config.get(CONF_PAYLOAD_OFF),
         config.get(CONF_OPTIMISTIC),
-        config.get(CONF_VALUE_TEMPLATE)
+        value_template,
     )])
 
 

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -14,7 +14,6 @@ from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (
     CONF_NAME, CONF_OPTIMISTIC, CONF_VALUE_TEMPLATE, CONF_PAYLOAD_OFF,
     CONF_PAYLOAD_ON)
-from homeassistant.helpers import template
 import homeassistant.components.mqtt as mqtt
 import homeassistant.helpers.config_validation as cv
 
@@ -39,10 +38,8 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the MQTT switch."""
     value_template = config.get(CONF_VALUE_TEMPLATE)
-
     if value_template is not None:
-        value_template = template.compile_template(hass, value_template)
-
+        value_template.hass = hass
     add_devices([MqttSwitch(
         hass,
         config.get(CONF_NAME),
@@ -78,8 +75,8 @@ class MqttSwitch(SwitchDevice):
         def message_received(topic, payload, qos):
             """A new MQTT message has been received."""
             if value_template is not None:
-                payload = template.render_with_possible_json_value(
-                    hass, value_template, payload)
+                payload = value_template.render_with_possible_json_value(
+                    payload)
             if payload == self._payload_on:
                 self._state = True
                 self.update_ha_state()

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -123,7 +123,7 @@ class SwitchTemplate(SwitchDevice):
     def update(self):
         """Update the state from the template."""
         try:
-            state = template.render(self.hass, self._template).lower()
+            state = template.render(self._template).lower()
 
             if state in _VALID_STATES:
                 self._state = state in ('true', STATE_ON)

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -12,7 +12,7 @@ from homeassistant.components.switch import (
     ENTITY_ID_FORMAT, SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, CONF_VALUE_TEMPLATE, STATE_OFF, STATE_ON,
-    ATTR_ENTITY_ID, MATCH_ALL, CONF_SWITCHES)
+    ATTR_ENTITY_ID, CONF_SWITCHES)
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.event import track_state_change
@@ -30,7 +30,7 @@ SWITCH_SCHEMA = vol.Schema({
     vol.Required(ON_ACTION): cv.SCRIPT_SCHEMA,
     vol.Required(OFF_ACTION): cv.SCRIPT_SCHEMA,
     vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
-    vol.Optional(ATTR_ENTITY_ID, default=MATCH_ALL): cv.entity_ids
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -48,7 +48,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         state_template = device_config[CONF_VALUE_TEMPLATE]
         on_action = device_config[ON_ACTION]
         off_action = device_config[OFF_ACTION]
-        entity_ids = device_config[ATTR_ENTITY_ID]
+        entity_ids = (device_config.get(ATTR_ENTITY_ID) or
+                      state_template.extract_entities())
 
         switches.append(
             SwitchTemplate(

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME, CONF_VALUE_TEMPLATE, STATE_OFF, STATE_ON,
     ATTR_ENTITY_ID, MATCH_ALL, CONF_SWITCHES)
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.event import track_state_change
 from homeassistant.helpers.script import Script
@@ -79,7 +78,8 @@ class SwitchTemplate(SwitchDevice):
         self.entity_id = generate_entity_id(ENTITY_ID_FORMAT, device_id,
                                             hass=hass)
         self._name = friendly_name
-        self._template = template.compile_template(hass, state_template)
+        self._template = state_template
+        state_template.hass = hass
         self._on_script = Script(hass, on_action)
         self._off_script = Script(hass, off_action)
         self._state = False
@@ -123,7 +123,7 @@ class SwitchTemplate(SwitchDevice):
     def update(self):
         """Update the state from the template."""
         try:
-            state = template.render(self._template).lower()
+            state = self._template.render().lower()
 
             if state in _VALID_STATES:
                 self._state = state in ('true', STATE_ON)

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -40,7 +40,7 @@ def and_from_config(config: ConfigType, config_validation: bool=True):
     """Create multi condition matcher using 'AND'."""
     if config_validation:
         config = cv.AND_CONDITION_SCHEMA(config)
-    checks = [from_config(entry) for entry in config['conditions']]
+    checks = [from_config(entry, False) for entry in config['conditions']]
 
     def if_and_condition(hass: HomeAssistant,
                          variables=None) -> bool:
@@ -62,7 +62,7 @@ def or_from_config(config: ConfigType, config_validation: bool=True):
     """Create multi condition matcher using 'OR'."""
     if config_validation:
         config = cv.OR_CONDITION_SCHEMA(config)
-    checks = [from_config(entry) for entry in config['conditions']]
+    checks = [from_config(entry, False) for entry in config['conditions']]
 
     def if_or_condition(hass: HomeAssistant,
                         variables=None) -> bool:

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import TemplateError, HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
+from homeassistant.util.async import run_callback_threadsafe
 
 FROM_CONFIG_FORMAT = '{}_from_config'
 
@@ -209,8 +210,15 @@ def sun_from_config(config, config_validation=True):
 
 def template(hass, value_template, variables=None):
     """Test if template condition matches."""
+    return run_callback_threadsafe(
+        hass.loop, async_template, hass, value_template, variables,
+    ).result()
+
+
+def async_template(hass, value_template, variables=None):
+    """Test if template condition matches."""
     try:
-        value = value_template.render(variables)
+        value = value_template.async_render(variables)
     except TemplateError as ex:
         _LOGGER.error('Error duriong template condition: %s', ex)
         return False

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -50,7 +50,8 @@ def call_from_config(hass, config, blocking=False, variables=None,
     else:
         try:
             domain_service = template.render(
-                hass, config[CONF_SERVICE_TEMPLATE], variables)
+                template.compile_template(hass, config[CONF_SERVICE_TEMPLATE]),
+                variables)
             domain_service = cv.service(domain_service)
         except TemplateError as ex:
             _LOGGER.error('Error rendering service name template: %s', ex)
@@ -73,7 +74,8 @@ def call_from_config(hass, config, blocking=False, variables=None,
             for key, element in value.items():
                 value[key] = _data_template_creator(element)
             return value
-        return template.render(hass, value, variables)
+        return template.render(template.compile_template(hass, value),
+                               variables)
 
     if CONF_SERVICE_DATA_TEMPLATE in config:
         for key, value in config[CONF_SERVICE_DATA_TEMPLATE].items():

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -9,7 +9,6 @@ import voluptuous as vol
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant  # NOQA
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template
 from homeassistant.loader import get_component
 import homeassistant.helpers.config_validation as cv
 
@@ -49,9 +48,8 @@ def call_from_config(hass, config, blocking=False, variables=None,
         domain_service = config[CONF_SERVICE]
     else:
         try:
-            domain_service = template.render(
-                template.compile_template(hass, config[CONF_SERVICE_TEMPLATE]),
-                variables)
+            config[CONF_SERVICE_TEMPLATE].hass = hass
+            domain_service = config[CONF_SERVICE_TEMPLATE].render(variables)
             domain_service = cv.service(domain_service)
         except TemplateError as ex:
             _LOGGER.error('Error rendering service name template: %s', ex)
@@ -74,8 +72,8 @@ def call_from_config(hass, config, blocking=False, variables=None,
             for key, element in value.items():
                 value[key] = _data_template_creator(element)
             return value
-        return template.render(template.compile_template(hass, value),
-                               variables)
+        value.hass = hass
+        return value.render(variables)
 
     if CONF_SERVICE_DATA_TEMPLATE in config:
         for key, value in config[CONF_SERVICE_DATA_TEMPLATE].items():

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -39,6 +39,17 @@ def attach(hass, obj):
         obj.hass = hass
 
 
+def extract_entities(template):
+    """Extract all entities for state_changed listener from template string."""
+    if template is None or _RE_NONE_ENTITIES.search(template):
+        return MATCH_ALL
+
+    extraction = _RE_GET_ENTITIES.findall(template)
+    if len(extraction) > 0:
+        return list(set(extraction))
+    return MATCH_ALL
+
+
 class Template(object):
     """Class to hold a template and manage caching and rendering."""
 
@@ -61,6 +72,10 @@ class Template(object):
             self._compiled_code = ENV.compile(self.template)
         except jinja2.exceptions.TemplateSyntaxError as err:
             raise TemplateError(err)
+
+    def extract_entities(self):
+        """Extract all entities for state_changed listener."""
+        return extract_entities(self.template)
 
     def render(self, variables=None, **kwargs):
         """Render given template."""
@@ -143,17 +158,6 @@ class Template(object):
             ENV, self._compiled_code, global_vars, None)
 
         return self._compiled
-
-
-def extract_entities(template):
-    """Extract all entities for state_changed listener from template string."""
-    if template is None or _RE_NONE_ENTITIES.search(template):
-        return MATCH_ALL
-
-    extraction = _RE_GET_ENTITIES.findall(template)
-    if len(extraction) > 0:
-        return list(set(extraction))
-    return MATCH_ALL
 
 
 class AllStates(object):

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -19,7 +19,7 @@ DATE_STR_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
 def attach(hass, obj):
-    """Recursively Attach hass to all template instances in list and dict."""
+    """Recursively attach hass to all template instances in list and dict."""
     if isinstance(obj, list):
         for child in obj:
             attach(hass, child)
@@ -34,6 +34,7 @@ class Template(object):
     """Class to hold a template and manage caching and rendering."""
 
     def __init__(self, template, hass=None):
+        """Instantiate a Template."""
         if not isinstance(template, str):
             raise TypeError('Expected template to be a string')
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -94,6 +94,7 @@ class Template(object):
             self.hass.loop, self.async_render_with_possible_json_value, value,
             error_value).result()
 
+    # pylint: disable=invalid-name
     def async_render_with_possible_json_value(self, value,
                                               error_value=_SENTINEL):
         """Render template with value exposed.

--- a/tests/components/binary_sensor/test_command_line.py
+++ b/tests/components/binary_sensor/test_command_line.py
@@ -4,6 +4,7 @@ import unittest
 from homeassistant.const import (STATE_ON, STATE_OFF)
 from homeassistant.components.binary_sensor import command_line
 from homeassistant import bootstrap
+from homeassistant.helpers import template
 
 from tests.common import get_test_home_assistant
 
@@ -56,7 +57,7 @@ class TestCommandSensorBinarySensor(unittest.TestCase):
 
         entity = command_line.CommandBinarySensor(
             self.hass, data, 'test', None, '1.0', '0',
-            '{{ value | multiply(0.1) }}')
+            template.Template('{{ value | multiply(0.1) }}', self.hass))
 
         self.assertEqual(STATE_ON, entity.state)
 

--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -4,8 +4,10 @@ from unittest import mock
 
 from homeassistant.const import EVENT_STATE_CHANGED, MATCH_ALL
 import homeassistant.bootstrap as bootstrap
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA
 from homeassistant.components.binary_sensor import template
 from homeassistant.exceptions import TemplateError
+from homeassistant.helpers import template as template_hlpr
 
 from tests.common import get_test_home_assistant
 
@@ -16,22 +18,24 @@ class TestBinarySensorTemplate(unittest.TestCase):
     @mock.patch.object(template, 'BinarySensorTemplate')
     def test_setup(self, mock_template):
         """"Test the setup."""
-        config = {
+        hass = mock.MagicMock()
+        tpl = template_hlpr.Template('{{ foo }}', hass)
+        config = PLATFORM_SCHEMA({
+            'platform': 'template',
             'sensors': {
                 'test': {
                     'friendly_name': 'virtual thingy',
-                    'value_template': '{{ foo }}',
+                    'value_template': tpl,
                     'sensor_class': 'motion',
                     'entity_id': 'test'
                 },
             }
-        }
-        hass = mock.MagicMock()
+        })
         add_devices = mock.MagicMock()
         result = template.setup_platform(hass, config, add_devices)
         self.assertTrue(result)
         mock_template.assert_called_once_with(hass, 'test', 'virtual thingy',
-                                              'motion', '{{ foo }}', 'test')
+                                              'motion', tpl, 'test')
         add_devices.assert_called_once_with([mock_template.return_value])
 
     def test_setup_no_sensors(self):
@@ -91,8 +95,9 @@ class TestBinarySensorTemplate(unittest.TestCase):
     def test_attributes(self):
         """"Test the attributes."""
         hass = mock.MagicMock()
-        vs = template.BinarySensorTemplate(hass, 'parent', 'Parent',
-                                           'motion', '{{ 1 > 1 }}', MATCH_ALL)
+        vs = template.BinarySensorTemplate(
+            hass, 'parent', 'Parent', 'motion',
+            template_hlpr.Template('{{ 1 > 1 }}', hass), MATCH_ALL)
         self.assertFalse(vs.should_poll)
         self.assertEqual('motion', vs.sensor_class)
         self.assertEqual('Parent', vs.name)
@@ -100,15 +105,16 @@ class TestBinarySensorTemplate(unittest.TestCase):
         vs.update()
         self.assertFalse(vs.is_on)
 
-        vs._template = "{{ 2 > 1 }}"
+        vs._template = template_hlpr.Template("{{ 2 > 1 }}", hass)
         vs.update()
         self.assertTrue(vs.is_on)
 
     def test_event(self):
         """"Test the event."""
         hass = get_test_home_assistant()
-        vs = template.BinarySensorTemplate(hass, 'parent', 'Parent',
-                                           'motion', '{{ 1 > 1 }}', MATCH_ALL)
+        vs = template.BinarySensorTemplate(
+            hass, 'parent', 'Parent', 'motion',
+            template_hlpr.Template('{{ 1 > 1 }}', hass), MATCH_ALL)
         vs.update_ha_state()
         hass.block_till_done()
 
@@ -120,12 +126,13 @@ class TestBinarySensorTemplate(unittest.TestCase):
             finally:
                 hass.stop()
 
-    @mock.patch('homeassistant.helpers.template.render')
+    @mock.patch('homeassistant.helpers.template.Template.render')
     def test_update_template_error(self, mock_render):
         """"Test the template update error."""
         hass = mock.MagicMock()
-        vs = template.BinarySensorTemplate(hass, 'parent', 'Parent',
-                                           'motion', '{{ 1 > 1 }}', MATCH_ALL)
+        vs = template.BinarySensorTemplate(
+            hass, 'parent', 'Parent', 'motion',
+            template_hlpr.Template('{{ 1 > 1 }}', hass), MATCH_ALL)
         mock_render.side_effect = TemplateError('foo')
         vs.update()
         mock_render.side_effect = TemplateError(

--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -41,8 +41,8 @@ class TestBinarySensorTemplate(unittest.TestCase):
         add_devices = mock.MagicMock()
         result = template.setup_platform(self.hass, config, add_devices)
         self.assertTrue(result)
-        mock_template.assert_called_once_with(self.hass, 'test', 'virtual thingy',
-                                              'motion', tpl, 'test')
+        mock_template.assert_called_once_with(
+            self.hass, 'test', 'virtual thingy', 'motion', tpl, 'test')
         add_devices.assert_called_once_with([mock_template.return_value])
 
     def test_setup_no_sensors(self):

--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -15,11 +15,18 @@ from tests.common import get_test_home_assistant
 class TestBinarySensorTemplate(unittest.TestCase):
     """Test for Binary sensor template platform."""
 
+    def setup_method(self, method):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
     @mock.patch.object(template, 'BinarySensorTemplate')
     def test_setup(self, mock_template):
         """"Test the setup."""
-        hass = mock.MagicMock()
-        tpl = template_hlpr.Template('{{ foo }}', hass)
+        tpl = template_hlpr.Template('{{ foo }}', self.hass)
         config = PLATFORM_SCHEMA({
             'platform': 'template',
             'sensors': {
@@ -32,16 +39,15 @@ class TestBinarySensorTemplate(unittest.TestCase):
             }
         })
         add_devices = mock.MagicMock()
-        result = template.setup_platform(hass, config, add_devices)
+        result = template.setup_platform(self.hass, config, add_devices)
         self.assertTrue(result)
-        mock_template.assert_called_once_with(hass, 'test', 'virtual thingy',
+        mock_template.assert_called_once_with(self.hass, 'test', 'virtual thingy',
                                               'motion', tpl, 'test')
         add_devices.assert_called_once_with([mock_template.return_value])
 
     def test_setup_no_sensors(self):
         """"Test setup with no sensors."""
-        hass = mock.MagicMock()
-        result = bootstrap.setup_component(hass, 'sensor', {
+        result = bootstrap.setup_component(self.hass, 'sensor', {
             'sensor': {
                 'platform': 'template'
             }
@@ -50,8 +56,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
 
     def test_setup_invalid_device(self):
         """"Test the setup with invalid devices."""
-        hass = mock.MagicMock()
-        result = bootstrap.setup_component(hass, 'sensor', {
+        result = bootstrap.setup_component(self.hass, 'sensor', {
             'sensor': {
                 'platform': 'template',
                 'sensors': {
@@ -63,8 +68,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
 
     def test_setup_invalid_sensor_class(self):
         """"Test setup with invalid sensor class."""
-        hass = mock.MagicMock()
-        result = bootstrap.setup_component(hass, 'sensor', {
+        result = bootstrap.setup_component(self.hass, 'sensor', {
             'sensor': {
                 'platform': 'template',
                 'sensors': {
@@ -79,8 +83,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
 
     def test_setup_invalid_missing_template(self):
         """"Test setup with invalid and missing template."""
-        hass = mock.MagicMock()
-        result = bootstrap.setup_component(hass, 'sensor', {
+        result = bootstrap.setup_component(self.hass, 'sensor', {
             'sensor': {
                 'platform': 'template',
                 'sensors': {
@@ -94,10 +97,9 @@ class TestBinarySensorTemplate(unittest.TestCase):
 
     def test_attributes(self):
         """"Test the attributes."""
-        hass = mock.MagicMock()
         vs = template.BinarySensorTemplate(
-            hass, 'parent', 'Parent', 'motion',
-            template_hlpr.Template('{{ 1 > 1 }}', hass), MATCH_ALL)
+            self.hass, 'parent', 'Parent', 'motion',
+            template_hlpr.Template('{{ 1 > 1 }}', self.hass), MATCH_ALL)
         self.assertFalse(vs.should_poll)
         self.assertEqual('motion', vs.sensor_class)
         self.assertEqual('Parent', vs.name)
@@ -105,34 +107,29 @@ class TestBinarySensorTemplate(unittest.TestCase):
         vs.update()
         self.assertFalse(vs.is_on)
 
-        vs._template = template_hlpr.Template("{{ 2 > 1 }}", hass)
+        vs._template = template_hlpr.Template("{{ 2 > 1 }}", self.hass)
         vs.update()
         self.assertTrue(vs.is_on)
 
     def test_event(self):
         """"Test the event."""
-        hass = get_test_home_assistant()
         vs = template.BinarySensorTemplate(
-            hass, 'parent', 'Parent', 'motion',
-            template_hlpr.Template('{{ 1 > 1 }}', hass), MATCH_ALL)
+            self.hass, 'parent', 'Parent', 'motion',
+            template_hlpr.Template('{{ 1 > 1 }}', self.hass), MATCH_ALL)
         vs.update_ha_state()
-        hass.block_till_done()
+        self.hass.block_till_done()
 
         with mock.patch.object(vs, 'update') as mock_update:
-            hass.bus.fire(EVENT_STATE_CHANGED)
-            hass.block_till_done()
-            try:
-                assert mock_update.call_count == 1
-            finally:
-                hass.stop()
+            self.hass.bus.fire(EVENT_STATE_CHANGED)
+            self.hass.block_till_done()
+            assert mock_update.call_count == 1
 
     @mock.patch('homeassistant.helpers.template.Template.render')
     def test_update_template_error(self, mock_render):
         """"Test the template update error."""
-        hass = mock.MagicMock()
         vs = template.BinarySensorTemplate(
-            hass, 'parent', 'Parent', 'motion',
-            template_hlpr.Template('{{ 1 > 1 }}', hass), MATCH_ALL)
+            self.hass, 'parent', 'Parent', 'motion',
+            template_hlpr.Template('{{ 1 > 1 }}', self.hass), MATCH_ALL)
         mock_render.side_effect = TemplateError('foo')
         vs.update()
         mock_render.side_effect = TemplateError(

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -118,20 +118,6 @@ class TestMQTT(unittest.TestCase):
         }, blocking=True)
         self.assertFalse(mqtt.MQTT_CLIENT.publish.called)
 
-    def test_service_call_without_payload_or_payload_template(self):
-        """Test the service call without payload or payload template.
-
-        Send empty message if neither 'payload' nor 'payload_template'
-        are provided.
-        """
-        # Call the service directly because the helper functions require you to
-        # provide a payload.
-        self.hass.services.call(mqtt.DOMAIN, mqtt.SERVICE_PUBLISH, {
-            mqtt.ATTR_TOPIC: "test/topic"
-        }, blocking=True)
-        self.assertTrue(mqtt.MQTT_CLIENT.publish.called)
-        self.assertEqual(mqtt.MQTT_CLIENT.publish.call_args[0][1], "")
-
     def test_service_call_with_ascii_qos_retain_flags(self):
         """Test the service call with args that can be misinterpreted.
 

--- a/tests/components/sensor/test_command_line.py
+++ b/tests/components/sensor/test_command_line.py
@@ -1,6 +1,7 @@
 """The tests for the Command line sensor platform."""
 import unittest
 
+from homeassistant.helpers.template import Template
 from homeassistant.components.sensor import command_line
 from homeassistant import bootstrap
 from tests.common import get_test_home_assistant
@@ -53,7 +54,8 @@ class TestCommandSensorSensor(unittest.TestCase):
         data = command_line.CommandSensorData('echo 50')
 
         entity = command_line.CommandSensor(
-            self.hass, data, 'test', 'in', '{{ value | multiply(0.1) }}')
+            self.hass, data, 'test', 'in',
+            Template('{{ value | multiply(0.1) }}', self.hass))
 
         self.assertEqual(5, float(entity.state))
 

--- a/tests/components/sensor/test_imap_email_content.py
+++ b/tests/components/sensor/test_imap_email_content.py
@@ -1,16 +1,16 @@
 """The tests for the IMAP email content sensor platform."""
-import unittest
+from collections import deque
 import email
-import datetime
-
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+import datetime
 from threading import Event
+import unittest
 
+from homeassistant.helpers.template import Template
 from homeassistant.helpers.event import track_state_change
-from collections import deque
-
 from homeassistant.components.sensor import imap_email_content
+
 from tests.common import get_test_home_assistant
 
 
@@ -218,7 +218,8 @@ class EmailContentSensor(unittest.TestCase):
             FakeEMailReader(deque([test_message])),
             "test_emails_sensor",
             ["sender@test.com"],
-            "{{ subject }} from {{ from }} with message {{ body }}")
+            Template("{{ subject }} from {{ from }} with message {{ body }}",
+                     self.hass))
 
         sensor.entity_id = "sensor.emailtest"
         sensor.update()

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -10,7 +10,7 @@ from homeassistant.components import rfxtrx as rfxtrx
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skip
+@pytest.mark.skipif("os.environ.get('RFXTRX') == 'SKIP'")
 class TestRFXTRX(unittest.TestCase):
     """Test the Rfxtrx component."""
 

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -3,11 +3,14 @@
 import unittest
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.bootstrap import _setup_component
 from homeassistant.components import rfxtrx as rfxtrx
 from tests.common import get_test_home_assistant
 
 
+@pytest.mark.skip
 class TestRFXTRX(unittest.TestCase):
     """Test the Rfxtrx component."""
 

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -2,7 +2,7 @@
 # pylint: disable=too-many-public-methods,protected-access
 import unittest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import script
 
 from tests.common import get_test_home_assistant
@@ -41,7 +41,7 @@ class TestScriptComponent(unittest.TestCase):
                 }
             },
         ):
-            assert not _setup_component(self.hass, 'script', {
+            assert not setup_component(self.hass, 'script', {
                 'script': value
             }), 'Script loaded with wrong config {}'.format(value)
 
@@ -58,7 +58,7 @@ class TestScriptComponent(unittest.TestCase):
 
         self.hass.bus.listen(event, record_event)
 
-        assert _setup_component(self.hass, 'script', {
+        assert setup_component(self.hass, 'script', {
             'script': {
                 'test': {
                     'sequence': [{
@@ -93,7 +93,7 @@ class TestScriptComponent(unittest.TestCase):
 
         self.hass.bus.listen(event, record_event)
 
-        assert _setup_component(self.hass, 'script', {
+        assert setup_component(self.hass, 'script', {
             'script': {
                 'test': {
                     'sequence': [{
@@ -127,7 +127,7 @@ class TestScriptComponent(unittest.TestCase):
 
         self.hass.services.register('test', 'script', record_call)
 
-        assert _setup_component(self.hass, 'script', {
+        assert setup_component(self.hass, 'script', {
             'script': {
                 'test': {
                     'sequence': {

--- a/tests/components/test_shell_command.py
+++ b/tests/components/test_shell_command.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import patch
 from subprocess import SubprocessError
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import shell_command
 
 from tests.common import get_test_home_assistant
@@ -26,7 +26,7 @@ class TestShellCommand(unittest.TestCase):
         """Test if able to call a configured service."""
         with tempfile.TemporaryDirectory() as tempdirname:
             path = os.path.join(tempdirname, 'called.txt')
-            assert _setup_component(self.hass, shell_command.DOMAIN, {
+            assert setup_component(self.hass, shell_command.DOMAIN, {
                 shell_command.DOMAIN: {
                     'test_service': "date > {}".format(path)
                 }
@@ -40,41 +40,54 @@ class TestShellCommand(unittest.TestCase):
 
     def test_config_not_dict(self):
         """Test if config is not a dict."""
-        assert not _setup_component(self.hass, shell_command.DOMAIN, {
+        assert not setup_component(self.hass, shell_command.DOMAIN, {
             shell_command.DOMAIN: ['some', 'weird', 'list']
         })
 
     def test_config_not_valid_service_names(self):
         """Test if config contains invalid service names."""
-        assert not _setup_component(self.hass, shell_command.DOMAIN, {
+        assert not setup_component(self.hass, shell_command.DOMAIN, {
             shell_command.DOMAIN: {
                 'this is invalid because space': 'touch bla.txt'
             }
         })
 
-    def test_template_render_no_template(self):
+    @patch('homeassistant.components.shell_command.subprocess.call')
+    def test_template_render_no_template(self, mock_call):
         """Ensure shell_commands without templates get rendered properly."""
-        cmd, shell = shell_command._parse_command(self.hass, 'ls /bin', {})
-        self.assertTrue(shell)
-        self.assertEqual(cmd, 'ls /bin')
+        assert setup_component(self.hass, shell_command.DOMAIN, {
+            shell_command.DOMAIN: {
+                'test_service': "ls /bin"
+            }
+        })
 
-    def test_template_render(self):
-        """Ensure shell_commands with templates get rendered properly."""
+        self.hass.services.call('shell_command', 'test_service',
+                                blocking=True)
+
+        cmd = mock_call.mock_calls[0][1][0]
+        shell = mock_call.mock_calls[0][2]['shell']
+
+        assert 'ls /bin' == cmd
+        assert shell
+
+    @patch('homeassistant.components.shell_command.subprocess.call')
+    def test_template_render(self, mock_call):
+        """Ensure shell_commands without templates get rendered properly."""
         self.hass.states.set('sensor.test_state', 'Works')
-        cmd, shell = shell_command._parse_command(
-            self.hass,
-            'ls /bin {{ states.sensor.test_state.state }}', {}
-        )
-        self.assertFalse(shell, False)
-        self.assertEqual(cmd[-1], 'Works')
+        assert setup_component(self.hass, shell_command.DOMAIN, {
+            shell_command.DOMAIN: {
+                'test_service': "ls /bin {{ states.sensor.test_state.state }}"
+            }
+        })
 
-    def test_invalid_template_fails(self):
-        """Test that shell_commands with invalid templates fail."""
-        cmd, _shell = shell_command._parse_command(
-            self.hass,
-            'ls /bin {{ states. .test_state.state }}', {}
-        )
-        self.assertEqual(cmd, None)
+        self.hass.services.call('shell_command', 'test_service',
+                                blocking=True)
+
+        cmd = mock_call.mock_calls[0][1][0]
+        shell = mock_call.mock_calls[0][2]['shell']
+
+        assert ['ls', '/bin', 'Works'] == cmd
+        assert not shell
 
     @patch('homeassistant.components.shell_command.subprocess.call',
            side_effect=SubprocessError)
@@ -83,7 +96,7 @@ class TestShellCommand(unittest.TestCase):
         """Test subprocess."""
         with tempfile.TemporaryDirectory() as tempdirname:
             path = os.path.join(tempdirname, 'called.txt')
-            assert _setup_component(self.hass, shell_command.DOMAIN, {
+            assert setup_component(self.hass, shell_command.DOMAIN, {
                 shell_command.DOMAIN: {
                     'test_service': "touch {}".format(path)
                 }

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -44,6 +44,32 @@ class TestConditionHelper:
         self.hass.states.set('sensor.temperature', 100)
         assert test(self.hass)
 
+    def test_and_condition_with_template(self):
+        """Test the 'and' condition."""
+        test = condition.from_config({
+            'condition': 'and',
+            'conditions': [
+                {
+                    'condition': 'template',
+                    'value_template':
+                    '{{ states.sensor.temperature.state == "100" }}',
+                }, {
+                    'condition': 'numeric_state',
+                    'entity_id': 'sensor.temperature',
+                    'below': 110,
+                }
+            ]
+        })
+
+        self.hass.states.set('sensor.temperature', 120)
+        assert not test(self.hass)
+
+        self.hass.states.set('sensor.temperature', 105)
+        assert not test(self.hass)
+
+        self.hass.states.set('sensor.temperature', 100)
+        assert test(self.hass)
+
     def test_or_condition(self):
         """Test the 'or' condition."""
         test = condition.from_config({
@@ -53,6 +79,32 @@ class TestConditionHelper:
                     'condition': 'state',
                     'entity_id': 'sensor.temperature',
                     'state': '100',
+                }, {
+                    'condition': 'numeric_state',
+                    'entity_id': 'sensor.temperature',
+                    'below': 110,
+                }
+            ]
+        })
+
+        self.hass.states.set('sensor.temperature', 120)
+        assert not test(self.hass)
+
+        self.hass.states.set('sensor.temperature', 105)
+        assert test(self.hass)
+
+        self.hass.states.set('sensor.temperature', 100)
+        assert test(self.hass)
+
+    def test_or_condition_with_template(self):
+        """Test the 'or' condition."""
+        test = condition.from_config({
+            'condition': 'or',
+            'conditions': [
+                {
+                    'condition': 'template',
+                    'value_template':
+                    '{{ states.sensor.temperature.state == "100" }}',
                 }, {
                     'condition': 'numeric_state',
                     'entity_id': 'sensor.temperature',

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -1,6 +1,7 @@
 """Test config validators."""
 from collections import OrderedDict
 from datetime import timedelta
+import enum
 import os
 import tempfile
 
@@ -302,7 +303,8 @@ def test_template():
     schema = vol.Schema(cv.template)
 
     for value in (None, '{{ partial_print }', '{% if True %}Hello', ['test']):
-        with pytest.raises(vol.MultipleInvalid):
+        with pytest.raises(vol.Invalid,
+                           message='{} not considered invalid'.format(value)):
             schema(value)
 
     for value in (
@@ -417,3 +419,18 @@ def test_ordered_dict_value_validator():
         schema({'hello': 'world'})
 
     schema({'hello': 5})
+
+
+def test_enum():
+    """Test enum validator."""
+    class TestEnum(enum.Enum):
+        """Test enum."""
+        value1 = "Value 1"
+        value2 = "Value 2"
+
+    schema = vol.Schema(cv.enum(TestEnum))
+
+    with pytest.raises(vol.Invalid):
+        schema('value3')
+
+    TestEnum['value1']

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -425,6 +425,7 @@ def test_enum():
     """Test enum validator."""
     class TestEnum(enum.Enum):
         """Test enum."""
+
         value1 = "Value 1"
         value2 = "Value 2"
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -6,7 +6,7 @@ import unittest
 # Otherwise can't test just this file (import order issue)
 import homeassistant.components  # noqa
 import homeassistant.util.dt as dt_util
-from homeassistant.helpers import script
+from homeassistant.helpers import script, config_validation as cv
 
 from tests.common import fire_time_changed, get_test_home_assistant
 
@@ -36,12 +36,12 @@ class TestScriptHelper(unittest.TestCase):
 
         self.hass.bus.listen(event, record_event)
 
-        script_obj = script.Script(self.hass, {
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA({
             'event': event,
             'event_data': {
                 'hello': 'world'
             }
-        })
+        }))
 
         script_obj.run()
 
@@ -61,14 +61,13 @@ class TestScriptHelper(unittest.TestCase):
 
         self.hass.services.register('test', 'script', record_call)
 
-        script_obj = script.Script(self.hass, {
+        script.call_from_config(self.hass, {
             'service': 'test.script',
             'data': {
                 'hello': 'world'
             }
         })
 
-        script_obj.run()
         self.hass.block_till_done()
 
         assert len(calls) == 1
@@ -84,7 +83,7 @@ class TestScriptHelper(unittest.TestCase):
 
         self.hass.services.register('test', 'script', record_call)
 
-        script_obj = script.Script(self.hass, {
+        script.call_from_config(self.hass, {
             'service_template': """
                 {% if True %}
                     test.script
@@ -102,8 +101,6 @@ class TestScriptHelper(unittest.TestCase):
             }
         })
 
-        script_obj.run()
-
         self.hass.block_till_done()
 
         assert len(calls) == 1
@@ -120,10 +117,10 @@ class TestScriptHelper(unittest.TestCase):
 
         self.hass.bus.listen(event, record_event)
 
-        script_obj = script.Script(self.hass, [
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
             {'event': event},
             {'delay': {'seconds': 5}},
-            {'event': event}])
+            {'event': event}]))
 
         script_obj.run()
 
@@ -152,10 +149,10 @@ class TestScriptHelper(unittest.TestCase):
 
         self.hass.bus.listen(event, record_event)
 
-        script_obj = script.Script(self.hass, [
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
             {'event': event},
             {'delay': '00:00:{{ 5 }}'},
-            {'event': event}])
+            {'event': event}]))
 
         script_obj.run()
 
@@ -184,9 +181,9 @@ class TestScriptHelper(unittest.TestCase):
 
         self.hass.bus.listen(event, record_event)
 
-        script_obj = script.Script(self.hass, [
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
             {'delay': {'seconds': 5}},
-            {'event': event}])
+            {'event': event}]))
 
         script_obj.run()
 
@@ -217,7 +214,7 @@ class TestScriptHelper(unittest.TestCase):
 
         self.hass.services.register('test', 'script', record_call)
 
-        script_obj = script.Script(self.hass, [
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
             {
                 'service': 'test.script',
                 'data_template': {
@@ -230,7 +227,7 @@ class TestScriptHelper(unittest.TestCase):
                 'data_template': {
                     'hello': '{{ greeting2 }}',
                 },
-            }])
+            }]))
 
         script_obj.run({
             'greeting': 'world',
@@ -264,14 +261,14 @@ class TestScriptHelper(unittest.TestCase):
 
         self.hass.states.set('test.entity', 'hello')
 
-        script_obj = script.Script(self.hass, [
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
             {'event': event},
             {
                 'condition': 'template',
                 'value_template': '{{ states.test.entity.state == "hello" }}',
             },
             {'event': event},
-        ])
+        ]))
 
         script_obj.run()
         self.hass.block_till_done()

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -328,16 +328,18 @@ class TestHelpersTemplate(unittest.TestCase):
         self.hass.states.set('test.object_2', 'happy', {
             'latitude': 10,
         })
-
+        tpl = template.Template('{{ distance(states.test.object_2) | round }}',
+                                self.hass)
         self.assertEqual(
             'None',
-            template.Template('{{ distance(states.test.object_2) | round }}', self.hass).render())
+            tpl.render())
 
     def test_distance_function_return_None_if_invalid_coord(self):
         """Test distance function return None if invalid coord."""
         self.assertEqual(
             'None',
-            template.Template('{{ distance("123", "abc") }}', self.hass).render())
+            template.Template(
+                '{{ distance("123", "abc") }}', self.hass).render())
 
         self.assertEqual(
             'None',
@@ -347,10 +349,11 @@ class TestHelpersTemplate(unittest.TestCase):
             'latitude': self.hass.config.latitude,
             'longitude': self.hass.config.longitude,
         })
-
+        tpl = template.Template('{{ distance("123", states.test_object_2) }}',
+                                self.hass)
         self.assertEqual(
             'None',
-            template.Template('{{ distance("123", states.test_object_2) }}', self.hass).render())
+            tpl.render())
 
     def test_closest_function_home_vs_domain(self):
         """Test closest function home vs domain."""

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -607,26 +607,26 @@ is_state_attr('device_tracker.phone_2', 'battery', 40)
             """))
 
         self.assertListEqual(
-            [
+            sorted([
                 'device_tracker.phone_1',
                 'device_tracker.phone_2',
-            ],
-            template.extract_entities("""
+            ]),
+            sorted(template.extract_entities("""
 {% if is_state('device_tracker.phone_1', 'home') %}
     Ha, Hercules is home!
 {% elif states.device_tracker.phone_2.attributes.battery < 40 %}
     Hercules you power goes done!.
 {% endif %}
-            """))
+            """)))
 
         self.assertListEqual(
-            [
+            sorted([
                 'sensor.pick_humidity',
                 'sensor.pick_temperature',
-            ],
-            template.extract_entities("""
+            ]),
+            sorted(template.extract_entities("""
 {{
     states.sensor.pick_temperature.state ~ „°C (“ ~
     states.sensor.pick_humidity.state ~ „ %“
 }}
-            """))
+            """)))


### PR DESCRIPTION
**Description:**
In #3515 I made an initial stab at pre-compiling templates. This PR continues that approach but goes all in with a HASS-wide refactor of how we handle templates.

This PR introduces a new `Template` class. This class will hold the template, is able to validate and render it. You will not have to initialize one yourself, they get created by the `cv.template` configuration validator.

It used to be that during config validation we would compile it, and then again on initialization of the platform/component. This is now done in 1 pass inside the `Template` class.

Also added voluptuous to Alexa.

FYI when code reviewing:
- Manually instantiating `Template` objects when there is no config validation.
- No check if value_template is None if it is a required field.

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
