### PR TITLE
Fix voluptuous alexa config

### DIFF
--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -63,7 +63,7 @@ CONFIG_SCHEMA = vol.Schema({
             }
         }
     }
-})
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -41,6 +41,8 @@ def setUpModule():   # pylint: disable=invalid-name
     hass.services.register('test', 'alexa', lambda call: calls.append(call))
 
     bootstrap.setup_component(hass, alexa.DOMAIN, {
+        # Key is here to verify we allow other keys in config too
+        'homeassistant': {},
         'alexa': {
             'intents': {
                 'WhereAreWeIntent': {


### PR DESCRIPTION
**Description:**
Alexa voluptuous config did not allow other components to be setup too.

**Related issue (if applicable):** fixes #3595

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
alexa:
homeassistant:
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
