### PR TITLE
 Fixed typo

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -57,7 +57,7 @@ class NestThermostat(ClimateDevice):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        if self.device.measurment_scale == 'F':
+        if self.device.measurement_scale == 'F':
             return TEMP_FAHRENHEIT
         elif self.device.measurement_scale == 'C':
             return TEMP_CELSIUS


### PR DESCRIPTION
**Description:**

Fixed typo on nest climate component

**Example entry for `configuration.yaml` (if applicable):**

``` python
Sep 29 00:59:22 tchellopi hass[21333]: 16-09-29 00:59:22 ERROR (Thread-1) [homeassistant.components.climate] Error while setting up platform nest
Sep 29 00:59:22 tchellopi hass[21333]: Traceback (most recent call last):
Sep 29 00:59:22 tchellopi hass[21333]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/helpers/entity_component.py", line 107, in _setup_platform
Sep 29 00:59:22 tchellopi hass[21333]: discovery_info)
Sep 29 00:59:22 tchellopi hass[21333]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/components/climate/nest.py", line 30, in setup_platform
Sep 29 00:59:22 tchellopi hass[21333]: for structure, device in nest.devices()])
Sep 29 00:59:22 tchellopi hass[21333]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/helpers/entity_component.py", line 198, in add_entities
Sep 29 00:59:22 tchellopi hass[21333]: if self.component.add_entity(entity, self):
Sep 29 00:59:22 tchellopi hass[21333]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/helpers/entity_component.py", line 134, in add_entity
Sep 29 00:59:22 tchellopi hass[21333]: entity.update_ha_state()
Sep 29 00:59:22 tchellopi hass[21333]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/helpers/entity.py", line 157, in update_ha_state
Sep 29 00:59:22 tchellopi hass[21333]: attr = self.state_attributes or {}
Sep 29 00:59:22 tchellopi hass[21333]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/components/climate/__init__.py", line 358, in state_attributes
Sep 29 00:59:22 tchellopi hass[21333]: self._convert_for_display(self.current_temperature),
Sep 29 00:59:22 tchellopi hass[21333]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/components/climate/__init__.py", line 539, in _convert_for_display
Sep 29 00:59:22 tchellopi hass[21333]: value = convert_temperature(temp, self.unit_of_measurement,
Sep 29 00:59:22 tchellopi hass[21333]: File "/home/hass/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/components/climate/nest.py", line 60, in unit_of_measurement
Sep 29 00:59:22 tchellopi hass[21333]: if self.device.measurment_scale == 'F':
Sep 29 00:59:22 tchellopi hass[21333]: AttributeError: 'Device' object has no attribute 'measurment_scale'
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
