### PR TITLE
Use voluptuous for eQ-3 thermostat

### DIFF
--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -1,24 +1,38 @@
 """
-Support for eq3 Bluetooth Smart thermostats.
+Support for eQ-3 Bluetooth Smart thermostats.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.eq3btsmart/
 """
 import logging
 
-from homeassistant.components.climate import ClimateDevice
-from homeassistant.const import TEMP_CELSIUS, CONF_DEVICES, ATTR_TEMPERATURE
+import voluptuous as vol
+
+from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_MAC, TEMP_CELSIUS, CONF_DEVICES, ATTR_TEMPERATURE)
 from homeassistant.util.temperature import convert
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['bluepy_devices==0.2.0']
 
-CONF_MAC = 'mac'
-
 _LOGGER = logging.getLogger(__name__)
+
+ATTR_MODE = 'mode'
+ATTR_MODE_READBLE = 'mode_readable'
+
+DEVICE_SCHEMA = vol.Schema({
+    vol.Optional(CONF_MAC): cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICES, default={}):
+        vol.Schema({cv.string: DEVICE_SCHEMA}),
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the eq3 BLE thermostats."""
+    """Setup the eQ-3 BLE thermostats."""
     devices = []
 
     for name, device_cfg in config[CONF_DEVICES].items():
@@ -30,14 +44,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 # pylint: disable=too-many-instance-attributes, import-error, abstract-method
 class EQ3BTSmartThermostat(ClimateDevice):
-    """Representation of a EQ3 Bluetooth Smart thermostat."""
+    """Representation of a eQ-3 Bluetooth Smart thermostat."""
 
     def __init__(self, _mac, _name):
         """Initialize the thermostat."""
         from bluepy_devices.devices import eq3btsmart
 
         self._name = _name
-
         self._thermostat = eq3btsmart.EQ3BTSmartThermostat(_mac)
 
     @property
@@ -70,8 +83,10 @@ class EQ3BTSmartThermostat(ClimateDevice):
     @property
     def device_state_attributes(self):
         """Return the device specific state attributes."""
-        return {"mode": self._thermostat.mode,
-                "mode_readable": self._thermostat.mode_readable}
+        return {
+            ATTR_MODE: self._thermostat.mode,
+            ATTR_MODE_READBLE: self._thermostat.mode_readable,
+        }
 
     @property
     def min_temp(self):

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -19,14 +19,14 @@ REQUIREMENTS = ['bluepy_devices==0.2.0']
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_MODE = 'mode'
-ATTR_MODE_READBLE = 'mode_readable'
+ATTR_MODE_READABLE = 'mode_readable'
 
 DEVICE_SCHEMA = vol.Schema({
-    vol.Optional(CONF_MAC): cv.string,
+    vol.Required(CONF_MAC): cv.string,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_DEVICES, default={}):
+    vol.Required(CONF_DEVICES):
         vol.Schema({cv.string: DEVICE_SCHEMA}),
 })
 
@@ -85,7 +85,7 @@ class EQ3BTSmartThermostat(ClimateDevice):
         """Return the device specific state attributes."""
         return {
             ATTR_MODE: self._thermostat.mode,
-            ATTR_MODE_READBLE: self._thermostat.mode_readable,
+            ATTR_MODE_READABLE: self._thermostat.mode_readable,
         }
 
     @property


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
climate:
  - platform: eq3btsmart
    devices:
      room1:
        mac: '00:11:22:33:44:55'
      room3:
        mac: '00:11:22:33:44:12'
```
