### PR TITLE
Add possibility to set temperature to a given operation_mode

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -79,6 +79,7 @@ SET_TEMPERATURE_SCHEMA = vol.Schema({
     vol.Inclusive(ATTR_TARGET_TEMP_HIGH, 'temperature'): vol.Coerce(float),
     vol.Inclusive(ATTR_TARGET_TEMP_LOW, 'temperature'): vol.Coerce(float),
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(ATTR_OPERATION_MODE): cv.string,
 })
 SET_FAN_MODE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
@@ -122,8 +123,10 @@ def set_aux_heat(hass, aux_heat, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_SET_AUX_HEAT, data)
 
 
+# pylint: disable=too-many-arguments
 def set_temperature(hass, temperature=None, entity_id=None,
-                    target_temp_high=None, target_temp_low=None):
+                    target_temp_high=None, target_temp_low=None,
+                    operation_mode=None):
     """Set new target temperature."""
     kwargs = {
         key: value for key, value in [
@@ -131,6 +134,7 @@ def set_temperature(hass, temperature=None, entity_id=None,
             (ATTR_TARGET_TEMP_HIGH, target_temp_high),
             (ATTR_TARGET_TEMP_LOW, target_temp_low),
             (ATTR_ENTITY_ID, entity_id),
+            (ATTR_OPERATION_MODE, operation_mode)
         ] if value is not None
     }
     _LOGGER.debug("set_temperature start data=%s", kwargs)

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -34,6 +34,18 @@ set_temperature:
       description: New target temperature for hvac
       example: 25
 
+    target_temp_high:
+      description: New target high tempereature for hvac
+      example: 26
+ 
+    target_temp_low:
+      description: New target low temperature for hvac
+      example: 20
+
+    operation_mode:
+      description: Operation mode to set temperature to
+      example: 'Heat'
+
 set_humidity:
   description: Set target humidity of climate device
 

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -43,7 +43,7 @@ set_temperature:
       example: 20
 
     operation_mode:
-      description: Operation mode to set temperature to
+      description: Operation mode to set temperature to. This defaults to current_operation mode if not set, or set incorrectly.
       example: 'Heat'
 
 set_humidity:

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -250,13 +250,17 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
         for value in (self._node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_THERMOSTAT_SETPOINT)
                       .values()):
-            if operation_mode:
+            _LOGGER.debug("Testing for operation_mode")
+            if operation_mode is not None:
+                _LOGGER.debug("operation_mode present")
                 setpoint_mode = SET_TEMP_TO_INDEX.get(operation_mode)
-                if value.index == setpoint_mode:
-                    _LOGGER.debug("setpoint_mode=%s", setpoint_mode)
-                    value.data = temperature
-                    break
+                if value.index != setpoint_mode:
+                    continue
+                _LOGGER.debug("setpoint_mode=%s", setpoint_mode)
+                value.data = temperature
+                break
 
+            _LOGGER.debug("operation_mode not present")
             if self.current_operation is not None:
                 if self._hrt4_zw and self.current_operation == 'Off':
                     # HRT4-ZW can change setpoint when off.

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -250,9 +250,7 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
         for value in (self._node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_THERMOSTAT_SETPOINT)
                       .values()):
-            _LOGGER.debug("Testing for operation_mode")
             if operation_mode is not None:
-                _LOGGER.debug("operation_mode present")
                 setpoint_mode = SET_TEMP_TO_INDEX.get(operation_mode)
                 if value.index != setpoint_mode:
                     continue
@@ -260,7 +258,6 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
                 value.data = temperature
                 break
 
-            _LOGGER.debug("operation_mode not present")
             if self.current_operation is not None:
                 if self._hrt4_zw and self.current_operation == 'Off':
                     # HRT4-ZW can change setpoint when off.

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -8,7 +8,8 @@ https://home-assistant.io/components/climate.zwave/
 # pylint: disable=import-error
 import logging
 from homeassistant.components.climate import DOMAIN
-from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate import (
+    ClimateDevice, ATTR_OPERATION_MODE)
 from homeassistant.components.zwave import ZWaveDeviceEntity
 from homeassistant.components import zwave
 from homeassistant.const import (
@@ -243,10 +244,19 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
             temperature = kwargs.get(ATTR_TEMPERATURE)
         else:
             return
+        operation_mode = kwargs.get(ATTR_OPERATION_MODE)
+        _LOGGER.debug("set_temperature operation_mode=%s", operation_mode)
 
         for value in (self._node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_THERMOSTAT_SETPOINT)
                       .values()):
+            if operation_mode:
+                setpoint_mode = SET_TEMP_TO_INDEX.get(operation_mode)
+                if value.index == setpoint_mode:
+                    _LOGGER.debug("setpoint_mode=%s", setpoint_mode)
+                    value.data = temperature
+                    break
+
             if self.current_operation is not None:
                 if self._hrt4_zw and self.current_operation == 'Off':
                     # HRT4-ZW can change setpoint when off.


### PR DESCRIPTION
**Description:**
Add the ability to set the temperature in a different operation mode than the one currently active.
This is added to zwave climate platform.

**Related issue (if applicable):** fixes #
#3213

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
