### PR TITLE
Upgrade Sphinx to 1.4.8 and set missing variables

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -340,8 +340,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Home-Assistant.tex', 'Home-Assistant Documentation',
-     'Home-Assistant Team', 'manual'),
+    (master_doc, 'home-assistant.tex', 'Home Assistant Documentation',
+     'Home Assistant Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -382,7 +382,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'home-assistant', 'Home-Assistant Documentation',
+    (master_doc, 'home-assistant', 'Home Assistant Documentation',
      [author], 1)
 ]
 
@@ -397,8 +397,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Home-Assistant', 'Home-Assistant Documentation',
-     author, 'Home-Assistant', 'One line description of project.',
+    (master_doc, 'Home-Assistant', 'Home Assistant Documentation',
+     author, 'Home Assistant', 'Open-source home automation platform.',
      'Miscellaneous'),
 ]
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
-Sphinx==1.4.6
+Sphinx==1.4.8
 sphinx-autodoc-typehints==1.1.0
 sphinx-autodoc-annotation==1.0.post1


### PR DESCRIPTION
## Release 1.4.8 (released Oct 1, 2016)
- #2996: The wheel package of Sphinx got crash with ImportError
## Release 1.4.7 (released Oct 1, 2016)
- Quickstart should return an error consistently on all error conditions
- flatten genindex columns' heights.
- Search on generated HTML site doesnt find some symbols
- Fall back to a GET request on 403 status in linkcheck
- jsdump.loads fails to load search index if keywords starts with underscore
- Fix epub content.opf: add auto generated orphan files to spine.
- Fix `hasdoc()` function in Jinja2 template. It can detect `genindex`, `search` collectly.
- Fix epub result: skip creating links from image tags to original image files.
-  inline code is hyphenated on HTML
- autosummary warns for namedtuple with attribute with trailing underscore
- Could not reference equations if `:nowrap:` option specified
- code-block overflow in latex (due to commas)
- sphinx.ext.intersphinx: broken links are generated if relative paths are used in `intersphinx_mapping`
- code-block directive with same :caption: causes warning of duplicate target.  Now `code-block` and `literalinclude` does not define hyperlink target using its caption automatically.
- latex: missing label of longtable
- autodoc: show-inheritance option breaks docstrings
