### PR TITLE
Add automations and scripts to group.all_automations and group.all_scripts

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -31,6 +31,8 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 DEPENDENCIES = ['group']
 
+GROUP_NAME_ALL_AUTOMATIONS = 'all automations'
+
 CONF_ALIAS = 'alias'
 CONF_HIDE_ENTITY = 'hide_entity'
 
@@ -139,7 +141,8 @@ def reload(hass):
 
 def setup(hass, config):
     """Setup the automation."""
-    component = EntityComponent(_LOGGER, DOMAIN, hass)
+    component = EntityComponent(_LOGGER, DOMAIN, hass,
+                                group_name=GROUP_NAME_ALL_AUTOMATIONS)
 
     success = run_coroutine_threadsafe(
         _async_process_config(hass, config, component), hass.loop).result()

--- a/homeassistant/components/script.py
+++ b/homeassistant/components/script.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.script import Script
 
 DOMAIN = "script"
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
+GROUP_NAME_ALL_SCRIPTS = 'all scripts'
 DEPENDENCIES = ["group"]
 
 CONF_SEQUENCE = "sequence"
@@ -73,7 +74,8 @@ def toggle(hass, entity_id):
 
 def setup(hass, config):
     """Load the scripts from the configuration."""
-    component = EntityComponent(_LOGGER, DOMAIN, hass)
+    component = EntityComponent(_LOGGER, DOMAIN, hass,
+                                group_name=GROUP_NAME_ALL_SCRIPTS)
 
     def service_handler(service):
         """Execute a service call to script.<script name>."""

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -74,6 +74,11 @@ class TestAutomation(unittest.TestCase):
         state = self.hass.states.get('automation.hello')
         assert state is not None
         assert state.attributes.get('last_triggered') == time
+        
+        state = self.hass.states.get('group.all_automations')
+        assert state is not None
+        assert state.attributes.get('entity_id') == ('automation.hello',)
+        
 
     def test_service_specify_entity_id(self):
         """Test service data."""

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -74,11 +74,10 @@ class TestAutomation(unittest.TestCase):
         state = self.hass.states.get('automation.hello')
         assert state is not None
         assert state.attributes.get('last_triggered') == time
-        
+
         state = self.hass.states.get('group.all_automations')
         assert state is not None
         assert state.attributes.get('entity_id') == ('automation.hello',)
-        
 
     def test_service_specify_entity_id(self):
         """Test service data."""

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -82,6 +82,10 @@ class TestScriptComponent(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(0, len(events))
 
+        state = self.hass.states.get('group.all_scripts')
+        assert state is not None
+        assert state.attributes.get('entity_id') == (ENTITY_ID,)
+
     def test_toggle_service(self):
         """Test the toggling of a service."""
         event = 'test_event'


### PR DESCRIPTION
**Description:**
Add automations to group.all_automations
Add scripts to group.all_scripts

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/create-groups-for-configurators-automations-and-scripts/4230

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
