### PR TITLE
Support splitting of input_boolean config

### DIFF
--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -13,7 +13,8 @@ from homeassistant.const import (
     SERVICE_TOGGLE, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity
-from homeassistant.helpers.entity_component import EntityComponent, generate_entity_id
+from homeassistant.helpers.entity_component import (EntityComponent,
+                                                    generate_entity_id)
 from homeassistant.helpers import extract_domain_configs
 
 DOMAIN = 'input_boolean'
@@ -70,8 +71,9 @@ def setup(hass, config):
             name = cfg.get(CONF_NAME)
             state = cfg.get(CONF_INITIAL, False)
             icon = cfg.get(CONF_ICON)
+            entity_id = generate_entity_id(ENTITY_ID_FORMAT, object_id, hass)
 
-            entities.append(InputBoolean(object_id, name, state, icon))
+            entities.append(InputBoolean(entity_id, name, state, icon))
 
     if not entities:
         return False
@@ -103,9 +105,9 @@ def setup(hass, config):
 class InputBoolean(ToggleEntity):
     """Representation of a boolean input."""
 
-    def __init__(self, object_id, name, state, icon):
+    def __init__(self, entity_id, name, state, icon):
         """Initialize a boolean input."""
-        self.entity_id = generate_entity_id(ENTITY_ID_FORMAT, object_id)
+        self.entity_id = entity_id
         self._name = name
         self._state = state
         self._icon = icon

--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers import extract_domain_configs
 
 DOMAIN = 'input_boolean'
 
@@ -61,15 +62,16 @@ def setup(hass, config):
 
     entities = []
 
-    for object_id, cfg in config[DOMAIN].items():
-        if not cfg:
-            cfg = {}
+    for config_key in extract_domain_configs(config, DOMAIN):
+        for object_id, cfg in config[config_key].items():
+            if not cfg:
+                cfg = {}
 
-        name = cfg.get(CONF_NAME)
-        state = cfg.get(CONF_INITIAL, False)
-        icon = cfg.get(CONF_ICON)
+            name = cfg.get(CONF_NAME)
+            state = cfg.get(CONF_INITIAL, False)
+            icon = cfg.get(CONF_ICON)
 
-        entities.append(InputBoolean(object_id, name, state, icon))
+            entities.append(InputBoolean(object_id, name, state, icon))
 
     if not entities:
         return False

--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -62,7 +62,7 @@ def setup(hass, config):
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     entities = []
-    entity_ids =[]
+    entity_ids = []
 
     for config_key in extract_domain_configs(config, DOMAIN):
         for object_id, cfg in config[config_key].items():
@@ -72,7 +72,8 @@ def setup(hass, config):
             name = cfg.get(CONF_NAME)
             state = cfg.get(CONF_INITIAL, False)
             icon = cfg.get(CONF_ICON)
-            entity_id = generate_entity_id(ENTITY_ID_FORMAT, object_id, entity_ids)
+            entity_id = generate_entity_id(ENTITY_ID_FORMAT,
+                                           object_id, entity_ids)
             entity_ids.append(entity_id)
             entities.append(InputBoolean(entity_id, name, state, icon))
 

--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -62,6 +62,7 @@ def setup(hass, config):
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     entities = []
+    entity_ids =[]
 
     for config_key in extract_domain_configs(config, DOMAIN):
         for object_id, cfg in config[config_key].items():
@@ -71,8 +72,8 @@ def setup(hass, config):
             name = cfg.get(CONF_NAME)
             state = cfg.get(CONF_INITIAL, False)
             icon = cfg.get(CONF_ICON)
-            entity_id = generate_entity_id(ENTITY_ID_FORMAT, object_id, hass)
-
+            entity_id = generate_entity_id(ENTITY_ID_FORMAT, object_id, entity_ids)
+            entity_ids.append(entity_id)
             entities.append(InputBoolean(entity_id, name, state, icon))
 
     if not entities:

--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     SERVICE_TOGGLE, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity
-from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.entity_component import EntityComponent, generate_entity_id
 from homeassistant.helpers import extract_domain_configs
 
 DOMAIN = 'input_boolean'
@@ -105,7 +105,7 @@ class InputBoolean(ToggleEntity):
 
     def __init__(self, object_id, name, state, icon):
         """Initialize a boolean input."""
-        self.entity_id = ENTITY_ID_FORMAT.format(object_id)
+        self.entity_id = generate_entity_id(ENTITY_ID_FORMAT, object_id)
         self._name = name
         self._state = state
         self._icon = icon

--- a/tests/components/test_input_boolean.py
+++ b/tests/components/test_input_boolean.py
@@ -25,7 +25,7 @@ class TestInputBoolean(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    def test_config(self):
+    def test_config_invalid_config(self):
         """Test config."""
         invalid_configs = [
             None,
@@ -37,6 +37,29 @@ class TestInputBoolean(unittest.TestCase):
         for cfg in invalid_configs:
             self.assertFalse(
                 setup_component(self.hass, DOMAIN, {DOMAIN: cfg}))
+
+    def test_config_valid_config(self):
+        """Test config."""
+        self.assertTrue(setup_component(self.hass, DOMAIN, {DOMAIN: {
+            'test_1': None}, DOMAIN + " 2": {'test_2': {'initial': True}}}))
+
+        entity_id = 'input_boolean.test_1'
+        entity_id2 = 'input_boolean.test_2'
+
+        self.assertFalse(
+            is_on(self.hass, entity_id))
+        self.assertTrue(
+            is_on(self.hass, entity_id2))
+
+        turn_on(self.hass, entity_id)
+        turn_off(self.hass, entity_id2)
+
+        self.hass.block_till_done()
+
+        self.assertTrue(
+            is_on(self.hass, entity_id))
+        self.assertFalse(
+            is_on(self.hass, entity_id2))
 
     def test_methods(self):
         """Test is_on, turn_on, turn_off methods."""

--- a/tests/components/test_input_boolean.py
+++ b/tests/components/test_input_boolean.py
@@ -31,7 +31,6 @@ class TestInputBoolean(unittest.TestCase):
             None,
             1,
             {},
-            {'name with space': None},
         ]
 
         for cfg in invalid_configs:


### PR DESCRIPTION
**Description:**
Allow splitting of input_boolean config.
To day the example config only loads the input_boolean.test1 component, ant the input_boolean.test2 is not loaded. There is no error message in the log to tell that something is wrong.

I will do the same with input_select and input_slider, if this solution is accepted. 

**Related issue (if applicable):** fixes #3065

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
input_boolean:
  test1:
    name: Test1

input_boolean 2:
  test2:
    name: Test2
```

**Checklist:**
 the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
