### PR TITLE
Fix notify group flakiness

### DIFF
--- a/homeassistant/components/notify/group.py
+++ b/homeassistant/components/notify/group.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/notify.group/
 """
 import collections
 import logging
-import copy
 import voluptuous as vol
 
 from homeassistant.const import ATTR_SERVICE
@@ -54,7 +53,7 @@ class GroupNotifyPlatform(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send message to all entities in the group."""
-        payload = copy.copy(kwargs)
+        payload = kwargs
         payload[ATTR_MESSAGE] = message
 
         for entity in self.entities:

--- a/homeassistant/components/notify/group.py
+++ b/homeassistant/components/notify/group.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/notify.group/
 import collections
 import logging
 import voluptuous as vol
+import copy
 
 from homeassistant.const import ATTR_SERVICE
 from homeassistant.components.notify import (DOMAIN, ATTR_MESSAGE, ATTR_DATA,
@@ -53,8 +54,8 @@ class GroupNotifyPlatform(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send message to all entities in the group."""
-        payload = {ATTR_MESSAGE: message}
-        payload.update({key: val for key, val in kwargs.items() if val})
+        payload = copy.copy(kwargs)
+        payload[ATTR_MESSAGE] = message
 
         for entity in self.entities:
             sending_payload = payload.copy()

--- a/homeassistant/components/notify/group.py
+++ b/homeassistant/components/notify/group.py
@@ -6,8 +6,8 @@ https://home-assistant.io/components/notify.group/
 """
 import collections
 import logging
-import voluptuous as vol
 import copy
+import voluptuous as vol
 
 from homeassistant.const import ATTR_SERVICE
 from homeassistant.components.notify import (DOMAIN, ATTR_MESSAGE, ATTR_DATA,

--- a/tests/components/notify/test_group.py
+++ b/tests/components/notify/test_group.py
@@ -28,7 +28,7 @@ class TestNotifyGroup(unittest.TestCase):
         self.service = group.get_service(self.hass, {'services': [
             {'service': 'demo1'},
             {'service': 'demo2',
-             'data': {'target': 'unnamed device',
+             'data': {'target': ['unnamed device'],
                       'data': {'test': 'message'}}}]})
 
         assert self.service is not None


### PR DESCRIPTION
This fixes an issue where the built payload would sometimes not include all the kwargs. I changed to copying the kwargs and then adding the message to it instead of iterating over all kwargs.
