### PR TITLE
Skip RFXtrx tests unless RFXTRX=RUN

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -49,6 +49,9 @@ omit =
     homeassistant/components/qwikswitch.py
     homeassistant/components/*/qwikswitch.py
 
+    homeassistant/components/rfxtrx.py
+    homeassistant/components/*/rfxtrx.py
+
     homeassistant/components/rpi_gpio.py
     homeassistant/components/*/rpi_gpio.py
 

--- a/tests/components/cover/test_rfxtrx.py
+++ b/tests/components/cover/test_rfxtrx.py
@@ -9,7 +9,7 @@ from homeassistant.components import rfxtrx as rfxtrx_core
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif("os.environ.get('RFXTRX') == 'SKIP'")
+@pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
 class TestCoverRfxtrx(unittest.TestCase):
     """Test the Rfxtrx cover platform."""
 

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -9,7 +9,7 @@ from homeassistant.components import rfxtrx as rfxtrx_core
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif("os.environ.get('RFXTRX') == 'SKIP'")
+@pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
 class TestLightRfxtrx(unittest.TestCase):
     """Test the Rfxtrx light platform."""
 

--- a/tests/components/rollershutter/test_rfxtrx.py
+++ b/tests/components/rollershutter/test_rfxtrx.py
@@ -9,7 +9,7 @@ from homeassistant.components import rfxtrx as rfxtrx_core
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif("os.environ.get('RFXTRX') == 'SKIP'")
+@pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
 class TestRollershutterRfxtrx(unittest.TestCase):
     """Test the Rfxtrx roller shutter platform."""
 

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -10,7 +10,7 @@ from homeassistant.const import TEMP_CELSIUS
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif("os.environ.get('RFXTRX') == 'SKIP'")
+@pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
 class TestSensorRfxtrx(unittest.TestCase):
     """Test the Rfxtrx sensor platform."""
 

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -23,8 +23,8 @@ class TestSensorRfxtrx(unittest.TestCase):
         """Stop everything that was started."""
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx_core.RFX_DEVICES = {}
-        if rfxtrx.RFXOBJECT:
-            rfxtrx.RFXOBJECT.close_connection()
+        if rfxtrx_core.RFXOBJECT:
+            rfxtrx_core.RFXOBJECT.close_connection()
         self.hass.stop()
 
     def test_default_config(self):

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -23,6 +23,8 @@ class TestSensorRfxtrx(unittest.TestCase):
         """Stop everything that was started."""
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx_core.RFX_DEVICES = {}
+        if rfxtrx.RFXOBJECT:
+            rfxtrx.RFXOBJECT.close_connection()
         self.hass.stop()
 
     def test_default_config(self):

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -9,7 +9,7 @@ from homeassistant.components import rfxtrx as rfxtrx_core
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif("os.environ.get('RFXTRX') == 'SKIP'")
+@pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
 class TestSwitchRfxtrx(unittest.TestCase):
     """Test the Rfxtrx switch platform."""
 

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -1,7 +1,6 @@
 """The tests for the Rfxtrx component."""
 # pylint: disable=too-many-public-methods,protected-access
 import unittest
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -1,4 +1,4 @@
-"""Th tests for the Rfxtrx component."""
+"""The tests for the Rfxtrx component."""
 # pylint: disable=too-many-public-methods,protected-access
 import unittest
 from unittest.mock import patch
@@ -10,7 +10,7 @@ from homeassistant.components import rfxtrx as rfxtrx
 from tests.common import get_test_home_assistant
 
 
-@pytest.mark.skipif("os.environ.get('RFXTRX') == 'SKIP'")
+@pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
 class TestRFXTRX(unittest.TestCase):
     """Test the Rfxtrx component."""
 

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -21,6 +21,8 @@ class TestRFXTRX(unittest.TestCase):
         """Stop everything that was started."""
         rfxtrx.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx.RFX_DEVICES = {}
+        if rfxtrx.RFXOBJECT:
+            rfxtrx.RFXOBJECT.close_connection()
         self.hass.stop()
 
     def test_default_config(self):

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -24,8 +24,7 @@ class TestRFXTRX(unittest.TestCase):
         rfxtrx.RFX_DEVICES = {}
         self.hass.stop()
 
-    @patch('RFXtrx.sleep')
-    def test_default_config(self, mock_sleep):
+    def test_default_config(self):
         """Test configuration."""
         self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
@@ -41,8 +40,7 @@ class TestRFXTRX(unittest.TestCase):
 
         self.assertEqual(len(rfxtrx.RFXOBJECT.sensors()), 2)
 
-    @patch('RFXtrx.sleep')
-    def test_valid_config(self, mock_sleep):
+    def test_valid_config(self):
         """Test configuration."""
         self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
@@ -71,8 +69,7 @@ class TestRFXTRX(unittest.TestCase):
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
                 'invalid_key': True}}))
 
-    @patch('RFXtrx.sleep')
-    def test_fire_event(self, mock_sleep):
+    def test_fire_event(self):
         """Test fire event."""
         self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
@@ -116,8 +113,7 @@ class TestRFXTRX(unittest.TestCase):
         self.assertEqual(calls[0].data,
                          {'entity_id': 'switch.test', 'state': 'on'})
 
-    @patch('RFXtrx.sleep')
-    def test_fire_event_sensor(self, mock_sleep):
+    def test_fire_event_sensor(self):
         """Test fire event."""
         self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {


### PR DESCRIPTION
The RFXtrx tests are not successfully cleaning up threads and are slowing down our CI runs. They went from 6 minutes to 35 minutes! Because our CI tests take more time and thus use more resources, Travis is giving us less runs.

For now we'll disable the RFXtrx tests. They can still be run by passing RFXTRX=RUN to py.test:

```
RFXTRX=RUN py.test
```

[48167ce - This one was still fast](https://github.com/home-assistant/home-assistant/commit/48167ce5a819cb931be702845bf3c0cf45a76a17)
[428f8c7 - This one was slow](https://github.com/home-assistant/home-assistant/commit/428f8c706dd3ffc75d4b4569e7afd654722d8d47)

![screen shot 2016-09-30 at 1 02 07 pm](https://cloud.githubusercontent.com/assets/1444314/19005316/bc49cea8-870e-11e6-9b0e-c0591b571ce1.png)

CC @Danielhiversen 
