### PR TITLE
Use voluptuous for Arduino

### DIFF
--- a/homeassistant/components/sensor/arduino.py
+++ b/homeassistant/components/sensor/arduino.py
@@ -8,28 +8,44 @@ https://home-assistant.io/components/sensor.arduino/
 """
 import logging
 
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 import homeassistant.components.arduino as arduino
-from homeassistant.const import DEVICE_DEFAULT_NAME
+from homeassistant.const import CONF_NAME
 from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_PINS = 'pins'
+CONF_TYPE = 'analog'
 
 DEPENDENCIES = ['arduino']
-_LOGGER = logging.getLogger(__name__)
+
+PIN_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_PINS):
+        vol.Schema({cv.positive_int: PIN_SCHEMA}),
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Arduino platform."""
+    """Set up the Arduino platform."""
     # Verify that the Arduino board is present
     if arduino.BOARD is None:
-        _LOGGER.error('A connection has not been made to the Arduino board.')
+        _LOGGER.error("A connection has not been made to the Arduino board")
         return False
 
+    pins = config.get(CONF_PINS)
+
     sensors = []
-    pins = config.get('pins')
     for pinnum, pin in pins.items():
-        if pin.get('name'):
-            sensors.append(ArduinoSensor(pin.get('name'),
-                                         pinnum,
-                                         'analog'))
+        sensors.append(ArduinoSensor(pin.get(CONF_NAME), pinnum, CONF_TYPE))
     add_devices(sensors)
 
 
@@ -39,7 +55,7 @@ class ArduinoSensor(Entity):
     def __init__(self, name, pin, pin_type):
         """Initialize the sensor."""
         self._pin = pin
-        self._name = name or DEVICE_DEFAULT_NAME
+        self._name = name
         self.pin_type = pin_type
         self.direction = 'in'
         self._value = None

--- a/homeassistant/components/switch/arduino.py
+++ b/homeassistant/components/switch/arduino.py
@@ -8,27 +8,46 @@ https://home-assistant.io/components/switch.arduino/
 """
 import logging
 
+import voluptuous as vol
+
 import homeassistant.components.arduino as arduino
-from homeassistant.components.switch import SwitchDevice
-from homeassistant.const import DEVICE_DEFAULT_NAME
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
 
 DEPENDENCIES = ['arduino']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_PINS = 'pins'
+CONF_TYPE = 'digital'
+CONF_NEGATE = 'negate'
+CONF_INITIAL = 'initial'
+
+PIN_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Optional(CONF_INITIAL, default=False): cv.boolean,
+    vol.Optional(CONF_NEGATE, default=False): cv.boolean,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_PINS, default={}):
+        vol.Schema({cv.positive_int: PIN_SCHEMA}),
+})
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Arduino platform."""
+    """Set up the Arduino platform."""
     # Verify that Arduino board is present
     if arduino.BOARD is None:
-        _LOGGER.error('A connection has not been made to the Arduino board.')
+        _LOGGER.error("A connection has not been made to the Arduino board")
         return False
 
+    pins = config.get(CONF_PINS)
+
     switches = []
-    pins = config.get('pins')
     for pinnum, pin in pins.items():
-        if pin.get('name'):
-            switches.append(ArduinoSwitch(pinnum, pin))
+        switches.append(ArduinoSwitch(pinnum, pin))
     add_devices(switches)
 
 
@@ -38,13 +57,13 @@ class ArduinoSwitch(SwitchDevice):
     def __init__(self, pin, options):
         """Initialize the Pin."""
         self._pin = pin
-        self._name = options.get('name') or DEVICE_DEFAULT_NAME
-        self.pin_type = options.get('type')
+        self._name = options.get(CONF_NAME)
+        self.pin_type = CONF_TYPE
         self.direction = 'out'
 
-        self._state = options.get('initial', False)
+        self._state = options.get(CONF_INITIAL)
 
-        if options.get('negate', False):
+        if options.get(CONF_NEGATE):
             self.turn_on_handler = arduino.BOARD.set_digital_out_low
             self.turn_off_handler = arduino.BOARD.set_digital_out_high
         else:


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

This is a breaking changes as defaults were removed from the configuration.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#1156

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
arduino:
  port: /dev/ttyUSB0

sensor:
  - platform: arduino
    pins:
      1:
        name: Door switch
      0:
        name: Brightness

switch:
  - platform: arduino
    pins:
      11:
        name: Pin 11
        negate: True
        initial: True
      13:
        name: Pin 13
```
