### PR TITLE
Add a Timeout for InfluxDB connections

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -71,7 +71,7 @@ def setup(hass, config):
     try:
         influx = InfluxDBClient(
             host=host, port=port, username=username, password=password,
-            database=database, ssl=ssl, verify_ssl=verify_ssl, 
+            database=database, ssl=ssl, verify_ssl=verify_ssl,
             timeout=TIMEOUT)
         influx.query("select * from /.*/ LIMIT 1;")
     except exceptions.InfluxDBClientError as exc:

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -28,6 +28,7 @@ DEFAULT_PORT = 8086
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = False
 DOMAIN = 'influxdb'
+TIMEOUT = 5
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -70,7 +71,8 @@ def setup(hass, config):
     try:
         influx = InfluxDBClient(
             host=host, port=port, username=username, password=password,
-            database=database, ssl=ssl, verify_ssl=verify_ssl)
+            database=database, ssl=ssl, verify_ssl=verify_ssl, 
+            timeout=TIMEOUT)
         influx.query("select * from /.*/ LIMIT 1;")
     except exceptions.InfluxDBClientError as exc:
         _LOGGER.error("Database host is not accessible due to '%s', please "


### PR DESCRIPTION
**Description:**
The connection attempt is a blocking operation, if the InfluxDB instance isn't reachable, it significantly slows down home assistant's startup. Neither the InfluxDB library nor the underlying urllib have a default timeout parameter defined, so a startup could take up to several minutes until some system routine detects the timeout. I have set the timeout to a fixed value of 5 seconds, i think even in modern internet at home connections this should be enough to reach a remote host. 
If you think this timeout value should be configurable, let me know, but i personally don't think so. 

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

The checklist is very short, since there are no new requirements or configuration elements, just a new default value for an API call. 
