### PR TITLE
Nest operation modes

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -31,7 +31,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                  for structure, device in nest.devices()])
 
 
-# pylint: disable=abstract-method
+# pylint: disable=abstract-method,too-many-public-methods
 class NestThermostat(ClimateDevice):
     """Representation of a Nest thermostat."""
 
@@ -64,6 +64,7 @@ class NestThermostat(ClimateDevice):
 
     @property
     def state(self):
+        """Return the current state."""
         if self.device.hvac_ac_state:
             return STATE_COOL
         elif self.device.hvac_heater_state:

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -12,7 +12,7 @@ from homeassistant.components.climate import (
     PLATFORM_SCHEMA, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW,
     ATTR_TEMPERATURE)
 from homeassistant.const import (
-    TEMP_CELSIUS, CONF_SCAN_INTERVAL, STATE_ON)
+    TEMP_CELSIUS, CONF_SCAN_INTERVAL, STATE_ON, STATE_OFF, STATE_UNKNOWN)
 from homeassistant.util.temperature import convert as convert_temperature
 
 DEPENDENCIES = ['nest']
@@ -41,7 +41,8 @@ class NestThermostat(ClimateDevice):
         self.structure = structure
         self.device = device
         self._fan_list = [STATE_ON, STATE_AUTO]
-        self._operation_list = [STATE_COOL, STATE_IDLE, STATE_HEAT]
+        self._operation_list = [STATE_HEAT, STATE_COOL, STATE_AUTO,
+                                STATE_OFF]
 
     @property
     def name(self):
@@ -79,12 +80,16 @@ class NestThermostat(ClimateDevice):
     @property
     def current_operation(self):
         """Return current operation ie. heat, cool, idle."""
-        if self.device.hvac_ac_state:
+        if self.device.mode == 'cool':
             return STATE_COOL
-        elif self.device.hvac_heater_state:
+        elif self.device.mode == 'heat':
             return STATE_HEAT
+        elif self.device.mode == 'range':
+            return STATE_AUTO
+        elif self.device.mode == 'off':
+            return STATE_OFF
         else:
-            return STATE_IDLE
+            return STATE_UNKNOWN
 
     @property
     def target_temperature(self):
@@ -139,7 +144,14 @@ class NestThermostat(ClimateDevice):
 
     def set_operation_mode(self, operation_mode):
         """Set operation mode."""
-        self.device.mode = operation_mode
+        if operation_mode == STATE_HEAT:
+            self.device.mode = 'heat'
+        elif operation_mode == STATE_COOL:
+            self.device.mode = 'cool'
+        elif operation_mode == STATE_AUTO:
+            self.device.mode = 'range'
+        elif operation_mode == STATE_OFF:
+            self.device.mode = 'off'
 
     @property
     def operation_list(self):

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -63,6 +63,15 @@ class NestThermostat(ClimateDevice):
         return TEMP_CELSIUS
 
     @property
+    def state(self):
+        if self.device.hvac_ac_state:
+            return STATE_COOL
+        elif self.device.hvac_heater_state:
+            return STATE_HEAT
+        else:
+            return STATE_IDLE
+
+    @property
     def device_state_attributes(self):
         """Return the device specific state attributes."""
         # Move these to Thermostat Device and make them global

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -78,7 +78,6 @@ class NestThermostat(ClimateDevice):
         return {
             "humidity": self.device.humidity,
             "target_humidity": self.device.target_humidity,
-            "mode": self.device.mode
         }
 
     @property

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -63,16 +63,6 @@ class NestThermostat(ClimateDevice):
         return TEMP_CELSIUS
 
     @property
-    def state(self):
-        """Return the current state."""
-        if self.device.hvac_ac_state:
-            return STATE_COOL
-        elif self.device.hvac_heater_state:
-            return STATE_HEAT
-        else:
-            return STATE_IDLE
-
-    @property
     def device_state_attributes(self):
         """Return the device specific state attributes."""
         # Move these to Thermostat Device and make them global

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 
 DEPENDENCIES = ['nest']
 SENSOR_TYPES = ['humidity',
-                'mode',
+                'operation_mode',
                 'last_ip',
                 'local_ip',
                 'last_connection',


### PR DESCRIPTION
**Description:**
The Nest operation modes in #3606 don't match with what you can actually set. I made changes to the operation mode corresponds to what mode the thermostat is in (heat, cool, auto, off) and the climate state refers to the current operation it is taking (heat, cool, idle). I also update the Nest sensor to use `operation_mode` instead of the legacy `mode` value.

![image](https://cloud.githubusercontent.com/assets/1368827/18982259/9df5bb80-86b2-11e6-8c93-314d895a1fc9.png)

I honestly think the card should be updated so instead of `current_operation` attribute it displays the climate `state`.

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
