### PR TITLE
MQTT Cover position

### DIFF
--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -141,7 +141,12 @@ class MqttCover(CoverDevice):
 
         None is unknown, 0 is closed, 100 is fully open.
         """
-        return self._position
+        if self._position is not None:
+            return self.position
+        elif self.is_closed is not None:
+            return 0 if self.is_closed else 100
+        else:
+            return None
 
     def open_cover(self, **kwargs):
         """Move the cover up."""


### PR DESCRIPTION
Mqtt cover's `current_cover_position` is `None`, which makes it always show both the up and down arrows. This falls back to using `is_closed` to disable up/down. Based on an workaround mentioned here: https://community.home-assistant.io/t/frontend-status-feedback-for-cover-component/3934/15
