### PR TITLE
Don't fail influxdb if it's not avaliable on startup

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -76,7 +76,6 @@ def setup(hass, config):
         _LOGGER.error("Database host is not accessible due to '%s', please "
                       "check your entries in the configuration file and that "
                       "the database exists and is READ/WRITE.", exc)
-        return False
 
     def influx_event_listener(event):
         """Listen for new messages on the bus and sends them to Influx."""

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -65,19 +65,6 @@ class TestInfluxDB(unittest.TestCase):
             del config_copy['influxdb'][missing]
             assert not setup_component(self.hass, influxdb.DOMAIN, config_copy)
 
-    def test_setup_query_fail(self, mock_client):
-        """Test the setup for query failures."""
-        config = {
-            'influxdb': {
-                'host': 'host',
-                'username': 'user',
-                'password': 'pass',
-            }
-        }
-        mock_client.return_value.query.side_effect = \
-            influx_client.exceptions.InfluxDBClientError('fake')
-        assert not setup_component(self.hass, influxdb.DOMAIN, config)
-
     def _setup(self):
         """Setup the client."""
         config = {


### PR DESCRIPTION
**Description:**

InfluxDB isn't socket based, each request makes a separate HTTP request using `requests`, if the InfluxDB cannot connect on startup, it may be available later. We don't turn the component off if a HTTP connection fails, so why here?

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
