### PR TITLE
The Kraken Sensor Platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -231,6 +231,7 @@ omit =
     homeassistant/components/sensor/hp_ilo.py
     homeassistant/components/sensor/imap.py
     homeassistant/components/sensor/imap_email_content.py
+    homeassistant/components/sensor/kraken.py
     homeassistant/components/sensor/lastfm.py
     homeassistant/components/sensor/linux_battery.py
     homeassistant/components/sensor/loopenergy.py

--- a/homeassistant/components/sensor/kraken.py
+++ b/homeassistant/components/sensor/kraken.py
@@ -19,6 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional('tentacles', default=1): cv.positive_int,
+    vol.Optional('templates', default=True): cv.boolean,
 })
 
 SCAN_INTERVAL = 1
@@ -39,13 +40,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None): \
                               '.state) + float(' + str(idx) + ') }}'}
 
     add_devices(devs)
+    
+    if config.get('templates'):
 
-    platform = bootstrap.loader.get_platform('sensor', 'template')
+        platform = bootstrap.loader.get_platform('sensor', 'template')
 
-    conf = {'platform': 'template', 'sensors': sen}
-    conf = platform.PLATFORM_SCHEMA(conf)
+        conf = {'platform': 'template', 'sensors': sen}
+        conf = platform.PLATFORM_SCHEMA(conf)
 
-    platform.setup_platform(hass, conf, add_devices)
+        platform.setup_platform(hass, conf, add_devices)
 
 
 def _seconds():

--- a/homeassistant/components/sensor/kraken.py
+++ b/homeassistant/components/sensor/kraken.py
@@ -1,0 +1,95 @@
+"""
+Support for unleashing the Kraken.
+
+This platform is for stress testing only.
+"""
+import logging
+import re
+import subprocess
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+import homeassistant.bootstrap as bootstrap
+
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional('tentacles', default=1): cv.positive_int,
+})
+
+SCAN_INTERVAL = 1
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None): \
+        # pylint: disable=unused-variable
+    """Setup the KRAKEN."""
+    sen = {}
+
+    devs = []
+    for idx in range(config['tentacles']):
+        nme = 'kraken_{}'.format(idx)
+        devs.append(KrakenSensor(nme))
+
+        sen['kraken__{}'.format(idx)] = {
+            'value_template': '{{ float(states.sensor.kraken_' + str(idx) +
+                              '.state) + float(' + str(idx) + ') }}'}
+
+    add_devices(devs)
+
+    platform = bootstrap.loader.get_platform('sensor', 'template')
+
+    conf = {'platform': 'template', 'sensors': sen}
+    conf = platform.PLATFORM_SCHEMA(conf)
+
+    platform.setup_platform(hass, conf, add_devices)
+
+
+def _seconds():
+    """Get date, based on arp from nmap."""
+    cmd = ['date', '+%H:%M:%S']
+    arp = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    out, _ = arp.communicate()
+    match = re.search(r'\d{2}:\d{2}:(\d{2})', str(out))
+    if match:
+        return match.group(1)
+    return 0
+
+
+class KrakenSensor(Entity):
+    """Representation of a Kraken Tentacle."""
+
+    def __init__(self, name):
+        """Initialize the sensor."""
+        self._name = name
+        self._state = None
+        self._unit_of_measurement = 's'
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self._unit_of_measurement
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {'About': 'The KRAKEN, handle with care.'}
+
+    def update(self):
+        """Get the latest data and updates the state."""
+        self._state = _seconds()
+        _LOGGER.debug('%s %s', self._name, self.state)

--- a/homeassistant/components/sensor/kraken.py
+++ b/homeassistant/components/sensor/kraken.py
@@ -28,6 +28,9 @@ SCAN_INTERVAL = 1
 def setup_platform(hass, config, add_devices, discovery_info=None): \
         # pylint: disable=unused-variable
     """Setup the KRAKEN."""
+    if not config.get('i_know_what_i_am_doing'):
+        return
+
     sen = {}
 
     devs = []
@@ -40,7 +43,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None): \
                               '.state) + float(' + str(idx) + ') }}'}
 
     add_devices(devs)
-    
+
     if config.get('templates'):
 
         platform = bootstrap.loader.get_platform('sensor', 'template')


### PR DESCRIPTION
**Description:**
Try to get segfaults #3453 by unleashing the Kraken as a sensor platform. Got my first segfault with this method and can consistently get it with 50 tentacles.

It create a configurable amount of sensor pairs ("tentacles"), that includes:
- creates a command line based sensor (date seconds)
- creates a corresponding template platform

**Related issue (if applicable):** fixes # 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor kraken:
- platform: kraken
  tentacles: 50

# Suggestion to disable core logging to increase the speed...
logger:
  default: info
  logs:
    homeassistant.core: warning
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New files were added to `.coveragerc`.
