### PR TITLE
Update zwave lights to increase update delay timer as needed

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -24,6 +24,22 @@ AEOTEC = 0x86
 AEOTEC_ZW098_LED_BULB = 0x62
 AEOTEC_ZW098_LED_BULB_LIGHT = (AEOTEC, AEOTEC_ZW098_LED_BULB)
 
+LINEAR = 0x14f
+LINEAR_WD500Z_DIMMER = 0x3034
+LINEAR_WD500Z_DIMMER_LIGHT = (LINEAR, LINEAR_WD500Z_DIMMER)
+
+GE = 0x63
+GE_12724_DIMMER = 0x3031
+GE_12724_DIMMER_LIGHT = (GE, GE_12724_DIMMER)
+
+DRAGONTECH = 0x184
+DRAGONTECH_PD100_DIMMER = 0x3032
+DRAGONTECH_PD100_DIMMER_LIGHT = (DRAGONTECH, DRAGONTECH_PD100_DIMMER)
+
+ACT = 0x01
+ACT_ZDP100_DIMMER = 0x3030
+ACT_ZDP100_DIMMER_LIGHT = (ACT, ACT_ZDP100_DIMMER)
+
 COLOR_CHANNEL_WARM_WHITE = 0x01
 COLOR_CHANNEL_COLD_WHITE = 0x02
 COLOR_CHANNEL_RED = 0x04
@@ -31,9 +47,14 @@ COLOR_CHANNEL_GREEN = 0x08
 COLOR_CHANNEL_BLUE = 0x10
 
 WORKAROUND_ZW098 = 'zw098'
+WORKAROUND_DELAY = 'alt_delay'
 
 DEVICE_MAPPINGS = {
-    AEOTEC_ZW098_LED_BULB_LIGHT: WORKAROUND_ZW098
+    AEOTEC_ZW098_LED_BULB_LIGHT: WORKAROUND_ZW098,
+    LINEAR_WD500Z_DIMMER_LIGHT: WORKAROUND_DELAY,
+    GE_12724_DIMMER_LIGHT: WORKAROUND_DELAY,
+    DRAGONTECH_PD100_DIMMER_LIGHT: WORKAROUND_DELAY,
+    ACT_ZDP100_DIMMER_LIGHT: WORKAROUND_DELAY
 }
 
 # Generate midpoint color temperatures for bulbs that have limited
@@ -95,6 +116,23 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
         self._brightness = None
         self._state = None
         self.update_properties()
+        self._alt_delay = None
+        self._zw098 = None
+
+        # Enable appropriate workaround flags for our device
+        # Make sure that we have values for the key before converting to int
+        if (value.node.manufacturer_id.strip() and
+                value.node.product_id.strip()):
+            specific_sensor_key = (int(value.node.manufacturer_id, 16),
+                                   int(value.node.product_id, 16))
+            if specific_sensor_key in DEVICE_MAPPINGS:
+                if DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_ZW098:
+                    _LOGGER.debug("AEOTEC ZW098 workaround enabled")
+                    self._zw098 = 1
+                elif DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_DELAY:
+                    _LOGGER.debug("Dimmer delay workaround enabled for node:"
+                                  " %s", value.parent_id)
+                    self._alt_delay = 1
 
         # Used for value change event handling
         self._refreshing = False
@@ -125,7 +163,10 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
                 if self._timer is not None and self._timer.isAlive():
                     self._timer.cancel()
 
-                self._timer = Timer(2, _refresh_value)
+                if self._alt_delay:
+                    self._timer = Timer(5, _refresh_value)
+                else:
+                    self._timer = Timer(2, _refresh_value)
                 self._timer.start()
 
             self.update_ha_state()
@@ -180,7 +221,6 @@ class ZwaveColorLight(ZwaveDimmer):
         self._color_channels = None
         self._rgb = None
         self._ct = None
-        self._zw098 = None
 
         # Here we attempt to find a zwave color value with the same instance
         # id as the dimmer value. Currently zwave nodes that change colors
@@ -201,17 +241,6 @@ class ZwaveColorLight(ZwaveDimmer):
 
         if self._value_color_channels is None:
             raise ValueError("Color Channels not found.")
-
-        # Make sure that we have values for the key before converting to int
-        if (value.node.manufacturer_id.strip() and
-                value.node.product_id.strip()):
-            specific_sensor_key = (int(value.node.manufacturer_id, 16),
-                                   int(value.node.product_id, 16))
-
-            if specific_sensor_key in DEVICE_MAPPINGS:
-                if DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_ZW098:
-                    _LOGGER.debug("AEOTEC ZW098 workaround enabled")
-                    self._zw098 = 1
 
         super().__init__(value)
 


### PR DESCRIPTION
**Description:**

Per the conversation from closed PR #3437 this PR allows the update delay to be extended to 5s from the default 2s for specific devices that don't support instant status or take longer than 2s to complete a transition.

**Related issue (if applicable):** fixes #3389 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
