### PR TITLE
Bugfix voluptuous for hue

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -50,7 +50,7 @@ SUPPORT_HUE = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_EFFECT |
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_ALLOW_UNREACHABLE): cv.boolean,
-    vol.Optional(CONF_FILENAME): cv.isfile,
+    vol.Optional(CONF_FILENAME): cv.string,
 })
 
 


### PR DESCRIPTION
**Description:**

This option is only possible for give a file name inside home-assistant config. So isfile is false.

**Related issue (if applicable):** fixes #3586 
