### PR TITLE
Upgrade dnspython3 to 1.14.0

### DIFF
--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -14,7 +14,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_PASSWORD, CONF_SENDER, CONF_RECIPIENT
 
 REQUIREMENTS = ['sleekxmpp==1.3.1',
-                'dnspython3==1.12.0',
+                'dnspython3==1.14.0',
                 'pyasn1==0.1.9',
                 'pyasn1-modules==0.0.8']
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -68,7 +68,7 @@ colorlog>2.1,<3
 directpy==0.1
 
 # homeassistant.components.notify.xmpp
-dnspython3==1.12.0
+dnspython3==1.14.0
 
 # homeassistant.components.dweet
 # homeassistant.components.sensor.dweet


### PR DESCRIPTION
## 1.14.0
- Add CSYNC RR support
- Fix bug in LOC which destroyed N/S and E/W distinctions within a degree of the equator or prime merdian respectively.
- Misc. fixes to deal with fallout from the Python 2 & 3 merge.
- Running with python optimization on caused issues when stripped docstrings were referenced.
- dns.zone.from_text() erroneously required the zone to be provided.

Tested with the following configuration:

``` yaml
notify:
  - platform: xmpp
    name: jabber
    sender: sender@swissjabber.org
    password: !secret xmpp_password
    recipient: recipient@swissjabber.org
```

Message sent with "Call Service" :

``` json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!",
  "title": "Test message"
}
```
