### PR TITLE
Load yaml using validator and include consider_home

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -43,6 +43,8 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 YAML_DEVICES = 'known_devices.yaml'
 
 CONF_TRACK_NEW = 'track_new_devices'
+DEFAULT_TRACK_NEW = True
+
 CONF_CONSIDER_HOME = 'consider_home'
 
 CONF_SCAN_INTERVAL = 'interval_seconds'
@@ -67,7 +69,7 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
 
 _CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.All(cv.ensure_list, [
     vol.Schema({
-        vol.Optional(CONF_TRACK_NEW, default=True): cv.boolean,
+        vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,
         vol.Optional(
             CONF_CONSIDER_HOME, default=timedelta(seconds=180)): vol.All(
                 cv.time_period, cv.positive_timedelta)

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -43,10 +43,7 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 YAML_DEVICES = 'known_devices.yaml'
 
 CONF_TRACK_NEW = 'track_new_devices'
-DEFAULT_TRACK_NEW = True
-
 CONF_CONSIDER_HOME = 'consider_home'
-DEFAULT_CONSIDER_HOME = 180  # seconds
 
 CONF_SCAN_INTERVAL = 'interval_seconds'
 DEFAULT_SCAN_INTERVAL = 12
@@ -70,8 +67,10 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
 
 _CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.All(cv.ensure_list, [
     vol.Schema({
-        vol.Optional(CONF_TRACK_NEW): cv.boolean,
-        vol.Optional(CONF_CONSIDER_HOME): cv.positive_int  # seconds
+        vol.Optional(CONF_TRACK_NEW, default=True): cv.boolean,
+        vol.Optional(
+            CONF_CONSIDER_HOME, default=timedelta(seconds=180)): vol.All(
+                cv.time_period, cv.positive_timedelta)
     }, extra=vol.ALLOW_EXTRA)])}, extra=vol.ALLOW_EXTRA)
 
 DISCOVERY_PLATFORMS = {
@@ -118,9 +117,8 @@ def setup(hass: HomeAssistantType, config: ConfigType):
         return False
     else:
         conf = conf[0] if len(conf) > 0 else {}
-        consider_home = timedelta(
-            seconds=conf.get(CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME))
-        track_new = conf.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
+        consider_home = conf[CONF_CONSIDER_HOME]
+        track_new = conf[CONF_TRACK_NEW]
 
     devices = load_config(yaml_path, hass, consider_home)
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -167,7 +167,16 @@ def time_period_str(value: str) -> timedelta:
     return offset
 
 
-time_period = vol.Any(time_period_str, timedelta, time_period_dict)
+def time_period_seconds(value: Union[int, str]) -> timedelta:
+    """Validate and transform seconds to a time offset."""
+    try:
+        return timedelta(seconds=int(value))
+    except (ValueError, TypeError):
+        raise vol.Invalid('Expected seconds, got {}'.format(value))
+
+
+time_period = vol.Any(time_period_seconds, time_period_str, timedelta,
+                      time_period_dict)
 
 
 def match_all(value):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -175,7 +175,7 @@ def time_period_seconds(value: Union[int, str]) -> timedelta:
         raise vol.Invalid('Expected seconds, got {}'.format(value))
 
 
-time_period = vol.Any(time_period_seconds, time_period_str, timedelta,
+time_period = vol.Any(time_period_str, time_period_seconds, timedelta,
                       time_period_dict)
 
 

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -73,7 +73,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         device = device_tracker.Device(
             self.hass, timedelta(seconds=180), True, dev_id,
             'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
-            away_hide=True)
+            hide_if_away=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
         self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
                                         TEST_PLATFORM))
@@ -209,7 +209,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
         device = device_tracker.Device(
             self.hass, timedelta(seconds=180), True, dev_id, None,
-            friendly_name, picture, away_hide=True)
+            friendly_name, picture, hide_if_away=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
 
         self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
@@ -226,7 +226,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
         device = device_tracker.Device(
             self.hass, timedelta(seconds=180), True, dev_id, None,
-            away_hide=True)
+            hide_if_away=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
 
         scanner = get_component('device_tracker.test').SCANNER
@@ -244,7 +244,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
         device = device_tracker.Device(
             self.hass, timedelta(seconds=180), True, dev_id, None,
-            away_hide=True)
+            hide_if_away=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
 
         scanner = get_component('device_tracker.test').SCANNER

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -59,15 +59,13 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     def test_reading_broken_yaml_config(self):  # pylint: disable=no-self-use
         """Test when known devices contains invalid data."""
         files = {'empty.yaml': '',
-                 'bad.yaml': '100',
-                 'ok.yaml': 'my_device:\n  name: Device'}
+                 'nodict.yaml': '100',
+                 'allok.yaml': 'my_device:\n  name: Device'}
+        args = {'hass': self.hass, 'consider_home': timedelta(seconds=60)}
         with patch_yaml_files(files):
-            # File is empty
-            assert device_tracker.load_config('empty.yaml', None, False) == []
-            # File contains a non-dict format
-            assert device_tracker.load_config('bad.yaml', None, False) == []
-            # A file that works fine
-            assert len(device_tracker.load_config('ok.yaml', None, False)) == 1
+            assert device_tracker.load_config('empty.yaml', **args) == []
+            assert device_tracker.load_config('nodict.yaml', **args) == []
+            assert len(device_tracker.load_config('allok.yaml', **args)) == 1
 
     def test_reading_yaml_config(self):
         """Test the rendering of the YAML configuration."""

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -200,17 +200,18 @@ def test_time_period():
     schema = vol.Schema(cv.time_period)
 
     for value in (
-        None, '', 1234, 'hello:world', '12:', '12:34:56:78',
+        None, '', 'hello:world', '12:', '12:34:56:78',
         {}, {'wrong_key': -10}
     ):
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
 
     for value in (
-        '8:20', '23:59', '-8:20', '-23:59:59', '-48:00', {'minutes': 5}
+        '8:20', '23:59', '-8:20', '-23:59:59', '-48:00', {'minutes': 5}, 1, '5'
     ):
         schema(value)
 
+    assert timedelta(seconds=180) == schema('180')
     assert timedelta(hours=23, minutes=59) == schema('23:59')
     assert -1 * timedelta(hours=1, minutes=15) == schema('-1:15')
 


### PR DESCRIPTION
**Description:**
The PR will load known_device.yaml using voluptuous validation. See #3547 

It will also load `consider_home` for devices [in seconds] if it exists. See #3041 for a discussion. For now it does not save `consider_home` and if it not manually edited into `known_devices.yaml` it will still use the _first_ platform's configured value, but give much more configuration flexibility.

CC: @CCOSTAN 

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been fixed. Covers consider_home
- [ ] Option: Additional tests required for consider_home verification?
