### PR TITLE
Service.call_from_config will no longer mutate passed in config if nested templates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -159,6 +159,12 @@ class Template(object):
 
         return self._compiled
 
+    def __eq__(self, other):
+        """Compare template with another."""
+        return (self.__class__ == other.__class__ and
+                self.template == other.template and
+                self.hass == other.hass)
+
 
 class AllStates(object):
     """Class to expose all HA states as attributes."""


### PR DESCRIPTION
**Description:**
`Service.call_from_config` would mutate the passed in config when the config contained nested templates. It would replace the templates with the rendered value.

This has been fixed.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
automation:
  trigger:
    platform: event
    event_type: 'state_changed'
  action:
    service: notify.notify
    data_template:
      data:
        this_value: 'gets overwritten by rendered output: {{ False }}'
```

CC @pvizeli 

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
