### PR TITLE
Monkey-patch a weakref set in Task to be a no-op.

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -19,6 +19,48 @@ from homeassistant.const import (
 from homeassistant.util.async import run_callback_threadsafe
 
 
+import asyncio.tasks
+
+
+def monkey_patch_asyncio():
+    """Replace weakref.WeakSet to address Python 3 bug.
+
+    Under heavy threading operations that schedule calls into
+    the asyncio event loop, Task objects are created. Due to
+    a bug in Python, GC may have an issue when switching between
+    the threads and objects with __del__ (which various components
+    in HASS have).
+
+    This monkey-patch removes the weakref.Weakset, and replaces it
+    with an object that ignores the only call utilizing it (the
+    Task.__init__ which calls _all_tasks.add(self)). It also removes
+    the __del__ which could trigger the future objects __del__ at
+    unpredictable times.
+
+    The side-effect of this manipulation of the Task is that
+    Task.all_tasks() is no longer accurate, and there will be no
+    warning emitted if a Task is GC'd while in use.
+
+    On Python 3.6, after the bug is fixed, this monkey-patch can be
+    disabled.
+
+    See https://bugs.python.org/issue26617 for details of the Python
+    bug.
+    """
+    class IgnoreCalls:
+        """Ignore add calls."""
+
+        def add(self, other):
+            """No-op add."""
+            return
+
+    asyncio.tasks.Task._all_tasks = IgnoreCalls()
+    try:
+        del asyncio.tasks.Task.__del__
+    except:
+        pass
+
+
 def validate_python() -> None:
     """Validate we're running the right Python version."""
     if sys.version_info[:3] < REQUIRED_PYTHON_VER:
@@ -308,6 +350,8 @@ def try_to_restart() -> None:
 
 def main() -> int:
     """Start Home Assistant."""
+    monkey_patch_asyncio()
+
     validate_python()
 
     args = get_arguments()

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -19,9 +19,6 @@ from homeassistant.const import (
 from homeassistant.util.async import run_callback_threadsafe
 
 
-import asyncio.tasks
-
-
 def monkey_patch_asyncio():
     """Replace weakref.WeakSet to address Python 3 bug.
 
@@ -47,6 +44,10 @@ def monkey_patch_asyncio():
     See https://bugs.python.org/issue26617 for details of the Python
     bug.
     """
+    # pylint: disable=no-self-use, too-few-public-methods, protected-access
+    # pylint: disable=bare-except
+    import asyncio.tasks
+
     class IgnoreCalls:
         """Ignore add calls."""
 


### PR DESCRIPTION
**Description:**

Monkey-patches the asyncio.tasks.Task object to remove its weakref.WeakSet and `__del__` method. These were both involved in causing seg-faults due to a Python bug (https://bugs.python.org/issue26617) that may not be addressed in a shipping Python for some time. The side-effect is that the Task.all_tasks() method will no longer work. If code relies on that method (nothing does that I've found thus far) then it will be inaccurate and throw an exception as the replacement object does not implement `__iter__`.

**Related issue (if applicable):** fixes #3453

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
