### PR TITLE
Use voluptuous for Heatmiser

### DIFF
--- a/homeassistant/components/climate/heatmiser.py
+++ b/homeassistant/components/climate/heatmiser.py
@@ -1,56 +1,54 @@
 """
 Support for the PRT Heatmiser themostats using the V3 protocol.
 
-See https://github.com/andylockran/heatmiserV3 for more info on the
-heatmiserV3 module dependency.
-
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.heatmiser/
 """
 import logging
 
-from homeassistant.components.climate import ClimateDevice
-from homeassistant.const import TEMP_CELSIUS, ATTR_TEMPERATURE
+import voluptuous as vol
 
-CONF_IPADDRESS = 'ipaddress'
-CONF_PORT = 'port'
-CONF_TSTATS = 'tstats'
+from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
+from homeassistant.const import (
+    TEMP_CELSIUS, ATTR_TEMPERATURE, CONF_PORT, CONF_NAME, CONF_ID)
+import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ["heatmiserV3==0.9.1"]
+REQUIREMENTS = ['heatmiserV3==0.9.1']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_IPADDRESS = 'ipaddress'
+CONF_TSTATS = 'tstats'
 
+TSTATS_SCHEMA = vol.Schema({
+    vol.Required(CONF_ID): cv.string,
+    vol.Required(CONF_NAME): cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_IPADDRESS): cv.string,
+    vol.Required(CONF_PORT): cv.port,
+    vol.Required(CONF_TSTATS, default={}):
+        vol.Schema({cv.string: TSTATS_SCHEMA}),
+})
+
+
+# pylint: disable=unused-variable
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the heatmiser thermostat."""
     from heatmiserV3 import heatmiser, connection
 
-    ipaddress = str(config[CONF_IPADDRESS])
-    port = str(config[CONF_PORT])
-
-    if ipaddress is None or port is None:
-        _LOGGER.error("Missing required configuration items %s or %s",
-                      CONF_IPADDRESS, CONF_PORT)
-        return False
+    ipaddress = config.get(CONF_IPADDRESS)
+    port = str(config.get(CONF_PORT))
+    tstats = config.get(CONF_TSTATS)
 
     serport = connection.connection(ipaddress, port)
     serport.open()
 
-    tstats = []
-    if CONF_TSTATS in config:
-        tstats = config[CONF_TSTATS]
-
-    if tstats is None:
-        _LOGGER.error("No thermostats configured.")
-        return False
-
-    for tstat in tstats:
+    for thermostat, tstat in tstats.items():
         add_devices([
             HeatmiserV3Thermostat(
-                heatmiser,
-                tstat.get("id"),
-                tstat.get("name"),
-                serport)
+                heatmiser, tstat.get(CONF_ID), tstat.get(CONF_NAME), serport)
             ])
     return
 
@@ -69,7 +67,7 @@ class HeatmiserV3Thermostat(ClimateDevice):
         self._id = device
         self.dcb = None
         self.update()
-        self._target_temperature = int(self.dcb.get("roomset"))
+        self._target_temperature = int(self.dcb.get('roomset'))
 
     @property
     def name(self):
@@ -85,9 +83,9 @@ class HeatmiserV3Thermostat(ClimateDevice):
     def current_temperature(self):
         """Return the current temperature."""
         if self.dcb is not None:
-            low = self.dcb.get("floortemplow ")
-            high = self.dcb.get("floortemphigh")
-            temp = (high*256 + low)/10.0
+            low = self.dcb.get('floortemplow ')
+            high = self.dcb.get('floortemphigh')
+            temp = (high * 256 + low) / 10.0
             self._current_temperature = temp
         else:
             self._current_temperature = None


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
climate:
  - platform: heatmiser
    ipaddress: 10.0.0.204
    port: 123
    tstats:
      1:
        id: 1xxx
        name: thermo1
      3:
        id: 2xxx
        name: thermo2
```

The docs were not clear how the `tstats:` should look like. This PR uses the same style for multiple entries as others do. 

It would be preferred if somebody with Heatmiser hardware could test this change.
