### PR TITLE
Fixes an issue where Chromecast audio groups were not properly discovered

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -71,7 +71,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     all_chromecasts = pychromecast._get_all_chromecasts()
 
     for host in hosts:
-        found = [device for device in all_chromecasts if device.host == host[0] and device.port == host[1]]
+        found = [device for device in all_chromecasts 
+                if device.host == host[0] and device.port == host[1]]
         if found:
             try:
                 casts.append(CastDevice(found[0]))
@@ -87,10 +88,10 @@ class CastDevice(MediaPlayerDevice):
 
     # pylint: disable=abstract-method
     # pylint: disable=too-many-public-methods
-    def __init__(self, host, port):
+    def __init__(self, chromecast):
         """Initialize the Cast device."""
         import pychromecast
-        self.cast = pychromecast.Chromecast(host, port)
+        self.cast = chromecast
 
         self.cast.socket_client.receiver_controller.register_status_listener(
             self)

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -71,8 +71,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     all_chromecasts = pychromecast.get_chromecasts()
 
     for host in hosts:
-        found = [device for device in all_chromecasts 
-                if device.host == host[0] and device.port == host[1]]
+        found = [device for device in all_chromecasts
+                if (device.host, device.port) == host]
         if found:
             try:
                 casts.append(CastDevice(found[0]))

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -68,7 +68,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     casts = []
 
-    all_chromecasts = pychromecast._get_all_chromecasts()
+    all_chromecasts = pychromecast.get_chromecasts()
 
     for host in hosts:
         found = [device for device in all_chromecasts 

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -90,7 +90,6 @@ class CastDevice(MediaPlayerDevice):
     # pylint: disable=too-many-public-methods
     def __init__(self, chromecast):
         """Initialize the Cast device."""
-        import pychromecast
         self.cast = chromecast
 
         self.cast.socket_client.receiver_controller.register_status_listener(

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -63,12 +63,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         hosts = [(config.get(CONF_HOST), DEFAULT_PORT)]
 
     else:
-        hosts = [tuple(dev[:2]) for dev in pychromecast.discover_chromecasts()
-                 if tuple(dev[:2]) not in KNOWN_HOSTS]
+        hosts = [tuple(dev[:2]) for dev in pychromecast.discover_chromecasts() if tuple(dev[:2]) not in KNOWN_HOSTS]
 
     casts = []
 
-    # in most cases this call will be executed only. In some cases discover_chromecasts() is also called
+    # get_chromecasts() returns Chromecast objects
+    # with the correct friendly name for grouped devices
     all_chromecasts = pychromecast.get_chromecasts()
 
     for host in hosts:

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -68,12 +68,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     casts = []
 
+    all_chromecasts = pychromecast._get_all_chromecasts()
+
     for host in hosts:
-        try:
-            casts.append(CastDevice(*host))
-            KNOWN_HOSTS.append(host)
-        except pychromecast.ChromecastConnectionError:
-            pass
+        found = [device for device in all_chromecasts if device.host == host[0] and device.port == host[1]]
+        if found:
+            try:
+                casts.append(CastDevice(found[0]))
+                KNOWN_HOSTS.append(host)
+            except pychromecast.ChromecastConnectionError:
+                pass
 
     add_devices(casts)
 

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -68,6 +68,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     casts = []
 
+    # in most cases this call will be executed only. In some cases discover_chromecasts() is also called
     all_chromecasts = pychromecast.get_chromecasts()
 
     for host in hosts:

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -63,7 +63,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         hosts = [(config.get(CONF_HOST), DEFAULT_PORT)]
 
     else:
-        hosts = [tuple(dev[:2]) for dev in pychromecast.discover_chromecasts() if tuple(dev[:2]) not in KNOWN_HOSTS]
+        hosts = [tuple(dev[:2]) for dev in pychromecast.discover_chromecasts() 
+                 if tuple(dev[:2]) not in KNOWN_HOSTS]
 
     casts = []
 
@@ -73,7 +74,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for host in hosts:
         found = [device for device in all_chromecasts
-                if (device.host, device.port) == host]
+                 if (device.host, device.port) == host]
         if found:
             try:
                 casts.append(CastDevice(found[0]))

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -63,7 +63,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         hosts = [(config.get(CONF_HOST), DEFAULT_PORT)]
 
     else:
-        hosts = [tuple(dev[:2]) for dev in pychromecast.discover_chromecasts() 
+        hosts = [tuple(dev[:2]) for dev in pychromecast.discover_chromecasts()
                  if tuple(dev[:2]) not in KNOWN_HOSTS]
 
     casts = []

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -5,13 +5,22 @@ from unittest.mock import patch
 
 from homeassistant.components.media_player import cast
 
+class FakeChromeCast(object):
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
 
 class TestCastMediaPlayer(unittest.TestCase):
     """Test the media_player module."""
 
     @patch('homeassistant.components.media_player.cast.CastDevice')
-    def test_filter_duplicates(self, mock_device):
+    @patch('pychromecast.get_chromecasts')
+    def test_filter_duplicates(self, mock_get_chromecasts, mock_device):
         """Test filtering of duplicates."""
+
+        mock_get_chromecasts.return_value = [FakeChromeCast('some_host', cast.DEFAULT_PORT)]
+
+        # Test chromecasts as if they were hardcoded in configuration.yaml
         cast.setup_platform(None, {
             'host': 'some_host'
         }, lambda _: _)
@@ -21,6 +30,7 @@ class TestCastMediaPlayer(unittest.TestCase):
         mock_device.reset_mock()
         assert not mock_device.called
 
+        # Test chromecasts as if they were automatically discovered
         cast.setup_platform(None, {}, lambda _: _, ('some_host',
                                                     cast.DEFAULT_PORT))
         assert not mock_device.called

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -5,10 +5,12 @@ from unittest.mock import patch
 
 from homeassistant.components.media_player import cast
 
+
 class FakeChromeCast(object):
     def __init__(self, host, port):
         self.host = host
         self.port = port
+
 
 class TestCastMediaPlayer(unittest.TestCase):
     """Test the media_player module."""
@@ -18,7 +20,9 @@ class TestCastMediaPlayer(unittest.TestCase):
     def test_filter_duplicates(self, mock_get_chromecasts, mock_device):
         """Test filtering of duplicates."""
 
-        mock_get_chromecasts.return_value = [FakeChromeCast('some_host', cast.DEFAULT_PORT)]
+        mock_get_chromecasts.return_value = [
+            FakeChromeCast('some_host', cast.DEFAULT_PORT)
+        ]
 
         # Test chromecasts as if they were hardcoded in configuration.yaml
         cast.setup_platform(None, {


### PR DESCRIPTION
The issue is described at #2909 

The fix is working on my setup, but I can't seem to prepare the test environment in order to successfully run `tox` (I get some `InvocationError` and a keychain issue somehow), even before my change.

Can somebody either help me reliably run the tests (so that I can adapt them for my modification), or take over this change and make it good enough to be merged? Thanks!
