### PR TITLE
Loopenergy library - bump to catch more exceptions in poll thread.

### DIFF
--- a/homeassistant/components/sensor/loopenergy.py
+++ b/homeassistant/components/sensor/loopenergy.py
@@ -15,7 +15,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyloopenergy==0.0.14']
+REQUIREMENTS = ['pyloopenergy==0.0.15']
 
 CONF_ELEC = 'electricity'
 CONF_GAS = 'gas'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -340,7 +340,7 @@ pyicloud==0.9.1
 pylast==1.6.0
 
 # homeassistant.components.sensor.loopenergy
-pyloopenergy==0.0.14
+pyloopenergy==0.0.15
 
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.3.3


### PR DESCRIPTION
**Description:**
There are occasional exception in the poll thread that kills the sensor. This bump to the library catches some of those seen in running and re-connects - and so should make the library more reliable

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
