### PR TITLE
Increase allowable zwave polling intensity values

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -133,7 +133,7 @@ SET_CONFIG_PARAMETER_SCHEMA = vol.Schema({
 
 CUSTOMIZE_SCHEMA = vol.Schema({
     vol.Optional(CONF_POLLING_INTENSITY):
-        vol.All(cv.positive_int, vol.In([0, 1, 2])),
+        vol.All(cv.positive_int, vol.In([0, 1, 2, 3, 4, 5])),
 })
 
 CONFIG_SCHEMA = vol.Schema({


### PR DESCRIPTION
**Description:**

Recent  voluptuous migration for the zwave component limited the polling intensity values to (0, 1, 2), but openzwave will act on any multiple and doesn't actually have a limit.  (See [http://www.openzwave.com/dev/classOpenZWave_1_1Manager.html#ab62582b7bcfec34574fb2aa7c54d147f])

This increases the allowable values up to 5, which is the max I use in my setup, but we may be better off just restricting it to int rather than a specific range.

If the code does not interact with devices:
- [X ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
