### PR TITLE
Added a dispatch call to the envisalink sensor to also get partition updates

### DIFF
--- a/homeassistant/components/sensor/envisalink.py
+++ b/homeassistant/components/sensor/envisalink.py
@@ -9,6 +9,7 @@ from homeassistant.components.envisalink import (EVL_CONTROLLER,
                                                  PARTITION_SCHEMA,
                                                  CONF_PARTITIONNAME,
                                                  EnvisalinkDevice,
+                                                 SIGNAL_PARTITION_UPDATE,
                                                  SIGNAL_KEYPAD_UPDATE)
 
 DEPENDENCIES = ['envisalink']
@@ -42,7 +43,9 @@ class EnvisalinkSensor(EnvisalinkDevice):
                                   partition_name + ' Keypad',
                                   info,
                                   controller)
-
+        dispatcher.connect(self._update_callback,
+                           signal=SIGNAL_PARTITION_UPDATE,
+                           sender=dispatcher.Any)
         dispatcher.connect(self._update_callback,
                            signal=SIGNAL_KEYPAD_UPDATE,
                            sender=dispatcher.Any)


### PR DESCRIPTION
**Description:**
The sensor component was not getting properly updated when a partition status update was occurring, and instead only when a general keypad update is sent.  This is fine for honeywell panels, but not for DSC panels. 

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

…status updates.
