### PR TITLE
Added additional checks which hides functions which are not supported by Nest

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -44,6 +44,7 @@ class NestThermostat(ClimateDevice):
         # Not all nest devices support cooling and heating remove unused
         self._operation_list = [STATE_OFF]
 
+        # Add supported nest thermostat features
         if self.can_heat:
             self._operation_list.append(STATE_HEAT)
 

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -40,16 +40,16 @@ class NestThermostat(ClimateDevice):
         self.structure = structure
         self.device = device
         self._fan_list = [STATE_ON, STATE_AUTO]
-        
-        """Not all nest devices support both cooling and heating so remove unused options"""
+
+        """Not all nest devices support cooling and heating remove unused"""
         self._operation_list = [STATE_HEAT, STATE_COOL, STATE_AUTO,
                                 STATE_OFF]
-                                
-        if(self.can_cool and not self.can_heat):
+
+        if self.can_cool and not self.can_heat:
             self._operation_list = [STATE_COOL, STATE_OFF]
-        elif(self.can_heat and not self.can_cool):
+        elif self.can_heat and not self.can_cool:
             self._operation_list = [STATE_HEAT, STATE_OFF]
-        
+
     @property
     def name(self):
         """Return the name of the nest, if any."""
@@ -71,14 +71,14 @@ class NestThermostat(ClimateDevice):
     @property
     def device_state_attributes(self):
         """Return the device specific state attributes."""
-        if( self.has_humidifier or self.has_dehumidifier ):
+        if self.has_humidifier or self.has_dehumidifier:
             # Move these to Thermostat Device and make them global
             return {
                 "humidity": self.device.humidity,
                 "target_humidity": self.device.target_humidity,
             }
         else:
-            """There is no way to control humidity so do not publish humidity and target_humidity"""
+            # No way to control humidity not show setting
             return {}
 
     @property
@@ -174,13 +174,13 @@ class NestThermostat(ClimateDevice):
 
     @property
     def current_fan_mode(self):
-        if( self.has_fan ):
-            """Return whether the fan is on."""
+        if self.has_fan:
+            # Return whether the fan is on
             return STATE_ON if self.device.fan else STATE_AUTO
         else:
-            """No Fan available so disable slider."""
+            # No Fan available so disable slider
             return None
-            
+
     @property
     def fan_list(self):
         """List of available fan modes."""
@@ -212,23 +212,29 @@ class NestThermostat(ClimateDevice):
         """Python-nest has its own mechanism for staying up to date."""
         pass
 
-    """ Exposing extra properties these properties will probally be added to python-nest 2.11 using getter """
+    # Exposing extra properties will probably be added to python-nest 2.11
+    # pylint: disable=protected-access
     @property
     def can_heat(self):
+        """Temp function to check if thermostat is able to heat."""
         return self.device._shared['can_heat']
 
     @property
     def can_cool(self):
+        """Temp function to check if thermostat is able to cool."""
         return self.device._shared['can_cool']
 
     @property
     def has_humidifier(self):
+        """Temp function to check if thermostat has humidifier."""
         return self.device._device['has_humidifier']
 
     @property
     def has_dehumidifier(self):
+        """Temp function to check if thermostat has dehumidifier."""
         return self.device._device['has_dehumidifier']
 
     @property
     def has_fan(self):
+        """Temp function to check if thermostat has a fan."""
         return self.device._device['has_fan']

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -41,14 +41,17 @@ class NestThermostat(ClimateDevice):
         self.device = device
         self._fan_list = [STATE_ON, STATE_AUTO]
 
-        """Not all nest devices support cooling and heating remove unused"""
-        self._operation_list = [STATE_HEAT, STATE_COOL, STATE_AUTO,
-                                STATE_OFF]
+        # Not all nest devices support cooling and heating remove unused
+        self._operation_list = [STATE_OFF]
 
-        if self.can_cool and not self.can_heat:
-            self._operation_list = [STATE_COOL, STATE_OFF]
-        elif self.can_heat and not self.can_cool:
-            self._operation_list = [STATE_HEAT, STATE_OFF]
+        if self.can_heat:
+            self._operation_list.append(STATE_HEAT)
+
+        if self.can_cool:
+            self._operation_list.append(STATE_COOL)
+
+        if self.can_heat and self.can_cool:
+            self._operation_list.append(STATE_AUTO)
 
     @property
     def name(self):

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -45,13 +45,13 @@ class NestThermostat(ClimateDevice):
         self._operation_list = [STATE_OFF]
 
         # Add supported nest thermostat features
-        if self.can_heat:
+        if self.device.can_heat:
             self._operation_list.append(STATE_HEAT)
 
-        if self.can_cool:
+        if self.device.can_cool:
             self._operation_list.append(STATE_COOL)
 
-        if self.can_heat and self.can_cool:
+        if self.device.can_heat and self.device.can_cool:
             self._operation_list.append(STATE_AUTO)
 
     @property
@@ -75,7 +75,7 @@ class NestThermostat(ClimateDevice):
     @property
     def device_state_attributes(self):
         """Return the device specific state attributes."""
-        if self.has_humidifier or self.has_dehumidifier:
+        if self.device.has_humidifier or self.device.has_dehumidifier:
             # Move these to Thermostat Device and make them global
             return {
                 "humidity": self.device.humidity,
@@ -179,7 +179,7 @@ class NestThermostat(ClimateDevice):
     @property
     def current_fan_mode(self):
         """Return whether the fan is on."""
-        if self.has_fan:
+        if self.device.has_fan:
             # Return whether the fan is on
             return STATE_ON if self.device.fan else STATE_AUTO
         else:
@@ -216,30 +216,3 @@ class NestThermostat(ClimateDevice):
     def update(self):
         """Python-nest has its own mechanism for staying up to date."""
         pass
-
-    # Exposing extra properties will probably be added to python-nest 2.11
-    # pylint: disable=protected-access
-    @property
-    def can_heat(self):
-        """Temp function to check if thermostat is able to heat."""
-        return self.device._shared['can_heat']
-
-    @property
-    def can_cool(self):
-        """Temp function to check if thermostat is able to cool."""
-        return self.device._shared['can_cool']
-
-    @property
-    def has_humidifier(self):
-        """Temp function to check if thermostat has humidifier."""
-        return self.device._device['has_humidifier']
-
-    @property
-    def has_dehumidifier(self):
-        """Temp function to check if thermostat has dehumidifier."""
-        return self.device._device['has_dehumidifier']
-
-    @property
-    def has_fan(self):
-        """Temp function to check if thermostat has a fan."""
-        return self.device._device['has_fan']

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -40,9 +40,16 @@ class NestThermostat(ClimateDevice):
         self.structure = structure
         self.device = device
         self._fan_list = [STATE_ON, STATE_AUTO]
+        
+        """Not all nest devices support both cooling and heating so remove unused options"""
         self._operation_list = [STATE_HEAT, STATE_COOL, STATE_AUTO,
                                 STATE_OFF]
-
+                                
+        if(self.can_cool and not self.can_heat):
+            self._operation_list = [STATE_COOL, STATE_OFF]
+        elif(self.can_heat and not self.can_cool):
+            self._operation_list = [STATE_HEAT, STATE_OFF]
+        
     @property
     def name(self):
         """Return the name of the nest, if any."""
@@ -64,11 +71,15 @@ class NestThermostat(ClimateDevice):
     @property
     def device_state_attributes(self):
         """Return the device specific state attributes."""
-        # Move these to Thermostat Device and make them global
-        return {
-            "humidity": self.device.humidity,
-            "target_humidity": self.device.target_humidity,
-        }
+        if( self.has_humidifier or self.has_dehumidifier ):
+            # Move these to Thermostat Device and make them global
+            return {
+                "humidity": self.device.humidity,
+                "target_humidity": self.device.target_humidity,
+            }
+        else:
+            """There is no way to control humidity so do not publish humidity and target_humidity"""
+            return {}
 
     @property
     def current_temperature(self):
@@ -163,9 +174,13 @@ class NestThermostat(ClimateDevice):
 
     @property
     def current_fan_mode(self):
-        """Return whether the fan is on."""
-        return STATE_ON if self.device.fan else STATE_AUTO
-
+        if( self.has_fan ):
+            """Return whether the fan is on."""
+            return STATE_ON if self.device.fan else STATE_AUTO
+        else:
+            """No Fan available so disable slider."""
+            return None
+            
     @property
     def fan_list(self):
         """List of available fan modes."""
@@ -196,3 +211,24 @@ class NestThermostat(ClimateDevice):
     def update(self):
         """Python-nest has its own mechanism for staying up to date."""
         pass
+
+    """ Exposing extra properties these properties will probally be added to python-nest 2.11 using getter """
+    @property
+    def can_heat(self):
+        return self.device._shared['can_heat']
+
+    @property
+    def can_cool(self):
+        return self.device._shared['can_cool']
+
+    @property
+    def has_humidifier(self):
+        return self.device._device['has_humidifier']
+
+    @property
+    def has_dehumidifier(self):
+        return self.device._device['has_dehumidifier']
+
+    @property
+    def has_fan(self):
+        return self.device._device['has_fan']

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -174,6 +174,7 @@ class NestThermostat(ClimateDevice):
 
     @property
     def current_fan_mode(self):
+        """Return whether the fan is on."""
         if self.has_fan:
             # Return whether the fan is on
             return STATE_ON if self.device.fan else STATE_AUTO

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -14,7 +14,7 @@ from homeassistant.const import (CONF_PASSWORD, CONF_USERNAME, CONF_STRUCTURE)
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['python-nest==2.10.0']
+REQUIREMENTS = ['python-nest==2.11.0']
 
 DOMAIN = 'nest'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -389,7 +389,7 @@ python-mpd2==0.5.5
 python-mystrom==0.3.6
 
 # homeassistant.components.nest
-python-nest==2.10.0
+python-nest==2.11.0
 
 # homeassistant.components.device_tracker.nmap_tracker
 python-nmap==0.6.1


### PR DESCRIPTION
**Description:**
Nest Thermostat devices are different in different countries. The EU version only supports heating (and has no way to cool as fans / airco's / humidifiers can not be connected. Added various checks (using the existing python-nest library) which checks which functions are available and hides these functions

**Related issue (if applicable):** fixes #
None

**Example entry for `configuration.yaml` (if applicable):**
No Changes Required

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the REQUIREMENTS variable (example).
- [x] New dependencies are only imported inside functions that use them (example).
- [x] New dependencies have been added to requirements_all.txt by running script/gen_requirements_all.py.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works. (none where available might be a feature project to work on :))
