### PR TITLE
Improved exception handling for Squeezebox

### DIFF
--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -79,18 +79,11 @@ class LogitechMediaServer(object):
 
     def _get_http_port(self):
         """Get http port from media server, it is used to get cover art."""
-        http_port = None
-        try:
-            http_port = self.query('pref', 'httpport', '?')
-            if not http_port:
-                _LOGGER.error("Unable to read data from server %s:%s",
-                              self.host, self.port)
-                return
-            return http_port
-        except ConnectionError as ex:
-            _LOGGER.error("Failed to connect to server %s:%s - %s",
-                          self.host, self.port, ex)
-            return
+        http_port = self.query('pref', 'httpport', '?')
+        if not http_port:
+            _LOGGER.error("Failed to connect to server %s:%s",
+                          self.host, self.port)
+        return http_port
 
     def create_players(self):
         """Create a list of SqueezeBoxDevices connected to the LMS."""
@@ -104,20 +97,27 @@ class LogitechMediaServer(object):
 
     def query(self, *parameters):
         """Send request and await response from server."""
-        telnet = telnetlib.Telnet(self.host, self.port)
-        if self._username and self._password:
-            telnet.write('login {username} {password}\n'.format(
-                username=self._username,
-                password=self._password).encode('UTF-8'))
-            telnet.read_until(b'\n', timeout=3)
-        message = '{}\n'.format(' '.join(parameters))
-        telnet.write(message.encode('UTF-8'))
-        response = telnet.read_until(b'\n', timeout=3)\
-            .decode('UTF-8')\
-            .split(' ')[-1]\
-            .strip()
-        telnet.write(b'exit\n')
-        return urllib.parse.unquote(response)
+        try:
+            telnet = telnetlib.Telnet(self.host, self.port)
+            if self._username and self._password:
+                telnet.write('login {username} {password}\n'.format(
+                    username=self._username,
+                    password=self._password).encode('UTF-8'))
+                telnet.read_until(b'\n', timeout=3)
+            message = '{}\n'.format(' '.join(parameters))
+            telnet.write(message.encode('UTF-8'))
+            response = telnet.read_until(b'\n', timeout=3)\
+                             .decode('UTF-8')\
+                             .split(' ')[-1]\
+                             .strip()
+            telnet.write(b'exit\n')
+            return urllib.parse.unquote(response)
+        except (OSError, ConnectionError) as error:
+            _LOGGER.error("Could not communicate with %s:%d: %s",
+                          self.host,
+                          self.port,
+                          error)
+            return None
 
     def get_player_status(self, player):
         """Get ithe status of a player."""
@@ -128,18 +128,24 @@ class LogitechMediaServer(object):
         # K (artwork_url): URL to remote artwork
         tags = 'adK'
         new_status = {}
-        telnet = telnetlib.Telnet(self.host, self.port)
-        telnet.write('{player} status - 1 tags:{tags}\n'.format(
-            player=player,
-            tags=tags
+        try:
+            telnet = telnetlib.Telnet(self.host, self.port)
+            telnet.write('{player} status - 1 tags:{tags}\n'.format(
+                player=player,
+                tags=tags
             ).encode('UTF-8'))
-        response = telnet.read_until(b'\n', timeout=3)\
-            .decode('UTF-8')\
-            .split(' ')
-        telnet.write(b'exit\n')
-        for item in response:
-            parts = urllib.parse.unquote(item).partition(':')
-            new_status[parts[0]] = parts[2]
+            response = telnet.read_until(b'\n', timeout=3)\
+                             .decode('UTF-8')\
+                             .split(' ')
+            telnet.write(b'exit\n')
+            for item in response:
+                parts = urllib.parse.unquote(item).partition(':')
+                new_status[parts[0]] = parts[2]
+        except (OSError, ConnectionError) as error:
+            _LOGGER.error("Could not communicate with %s:%d: %s",
+                          self.host,
+                          self.port,
+                          error)
         return new_status
 
 


### PR DESCRIPTION
**Description:**

When on an unstable network connection or when pulling the network cable, there will be exceptions printed in the logs like the following:

```
6-10-07 15:20:02 ERROR (ThreadPool Worker 7) [homeassistant.core] BusHandler:Exception doing job
Traceback (most recent call last):
  File "/home/ee/home-assistant/homeassistant/core.py", line 1170, in job_handler
    func(*args)
  File "/home/ee/home-assistant/homeassistant/helpers/entity_component.py", line 229, in _update_entity_states
    entity.update_ha_state(True)
  File "/home/ee/home-assistant/homeassistant/helpers/entity.py", line 166, in update_ha_state
    self.update()
  File "/home/ee/home-assistant/homeassistant/components/media_player/squeezebox.py", line 181, in update
    self._status = self._lms.get_player_status(self._id)
  File "/home/ee/home-assistant/homeassistant/components/media_player/squeezebox.py", line 131, in get_player_status
    telnet = telnetlib.Telnet(self.host, self.port)
  File "/usr/lib/python3.5/telnetlib.py", line 218, in __init__
    self.open(host, port, timeout)
  File "/usr/lib/python3.5/telnetlib.py", line 234, in open
    self.sock = socket.create_connection((host, port), timeout)
  File "/usr/lib/python3.5/socket.py", line 711, in create_connection
    raise err
  File "/usr/lib/python3.5/socket.py", line 702, in create_connection
    sock.connect(sa)
OSError: [Errno 113] No route to host

```

Now, instead properly catch exceptions (ConnectionException and OSError and print error message in log.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
