### PR TITLE
Optimize template -> entities extractor

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2,11 +2,13 @@
 # pylint: disable=too-few-public-methods
 import json
 import logging
+import re
 
 import jinja2
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 
-from homeassistant.const import STATE_UNKNOWN, ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.const import (
+    STATE_UNKNOWN, ATTR_LATITUDE, ATTR_LONGITUDE, MATCH_ALL)
 from homeassistant.core import State
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import location as loc_helper
@@ -16,6 +18,12 @@ from homeassistant.util import convert, dt as dt_util, location as loc_util
 _LOGGER = logging.getLogger(__name__)
 _SENTINEL = object()
 DATE_STR_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+_RE_NONE_ENTITIES = re.compile(r"distance\(|closest\(", re.I | re.M)
+_RE_GET_ENTITIES = re.compile(
+    r"(?:(?:states\.|(?:is_state|is_state_attr|states)\(.)([\w]+\.[\w]+))",
+    re.I | re.M
+)
 
 
 def compile_template(hass, template):
@@ -69,6 +77,17 @@ def render(hass, template, variables=None, **kwargs):
         return template.render(kwargs).strip()
     except jinja2.TemplateError as err:
         raise TemplateError(err)
+
+
+def extract_entities(template):
+    """Extract all entities for state_changed listener from template string."""
+    if template is None or _RE_NONE_ENTITIES.search(template):
+        return MATCH_ALL
+
+    extraction = _RE_GET_ENTITIES.findall(template)
+    if len(extraction) > 0:
+        return list(set(extraction))
+    return MATCH_ALL
 
 
 class AllStates(object):

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -652,26 +652,26 @@ is_state_attr('device_tracker.phone_2', 'battery', 40)
             """))
 
         self.assertListEqual(
-            [
+            sorted([
                 'device_tracker.phone_1',
                 'device_tracker.phone_2',
-            ],
-            template.extract_entities("""
+            ]),
+            sorted(template.extract_entities("""
 {% if is_state('device_tracker.phone_1', 'home') %}
     Ha, Hercules is home!
 {% elif states.device_tracker.phone_2.attributes.battery < 40 %}
     Hercules you power goes done!.
 {% endif %}
-            """))
+            """)))
 
         self.assertListEqual(
-            [
+            sorted([
                 'sensor.pick_humidity',
                 'sensor.pick_temperature',
-            ],
-            template.extract_entities("""
+            ]),
+            sorted(template.extract_entities("""
 {{
     states.sensor.pick_temperature.state ~ „°C (“ ~
     states.sensor.pick_humidity.state ~ „ %“
 }}
-            """))
+            """)))

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     MASS_GRAMS,
     VOLUME_LITERS,
+    MATCH_ALL,
 )
 import homeassistant.util.dt as dt_util
 
@@ -589,3 +590,88 @@ class TestUtilTemplate(unittest.TestCase):
         with patch('homeassistant.helpers.template.compile_template',
                    side_effect=Exception('Should not be called')):
             assert 'world' == template.render(self.hass, compiled)
+
+    def test_extract_entities_none_exclude_stuff(self):
+        """Test extract entities function with none or exclude stuff."""
+        self.assertEqual(MATCH_ALL, template.extract_entities(None))
+
+        self.assertEqual(
+            MATCH_ALL,
+            template.extract_entities(
+                '{{ closest(states.zone.far_away, '
+                'states.test_domain).entity_id }}'))
+
+        self.assertEqual(
+            MATCH_ALL,
+            template.extract_entities(
+                '{{ distance("123", states.test_object_2) }}'))
+
+    def test_extract_entities_no_match_entities(self):
+        """Test extract entities function with none entities stuff."""
+        self.assertEqual(
+            MATCH_ALL,
+            template.extract_entities(
+                "{{ value_json.tst | timestamp_custom('%Y' True) }}"))
+
+        self.assertEqual(
+            MATCH_ALL,
+            template.extract_entities("""
+{% for state in states.sensor %}
+  {{ state.entity_id }}={{ state.state }},
+{% endfor %}
+            """))
+
+    def test_extract_entities_match_entities(self):
+        """Test extract entities function with entities stuff."""
+        self.assertListEqual(
+            ['device_tracker.phone_1'],
+            template.extract_entities("""
+{% if is_state('device_tracker.phone_1', 'home') %}
+    Ha, Hercules is home!
+{% else %}
+    Hercules is at {{ states('device_tracker.phone_1') }}.
+{% endif %}
+            """))
+
+        self.assertListEqual(
+            ['binary_sensor.garage_door'],
+            template.extract_entities("""
+{{ as_timestamp(states.binary_sensor.garage_door.last_changed) }}
+            """))
+
+        self.assertListEqual(
+            ['binary_sensor.garage_door'],
+            template.extract_entities("""
+{{ states("binary_sensor.garage_door") }}
+            """))
+
+        self.assertListEqual(
+            ['device_tracker.phone_2'],
+            template.extract_entities("""
+is_state_attr('device_tracker.phone_2', 'battery', 40)
+            """))
+
+        self.assertListEqual(
+            [
+                'device_tracker.phone_1',
+                'device_tracker.phone_2',
+            ],
+            template.extract_entities("""
+{% if is_state('device_tracker.phone_1', 'home') %}
+    Ha, Hercules is home!
+{% elif states.device_tracker.phone_2.attributes.battery < 40 %}
+    Hercules you power goes done!.
+{% endif %}
+            """))
+
+        self.assertListEqual(
+            [
+                'sensor.pick_humidity',
+                'sensor.pick_temperature',
+            ],
+            template.extract_entities("""
+{{
+    states.sensor.pick_temperature.state ~ „°C (“ ~
+    states.sensor.pick_humidity.state ~ „ %“
+}}
+            """))


### PR DESCRIPTION
**Description:**

A possible Extension to #3521

It's allow to extract all entities they change have a effect on the template value. Thas is only for template stuff with need to have a state_changed listener.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
