### PR TITLE
Passing original config reference to load_platform.

### DIFF
--- a/homeassistant/components/envisalink.py
+++ b/homeassistant/components/envisalink.py
@@ -184,13 +184,13 @@ def setup(hass, base_config):
         load_platform(hass, 'alarm_control_panel', 'envisalink',
                       {CONF_PARTITIONS: _partitions,
                        CONF_CODE: _code,
-                       CONF_PANIC: _panic_type}, config)
+                       CONF_PANIC: _panic_type}, base_config)
         load_platform(hass, 'sensor', 'envisalink',
                       {CONF_PARTITIONS: _partitions,
-                       CONF_CODE: _code}, config)
+                       CONF_CODE: _code}, base_config)
     if _zones:
         load_platform(hass, 'binary_sensor', 'envisalink',
-                      {CONF_ZONES: _zones}, config)
+                      {CONF_ZONES: _zones}, base_config)
 
     return True
 


### PR DESCRIPTION
**Description:**
Improper call of load_platform causes subsequent entities of the same type to not be loaded.

**Related issue (if applicable):** fixes #3554

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
