### PR TITLE
Fix bug in fritzboxscanner

### DIFF
--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -85,7 +85,9 @@ class FritzBoxScanner(object):
 
     def get_device_name(self, mac):
         """Return the name of the given device or None if is not known."""
-        ret = self.fritz_box.get_specific_host_entry(mac)['NewHostName']
+        ret = self.fritz_box.get_specific_host_entry(mac).get(
+            'NewHostName'
+        )
         if ret == {}:
             return None
         return ret


### PR DESCRIPTION
**Description:**
Fix a bug that occurs when the fritzbox forgets about a mac address. 

**Related issue (if applicable):** fixes #3621

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
