### PR TITLE
Add discovery support for Netatmo weather Station

### DIFF
--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -16,7 +16,7 @@ import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = [
     'https://github.com/jabesq/netatmo-api-python/archive/'
-    'v0.5.0.zip#lnetatmo==0.5.0']
+    'v0.6.0.zip#lnetatmo==0.6.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -77,7 +77,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 dev.append(NetAtmoSensor(data, module_name, variable))
     else:
         for module_name in data.get_module_names():
-            for variable in data.stationDatas.monitoredConditions(module_name):
+            for variable in data.stationData.monitoredConditions(module_name):
                 dev.append(NetAtmoSensor(data, module_name, variable))
 
     add_devices(dev)
@@ -96,12 +96,21 @@ class NetAtmoSensor(Entity):
         self.type = sensor_type
         self._state = None
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+        module_id = self.netatmo_data.stationData.moduleByName(module=module_name)['_id']
+        self._unique_id = "Netatmo Sensor {0} - {1} ({2})".format(self._name,
+                                                                    module_id,
+                                                                    self.type)
         self.update()
 
     @property
     def name(self):
         """Return the name of the sensor."""
         return self._name
+
+    @property
+    def unique_id(self):
+        """Return the unique ID for this sensor."""
+        return self._unique_id
 
     @property
     def icon(self):
@@ -224,7 +233,7 @@ class NetAtmoData(object):
         """Initialize the data object."""
         self.auth = auth
         self.data = None
-        self.stationDatas = None
+        self.stationData = None
         self.station = station
 
     def get_module_names(self):
@@ -236,9 +245,9 @@ class NetAtmoData(object):
     def update(self):
         """Call the Netatmo API to update the data."""
         import lnetatmo
-        self.stationDatas = lnetatmo.DeviceList(self.auth)
+        self.stationData = lnetatmo.DeviceList(self.auth)
 
         if self.station is not None:
-            self.data = self.stationDatas.lastData(station=self.station, exclude=3600)
+            self.data = self.stationData.lastData(station=self.station, exclude=3600)
         else:
-            self.data = self.stationDatas.lastData(exclude=3600)
+            self.data = self.stationData.lastData(exclude=3600)

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -77,7 +77,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 dev.append(NetAtmoSensor(data, module_name, variable))
     else:
         for module_name in data.get_module_names():
-            for variable in data.stationData.monitoredConditions(module_name):
+            for variable in data.station_data.monitoredConditions(module_name):
                 dev.append(NetAtmoSensor(data, module_name, variable))
 
     add_devices(dev)
@@ -96,10 +96,11 @@ class NetAtmoSensor(Entity):
         self.type = sensor_type
         self._state = None
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
-        module_id = self.netatmo_data.stationData.moduleByName(module=module_name)['_id']
+        module_id = self.netatmo_data.\
+            station_data.moduleByName(module=module_name)['_id']
         self._unique_id = "Netatmo Sensor {0} - {1} ({2})".format(self._name,
-                                                                    module_id,
-                                                                    self.type)
+                                                                  module_id,
+                                                                  self.type)
         self.update()
 
     @property
@@ -233,7 +234,7 @@ class NetAtmoData(object):
         """Initialize the data object."""
         self.auth = auth
         self.data = None
-        self.stationData = None
+        self.station_data = None
         self.station = station
 
     def get_module_names(self):
@@ -245,9 +246,10 @@ class NetAtmoData(object):
     def update(self):
         """Call the Netatmo API to update the data."""
         import lnetatmo
-        self.stationData = lnetatmo.DeviceList(self.auth)
+        self.station_data = lnetatmo.DeviceList(self.auth)
 
         if self.station is not None:
-            self.data = self.stationData.lastData(station=self.station, exclude=3600)
+            self.data = self.station_data.lastData(station=self.station,
+                                                   exclude=3600)
         else:
-            self.data = self.stationData.lastData(exclude=3600)
+            self.data = self.station_data.lastData(exclude=3600)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -174,7 +174,7 @@ https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.
 https://github.com/gadgetreactor/pyHS100/archive/master.zip#pyHS100==0.1.2
 
 # homeassistant.components.netatmo
-https://github.com/jabesq/netatmo-api-python/archive/v0.5.0.zip#lnetatmo==0.5.0
+https://github.com/jabesq/netatmo-api-python/archive/v0.6.0.zip#lnetatmo==0.6.0
 
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1


### PR DESCRIPTION
**Description:**

This will simplify the configuration of the weather station as only the Netatmo credential will be needed. The discover only returns the weather information from the station, it means that the following information still needs to be setup manually: rf_status, wifi_status, battery_vp

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
