### PR TITLE
Customize initial state of automation

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -38,6 +38,7 @@ CONF_CONDITION = 'condition'
 CONF_ACTION = 'action'
 CONF_TRIGGER = 'trigger'
 CONF_CONDITION_TYPE = 'condition_type'
+CONF_INITIAL_STATE = 'initial_state'
 
 CONDITION_USE_TRIGGER_VALUES = 'use_trigger_values'
 CONDITION_TYPE_AND = 'and'
@@ -45,6 +46,7 @@ CONDITION_TYPE_OR = 'or'
 
 DEFAULT_CONDITION_TYPE = CONDITION_TYPE_AND
 DEFAULT_HIDE_ENTITY = False
+DEFAULT_INITIAL_STATE = True
 
 ATTR_LAST_TRIGGERED = 'last_triggered'
 ATTR_VARIABLES = 'variables'
@@ -79,6 +81,8 @@ _CONDITION_SCHEMA = vol.All(cv.ensure_list, [cv.CONDITION_SCHEMA])
 
 PLATFORM_SCHEMA = vol.Schema({
     CONF_ALIAS: cv.string,
+    vol.Optional(CONF_INITIAL_STATE,
+                 default=DEFAULT_INITIAL_STATE): cv.boolean,
     vol.Optional(CONF_HIDE_ENTITY, default=DEFAULT_HIDE_ENTITY): cv.boolean,
     vol.Required(CONF_TRIGGER): _TRIGGER_SCHEMA,
     vol.Optional(CONF_CONDITION): _CONDITION_SCHEMA,
@@ -333,7 +337,8 @@ def _async_process_config(hass, config, component):
                 config_block.get(CONF_TRIGGER, []), name)
             entity = AutomationEntity(name, async_attach_triggers, cond_func,
                                       action, hidden)
-            tasks.append(hass.loop.create_task(entity.async_enable()))
+            if config_block[CONF_INITIAL_STATE]:
+                tasks.append(hass.loop.create_task(entity.async_enable()))
             entities.append(entity)
 
     yield from asyncio.gather(*tasks, loop=hass.loop)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -96,6 +96,46 @@ class TestAutomation(unittest.TestCase):
         self.assertEqual(['hello.world'],
                          self.calls[0].data.get(ATTR_ENTITY_ID))
 
+    def test_service_initial_value_off(self):
+        """Test initial value off."""
+        entity_id = 'automation.hello'
+
+        assert setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'alias': 'hello',
+                'initial_state': 'off',
+                'trigger': {
+                    'platform': 'event',
+                    'event_type': 'test_event',
+                },
+                'action': {
+                    'service': 'test.automation',
+                    'entity_id': ['hello.world', 'hello.world2']
+                }
+            }
+        })
+        assert not automation.is_on(self.hass, entity_id)
+
+    def test_service_initial_value_on(self):
+        """Test initial value on."""
+        entity_id = 'automation.hello'
+
+        assert setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'alias': 'hello',
+                'initial_state': 'on',
+                'trigger': {
+                    'platform': 'event',
+                    'event_type': 'test_event',
+                },
+                'action': {
+                    'service': 'test.automation',
+                    'entity_id': ['hello.world', 'hello.world2']
+                }
+            }
+        })
+        assert automation.is_on(self.hass, entity_id)
+
     def test_service_specify_entity_id_list(self):
         """Test service data."""
         assert setup_component(self.hass, automation.DOMAIN, {


### PR DESCRIPTION
**Description:**
Possible to set an automation to be disabled when HASS starts

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/automation-initially-off-and-persistent/3831

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
automation:
  - alias: 'Test automation'
    initial_state: 'off'
    trigger:
      platform: state
      entity_id: switch.kitchen
      state: 'off'
    condition:
    - condition: state
      entity_id: switch.kitchen
      state: 'off'
    action:
      service: light.turn_off
      entity_id: light.diningtable_left
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
