### PR TITLE
customize if pushetta should send test message on start up

### DIFF
--- a/homeassistant/components/notify/pushetta.py
+++ b/homeassistant/components/notify/pushetta.py
@@ -18,45 +18,51 @@ REQUIREMENTS = ['pushetta==1.0.15']
 
 
 CONF_CHANNEL_NAME = 'channel_name'
+CONF_SEND_TEST_MSG = 'send_test_msg'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_CHANNEL_NAME): cv.string,
+    vol.Optional(CONF_SEND_TEST_MSG, default=False): cv.boolean,
 })
 
 
 def get_service(hass, config):
     """Get the Pushetta notification service."""
-    from pushetta import Pushetta, exceptions
+    pushetta_service = PushettaNotificationService(config[CONF_API_KEY],
+                                                   config[CONF_CHANNEL_NAME],
+                                                   config[CONF_SEND_TEST_MSG])
 
-    try:
-        pushetta = Pushetta(config[CONF_API_KEY])
-        pushetta.pushMessage(config[CONF_CHANNEL_NAME],
-                             "Home Assistant started")
-    except exceptions.TokenValidationError:
-        _LOGGER.error("Please check your access token")
-        return None
-    except exceptions.ChannelNotFoundError:
-        _LOGGER.error("Channel '%s' not found", config[CONF_CHANNEL_NAME])
-        return None
-
-    return PushettaNotificationService(config[CONF_API_KEY],
-                                       config[CONF_CHANNEL_NAME])
+    if pushetta_service.is_valid:
+        return pushetta_service
 
 
 # pylint: disable=too-few-public-methods
 class PushettaNotificationService(BaseNotificationService):
     """Implement the notification service for Pushetta."""
 
-    def __init__(self, api_key, channel_name):
+    def __init__(self, api_key, channel_name, send_test_msg):
         """Initialize the service."""
         from pushetta import Pushetta
         self._api_key = api_key
         self._channel_name = channel_name
-        self.pushetta = Pushetta(self._api_key)
+        self.is_valid = True
+        self.pushetta = Pushetta(api_key)
+
+        if send_test_msg:
+            self.send_message("Home Assistant started")
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
+        from pushetta import exceptions
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
-        self.pushetta.pushMessage(self._channel_name,
-                                  "{} {}".format(title, message))
+
+        try:
+            self.pushetta.pushMessage(self._channel_name,
+                                      "{} {}".format(title, message))
+        except exceptions.TokenValidationError:
+            _LOGGER.error("Please check your access token")
+            self.is_valid = False
+        except exceptions.ChannelNotFoundError:
+            _LOGGER.error("Channel '%s' not found", self._channel_name)
+            self.is_valid = False


### PR DESCRIPTION
**Description:**
customize if pushetta should send test message on start up

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/remove-pushetta-home-assistant-started-messages/4443

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
notify:
  name: NOTIFIER_NAME
  platform: pushetta
  api_key: YOUR_API_KEY
  channel_name: YOUR_CHANNEL_NAME
  send_test_msg: False
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
