### PR TITLE
Async exception handling

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -332,9 +332,10 @@ class HomeAssistant(object):
         # for debug modus
         exception = context.get('exception')
         if exception is not None:
+            exc_info = (type(exception), exception, exception.__traceback__)
             _LOGGER.debug(
-                "Exception inside async loop: %s",
-                exception
+                "Exception inside async loop: ",
+                exc_info=exc_info
             )
 
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -136,6 +136,7 @@ class HomeAssistant(object):
         self.loop = loop or asyncio.get_event_loop()
         self.executor = ThreadPoolExecutor(max_workers=5)
         self.loop.set_default_executor(self.executor)
+        self.loop.set_exception_handler(self._async_exception_handler)
         self.pool = pool = create_worker_pool()
         self.bus = EventBus(pool, self.loop)
         self.services = ServiceRegistry(self.bus, self.add_job, self.loop)
@@ -317,6 +318,13 @@ class HomeAssistant(object):
         self.executor.shutdown()
         self.state = CoreState.not_running
         self.loop.stop()
+
+    def _async_exception_handler(self, loop, context):
+        """Handle all exception inside the core loop."""
+        _LOGGER.warning(
+            "Exception inside async loop: %s",
+            context.get('message')
+        )
 
 
 class EventOrigin(enum.Enum):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -322,10 +322,20 @@ class HomeAssistant(object):
     # pylint: disable=no-self-use
     def _async_exception_handler(self, loop, context):
         """Handle all exception inside the core loop."""
-        _LOGGER.warning(
-            "Exception inside async loop: %s",
-            context.get('message')
-        )
+        message = context.get('message')
+        if message:
+            _LOGGER.warning(
+                "Error inside async loop: %s",
+                message
+            )
+
+        # for debug modus
+        exception = context.get('exception')
+        if exception is not None:
+            _LOGGER.debug(
+                "Exception inside async loop: %s",
+                exception
+            )
 
 
 class EventOrigin(enum.Enum):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -319,6 +319,7 @@ class HomeAssistant(object):
         self.state = CoreState.not_running
         self.loop.stop()
 
+    # pylint: disable=no-self-use
     def _async_exception_handler(self, loop, context):
         """Handle all exception inside the core loop."""
         _LOGGER.warning(

--- a/homeassistant/util/async.py
+++ b/homeassistant/util/async.py
@@ -120,7 +120,7 @@ def run_coroutine_threadsafe(coro, loop):
             if future.set_running_or_notify_cancel():
                 future.set_exception(exc)
             else:
-                _LOGGER.warning("Exception on lost future: %s", exc)
+                _LOGGER.warning("Exception on lost future: ", exc_info=True)
 
     loop.call_soon_threadsafe(callback)
     return future
@@ -169,7 +169,7 @@ def run_callback_threadsafe(loop, callback, *args):
             if future.set_running_or_notify_cancel():
                 future.set_exception(exc)
             else:
-                _LOGGER.warning("Exception on lost future: %s", exc)
+                _LOGGER.warning("Exception on lost future: ", exc_info=True)
 
     loop.call_soon_threadsafe(run_callback)
     return future

--- a/homeassistant/util/async.py
+++ b/homeassistant/util/async.py
@@ -1,6 +1,7 @@
 """Asyncio backports for Python 3.4.3 compatibility."""
 import concurrent.futures
 import threading
+import logging
 from asyncio import coroutines
 from asyncio.futures import Future
 
@@ -11,6 +12,9 @@ except ImportError:
     # pylint: disable=unused-import
     from asyncio import async
     ensure_future = async
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _set_result_unless_cancelled(fut, result):
@@ -114,6 +118,8 @@ def run_coroutine_threadsafe(coro, loop):
         except Exception as exc:
             if future.set_running_or_notify_cancel():
                 future.set_exception(exc)
+            else:
+                _LOGGER.warning("Exception on lost future: %s", exc)
 
     loop.call_soon_threadsafe(callback)
     return future
@@ -160,6 +166,8 @@ def run_callback_threadsafe(loop, callback, *args):
         except Exception as exc:
             if future.set_running_or_notify_cancel():
                 future.set_exception(exc)
+            else:
+                _LOGGER.warning("Exception on lost future: %s", exc)
 
     loop.call_soon_threadsafe(run_callback)
     return future

--- a/homeassistant/util/async.py
+++ b/homeassistant/util/async.py
@@ -115,6 +115,7 @@ def run_coroutine_threadsafe(coro, loop):
         try:
             # pylint: disable=deprecated-method
             _chain_future(ensure_future(coro, loop=loop), future)
+        # pylint: disable=broad-except
         except Exception as exc:
             if future.set_running_or_notify_cancel():
                 future.set_exception(exc)
@@ -163,6 +164,7 @@ def run_callback_threadsafe(loop, callback, *args):
         """Run callback and store result."""
         try:
             future.set_result(callback(*args))
+        # pylint: disable=broad-except
         except Exception as exc:
             if future.set_running_or_notify_cancel():
                 future.set_exception(exc)

--- a/homeassistant/util/async.py
+++ b/homeassistant/util/async.py
@@ -114,7 +114,6 @@ def run_coroutine_threadsafe(coro, loop):
         except Exception as exc:
             if future.set_running_or_notify_cancel():
                 future.set_exception(exc)
-            raise
 
     loop.call_soon_threadsafe(callback)
     return future
@@ -161,7 +160,6 @@ def run_callback_threadsafe(loop, callback, *args):
         except Exception as exc:
             if future.set_running_or_notify_cancel():
                 future.set_exception(exc)
-            raise
 
     loop.call_soon_threadsafe(run_callback)
     return future


### PR DESCRIPTION
**Description:**

Don't trow a exception on `run_callback_threadsafe` and `run_coroutine_threadsafe`. It save that to Future if a process is waiting to or it make a warning to log for developer that he know that it make a misstake.

Add a own exception handler to async loop and print a warning if exception is catch on loop. In debug mode it print a trace. So have the user only a message and not a lot uf stuff who are not understund. This ignore also message like "exception was never retrieved" and protect the async loop.

CC @balloob @bbangert 

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
