### PR TITLE
Adjust vol to accept filenames (fixes #3701)

### DIFF
--- a/homeassistant/components/sensor/gtfs.py
+++ b/homeassistant/components/sensor/gtfs.py
@@ -36,14 +36,14 @@ TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ORIGIN): cv.string,
     vol.Required(CONF_DESTINATION): cv.string,
-    vol.Required(CONF_DATA): cv.isfile,
+    vol.Required(CONF_DATA): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
 
 # pylint: disable=too-many-locals
 def get_next_departure(sched, start_station_id, end_station_id):
-    """Get the next departure for the given sched."""
+    """Get the next departure for the given schedule."""
     origin_station = sched.stops_by_id(start_station_id)[0]
     destination_station = sched.stops_by_id(end_station_id)[0]
 
@@ -147,7 +147,7 @@ def get_next_departure(sched, start_station_id, end_station_id):
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Get the GTFS sensor."""
+    """Set up the GTFS sensor."""
     gtfs_dir = hass.config.path(DEFAULT_PATH)
     data = config.get(CONF_DATA)
     origin = config.get(CONF_ORIGIN)


### PR DESCRIPTION
**Description:**
The `data:` needs to allow a filename and not a path.

**Related issue (if applicable):** fixes #3701

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: gtfs
  origin: STOP_ID
  destination: STOP_ID
  data: DATA_SOURCE
```

**Checklist:**

If code communicates with devices, web services, or a:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
