### PR TITLE
WIP: Add async to yr.no sensor

### DIFF
--- a/homeassistant/util/aiohttp.py
+++ b/homeassistant/util/aiohttp.py
@@ -1,0 +1,28 @@
+"""Aiohttp helpers."""
+import aiohttp
+from aiohttp.web_exceptions import HTTPException  # NOQA # pylint: disable=unused-import
+import asyncio
+import async_timeout
+
+SESSION = aiohttp.ClientSession()
+
+
+@asyncio.coroutine
+def fetch(url, json=False, timeout=10):
+    """Fetch a URL coroutine."""
+    with async_timeout.timeout(timeout):
+        resp = yield from SESSION.get(url)
+        try:
+            if resp.status_code != 200:
+                return (resp.status_code, None)
+            if json:
+                return (200, (yield from resp.json()))
+            else:
+                return (200, (yield from resp.text()))
+        except asyncio.TimeoutError:
+            return (0, None)
+        except Exception as err:
+            resp.close()
+            raise err
+        finally:
+            yield from resp.release()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,6 +6,7 @@ pip>=7.0.0
 jinja2>=2.8
 voluptuous==0.9.2
 typing>=3,<4
+aiohttp>=1.0.2,<2
 
 # homeassistant.components.nuimo_controller
 --only-binary=all git+https://github.com/getSenic/nuimo-linux-python#nuimo==1.0.0


### PR DESCRIPTION
**Description:**
WIP

Initial stab at adding aiohttp to a sensor. Changed the data update method to be async, but unsure if:
- the Entity should be made async
- update method scheduled on a timer on the eventloop and entity simply update from fetched data

Added a aiohttp fetch helper util

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Checklist:**

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.
