### PR TITLE
Emoncms history component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -144,6 +144,7 @@ omit =
     homeassistant/components/device_tracker/volvooncall.py
     homeassistant/components/discovery.py
     homeassistant/components/downloader.py
+    homeassistant/components/emoncms_history.py
     homeassistant/components/fan/mqtt.py
     homeassistant/components/feedreader.py
     homeassistant/components/foursquare.py

--- a/homeassistant/components/emoncms_history.py
+++ b/homeassistant/components/emoncms_history.py
@@ -1,0 +1,88 @@
+"""
+A component which allows you to send data to Emoncms.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/emoncms_history/
+"""
+import logging
+import json
+
+import voluptuous as vol
+import requests
+
+from homeassistant.const import (
+    CONF_API_KEY, CONF_WHITELIST,
+    CONF_URL, STATE_UNKNOWN,
+    STATE_UNAVAILABLE)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import state as state_helper
+from homeassistant.helpers.event import track_state_change
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "emoncms_history"
+CONF_INPUTNODE = "inputnode"
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_API_KEY): cv.string,
+        vol.Required(CONF_URL): cv.string,
+        vol.Required(CONF_INPUTNODE): cv.positive_int,
+        vol.Required(CONF_WHITELIST): cv.entity_ids,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Setup the emoncms_history component."""
+    conf = config[DOMAIN]
+    whitelist = conf.get(CONF_WHITELIST)
+    # defined here so that previous values that did not change
+    # are send as well, otherwise emoncms will list the inputs
+    # as inactive and possibly send emails that feeds based
+    # on the input value have not changed (if the user enabled
+    # that with the extra, optional scripts)
+    json_body = {}
+
+    def _state_changed(entity_id, old_state, new_state):
+        """Send new states to emoncms."""
+        if new_state is None or new_state in (STATE_UNKNOWN, "",
+                                              STATE_UNAVAILABLE):
+            return
+
+        try:
+            _state = state_helper.state_as_number(new_state)
+        except ValueError:
+            return
+
+        json_body[entity_id] = _state
+        json_str = json.dumps(json_body, separators=(",", ":"))
+        json_str = json_str.replace("\"", "")
+        json_str = json_str.replace("{", "").replace("}", "")
+        json_str = "{{{}}}".format(json_str)
+
+        send_data(conf.get(CONF_URL), conf.get(CONF_API_KEY),
+                  str(conf.get(CONF_INPUTNODE)), json_str)
+
+    track_state_change(hass, whitelist, _state_changed)
+
+    return True
+
+
+def send_data(url, apikey, node, jsonstr):
+    """Send the collected data to emoncms."""
+    try:
+        fullurl = "{}/input/post.json".format(url)
+        req = requests.get(fullurl, params={"apikey": apikey,
+                                            "node": node,
+                                            "json": jsonstr},
+                           allow_redirects=True, timeout=5)
+
+    except requests.exceptions.RequestException:
+        _LOGGER.error("Error saving data '%s' to '%s'", json, fullurl)
+
+    else:
+        if req.status_code != 200:
+            _LOGGER.error("Error saving data '%s' to '%s'" +
+                          "(http status code = %d)", json, fullurl,
+                          req.status_code)

--- a/homeassistant/components/emoncms_history.py
+++ b/homeassistant/components/emoncms_history.py
@@ -5,7 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/emoncms_history/
 """
 import logging
-import json
+from datetime import timedelta
 
 import voluptuous as vol
 import requests
@@ -13,10 +13,12 @@ import requests
 from homeassistant.const import (
     CONF_API_KEY, CONF_WHITELIST,
     CONF_URL, STATE_UNKNOWN,
-    STATE_UNAVAILABLE)
+    STATE_UNAVAILABLE,
+    CONF_SCAN_INTERVAL)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import state as state_helper
-from homeassistant.helpers.event import track_state_change
+from homeassistant.helpers.event import track_point_in_time
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +31,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_URL): cv.string,
         vol.Required(CONF_INPUTNODE): cv.positive_int,
         vol.Required(CONF_WHITELIST): cv.entity_ids,
+        vol.Optional(CONF_SCAN_INTERVAL, default=30): cv.positive_int,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -37,52 +40,56 @@ def setup(hass, config):
     """Setup the emoncms_history component."""
     conf = config[DOMAIN]
     whitelist = conf.get(CONF_WHITELIST)
-    # defined here so that previous values that did not change
-    # are send as well, otherwise emoncms will list the inputs
-    # as inactive and possibly send emails that feeds based
-    # on the input value have not changed (if the user enabled
-    # that with the extra, optional scripts)
-    json_body = {}
 
-    def _state_changed(entity_id, old_state, new_state):
-        """Send new states to emoncms."""
-        if new_state is None or new_state in (STATE_UNKNOWN, "",
-                                              STATE_UNAVAILABLE):
-            return
-
+    def send_data(url, apikey, node, payload):
+        """Send payload data to emoncms."""
         try:
-            _state = state_helper.state_as_number(new_state)
-        except ValueError:
-            return
+            fullurl = "{}/input/post.json".format(url)
+            req = requests.post(fullurl,
+                                params={"node": node},
+                                data={"apikey": apikey,
+                                      "data": payload},
+                                allow_redirects=True,
+                                timeout=5)
 
-        json_body[entity_id] = _state
-        json_str = json.dumps(json_body, separators=(",", ":"))
-        json_str = json_str.replace("\"", "")
-        json_str = json_str.replace("{", "").replace("}", "")
-        json_str = "{{{}}}".format(json_str)
+        except requests.exceptions.RequestException:
+            _LOGGER.error("Error saving data '%s' to '%s'",
+                          payload, fullurl)
 
-        send_data(conf.get(CONF_URL), conf.get(CONF_API_KEY),
-                  str(conf.get(CONF_INPUTNODE)), json_str)
+        else:
+            if req.status_code != 200:
+                _LOGGER.error("Error saving data '%s' to '%s'" +
+                              "(http status code = %d)", payload,
+                              fullurl, req.status_code)
 
-    track_state_change(hass, whitelist, _state_changed)
+    def update_emoncms(time):
+        """Send whitelisted entities states reguarly to emoncms."""
+        payload_dict = {}
 
+        for entity_id in whitelist:
+            state = hass.states.get(entity_id)
+
+            if state is None or state.state in (
+                    STATE_UNKNOWN, "", STATE_UNAVAILABLE):
+                continue
+
+            try:
+                payload_dict[entity_id] = state_helper.state_as_number(
+                    state)
+            except ValueError:
+                continue
+
+        if len(payload_dict) > 0:
+            payload = "{%s}" % ",".join("{}:{}".format(key, val)
+                                        for key, val in
+                                        payload_dict.items())
+
+            send_data(conf.get(CONF_URL), conf.get(CONF_API_KEY),
+                      str(conf.get(CONF_INPUTNODE)), payload)
+
+        track_point_in_time(hass, update_emoncms, time +
+                            timedelta(seconds=conf.get(
+                                CONF_SCAN_INTERVAL)))
+
+    update_emoncms(dt_util.utcnow())
     return True
-
-
-def send_data(url, apikey, node, jsonstr):
-    """Send the collected data to emoncms."""
-    try:
-        fullurl = "{}/input/post.json".format(url)
-        req = requests.get(fullurl, params={"apikey": apikey,
-                                            "node": node,
-                                            "json": jsonstr},
-                           allow_redirects=True, timeout=5)
-
-    except requests.exceptions.RequestException:
-        _LOGGER.error("Error saving data '%s' to '%s'", json, fullurl)
-
-    else:
-        if req.status_code != 200:
-            _LOGGER.error("Error saving data '%s' to '%s'" +
-                          "(http status code = %d)", json, fullurl,
-                          req.status_code)


### PR DESCRIPTION
**Description:**

Emoncms history compnent is a history component just like / based on the dweet.io history component and has the same functionality but sends the data to emoncms.

This would for example let people push there power readings from zwave power devices to emoncms for further processing. 

But can be used to send any (numerical) data

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

https://github.com/home-assistant/home-assistant.github.io/pull/991

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
# Example configuration.yaml entry
emoncms_history:
  api_key: put your emoncms WRITE api key here
  url: https://emoncms.org
  inputnode: 19
  whitelist:
    - sensor.owm_temperature
    - sensor.owm_wind_speed
    - sensor.owm_humidity
    - sensor.mold_indicator
    - sensor.emoncms1_feedid_29
    - sensor.cpu_use
    - binary_sensor.pir_motion
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [N/A] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  tox doesn't run on windows
- [N/A] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  no new dependcies
- [N/A] New dependencies are only imported inside functions that use them ([example][ex-import]).
   no new dependcies
- [N/A] New dependencies have been added to `requirements_all.txt` by running 
  `script/gen_requirements_all.py`.
   no new dependcies 
- [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
