### PR TITLE
Only query vehicle attributes once

### DIFF
--- a/homeassistant/components/device_tracker/volvooncall.py
+++ b/homeassistant/components/device_tracker/volvooncall.py
@@ -67,6 +67,12 @@ def setup_scanner(hass, config, see):
         user = query("customeraccounts")
         rel = query(user["accountVehicleRelations"][0])
         vehicle_url = rel["vehicle"] + '/'
+        attributes = query("attributes", vehicle_url)
+
+        dev_id = "volvo_" + attributes["registrationNumber"]
+        host_name = "%s %s/%s" % (attributes["registrationNumber"],
+                                  attributes["vehicleType"],
+                                  attributes["modelYear"])
     except requests.exceptions.RequestException:
         _LOGGER.error("Could not log in to service. "
                       "Please check configuration.")
@@ -78,12 +84,6 @@ def setup_scanner(hass, config, see):
 
         status = query("status", vehicle_url)
         position = query("position", vehicle_url)
-        attributes = query("attributes", vehicle_url)
-
-        dev_id = "volvo_" + attributes["vin"]
-        host_name = "%s %s/%s" % (attributes["registrationNumber"],
-                                  attributes["vehicleType"],
-                                  attributes["modelYear"])
 
         see(dev_id=dev_id,
             host_name=host_name,


### PR DESCRIPTION
**Description:**
Instead of requesting vehicle attributes on each update, just do it once when initializing
Also, use vehicle registration number as default device id, instead of the (longer) vehicle identification number.

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

use registration number as dev id
