### PR TITLE
Add support for Monzo

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -243,6 +243,7 @@ omit =
     homeassistant/components/sensor/loopenergy.py
     homeassistant/components/sensor/mhz19.py
     homeassistant/components/sensor/miflora.py
+    homeassistant/components/sensor/monzo.py
     homeassistant/components/sensor/mqtt_room.py
     homeassistant/components/sensor/neurio_energy.py
     homeassistant/components/sensor/nzbget.py

--- a/homeassistant/components/sensor/monzo.py
+++ b/homeassistant/components/sensor/monzo.py
@@ -1,0 +1,157 @@
+"""
+Support for Monzo service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.monzo/
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_NAME, CONF_MONITORED_VARIABLES, CONF_ACCESS_TOKEN)
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['monzo==0.5.3']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ACCOUNT_ID = 'account_id'
+
+ICON_EUR = 'mdi:currency-eur'
+ICON_GBP = 'mdi:currency-gbp'
+ICON_INR = 'mdi:currency-inr'
+ICON_NGN = 'mdi:currency-ngn'
+ICON_RUB = 'mdi:currency-rub'
+ICON_TRY = 'mdi:currency-try'
+ICON_USD = 'mdi:currency-usd'
+
+DEFAULT_NAME = 'Monzo'
+
+VARIABLE_TYPES = {
+    'balance': 'Balance',
+    'currency': 'Currency',
+    'spend_today': 'Spend today',
+    'local_currency': 'Local currency',
+    'local_exchange_rate': 'Local exchange rate'
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ACCESS_TOKEN): cv.string,
+    vol.Required(CONF_MONITORED_VARIABLES, default=[]):
+        vol.All(cv.ensure_list, [vol.In(VARIABLE_TYPES)]),
+    vol.Optional(CONF_ACCOUNT_ID): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string
+})
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=10)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Monzo sensor."""
+    access_token = config.get(CONF_ACCESS_TOKEN)
+    account_id = config.get(CONF_ACCOUNT_ID)
+    name = config.get(CONF_NAME)
+
+    data = MonzoData(access_token, account_id)
+    dev = []
+    for variable in config[CONF_MONITORED_VARIABLES]:
+        dev.append(MonzoSensor(data, variable, name))
+
+    add_devices(dev)
+
+
+# pylint: disable=too-few-public-methods
+class MonzoSensor(Entity):
+    """Representation of a Monzo sensor."""
+
+    def __init__(self, data, variable, name):
+        """Initialize the sensor."""
+        self.client_name = name
+        self.data = data
+        self.type = variable
+        self._name = VARIABLE_TYPES[variable]
+        self._unit_of_measurement = None
+        self._state = None
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{} {}'.format(self.client_name, self._name)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self._unit_of_measurement
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        icon = ICON_USD
+
+        if not self._unit_of_measurement:
+            return icon
+        elif self._unit_of_measurement.lower() == 'eur':
+            icon = ICON_EUR
+        elif self._unit_of_measurement.lower() == 'gbp':
+            icon = ICON_GBP
+        elif self._unit_of_measurement.lower() == 'inr':
+            icon = ICON_INR
+        elif self._unit_of_measurement.lower() == 'ngn':
+            icon = ICON_NGN
+        elif self._unit_of_measurement.lower() == 'rub':
+            icon = ICON_RUB
+        elif self._unit_of_measurement.lower() == 'try':
+            icon = ICON_TRY
+
+        return icon
+
+    def update(self):
+        """Get the latest data and updates the states."""
+        self.data.update()
+        balance = self.data.balance
+
+        if self.type == 'balance':
+            self._state = balance['balance']
+            self._unit_of_measurement = balance['currency']
+        elif self.type == 'currency':
+            self._state = balance['currency']
+        elif self.type == 'spend_today':
+            self._state = balance['spend_today']
+            self._unit_of_measurement = balance['currency']
+        elif self.type == 'local_currency':
+            self._state = balance['local_currency']
+        elif self.type == 'local_exchange_rate':
+            self._state = balance['local_exchange_rate']
+            self._unit_of_measurement = balance['currency']
+
+
+class MonzoData(object):
+    """Get the latest data and update the states."""
+
+    def __init__(self, access_token, account_id):
+        """Initialize the data object."""
+        from monzo.monzo import Monzo
+
+        self._monzo = Monzo(access_token)
+        if account_id:
+            self._account_id = account_id
+        else:
+            self._account_id = self._monzo.get_first_account()['id']
+        self.balance = None
+        self.update()
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Get the latest data from Monzo."""
+        self.balance = self._monzo.get_balance(self._account_id)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -257,6 +257,9 @@ mficlient==0.3.0
 # homeassistant.components.sensor.miflora
 miflora==0.1.9
 
+# homeassistant.components.sensor.monzo
+monzo==0.5.3
+
 # homeassistant.components.discovery
 netdisco==0.7.1
 


### PR DESCRIPTION
**Description:**

Add support for https://monzo.com.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#1176

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
- platform: monzo
  access_token: 'access_token'
  account_id: 'account_id'
  monitored_variables:
    - balance
    - currency
    - spend_today
    - local_currency
    - local_exchange_rate
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
