### PR TITLE
Add Alexa Flash Briefing Skill API support

### DIFF
--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -86,7 +86,7 @@ CONFIG_SCHEMA = vol.Schema({
                 vol.Optional(CONF_DATE, default=datetime.utcnow()): cv.time,
                 vol.Required(CONF_TITLE): cv.template,
                 vol.Optional(CONF_AUDIO): cv.url,
-                vol.Required(CONF_TEXT): cv.template,
+                vol.Required(CONF_TEXT, default=""): cv.template,
                 vol.Optional(CONF_DISPLAY_URL): cv.template,
             }]),
         }

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -13,17 +13,18 @@ from tests.common import get_test_instance_port, get_test_home_assistant
 
 API_PASSWORD = "test1234"
 SERVER_PORT = get_test_instance_port()
-API_URL = "http://127.0.0.1:{}{}".format(SERVER_PORT,
-                                         alexa.INTENTS_API_ENDPOINT)
+INTENTS_API_URL = "http://127.0.0.1:{}{}".format(SERVER_PORT,
+                                                 alexa.INTENTS_API_ENDPOINT)
 HA_HEADERS = {
     const.HTTP_HEADER_HA_AUTH: API_PASSWORD,
     const.HTTP_HEADER_CONTENT_TYPE: const.CONTENT_TYPE_JSON,
 }
 
-SESSION_ID = 'amzn1.echo-api.session.0000000-0000-0000-0000-00000000000'
-APPLICATION_ID = 'amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe'
-REQUEST_ID = 'amzn1.echo-api.request.0000000-0000-0000-0000-00000000000'
+SESSION_ID = "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000"
+APPLICATION_ID = "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+REQUEST_ID = "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000"
 
+# pylint: disable=invalid-name
 hass = None
 calls = []
 
@@ -37,23 +38,23 @@ def setUpModule():   # pylint: disable=invalid-name
     bootstrap.setup_component(
         hass, http.DOMAIN,
         {http.DOMAIN: {http.CONF_API_PASSWORD: API_PASSWORD,
-         http.CONF_SERVER_PORT: SERVER_PORT}})
+                       http.CONF_SERVER_PORT: SERVER_PORT}})
 
-    hass.services.register('test', 'alexa', lambda call: calls.append(call))
+    hass.services.register("test", "alexa", lambda call: calls.append(call))
 
     bootstrap.setup_component(hass, alexa.DOMAIN, {
         # Key is here to verify we allow other keys in config too
-        'homeassistant': {},
-        'alexa': {
-            'intents': {
-                'WhereAreWeIntent': {
-                    'speech': {
-                        'type': 'plaintext',
-                        'text':
+        "homeassistant": {},
+        "alexa": {
+            "intents": {
+                "WhereAreWeIntent": {
+                    "speech": {
+                        "type": "plaintext",
+                        "text":
                         """
-                            {%- if is_state('device_tracker.paulus', 'home')
-                                   and is_state('device_tracker.anne_therese',
-                                                'home') -%}
+                            {%- if is_state("device_tracker.paulus", "home")
+                                   and is_state("device_tracker.anne_therese",
+                                                "home") -%}
                                 You are both home, you silly
                             {%- else -%}
                                 Anne Therese is at {{
@@ -65,23 +66,23 @@ def setUpModule():   # pylint: disable=invalid-name
                         """,
                     }
                 },
-                'GetZodiacHoroscopeIntent': {
-                    'speech': {
-                        'type': 'plaintext',
-                        'text': 'You told us your sign is {{ ZodiacSign }}.',
+                "GetZodiacHoroscopeIntent": {
+                    "speech": {
+                        "type": "plaintext",
+                        "text": "You told us your sign is {{ ZodiacSign }}.",
                     }
                 },
-                'CallServiceIntent': {
-                    'speech': {
-                        'type': 'plaintext',
-                        'text': 'Service called',
+                "CallServiceIntent": {
+                    "speech": {
+                        "type": "plaintext",
+                        "text": "Service called",
                     },
-                    'action': {
-                        'service': 'test.alexa',
-                        'data_template': {
-                            'hello': '{{ ZodiacSign }}'
+                    "action": {
+                        "service": "test.alexa",
+                        "data_template": {
+                            "hello": "{{ ZodiacSign }}"
                         },
-                        'entity_id': 'switch.test',
+                        "entity_id": "switch.test",
                     }
                 }
             }
@@ -98,7 +99,7 @@ def tearDownModule():   # pylint: disable=invalid-name
 
 
 def _req(data={}):
-    return requests.post(API_URL, data=json.dumps(data), timeout=5,
+    return requests.post(INTENTS_API_URL, data=json.dumps(data), timeout=5,
                          headers=HA_HEADERS)
 
 
@@ -109,63 +110,63 @@ class TestAlexa(unittest.TestCase):
         """Stop everything that was started."""
         hass.block_till_done()
 
-    def test_launch_request(self):
+    def test_intent_launch_request(self):
         """Test the launch of a request."""
         data = {
-            'version': '1.0',
-            'session': {
-                'new': True,
-                'sessionId': SESSION_ID,
-                'application': {
-                    'applicationId': APPLICATION_ID
+            "version": "1.0",
+            "session": {
+                "new": True,
+                "sessionId": SESSION_ID,
+                "application": {
+                    "applicationId": APPLICATION_ID
                 },
-                'attributes': {},
-                'user': {
-                    'userId': 'amzn1.account.AM3B00000000000000000000000'
+                "attributes": {},
+                "user": {
+                    "userId": "amzn1.account.AM3B00000000000000000000000"
                 }
             },
-            'request': {
-                'type': 'LaunchRequest',
-                'requestId': REQUEST_ID,
-                'timestamp': '2015-05-13T12:34:56Z'
+            "request": {
+                "type": "LaunchRequest",
+                "requestId": REQUEST_ID,
+                "timestamp": "2015-05-13T12:34:56Z"
             }
         }
         req = _req(data)
         self.assertEqual(200, req.status_code)
         resp = req.json()
-        self.assertIn('outputSpeech', resp['response'])
+        self.assertIn("outputSpeech", resp["response"])
 
     def test_intent_request_with_slots(self):
         """Test a request with slots."""
         data = {
-            'version': '1.0',
-            'session': {
-                'new': False,
-                'sessionId': SESSION_ID,
-                'application': {
-                    'applicationId': APPLICATION_ID
+            "version": "1.0",
+            "session": {
+                "new": False,
+                "sessionId": SESSION_ID,
+                "application": {
+                    "applicationId": APPLICATION_ID
                 },
-                'attributes': {
-                    'supportedHoroscopePeriods': {
-                        'daily': True,
-                        'weekly': False,
-                        'monthly': False
+                "attributes": {
+                    "supportedHoroscopePeriods": {
+                        "daily": True,
+                        "weekly": False,
+                        "monthly": False
                     }
                 },
-                'user': {
-                    'userId': 'amzn1.account.AM3B00000000000000000000000'
+                "user": {
+                    "userId": "amzn1.account.AM3B00000000000000000000000"
                 }
             },
-            'request': {
-                'type': 'IntentRequest',
-                'requestId': REQUEST_ID,
-                'timestamp': '2015-05-13T12:34:56Z',
-                'intent': {
-                    'name': 'GetZodiacHoroscopeIntent',
-                    'slots': {
-                        'ZodiacSign': {
-                            'name': 'ZodiacSign',
-                            'value': 'virgo'
+            "request": {
+                "type": "IntentRequest",
+                "requestId": REQUEST_ID,
+                "timestamp": "2015-05-13T12:34:56Z",
+                "intent": {
+                    "name": "GetZodiacHoroscopeIntent",
+                    "slots": {
+                        "ZodiacSign": {
+                            "name": "ZodiacSign",
+                            "value": "virgo"
                         }
                     }
                 }
@@ -173,40 +174,40 @@ class TestAlexa(unittest.TestCase):
         }
         req = _req(data)
         self.assertEqual(200, req.status_code)
-        text = req.json().get('response', {}).get('outputSpeech',
-                                                  {}).get('text')
-        self.assertEqual('You told us your sign is virgo.', text)
+        text = req.json().get("response", {}).get("outputSpeech",
+                                                  {}).get("text")
+        self.assertEqual("You told us your sign is virgo.", text)
 
     def test_intent_request_with_slots_but_no_value(self):
         """Test a request with slots but no value."""
         data = {
-            'version': '1.0',
-            'session': {
-                'new': False,
-                'sessionId': SESSION_ID,
-                'application': {
-                    'applicationId': APPLICATION_ID
+            "version": "1.0",
+            "session": {
+                "new": False,
+                "sessionId": SESSION_ID,
+                "application": {
+                    "applicationId": APPLICATION_ID
                 },
-                'attributes': {
-                    'supportedHoroscopePeriods': {
-                        'daily': True,
-                        'weekly': False,
-                        'monthly': False
+                "attributes": {
+                    "supportedHoroscopePeriods": {
+                        "daily": True,
+                        "weekly": False,
+                        "monthly": False
                     }
                 },
-                'user': {
-                    'userId': 'amzn1.account.AM3B00000000000000000000000'
+                "user": {
+                    "userId": "amzn1.account.AM3B00000000000000000000000"
                 }
             },
-            'request': {
-                'type': 'IntentRequest',
-                'requestId': REQUEST_ID,
-                'timestamp': '2015-05-13T12:34:56Z',
-                'intent': {
-                    'name': 'GetZodiacHoroscopeIntent',
-                    'slots': {
-                        'ZodiacSign': {
-                            'name': 'ZodiacSign',
+            "request": {
+                "type": "IntentRequest",
+                "requestId": REQUEST_ID,
+                "timestamp": "2015-05-13T12:34:56Z",
+                "intent": {
+                    "name": "GetZodiacHoroscopeIntent",
+                    "slots": {
+                        "ZodiacSign": {
+                            "name": "ZodiacSign",
                         }
                     }
                 }
@@ -214,82 +215,82 @@ class TestAlexa(unittest.TestCase):
         }
         req = _req(data)
         self.assertEqual(200, req.status_code)
-        text = req.json().get('response', {}).get('outputSpeech',
-                                                  {}).get('text')
-        self.assertEqual('You told us your sign is .', text)
+        text = req.json().get("response", {}).get("outputSpeech",
+                                                  {}).get("text")
+        self.assertEqual("You told us your sign is .", text)
 
     def test_intent_request_without_slots(self):
         """Test a request without slots."""
         data = {
-            'version': '1.0',
-            'session': {
-                'new': False,
-                'sessionId': SESSION_ID,
-                'application': {
-                    'applicationId': APPLICATION_ID
+            "version": "1.0",
+            "session": {
+                "new": False,
+                "sessionId": SESSION_ID,
+                "application": {
+                    "applicationId": APPLICATION_ID
                 },
-                'attributes': {
-                    'supportedHoroscopePeriods': {
-                        'daily': True,
-                        'weekly': False,
-                        'monthly': False
+                "attributes": {
+                    "supportedHoroscopePeriods": {
+                        "daily": True,
+                        "weekly": False,
+                        "monthly": False
                     }
                 },
-                'user': {
-                    'userId': 'amzn1.account.AM3B00000000000000000000000'
+                "user": {
+                    "userId": "amzn1.account.AM3B00000000000000000000000"
                 }
             },
-            'request': {
-                'type': 'IntentRequest',
-                'requestId': REQUEST_ID,
-                'timestamp': '2015-05-13T12:34:56Z',
-                'intent': {
-                    'name': 'WhereAreWeIntent',
+            "request": {
+                "type": "IntentRequest",
+                "requestId": REQUEST_ID,
+                "timestamp": "2015-05-13T12:34:56Z",
+                "intent": {
+                    "name": "WhereAreWeIntent",
                 }
             }
         }
         req = _req(data)
         self.assertEqual(200, req.status_code)
-        text = req.json().get('response', {}).get('outputSpeech',
-                                                  {}).get('text')
+        text = req.json().get("response", {}).get("outputSpeech",
+                                                  {}).get("text")
 
-        self.assertEqual('Anne Therese is at unknown and Paulus is at unknown',
+        self.assertEqual("Anne Therese is at unknown and Paulus is at unknown",
                          text)
 
-        hass.states.set('device_tracker.paulus', 'home')
-        hass.states.set('device_tracker.anne_therese', 'home')
+        hass.states.set("device_tracker.paulus", "home")
+        hass.states.set("device_tracker.anne_therese", "home")
 
         req = _req(data)
         self.assertEqual(200, req.status_code)
-        text = req.json().get('response', {}).get('outputSpeech',
-                                                  {}).get('text')
-        self.assertEqual('You are both home, you silly', text)
+        text = req.json().get("response", {}).get("outputSpeech",
+                                                  {}).get("text")
+        self.assertEqual("You are both home, you silly", text)
 
     def test_intent_request_calling_service(self):
         """Test a request for calling a service."""
         data = {
-            'version': '1.0',
-            'session': {
-                'new': False,
-                'sessionId': SESSION_ID,
-                'application': {
-                    'applicationId': APPLICATION_ID
+            "version": "1.0",
+            "session": {
+                "new": False,
+                "sessionId": SESSION_ID,
+                "application": {
+                    "applicationId": APPLICATION_ID
                 },
-                'attributes': {},
-                'user': {
-                    'userId': 'amzn1.account.AM3B00000000000000000000000'
+                "attributes": {},
+                "user": {
+                    "userId": "amzn1.account.AM3B00000000000000000000000"
                 }
             },
-            'request': {
-                'type': 'IntentRequest',
-                'requestId': REQUEST_ID,
-                'timestamp': '2015-05-13T12:34:56Z',
-                'intent': {
-                    'name': 'CallServiceIntent',
-                    'slots': {
-                        'ZodiacSign': {
-                            'name': 'ZodiacSign',
-                            'value': 'virgo',
+            "request": {
+                "type": "IntentRequest",
+                "requestId": REQUEST_ID,
+                "timestamp": "2015-05-13T12:34:56Z",
+                "intent": {
+                    "name": "CallServiceIntent",
+                    "slots": {
+                        "ZodiacSign": {
+                            "name": "ZodiacSign",
+                            "value": "virgo",
                         }
                     }
                 }
@@ -300,40 +301,40 @@ class TestAlexa(unittest.TestCase):
         self.assertEqual(200, req.status_code)
         self.assertEqual(call_count + 1, len(calls))
         call = calls[-1]
-        self.assertEqual('test', call.domain)
-        self.assertEqual('alexa', call.service)
-        self.assertEqual(['switch.test'], call.data.get('entity_id'))
-        self.assertEqual('virgo', call.data.get('hello'))
+        self.assertEqual("test", call.domain)
+        self.assertEqual("alexa", call.service)
+        self.assertEqual(["switch.test"], call.data.get("entity_id"))
+        self.assertEqual("virgo", call.data.get("hello"))
 
-    def test_session_ended_request(self):
+    def test_intent_session_ended_request(self):
         """Test the request for ending the session."""
         data = {
-            'version': '1.0',
-            'session': {
-                'new': False,
-                'sessionId': SESSION_ID,
-                'application': {
-                    'applicationId': APPLICATION_ID
+            "version": "1.0",
+            "session": {
+                "new": False,
+                "sessionId": SESSION_ID,
+                "application": {
+                    "applicationId": APPLICATION_ID
                 },
-                'attributes': {
-                    'supportedHoroscopePeriods': {
-                      'daily': True,
-                      'weekly': False,
-                      'monthly': False
+                "attributes": {
+                    "supportedHoroscopePeriods": {
+                        "daily": True,
+                        "weekly": False,
+                        "monthly": False
                     }
                 },
-                'user': {
-                    'userId': 'amzn1.account.AM3B00000000000000000000000'
+                "user": {
+                    "userId": "amzn1.account.AM3B00000000000000000000000"
                 }
             },
-            'request': {
-                'type': 'SessionEndedRequest',
-                'requestId': REQUEST_ID,
-                'timestamp': '2015-05-13T12:34:56Z',
-                'reason': 'USER_INITIATED'
+            "request": {
+                "type": "SessionEndedRequest",
+                "requestId": REQUEST_ID,
+                "timestamp": "2015-05-13T12:34:56Z",
+                "reason": "USER_INITIATED"
             }
         }
 
         req = _req(data)
         self.assertEqual(200, req.status_code)
-        self.assertEqual('', req.text)
+        self.assertEqual("", req.text)

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -13,7 +13,8 @@ from tests.common import get_test_instance_port, get_test_home_assistant
 
 API_PASSWORD = "test1234"
 SERVER_PORT = get_test_instance_port()
-API_URL = "http://127.0.0.1:{}{}".format(SERVER_PORT, alexa.API_ENDPOINT)
+API_URL = "http://127.0.0.1:{}{}".format(SERVER_PORT,
+                                         alexa.INTENTS_API_ENDPOINT)
 HA_HEADERS = {
     const.HTTP_HEADER_HA_AUTH: API_PASSWORD,
     const.HTTP_HEADER_CONTENT_TYPE: const.CONTENT_TYPE_JSON,

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -405,5 +405,4 @@ class TestAlexa(unittest.TestCase):
         req = _flash_briefing_req("news_audio")
         self.assertEqual(200, req.status_code)
         response = req.json()
-        print("response", response)
         self.assertEqual(response, data)


### PR DESCRIPTION
**Description:** Adds support for the new [Alexa Flash Briefing Skill API](https://developer.amazon.com/alexa-skills-kit/flash-briefing).

**Related issue (if applicable):** Closes #3680

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
alexa:
  flash_briefings:
    weather:
      - title: Weather information
        text: "Here's the forecast for the week: {{ states.sensor.dark_sky_daily_summary.state }}."
      - title: Another test
        text: Hello world, this is a test of multiple items.
      - title: Another test
        text: Goodbye world, this is the final test of multiple items.
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
