### PR TITLE
Suppress exception (sensor.pi_hole)

### DIFF
--- a/homeassistant/components/sensor/pi_hole.py
+++ b/homeassistant/components/sensor/pi_hole.py
@@ -25,7 +25,7 @@ ATTR_QUERIES_TODAY = 'queries_today'
 
 DEFAULT_HOST = 'localhost'
 DEFAULT_METHOD = 'GET'
-DEFAULT_NAME = 'Pi-hole'
+DEFAULT_NAME = 'Pi-Hole'
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
 
@@ -59,7 +59,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     rest.update()
 
     if rest.data is None:
-        _LOGGER.error('Unable to fetch REST data')
+        _LOGGER.error("Unable to fetch data from Pi-Hole")
         return False
 
     add_devices([PiHoleSensor(hass, rest, name)])
@@ -99,5 +99,8 @@ class PiHoleSensor(Entity):
 
     def update(self):
         """Get the latest data from REST API and updates the state."""
-        self.rest.update()
-        self._state = json.loads(self.rest.data)
+        try:
+            self.rest.update()
+            self._state = json.loads(self.rest.data)
+        except TypeError:
+            _LOGGER.error("Unable to fetch data from Pi-Hole")


### PR DESCRIPTION
**Description:**
If a Pi-Hole goes offline then the sensor showed a traceback. This is now suppressed and an additional log messages created that point to the source of the REST error. 

**Related issue (if applicable):** fixes #3699

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: pi_hole
    host: 192.168.1.2
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
