### PR TITLE
Add anel_pwrctrl platform to control switches on ANEL PwrCtrl devices

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -273,6 +273,7 @@ omit =
     homeassistant/components/sensor/yahoo_finance.py
     homeassistant/components/sensor/yweather.py
     homeassistant/components/switch/acer_projector.py
+    homeassistant/components/switch/anel_pwrctrl.py
     homeassistant/components/switch/arest.py
     homeassistant/components/switch/dlink.py
     homeassistant/components/switch/edimax.py
@@ -281,7 +282,6 @@ omit =
     homeassistant/components/switch/netio.py
     homeassistant/components/switch/orvibo.py
     homeassistant/components/switch/pulseaudio_loopback.py
-    homeassistant/components/switch/pwrctrl.py
     homeassistant/components/switch/rest.py
     homeassistant/components/switch/rpi_rf.py
     homeassistant/components/switch/tplink.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -281,6 +281,7 @@ omit =
     homeassistant/components/switch/netio.py
     homeassistant/components/switch/orvibo.py
     homeassistant/components/switch/pulseaudio_loopback.py
+    homeassistant/components/switch/pwrctrl.py
     homeassistant/components/switch/rest.py
     homeassistant/components/switch/rpi_rf.py
     homeassistant/components/switch/tplink.py

--- a/homeassistant/components/switch/anel_pwrctrl.py
+++ b/homeassistant/components/switch/anel_pwrctrl.py
@@ -41,8 +41,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     host = config.get(CONF_HOST, None)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
-    port_recv = int(config.get(CONF_PORT_RECV))
-    port_send = int(config.get(CONF_PORT_SEND))
+    port_recv = config.get(CONF_PORT_RECV)
+    port_send = config.get(CONF_PORT_SEND)
 
     from anel_pwrctrl import DeviceMaster
 

--- a/homeassistant/components/switch/pwrctrl.py
+++ b/homeassistant/components/switch/pwrctrl.py
@@ -1,0 +1,125 @@
+"""
+Support for ANEL PwrCtrl switches.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.pwrctrl/
+"""
+import logging
+import socket
+from datetime import timedelta
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_HOST, CONF_PASSWORD, CONF_USERNAME)
+from homeassistant.util import Throttle
+
+
+REQUIREMENTS = ['https://github.com/mweinelt/anel-pwrctrl/archive/'
+                'master.zip#anel_pwrctrl==0.0.1']
+
+CONF_PORT_RECV = "port_recv"
+CONF_PORT_SEND = "port_send"
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_PORT_RECV): cv.port,
+    vol.Required(CONF_PORT_SEND): cv.port,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_HOST): cv.string,
+})
+
+
+# pylint: disable=unused-variable
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup PwrCtrl devices/switches."""
+    host = config.get(CONF_HOST, None)
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    port_recv = int(config.get(CONF_PORT_RECV))
+    port_send = int(config.get(CONF_PORT_SEND))
+
+    from anel_pwrctrl import DeviceMaster
+
+    try:
+        master = DeviceMaster(username=username,
+                              password=password,
+                              read_port=port_send,
+                              write_port=port_recv)
+        master.query(ip_addr=host)
+    except socket.error as ex:
+        _LOGGER.error('Unable to discover PwrCtrl device: %s', str(ex))
+        return False
+
+    devices = []
+    for device in master.devices.values():
+        parent_device = PwrCtrlDevice(device)
+        devices.extend(
+            PwrCtrlSwitch(switch, parent_device)
+            for switch in device.switches.values()
+        )
+
+    add_devices(devices)
+
+
+class PwrCtrlSwitch(SwitchDevice):
+    """Representation of a PwrCtrl switch."""
+
+    def __init__(self, port, parent_device):
+        """Initialize the PwrCtrl switch."""
+        self._port = port
+        self._parent_device = parent_device
+
+    @property
+    def should_poll(self):
+        """Polling is needed."""
+        return True
+
+    @property
+    def unique_id(self):
+        """Return the unique ID of the device."""
+        return "{device}-{switch_idx}".format(
+            device=self._port.device.host,
+            switch_idx=self._port.get_index()
+        )
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._port.label
+
+    @property
+    def is_on(self):
+        """Return true if the device is on."""
+        return self._port.get_state()
+
+    def update(self):
+        """Trigger update for all switches on the parent device."""
+        self._parent_device.update()
+
+    def turn_on(self):
+        """Turn the switch on."""
+        self._port.on()
+
+    def turn_off(self):
+        """Turn the switch off."""
+        self._port.off()
+
+
+# pylint: disable=too-few-public-methods
+class PwrCtrlDevice(object):
+    """Device representation for per device throttling."""
+
+    def __init__(self, device):
+        """Initialize the PwrCtrl device."""
+        self._device = device
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Update the device and all its switches."""
+        self._device.update()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,6 +185,9 @@ https://github.com/kellerza/pyqwikswitch/archive/v0.4.zip#pyqwikswitch==0.4
 # homeassistant.components.media_player.russound_rnet
 https://github.com/laf/russound/archive/0.1.6.zip#russound==0.1.6
 
+# homeassistant.components.switch.pwrctrl
+https://github.com/mweinelt/anel-pwrctrl/archive/master.zip#anel_pwrctrl==0.0.1
+
 # homeassistant.components.ecobee
 https://github.com/nkgilley/python-ecobee-api/archive/4856a704670c53afe1882178a89c209b5f98533d.zip#python-ecobee==0.0.6
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ https://github.com/kellerza/pyqwikswitch/archive/v0.4.zip#pyqwikswitch==0.4
 # homeassistant.components.media_player.russound_rnet
 https://github.com/laf/russound/archive/0.1.6.zip#russound==0.1.6
 
-# homeassistant.components.switch.pwrctrl
+# homeassistant.components.switch.anel_pwrctrl
 https://github.com/mweinelt/anel-pwrctrl/archive/master.zip#anel_pwrctrl==0.0.1
 
 # homeassistant.components.ecobee


### PR DESCRIPTION
**Description:**

Add support for ANELs platform for switches, called PwrCtrl, tested against the PwrCtrl HUT.

http://anel-elektronik.de/index.htm?src=SITE/produkte/home/home.htm

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#1036

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switches:
  - platform: pwrctrl
    port_send: 4165
    port_recv: 4166
    username: someuser
    password: changeme
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
