### PR TITLE
Setup all valid platforms, ignore invalid platforms

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -38,6 +38,7 @@ def setup_component(hass: core.HomeAssistant, domain: str,
                     config: Optional[Dict]=None) -> bool:
     """Setup a component and all its dependencies."""
     if domain in hass.config.components:
+        _LOGGER.debug('Component %s already set up.', domain)
         return True
 
     _ensure_loader_prepared(hass)
@@ -53,6 +54,7 @@ def setup_component(hass: core.HomeAssistant, domain: str,
 
     for component in components:
         if not _setup_component(hass, component, config):
+            _LOGGER.error('Component %s failed to setup', component)
             return False
 
     return True
@@ -158,7 +160,7 @@ def prepare_setup_component(hass: core.HomeAssistant, config: dict,
                 p_validated = component.PLATFORM_SCHEMA(p_config)
             except vol.Invalid as ex:
                 log_exception(ex, domain, config)
-                return None
+                continue
 
             # Not all platform components follow same pattern for platforms
             # So if p_name is None we are not going to validate platform
@@ -171,7 +173,7 @@ def prepare_setup_component(hass: core.HomeAssistant, config: dict,
                                               p_name)
 
             if platform is None:
-                return None
+                continue
 
             # Validate platform specific schema
             if hasattr(platform, 'PLATFORM_SCHEMA'):
@@ -180,7 +182,7 @@ def prepare_setup_component(hass: core.HomeAssistant, config: dict,
                 except vol.Invalid as ex:
                     log_exception(ex, '{}.{}'.format(domain, p_name),
                                   p_validated)
-                    return None
+                    continue
 
             platforms.append(p_validated)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,9 +7,10 @@ from unittest.mock import patch
 from io import StringIO
 import logging
 import threading
+from contextlib import contextmanager
 
 from homeassistant import core as ha, loader
-from homeassistant.bootstrap import setup_component
+from homeassistant.bootstrap import setup_component, prepare_setup_component
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.util.unit_system import METRIC_SYSTEM
 import homeassistant.util.dt as date_util
@@ -58,6 +59,8 @@ def get_test_home_assistant(num_threads=None):
     stop_event = threading.Event()
 
     def run_loop():
+        """Run event loop."""
+        # pylint: disable=protected-access
         loop._thread_ident = threading.get_ident()
         loop.run_forever()
         loop.close()
@@ -70,6 +73,7 @@ def get_test_home_assistant(num_threads=None):
 
     @asyncio.coroutine
     def fake_stop():
+        """Fake stop."""
         yield None
 
     def start_hass():
@@ -84,6 +88,7 @@ def get_test_home_assistant(num_threads=None):
                             hass.block_till_done()
 
     def stop_hass():
+        """Stop hass."""
         orig_stop()
         stop_event.wait()
 
@@ -112,6 +117,7 @@ def mock_service(hass, domain, service):
     """
     calls = []
 
+    # pylint: disable=unnecessary-lambda
     hass.services.register(domain, service, lambda call: calls.append(call))
 
     return calls
@@ -315,3 +321,41 @@ def patch_yaml_files(files_dict, endswith=True):
         raise FileNotFoundError('File not found: {}'.format(fname))
 
     return patch.object(yaml, 'open', mock_open_f, create=True)
+
+
+@contextmanager
+def assert_setup_component(count, domain=None):
+    """Collect valid configuration from setup_component.
+
+    - count: The amount of valid platforms that should be setup
+    - domain: The domain to count is optional. It can be automatically
+              determined most of the time
+
+    Use as a context manager aroung bootstrap.setup_component
+        with assert_setup_component(0) as result_config:
+            setup_component(hass, start_config, domain)
+            # using result_config is optional
+    """
+    config = {}
+
+    def mock_psc(hass, config_input, domain):
+        """Mock the prepare_setup_component to capture config."""
+        res = prepare_setup_component(hass, config_input, domain)
+        config[domain] = None if res is None else res.get(domain)
+        _LOGGER.debug('Configuration for %s, Validated: %s, Original %s',
+                      domain, config[domain], config_input.get(domain))
+        return res
+
+    assert isinstance(config, dict)
+    with patch('homeassistant.bootstrap.prepare_setup_component', mock_psc):
+        yield config
+
+    if domain is None:
+        assert len(config) == 1, ('assert_setup_component requires DOMAIN: {}'
+                                  .format(list(config.keys())))
+        domain = list(config.keys())[0]
+
+    res = config.get(domain)
+    res_len = 0 if res is None else len(res)
+    assert res_len == count, 'setup_component failed, expected {} got {}: {}' \
+        .format(count, res_len, res)

--- a/tests/components/alarm_control_panel/test_mqtt.py
+++ b/tests/components/alarm_control_panel/test_mqtt.py
@@ -1,14 +1,15 @@
 """The tests the MQTT alarm control panel component."""
 import unittest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.const import (
     STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED, STATE_UNKNOWN)
 from homeassistant.components import alarm_control_panel
 
 from tests.common import (
-    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant)
+    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant,
+    assert_setup_component)
 
 CODE = 'HELLO_CODE'
 
@@ -16,7 +17,9 @@ CODE = 'HELLO_CODE'
 class TestAlarmControlPanelMQTT(unittest.TestCase):
     """Test the manual alarm module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
@@ -28,27 +31,30 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
     def test_fail_setup_without_state_topic(self):
         """Test for failing with no state topic."""
         self.hass.config.components = ['mqtt']
-        assert not _setup_component(self.hass, alarm_control_panel.DOMAIN, {
-            alarm_control_panel.DOMAIN: {
-                'platform': 'mqtt',
-                'command_topic': 'alarm/command'
-            }
-        })
+        with assert_setup_component(0) as config:
+            assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
+                alarm_control_panel.DOMAIN: {
+                    'platform': 'mqtt',
+                    'command_topic': 'alarm/command'
+                }
+            })
+            assert not config[alarm_control_panel.DOMAIN]
 
     def test_fail_setup_without_command_topic(self):
         """Test failing with no command topic."""
         self.hass.config.components = ['mqtt']
-        assert not _setup_component(self.hass, alarm_control_panel.DOMAIN, {
-            alarm_control_panel.DOMAIN: {
-                'platform': 'mqtt',
-                'state_topic': 'alarm/state'
-            }
-        })
+        with assert_setup_component(0):
+            assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
+                alarm_control_panel.DOMAIN: {
+                    'platform': 'mqtt',
+                    'state_topic': 'alarm/state'
+                }
+            })
 
     def test_update_state_via_state_topic(self):
         """Test updating with via state topic."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, alarm_control_panel.DOMAIN, {
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -72,7 +78,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
     def test_ignore_update_state_if_unknown_via_state_topic(self):
         """Test ignoring updates via state topic."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, alarm_control_panel.DOMAIN, {
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -93,7 +99,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
     def test_arm_home_publishes_mqtt(self):
         """Test publishing of MQTT messages while armed."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, alarm_control_panel.DOMAIN, {
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -110,7 +116,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
     def test_arm_home_not_publishes_mqtt_with_invalid_code(self):
         """Test not publishing of MQTT messages with invalid code."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, alarm_control_panel.DOMAIN, {
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -128,7 +134,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
     def test_arm_away_publishes_mqtt(self):
         """Test publishing of MQTT messages while armed."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, alarm_control_panel.DOMAIN, {
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -145,7 +151,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
     def test_arm_away_not_publishes_mqtt_with_invalid_code(self):
         """Test not publishing of MQTT messages with invalid code."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, alarm_control_panel.DOMAIN, {
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -163,7 +169,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
     def test_disarm_publishes_mqtt(self):
         """Test publishing of MQTT messages while disarmed."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, alarm_control_panel.DOMAIN, {
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -180,7 +186,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
     def test_disarm_not_publishes_mqtt_with_invalid_code(self):
         """Test not publishing of MQTT messages with invalid code."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, alarm_control_panel.DOMAIN, {
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',

--- a/tests/components/binary_sensor/test_sleepiq.py
+++ b/tests/components/binary_sensor/test_sleepiq.py
@@ -4,10 +4,11 @@ from unittest.mock import MagicMock
 
 import requests_mock
 
-from homeassistant import core as ha
+from homeassistant.bootstrap import setup_component
 from homeassistant.components.binary_sensor import sleepiq
 
 from tests.components.test_sleepiq import mock_responses
+from tests.common import get_test_home_assistant
 
 
 class TestSleepIQBinarySensorSetup(unittest.TestCase):
@@ -22,7 +23,7 @@ class TestSleepIQBinarySensorSetup(unittest.TestCase):
 
     def setUp(self):
         """Initialize values for this testcase class."""
-        self.hass = ha.HomeAssistant()
+        self.hass = get_test_home_assistant()
         self.username = 'foo'
         self.password = 'bar'
         self.config = {
@@ -34,6 +35,9 @@ class TestSleepIQBinarySensorSetup(unittest.TestCase):
     def test_setup(self, mock):
         """Test for successfully setting up the SleepIQ platform."""
         mock_responses(mock)
+
+        setup_component(self.hass, 'sleepiq', {
+            'sleepiq': self.config})
 
         sleepiq.setup_platform(self.hass,
                                self.config,

--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -9,11 +9,14 @@ from homeassistant.components.binary_sensor import template
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template as template_hlpr
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, assert_setup_component
 
 
 class TestBinarySensorTemplate(unittest.TestCase):
     """Test for Binary sensor template platform."""
+
+    hass = None
+    # pylint: disable=invalid-name
 
     def setup_method(self, method):
         """Setup things to be run when tests are started."""
@@ -47,53 +50,53 @@ class TestBinarySensorTemplate(unittest.TestCase):
 
     def test_setup_no_sensors(self):
         """"Test setup with no sensors."""
-        result = bootstrap.setup_component(self.hass, 'sensor', {
-            'sensor': {
-                'platform': 'template'
-            }
-        })
-        self.assertFalse(result)
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template'
+                }
+            })
 
     def test_setup_invalid_device(self):
         """"Test the setup with invalid devices."""
-        result = bootstrap.setup_component(self.hass, 'sensor', {
-            'sensor': {
-                'platform': 'template',
-                'sensors': {
-                    'foo bar': {},
-                },
-            }
-        })
-        self.assertFalse(result)
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'foo bar': {},
+                    },
+                }
+            })
 
     def test_setup_invalid_sensor_class(self):
         """"Test setup with invalid sensor class."""
-        result = bootstrap.setup_component(self.hass, 'sensor', {
-            'sensor': {
-                'platform': 'template',
-                'sensors': {
-                    'test': {
-                        'value_template': '{{ foo }}',
-                        'sensor_class': 'foobarnotreal',
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test': {
+                            'value_template': '{{ foo }}',
+                            'sensor_class': 'foobarnotreal',
+                        },
                     },
-                },
-            }
-        })
-        self.assertFalse(result)
+                }
+            })
 
     def test_setup_invalid_missing_template(self):
         """"Test setup with invalid and missing template."""
-        result = bootstrap.setup_component(self.hass, 'sensor', {
-            'sensor': {
-                'platform': 'template',
-                'sensors': {
-                    'test': {
-                        'sensor_class': 'motion',
-                    },
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test': {
+                            'sensor_class': 'motion',
+                        },
+                    }
                 }
-            }
-        })
-        self.assertFalse(result)
+            })
 
     def test_attributes(self):
         """"Test the attributes."""
@@ -107,7 +110,9 @@ class TestBinarySensorTemplate(unittest.TestCase):
         vs.update()
         self.assertFalse(vs.is_on)
 
+        # pylint: disable=protected-access
         vs._template = template_hlpr.Template("{{ 2 > 1 }}", self.hass)
+
         vs.update()
         self.assertTrue(vs.is_on)
 

--- a/tests/components/binary_sensor/test_trend.py
+++ b/tests/components/binary_sensor/test_trend.py
@@ -1,11 +1,13 @@
 """The test for the Trend sensor platform."""
 import homeassistant.bootstrap as bootstrap
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, assert_setup_component
 
 
 class TestTrendBinarySensor:
     """Test the Trend sensor."""
+
+    hass = None
 
     def setup_method(self, method):
         """Setup things to be run when tests are started."""
@@ -189,41 +191,46 @@ class TestTrendBinarySensor:
         state = self.hass.states.get('binary_sensor.test_trend_sensor')
         assert state.state == 'off'
 
-    def test_invalid_name_does_not_create(self):
+    def test_invalid_name_does_not_create(self): \
+            # pylint: disable=invalid-name
         """Test invalid name."""
-        assert not bootstrap.setup_component(self.hass, 'binary_sensor', {
-            'binary_sensor': {
-                'platform': 'template',
-                'sensors': {
-                    'test INVALID sensor': {
-                        'entity_id':
-                            "sensor.test_state"
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+                'binary_sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test INVALID sensor': {
+                            'entity_id':
+                                "sensor.test_state"
+                        }
                     }
                 }
-            }
-        })
+            })
         assert self.hass.states.all() == []
 
-    def test_invalid_sensor_does_not_create(self):
+    def test_invalid_sensor_does_not_create(self): \
+            # pylint: disable=invalid-name
         """Test invalid sensor."""
-        assert not bootstrap.setup_component(self.hass, 'binary_sensor', {
-            'binary_sensor': {
-                'platform': 'template',
-                'sensors': {
-                    'test_trend_sensor': {
-                        'not_entity_id':
-                            "sensor.test_state"
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+                'binary_sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test_trend_sensor': {
+                            'not_entity_id':
+                                "sensor.test_state"
+                        }
                     }
                 }
-            }
-        })
+            })
         assert self.hass.states.all() == []
 
     def test_no_sensors_does_not_create(self):
         """Test no sensors."""
-        assert not bootstrap.setup_component(self.hass, 'binary_sensor', {
-            'binary_sensor': {
-                'platform': 'trend'
-            }
-        })
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+                'binary_sensor': {
+                    'platform': 'trend'
+                }
+            })
         assert self.hass.states.all() == []

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.components import climate
 
-from tests.common import get_test_home_assistant
+from tests.common import assert_setup_component, get_test_home_assistant
 
 
 ENTITY = 'climate.test'
@@ -44,8 +44,9 @@ class TestSetupClimateGenericThermostat(unittest.TestCase):
             'name': 'test',
             'target_sensor': ENT_SENSOR
         }
-        self.assertFalse(setup_component(self.hass, 'climate', {
-            'climate': config}))
+        with assert_setup_component(0):
+            setup_component(self.hass, 'climate', {
+                'climate': config})
 
     def test_valid_conf(self):
         """Test set up genreic_thermostat with valid config values."""

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -17,7 +17,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import (
     get_test_home_assistant, fire_time_changed, fire_service_discovered,
-    patch_yaml_files)
+    patch_yaml_files, assert_setup_component)
 
 TEST_PLATFORM = {device_tracker.DOMAIN: {CONF_PLATFORM: 'test'}}
 
@@ -338,6 +338,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     @patch('homeassistant.components.device_tracker.log_exception')
     def test_config_failure(self, mock_ex):
         """Test that the device tracker see failures."""
-        assert not setup_component(self.hass, device_tracker.DOMAIN,
-                                   {device_tracker.DOMAIN: {
-                                    device_tracker.CONF_CONSIDER_HOME: -1}})
+        with assert_setup_component(0, device_tracker.DOMAIN):
+            setup_component(self.hass, device_tracker.DOMAIN,
+                            {device_tracker.DOMAIN: {
+                                device_tracker.CONF_CONSIDER_HOME: -1}})

--- a/tests/components/garage_door/test_mqtt.py
+++ b/tests/components/garage_door/test_mqtt.py
@@ -1,18 +1,21 @@
 """The tests for the MQTT Garge door platform."""
 import unittest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.const import STATE_OPEN, STATE_CLOSED, ATTR_ASSUMED_STATE
 
 import homeassistant.components.garage_door as garage_door
 from tests.common import (
-    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant)
+    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant,
+    assert_setup_component)
 
 
 class TestGarageDoorMQTT(unittest.TestCase):
     """Test the MQTT Garage door."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
@@ -24,29 +27,31 @@ class TestGarageDoorMQTT(unittest.TestCase):
     def test_fail_setup_if_no_command_topic(self):
         """Test if command fails with command topic."""
         self.hass.config.components = ['mqtt']
-        assert not _setup_component(self.hass, garage_door.DOMAIN, {
-            garage_door.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': '/home/garage_door/door'
-            }
-        })
+        with assert_setup_component(0):
+            assert setup_component(self.hass, garage_door.DOMAIN, {
+                garage_door.DOMAIN: {
+                    'platform': 'mqtt',
+                    'name': 'test',
+                    'state_topic': '/home/garage_door/door'
+                }
+            })
         self.assertIsNone(self.hass.states.get('garage_door.test'))
 
     def test_controlling_state_via_topic(self):
         """Test the controlling state via topic."""
-        assert _setup_component(self.hass, garage_door.DOMAIN, {
-            garage_door.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'state_open': 1,
-                'state_closed': 0,
-                'service_open': 1,
-                'service_close': 0
-            }
-        })
+        with assert_setup_component(1):
+            assert setup_component(self.hass, garage_door.DOMAIN, {
+                garage_door.DOMAIN: {
+                    'platform': 'mqtt',
+                    'name': 'test',
+                    'state_topic': 'state-topic',
+                    'command_topic': 'command-topic',
+                    'state_open': 1,
+                    'state_closed': 0,
+                    'service_open': 1,
+                    'service_close': 0
+                }
+            })
 
         state = self.hass.states.get('garage_door.test')
         self.assertEqual(STATE_CLOSED, state.state)
@@ -66,18 +71,19 @@ class TestGarageDoorMQTT(unittest.TestCase):
 
     def test_sending_mqtt_commands_and_optimistic(self):
         """Test the sending MQTT commands in optimistic mode."""
-        assert _setup_component(self.hass, garage_door.DOMAIN, {
-            garage_door.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'command_topic': 'command-topic',
-                'state_open': 'beer state open',
-                'state_closed': 'beer state closed',
-                'service_open': 'beer open',
-                'service_close': 'beer close',
-                'qos': '2'
-            }
-        })
+        with assert_setup_component(1):
+            assert setup_component(self.hass, garage_door.DOMAIN, {
+                garage_door.DOMAIN: {
+                    'platform': 'mqtt',
+                    'name': 'test',
+                    'command_topic': 'command-topic',
+                    'state_open': 'beer state open',
+                    'state_closed': 'beer state closed',
+                    'service_open': 'beer open',
+                    'service_close': 'beer close',
+                    'qos': '2'
+                }
+            })
 
         state = self.hass.states.get('garage_door.test')
         self.assertEqual(STATE_CLOSED, state.state)
@@ -101,19 +107,20 @@ class TestGarageDoorMQTT(unittest.TestCase):
 
     def test_controlling_state_via_topic_and_json_message(self):
         """Test the controlling state via topic and JSON message."""
-        assert _setup_component(self.hass, garage_door.DOMAIN, {
-            garage_door.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'state_open': 'beer open',
-                'state_closed': 'beer closed',
-                'service_open': 'beer service open',
-                'service_close': 'beer service close',
-                'value_template': '{{ value_json.val }}'
-            }
-        })
+        with assert_setup_component(1):
+            assert setup_component(self.hass, garage_door.DOMAIN, {
+                garage_door.DOMAIN: {
+                    'platform': 'mqtt',
+                    'name': 'test',
+                    'state_topic': 'state-topic',
+                    'command_topic': 'command-topic',
+                    'state_open': 'beer open',
+                    'state_closed': 'beer closed',
+                    'service_open': 'beer service open',
+                    'service_close': 'beer service close',
+                    'value_template': '{{ value_json.val }}'
+                }
+            })
 
         state = self.hass.states.get('garage_door.test')
         self.assertEqual(STATE_CLOSED, state.state)

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -30,11 +30,12 @@ light:
 import json
 import unittest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import _setup_component, setup_component
 from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.light as light
 from tests.common import (
-    get_test_home_assistant, mock_mqtt_component, fire_mqtt_message)
+    get_test_home_assistant, mock_mqtt_component, fire_mqtt_message,
+    assert_setup_component)
 
 
 class TestLightMQTTJSON(unittest.TestCase):
@@ -49,18 +50,21 @@ class TestLightMQTTJSON(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    def test_fail_setup_if_no_command_topic(self):
+    def test_fail_setup_if_no_command_topic(self): \
+            # pylint: disable=invalid-name
         """Test if setup fails with no command topic."""
         self.hass.config.components = ['mqtt']
-        assert not _setup_component(self.hass, light.DOMAIN, {
-            light.DOMAIN: {
-                'platform': 'mqtt_json',
-                'name': 'test',
-            }
-        })
+        with assert_setup_component(0):
+            assert setup_component(self.hass, light.DOMAIN, {
+                light.DOMAIN: {
+                    'platform': 'mqtt_json',
+                    'name': 'test',
+                }
+            })
         self.assertIsNone(self.hass.states.get('light.test'))
 
-    def test_no_color_or_brightness_if_no_config(self):
+    def test_no_color_or_brightness_if_no_config(self): \
+            # pylint: disable=invalid-name
         """Test if there is no color and brightness if they aren't defined."""
         self.hass.config.components = ['mqtt']
         assert _setup_component(self.hass, light.DOMAIN, {
@@ -85,7 +89,8 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertIsNone(state.attributes.get('rgb_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-    def test_controlling_state_via_topic(self):
+    def test_controlling_state_via_topic(self): \
+            # pylint: disable=invalid-name
         """Test the controlling of the state via topic."""
         self.hass.config.components = ['mqtt']
         assert _setup_component(self.hass, light.DOMAIN, {
@@ -108,10 +113,9 @@ class TestLightMQTTJSON(unittest.TestCase):
 
         # Turn on the light, full white
         fire_mqtt_message(self.hass, 'test_light_rgb',
-                          '{"state":"ON",' +
-                          '"color":{"r":255,"g":255,"b":255},' +
-                          '"brightness":255}'
-                          )
+                          '{"state":"ON",'
+                          '"color":{"r":255,"g":255,"b":255},'
+                          '"brightness":255}')
         self.hass.block_till_done()
 
         state = self.hass.states.get('light.test')
@@ -127,9 +131,8 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertEqual(STATE_OFF, state.state)
 
         fire_mqtt_message(self.hass, 'test_light_rgb',
-                          '{"state":"ON",' +
-                          '"brightness":100}'
-                          )
+                          '{"state":"ON",'
+                          '"brightness":100}')
         self.hass.block_till_done()
 
         light_state = self.hass.states.get('light.test')
@@ -138,16 +141,16 @@ class TestLightMQTTJSON(unittest.TestCase):
                          light_state.attributes['brightness'])
 
         fire_mqtt_message(self.hass, 'test_light_rgb',
-                          '{"state":"ON",' +
-                          '"color":{"r":125,"g":125,"b":125}}'
-                          )
+                          '{"state":"ON",'
+                          '"color":{"r":125,"g":125,"b":125}}')
         self.hass.block_till_done()
 
         light_state = self.hass.states.get('light.test')
         self.assertEqual([125, 125, 125],
                          light_state.attributes.get('rgb_color'))
 
-    def test_sending_mqtt_commands_and_optimistic(self):
+    def test_sending_mqtt_commands_and_optimistic(self): \
+            # pylint: disable=invalid-name
         """Test the sending of command in optimistic mode."""
         self.hass.config.components = ['mqtt']
         assert _setup_component(self.hass, light.DOMAIN, {
@@ -202,7 +205,8 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertEqual((75, 75, 75), state.attributes['rgb_color'])
         self.assertEqual(50, state.attributes['brightness'])
 
-    def test_flash_short_and_long(self):
+    def test_flash_short_and_long(self): \
+            # pylint: disable=invalid-name
         """Test for flash length being sent when included."""
         self.hass.config.components = ['mqtt']
         assert _setup_component(self.hass, light.DOMAIN, {
@@ -285,7 +289,8 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertEqual(10, message_json["transition"])
         self.assertEqual("OFF", message_json["state"])
 
-    def test_invalid_color_and_brightness_values(self):
+    def test_invalid_color_and_brightness_values(self): \
+            # pylint: disable=invalid-name
         """Test that invalid color/brightness values are ignored."""
         self.hass.config.components = ['mqtt']
         assert _setup_component(self.hass, light.DOMAIN, {
@@ -308,10 +313,9 @@ class TestLightMQTTJSON(unittest.TestCase):
 
         # Turn on the light
         fire_mqtt_message(self.hass, 'test_light_rgb',
-                          '{"state":"ON",' +
-                          '"color":{"r":255,"g":255,"b":255},' +
-                          '"brightness": 255}'
-                          )
+                          '{"state":"ON",'
+                          '"color":{"r":255,"g":255,"b":255},'
+                          '"brightness": 255}')
         self.hass.block_till_done()
 
         state = self.hass.states.get('light.test')
@@ -321,9 +325,8 @@ class TestLightMQTTJSON(unittest.TestCase):
 
         # Bad color values
         fire_mqtt_message(self.hass, 'test_light_rgb',
-                          '{"state":"ON",' +
-                          '"color":{"r":"bad","g":"val","b":"test"}}'
-                          )
+                          '{"state":"ON",'
+                          '"color":{"r":"bad","g":"val","b":"test"}}')
         self.hass.block_till_done()
 
         # Color should not have changed
@@ -333,9 +336,8 @@ class TestLightMQTTJSON(unittest.TestCase):
 
         # Bad brightness values
         fire_mqtt_message(self.hass, 'test_light_rgb',
-                          '{"state":"ON",' +
-                          '"brightness": "badValue"}'
-                          )
+                          '{"state":"ON",'
+                          '"brightness": "badValue"}')
         self.hass.block_till_done()
 
         # Brightness should not have changed

--- a/tests/components/notify/test_group.py
+++ b/tests/components/notify/test_group.py
@@ -5,7 +5,7 @@ from homeassistant.bootstrap import setup_component
 import homeassistant.components.notify as notify
 from homeassistant.components.notify import group
 
-from tests.common import get_test_home_assistant
+from tests.common import assert_setup_component, get_test_home_assistant
 
 
 class TestNotifyGroup(unittest.TestCase):
@@ -15,15 +15,16 @@ class TestNotifyGroup(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.events = []
-        self.assertTrue(setup_component(self.hass, notify.DOMAIN, {
-            'notify': [{
-                'name': 'demo1',
-                'platform': 'demo'
-            }, {
-                'name': 'demo2',
-                'platform': 'demo'
-            }]
-        }))
+        with assert_setup_component(2):
+            setup_component(self.hass, notify.DOMAIN, {
+                'notify': [{
+                    'name': 'demo1',
+                    'platform': 'demo'
+                }, {
+                    'name': 'demo2',
+                    'platform': 'demo'
+                }]
+            })
 
         self.service = group.get_service(self.hass, {'services': [
             {'service': 'demo1'},

--- a/tests/components/sensor/test_darksky.py
+++ b/tests/components/sensor/test_darksky.py
@@ -57,12 +57,12 @@ class TestDarkSkySetup(unittest.TestCase):
 
     @requests_mock.Mocker()
     @patch('forecastio.api.get_forecast', wraps=forecastio.api.get_forecast)
-    def test_setup(self, m, mock_get_forecast):
+    def test_setup(self, mock_req, mock_get_forecast):
         """Test for successfully setting up the forecast.io platform."""
-        uri = ('https://api.darksky.net\/forecast\/(\w+)\/'
-               '(-?\d+\.?\d*),(-?\d+\.?\d*)')
-        m.get(re.compile(uri),
-              text=load_fixture('darksky.json'))
+        uri = (r'https://api.(darksky.net|forecast.io)\/forecast\/(\w+)\/'
+               r'(-?\d+\.?\d*),(-?\d+\.?\d*)')
+        mock_req.get(re.compile(uri),
+                     text=load_fixture('darksky.json'))
         darksky.setup_platform(self.hass, self.config, MagicMock())
         self.assertTrue(mock_get_forecast.called)
         self.assertEqual(mock_get_forecast.call_count, 1)

--- a/tests/components/sensor/test_sleepiq.py
+++ b/tests/components/sensor/test_sleepiq.py
@@ -4,10 +4,10 @@ from unittest.mock import MagicMock
 
 import requests_mock
 
-from homeassistant import core as ha
 from homeassistant.components.sensor import sleepiq
 
 from tests.components.test_sleepiq import mock_responses
+from tests.common import get_test_home_assistant
 
 
 class TestSleepIQSensorSetup(unittest.TestCase):
@@ -22,7 +22,7 @@ class TestSleepIQSensorSetup(unittest.TestCase):
 
     def setUp(self):
         """Initialize values for this testcase class."""
-        self.hass = ha.HomeAssistant()
+        self.hass = get_test_home_assistant()
         self.username = 'foo'
         self.password = 'bar'
         self.config = {

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -1,11 +1,14 @@
 """The test for the Template sensor platform."""
-import homeassistant.bootstrap as bootstrap
+from homeassistant.bootstrap import setup_component
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, assert_setup_component
 
 
 class TestTemplateSensor:
     """Test the Template sensor."""
+
+    hass = None
+    # pylint: disable=invalid-name
 
     def setup_method(self, method):
         """Setup things to be run when tests are started."""
@@ -17,17 +20,18 @@ class TestTemplateSensor:
 
     def test_template(self):
         """Test template."""
-        assert bootstrap.setup_component(self.hass, 'sensor', {
-            'sensor': {
-                'platform': 'template',
-                'sensors': {
-                    'test_template_sensor': {
-                        'value_template':
-                            "It {{ states.sensor.test_state.state }}."
+        with assert_setup_component(1):
+            assert setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test_template_sensor': {
+                            'value_template':
+                                "It {{ states.sensor.test_state.state }}."
+                        }
                     }
                 }
-            }
-        })
+            })
 
         state = self.hass.states.get('sensor.test_template_sensor')
         assert state.state == 'It .'
@@ -39,83 +43,89 @@ class TestTemplateSensor:
 
     def test_template_syntax_error(self):
         """Test templating syntax error."""
-        assert not bootstrap.setup_component(self.hass, 'sensor', {
-            'sensor': {
-                'platform': 'template',
-                'sensors': {
-                    'test_template_sensor': {
-                        'value_template':
-                            "{% if rubbish %}"
+        with assert_setup_component(0):
+            assert setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test_template_sensor': {
+                            'value_template':
+                                "{% if rubbish %}"
+                        }
                     }
                 }
-            }
-        })
+            })
         assert self.hass.states.all() == []
 
     def test_template_attribute_missing(self):
         """Test missing attribute template."""
-        assert bootstrap.setup_component(self.hass, 'sensor', {
-            'sensor': {
-                'platform': 'template',
-                'sensors': {
-                    'test_template_sensor': {
-                        'value_template':
-                        "It {{ states.sensor.test_state.attributes.missing }}."
+        with assert_setup_component(1):
+            assert setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test_template_sensor': {
+                            'value_template': 'It {{ states.sensor.test_state'
+                                              '.attributes.missing }}.'
+                        }
                     }
                 }
-            }
-        })
+            })
 
         state = self.hass.states.get('sensor.test_template_sensor')
         assert state.state == 'unknown'
 
     def test_invalid_name_does_not_create(self):
         """Test invalid name."""
-        assert not bootstrap.setup_component(self.hass, 'sensor', {
-            'sensor': {
-                'platform': 'template',
-                'sensors': {
-                    'test INVALID sensor': {
-                        'value_template':
-                            "{{ states.sensor.test_state.state }}"
+        with assert_setup_component(0):
+            assert setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test INVALID sensor': {
+                            'value_template':
+                                "{{ states.sensor.test_state.state }}"
+                        }
                     }
                 }
-            }
-        })
+            })
         assert self.hass.states.all() == []
 
     def test_invalid_sensor_does_not_create(self):
         """Test invalid sensor."""
-        assert not bootstrap.setup_component(self.hass, 'sensor', {
-            'sensor': {
-                'platform': 'template',
-                'sensors': {
-                    'test_template_sensor': 'invalid'
+        with assert_setup_component(0):
+            assert setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test_template_sensor': 'invalid'
+                    }
                 }
-            }
-        })
+            })
         assert self.hass.states.all() == []
 
     def test_no_sensors_does_not_create(self):
         """Test no sensors."""
-        assert not bootstrap.setup_component(self.hass, 'sensor', {
-            'sensor': {
-                'platform': 'template'
-            }
-        })
+        with assert_setup_component(0):
+            assert setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template'
+                }
+            })
         assert self.hass.states.all() == []
 
     def test_missing_template_does_not_create(self):
         """Test missing template."""
-        assert not bootstrap.setup_component(self.hass, 'sensor', {
-            'sensor': {
-                'platform': 'template',
-                'sensors': {
-                    'test_template_sensor': {
-                        'not_value_template':
-                            "{{ states.sensor.test_state.state }}"
+        with assert_setup_component(0):
+            assert setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test_template_sensor': {
+                            'not_value_template':
+                                "{{ states.sensor.test_state.state }}"
+                        }
                     }
                 }
-            }
-        })
+            })
         assert self.hass.states.all() == []

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -1,6 +1,6 @@
 """The tests for the Flux switch platform."""
-import unittest
 from datetime import timedelta
+import unittest
 from unittest.mock import patch
 
 from homeassistant.bootstrap import setup_component
@@ -8,8 +8,10 @@ from homeassistant.components import switch, light
 from homeassistant.const import CONF_PLATFORM, STATE_ON, SERVICE_TURN_ON
 import homeassistant.loader as loader
 import homeassistant.util.dt as dt_util
-from tests.common import get_test_home_assistant
-from tests.common import fire_time_changed, mock_service
+
+from tests.common import (
+    assert_setup_component, get_test_home_assistant, fire_time_changed,
+    mock_service)
 
 
 class TestSwitchFlux(unittest.TestCase):
@@ -50,21 +52,23 @@ class TestSwitchFlux(unittest.TestCase):
 
     def test_valid_config_no_name(self):
         """Test configuration."""
-        assert setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'flux',
-                'lights': ['light.desk', 'light.lamp']
-            }
-        })
+        with assert_setup_component(1, 'switch'):
+            assert setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'flux',
+                    'lights': ['light.desk', 'light.lamp']
+                }
+            })
 
     def test_invalid_config_no_lights(self):
         """Test configuration."""
-        assert not setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'flux',
-                'name': 'flux'
-            }
-        })
+        with assert_setup_component(0, 'switch'):
+            assert setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'flux',
+                    'name': 'flux'
+                }
+            })
 
     def test_flux_when_switch_is_off(self):
         """Test the flux switch when it is off."""

--- a/tests/components/switch/test_template.py
+++ b/tests/components/switch/test_template.py
@@ -6,11 +6,15 @@ from homeassistant.const import (
     STATE_ON,
     STATE_OFF)
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, assert_setup_component
 
 
 class TestTemplateSwitch:
     """Test the Template switch."""
+
+    hass = None
+    calls = None
+    # pylint: disable=invalid-name
 
     def setup_method(self, method):
         """Setup things to be run when tests are started."""
@@ -29,25 +33,26 @@ class TestTemplateSwitch:
 
     def test_template_state_text(self):
         """"Test the state text of a template."""
-        assert bootstrap.setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'template',
-                'switches': {
-                    'test_template_switch': {
-                        'value_template':
-                            "{{ states.switch.test_state.state }}",
-                        'turn_on': {
-                            'service': 'switch.turn_on',
-                            'entity_id': 'switch.test_state'
-                        },
-                        'turn_off': {
-                            'service': 'switch.turn_off',
-                            'entity_id': 'switch.test_state'
-                        },
+        with assert_setup_component(1):
+            assert bootstrap.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'template',
+                    'switches': {
+                        'test_template_switch': {
+                            'value_template':
+                                "{{ states.switch.test_state.state }}",
+                            'turn_on': {
+                                'service': 'switch.turn_on',
+                                'entity_id': 'switch.test_state'
+                            },
+                            'turn_off': {
+                                'service': 'switch.turn_off',
+                                'entity_id': 'switch.test_state'
+                            },
+                        }
                     }
                 }
-            }
-        })
+            })
 
         state = self.hass.states.set('switch.test_state', STATE_ON)
         self.hass.block_till_done()
@@ -63,188 +68,197 @@ class TestTemplateSwitch:
 
     def test_template_state_boolean_on(self):
         """Test the setting of the state with boolean on."""
-        assert bootstrap.setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'template',
-                'switches': {
-                    'test_template_switch': {
-                        'value_template':
-                            "{{ 1 == 1 }}",
-                        'turn_on': {
-                            'service': 'switch.turn_on',
-                            'entity_id': 'switch.test_state'
-                        },
-                        'turn_off': {
-                            'service': 'switch.turn_off',
-                            'entity_id': 'switch.test_state'
-                        },
+        with assert_setup_component(1):
+            assert bootstrap.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'template',
+                    'switches': {
+                        'test_template_switch': {
+                            'value_template':
+                                "{{ 1 == 1 }}",
+                            'turn_on': {
+                                'service': 'switch.turn_on',
+                                'entity_id': 'switch.test_state'
+                            },
+                            'turn_off': {
+                                'service': 'switch.turn_off',
+                                'entity_id': 'switch.test_state'
+                            },
+                        }
                     }
                 }
-            }
-        })
+            })
 
         state = self.hass.states.get('switch.test_template_switch')
         assert state.state == STATE_ON
 
     def test_template_state_boolean_off(self):
         """Test the setting of the state with off."""
-        assert bootstrap.setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'template',
-                'switches': {
-                    'test_template_switch': {
-                        'value_template':
-                            "{{ 1 == 2 }}",
-                        'turn_on': {
-                            'service': 'switch.turn_on',
-                            'entity_id': 'switch.test_state'
-                        },
-                        'turn_off': {
-                            'service': 'switch.turn_off',
-                            'entity_id': 'switch.test_state'
-                        },
+        with assert_setup_component(1):
+            assert bootstrap.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'template',
+                    'switches': {
+                        'test_template_switch': {
+                            'value_template':
+                                "{{ 1 == 2 }}",
+                            'turn_on': {
+                                'service': 'switch.turn_on',
+                                'entity_id': 'switch.test_state'
+                            },
+                            'turn_off': {
+                                'service': 'switch.turn_off',
+                                'entity_id': 'switch.test_state'
+                            },
+                        }
                     }
                 }
-            }
-        })
+            })
 
         state = self.hass.states.get('switch.test_template_switch')
         assert state.state == STATE_OFF
 
     def test_template_syntax_error(self):
         """Test templating syntax error."""
-        assert not bootstrap.setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'template',
-                'switches': {
-                    'test_template_switch': {
-                        'value_template':
-                            "{% if rubbish %}",
-                        'turn_on': {
-                            'service': 'switch.turn_on',
-                            'entity_id': 'switch.test_state'
-                        },
-                        'turn_off': {
-                            'service': 'switch.turn_off',
-                            'entity_id': 'switch.test_state'
-                        },
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'template',
+                    'switches': {
+                        'test_template_switch': {
+                            'value_template':
+                                "{% if rubbish %}",
+                            'turn_on': {
+                                'service': 'switch.turn_on',
+                                'entity_id': 'switch.test_state'
+                            },
+                            'turn_off': {
+                                'service': 'switch.turn_off',
+                                'entity_id': 'switch.test_state'
+                            },
+                        }
                     }
                 }
-            }
-        })
+            })
         assert self.hass.states.all() == []
 
     def test_invalid_name_does_not_create(self):
         """Test invalid name."""
-        assert not bootstrap.setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'template',
-                'switches': {
-                    'test INVALID switch': {
-                        'value_template':
-                            "{{ rubbish }",
-                        'turn_on': {
-                            'service': 'switch.turn_on',
-                            'entity_id': 'switch.test_state'
-                        },
-                        'turn_off': {
-                            'service': 'switch.turn_off',
-                            'entity_id': 'switch.test_state'
-                        },
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'template',
+                    'switches': {
+                        'test INVALID switch': {
+                            'value_template':
+                                "{{ rubbish }",
+                            'turn_on': {
+                                'service': 'switch.turn_on',
+                                'entity_id': 'switch.test_state'
+                            },
+                            'turn_off': {
+                                'service': 'switch.turn_off',
+                                'entity_id': 'switch.test_state'
+                            },
+                        }
                     }
                 }
-            }
-        })
+            })
         assert self.hass.states.all() == []
 
     def test_invalid_switch_does_not_create(self):
         """Test invalid switch."""
-        assert not bootstrap.setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'template',
-                'switches': {
-                    'test_template_switch': 'Invalid'
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'template',
+                    'switches': {
+                        'test_template_switch': 'Invalid'
+                    }
                 }
-            }
-        })
+            })
         assert self.hass.states.all() == []
 
     def test_no_switches_does_not_create(self):
         """Test if there are no switches no creation."""
-        assert not bootstrap.setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'template'
-            }
-        })
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'template'
+                }
+            })
         assert self.hass.states.all() == []
 
     def test_missing_template_does_not_create(self):
         """Test missing template."""
-        assert not bootstrap.setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'template',
-                'switches': {
-                    'test_template_switch': {
-                        'not_value_template':
-                            "{{ states.switch.test_state.state }}",
-                        'turn_on': {
-                            'service': 'switch.turn_on',
-                            'entity_id': 'switch.test_state'
-                        },
-                        'turn_off': {
-                            'service': 'switch.turn_off',
-                            'entity_id': 'switch.test_state'
-                        },
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'template',
+                    'switches': {
+                        'test_template_switch': {
+                            'not_value_template':
+                                "{{ states.switch.test_state.state }}",
+                            'turn_on': {
+                                'service': 'switch.turn_on',
+                                'entity_id': 'switch.test_state'
+                            },
+                            'turn_off': {
+                                'service': 'switch.turn_off',
+                                'entity_id': 'switch.test_state'
+                            },
+                        }
                     }
                 }
-            }
-        })
+            })
         assert self.hass.states.all() == []
 
     def test_missing_on_does_not_create(self):
         """Test missing on."""
-        assert not bootstrap.setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'template',
-                'switches': {
-                    'test_template_switch': {
-                        'value_template':
-                            "{{ states.switch.test_state.state }}",
-                        'not_on': {
-                            'service': 'switch.turn_on',
-                            'entity_id': 'switch.test_state'
-                        },
-                        'turn_off': {
-                            'service': 'switch.turn_off',
-                            'entity_id': 'switch.test_state'
-                        },
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'template',
+                    'switches': {
+                        'test_template_switch': {
+                            'value_template':
+                                "{{ states.switch.test_state.state }}",
+                            'not_on': {
+                                'service': 'switch.turn_on',
+                                'entity_id': 'switch.test_state'
+                            },
+                            'turn_off': {
+                                'service': 'switch.turn_off',
+                                'entity_id': 'switch.test_state'
+                            },
+                        }
                     }
                 }
-            }
-        })
+            })
         assert self.hass.states.all() == []
 
     def test_missing_off_does_not_create(self):
         """Test missing off."""
-        assert not bootstrap.setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'template',
-                'switches': {
-                    'test_template_switch': {
-                        'value_template':
-                            "{{ states.switch.test_state.state }}",
-                        'turn_on': {
-                            'service': 'switch.turn_on',
-                            'entity_id': 'switch.test_state'
-                        },
-                        'not_off': {
-                            'service': 'switch.turn_off',
-                            'entity_id': 'switch.test_state'
-                        },
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'template',
+                    'switches': {
+                        'test_template_switch': {
+                            'value_template':
+                                "{{ states.switch.test_state.state }}",
+                            'turn_on': {
+                                'service': 'switch.turn_on',
+                                'entity_id': 'switch.test_state'
+                            },
+                            'not_off': {
+                                'service': 'switch.turn_off',
+                                'entity_id': 'switch.test_state'
+                            },
+                        }
                     }
                 }
-            }
-        })
+            })
         assert self.hass.states.all() == []
 
     def test_on_action(self):

--- a/tests/components/thermostat/test_heat_control.py
+++ b/tests/components/thermostat/test_heat_control.py
@@ -4,7 +4,7 @@ import unittest
 from unittest import mock
 
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     SERVICE_TURN_OFF,
@@ -16,7 +16,7 @@ from homeassistant.const import (
 from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.components import thermostat
 
-from tests.common import get_test_home_assistant
+from tests.common import assert_setup_component, get_test_home_assistant
 
 
 ENTITY = 'thermostat.test'
@@ -44,12 +44,13 @@ class TestSetupThermostatHeatControl(unittest.TestCase):
             'name': 'test',
             'target_sensor': ENT_SENSOR
         }
-        self.assertFalse(_setup_component(self.hass, 'thermostat', {
-            'thermostat': config}))
+        with assert_setup_component(0):
+            setup_component(self.hass, 'thermostat', {
+                'thermostat': config})
 
     def test_valid_conf(self):
         """Test set up heat_control with valid config values."""
-        self.assertTrue(_setup_component(self.hass, 'thermostat',
+        self.assertTrue(setup_component(self.hass, 'thermostat',
                         {'thermostat': {
                             'platform': 'heat_control',
                             'name': 'test',

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -89,14 +89,18 @@ class TestCheckConfig(unittest.TestCase):
         with patch_yaml_files(files):
             res = check_config.check(get_test_config_dir('platform.yaml'))
             change_yaml_files(res)
-            self.assertDictEqual({
-                'components': {'mqtt': {'keepalive': 60, 'port': 1883,
-                                        'protocol': '3.1.1'}},
-                'except': {'light.mqtt_json': {'platform': 'mqtt_json'}},
-                'secret_cache': {},
-                'secrets': {},
-                'yaml_files': ['.../platform.yaml']
-            }, res)
+            self.assertDictEqual(
+                {'mqtt': {'keepalive': 60, 'port': 1883, 'protocol': '3.1.1'},
+                 'light': []},
+                res['components']
+            )
+            self.assertDictEqual(
+                {'light.mqtt_json': {'platform': 'mqtt_json'}},
+                res['except']
+            )
+            self.assertDictEqual({}, res['secret_cache'])
+            self.assertDictEqual({}, res['secrets'])
+            self.assertListEqual(['.../platform.yaml'], res['yaml_files'])
 
     def test_component_platform_not_found(self, mock_get_loop):
         """Test errors if component or platform not found."""
@@ -107,25 +111,23 @@ class TestCheckConfig(unittest.TestCase):
         with patch_yaml_files(files):
             res = check_config.check(get_test_config_dir('badcomponent.yaml'))
             change_yaml_files(res)
-            self.assertDictEqual({
-                'components': {},
-                'except': {check_config.ERROR_STR:
-                           ['Component not found: beer']},
-                'secret_cache': {},
-                'secrets': {},
-                'yaml_files': ['.../badcomponent.yaml']
-            }, res)
+            self.assertDictEqual({}, res['components'])
+            self.assertDictEqual({check_config.ERROR_STR:
+                                  ['Component not found: beer']},
+                                 res['except'])
+            self.assertDictEqual({}, res['secret_cache'])
+            self.assertDictEqual({}, res['secrets'])
+            self.assertListEqual(['.../badcomponent.yaml'], res['yaml_files'])
 
             res = check_config.check(get_test_config_dir('badplatform.yaml'))
             change_yaml_files(res)
-            self.assertDictEqual({
-                'components': {},
-                'except': {check_config.ERROR_STR:
-                           ['Platform not found: light.beer']},
-                'secret_cache': {},
-                'secrets': {},
-                'yaml_files': ['.../badplatform.yaml']
-            }, res)
+            self.assertDictEqual({'light': []}, res['components'])
+            self.assertDictEqual({check_config.ERROR_STR:
+                                  ['Platform not found: light.beer']},
+                                 res['except'])
+            self.assertDictEqual({}, res['secret_cache'])
+            self.assertDictEqual({}, res['secrets'])
+            self.assertListEqual(['.../badplatform.yaml'], res['yaml_files'])
 
     def test_secrets(self, mock_get_loop):
         """Test secrets config checking method."""

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -3,6 +3,7 @@
 import tempfile
 from unittest import mock
 import threading
+import logging
 
 import voluptuous as vol
 
@@ -10,13 +11,21 @@ from homeassistant import bootstrap, loader
 import homeassistant.util.dt as dt_util
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 
-from tests.common import get_test_home_assistant, MockModule, MockPlatform
+from tests.common import \
+    get_test_home_assistant, MockModule, MockPlatform, assert_setup_component
 
 ORIG_TIMEZONE = dt_util.DEFAULT_TIME_ZONE
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class TestBootstrap:
     """Test the bootstrap utils."""
+
+    hass = None
+    backup_cache = None
+
+    # pylint: disable=invalid-name, no-self-use
 
     def setup_method(self, method):
         """Setup the test."""
@@ -110,59 +119,72 @@ class TestBootstrap:
         loader.set_component(
             'platform_conf.whatever', MockPlatform('whatever'))
 
-        assert not bootstrap._setup_component(self.hass, 'platform_conf', {
-            'platform_conf': {
-                'hello': 'world',
-                'invalid': 'extra',
-            }
-        })
-
-        assert not bootstrap._setup_component(self.hass, 'platform_conf', {
-            'platform_conf': {
-                'platform': 'whatever',
-                'hello': 'world',
-            },
-
-            'platform_conf 2': {
-                'invalid': True
-            }
-        })
-
-        assert not bootstrap._setup_component(self.hass, 'platform_conf', {
-            'platform_conf': {
-                'platform': 'not_existing',
-                'hello': 'world',
-            }
-        })
-
-        assert bootstrap._setup_component(self.hass, 'platform_conf', {
-            'platform_conf': {
-                'platform': 'whatever',
-                'hello': 'world',
-            }
-        })
+        with assert_setup_component(0):
+            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+                'platform_conf': {
+                    'hello': 'world',
+                    'invalid': 'extra',
+                }
+            })
 
         self.hass.config.components.remove('platform_conf')
 
-        assert bootstrap._setup_component(self.hass, 'platform_conf', {
-            'platform_conf': [{
-                'platform': 'whatever',
-                'hello': 'world',
-            }]
-        })
+        with assert_setup_component(1):
+            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+                'platform_conf': {
+                    'platform': 'whatever',
+                    'hello': 'world',
+                },
+                'platform_conf 2': {
+                    'invalid': True
+                }
+            })
 
         self.hass.config.components.remove('platform_conf')
 
-        # Any falsey paltform config will be ignored (None, {}, etc)
-        assert bootstrap._setup_component(self.hass, 'platform_conf', {
-            'platform_conf': None
-        })
+        with assert_setup_component(0):
+            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+                'platform_conf': {
+                    'platform': 'not_existing',
+                    'hello': 'world',
+                }
+            })
 
         self.hass.config.components.remove('platform_conf')
 
-        assert bootstrap._setup_component(self.hass, 'platform_conf', {
-            'platform_conf': {}
-        })
+        with assert_setup_component(1):
+            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+                'platform_conf': {
+                    'platform': 'whatever',
+                    'hello': 'world',
+                }
+            })
+
+        self.hass.config.components.remove('platform_conf')
+
+        with assert_setup_component(1):
+            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+                'platform_conf': [{
+                    'platform': 'whatever',
+                    'hello': 'world',
+                }]
+            })
+
+        self.hass.config.components.remove('platform_conf')
+
+        # Any falsey platform config will be ignored (None, {}, etc)
+        with assert_setup_component(0) as config:
+            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+                'platform_conf': None
+            })
+            assert 'platform_conf' in self.hass.config.components
+            assert not config['platform_conf']  # empty
+
+            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+                'platform_conf': {}
+            })
+            assert 'platform_conf' in self.hass.config.components
+            assert not config['platform_conf']  # empty
 
     def test_component_not_found(self):
         """setup_component should not crash if component doesn't exist."""
@@ -170,7 +192,6 @@ class TestBootstrap:
 
     def test_component_not_double_initialized(self):
         """Test we do not setup a component twice."""
-
         mock_setup = mock.MagicMock(return_value=True)
 
         loader.set_component('comp', MockModule('comp', setup=mock_setup))
@@ -195,15 +216,13 @@ class TestBootstrap:
         assert 'comp' not in self.hass.config.components
 
     def test_component_not_setup_twice_if_loaded_during_other_setup(self):
-        """
-        Test component that gets setup while waiting for lock is not setup
-        twice.
-        """
+        """Test component setup while waiting for lock is not setup twice."""
         loader.set_component('comp', MockModule('comp'))
 
         result = []
 
         def setup_component():
+            """Setup the component."""
             result.append(bootstrap.setup_component(self.hass, 'comp'))
 
         with bootstrap._SETUP_LOCK:
@@ -258,7 +277,6 @@ class TestBootstrap:
 
     def test_component_setup_with_validation_and_dependency(self):
         """Test all config is passed to dependencies."""
-
         def config_check_setup(hass, config):
             """Setup method that tests config is passed in."""
             if config.get('comp_a', {}).get('valid', False):
@@ -283,36 +301,48 @@ class TestBootstrap:
 
     def test_platform_specific_config_validation(self):
         """Test platform that specifies config."""
-
         platform_schema = PLATFORM_SCHEMA.extend({
             'valid': True,
         }, extra=vol.PREVENT_EXTRA)
 
+        mock_setup = mock.MagicMock()
+
         loader.set_component(
             'switch.platform_a',
-            MockPlatform(platform_schema=platform_schema))
+            MockPlatform(platform_schema=platform_schema,
+                         setup_platform=mock_setup))
 
-        assert not bootstrap.setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'platform_a',
-                'invalid': True
-            }
-        })
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'platform_a',
+                    'invalid': True
+                }
+            })
+            assert mock_setup.call_count == 0
 
-        assert not bootstrap.setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'platform_a',
-                'valid': True,
-                'invalid_extra': True,
-            }
-        })
+        self.hass.config.components.remove('switch')
 
-        assert bootstrap.setup_component(self.hass, 'switch', {
-            'switch': {
-                'platform': 'platform_a',
-                'valid': True
-            }
-        })
+        with assert_setup_component(0):
+            assert bootstrap.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'platform_a',
+                    'valid': True,
+                    'invalid_extra': True,
+                }
+            })
+            assert mock_setup.call_count == 0
+
+        self.hass.config.components.remove('switch')
+
+        with assert_setup_component(1):
+            assert bootstrap.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'platform_a',
+                    'valid': True
+                }
+            })
+            assert mock_setup.call_count == 1
 
     def test_disable_component_if_invalid_return(self):
         """Test disabling component if invalid return."""


### PR DESCRIPTION
**Description:**
Setup all valid platforms, while ignoring invalid ones - #3550 - [story](https://www.pivotaltracker.com/story/show/116917427)

`setup_component` will now almost always return true. In order to check valid/invalid setups a new context manager was added to `tests/common`

``` python
def assert_setup_component(count, domain=None):
```

Parameters:
- count: The amount of valid platforms that should be setup
- domain: The domain to count is optional. It can be automatically
            determined most of the time

Example usage (Use as a context manager aroung bootstrap.setup_component)

``` python
        with assert_setup_component(0) as result_config:
            setup_component(hass, start_config, domain)
            # using result_config is optional
```

**Related issue (if applicable):** fixes #

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
- platform: forecast
  api_key: !secret forecast_key
  monitored_conditions:
    - summary
    - icon
- platform: darksky
  api_key: !secret forecast_key
  monitored_conditions:
    - summary
    - icon
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
