### PR TITLE
Fix starting of remote slaves.

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -135,13 +135,13 @@ def setup(hass, config):
         """Start the WSGI server."""
         server.start()
 
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_wsgi_server)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, start_wsgi_server)
 
     def stop_wsgi_server(event):
         """Stop the WSGI server."""
         server.stop()
 
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_wsgi_server)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_wsgi_server)
 
     hass.wsgi = server
     hass.config.api = rem.API(server_host if server_host != '0.0.0.0'

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -283,6 +283,11 @@ class StateMachine(ha.StateMachine):
         if event.data['new_state'] is None:
             self._states.pop(event.data['entity_id'], None)
         else:
+            # set remote state
+            self.set(event.data['entity_id'],
+                     event.data['new_state'].state,
+                     attributes=dict(event.data['new_state'].attributes))
+            # set state in our state machine
             self._states[event.data['entity_id']] = event.data['new_state']
 
 

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -122,7 +122,6 @@ class HomeAssistant(ha.HomeAssistant):
                     remote_api.host, remote_api.port, remote_api.status))
 
         self.remote_api = remote_api
-
         self.loop = loop or asyncio.get_event_loop()
         self.pool = pool = ha.create_worker_pool()
 
@@ -131,8 +130,22 @@ class HomeAssistant(ha.HomeAssistant):
         self.states = StateMachine(self.bus, self.loop, self.remote_api)
         self.config = ha.Config()
         self.state = ha.CoreState.not_running
-
         self.config.api = local_api
+
+    @asyncio.coroutine
+    def async_start(self):
+        """Finalize startup from inside the event loop.
+
+        This method is a coroutine.
+        """
+        # pylint: disable=protected-access
+        self.loop._thread_ident = threading.get_ident()
+        ha.async_create_timer(self)
+        ha.async_monitor_worker_pool(self)
+        self.bus.fire(ha.EVENT_HOMEASSISTANT_START,
+                      origin=ha.EventOrigin.remote)
+        yield from self.loop.run_in_executor(None, self.pool.block_till_done)
+        self.state = ha.CoreState.running
 
     def start(self):
         """Start the instance."""
@@ -142,24 +155,7 @@ class HomeAssistant(ha.HomeAssistant):
                 raise HomeAssistantError(
                     'Unable to setup local API to receive events')
 
-        self.state = ha.CoreState.starting
-        ha.async_create_timer(self)
-
-        self.bus.fire(ha.EVENT_HOMEASSISTANT_START,
-                      origin=ha.EventOrigin.remote)
-
-        # Ensure local HTTP is started
-        self.block_till_done()
-        self.state = ha.CoreState.running
-        time.sleep(0.05)
-
-        # Setup that events from remote_api get forwarded to local_api
-        # Do this after we are running, otherwise HTTP is not started
-        # or requests are blocked
-        if not connect_remote_events(self.remote_api, self.config.api):
-            raise HomeAssistantError((
-                'Could not setup event forwarding from api {} to '
-                'local api {}').format(self.remote_api, self.config.api))
+        super().start()
 
     def stop(self):
         """Stop Home Assistant and shuts down all threads."""
@@ -264,7 +260,7 @@ class StateMachine(ha.StateMachine):
         self._api = api
         self.mirror()
 
-        bus.listen(ha.EVENT_STATE_CHANGED, self._state_changed_listener)
+        bus.async_listen(ha.EVENT_STATE_CHANGED, self._state_changed_listener)
 
     def remove(self, entity_id):
         """Remove the state of an entity.


### PR DESCRIPTION
**Description:**

Related to my issue #3669 

I cannot start my slave with state sharing

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices, web services, or a:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#;;)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

```

#! /Users/michaelkuty/projects/hass/bin/python3
import logging


import homeassistant.bootstrap as bootstrap
import homeassistant.config as config
import homeassistant.remote as remote
from homeassistant.const import EVENT_HOMEASSISTANT_START

# setup logging
logging.basicConfig(level=logging.DEBUG)

# Location of the Master API: host, password, port.
# Password and port are optional.
remote_api = remote.API("localhost", port=8124)

# Initialize slave
hass = remote.HomeAssistant(remote_api)
hass.config.config_dir = "/Users/michaelkuty/projects/hass/.config"
myconfig = config.load_yaml_config_file(
    "/Users/michaelkuty/projects/hass/conf.yaml")

# To add an interface to the slave on localhost:8123
#bootstrap.setup_component(hass, 'frontend', myconfig)

def setup_platforms(event):
    """Setup platforms."""
    bootstrap.setup_component(hass, 'api', myconfig)
    bootstrap.setup_component(hass, 'http', myconfig)
    bootstrap.setup_component(hass, 'switch', myconfig)
    bootstrap.setup_component(hass, 'sensor', myconfig)

hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, setup_platforms)

hass.start()

```
