### PR TITLE
Update command_line.py with scan_interval

### DIFF
--- a/homeassistant/components/binary_sensor/command_line.py
+++ b/homeassistant/components/binary_sensor/command_line.py
@@ -14,7 +14,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.components.sensor.command_line import CommandSensorData
 from homeassistant.const import (
     CONF_PAYLOAD_OFF, CONF_PAYLOAD_ON, CONF_NAME, CONF_VALUE_TEMPLATE,
-    CONF_SENSOR_CLASS, CONF_COMMAND)
+    CONF_SENSOR_CLASS, CONF_COMMAND, CONF_SCAN_INTERVAL)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ DEFAULT_NAME = 'Binary Command Sensor'
 DEFAULT_PAYLOAD_ON = 'ON'
 DEFAULT_PAYLOAD_OFF = 'OFF'
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COMMAND): cv.string,
@@ -46,7 +46,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
         value_template.hass = hass
-    data = CommandSensorData(command)
+    scan_interval = config.get(CONF_SCAN_INTERVAL)
+    data = CommandSensorData(command, scan_interval)
 
     add_devices([CommandBinarySensor(
         hass, data, name, sensor_class, payload_on, payload_off,

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME, CONF_VALUE_TEMPLATE, CONF_UNIT_OF_MEASUREMENT, CONF_COMMAND)
+    CONF_NAME, CONF_VALUE_TEMPLATE, CONF_UNIT_OF_MEASUREMENT, CONF_COMMAND, CONF_SCAN_INTERVAL)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Command Sensor'
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COMMAND): cv.string,
@@ -40,7 +40,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
         value_template.hass = hass
-    data = CommandSensorData(command)
+    scan_interval = config.get(CONF_SCAN_INTERVAL)
+    data = CommandSensorData(command, scan_interval)
 
     add_devices([CommandSensor(hass, data, name, unit, value_template)])
 
@@ -90,9 +91,10 @@ class CommandSensor(Entity):
 class CommandSensorData(object):
     """The class for handling the data retrieval."""
 
-    def __init__(self, command):
+    def __init__(self, command, interval):
         """Initialize the data object."""
         self.command = command
+        self._interval = interval
         self.value = None
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -12,7 +12,8 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME, CONF_VALUE_TEMPLATE, CONF_UNIT_OF_MEASUREMENT, CONF_COMMAND, CONF_SCAN_INTERVAL)
+    CONF_NAME, CONF_VALUE_TEMPLATE, CONF_UNIT_OF_MEASUREMENT, CONF_COMMAND,
+    CONF_SCAN_INTERVAL)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv


### PR DESCRIPTION
**Description:**
At the moment, the scan interval of a command line sensor is a hardcoded 60 seconds, increased with the `scan_interval` value from the user's sensor configuration if the user defined it. This PR should just use the user defined `scan_interval`, if present.

Please take note that this is my very first PR so any feedback is welcome. I used [this commit](https://github.com/home-assistant/home-assistant/pull/3486/commits/9184773f8f9111ad7d1d4473204aab6e0dfe97fe) as a reference. I may also need some assistance to finalize this PR.

Known issue: the scan interval is limited to 60 seconds when the user defined `scan_interval` exceeds 60, see related issue #2499 => separate PR?

**Related pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** fixes PR #2994

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
- platform: command_line
  name: "Hombot Status"
  command: "python3 /home/hass/.homeassistant/python/hombot_retrieve_status.py 'JSON_ROBOT_STATE'"
  scan_interval: 10
  value_template: "{{ value | capitalize() }}"

- platform: command_line
  name: "Hombot Battery"
  command: "python3 /home/hass/.homeassistant/python/hombot_retrieve_status.py 'JSON_BATTPERC'"
  unit_of_measurement: '%'
  scan_interval: 30

- platform: command_line
  name: "Hombot Last Clean"
  command: "python3 /home/hass/.homeassistant/python/hombot_retrieve_status.py 'CLREC_LAST_CLEAN'"
#  scan_interval: 30
  value_template: >-
    {%- if value == "n/a" -%}
      n/a
    {%- else -%}
      {{ value.split('/')[2] }}/{{ value.split('/')[1] }}/{{ value.split('/')[0] }} {{ value.split('/')[3] }}:{{ value.split('/')[4] }}
    {%- endif -%}

- platform: command_line
  name: "Hombot finished ZZ"
  command: "python3 /home/hass/.homeassistant/python/hombot_retrieve_statistic.py 'NUM FINISH ZZ'"
  scan_interval: 120

- platform: command_line
  name: "Hombot finished SB"
  command: "python3 /home/hass/.homeassistant/python/hombot_retrieve_statistic.py 'NUM FINISH SB'"
  scan_interval: 60

- platform: command_line
  name: "Hombot finished SPOT"
  command: "python3 /home/hass/.homeassistant/python/hombot_retrieve_statistic.py 'NUM FINISH SPOT'"
  scan_interval: 60
```

**Checklist:**

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
