### PR TITLE
Added support for Wink Smoke and CO detectors

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -21,7 +21,9 @@ SENSOR_TYPES = {
     "loudness": "sound",
     "liquid_detected": "moisture",
     "motion": "motion",
-    "presence": "occupancy"
+    "presence": "occupancy",
+    "co_detected": "gas",
+    "smoke_detected": "smoke"
 }
 
 
@@ -35,6 +37,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for key in pywink.get_keys():
         add_devices([WinkBinarySensorDevice(key)])
+
+    for sensor in pywink.get_smoke_and_co_detectors():
+        add_devices([WinkBinarySensorDevice(sensor)])
 
 
 class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
@@ -70,6 +75,10 @@ class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
             state = self.wink.motion_boolean()
         elif self.capability == "presence":
             state = self.wink.presence_boolean()
+        elif self.capability == "co_detected":
+            state = self.wink.co_detected_boolean()
+        elif self.capability == "smoke_detected":
+            state = self.wink.smoke_detected_boolean()
         else:
             state = self.wink.state()
 

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL, \
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-wink==0.8.0', 'pubnub==3.8.2']
+REQUIREMENTS = ['python-wink==0.9.0', 'pubnub==3.8.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -396,7 +396,7 @@ python-telegram-bot==5.1.0
 python-twitch==1.3.0
 
 # homeassistant.components.wink
-python-wink==0.8.0
+python-wink==0.9.0
 
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11


### PR DESCRIPTION
**Description:**
This adds support for Wink smoke and Co detectors, these will show up as binary sensors, one for smoke and one for co. 

@rbflurry Can you test this?

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
