### PR TITLE
Fix typo (netatmo)

### DIFF
--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -37,7 +37,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 
 def setup(hass, config):
-    """Setup the Netatmo devices."""
+    """Set up the Netatmo devices."""
     import lnetatmo
 
     global NETATMO_AUTH
@@ -47,7 +47,7 @@ def setup(hass, config):
             config[DOMAIN][CONF_USERNAME], config[DOMAIN][CONF_PASSWORD],
             'read_station read_camera access_camera')
     except HTTPError:
-        _LOGGER.error("Unable to connect to NatAtmo API")
+        _LOGGER.error("Unable to connect to Netatmo API")
         return False
 
     for component in 'camera', 'sensor':


### PR DESCRIPTION
**Description:**
As reported [4636](https://community.home-assistant.io/t/netatmo-failes-to-initialise/4636) in this thread.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
netatmo:
  api_key: YOUR_API_KEY
  secret_key: YOUR_SECRET_KEY
  username: YOUR_USERNAME
  password: YOUR_PASSWORD
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
