### PR TITLE
Update ha-alpr / change default interval

### DIFF
--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -27,7 +27,7 @@ DEPENDENCIES = ['ffmpeg']
 REQUIREMENTS = [
     'https://github.com/pvizeli/cloudapi/releases/download/1.0.2/'
     'python-1.0.2.zip#cloud_api==1.0.2',
-    'ha-alpr==0.2']
+    'ha-alpr==0.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,7 +68,7 @@ DEFAULT_NAME = 'OpenAlpr'
 DEFAULT_ENGINE = ENGINE_LOCAL
 DEFAULT_RENDER = RENDER_FFMPEG
 DEFAULT_BINARY = 'alpr'
-DEFAULT_INTERVAL = 2
+DEFAULT_INTERVAL = 10
 DEFAULT_CONFIDENCE = 80.0
 
 DEVICE_SCHEMA = vol.Schema({

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -120,7 +120,7 @@ googlemaps==2.4.4
 gps3==0.33.3
 
 # homeassistant.components.openalpr
-ha-alpr==0.2
+ha-alpr==0.3
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==0.13


### PR DESCRIPTION
**Description:**
- Update ha-alpr to Version 0.3 that fix a bug that if alpr to old, it can block the thread.
- Default interval to 10 second to protect overloaded Systems with user who not know what he do.
