### PR TITLE
Expose Configuration path to frontend

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1088,6 +1088,7 @@ class Config(object):
             'location_name': self.location_name,
             'time_zone': time_zone.zone,
             'components': self.components,
+            'config_dir': self.config_dir,
             'version': __version__
         }
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -199,8 +199,6 @@ class HomeAssistant(object):
 
         This method is a coroutine.
         """
-        # pylint: disable=protected-access
-        self.loop._thread_ident = threading.get_ident()
         async_create_timer(self)
         async_monitor_worker_pool(self)
         self.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1088,6 +1086,7 @@ class Config(object):
             'location_name': self.location_name,
             'time_zone': time_zone.zone,
             'components': self.components,
+            'config_dir': self.config_dir,
             'version': __version__
         }
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -199,6 +199,8 @@ class HomeAssistant(object):
 
         This method is a coroutine.
         """
+        # pylint: disable=protected-access
+        self.loop._thread_ident = threading.get_ident()
         async_create_timer(self)
         async_monitor_worker_pool(self)
         self.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1086,7 +1088,6 @@ class Config(object):
             'location_name': self.location_name,
             'time_zone': time_zone.zone,
             'components': self.components,
-            'config_dir': self.config_dir,
             'version': __version__
         }
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -448,6 +448,7 @@ class TestConfig(unittest.TestCase):
 
     def test_as_dict(self):
         """Test as dict."""
+        self.config.config_dir = '/tmp/ha-config'
         expected = {
             'latitude': None,
             'longitude': None,
@@ -455,6 +456,7 @@ class TestConfig(unittest.TestCase):
             'location_name': None,
             'time_zone': 'UTC',
             'components': [],
+            'config_dir': '/tmp/ha-config',
             'version': __version__,
         }
 


### PR DESCRIPTION
**Description:**
Expose configuration to the frontend.

**Related issue (if applicable):** 
https://github.com/home-assistant/home-assistant/issues/3556

**Related PR's:** 
https://github.com/home-assistant/home-assistant-polymer/pull/115
https://github.com/home-assistant/home-assistant-js/pull/23

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
