### PR TITLE
Add async_safe annotation

### DIFF
--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -4,11 +4,11 @@ Offer event listening automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#event-trigger
 """
-import asyncio
 import logging
 
 import voluptuous as vol
 
+from homeassistant.core import async_safe
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.helpers import config_validation as cv
 
@@ -29,7 +29,7 @@ def async_trigger(hass, config, action):
     event_type = config.get(CONF_EVENT_TYPE)
     event_data = config.get(CONF_EVENT_DATA)
 
-    @asyncio.coroutine
+    @async_safe
     def handle_event(event):
         """Listen for events and calls the action when data matches."""
         if not event_data or all(val == event.data.get(key) for key, val

--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -34,7 +34,7 @@ def async_trigger(hass, config, action):
         """Listen for events and calls the action when data matches."""
         if not event_data or all(val == event.data.get(key) for key, val
                                  in event_data.items()):
-            hass.async_add_job(action, {
+            hass.async_run_job(action, {
                 'trigger': {
                     'platform': 'event',
                     'event': event,

--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -8,7 +8,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import async_safe
+from homeassistant.core import callback
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.helpers import config_validation as cv
 
@@ -29,7 +29,7 @@ def async_trigger(hass, config, action):
     event_type = config.get(CONF_EVENT_TYPE)
     event_data = config.get(CONF_EVENT_DATA)
 
-    @async_safe
+    @callback
     def handle_event(event):
         """Listen for events and calls the action when data matches."""
         if not event_data or all(val == event.data.get(key) for key, val

--- a/homeassistant/components/automation/mqtt.py
+++ b/homeassistant/components/automation/mqtt.py
@@ -4,9 +4,9 @@ Offer MQTT listening automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#mqtt-trigger
 """
-import asyncio
 import voluptuous as vol
 
+from homeassistant.core import async_safe
 import homeassistant.components.mqtt as mqtt
 from homeassistant.const import (CONF_PLATFORM, CONF_PAYLOAD)
 import homeassistant.helpers.config_validation as cv
@@ -27,7 +27,7 @@ def async_trigger(hass, config, action):
     topic = config.get(CONF_TOPIC)
     payload = config.get(CONF_PAYLOAD)
 
-    @asyncio.coroutine
+    @async_safe
     def mqtt_automation_listener(msg_topic, msg_payload, qos):
         """Listen for MQTT messages."""
         if payload is None or payload == msg_payload:

--- a/homeassistant/components/automation/mqtt.py
+++ b/homeassistant/components/automation/mqtt.py
@@ -6,7 +6,7 @@ at https://home-assistant.io/components/automation/#mqtt-trigger
 """
 import voluptuous as vol
 
-from homeassistant.core import async_safe
+from homeassistant.core import callback
 import homeassistant.components.mqtt as mqtt
 from homeassistant.const import (CONF_PLATFORM, CONF_PAYLOAD)
 import homeassistant.helpers.config_validation as cv
@@ -27,7 +27,7 @@ def async_trigger(hass, config, action):
     topic = config.get(CONF_TOPIC)
     payload = config.get(CONF_PAYLOAD)
 
-    @async_safe
+    @callback
     def mqtt_automation_listener(msg_topic, msg_payload, qos):
         """Listen for MQTT messages."""
         if payload is None or payload == msg_payload:

--- a/homeassistant/components/automation/mqtt.py
+++ b/homeassistant/components/automation/mqtt.py
@@ -31,7 +31,7 @@ def async_trigger(hass, config, action):
     def mqtt_automation_listener(msg_topic, msg_payload, qos):
         """Listen for MQTT messages."""
         if payload is None or payload == msg_payload:
-            hass.async_add_job(action, {
+            hass.async_run_job(action, {
                 'trigger': {
                     'platform': 'mqtt',
                     'topic': msg_topic,

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -4,11 +4,11 @@ Offer numeric state listening automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#numeric-state-trigger
 """
-import asyncio
 import logging
 
 import voluptuous as vol
 
+from homeassistant.core import async_safe
 from homeassistant.const import (
     CONF_VALUE_TEMPLATE, CONF_PLATFORM, CONF_ENTITY_ID,
     CONF_BELOW, CONF_ABOVE)
@@ -35,7 +35,7 @@ def async_trigger(hass, config, action):
     if value_template is not None:
         value_template.hass = hass
 
-    @asyncio.coroutine
+    @async_safe
     def state_automation_listener(entity, from_s, to_s):
         """Listen for state changes and calls action."""
         if to_s is None:

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -64,6 +64,6 @@ def async_trigger(hass, config, action):
         variables['trigger']['from_state'] = from_s
         variables['trigger']['to_state'] = to_s
 
-        hass.async_add_job(action, variables)
+        hass.async_run_job(action, variables)
 
     return async_track_state_change(hass, entity_id, state_automation_listener)

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -8,7 +8,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import async_safe
+from homeassistant.core import callback
 from homeassistant.const import (
     CONF_VALUE_TEMPLATE, CONF_PLATFORM, CONF_ENTITY_ID,
     CONF_BELOW, CONF_ABOVE)
@@ -35,7 +35,7 @@ def async_trigger(hass, config, action):
     if value_template is not None:
         value_template.hass = hass
 
-    @async_safe
+    @callback
     def state_automation_listener(entity, from_s, to_s):
         """Listen for state changes and calls action."""
         if to_s is None:

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -4,9 +4,9 @@ Offer state listening automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#state-trigger
 """
-import asyncio
 import voluptuous as vol
 
+from homeassistant.core import async_safe
 import homeassistant.util.dt as dt_util
 from homeassistant.const import MATCH_ALL, CONF_PLATFORM
 from homeassistant.helpers.event import (
@@ -43,7 +43,7 @@ def async_trigger(hass, config, action):
     async_remove_state_for_cancel = None
     async_remove_state_for_listener = None
 
-    @asyncio.coroutine
+    @async_safe
     def state_automation_listener(entity, from_s, to_s):
         """Listen for state changes and calls action."""
         nonlocal async_remove_state_for_cancel, async_remove_state_for_listener
@@ -64,13 +64,13 @@ def async_trigger(hass, config, action):
             call_action()
             return
 
-        @asyncio.coroutine
+        @async_safe
         def state_for_listener(now):
             """Fire on state changes after a delay and calls action."""
             async_remove_state_for_cancel()
             call_action()
 
-        @asyncio.coroutine
+        @async_safe
         def state_for_cancel_listener(entity, inner_from_s, inner_to_s):
             """Fire on changes and cancel for listener if changed."""
             if inner_to_s.state == to_s.state:

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -6,7 +6,7 @@ at https://home-assistant.io/components/automation/#state-trigger
 """
 import voluptuous as vol
 
-from homeassistant.core import async_safe
+from homeassistant.core import callback
 import homeassistant.util.dt as dt_util
 from homeassistant.const import MATCH_ALL, CONF_PLATFORM
 from homeassistant.helpers.event import (
@@ -43,7 +43,7 @@ def async_trigger(hass, config, action):
     async_remove_state_for_cancel = None
     async_remove_state_for_listener = None
 
-    @async_safe
+    @callback
     def state_automation_listener(entity, from_s, to_s):
         """Listen for state changes and calls action."""
         nonlocal async_remove_state_for_cancel, async_remove_state_for_listener
@@ -64,13 +64,13 @@ def async_trigger(hass, config, action):
             call_action()
             return
 
-        @async_safe
+        @callback
         def state_for_listener(now):
             """Fire on state changes after a delay and calls action."""
             async_remove_state_for_cancel()
             call_action()
 
-        @async_safe
+        @callback
         def state_for_cancel_listener(entity, inner_from_s, inner_to_s):
             """Fire on changes and cancel for listener if changed."""
             if inner_to_s.state == to_s.state:

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -50,7 +50,7 @@ def async_trigger(hass, config, action):
 
         def call_action():
             """Call action with right context."""
-            hass.async_add_job(action, {
+            hass.async_run_job(action, {
                 'trigger': {
                     'platform': 'state',
                     'entity_id': entity,

--- a/homeassistant/components/automation/sun.py
+++ b/homeassistant/components/automation/sun.py
@@ -9,7 +9,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import async_safe
+from homeassistant.core import callback
 from homeassistant.const import (
     CONF_EVENT, CONF_OFFSET, CONF_PLATFORM, SUN_EVENT_SUNRISE)
 from homeassistant.helpers.event import async_track_sunrise, async_track_sunset
@@ -31,7 +31,7 @@ def async_trigger(hass, config, action):
     event = config.get(CONF_EVENT)
     offset = config.get(CONF_OFFSET)
 
-    @async_safe
+    @callback
     def call_action():
         """Call action with right context."""
         hass.async_run_job(action, {

--- a/homeassistant/components/automation/sun.py
+++ b/homeassistant/components/automation/sun.py
@@ -4,12 +4,12 @@ Offer sun based automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#sun-trigger
 """
-import asyncio
 from datetime import timedelta
 import logging
 
 import voluptuous as vol
 
+from homeassistant.core import async_safe
 from homeassistant.const import (
     CONF_EVENT, CONF_OFFSET, CONF_PLATFORM, SUN_EVENT_SUNRISE)
 from homeassistant.helpers.event import async_track_sunrise, async_track_sunset
@@ -31,7 +31,7 @@ def async_trigger(hass, config, action):
     event = config.get(CONF_EVENT)
     offset = config.get(CONF_OFFSET)
 
-    @asyncio.coroutine
+    @async_safe
     def call_action():
         """Call action with right context."""
         hass.async_run_job(action, {

--- a/homeassistant/components/automation/sun.py
+++ b/homeassistant/components/automation/sun.py
@@ -34,7 +34,7 @@ def async_trigger(hass, config, action):
     @asyncio.coroutine
     def call_action():
         """Call action with right context."""
-        hass.async_add_job(action, {
+        hass.async_run_job(action, {
             'trigger': {
                 'platform': 'sun',
                 'event': event,

--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -40,7 +40,7 @@ def async_trigger(hass, config, action):
         # Check to see if template returns true
         if template_result and not already_triggered:
             already_triggered = True
-            hass.async_add_job(action, {
+            hass.async_run_job(action, {
                 'trigger': {
                     'platform': 'template',
                     'entity_id': entity_id,

--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -8,7 +8,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import async_safe
+from homeassistant.core import callback
 from homeassistant.const import CONF_VALUE_TEMPLATE, CONF_PLATFORM
 from homeassistant.helpers import condition
 from homeassistant.helpers.event import async_track_state_change
@@ -31,7 +31,7 @@ def async_trigger(hass, config, action):
     # Local variable to keep track of if the action has already been triggered
     already_triggered = False
 
-    @async_safe
+    @callback
     def state_changed_listener(entity_id, from_s, to_s):
         """Listen for state changes and calls action."""
         nonlocal already_triggered

--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -4,11 +4,11 @@ Offer template automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#template-trigger
 """
-import asyncio
 import logging
 
 import voluptuous as vol
 
+from homeassistant.core import async_safe
 from homeassistant.const import CONF_VALUE_TEMPLATE, CONF_PLATFORM
 from homeassistant.helpers import condition
 from homeassistant.helpers.event import async_track_state_change
@@ -31,7 +31,7 @@ def async_trigger(hass, config, action):
     # Local variable to keep track of if the action has already been triggered
     already_triggered = False
 
-    @asyncio.coroutine
+    @async_safe
     def state_changed_listener(entity_id, from_s, to_s):
         """Listen for state changes and calls action."""
         nonlocal already_triggered

--- a/homeassistant/components/automation/time.py
+++ b/homeassistant/components/automation/time.py
@@ -4,11 +4,11 @@ Offer time listening automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#time-trigger
 """
-import asyncio
 import logging
 
 import voluptuous as vol
 
+from homeassistant.core import async_safe
 from homeassistant.const import CONF_AFTER, CONF_PLATFORM
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_track_time_change
@@ -39,7 +39,7 @@ def async_trigger(hass, config, action):
         minutes = config.get(CONF_MINUTES)
         seconds = config.get(CONF_SECONDS)
 
-    @asyncio.coroutine
+    @async_safe
     def time_automation_listener(now):
         """Listen for time changes and calls action."""
         hass.async_run_job(action, {

--- a/homeassistant/components/automation/time.py
+++ b/homeassistant/components/automation/time.py
@@ -42,7 +42,7 @@ def async_trigger(hass, config, action):
     @asyncio.coroutine
     def time_automation_listener(now):
         """Listen for time changes and calls action."""
-        hass.async_add_job(action, {
+        hass.async_run_job(action, {
             'trigger': {
                 'platform': 'time',
                 'now': now,

--- a/homeassistant/components/automation/time.py
+++ b/homeassistant/components/automation/time.py
@@ -8,7 +8,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import async_safe
+from homeassistant.core import callback
 from homeassistant.const import CONF_AFTER, CONF_PLATFORM
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_track_time_change
@@ -39,7 +39,7 @@ def async_trigger(hass, config, action):
         minutes = config.get(CONF_MINUTES)
         seconds = config.get(CONF_SECONDS)
 
-    @async_safe
+    @callback
     def time_automation_listener(now):
         """Listen for time changes and calls action."""
         hass.async_run_job(action, {

--- a/homeassistant/components/automation/zone.py
+++ b/homeassistant/components/automation/zone.py
@@ -6,7 +6,7 @@ at https://home-assistant.io/components/automation/#zone-trigger
 """
 import voluptuous as vol
 
-from homeassistant.core import async_safe
+from homeassistant.core import callback
 from homeassistant.const import (
     CONF_EVENT, CONF_ENTITY_ID, CONF_ZONE, MATCH_ALL, CONF_PLATFORM)
 from homeassistant.helpers.event import async_track_state_change
@@ -32,7 +32,7 @@ def async_trigger(hass, config, action):
     zone_entity_id = config.get(CONF_ZONE)
     event = config.get(CONF_EVENT)
 
-    @async_safe
+    @callback
     def zone_automation_listener(entity, from_s, to_s):
         """Listen for state changes and calls action."""
         if from_s and not location.has_location(from_s) or \

--- a/homeassistant/components/automation/zone.py
+++ b/homeassistant/components/automation/zone.py
@@ -49,7 +49,7 @@ def async_trigger(hass, config, action):
         # pylint: disable=too-many-boolean-expressions
         if event == EVENT_ENTER and not from_match and to_match or \
            event == EVENT_LEAVE and from_match and not to_match:
-            hass.async_add_job(action, {
+            hass.async_run_job(action, {
                 'trigger': {
                     'platform': 'zone',
                     'entity_id': entity,

--- a/homeassistant/components/automation/zone.py
+++ b/homeassistant/components/automation/zone.py
@@ -4,9 +4,9 @@ Offer zone automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#zone-trigger
 """
-import asyncio
 import voluptuous as vol
 
+from homeassistant.core import async_safe
 from homeassistant.const import (
     CONF_EVENT, CONF_ENTITY_ID, CONF_ZONE, MATCH_ALL, CONF_PLATFORM)
 from homeassistant.helpers.event import async_track_state_change
@@ -32,7 +32,7 @@ def async_trigger(hass, config, action):
     zone_entity_id = config.get(CONF_ZONE)
     event = config.get(CONF_EVENT)
 
-    @asyncio.coroutine
+    @async_safe
     def zone_automation_listener(entity, from_s, to_s):
         """Listen for state changes and calls action."""
         if from_s and not location.has_location(from_s) or \

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -9,7 +9,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import async_safe
+from homeassistant.core import callback
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, ENTITY_ID_FORMAT, PLATFORM_SCHEMA,
     SENSOR_CLASSES_SCHEMA)
@@ -83,7 +83,7 @@ class BinarySensorTemplate(BinarySensorDevice):
 
         self.update()
 
-        @async_safe
+        @callback
         def template_bsensor_state_listener(entity, old_state, new_state):
             """Called when the target device changes state."""
             hass.loop.create_task(self.async_update_ha_state(True))

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -9,6 +9,7 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.core import async_safe
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, ENTITY_ID_FORMAT, PLATFORM_SCHEMA,
     SENSOR_CLASSES_SCHEMA)
@@ -82,7 +83,7 @@ class BinarySensorTemplate(BinarySensorDevice):
 
         self.update()
 
-        @asyncio.coroutine
+        @async_safe
         def template_bsensor_state_listener(entity, old_state, new_state):
             """Called when the target device changes state."""
             hass.loop.create_task(self.async_update_ha_state(True))

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -171,7 +171,7 @@ def async_subscribe(hass, topic, callback, qos=DEFAULT_QOS):
         if not _match_topic(topic, event.data[ATTR_TOPIC]):
             return
 
-        hass.async_add_job(callback, event.data[ATTR_TOPIC],
+        hass.async_run_job(callback, event.data[ATTR_TOPIC],
                            event.data[ATTR_PAYLOAD], event.data[ATTR_QOS])
 
     async_remove = hass.bus.async_listen(EVENT_MQTT_MESSAGE_RECEIVED,

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -9,6 +9,7 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.core import async_safe
 from homeassistant.components.sensor import ENTITY_ID_FORMAT, PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE,
@@ -79,7 +80,7 @@ class SensorTemplate(Entity):
 
         self.update()
 
-        @asyncio.coroutine
+        @async_safe
         def template_sensor_state_listener(entity, old_state, new_state):
             """Called when the target device changes state."""
             hass.loop.create_task(self.async_update_ha_state(True))

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -9,7 +9,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import async_safe
+from homeassistant.core import callback
 from homeassistant.components.sensor import ENTITY_ID_FORMAT, PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE,
@@ -80,7 +80,7 @@ class SensorTemplate(Entity):
 
         self.update()
 
-        @async_safe
+        @callback
         def template_sensor_state_listener(entity, old_state, new_state):
             """Called when the target device changes state."""
             hass.loop.create_task(self.async_update_ha_state(True))

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -9,6 +9,7 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.core import async_safe
 from homeassistant.components.switch import (
     ENTITY_ID_FORMAT, SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
@@ -88,7 +89,7 @@ class SwitchTemplate(SwitchDevice):
 
         self.update()
 
-        @asyncio.coroutine
+        @async_safe
         def template_switch_state_listener(entity, old_state, new_state):
             """Called when the target device changes state."""
             hass.loop.create_task(self.async_update_ha_state(True))

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -9,7 +9,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import async_safe
+from homeassistant.core import callback
 from homeassistant.components.switch import (
     ENTITY_ID_FORMAT, SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
@@ -89,7 +89,7 @@ class SwitchTemplate(SwitchDevice):
 
         self.update()
 
-        @async_safe
+        @callback
         def template_switch_state_listener(entity, old_state, new_state):
             """Called when the target device changes state."""
             hass.loop.create_task(self.async_update_ha_state(True))

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -78,14 +78,14 @@ def valid_entity_id(entity_id: str) -> bool:
     return ENTITY_ID_PATTERN.match(entity_id) is not None
 
 
-def callback(func: Callable[..., None]):
+def callback(func: Callable[..., Callable]):
     """Annotation to mark method as safe to call from within the event loop."""
     # pylint: disable=protected-access
     func._hass_callback = True
     return func
 
 
-def is_callback(func: Callable[..., None]):
+def is_callback(func: Callable[..., Callable]):
     """Check if function is safe to be called in the event loop."""
     return '_hass_callback' in func.__dict__
 
@@ -405,7 +405,6 @@ class EventBus(object):
 
         self._loop.call_soon_threadsafe(self.async_fire, event_type,
                                         event_data, origin)
-        return
 
     def async_fire(self, event_type: str, event_data=None,
                    origin=EventOrigin.local, wait=False):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -80,6 +80,7 @@ def valid_entity_id(entity_id: str) -> bool:
 
 def async_safe(func):
     """Annotation to mark method as safe to call from within the event loop."""
+    # pylint: disable=protected-access
     func._hass_async_safe = True
     return func
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -78,14 +78,14 @@ def valid_entity_id(entity_id: str) -> bool:
     return ENTITY_ID_PATTERN.match(entity_id) is not None
 
 
-def callback(func: Callable[..., Callable]):
+def callback(func: Callable[..., None]) -> Callable[..., None]:
     """Annotation to mark method as safe to call from within the event loop."""
     # pylint: disable=protected-access
     func._hass_callback = True
     return func
 
 
-def is_callback(func: Callable[..., Callable]):
+def is_callback(func: Callable[..., Any]) -> bool:
     """Check if function is safe to be called in the event loop."""
     return '_hass_callback' in func.__dict__
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1034,7 +1034,8 @@ class ServiceRegistry(object):
 
             data = {ATTR_SERVICE_CALL_ID: call_id}
 
-            if service_handler.is_coroutinefunction:
+            if (service_handler.is_coroutinefunction or
+                    service_handler.is_callback):
                 self._bus.async_fire(EVENT_SERVICE_EXECUTED, data)
             else:
                 self._bus.fire(EVENT_SERVICE_EXECUTED, data)

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -2,7 +2,7 @@
 import functools as ft
 from datetime import timedelta
 
-from ..core import HomeAssistant, async_safe
+from ..core import HomeAssistant, callback
 from ..const import (
     ATTR_NOW, EVENT_STATE_CHANGED, EVENT_TIME_CHANGED, MATCH_ALL)
 from ..util import dt as dt_util
@@ -56,7 +56,7 @@ def async_track_state_change(hass, entity_ids, action, from_state=None,
     else:
         entity_ids = tuple(entity_id.lower() for entity_id in entity_ids)
 
-    @async_safe
+    @callback
     def state_change_listener(event):
         """The listener that listens for specific state changes."""
         if entity_ids != MATCH_ALL and \
@@ -88,7 +88,7 @@ def async_track_point_in_time(hass, action, point_in_time):
     """Add a listener that fires once after a spefic point in time."""
     utc_point_in_time = dt_util.as_utc(point_in_time)
 
-    @async_safe
+    @callback
     def utc_converter(utc_now):
         """Convert passed in UTC now to local now."""
         hass.async_run_job(action, dt_util.as_local(utc_now))
@@ -105,7 +105,7 @@ def async_track_point_in_utc_time(hass, action, point_in_time):
     # Ensure point_in_time is UTC
     point_in_time = dt_util.as_utc(point_in_time)
 
-    @async_safe
+    @callback
     def point_in_time_listener(event):
         """Listen for matching time_changed events."""
         now = event.data[ATTR_NOW]
@@ -147,7 +147,7 @@ def async_track_sunrise(hass, action, offset=None):
 
         return next_time
 
-    @async_safe
+    @callback
     def sunrise_automation_listener(now):
         """Called when it's time for action."""
         nonlocal remove
@@ -182,7 +182,7 @@ def async_track_sunset(hass, action, offset=None):
 
         return next_time
 
-    @async_safe
+    @callback
     def sunset_automation_listener(now):
         """Called when it's time for action."""
         nonlocal remove
@@ -211,7 +211,7 @@ def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
     # We do not have to wrap the function with time pattern matching logic
     # if no pattern given
     if all(val is None for val in (year, month, day, hour, minute, second)):
-        @async_safe
+        @callback
         def time_change_listener(event):
             """Fire every time event that comes in."""
             hass.async_run_job(action, event.data[ATTR_NOW])
@@ -222,7 +222,7 @@ def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
     year, month, day = pmp(year), pmp(month), pmp(day)
     hour, minute, second = pmp(hour), pmp(minute), pmp(second)
 
-    @async_safe
+    @callback
     def pattern_time_change_listener(event):
         """Listen for matching time_changed events."""
         now = event.data[ATTR_NOW]

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1,5 +1,4 @@
 """Helpers for listening to events."""
-import asyncio
 import functools as ft
 from datetime import timedelta
 
@@ -57,7 +56,6 @@ def async_track_state_change(hass, entity_ids, action, from_state=None,
     else:
         entity_ids = tuple(entity_id.lower() for entity_id in entity_ids)
 
-    @ft.wraps(action)
     @async_safe
     def state_change_listener(event):
         """The listener that listens for specific state changes."""
@@ -90,7 +88,6 @@ def async_track_point_in_time(hass, action, point_in_time):
     """Add a listener that fires once after a spefic point in time."""
     utc_point_in_time = dt_util.as_utc(point_in_time)
 
-    @ft.wraps(action)
     @async_safe
     def utc_converter(utc_now):
         """Convert passed in UTC now to local now."""
@@ -108,7 +105,6 @@ def async_track_point_in_utc_time(hass, action, point_in_time):
     # Ensure point_in_time is UTC
     point_in_time = dt_util.as_utc(point_in_time)
 
-    @ft.wraps(action)
     @async_safe
     def point_in_time_listener(event):
         """Listen for matching time_changed events."""
@@ -151,7 +147,6 @@ def async_track_sunrise(hass, action, offset=None):
 
         return next_time
 
-    @ft.wraps(action)
     @async_safe
     def sunrise_automation_listener(now):
         """Called when it's time for action."""
@@ -187,7 +182,6 @@ def async_track_sunset(hass, action, offset=None):
 
         return next_time
 
-    @ft.wraps(action)
     @async_safe
     def sunset_automation_listener(now):
         """Called when it's time for action."""
@@ -217,7 +211,6 @@ def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
     # We do not have to wrap the function with time pattern matching logic
     # if no pattern given
     if all(val is None for val in (year, month, day, hour, minute, second)):
-        @ft.wraps(action)
         @async_safe
         def time_change_listener(event):
             """Fire every time event that comes in."""
@@ -229,7 +222,6 @@ def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
     year, month, day = pmp(year), pmp(month), pmp(day)
     hour, minute, second = pmp(hour), pmp(minute), pmp(second)
 
-    @ft.wraps(action)
     @async_safe
     def pattern_time_change_listener(event):
         """Listen for matching time_changed events."""

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -76,7 +76,7 @@ def async_track_state_change(hass, entity_ids, action, from_state=None,
             new_state = None
 
         if _matcher(old_state, from_state) and _matcher(new_state, to_state):
-            hass.async_add_job(action, event.data.get('entity_id'),
+            hass.async_run_job(action, event.data.get('entity_id'),
                                event.data.get('old_state'),
                                event.data.get('new_state'))
 
@@ -94,7 +94,7 @@ def async_track_point_in_time(hass, action, point_in_time):
     @asyncio.coroutine
     def utc_converter(utc_now):
         """Convert passed in UTC now to local now."""
-        hass.async_add_job(action, dt_util.as_local(utc_now))
+        hass.async_run_job(action, dt_util.as_local(utc_now))
 
     return async_track_point_in_utc_time(hass, utc_converter,
                                          utc_point_in_time)
@@ -125,7 +125,7 @@ def async_track_point_in_utc_time(hass, action, point_in_time):
         point_in_time_listener.run = True
         async_unsub()
 
-        hass.async_add_job(action, now)
+        hass.async_run_job(action, now)
 
     async_unsub = hass.bus.async_listen(EVENT_TIME_CHANGED,
                                         point_in_time_listener)
@@ -158,7 +158,7 @@ def async_track_sunrise(hass, action, offset=None):
         nonlocal remove
         remove = async_track_point_in_utc_time(
             hass, sunrise_automation_listener, next_rise())
-        hass.async_add_job(action)
+        hass.async_run_job(action)
 
     remove = async_track_point_in_utc_time(
         hass, sunrise_automation_listener, next_rise())
@@ -194,7 +194,7 @@ def async_track_sunset(hass, action, offset=None):
         nonlocal remove
         remove = async_track_point_in_utc_time(
             hass, sunset_automation_listener, next_set())
-        hass.async_add_job(action)
+        hass.async_run_job(action)
 
     remove = async_track_point_in_utc_time(
         hass, sunset_automation_listener, next_set())
@@ -246,7 +246,7 @@ def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
            mat(now.minute, minute) and \
            mat(now.second, second):
 
-            hass.async_add_job(action, now)
+            hass.async_run_job(action, now)
 
     return hass.bus.async_listen(EVENT_TIME_CHANGED,
                                  pattern_time_change_listener)

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -3,7 +3,7 @@ import asyncio
 import functools as ft
 from datetime import timedelta
 
-from ..core import HomeAssistant
+from ..core import HomeAssistant, async_safe
 from ..const import (
     ATTR_NOW, EVENT_STATE_CHANGED, EVENT_TIME_CHANGED, MATCH_ALL)
 from ..util import dt as dt_util
@@ -58,7 +58,7 @@ def async_track_state_change(hass, entity_ids, action, from_state=None,
         entity_ids = tuple(entity_id.lower() for entity_id in entity_ids)
 
     @ft.wraps(action)
-    @asyncio.coroutine
+    @async_safe
     def state_change_listener(event):
         """The listener that listens for specific state changes."""
         if entity_ids != MATCH_ALL and \
@@ -91,7 +91,7 @@ def async_track_point_in_time(hass, action, point_in_time):
     utc_point_in_time = dt_util.as_utc(point_in_time)
 
     @ft.wraps(action)
-    @asyncio.coroutine
+    @async_safe
     def utc_converter(utc_now):
         """Convert passed in UTC now to local now."""
         hass.async_run_job(action, dt_util.as_local(utc_now))
@@ -109,7 +109,7 @@ def async_track_point_in_utc_time(hass, action, point_in_time):
     point_in_time = dt_util.as_utc(point_in_time)
 
     @ft.wraps(action)
-    @asyncio.coroutine
+    @async_safe
     def point_in_time_listener(event):
         """Listen for matching time_changed events."""
         now = event.data[ATTR_NOW]
@@ -152,7 +152,7 @@ def async_track_sunrise(hass, action, offset=None):
         return next_time
 
     @ft.wraps(action)
-    @asyncio.coroutine
+    @async_safe
     def sunrise_automation_listener(now):
         """Called when it's time for action."""
         nonlocal remove
@@ -188,7 +188,7 @@ def async_track_sunset(hass, action, offset=None):
         return next_time
 
     @ft.wraps(action)
-    @asyncio.coroutine
+    @async_safe
     def sunset_automation_listener(now):
         """Called when it's time for action."""
         nonlocal remove
@@ -218,6 +218,7 @@ def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
     # if no pattern given
     if all(val is None for val in (year, month, day, hour, minute, second)):
         @ft.wraps(action)
+        @async_safe
         def time_change_listener(event):
             """Fire every time event that comes in."""
             hass.async_run_job(action, event.data[ATTR_NOW])
@@ -229,7 +230,7 @@ def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
     hour, minute, second = pmp(hour), pmp(minute), pmp(second)
 
     @ft.wraps(action)
-    @asyncio.coroutine
+    @async_safe
     def pattern_time_change_listener(event):
         """Listen for matching time_changed events."""
         now = event.data[ATTR_NOW]

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -220,7 +220,7 @@ def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
         @ft.wraps(action)
         def time_change_listener(event):
             """Fire every time event that comes in."""
-            action(event.data[ATTR_NOW])
+            hass.async_run_job(action, event.data[ATTR_NOW])
 
         return hass.bus.async_listen(EVENT_TIME_CHANGED, time_change_listener)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -111,7 +111,7 @@ def mock_service(hass, domain, service):
     """
     calls = []
 
-    hass.services.register(domain, service, calls.append)
+    hass.services.register(domain, service, lambda call: calls.append(call))
 
     return calls
 

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -139,7 +139,8 @@ class TestAPI(unittest.TestCase):
         hass.states.set("test.test", "not_to_be_set")
 
         events = []
-        hass.bus.listen(const.EVENT_STATE_CHANGED, events.append)
+        hass.bus.listen(const.EVENT_STATE_CHANGED,
+                        lambda ev: events.append(ev))
 
         requests.post(_url(const.URL_API_STATES_ENTITY.format("test.test")),
                       data=json.dumps({"state": "not_to_be_set"}),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -387,7 +387,7 @@ class TestStateMachine(unittest.TestCase):
     def test_force_update(self):
         """Test force update option."""
         events = []
-        self.hass.bus.listen(EVENT_STATE_CHANGED, events.append)
+        self.hass.bus.listen(EVENT_STATE_CHANGED, lambda ev: events.append(ev))
 
         self.states.set('light.bowl', 'on')
         self.hass.block_till_done()
@@ -581,8 +581,7 @@ class TestWorkerPoolMonitor(object):
         check_threshold()
         assert mock_warning.called
 
-        event_loop.run_until_complete(
-            hass.bus.async_listen_once.mock_calls[0][1][1](None))
+        hass.bus.async_listen_once.mock_calls[0][1][1](None)
         assert schedule_handle.cancel.called
 
 
@@ -618,5 +617,5 @@ class TestAsyncCreateTimer(object):
         assert {ha.ATTR_NOW: now} == event_data
 
         stop_timer = hass.bus.async_listen_once.mock_calls[0][1][1]
-        event_loop.run_until_complete(stop_timer(None))
+        stop_timer(None)
         assert event.set.called

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,12 +28,12 @@ def test_split_entity_id():
     assert ha.split_entity_id('domain.object_id') == ['domain', 'object_id']
 
 
-def test_async_add_job_schedule_async_safe():
+def test_async_add_job_schedule_callback():
     """Test that we schedule coroutines and add jobs to the job pool."""
     hass = MagicMock()
     job = MagicMock()
 
-    ha.HomeAssistant.async_add_job(hass, ha.async_safe(job))
+    ha.HomeAssistant.async_add_job(hass, ha.callback(job))
     assert len(hass.loop.call_soon.mock_calls) == 1
     assert len(hass.loop.create_task.mock_calls) == 0
     assert len(hass.add_job.mock_calls) == 0
@@ -63,21 +63,21 @@ def test_async_add_job_add_threaded_job_to_pool(mock_iscoro):
     assert len(hass.add_job.mock_calls) == 1
 
 
-def test_async_run_job_calls_async_safe():
-    """Test that the async_safe annotation is respected."""
+def test_async_run_job_calls_callback():
+    """Test that the callback annotation is respected."""
     hass = MagicMock()
     calls = []
 
     def job():
         calls.append(1)
 
-    ha.HomeAssistant.async_run_job(hass, ha.async_safe(job))
+    ha.HomeAssistant.async_run_job(hass, ha.callback(job))
     assert len(calls) == 1
     assert len(hass.async_add_job.mock_calls) == 0
 
 
 def test_async_run_job_delegates_non_async():
-    """Test that the async_safe annotation is respected."""
+    """Test that the callback annotation is respected."""
     hass = MagicMock()
     calls = []
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -230,6 +230,44 @@ class TestEventBus(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(1, len(runs))
 
+    def test_thread_event_listener(self):
+        """Test a  event listener listeners."""
+        thread_calls = []
+
+        def thread_listener(event):
+            thread_calls.append(event)
+
+        self.bus.listen('test_thread', thread_listener)
+        self.bus.fire('test_thread')
+        self.hass.block_till_done()
+        assert len(thread_calls) == 1
+
+    def test_callback_event_listener(self):
+        """Test a  event listener listeners."""
+        callback_calls = []
+
+        @ha.callback
+        def callback_listener(event):
+            callback_calls.append(event)
+
+        self.bus.listen('test_callback', callback_listener)
+        self.bus.fire('test_callback')
+        self.hass.block_till_done()
+        assert len(callback_calls) == 1
+
+    def test_coroutine_event_listener(self):
+        """Test a  event listener listeners."""
+        coroutine_calls = []
+
+        @asyncio.coroutine
+        def coroutine_listener(event):
+            coroutine_calls.append(event)
+
+        self.bus.listen('test_coroutine', coroutine_listener)
+        self.bus.fire('test_coroutine')
+        self.hass.block_till_done()
+        assert len(coroutine_calls) == 1
+
 
 class TestState(unittest.TestCase):
     """Test State methods."""
@@ -471,6 +509,22 @@ class TestServiceRegistry(unittest.TestCase):
         calls = []
 
         @asyncio.coroutine
+        def service_handler(call):
+            """Service handler coroutine."""
+            calls.append(call)
+
+        self.services.register('test_domain', 'register_calls',
+                               service_handler)
+        self.assertTrue(
+            self.services.call('test_domain', 'REGISTER_CALLS', blocking=True))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(calls))
+
+    def test_callback_service(self):
+        """Test registering and calling an async service."""
+        calls = []
+
+        @ha.callback
         def service_handler(call):
             """Service handler coroutine."""
             calls.append(call)

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -163,7 +163,7 @@ class TestRemoteMethods(unittest.TestCase):
     def test_set_state_with_push(self):
         """Test Python API set_state with push option."""
         events = []
-        hass.bus.listen(EVENT_STATE_CHANGED, events.append)
+        hass.bus.listen(EVENT_STATE_CHANGED, lambda ev: events.append(ev))
 
         remote.set_state(master_api, 'test.test', 'set_test_2')
         remote.set_state(master_api, 'test.test', 'set_test_2')


### PR DESCRIPTION
**Description:**
What would be a day without an async PR 😆 

Adds a new annotation to indicate that a method is `async_safe`. This new annotation will be used by the methods `async_add_job` and the new method `async_run_job`. The difference between both is that in the case of `async_run_job`, the job will be run immediately instead of scheduled to be run.

To do:
- [x] Add tests to core for registering all 3 different types as service
- [x] Add tests to core for registering all 3 different types as event listener

CC @bbangert 

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
