### PR TITLE
Support for encrypted Owntracks payload

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -230,6 +230,9 @@ keyring>=9.3,<10.0
 # homeassistant.components.knx
 knxip==0.3.3
 
+# homeassistant.components.device_tracker.owntracks
+libnacl==1.5.0
+
 # homeassistant.components.light.lifx
 liffylights==0.9.4
 


### PR DESCRIPTION
**Description:**

Implement support for encrypted location updates according to http://owntracks.org/booklet/features/encrypt/ to be able to keep your location private while using a public (where anyone can subscribe to any topic) or third party (hosted by an untrusted party) MQTT broker.

This depends on libnacl (https://pypi.python.org/pypi/libnacl), which in turn depends on libsodium (https://github.com/jedisct1/libsodium).

**Related issue (if applicable):**

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

Simple setup with just one key

``` yaml
device_tracker:
- platform: owntracks
  secret: s3cretkey
```

Setup with topic-specific keys

``` yaml
device_tracker:
- platform: owntracks
  secret:
    owntracks/erik/nexus: s3cretkey
    owntracks/lisa/iphone: others3cret
```

with the corresponding secret added in the Owntracks client.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
