### PR TITLE
Fixed issue #3624 and bumped python-nest to 2.10.0 version

### DIFF
--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -14,7 +14,7 @@ from homeassistant.const import (CONF_PASSWORD, CONF_USERNAME, CONF_STRUCTURE)
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['python-nest==2.9.2']
+REQUIREMENTS = ['python-nest==2.10.0']
 
 DOMAIN = 'nest'
 

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 
 DEPENDENCIES = ['nest']
 SENSOR_TYPES = ['humidity',
-                'operation_mode',
+                'mode',
                 'last_ip',
                 'local_ip',
                 'last_connection',

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -109,7 +109,7 @@ class NestBasicSensor(NestSensor):
     @property
     def state(self):
         """Return the state of the sensor."""
-        if self.device.variable == 'operation_mode':
+        if self.variable == 'operation_mode':
             return getattr(self.device, "mode")
         else:
             return getattr(self.device, self.variable)

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 
 DEPENDENCIES = ['nest']
 SENSOR_TYPES = ['humidity',
-                'mode',
+                'operation_mode',
                 'last_ip',
                 'local_ip',
                 'last_connection',
@@ -109,7 +109,10 @@ class NestBasicSensor(NestSensor):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return getattr(self.device, self.variable)
+        if self.device.variable == 'operation_mode':
+            return getattr(self.device, "mode")
+        else:
+            return getattr(self.device, self.variable)
 
     @property
     def unit_of_measurement(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -386,7 +386,7 @@ python-mpd2==0.5.5
 python-mystrom==0.3.6
 
 # homeassistant.components.nest
-python-nest==2.9.2
+python-nest==2.10.0
 
 # homeassistant.components.device_tracker.nmap_tracker
 python-nmap==0.6.1


### PR DESCRIPTION
**Description:**

This patch fixes the sensor/Nest issue below which was fixed in python-nest 2.10.0 as reported at https://github.com/jkoelker/python-nest/issues/47

``` python
Oct 01 00:36:19 automation hass[18289]: File "/srv/hass/hass_venv/lib/python3.4/site-packages/homeassistant/components/sensor/nest.py", line 145, in state
Oct 01 00:36:19 automation hass[18289]: return getattr(self.structure.weather.current.wind, self.variable)
Oct 01 00:36:19 automation hass[18289]: File "/home/hass/.homeassistant/deps/nest/nest.py", line 254, in current
Oct 01 00:36:19 automation hass[18289]: return Forecast(self._current, self._tz)
Oct 01 00:36:19 automation hass[18289]: File "/home/hass/.homeassistant/deps/nest/nest.py", line 205, in __init__
Oct 01 00:36:19 automation hass[18289]: fget('observation_epoch')))))
Oct 01 00:36:19 automation hass[18289]: TypeError: float() argument must be a string or a number, not 'NoneType'
```

It also includes a fix to return the 'operation_mode' attribute.

**Related issue (if applicable):** fixes #3624

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: nest
    monitored_conditions:
      - 'temperature'
      - 'target'
      - 'humidity'
      - 'last_ip'
      - 'local_ip'
      - 'last_connection'
      - 'battery_level'
      - 'operation_mode'
      - 'weather_condition'
      - 'weather_temperature'
      - 'weather_humidity'
      - 'wind_speed'
      - 'wind_direction'
      - 'co_status'
      - 'smoke_status'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in https://github.com/home-assistant/home-assistant.github.io/pull/1082

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
