### PR TITLE
Paradox Hub Status Monitoring

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -46,6 +46,9 @@ omit =
     homeassistant/components/octoprint.py
     homeassistant/components/*/octoprint.py
 
+    homeassistant/components/paradox.py
+    homeassistant/components/*/paradox.py
+
     homeassistant/components/qwikswitch.py
     homeassistant/components/*/qwikswitch.py
 

--- a/homeassistant/components/alarm_control_panel/paradox.py
+++ b/homeassistant/components/alarm_control_panel/paradox.py
@@ -100,3 +100,20 @@ class ParadoxAlarm(alarm.AlarmControlPanel):
             return STATE_ALARM_DISARMED
         else:
             return STATE_UNKNOWN
+
+    def alarm_disarm(self, code=None):
+        """Send disarm command."""
+        raise NotImplementedError()
+
+    def alarm_arm_home(self, code=None):
+        """Send arm home command."""
+        raise NotImplementedError()
+
+    def alarm_arm_away(self, code=None):
+        """Send arm away command."""
+        raise NotImplementedError()
+
+    def alarm_trigger(self, code=None):
+        """Send alarm trigger command."""
+        raise NotImplementedError()
+

--- a/homeassistant/components/alarm_control_panel/paradox.py
+++ b/homeassistant/components/alarm_control_panel/paradox.py
@@ -106,17 +106,17 @@ class ParadoxAlarm(alarm.AlarmControlPanel):
             return STATE_UNKNOWN
 
     def alarm_disarm(self, code=None):
-        """Send disarm command."""
+        """Send disarm command. Planned for next version."""
         raise NotImplementedError()
 
     def alarm_arm_home(self, code=None):
-        """Send arm home command."""
+        """Send arm home command. Planned for next version."""
         raise NotImplementedError()
 
     def alarm_arm_away(self, code=None):
-        """Send arm away command."""
+        """Send arm away command. Planned for next version."""
         raise NotImplementedError()
 
     def alarm_trigger(self, code=None):
-        """Send alarm trigger command."""
+        """Send alarm trigger command. Planned for next version."""
         raise NotImplementedError()

--- a/homeassistant/components/alarm_control_panel/paradox.py
+++ b/homeassistant/components/alarm_control_panel/paradox.py
@@ -1,5 +1,6 @@
 """
 Support for Paradox Alarm area/partition states.
+
  - represented as an alarm control panel.
 
 For more details about this platform, please refer to the documentation at
@@ -29,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """
     Set up the Paradox alarm control panel platform.
-    
+
     Based on configuration file contents, not auto discovery.
     """
     # Get the area information specified in the configuration/yaml file.
@@ -78,7 +79,7 @@ class ParadoxAlarm(alarm.AlarmControlPanel):
     def name(self):
         """
         Return the name of the alarm control panel device.
-        
+
         (Area/Partition name/label)
         """
         _LOGGER.debug('HA reports area name as ' + self._name)

--- a/homeassistant/components/alarm_control_panel/paradox.py
+++ b/homeassistant/components/alarm_control_panel/paradox.py
@@ -1,5 +1,5 @@
 """
-Support for Paradox Alarm area/partition states
+Support for Paradox Alarm area/partition states.
  - represented as an alarm control panel.
 
 For more details about this platform, please refer to the documentation at
@@ -29,6 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """
     Set up the Paradox alarm control panel platform.
+    
     Based on configuration file contents, not auto discovery.
     """
     # Get the area information specified in the configuration/yaml file.
@@ -39,11 +40,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         # Add the partition as a HA device.
         # Each area is represented as an alarm control panel in HA
         add_devices(
-            [ParadoxAlarm(hass,
-                          area_number,
-                          _device_config_data[CONF_PARTITIONNAME],
-                          PARADOX_CONTROLLER.alarm_state['partition'][area_number]
-                          )])
+            [ParadoxAlarm(
+                hass,
+                area_number,
+                _device_config_data[CONF_PARTITIONNAME],
+                PARADOX_CONTROLLER.alarm_state['partition'][area_number]
+                )])
     return True
 
 
@@ -76,6 +78,7 @@ class ParadoxAlarm(alarm.AlarmControlPanel):
     def name(self):
         """
         Return the name of the alarm control panel device.
+        
         (Area/Partition name/label)
         """
         _LOGGER.debug('HA reports area name as ' + self._name)
@@ -116,4 +119,3 @@ class ParadoxAlarm(alarm.AlarmControlPanel):
     def alarm_trigger(self, code=None):
         """Send alarm trigger command."""
         raise NotImplementedError()
-

--- a/homeassistant/components/alarm_control_panel/paradox.py
+++ b/homeassistant/components/alarm_control_panel/paradox.py
@@ -1,0 +1,95 @@
+"""
+Support for Paradox Alarm area/partition states - represented as an alarm control panel.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/alarm_control_panel.paradox/
+"""
+import logging
+import homeassistant.components.alarm_control_panel as alarm
+from homeassistant.components.paradox import (PARADOX_CONTROLLER,
+                                              PARTITION_SCHEMA,
+                                              CONF_PARTITIONNAME)
+from homeassistant.const import (
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED,
+    STATE_ALARM_TRIGGERED, STATE_UNKNOWN)
+
+# Mandatory items specified in configuration.yaml file
+PANEL_TYPE = 'panel_type'
+PORT = 'port'
+SPEED = 'speed'
+
+DEPENDENCIES = ['paradox']
+_LOGGER = logging.getLogger(__name__)
+
+# DOMAIN = 'alarm_control_panel'
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Sets up the Paradox alarm control panel platform, based on configuration file contents."""
+
+    # Get the area/partition information specified in the configuration/yaml file.
+    _configured_partitions = discovery_info['partitions']
+    for area_number in _configured_partitions:
+        # For each area specified, get the detail for that area.
+        _device_config_data = PARTITION_SCHEMA(_configured_partitions[area_number])
+        # Add the partition as a HA device.
+        # Each area is represented as an alarm control panel in HA
+        add_devices([ParadoxAlarm(hass,
+                                  area_number,
+                                  _device_config_data[CONF_PARTITIONNAME],
+                                  PARADOX_CONTROLLER.alarm_state['partition'][area_number]
+                                 )])
+    return True
+
+
+class ParadoxAlarm(alarm.AlarmControlPanel):
+    """Representation of an Paradox area as a alarm control panel."""
+
+    def __init__(self, hass, area_number, area_name, area_info):
+        """Initialize the Paradox area as a alarm control panel."""
+        # from pyparadox_alarm import paradox_defaults
+
+        self._area_info = area_info  # As defined in Alarm State dictionary
+        # self._hass = hass
+        self._area_number = area_number
+        if area_name in '':
+            # When no name provided request area label from the panel.
+            # PARADOX_CONTROLLER.submit_area_label_request(self._area_number)
+            # but it is asynchronous so set default name in the mean time
+            self._name = self._area_info['name']  # Alarm state default label
+        else:
+            self._name = area_name  # Name in configuration/yaml file
+
+        # At startup the area status should be requested from the alarm panel.
+        # Request the area status from the alarm panel
+        PARADOX_CONTROLLER.submit_area_status_request(self._area_number)
+        # No need to wait status will be updated when it returns from the panel.
+
+        _LOGGER.debug('HA added area: ' + area_name)
+
+    @property
+    def name(self):
+        """Return the name of the alarm control panel device. (Area/Partition name/label)"""
+        _LOGGER.debug('HA reports area name as ' + self._name)
+        return self._name
+
+    @property
+    def should_poll(self):
+        """Alarm status is pushed by alarm panel, so no polling needed."""
+        return False
+
+    @property
+    def state(self):
+        """Return the state of the area/partition."""
+        # Status is available/mirrored in alarm state dictionary.
+        if self._area_info['status']['alarm']:
+            return STATE_ALARM_TRIGGERED
+        elif self._area_info['status']['armed_away']:
+            return STATE_ALARM_ARMED_AWAY
+        elif self._area_info['status']['armed_stay']:
+            return STATE_ALARM_ARMED_HOME
+        elif self._area_info['status']['alpha']:
+            return STATE_ALARM_DISARMED
+        else:
+            return STATE_UNKNOWN

--- a/homeassistant/components/alarm_control_panel/paradox.py
+++ b/homeassistant/components/alarm_control_panel/paradox.py
@@ -1,5 +1,6 @@
 """
-Support for Paradox Alarm area/partition states - represented as an alarm control panel.
+Support for Paradox Alarm area/partition states
+ - represented as an alarm control panel.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/alarm_control_panel.paradox/
@@ -26,20 +27,23 @@ _LOGGER = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Sets up the Paradox alarm control panel platform, based on configuration file contents."""
-
-    # Get the area/partition information specified in the configuration/yaml file.
-    _configured_partitions = discovery_info['partitions']
-    for area_number in _configured_partitions:
+    """
+    Set up the Paradox alarm control panel platform.
+    Based on configuration file contents, not auto discovery.
+    """
+    # Get the area information specified in the configuration/yaml file.
+    _yaml_partitions = discovery_info['partitions']
+    for area_number in _yaml_partitions:
         # For each area specified, get the detail for that area.
-        _device_config_data = PARTITION_SCHEMA(_configured_partitions[area_number])
+        _device_config_data = PARTITION_SCHEMA(_yaml_partitions[area_number])
         # Add the partition as a HA device.
         # Each area is represented as an alarm control panel in HA
-        add_devices([ParadoxAlarm(hass,
-                                  area_number,
-                                  _device_config_data[CONF_PARTITIONNAME],
-                                  PARADOX_CONTROLLER.alarm_state['partition'][area_number]
-                                 )])
+        add_devices(
+            [ParadoxAlarm(hass,
+                          area_number,
+                          _device_config_data[CONF_PARTITIONNAME],
+                          PARADOX_CONTROLLER.alarm_state['partition'][area_number]
+                          )])
     return True
 
 
@@ -64,13 +68,16 @@ class ParadoxAlarm(alarm.AlarmControlPanel):
         # At startup the area status should be requested from the alarm panel.
         # Request the area status from the alarm panel
         PARADOX_CONTROLLER.submit_area_status_request(self._area_number)
-        # No need to wait status will be updated when it returns from the panel.
+        # No need to wait, status will be updated when it returns from alarm.
 
         _LOGGER.debug('HA added area: ' + area_name)
 
     @property
     def name(self):
-        """Return the name of the alarm control panel device. (Area/Partition name/label)"""
+        """
+        Return the name of the alarm control panel device.
+        (Area/Partition name/label)
+        """
         _LOGGER.debug('HA reports area name as ' + self._name)
         return self._name
 

--- a/homeassistant/components/binary_sensor/paradox.py
+++ b/homeassistant/components/binary_sensor/paradox.py
@@ -16,19 +16,23 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Sets up Paradox binary sensor platform, based on configuration/yaml file contents."""
+    """
+    Set up Paradox binary sensor platform.
+    Based on configuration/yaml file contents, not auto discovery.
+    """
     # Get the zone information specified in the configuration/yaml file.
     _configured_zones = discovery_info['zones']
     for zone_num in _configured_zones:
         # For each zone specified, get the detail for that zone.
         _device_config_data = ZONE_SCHEMA(_configured_zones[zone_num])
         # Add the zone as a HA device.
-        add_devices([ParadoxBinarySensor(hass,
-                                         zone_num,
-                                         _device_config_data[CONF_ZONENAME],
-                                         _device_config_data[CONF_ZONETYPE],
-                                         PARADOX_CONTROLLER.alarm_state['zone'][zone_num]
-                                        )])
+        add_devices(
+            [ParadoxBinarySensor(hass,
+                                 zone_num,
+                                 _device_config_data[CONF_ZONENAME],
+                                 _device_config_data[CONF_ZONETYPE],
+                                 PARADOX_CONTROLLER.alarm_state['zone'][zone_num]
+                                 )])
     return True
 
 
@@ -53,13 +57,13 @@ class ParadoxBinarySensor(BinarySensorDevice):
         # At startup Alarm State will not contain any zone statuses yet
         # Request the zone status from the alarm panel
         PARADOX_CONTROLLER.submit_zone_status_request(self._zone_number)
-        # No need to wait, the status will be updated when it returns from the panel.
+        # No need to wait, status will be updated when it returns from alarm.
 
         _LOGGER.debug('HA added zone: ' + zone_name)
 
     @property
     def name(self):
-        """Return the name of the binary sensor device. (Zone name/label)"""
+        """Return the name of the binary sensor device (Zone name/label)."""
         _LOGGER.debug('HA reports zone name as ' + self._name)
         return self._name
 
@@ -67,7 +71,7 @@ class ParadoxBinarySensor(BinarySensorDevice):
     def is_on(self):
         """Return true if sensor is on."""
         # Do we need to set/assign the state or is that done by HA later?
-        # self._state = PARADOX_CONTROLLER.alarm_state['zone']['status']['open']
+        # self._state=PARADOX_CONTROLLER.alarm_state['zone']['status']['open']
         # return self._state
         _LOGGER.debug('HA is checking the status of %s', self._name)
         return self._zone_mirror['status']['open']
@@ -83,7 +87,7 @@ class ParadoxBinarySensor(BinarySensorDevice):
         return False
 
     def update(self):
-        """Updates the zone state."""
+        """Update the zone state."""
         # Can this to work...
         # self._state = new_state
         _LOGGER.debug('Updating zone status.')

--- a/homeassistant/components/binary_sensor/paradox.py
+++ b/homeassistant/components/binary_sensor/paradox.py
@@ -39,7 +39,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class ParadoxBinarySensor(BinarySensorDevice):
-    """Representation of an Paradox zone as binary sensor."""
+    """Representation of an Paradox zone as a binary sensor."""
 
     # pylint: disable=too-many-arguments
     def __init__(self, hass, zone_number, zone_name, zone_type, zone_info):

--- a/homeassistant/components/binary_sensor/paradox.py
+++ b/homeassistant/components/binary_sensor/paradox.py
@@ -18,6 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """
     Set up Paradox binary sensor platform.
+    
     Based on configuration/yaml file contents, not auto discovery.
     """
     # Get the zone information specified in the configuration/yaml file.
@@ -27,12 +28,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _device_config_data = ZONE_SCHEMA(_configured_zones[zone_num])
         # Add the zone as a HA device.
         add_devices(
-            [ParadoxBinarySensor(hass,
-                                 zone_num,
-                                 _device_config_data[CONF_ZONENAME],
-                                 _device_config_data[CONF_ZONETYPE],
-                                 PARADOX_CONTROLLER.alarm_state['zone'][zone_num]
-                                 )])
+            [ParadoxBinarySensor(
+                hass,
+                zone_num,
+                _device_config_data[CONF_ZONENAME],
+                _device_config_data[CONF_ZONETYPE],
+                PARADOX_CONTROLLER.alarm_state['zone'][zone_num]
+                )])
     return True
 
 

--- a/homeassistant/components/binary_sensor/paradox.py
+++ b/homeassistant/components/binary_sensor/paradox.py
@@ -1,0 +1,91 @@
+"""
+Support for Paradox Alarm zone states - represented as binary sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.paradox/
+"""
+import logging
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.paradox import (PARADOX_CONTROLLER,
+                                              ZONE_SCHEMA,
+                                              CONF_ZONENAME,
+                                              CONF_ZONETYPE)
+
+DEPENDENCIES = ['paradox']
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Sets up Paradox binary sensor platform, based on configuration/yaml file contents."""
+    # Get the zone information specified in the configuration/yaml file.
+    _configured_zones = discovery_info['zones']
+    for zone_num in _configured_zones:
+        # For each zone specified, get the detail for that zone.
+        _device_config_data = ZONE_SCHEMA(_configured_zones[zone_num])
+        # Add the zone as a HA device.
+        add_devices([ParadoxBinarySensor(hass,
+                                         zone_num,
+                                         _device_config_data[CONF_ZONENAME],
+                                         _device_config_data[CONF_ZONETYPE],
+                                         PARADOX_CONTROLLER.alarm_state['zone'][zone_num]
+                                        )])
+    return True
+
+
+class ParadoxBinarySensor(BinarySensorDevice):
+    """Representation of an Paradox zone as binary sensor."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, hass, zone_number, zone_name, zone_type, zone_info):
+        """Initialize the Paradox zone as binary_sensor."""
+        self._zone_mirror = zone_info  # As defined in Alarm State dictionary
+        self._zone_type = zone_type
+        self._zone_number = zone_number
+        if zone_name in '':
+            # When no label provided, get zone label from alarm panel
+            # PARADOX_CONTROLLER.submit_zone_label_request(self._zone_number)
+            # but it is asynchronous so set default name in the mean time
+            self._name = self._zone_mirror['name']  # Alarm State default label
+        else:
+            self._name = zone_name  # Name in configuration/yaml file
+
+        self._state = None
+        # At startup Alarm State will not contain any zone statuses yet
+        # Request the zone status from the alarm panel
+        PARADOX_CONTROLLER.submit_zone_status_request(self._zone_number)
+        # No need to wait, the status will be updated when it returns from the panel.
+
+        _LOGGER.debug('HA added zone: ' + zone_name)
+
+    @property
+    def name(self):
+        """Return the name of the binary sensor device. (Zone name/label)"""
+        _LOGGER.debug('HA reports zone name as ' + self._name)
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if sensor is on."""
+        # Do we need to set/assign the state or is that done by HA later?
+        # self._state = PARADOX_CONTROLLER.alarm_state['zone']['status']['open']
+        # return self._state
+        _LOGGER.debug('HA is checking the status of %s', self._name)
+        return self._zone_mirror['status']['open']
+
+    @property
+    def sensor_class(self):
+        """Return the class of this sensor, from SENSOR_CLASSES."""
+        return self._zone_type
+
+    @property
+    def should_poll(self):
+        """Zone status is pushed by alarm panel, so no polling needed."""
+        return False
+
+    def update(self):
+        """Updates the zone state."""
+        # Can this to work...
+        # self._state = new_state
+        _LOGGER.debug('Updating zone status.')
+        self.update_ha_state()  # Force an is_on first?
+        return True

--- a/homeassistant/components/binary_sensor/paradox.py
+++ b/homeassistant/components/binary_sensor/paradox.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """
     Set up Paradox binary sensor platform.
-    
+
     Based on configuration/yaml file contents, not auto discovery.
     """
     # Get the zone information specified in the configuration/yaml file.

--- a/homeassistant/components/paradox.py
+++ b/homeassistant/components/paradox.py
@@ -1,5 +1,6 @@
 """
 Support for Paradox Alarms.
+
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/paradox/
 
@@ -9,8 +10,8 @@ Focus for getting the PRT3 to work for now.
 Because the Evisalink looks very close to the IP100/1500, the evisalink code
 was changed to IP100/150 and then commented out for later testing.
 
-I'm hoping that this file can cater for whichever comms (USB/IP) module is being used.
-I'm also assuming that both modules may be used at the same time even if it doesn't make much sense.
+I'm hoping that this file can cater for both comms modules (USB/IP).
+I'm also assuming that both modules may be used at the same time.
 """
 import logging
 import time
@@ -23,8 +24,6 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
 #   STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED, STATE_UNKNOWN)
 
-# REQUIREMENTS = ['https://github.com/PollieKrismis/pyparadox_alarm/archive/v0.1.4.zip'
-#                '#pyparadox_alarm==0.1.4']
 REQUIREMENTS = ['pyparadox_alarm==1.0.0']
 
 _LOGGER = logging.getLogger(__name__)
@@ -89,11 +88,10 @@ ZONE_SCHEMA = vol.Schema({
 # pylint: disable=too-many-return-statements
 def setup(hass, base_config):
     """
-    Sets up a Home Assistant component to represent a Paradox Alarm, as a hub.
+    Set up a Home Assistant component to represent a Paradox Alarm, as a hub.
     I.e. it will consist of an alarm platform to represent each alarm partition,
     as well as a binary sensor platform to represent each zone.
     """
-
     from pyparadox_alarm.alarm_panel import ParadoxAlarmPanel
     # from pydispatch import dispatcher
 
@@ -143,14 +141,15 @@ def setup(hass, base_config):
             _LOGGER.info('Paradox controller not initialised')
             return False
         else:
-            _LOGGER.info('Paradox controller initialised as %s.', PARADOX_CONTROLLER.paradox_model)
+            _LOGGER.info('Paradox controller initialised as %s.',
+                         PARADOX_CONTROLLER.paradox_model)
 
     def update_alarm_armed_cb(area_number):
-        '''Process the area/partition armed event received from alarm panel.'''
+        """Process the area/partition armed event received from alarm panel."""
         _LOGGER.debug('Area %d received armed event.', area_number)
         try:
             # Area in use on alarm panel might not be setup/defined in HA
-            _affected_area = PARTITION_SCHEMA(_partitions[area_number])  # Hass partition dict
+            _affected_area = PARTITION_SCHEMA(_partitions[area_number])
             _LOGGER.debug('HA area %s to be armed.', _affected_area[CONF_PARTITIONNAME])
             # This does not seem to be the correct way to set the state.
 
@@ -164,17 +163,19 @@ def setup(hass, base_config):
         return True
 
     def update_alarm_stay_armed_cb(area_number):
-        '''Process the area/partition stay armed event received from alarm panel.'''
+        """Process the area/partition stay armed event received from alarm panel."""
         _LOGGER.debug('Area %d received stay armed event.', area_number)
         try:
             # Area in use on alarm panel might not be setup/defined in HA
-            _affected_area = PARTITION_SCHEMA(_partitions[area_number])  # Hass partition dict
-            _LOGGER.debug('HA area %s to be stay armed.', _affected_area[CONF_PARTITIONNAME])
+            _affected_area = PARTITION_SCHEMA(_partitions[area_number])
+            _LOGGER.debug('HA area %s to be stay armed.',
+                          _affected_area[CONF_PARTITIONNAME])
             # This does not seem to be the correct way to set the state.
 
             _att = {'friendly_name': _affected_area[CONF_PARTITIONNAME]}
 
-            hass.states.set('alarm_control_panel.' + _affected_area[CONF_PARTITIONNAME],
+            hass.states.set('alarm_control_panel.' +
+                            _affected_area[CONF_PARTITIONNAME],
                             STATE_ALARM_ARMED_HOME, _att)
         except KeyError:
             _LOGGER.debug('Area %d not defined in HA.', area_number)
@@ -182,17 +183,19 @@ def setup(hass, base_config):
         return True
 
     def update_alarm_disarmed_cb(area_number):
-        '''Process the area/partition disarmed event received from alarm panel.'''
+        """Process the area/partition disarmed event received from alarm panel."""
         _LOGGER.debug('Area %d received disarmed event.', area_number)
         try:
             # Area in use on alarm panel might not be setup/defined in HA
-            _affected_area = PARTITION_SCHEMA(_partitions[area_number])  # Hass partition dict
-            _LOGGER.debug('HA area %s to be disarmed.', _affected_area[CONF_PARTITIONNAME])
+            _affected_area = PARTITION_SCHEMA(_partitions[area_number])
+            _LOGGER.debug('HA area %s to be disarmed.',
+                          _affected_area[CONF_PARTITIONNAME])
 
             _att = {'friendly_name': _affected_area[CONF_PARTITIONNAME]}
 
             # This does not seem to be the correct way to set the state.
-            hass.states.set('alarm_control_panel.' + _affected_area[CONF_PARTITIONNAME],
+            hass.states.set('alarm_control_panel.' +
+                            _affected_area[CONF_PARTITIONNAME],
                             STATE_ALARM_DISARMED, _att)
         except KeyError:
             _LOGGER.debug('Area %d not defined in HA.', area_number)
@@ -200,15 +203,17 @@ def setup(hass, base_config):
         return True
 
     def update_zone_status_cb(zone_number):
-        '''Process the zone status change received from alarm panel.'''
+        """Process the zone status change received from alarm panel."""
         # Rather define 'zone' as a constant.
         # This is not needed, the new status is getting passed in!
         _new_status = PARADOX_CONTROLLER.alarm_state['zone'][zone_number]['status']['open']
-        _LOGGER.debug('Zone %d received new status %s.', zone_number, _new_status)
+        _LOGGER.debug('Zone %d received new status %s.',
+                      zone_number, _new_status)
         try:
             # Zone on alarm panel might not be setup/defined in HA
-            _affected_zone = ZONE_SCHEMA(_zones[zone_number])  # Hass zone dictionary
-            _LOGGER.debug('HA zone %s to be updated.', _affected_zone[CONF_ZONENAME])
+            _affected_zone = ZONE_SCHEMA(_zones[zone_number])
+            _LOGGER.debug('HA zone %s to be updated.',
+                          _affected_zone[CONF_ZONENAME])
             # This does not seem to be the correct way to set the state.
             if _new_status:
                 _new_status = 'on'
@@ -218,7 +223,8 @@ def setup(hass, base_config):
             _att = {'friendly_name': _affected_zone[CONF_ZONENAME],
                     'sensor_class': _affected_zone[CONF_ZONETYPE]}
 
-            hass.states.set('binary_sensor.' + _affected_zone[CONF_ZONENAME], _new_status, _att)
+            hass.states.set('binary_sensor.' + _affected_zone[CONF_ZONENAME],
+                            _new_status, _att)
         except KeyError:
             _LOGGER.debug('Zone %d not defined in HA.', zone_number)
 
@@ -239,7 +245,7 @@ def setup(hass, base_config):
 
         return True
 
-    # Overwrite the controllers default callback so it calls the hass functions instead
+    # Overwrite the controllers default callback to call the hass functions
     PARADOX_CONTROLLER.callback_area_armed = update_alarm_armed_cb
     PARADOX_CONTROLLER.callback_area_stay_armed = update_alarm_stay_armed_cb
     PARADOX_CONTROLLER.callback_area_disarmed = update_alarm_disarmed_cb

--- a/homeassistant/components/paradox.py
+++ b/homeassistant/components/paradox.py
@@ -210,8 +210,9 @@ def setup(hass, base_config):
         """Process the zone status change received from alarm panel."""
         # Rather define 'zone' as a constant.
         # This is not needed, the new status is getting passed in!
-        _new_status = PARADOX_CONTROLLER.alarm_state['zone']
-        [zone_number]['status']['open']
+        _new_status = PARADOX_CONTROLLER.alarm_state['zone'][zone_number][
+            'status'
+            ]['open']
         _LOGGER.debug('Zone %d received new status %s.',
                       zone_number, _new_status)
         try:

--- a/homeassistant/components/paradox.py
+++ b/homeassistant/components/paradox.py
@@ -89,8 +89,9 @@ ZONE_SCHEMA = vol.Schema({
 def setup(hass, base_config):
     """
     Set up a Home Assistant component to represent a Paradox Alarm, as a hub.
-    I.e. it will consist of an alarm platform to represent each alarm partition,
-    as well as a binary sensor platform to represent each zone.
+    
+    I.e. it will consist of an alarm platform to represent each alarm area/
+    partition, as well as a binary sensor platform to represent each zone.
     """
     from pyparadox_alarm.alarm_panel import ParadoxAlarmPanel
     # from pydispatch import dispatcher
@@ -123,7 +124,8 @@ def setup(hass, base_config):
     if 'IP' in _comm_module:
         IP_MODULE = True
     '''
-    # These will be auto discovered in later versions if we can get the serial speed sorted.
+    # These will be auto discovered in later versions.
+    # ...if we can get the serial speed sorted.
     _zones = config.get(CONF_ZONES)
     _partitions = config.get(CONF_PARTITIONS)
     # _connect_status = {}
@@ -145,17 +147,19 @@ def setup(hass, base_config):
                          PARADOX_CONTROLLER.paradox_model)
 
     def update_alarm_armed_cb(area_number):
-        """Process the area/partition armed event received from alarm panel."""
+        """Process the area armed event received from alarm panel."""
         _LOGGER.debug('Area %d received armed event.', area_number)
         try:
             # Area in use on alarm panel might not be setup/defined in HA
             _affected_area = PARTITION_SCHEMA(_partitions[area_number])
-            _LOGGER.debug('HA area %s to be armed.', _affected_area[CONF_PARTITIONNAME])
+            _LOGGER.debug('HA area %s to be armed.', 
+                          _affected_area[CONF_PARTITIONNAME])
             # This does not seem to be the correct way to set the state.
 
             _att = {'friendly_name': _affected_area[CONF_PARTITIONNAME]}
 
-            hass.states.set('alarm_control_panel.' + _affected_area[CONF_PARTITIONNAME],
+            hass.states.set('alarm_control_panel.' + 
+                            _affected_area[CONF_PARTITIONNAME],
                             STATE_ALARM_ARMED_AWAY, _att)
         except KeyError:
             _LOGGER.debug('Area %d not defined in HA.', area_number)
@@ -163,7 +167,7 @@ def setup(hass, base_config):
         return True
 
     def update_alarm_stay_armed_cb(area_number):
-        """Process the area/partition stay armed event received from alarm panel."""
+        """Process area stay armed event received from alarm panel."""
         _LOGGER.debug('Area %d received stay armed event.', area_number)
         try:
             # Area in use on alarm panel might not be setup/defined in HA
@@ -183,7 +187,7 @@ def setup(hass, base_config):
         return True
 
     def update_alarm_disarmed_cb(area_number):
-        """Process the area/partition disarmed event received from alarm panel."""
+        """Process area/partition disarmed event received from alarm panel."""
         _LOGGER.debug('Area %d received disarmed event.', area_number)
         try:
             # Area in use on alarm panel might not be setup/defined in HA

--- a/homeassistant/components/paradox.py
+++ b/homeassistant/components/paradox.py
@@ -211,7 +211,7 @@ def setup(hass, base_config):
         # Rather define 'zone' as a constant.
         # This is not needed, the new status is getting passed in!
         _new_status = PARADOX_CONTROLLER.alarm_state['zone']\
-                        [zone_number]['status']['open']
+        [zone_number]['status']['open']
         _LOGGER.debug('Zone %d received new status %s.',
                       zone_number, _new_status)
         try:

--- a/homeassistant/components/paradox.py
+++ b/homeassistant/components/paradox.py
@@ -1,0 +1,270 @@
+"""
+Support for Paradox Alarms.
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/paradox/
+
+Assumes PRT3 module is connected via USB on same server as HA
+
+Focus for getting the PRT3 to work for now.
+Because the Evisalink looks very close to the IP100/1500, the evisalink code
+was changed to IP100/150 and then commented out for later testing.
+
+I'm hoping that this file can cater for whichever comms (USB/IP) module is being used.
+I'm also assuming that both modules may be used at the same time even if it doesn't make much sense.
+"""
+import logging
+import time
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+# from homeassistant.helpers.entity import Entity
+from homeassistant.components.discovery import load_platform
+from homeassistant.const import (
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
+#   STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED, STATE_UNKNOWN)
+
+# REQUIREMENTS = ['https://github.com/PollieKrismis/pyparadox_alarm/archive/v0.1.4.zip'
+#                '#pyparadox_alarm==0.1.4']
+REQUIREMENTS = ['pyparadox_alarm==1.0.0']
+
+_LOGGER = logging.getLogger(__name__)
+DOMAIN = 'paradox'
+PLATFORM_TYPE = 'alarm_control_panel'
+SENSOR_TYPE = 'binary_sensor'
+
+PARADOX_CONTROLLER = None
+PRT_MODULE = False
+IP_MODULE = False
+
+# The following items we expect to find in the yaml config file
+# Most only apply to IP modules.
+# Paradox Panel Type parameters
+CONF_PARADOX_MODEL = 'panel_type'
+CONF_COMM_MODULE = 'communication_module'
+# IP100/150 parameters
+CONF_IP_HOST = 'ip_host'
+CONF_IP_PORT = 'ip_port'
+CONF_IP_KEEPALIVE = 'keepalive_interval'
+CONF_ZONEDUMP_INTERVAL = 'zonedump_interval'
+# PRT3 parameters
+CONF_PRT_SPEED = 'speed'
+CONF_PRT_PORT = 'port'
+# Panel Access parameters
+CONF_CODE = 'code'
+CONF_USERNAME = 'user_name'
+CONF_PASS = 'password'
+# Partition and zone parameters - should rather be auto discovered
+CONF_ZONES = 'zones'
+CONF_PARTITIONS = 'partitions'
+CONF_ZONENAME = 'name'
+CONF_ZONETYPE = 'type'
+CONF_PARTITIONNAME = 'name'
+# End of yaml config file parameters
+
+# Defauls for when nothing is found in the yaml config file
+DEFAULT_PRT_SPEED = 57600
+DEFAULT_PRT_PORT = '/dev/ttyUSB0'
+DEFAULT_IP_HOST = '???'
+DEFAULT_IP_PORT = '???'
+DEFAULT_IP_VERSION = 150
+DEFAULT_KEEPALIVE = 60
+DEFAULT_ZONEDUMP_INTERVAL = 30
+DEFAULT_ZONETYPE = 'opening'
+
+# We do not use dispatcher, so is this needed?
+SIGNAL_ZONE_UPDATE = 'zones_updated'
+SIGNAL_PARTITION_UPDATE = 'partition_updated'
+SIGNAL_KEYPAD_UPDATE = 'keypad_updated'
+
+# User codes to be added later to allow disarming.
+PARTITION_SCHEMA = vol.Schema({
+    vol.Required(CONF_PARTITIONNAME): cv.string})
+
+ZONE_SCHEMA = vol.Schema({
+    vol.Required(CONF_ZONENAME): cv.string,
+    vol.Optional(CONF_ZONETYPE, default=DEFAULT_ZONETYPE): cv.string})
+
+
+# pylint: disable=unused-argument, too-many-function-args, too-many-locals
+# pylint: disable=too-many-return-statements
+def setup(hass, base_config):
+    """
+    Sets up a Home Assistant component to represent a Paradox Alarm, as a hub.
+    I.e. it will consist of an alarm platform to represent each alarm partition,
+    as well as a binary sensor platform to represent each zone.
+    """
+
+    from pyparadox_alarm.alarm_panel import ParadoxAlarmPanel
+    # from pydispatch import dispatcher
+
+    global PARADOX_CONTROLLER  # Represents the complete panel
+
+    # Get the (paradox) domain entries from the yaml config file
+    config = base_config.get(DOMAIN)
+
+    # Needed for panel itself
+    _paradox_model = config.get(CONF_PARADOX_MODEL)
+    _comm_module = config.get(CONF_COMM_MODULE)
+    _code = config.get(CONF_CODE)
+    # _user = config.get(CONF_USERNAME)
+    # _pass = config.get(CONF_PASS)
+    # Needed for the PRT3
+    _prt_port = config.get(CONF_PRT_PORT)
+    _prt_speed = config.get(CONF_PRT_SPEED)
+    '''
+    # Needed for the IP100/150
+    _ip_host = config.get(CONF_IP_HOST)
+    _ip_port = config.get(CONF_IP_PORT)
+    _zone_dump = config.get(CONF_ZONEDUMP_INTERVAL)
+    _keep_alive = config.get(CONF_IP_KEEPALIVE)
+    # Assign it here or rather send it all with kwargs?
+    # How do we need to communicate with alarm panel
+    if 'PRT3' in _comm_module:
+        PRT_MODULE = True
+
+    if 'IP' in _comm_module:
+        IP_MODULE = True
+    '''
+    # These will be auto discovered in later versions if we can get the serial speed sorted.
+    _zones = config.get(CONF_ZONES)
+    _partitions = config.get(CONF_PARTITIONS)
+    # _connect_status = {}
+
+    if PARADOX_CONTROLLER is None:
+        _LOGGER.info('Setting up %s on port %s.', _paradox_model, _prt_port)
+        # Rather pass all the parameters using kwargs?
+        PARADOX_CONTROLLER = ParadoxAlarmPanel(_paradox_model,
+                                               _comm_module,
+                                               # _user,
+                                               # _pass,
+                                               _prt_port,
+                                               _prt_speed)
+        if PARADOX_CONTROLLER is None:
+            _LOGGER.info('Paradox controller not initialised')
+            return False
+        else:
+            _LOGGER.info('Paradox controller initialised as %s.', PARADOX_CONTROLLER.paradox_model)
+
+    def update_alarm_armed_cb(area_number):
+        '''Process the area/partition armed event received from alarm panel.'''
+        _LOGGER.debug('Area %d received armed event.', area_number)
+        try:
+            # Area in use on alarm panel might not be setup/defined in HA
+            _affected_area = PARTITION_SCHEMA(_partitions[area_number])  # Hass partition dict
+            _LOGGER.debug('HA area %s to be armed.', _affected_area[CONF_PARTITIONNAME])
+            # This does not seem to be the correct way to set the state.
+
+            _att = {'friendly_name': _affected_area[CONF_PARTITIONNAME]}
+
+            hass.states.set('alarm_control_panel.' + _affected_area[CONF_PARTITIONNAME],
+                            STATE_ALARM_ARMED_AWAY, _att)
+        except KeyError:
+            _LOGGER.debug('Area %d not defined in HA.', area_number)
+
+        return True
+
+    def update_alarm_stay_armed_cb(area_number):
+        '''Process the area/partition stay armed event received from alarm panel.'''
+        _LOGGER.debug('Area %d received stay armed event.', area_number)
+        try:
+            # Area in use on alarm panel might not be setup/defined in HA
+            _affected_area = PARTITION_SCHEMA(_partitions[area_number])  # Hass partition dict
+            _LOGGER.debug('HA area %s to be stay armed.', _affected_area[CONF_PARTITIONNAME])
+            # This does not seem to be the correct way to set the state.
+
+            _att = {'friendly_name': _affected_area[CONF_PARTITIONNAME]}
+
+            hass.states.set('alarm_control_panel.' + _affected_area[CONF_PARTITIONNAME],
+                            STATE_ALARM_ARMED_HOME, _att)
+        except KeyError:
+            _LOGGER.debug('Area %d not defined in HA.', area_number)
+
+        return True
+
+    def update_alarm_disarmed_cb(area_number):
+        '''Process the area/partition disarmed event received from alarm panel.'''
+        _LOGGER.debug('Area %d received disarmed event.', area_number)
+        try:
+            # Area in use on alarm panel might not be setup/defined in HA
+            _affected_area = PARTITION_SCHEMA(_partitions[area_number])  # Hass partition dict
+            _LOGGER.debug('HA area %s to be disarmed.', _affected_area[CONF_PARTITIONNAME])
+
+            _att = {'friendly_name': _affected_area[CONF_PARTITIONNAME]}
+
+            # This does not seem to be the correct way to set the state.
+            hass.states.set('alarm_control_panel.' + _affected_area[CONF_PARTITIONNAME],
+                            STATE_ALARM_DISARMED, _att)
+        except KeyError:
+            _LOGGER.debug('Area %d not defined in HA.', area_number)
+
+        return True
+
+    def update_zone_status_cb(zone_number):
+        '''Process the zone status change received from alarm panel.'''
+        # Rather define 'zone' as a constant.
+        # This is not needed, the new status is getting passed in!
+        _new_status = PARADOX_CONTROLLER.alarm_state['zone'][zone_number]['status']['open']
+        _LOGGER.debug('Zone %d received new status %s.', zone_number, _new_status)
+        try:
+            # Zone on alarm panel might not be setup/defined in HA
+            _affected_zone = ZONE_SCHEMA(_zones[zone_number])  # Hass zone dictionary
+            _LOGGER.debug('HA zone %s to be updated.', _affected_zone[CONF_ZONENAME])
+            # This does not seem to be the correct way to set the state.
+            if _new_status:
+                _new_status = 'on'
+            else:
+                _new_status = 'off'
+
+            _att = {'friendly_name': _affected_zone[CONF_ZONENAME],
+                    'sensor_class': _affected_zone[CONF_ZONETYPE]}
+
+            hass.states.set('binary_sensor.' + _affected_zone[CONF_ZONENAME], _new_status, _att)
+        except KeyError:
+            _LOGGER.debug('Zone %d not defined in HA.', zone_number)
+
+        return True
+
+    def stop_paradox(event):
+        """Shutdown Paradox connection and threads on exit."""
+        _LOGGER.info("Shutting down connection to Paradox alarm.")
+        PARADOX_CONTROLLER.stop()
+
+    def start_paradox(event):
+        """Startup process to connect to the Paradox alarm."""
+        _LOGGER.debug('Connect to Paradox Alarm panel')
+        PARADOX_CONTROLLER.start()
+        # Add a test to see it is connected
+        time.sleep(4)  # Give ait a few seconds to make the connection
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_paradox)
+
+        return True
+
+    # Overwrite the controllers default callback so it calls the hass functions instead
+    PARADOX_CONTROLLER.callback_area_armed = update_alarm_armed_cb
+    PARADOX_CONTROLLER.callback_area_stay_armed = update_alarm_stay_armed_cb
+    PARADOX_CONTROLLER.callback_area_disarmed = update_alarm_disarmed_cb
+    PARADOX_CONTROLLER.callback_zone_state_change = update_zone_status_cb
+
+    # Connect to the Paradox Alarm.
+    _connected = start_paradox(None)
+    if not _connected:
+        return False
+
+    # States are in the format DOMAIN.OBJECT_ID
+    hass.states.set('paradox.Paradox_State', 'Connected')
+
+    # Load sub-components for a Paradox Alarm
+
+    if _partitions:
+        # The partitions are the Alarm Panel in Home Assistant
+        _LOGGER.info('Load Paradox Alarm partitions as platform.')
+        load_platform(hass, PLATFORM_TYPE, DOMAIN,
+                      {CONF_PARTITIONS: _partitions,
+                       'code': _code}, config)
+
+    if _zones:
+        _LOGGER.info('Load Paradox Alarm zones as platform.')
+        load_platform(hass, SENSOR_TYPE, DOMAIN,
+                      {CONF_ZONES: _zones}, config)
+
+    return True

--- a/homeassistant/components/paradox.py
+++ b/homeassistant/components/paradox.py
@@ -10,7 +10,7 @@ Focus for getting the PRT3 to work for now.
 Because the Evisalink looks very close to the IP100/1500, the evisalink code
 was changed to IP100/150 and then commented out for later testing.
 
-I'm hoping that this file can cater for both comms modules (USB/IP).
+I'm hoping that the hub can cater for both comms modules (USB/IP).
 I'm also assuming that both modules may be used at the same time.
 """
 import logging

--- a/homeassistant/components/paradox.py
+++ b/homeassistant/components/paradox.py
@@ -89,7 +89,7 @@ ZONE_SCHEMA = vol.Schema({
 def setup(hass, base_config):
     """
     Set up a Home Assistant component to represent a Paradox Alarm, as a hub.
-    
+
     I.e. it will consist of an alarm platform to represent each alarm area/
     partition, as well as a binary sensor platform to represent each zone.
     """
@@ -152,13 +152,13 @@ def setup(hass, base_config):
         try:
             # Area in use on alarm panel might not be setup/defined in HA
             _affected_area = PARTITION_SCHEMA(_partitions[area_number])
-            _LOGGER.debug('HA area %s to be armed.', 
+            _LOGGER.debug('HA area %s to be armed.',
                           _affected_area[CONF_PARTITIONNAME])
             # This does not seem to be the correct way to set the state.
 
             _att = {'friendly_name': _affected_area[CONF_PARTITIONNAME]}
 
-            hass.states.set('alarm_control_panel.' + 
+            hass.states.set('alarm_control_panel.' +
                             _affected_area[CONF_PARTITIONNAME],
                             STATE_ALARM_ARMED_AWAY, _att)
         except KeyError:
@@ -210,7 +210,8 @@ def setup(hass, base_config):
         """Process the zone status change received from alarm panel."""
         # Rather define 'zone' as a constant.
         # This is not needed, the new status is getting passed in!
-        _new_status = PARADOX_CONTROLLER.alarm_state['zone'][zone_number]['status']['open']
+        _new_status = PARADOX_CONTROLLER.alarm_state['zone']\
+                        [zone_number]['status']['open']
         _LOGGER.debug('Zone %d received new status %s.',
                       zone_number, _new_status)
         try:

--- a/homeassistant/components/paradox.py
+++ b/homeassistant/components/paradox.py
@@ -210,7 +210,7 @@ def setup(hass, base_config):
         """Process the zone status change received from alarm panel."""
         # Rather define 'zone' as a constant.
         # This is not needed, the new status is getting passed in!
-        _new_status = PARADOX_CONTROLLER.alarm_state['zone']\
+        _new_status = PARADOX_CONTROLLER.alarm_state['zone']
         [zone_number]['status']['open']
         _LOGGER.debug('Zone %d received new status %s.',
                       zone_number, _new_status)

--- a/homeassistant/components/paradox.py
+++ b/homeassistant/components/paradox.py
@@ -110,20 +110,20 @@ def setup(hass, base_config):
     # Needed for the PRT3
     _prt_port = config.get(CONF_PRT_PORT)
     _prt_speed = config.get(CONF_PRT_SPEED)
-    '''
+
     # Needed for the IP100/150
-    _ip_host = config.get(CONF_IP_HOST)
-    _ip_port = config.get(CONF_IP_PORT)
-    _zone_dump = config.get(CONF_ZONEDUMP_INTERVAL)
-    _keep_alive = config.get(CONF_IP_KEEPALIVE)
+    # _ip_host = config.get(CONF_IP_HOST)
+    # _ip_port = config.get(CONF_IP_PORT)
+    # _zone_dump = config.get(CONF_ZONEDUMP_INTERVAL)
+    # _keep_alive = config.get(CONF_IP_KEEPALIVE)
     # Assign it here or rather send it all with kwargs?
     # How do we need to communicate with alarm panel
-    if 'PRT3' in _comm_module:
-        PRT_MODULE = True
+    # if 'PRT3' in _comm_module:
+    #    PRT_MODULE = True
 
-    if 'IP' in _comm_module:
-        IP_MODULE = True
-    '''
+    # if 'IP' in _comm_module:
+    #    IP_MODULE = True
+
     # These will be auto discovered in later versions.
     # ...if we can get the serial speed sorted.
     _zones = config.get(CONF_ZONES)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -367,6 +367,9 @@ pynx584==0.2
 # homeassistant.components.sensor.openweathermap
 pyowm==2.4.0
 
+# homeassistant.components.paradox
+pyparadox_alarm==1.0.0
+
 # homeassistant.components.switch.acer_projector
 pyserial==3.1.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -179,6 +179,10 @@ https://github.com/jabesq/netatmo-api-python/archive/v0.5.0.zip#lnetatmo==0.5.0
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
 
+# homeassistant.components.paradox_alarm
+#https://github.com/PollieKrismis/pyparadox_alarm/archive/v1.0.0.zip
+pyparadox_alarm==1.0.0
+
 # homeassistant.components.qwikswitch
 https://github.com/kellerza/pyqwikswitch/archive/v0.4.zip#pyqwikswitch==0.4
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -179,10 +179,6 @@ https://github.com/jabesq/netatmo-api-python/archive/v0.5.0.zip#lnetatmo==0.5.0
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
 
-# homeassistant.components.paradox_alarm
-#https://github.com/PollieKrismis/pyparadox_alarm/archive/v1.0.0.zip
-pyparadox_alarm==1.0.0
-
 # homeassistant.components.qwikswitch
 https://github.com/kellerza/pyqwikswitch/archive/v0.4.zip#pyqwikswitch==0.4
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -179,10 +179,6 @@ https://github.com/jabesq/netatmo-api-python/archive/v0.5.0.zip#lnetatmo==0.5.0
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
 
-# homeassistant.components.paradox_alarm
-#https://github.com/PollieKrismis/pyparadox_alarm/archive/v1.0.0.zip
-pyparadox_alarm==1.0.0
-
 # homeassistant.components.qwikswitch
 https://github.com/kellerza/pyqwikswitch/archive/v0.4.zip#pyqwikswitch==0.4
 
@@ -366,6 +362,9 @@ pynx584==0.2
 
 # homeassistant.components.sensor.openweathermap
 pyowm==2.4.0
+
+# homeassistant.components.paradox
+pyparadox_alarm==1.0.0
 
 # homeassistant.components.switch.acer_projector
 pyserial==3.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -179,6 +179,10 @@ https://github.com/jabesq/netatmo-api-python/archive/v0.5.0.zip#lnetatmo==0.5.0
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
 
+# homeassistant.components.paradox_alarm
+# https://github.com/PollieKrismis/pyparadox_alarm/archive/v1.0.0.zip
+pyparadox_alarm==1.0.0
+
 # homeassistant.components.qwikswitch
 https://github.com/kellerza/pyqwikswitch/archive/v0.4.zip#pyqwikswitch==0.4
 
@@ -533,3 +537,4 @@ yahooweather==0.8
 
 # homeassistant.components.zeroconf
 zeroconf==0.17.6
+

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -179,10 +179,6 @@ https://github.com/jabesq/netatmo-api-python/archive/v0.5.0.zip#lnetatmo==0.5.0
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
 
-# homeassistant.components.paradox_alarm
-# https://github.com/PollieKrismis/pyparadox_alarm/archive/v1.0.0.zip
-pyparadox_alarm==1.0.0
-
 # homeassistant.components.qwikswitch
 https://github.com/kellerza/pyqwikswitch/archive/v0.4.zip#pyqwikswitch==0.4
 
@@ -537,4 +533,3 @@ yahooweather==0.8
 
 # homeassistant.components.zeroconf
 zeroconf==0.17.6
-

--- a/setup
+++ b/setup
@@ -1,0 +1,5 @@
+Script started on Mon 10 Oct 2016 23:39:19 SAST
+]0;homeassistant@raspberrypi: /srv/homeassistant/home-assistant[01;32mhomeassistant@raspberrypi[00m:[01;34m/srv/homeassistant/home-assistant $[00m exit
+exit
+
+Script done on Mon 10 Oct 2016 23:39:43 SAST


### PR DESCRIPTION
**Description:**
Adds support for Paradox Alarms. Monitoring status changes only.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#1181

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
# Enables Paradox Alarm Panel as a hub
paradox:
  panel_type: EVO48
  port: /dev/ttyUSB0
  speed: 57600

  zones:
    2:
      name: 'Bedroom'
      type: 'motion'

    4:
      name: 'Study'
      type: 'motion'

  partitions:
    1:
      name: 'House'

    2:
      name: 'Perimeter'

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
          - performed individual flake8, pylint testing. Not sure how to setup py.test testing
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
