### PR TITLE
Added include and exclude functionality to history component

### DIFF
--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -265,7 +265,7 @@ class Filters(object):
         if self.excluded_domains and not self.included_domains:
             filter_query = ~states.domain.in_(self.excluded_domains)
             if self.included_entities:
-                filter_query |= states.entity_id.in_(self.included_entities)
+                filter_query &= states.entity_id.in_(self.included_entities)
         # filter if only included domain is configured
         elif not self.excluded_domains and self.included_domains:
             filter_query = states.domain.in_(self.included_domains)

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -236,7 +236,8 @@ class TestComponentHistory(unittest.TestCase):
 
         config = history.CONFIG_SCHEMA({
             ha.DOMAIN: {},
-            history.DOMAIN: {history.CONF_INCLUDE: {
+            history.DOMAIN: {
+                history.CONF_INCLUDE: {
                     history.CONF_ENTITIES: ['media_player.test',
                                             'thermostat.test']},
                 history.CONF_EXCLUDE: {

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -229,8 +229,7 @@ class TestComponentHistory(unittest.TestCase):
         self.check_significant_states(zero, four, states, config)
 
     def test_get_significant_states_include_exclude_domain(self):
-        """Test if significant states are returned when excluding and including
-        domains.
+        """Test if significant states when excluding and including domains.
 
         We should not get back any changes since we include only the
         media_player domain but also exclude it.
@@ -251,8 +250,7 @@ class TestComponentHistory(unittest.TestCase):
         self.check_significant_states(zero, four, states, config)
 
     def test_get_significant_states_include_exclude_entity(self):
-        """Test if significant states are returned when excluding and including
-        domains.
+        """Test if significant states when excluding and including domains.
 
         We should not get back any changes since we include only
         media_player.test but also exclude it.
@@ -273,8 +271,7 @@ class TestComponentHistory(unittest.TestCase):
         self.check_significant_states(zero, four, states, config)
 
     def test_get_significant_states_include_exclude(self):
-        """Test if significant states are returned when excluding and including
-        domains and entities.
+        """Test if significant states when in/excluding domains and entities.
 
         We should only get back changes of the media_player.test2 entity.
         """

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -145,14 +145,172 @@ class TestComponentHistory(unittest.TestCase):
     def test_get_significant_states(self):
         """Test that only significant states are returned.
 
-        We inject a bunch of state updates from media player, zone and
-        thermostat. We should get back every thermostat change that
+        We should get back every thermostat change that
         includes an attribute change, but only the state updates for
         media player (attribute changes are not significant and not returned).
         """
+        zero, four, states = self.record_states()
+        hist = history.get_significant_states(zero, four)
+        assert states == hist
+
+    def test_get_significant_states_enitty_id(self):
+        """Test that only significant states are returned for one entity."""
+        zero, four, states = self.record_states()
+        del states['media_player.test2']
+        del states['thermostat.test']
+        del states['thermostat.test2']
+        del states['script.can_cancel_this_one']
+
+        hist = history.get_significant_states(zero, four, 'media_player.test')
+        assert states == hist
+
+    def test_get_significant_states_exclude_domain(self):
+        """Test if significant states are returned when excluding domains.
+
+        We should get back every thermostat change that includes an attribute
+        change, but no media player changes.
+        """
+        zero, four, states = self.record_states()
+        del states['media_player.test']
+        del states['media_player.test2']
+
+        config = history.CONFIG_SCHEMA({
+            ha.DOMAIN: {},
+            history.DOMAIN: {history.CONF_EXCLUDE: {
+                history.CONF_DOMAINS: ['media_player', ]}}})
+        self.check_significant_states(zero, four, states, config)
+
+    def test_get_significant_states_exclude_entity(self):
+        """Test if significant states are returned when excluding entities.
+
+        We should get back every thermostat and script changes, but no media
+        player changes.
+        """
+        zero, four, states = self.record_states()
+        del states['media_player.test']
+
+        config = history.CONFIG_SCHEMA({
+            ha.DOMAIN: {},
+            history.DOMAIN: {history.CONF_EXCLUDE: {
+                history.CONF_ENTITIES: ['media_player.test', ]}}})
+        self.check_significant_states(zero, four, states, config)
+
+    def test_get_significant_states_include_domain(self):
+        """Test if significant states are returned when including domains.
+
+        We should get back every thermostat and script changes, but no media
+        player changes.
+        """
+        zero, four, states = self.record_states()
+        del states['media_player.test']
+        del states['media_player.test2']
+
+        config = history.CONFIG_SCHEMA({
+            ha.DOMAIN: {},
+            history.DOMAIN: {history.CONF_INCLUDE: {
+                history.CONF_DOMAINS: ['thermostat', 'script']}}})
+        self.check_significant_states(zero, four, states, config)
+
+    def test_get_significant_states_include_entity(self):
+        """Test if significant states are returned when excluding domains.
+
+        We should only get back changes of the media_player.test entity.
+        """
+        zero, four, states = self.record_states()
+        del states['media_player.test2']
+        del states['thermostat.test']
+        del states['thermostat.test2']
+        del states['script.can_cancel_this_one']
+
+        config = history.CONFIG_SCHEMA({
+            ha.DOMAIN: {},
+            history.DOMAIN: {history.CONF_INCLUDE: {
+                history.CONF_ENTITIES: ['media_player.test']}}})
+        self.check_significant_states(zero, four, states, config)
+
+    def test_get_significant_states_include_exclude_domain(self):
+        """Test if significant states are returned when excluding and including
+        domains.
+
+        We should not get back any changes since we include only the
+        media_player domain but also exclude it.
+        """
+        zero, four, states = self.record_states()
+        del states['media_player.test']
+        del states['media_player.test2']
+        del states['thermostat.test']
+        del states['thermostat.test2']
+        del states['script.can_cancel_this_one']
+
+        config = history.CONFIG_SCHEMA({
+            ha.DOMAIN: {},
+            history.DOMAIN: {history.CONF_INCLUDE: {
+                    history.CONF_DOMAINS: ['media_player']},
+                history.CONF_EXCLUDE: {
+                    history.CONF_DOMAINS: ['media_player']}}})
+        self.check_significant_states(zero, four, states, config)
+
+    def test_get_significant_states_include_exclude_entity(self):
+        """Test if significant states are returned when excluding and including
+        domains.
+
+        We should not get back any changes since we include only
+        media_player.test but also exclude it.
+        """
+        zero, four, states = self.record_states()
+        del states['media_player.test']
+        del states['media_player.test2']
+        del states['thermostat.test']
+        del states['thermostat.test2']
+        del states['script.can_cancel_this_one']
+
+        config = history.CONFIG_SCHEMA({
+            ha.DOMAIN: {},
+            history.DOMAIN: {history.CONF_INCLUDE: {
+                    history.CONF_ENTITIES: ['media_player.test']},
+                history.CONF_EXCLUDE: {
+                    history.CONF_ENTITIES: ['media_player.test']}}})
+        self.check_significant_states(zero, four, states, config)
+
+    def test_get_significant_states_include_exclude(self):
+        """Test if significant states are returned when excluding and including
+        domains and entities.
+
+        We should only get back changes of the media_player.test2 entity.
+        """
+        zero, four, states = self.record_states()
+        del states['media_player.test']
+        del states['thermostat.test']
+        del states['thermostat.test2']
+        del states['script.can_cancel_this_one']
+
+        config = history.CONFIG_SCHEMA({
+            ha.DOMAIN: {},
+            history.DOMAIN: {history.CONF_INCLUDE: {
+                    history.CONF_DOMAINS: ['media_player'],
+                    history.CONF_ENTITIES: ['thermostat.test']},
+                history.CONF_EXCLUDE: {
+                    history.CONF_DOMAINS: ['thermostat'],
+                    history.CONF_ENTITIES: ['media_player.test']}}})
+        self.check_significant_states(zero, four, states, config)
+
+    def check_significant_states(self, zero, four, states, config):
+        """Check if significant states are retrieved."""
+        filters = history.Filters(config)
+        hist = history.get_significant_states(zero, four, filters=filters)
+        assert states == hist
+
+    def record_states(self):
+        """Record some test states.
+
+        We inject a bunch of state updates from media player, zone and
+        thermostat.
+        """
         self.init_recorder()
         mp = 'media_player.test'
+        mp2 = 'media_player.test2'
         therm = 'thermostat.test'
+        therm2 = 'thermostat.test2'
         zone = 'zone.home'
         script_nc = 'script.cannot_cancel_this_one'
         script_c = 'script.can_cancel_this_one'
@@ -168,7 +326,7 @@ class TestComponentHistory(unittest.TestCase):
         three = two + timedelta(seconds=1)
         four = three + timedelta(seconds=1)
 
-        states = {therm: [], mp: [], script_c: []}
+        states = {therm: [], therm2: [], mp: [], mp2: [], script_c: []}
         with patch('homeassistant.components.recorder.dt_util.utcnow',
                    return_value=one):
             states[mp].append(
@@ -176,6 +334,9 @@ class TestComponentHistory(unittest.TestCase):
                           attributes={'media_title': str(sentinel.mt1)}))
             states[mp].append(
                 set_state(mp, 'YouTube',
+                          attributes={'media_title': str(sentinel.mt2)}))
+            states[mp2].append(
+                set_state(mp2, 'YouTube',
                           attributes={'media_title': str(sentinel.mt2)}))
             states[therm].append(
                 set_state(therm, 20, attributes={'current_temperature': 19.5}))
@@ -192,6 +353,8 @@ class TestComponentHistory(unittest.TestCase):
                 set_state(script_c, 'off', attributes={'can_cancel': True}))
             states[therm].append(
                 set_state(therm, 21, attributes={'current_temperature': 19.8}))
+            states[therm2].append(
+                set_state(therm2, 20, attributes={'current_temperature': 19}))
 
         with patch('homeassistant.components.recorder.dt_util.utcnow',
                    return_value=three):
@@ -201,6 +364,7 @@ class TestComponentHistory(unittest.TestCase):
             # Attributes changed even though state is the same
             states[therm].append(
                 set_state(therm, 21, attributes={'current_temperature': 20}))
-
-        hist = history.get_significant_states(zero, four)
-        assert states == hist
+            # state will be skipped since entity is hidden
+            set_state(therm, 22, attributes={'current_temperature': 21,
+                                             'hidden': True})
+        return zero, four, states


### PR DESCRIPTION
**Description:**
Added `include` and `exclude` configuration to the history component.

Without any `include` or `exclude` configuration the history displays graphs for every entity (well that's not exactly true - for instance `hidden` entities or `scenes` are never shown) on a given date. If you are only interested in some of the entities you several options:
- define domains and entities to `exclude` (aka. blacklist) 
- define domains and entities to display by using the `include` configuration (aka. whitelist).
- use the `include` list to define the domains/entities to display, and exclude some of them with in the `exclude` list. This makes sense if you for instance include the sensor domain, but want to exclude some specific sensor like in the example below. 

**Related issue (if applicable):** fixes #3311

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#1094

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
# Example configuration.yaml entry without any filters
history:

# Example configuration.yaml entry with exclude
history:
  exclude:
    domains:
      - automation
      - sun
      - weblink
      - group
      - updater
    entities:
      - sensor.last_boot
      - sensor.date

# Example configuration.yaml entry with include and exclude
history:
  include:
    domains:
      - sensor
      - switch
      - media_player
  exclude:
    entities:
     - sensor.last_boot
     - sensor.date
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
