### PR TITLE
Fixed issue #3574 - Temperature slider fixed on frontend on heat/cool mode

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -9,9 +9,10 @@ import voluptuous as vol
 import homeassistant.components.nest as nest
 from homeassistant.components.climate import (
     STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_IDLE, ClimateDevice,
-    PLATFORM_SCHEMA, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW)
+    PLATFORM_SCHEMA, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW,
+    ATTR_TEMPERATURE)
 from homeassistant.const import (
-    TEMP_CELSIUS, CONF_SCAN_INTERVAL, STATE_ON, TEMP_FAHRENHEIT)
+    TEMP_CELSIUS, CONF_SCAN_INTERVAL, STATE_ON)
 from homeassistant.util.temperature import convert as convert_temperature
 
 DEPENDENCIES = ['nest']
@@ -40,6 +41,7 @@ class NestThermostat(ClimateDevice):
         self.structure = structure
         self.device = device
         self._fan_list = [STATE_ON, STATE_AUTO]
+        self._operation_list = [STATE_COOL, STATE_IDLE, STATE_HEAT]
 
     @property
     def name(self):
@@ -57,10 +59,7 @@ class NestThermostat(ClimateDevice):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        if self.device.measurement_scale == 'F':
-            return TEMP_FAHRENHEIT
-        elif self.device.measurement_scale == 'C':
-            return TEMP_CELSIUS
+        return TEMP_CELSIUS
 
     @property
     def device_state_attributes(self):
@@ -78,14 +77,22 @@ class NestThermostat(ClimateDevice):
         return self.device.temperature
 
     @property
-    def operation(self):
+    def current_operation(self):
         """Return current operation ie. heat, cool, idle."""
-        if self.device.hvac_ac_state is True:
+        if self.device.hvac_ac_state:
             return STATE_COOL
-        elif self.device.hvac_heater_state is True:
+        elif self.device.hvac_heater_state:
             return STATE_HEAT
         else:
             return STATE_IDLE
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        if self.device.mode != 'range':
+            return self.device.target
+        else:
+            return None
 
     @property
     def target_temperature_low(self):
@@ -95,7 +102,8 @@ class NestThermostat(ClimateDevice):
             return self.device.away_temperature[0]
         if self.device.mode == 'range':
             return self.device.target[0]
-        return self.target_temperature
+        else:
+            return None
 
     @property
     def target_temperature_high(self):
@@ -105,7 +113,8 @@ class NestThermostat(ClimateDevice):
             return self.device.away_temperature[1]
         if self.device.mode == 'range':
             return self.device.target[1]
-        return self.target_temperature
+        else:
+            return None
 
     @property
     def is_away_mode_on(self):
@@ -121,13 +130,21 @@ class NestThermostat(ClimateDevice):
             target_temp_low = convert_temperature(kwargs.get(
                 ATTR_TARGET_TEMP_LOW), self._unit, TEMP_CELSIUS)
 
-        temp = (target_temp_low, target_temp_high)
+            if self.device.mode == 'range':
+                temp = (target_temp_low, target_temp_high)
+        else:
+            temp = kwargs.get(ATTR_TEMPERATURE)
         _LOGGER.debug("Nest set_temperature-output-value=%s", temp)
         self.device.target = temp
 
     def set_operation_mode(self, operation_mode):
         """Set operation mode."""
         self.device.mode = operation_mode
+
+    @property
+    def operation_list(self):
+        """List of available operation modes."""
+        return self._operation_list
 
     def turn_away_mode_on(self):
         """Turn away on."""

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -89,7 +89,7 @@ class NestThermostat(ClimateDevice):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        if self.device.mode != 'range':
+        if self.device.mode != 'range' and not self.is_away_mode_on:
             return self.device.target
         else:
             return None


### PR DESCRIPTION
**Description:**

Fixed the climate/nest issue reported at #3574 that was blocking the temperature slider to displayed on the frontend and to load the component on 0.29 version. 

This fix is inspired on PR https://github.com/home-assistant/home-assistant/pull/3591 provided by @turbokongen. 

Many thanks to @turbokongen and @balloob that helped on this fix. 

This patch does not address the issues with the temperature symbol however, @balloob already created a new issue #3605 for it and it will be addressed separately.

The results obtained by this PR:
- single mode (heat/cool) - single temperature
  ![mode_cool operation_list](https://cloud.githubusercontent.com/assets/809840/18980868/8abac382-86a6-11e6-8cea-de32c2acb004.png)
- range mode - temperature range
  ![temperature_range](https://cloud.githubusercontent.com/assets/809840/18980872/937b02de-86a6-11e6-972d-c341b9bc70e5.png)

I tested the component to turn the fan on and worked as well. 

**Related issue (if applicable):** fixes #3574 

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

… 
