### PR TITLE
Haveibeenpwned sensor platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -235,6 +235,7 @@ omit =
     homeassistant/components/sensor/google_travel_time.py
     homeassistant/components/sensor/gpsd.py
     homeassistant/components/sensor/gtfs.py
+    homeassistant/components/sensor/haveibeenpwned.py
     homeassistant/components/sensor/hp_ilo.py
     homeassistant/components/sensor/imap.py
     homeassistant/components/sensor/imap_email_content.py

--- a/homeassistant/components/sensor/haveibeenpwned.py
+++ b/homeassistant/components/sensor/haveibeenpwned.py
@@ -120,7 +120,7 @@ class HaveIBeenPwnedData(object):
             url = "https://haveibeenpwned.com/api/v2/breachedaccount/{}". \
                 format(self.email)
 
-            _LOGGER.error("Checking for breaches for email %s", self.email)
+            _LOGGER.info("Checking for breaches for email %s", self.email)
 
             req = requests.get(url, headers={"User-agent": USER_AGENT},
                                verify=False, allow_redirects=True, timeout=5)

--- a/homeassistant/components/sensor/haveibeenpwned.py
+++ b/homeassistant/components/sensor/haveibeenpwned.py
@@ -121,7 +121,7 @@ class HaveIBeenPwnedData(object):
             _LOGGER.info("Checking for breaches for email %s", self.email)
 
             req = requests.get(url, headers={"User-agent": USER_AGENT},
-                               verify=False, allow_redirects=True, timeout=5)
+                               allow_redirects=True, timeout=5)
 
             # Intial data for all email addresses have been gathered
             # Throttle the amount of requests made to 1 per 15 minutes to

--- a/homeassistant/components/sensor/haveibeenpwned.py
+++ b/homeassistant/components/sensor/haveibeenpwned.py
@@ -1,0 +1,149 @@
+"""
+Support for haveibeenpwned (email breaches) sensor.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.haveibeenpwned/
+"""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+import requests
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (STATE_UNKNOWN, CONF_EMAIL)
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
+import homeassistant.util.dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+DATE_STR_FORMAT = "%Y-%m-%d %H:%M:%S"
+USER_AGENT = "Home Assistant HaveIBeenPwned Sensor Component"
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=4)
+SCAN_INTERVAL = 5
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_EMAIL): vol.All(cv.ensure_list, [cv.string]),
+})
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the RESTful sensor."""
+    emails = config.get(CONF_EMAIL)
+
+    data = HaveIBeenPwnedData(emails)
+    data.update = Throttle(MIN_TIME_BETWEEN_UPDATES)(data.update)
+
+    dev = []
+    for email in emails:
+        dev.append(HaveIBeenPwnedSensor(data, email))
+
+    add_devices(dev)
+
+
+class HaveIBeenPwnedSensor(Entity):
+    """Implementation of HaveIBeenPwnedSensor."""
+
+    def __init__(self, data, email):
+        """Initialize the HaveIBeenPwnedSensor sensor."""
+        self._value = None
+        self._data = data
+        self._email = email
+        self._unit_of_measurement = "Hits"
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return "Breaches {}".format(self._email)
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self._unit_of_measurement
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        if self._value is None:
+            return STATE_UNKNOWN
+        else:
+            return len(self._value)
+
+    @property
+    def state_attributes(self):
+        """Return the atrributes of the sensor."""
+        val = {}
+        if self._value is None:
+            return val
+
+        for idx, value in enumerate(self._value):
+            tmpname = "breach {}".format(idx+1)
+            tmpvalue = "{} {}".format(
+                value["Title"],
+                dt_util.as_local(dt_util.parse_datetime(
+                    value["AddedDate"])).strftime(DATE_STR_FORMAT))
+            val[tmpname] = tmpvalue
+
+        return val
+
+    def update(self):
+        """Get data for (next) email and set value if it's our email."""
+        self._data.update()
+        if self._data.email == self._email:
+            self._value = self._data.data
+
+# pylint: disable=too-few-public-methods
+class HaveIBeenPwnedData(object):
+    """Class for handling the data retrieval."""
+
+    def __init__(self, emails):
+        """Initialize the data object."""
+        self._email_count = len(emails)
+        self._current_index = -1
+        self.data = None
+        self.email = None
+        self._current_url = None
+        self._emails = emails
+
+    def update(self):
+        """Get the latest data for current email from REST service."""
+        try:
+            self.data = None
+            self._current_index = (self._current_index + 1) % self._email_count
+            self.email = self._emails[self._current_index]
+            url = "https://haveibeenpwned.com/api/v2/breachedaccount/{}". \
+                format(self.email)
+
+            _LOGGER.error("Checking for breaches for email %s", self.email)
+
+            req = requests.get(url, headers={"User-agent": USER_AGENT},
+                               verify=False, allow_redirects=True, timeout=5)
+
+            # Intial data for all email addresses have been gathered
+            # Throttle the amount of requests made to 1 per 15 minutes to
+            # prevent abuse and because the data will almost never change.
+            # This means the more email addresses that are specified the
+            # longer it will take to update them all, this is part of
+            # abuse protection. I emailed the owner of the api to see
+            # if he was ok with this abuse protection scheme and it
+            # was fine for him like this
+            if self._current_index == self._email_count - 1:
+                self.update = Throttle(timedelta(minutes=14))(self.update)
+
+        except requests.exceptions.RequestException as exception:
+            _LOGGER.error(exception)
+            return
+
+        if req.status_code == 200:
+            self.data = sorted(req.json(), key=lambda k: k["AddedDate"],
+                               reverse=True)
+        elif req.status_code == 404:
+            self.data = []
+        else:
+            _LOGGER.error("failed fetching HaveIBeenPwned Data for '%s'"
+                          "(HTTP Status_code = %d)", self.email,
+                          req.status_code)

--- a/homeassistant/components/sensor/haveibeenpwned.py
+++ b/homeassistant/components/sensor/haveibeenpwned.py
@@ -34,7 +34,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the RESTful sensor."""
-
     emails = config.get(CONF_EMAIL)
     data = HaveIBeenPwnedData(emails)
 

--- a/homeassistant/components/sensor/haveibeenpwned.py
+++ b/homeassistant/components/sensor/haveibeenpwned.py
@@ -29,6 +29,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_EMAIL): vol.All(cv.ensure_list, [cv.string]),
 })
 
+
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the RESTful sensor."""
@@ -95,6 +96,7 @@ class HaveIBeenPwnedSensor(Entity):
         self._data.update()
         if self._data.email == self._email:
             self._value = self._data.data
+
 
 # pylint: disable=too-few-public-methods
 class HaveIBeenPwnedData(object):


### PR DESCRIPTION
**Description:**
The `haveibeenpwned` sensor platform creates sensors that check for breached email accounts on [haveibeenpwned](https://haveibeenpwned.com).

it will list every specified email address as a sensor showing the number of breaches on that email account as well as breach meta data (site title + date breach data added)

during hass startup it will request breach data for all email's specified with 5 seconds between each request. After hass has been started this delay is increased to 15 minutes. So it will check 1 email address per 15 minutes. This is done so to prevent abuse on the one hand and on the other hand the breach data almost never changes so there is no need to check frequently for new breach data. The author (troy hunt) of the service had no problems with this protection scheme (i emailed him before creating this pr)

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

https://github.com/home-assistant/home-assistant.github.io/pull/1023

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
# Example configuration.yaml entry using cloud based emoncms
sensor:
  platform: haveibeenpwned
  email: 
    - your_email1@domain.com
    - your_email2@domain.com
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [N/A] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  can't run tox on windows
- [N/A] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
  no new depencies
- [N/A] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
  no new depencies
- [N/A] New dependencies have been added to `requirements_all.txt` by running 
  `script/gen_requirements_all.py`.
  no new depencies
- [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
