### PR TITLE
Check that no configuration is provided

### DIFF
--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -29,6 +29,10 @@ SERVICE_PROCESS_SCHEMA = vol.Schema({
     vol.Required(ATTR_TEXT): vol.All(cv.string, vol.Lower),
 })
 
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({}),
+}, extra=vol.ALLOW_EXTRA)
+
 
 def setup(hass, config):
     """Register the process service."""
@@ -48,8 +52,8 @@ def setup(hass, config):
 
         name, command = match.groups()
         entities = {state.entity_id: state.name for state in hass.states.all()}
-        entity_ids = fuzzyExtract.extractOne(name, entities,
-                                             score_cutoff=65)[2]
+        entity_ids = fuzzyExtract.extractOne(
+            name, entities, score_cutoff=65)[2]
 
         if not entity_ids:
             logger.error(
@@ -70,6 +74,7 @@ def setup(hass, config):
             logger.error('Got unsupported command %s from text %s',
                          command, text)
 
-    hass.services.register(DOMAIN, SERVICE_PROCESS, process,
-                           schema=SERVICE_PROCESS_SCHEMA)
+    hass.services.register(
+        DOMAIN, SERVICE_PROCESS, process, schema=SERVICE_PROCESS_SCHEMA)
+
     return True

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -9,6 +9,8 @@ loaded before the EVENT_PLATFORM_DISCOVERED is fired.
 import logging
 import threading
 
+import voluptuous as vol
+
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.helpers.discovery import load_platform, discover
 
@@ -32,6 +34,10 @@ SERVICE_HANDLERS = {
     'logitech_mediaserver': ('media_player', 'squeezebox'),
     'directv': ('media_player', 'directv'),
 }
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({}),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):

--- a/homeassistant/components/introduction.py
+++ b/homeassistant/components/introduction.py
@@ -6,7 +6,13 @@ https://home-assistant.io/components/introduction/
 """
 import logging
 
+import voluptuous as vol
+
 DOMAIN = 'introduction'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({}),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config=None):

--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -7,26 +7,38 @@ https://home-assistant.io/components/sun/
 import logging
 from datetime import timedelta
 
-import homeassistant.util as util
+import voluptuous as vol
+
+from homeassistant.const import CONF_ELEVATION
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
     track_point_in_utc_time, track_utc_time_change)
 from homeassistant.util import dt as dt_util
-from homeassistant.const import CONF_ELEVATION
+import homeassistant.helpers.config_validation as cv
+import homeassistant.util as util
+
 
 REQUIREMENTS = ['astral==1.2']
-DOMAIN = "sun"
-ENTITY_ID = "sun.sun"
-
-STATE_ABOVE_HORIZON = "above_horizon"
-STATE_BELOW_HORIZON = "below_horizon"
-
-STATE_ATTR_NEXT_RISING = "next_rising"
-STATE_ATTR_NEXT_SETTING = "next_setting"
-STATE_ATTR_ELEVATION = "elevation"
-STATE_ATTR_AZIMUTH = "azimuth"
 
 _LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'sun'
+
+ENTITY_ID = 'sun.sun'
+
+STATE_ABOVE_HORIZON = 'above_horizon'
+STATE_BELOW_HORIZON = 'below_horizon'
+
+STATE_ATTR_AZIMUTH = 'azimuth'
+STATE_ATTR_ELEVATION = 'elevation'
+STATE_ATTR_NEXT_RISING = 'next_rising'
+STATE_ATTR_NEXT_SETTING = 'next_setting'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_ELEVATION): cv.positive_int,
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def is_on(hass, entity_id=None):

--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -1,28 +1,35 @@
 """
 Support to check for available updates.
 
-For more details about this platform, please refer to the documentation at
-at https://home-assistant.io/components/updater/
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/updater/
 """
 import logging
 
 import requests
+import voluptuous as vol
 
 from homeassistant.const import __version__ as CURRENT_VERSION
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.helpers import event
 
 _LOGGER = logging.getLogger(__name__)
-PYPI_URL = 'https://pypi.python.org/pypi/homeassistant/json'
+
 DOMAIN = 'updater'
+
 ENTITY_ID = 'updater.updater'
+
+PYPI_URL = 'https://pypi.python.org/pypi/homeassistant/json'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({}),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
     """Setup the updater component."""
     if 'dev' in CURRENT_VERSION:
-        # This component only makes sense in release versions
-        _LOGGER.warning('Updater not supported in development version')
+        _LOGGER.warning("Updater not supported in development version")
         return False
 
     def check_newest_version(_=None):
@@ -31,10 +38,10 @@ def setup(hass, config):
 
         if newest != CURRENT_VERSION and newest is not None:
             hass.states.set(
-                ENTITY_ID, newest, {ATTR_FRIENDLY_NAME: 'Update Available'})
+                ENTITY_ID, newest, {ATTR_FRIENDLY_NAME: 'Update available'})
 
-    event.track_time_change(hass, check_newest_version,
-                            hour=[0, 12], minute=0, second=0)
+    event.track_time_change(
+        hass, check_newest_version, hour=[0, 12], minute=0, second=0)
 
     check_newest_version()
 
@@ -48,11 +55,11 @@ def get_newest_version():
 
         return req.json()['info']['version']
     except requests.RequestException:
-        _LOGGER.exception('Could not contact PyPI to check for updates')
+        _LOGGER.exception("Could not contact PyPI to check for updates")
         return None
     except ValueError:
-        _LOGGER.exception('Received invalid response from PyPI')
+        _LOGGER.exception("Received invalid response from PyPI")
         return None
     except KeyError:
-        _LOGGER.exception('Response from PyPI did not include version')
+        _LOGGER.exception("Response from PyPI did not include version")
         return None

--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -6,39 +6,41 @@ https://home-assistant.io/components/upnp/
 """
 import logging
 
-from homeassistant.const import (EVENT_HOMEASSISTANT_STOP)
+import voluptuous as vol
 
-DEPENDENCIES = ["api"]
+from homeassistant.const import (EVENT_HOMEASSISTANT_STOP)
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "upnp"
+DEPENDENCIES = ['api']
+DOMAIN = 'upnp'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({}),
+}, extra=vol.ALLOW_EXTRA)
 
 
+# pylint: disable=import-error, no-member, broad-except
 def setup(hass, config):
     """Register a port mapping for Home Assistant via UPnP."""
-    # pylint: disable=import-error
     import miniupnpc
 
-    # pylint: disable=no-member
     upnp = miniupnpc.UPnP()
 
     upnp.discoverdelay = 200
     upnp.discover()
     try:
         upnp.selectigd()
-    # pylint: disable=broad-except
     except Exception:
         _LOGGER.exception("Error when attempting to discover a UPnP IGD")
         return False
 
-    upnp.addportmapping(hass.config.api.port, "TCP",
-                        hass.config.api.host, hass.config.api.port,
-                        "Home Assistant", "")
+    upnp.addportmapping(hass.config.api.port, 'TCP', hass.config.api.host,
+                        hass.config.api.port, 'Home Assistant', '')
 
     def deregister_port(event):
         """De-register the UPnP port mapping."""
-        upnp.deleteportmapping(hass.config.api.port, "TCP")
+        upnp.deleteportmapping(hass.config.api.port, 'TCP')
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, deregister_port)
 

--- a/homeassistant/components/zeroconf.py
+++ b/homeassistant/components/zeroconf.py
@@ -1,25 +1,28 @@
 """
 This module exposes Home Assistant via Zeroconf.
 
-Zeroconf is also known as Bonjour, Avahi or Multicast DNS (mDNS).
-
-For more details about Zeroconf, please refer to the documentation at
+For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/zeroconf/
 """
 import logging
 import socket
 
+import voluptuous as vol
+
 from homeassistant.const import (EVENT_HOMEASSISTANT_STOP, __version__)
-
-REQUIREMENTS = ["zeroconf==0.17.6"]
-
-DEPENDENCIES = ["api"]
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "zeroconf"
+DEPENDENCIES = ['api']
+DOMAIN = 'zeroconf'
 
-ZEROCONF_TYPE = "_home-assistant._tcp.local."
+REQUIREMENTS = ['zeroconf==0.17.6']
+
+ZEROCONF_TYPE = '_home-assistant._tcp.local.'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({}),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
@@ -28,12 +31,14 @@ def setup(hass, config):
 
     zeroconf = Zeroconf()
 
-    zeroconf_name = "{}.{}".format(hass.config.location_name,
-                                   ZEROCONF_TYPE)
+    zeroconf_name = '{}.{}'.format(hass.config.location_name, ZEROCONF_TYPE)
 
-    requires_api_password = (hass.config.api.api_password is not None)
-    params = {"version": __version__, "base_url": hass.config.api.base_url,
-              "requires_api_password": requires_api_password}
+    requires_api_password = hass.config.api.api_password is not None
+    params = {
+        'version': __version__,
+        'base_url': hass.config.api.base_url,
+        'requires_api_password': requires_api_password,
+    }
 
     info = ServiceInfo(ZEROCONF_TYPE, zeroconf_name,
                        socket.inet_aton(hass.config.api.host),

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -33,11 +33,11 @@ class TestUpdater(unittest.TestCase):
         updater.CURRENT_VERSION = MOCK_CURRENT_VERSION
 
         self.assertTrue(setup_component(self.hass, updater.DOMAIN, {
-            'updater': None
+            'updater': {}
         }))
 
-        self.assertTrue(self.hass.states.is_state(updater.ENTITY_ID,
-                                                  NEW_VERSION))
+        self.assertTrue(self.hass.states.is_state(
+            updater.ENTITY_ID, NEW_VERSION))
 
     @patch('homeassistant.components.updater.get_newest_version')
     def test_no_entity_on_same_version(self, mock_get_newest_version):
@@ -46,20 +46,20 @@ class TestUpdater(unittest.TestCase):
         updater.CURRENT_VERSION = MOCK_CURRENT_VERSION
 
         self.assertTrue(setup_component(self.hass, updater.DOMAIN, {
-            'updater': None
+            'updater': {}
         }))
 
         self.assertIsNone(self.hass.states.get(updater.ENTITY_ID))
 
         mock_get_newest_version.return_value = NEW_VERSION
 
-        fire_time_changed(self.hass,
-                          dt_util.utcnow().replace(hour=0, minute=0, second=0))
+        fire_time_changed(
+            self.hass, dt_util.utcnow().replace(hour=0, minute=0, second=0))
 
         self.hass.block_till_done()
 
-        self.assertTrue(self.hass.states.is_state(updater.ENTITY_ID,
-                                                  NEW_VERSION))
+        self.assertTrue(self.hass.states.is_state(
+            updater.ENTITY_ID, NEW_VERSION))
 
     @patch('homeassistant.components.updater.requests.get')
     def test_errors_while_fetching_new_version(self, mock_get):
@@ -78,5 +78,5 @@ class TestUpdater(unittest.TestCase):
         updater.CURRENT_VERSION = MOCK_CURRENT_VERSION + 'dev'
 
         self.assertFalse(setup_component(self.hass, updater.DOMAIN, {
-            'updater': None
+            'updater': {}
         }))


### PR DESCRIPTION
**Description:**
For various components is possible to add additional keys to the configuration. Like:

``` yaml
conversation:
  name: invalid_entry
```

This PR will check that only the component's name is present in the `configuration.yaml` file. To create the same error message as the components with a configuration the check is done for a schema and not `None`. Unfortunately the error messages contains two times the domain (could be tweaked with #3530), seems only to point to the right key for platforms (`Check: zone->name1`). 

```
Invalid config for [conversation]: [name] is an invalid option for [conversation]. Check: conversation->conversation->name.
Invalid config for [mqtt]: [broker1] is an invalid option for [mqtt]. Check: mqtt->mqtt->broker1.
```

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
