### PR TITLE
Upgrade fuzzywuzzy to 0.12.0

### DIFF
--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['fuzzywuzzy==0.11.1']
+REQUIREMENTS = ['fuzzywuzzy==0.12.0']
 
 ATTR_TEXT = 'text'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -103,7 +103,7 @@ fixerio==0.1.1
 freesms==0.1.0
 
 # homeassistant.components.conversation
-fuzzywuzzy==0.11.1
+fuzzywuzzy==0.12.0
 
 # homeassistant.components.device_tracker.bluetooth_le_tracker
 # gattlib==0.20150805


### PR DESCRIPTION
## 0.12.0 (2016-09-14)
- Declare support for universal wheels. [Thomas Grainger]
- Clarify that license is GPLv2. [Gareth Tan]

Tested with the following configuration:

``` yaml
conversation:
```
