### PR TITLE
update limitlessled to 1.0.2 (#3541)

### DIFF
--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -14,7 +14,7 @@ from homeassistant.components.light import (
     SUPPORT_RGB_COLOR, SUPPORT_TRANSITION, Light)
 
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ['limitlessled==1.0.0']
+REQUIREMENTS = ['limitlessled==1.0.2']
 RGB_BOUNDARY = 40
 DEFAULT_TRANSITION = 0
 DEFAULT_PORT = 8899

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -225,7 +225,7 @@ liffylights==0.9.4
 lightify==1.0.3
 
 # homeassistant.components.light.limitlessled
-limitlessled==1.0.0
+limitlessled==1.0.2
 
 # homeassistant.components.notify.message_bird
 messagebird==1.2.0


### PR DESCRIPTION
**Description:**    update limitlessled to 1.0.2
This version of limitlessled handles transitions to the same color/brightness

**Related issue (if applicable):** fixes #3541

**Checklist:**
If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.
