### PR TITLE
Replacing tempfile with mock_open in tests

### DIFF
--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -1,5 +1,4 @@
 """The tests for local file camera component."""
-from tempfile import NamedTemporaryFile
 import unittest
 from unittest import mock
 
@@ -26,45 +25,46 @@ class TestLocalCamera(unittest.TestCase):
 
     def test_loading_file(self):
         """Test that it loads image from disk."""
+        test_string = 'hello'
         self.hass.wsgi = mock.MagicMock()
 
-        with NamedTemporaryFile() as fptr:
-            fptr.write('hello'.encode('utf-8'))
-            fptr.flush()
-
+        with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
+                mock.patch('os.access', mock.Mock(return_value=True)):
             assert setup_component(self.hass, 'camera', {
                 'camera': {
                     'name': 'config_test',
                     'platform': 'local_file',
-                    'file_path': fptr.name,
+                    'file_path': 'mock.file',
                 }})
 
-            image_view = self.hass.wsgi.mock_calls[0][1][0]
+        image_view = self.hass.wsgi.mock_calls[0][1][0]
 
+        m_open = mock.mock_open(read_data=test_string)
+        with mock.patch(
+                'homeassistant.components.camera.local_file.open',
+                m_open, create=True
+        ):
             builder = EnvironBuilder(method='GET')
             Request = request_class()  # pylint: disable=invalid-name
             request = Request(builder.get_environ())
             request.authenticated = True
             resp = image_view.get(request, 'camera.config_test')
 
-            assert resp.status_code == 200, resp.response
-            assert resp.response[0].decode('utf-8') == 'hello'
+        assert resp.status_code == 200, resp.response
+        assert resp.response[0].decode('utf-8') == test_string
 
     def test_file_not_readable(self):
         """Test local file will not setup when file is not readable."""
         self.hass.wsgi = mock.MagicMock()
 
-        with NamedTemporaryFile() as fptr:
-            fptr.write('hello'.encode('utf-8'))
-            fptr.flush()
+        with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
+                mock.patch('os.access', return_value=False), \
+                assert_setup_component(0):
+            assert setup_component(self.hass, 'camera', {
+                'camera': {
+                    'name': 'config_test',
+                    'platform': 'local_file',
+                    'file_path': 'mock.file',
+                }})
 
-            with mock.patch('os.access', return_value=False), \
-                    assert_setup_component(0):
-                assert setup_component(self.hass, 'camera', {
-                    'camera': {
-                        'name': 'config_test',
-                        'platform': 'local_file',
-                        'file_path': fptr.name,
-                    }})
-
-                assert [] == self.hass.states.all()
+            assert [] == self.hass.states.all()

--- a/tests/components/mqtt/test_server.py
+++ b/tests/components/mqtt/test_server.py
@@ -1,5 +1,5 @@
 """The tests for the MQTT component embedded server."""
-from unittest.mock import MagicMock, patch
+from unittest.mock import Mock, MagicMock, patch
 
 from homeassistant.bootstrap import _setup_component
 import homeassistant.components.mqtt as mqtt
@@ -18,14 +18,12 @@ class TestMQTT:
         """Stop everything that was started."""
         self.hass.stop()
 
-    @patch('passlib.apps.custom_app_context', return_value='')
-    @patch('tempfile.NamedTemporaryFile', return_value=MagicMock())
+    @patch('passlib.apps.custom_app_context', Mock(return_value=''))
+    @patch('tempfile.NamedTemporaryFile', Mock(return_value=MagicMock()))
+    @patch('asyncio.new_event_loop', Mock())
     @patch('homeassistant.components.mqtt.MQTT')
     @patch('asyncio.gather')
-    @patch('asyncio.new_event_loop')
-    def test_creating_config_with_http_pass(self, mock_new_loop, mock_gather,
-                                            mock_mqtt, mock_temp,
-                                            mock_context):
+    def test_creating_config_with_http_pass(self, mock_gather, mock_mqtt):
         """Test if the MQTT server gets started and subscribe/publish msg."""
         self.hass.config.components.append('http')
         password = 'super_secret'
@@ -45,10 +43,10 @@ class TestMQTT:
         assert mock_mqtt.mock_calls[0][1][5] is None
         assert mock_mqtt.mock_calls[0][1][6] is None
 
-    @patch('tempfile.NamedTemporaryFile', return_value=MagicMock())
+    @patch('tempfile.NamedTemporaryFile', Mock(return_value=MagicMock()))
+    @patch('asyncio.new_event_loop', Mock())
     @patch('asyncio.gather')
-    @patch('asyncio.new_event_loop')
-    def test_broker_config_fails(self, mock_new_loop, mock_gather, mock_temp):
+    def test_broker_config_fails(self, mock_gather):
         """Test if the MQTT component fails if server fails."""
         self.hass.config.components.append('http')
         from hbmqtt.broker import BrokerException

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -1,12 +1,10 @@
 """The tests for the notify demo platform."""
-import tempfile
 import unittest
 
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.notify as notify
 from homeassistant.components.notify import demo
 from homeassistant.helpers import script
-from homeassistant.util import yaml
 
 from tests.common import get_test_home_assistant
 
@@ -70,21 +68,18 @@ class TestNotifyDemo(unittest.TestCase):
 
     def test_calling_notify_from_script_loaded_from_yaml_without_title(self):
         """Test if we can call a notify from a script."""
-        yaml_conf = """
-service: notify.notify
-data:
-  data:
-    push:
-      sound: US-EN-Morgan-Freeman-Roommate-Is-Arriving.wav
-data_template:
-  message: >
-          Test 123 {{ 2 + 2 }}
-"""
-
-        with tempfile.NamedTemporaryFile() as fp:
-            fp.write(yaml_conf.encode('utf-8'))
-            fp.flush()
-            conf = yaml.load_yaml(fp.name)
+        conf = {
+            'service': 'notify.notify',
+            'data': {
+                'data': {
+                    'push': {
+                        'sound':
+                        'US-EN-Morgan-Freeman-Roommate-Is-Arriving.wav'
+                    }
+                }
+            },
+            'data_template': {'message': 'Test 123 {{ 2 + 2 }}\n'},
+        }
 
         script.call_from_config(self.hass, conf)
         self.hass.block_till_done()
@@ -99,22 +94,21 @@ data_template:
 
     def test_calling_notify_from_script_loaded_from_yaml_with_title(self):
         """Test if we can call a notify from a script."""
-        yaml_conf = """
-service: notify.notify
-data:
-  data:
-    push:
-      sound: US-EN-Morgan-Freeman-Roommate-Is-Arriving.wav
-data_template:
-  title: Test
-  message: >
-          Test 123 {{ 2 + 2 }}
-"""
-
-        with tempfile.NamedTemporaryFile() as fp:
-            fp.write(yaml_conf.encode('utf-8'))
-            fp.flush()
-            conf = yaml.load_yaml(fp.name)
+        conf = {
+            'service': 'notify.notify',
+            'data': {
+                'data': {
+                    'push': {
+                        'sound':
+                        'US-EN-Morgan-Freeman-Roommate-Is-Arriving.wav'
+                    }
+                }
+            },
+            'data_template': {
+                'message': 'Test 123 {{ 2 + 2 }}\n',
+                'title': 'Test'
+            }
+        }
 
         script.call_from_config(self.hass, conf)
         self.hass.pool.block_till_done()

--- a/tests/components/notify/test_file.py
+++ b/tests/components/notify/test_file.py
@@ -1,8 +1,7 @@
 """The tests for the notify file platform."""
 import os
 import unittest
-import tempfile
-from unittest.mock import patch
+from unittest.mock import call, mock_open, patch
 
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.notify as notify
@@ -34,13 +33,19 @@ class TestNotifyFile(unittest.TestCase):
             },
         }))
 
+    @patch('homeassistant.components.notify.file.os.stat')
     @patch('homeassistant.util.dt.utcnow')
-    def test_notify_file(self, mock_utcnow):
+    def test_notify_file(self, mock_utcnow, mock_stat):
         """Test the notify file output."""
         mock_utcnow.return_value = dt_util.as_utc(dt_util.now())
+        mock_stat.return_value.st_size = 0
 
-        with tempfile.TemporaryDirectory() as tempdirname:
-            filename = os.path.join(tempdirname, 'notify.txt')
+        m_open = mock_open()
+        with patch(
+                'homeassistant.components.notify.file.open',
+                m_open, create=True
+        ):
+            filename = 'mock_file'
             message = 'one, two, testing, testing'
             self.assertTrue(setup_component(self.hass, notify.DOMAIN, {
                 'notify': {
@@ -58,5 +63,12 @@ class TestNotifyFile(unittest.TestCase):
             self.hass.services.call('notify', 'test', {'message': message},
                                     blocking=True)
 
-            result = open(filename).read()
-            self.assertEqual(result, "{}{}\n".format(title, message))
+            full_filename = os.path.join(self.hass.config.path(), filename)
+            self.assertEqual(m_open.call_count, 1)
+            self.assertEqual(m_open.call_args, call(full_filename, 'a'))
+
+            self.assertEqual(m_open.return_value.write.call_count, 2)
+            self.assertEqual(
+                m_open.return_value.write.call_args_list,
+                [call(title), call(message + '\n')]
+            )

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -2,10 +2,9 @@
 # pylint: disable=protected-access,too-many-public-methods
 from contextlib import closing
 import json
-import tempfile
 import time
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import requests
 
@@ -244,15 +243,20 @@ class TestAPI(unittest.TestCase):
 
     def test_api_get_error_log(self):
         """Test the return of the error log."""
-        test_content = 'Test String°'
-        with tempfile.NamedTemporaryFile() as log:
-            log.write(test_content.encode('utf-8'))
-            log.flush()
+        test_string = 'Test String°'.encode('UTF-8')
 
-            with patch.object(hass.config, 'path', return_value=log.name):
-                req = requests.get(_url(const.URL_API_ERROR_LOG),
-                                   headers=HA_HEADERS)
-            self.assertEqual(test_content, req.text)
+        # Can't use read_data with wsgiserver in Python 3.4.2. Due to a
+        # bug in read_data, it can't handle byte types ('Type str doesn't
+        # support the buffer API'), but wsgiserver requires byte types
+        # ('WSGI Applications must yield bytes'). So just mock our own
+        # read method.
+        m_open = Mock(return_value=Mock(
+            read=Mock(side_effect=[test_string]))
+        )
+        with patch('homeassistant.components.http.open', m_open, create=True):
+            req = requests.get(_url(const.URL_API_ERROR_LOG),
+                               headers=HA_HEADERS)
+            self.assertEqual(test_string, req.text.encode('UTF-8'))
             self.assertIsNone(req.headers.get('expires'))
 
     def test_api_get_event_listeners(self):

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -1,9 +1,12 @@
 """Test Home Assistant package util methods."""
 import os
-import tempfile
+import pkg_resources
+import subprocess
 import unittest
 
-from homeassistant.bootstrap import mount_local_lib_path
+from distutils.sysconfig import get_python_lib
+from unittest.mock import call, patch
+
 import homeassistant.util.package as package
 
 RESOURCE_DIR = os.path.abspath(
@@ -15,43 +18,114 @@ TEST_ZIP_REQ = 'file://{}#{}' \
     .format(os.path.join(RESOURCE_DIR, 'pyhelloworld3.zip'), TEST_NEW_REQ)
 
 
-class TestPackageUtil(unittest.TestCase):
+@patch('homeassistant.util.package.subprocess.call')
+@patch('homeassistant.util.package.check_package_exists')
+class TestPackageUtilInstallPackage(unittest.TestCase):
     """Test for homeassistant.util.package module."""
 
-    def setUp(self):
-        """Create local library for testing."""
-        self.tmp_dir = tempfile.TemporaryDirectory()
-        self.lib_dir = mount_local_lib_path(self.tmp_dir.name)
-
-    def tearDown(self):
-        """Stop everything that was started."""
-        self.tmp_dir.cleanup()
-
-    def test_install_existing_package(self):
+    def test_install_existing_package(self, mock_exists, mock_subprocess):
         """Test an install attempt on an existing package."""
-        self.assertTrue(package.check_package_exists(
-            TEST_EXIST_REQ, self.lib_dir))
+        mock_exists.return_value = True
 
         self.assertTrue(package.install_package(TEST_EXIST_REQ))
 
-    def test_install_package_zip(self):
-        """Test an install attempt from a zip path."""
-        self.assertFalse(package.check_package_exists(
-            TEST_ZIP_REQ, self.lib_dir))
-        self.assertFalse(package.check_package_exists(
-            TEST_NEW_REQ, self.lib_dir))
+        self.assertEqual(mock_exists.call_count, 1)
+        self.assertEqual(mock_exists.call_args, call(TEST_EXIST_REQ, None))
 
-        self.assertTrue(package.install_package(
-            TEST_ZIP_REQ, True, self.lib_dir))
+        self.assertEqual(mock_subprocess.call_count, 0)
 
-        self.assertTrue(package.check_package_exists(
-            TEST_ZIP_REQ, self.lib_dir))
-        self.assertTrue(package.check_package_exists(
-            TEST_NEW_REQ, self.lib_dir))
+    @patch('homeassistant.util.package.sys')
+    def test_install(self, mock_sys, mock_exists, mock_subprocess):
+        """Test an install attempt on a package that doesn't exist."""
+        mock_exists.return_value = False
+        mock_subprocess.return_value = 0
 
-        try:
-            import pyhelloworld3
-        except ImportError:
-            self.fail('Unable to import pyhelloworld3 after installing it.')
+        self.assertTrue(package.install_package(TEST_NEW_REQ, False))
 
-        self.assertEqual(pyhelloworld3.__version__, '1.0.0')
+        self.assertEqual(mock_exists.call_count, 1)
+
+        self.assertEqual(mock_subprocess.call_count, 1)
+        self.assertEqual(
+            mock_subprocess.call_args,
+            call([
+                mock_sys.executable, '-m', 'pip',
+                'install', '--quiet', TEST_NEW_REQ
+            ])
+        )
+
+    @patch('homeassistant.util.package.sys')
+    def test_install_upgrade(self, mock_sys, mock_exists, mock_subprocess):
+        """Test an upgrade attempt on a package."""
+        mock_exists.return_value = False
+        mock_subprocess.return_value = 0
+
+        self.assertTrue(package.install_package(TEST_NEW_REQ))
+
+        self.assertEqual(mock_exists.call_count, 1)
+
+        self.assertEqual(mock_subprocess.call_count, 1)
+        self.assertEqual(
+            mock_subprocess.call_args,
+            call([
+                mock_sys.executable, '-m', 'pip', 'install',
+                '--quiet', TEST_NEW_REQ, '--upgrade'
+            ])
+        )
+
+    @patch('homeassistant.util.package.sys')
+    def test_install_target(self, mock_sys, mock_exists, mock_subprocess):
+        """Test an install with a target."""
+        target = 'target_folder'
+        mock_exists.return_value = False
+        mock_subprocess.return_value = 0
+
+        self.assertTrue(
+            package.install_package(TEST_NEW_REQ, False, target=target)
+        )
+
+        self.assertEqual(mock_exists.call_count, 1)
+
+        self.assertEqual(mock_subprocess.call_count, 1)
+        self.assertEqual(
+            mock_subprocess.call_args,
+            call([
+                mock_sys.executable, '-m', 'pip', 'install', '--quiet',
+                TEST_NEW_REQ, '--target', os.path.abspath(target)
+            ])
+        )
+
+    @patch('homeassistant.util.package._LOGGER')
+    @patch('homeassistant.util.package.sys')
+    def test_install_error(
+            self, mock_sys, mock_logger, mock_exists, mock_subprocess
+    ):
+        """Test an install with a target."""
+        mock_exists.return_value = False
+        mock_subprocess.side_effect = [subprocess.SubprocessError]
+
+        self.assertFalse(package.install_package(TEST_NEW_REQ))
+
+        self.assertEqual(mock_logger.exception.call_count, 1)
+
+
+class TestPackageUtilCheckPackageExists(unittest.TestCase):
+    """Test for homeassistant.util.package module."""
+
+    def test_check_package_global(self):
+        """Test for a globally-installed package"""
+        installed_package = list(pkg_resources.working_set)[0].project_name
+
+        self.assertTrue(package.check_package_exists(installed_package, None))
+
+    def test_check_package_local(self):
+        """Test for a locally-installed package"""
+        lib_dir = get_python_lib()
+        installed_package = list(pkg_resources.working_set)[0].project_name
+
+        self.assertTrue(
+            package.check_package_exists(installed_package, lib_dir)
+        )
+
+    def test_check_package_zip(self):
+        """Test for an installed zip package"""
+        self.assertFalse(package.check_package_exists(TEST_ZIP_REQ, None))

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -2,7 +2,6 @@
 import io
 import unittest
 import os
-import tempfile
 from unittest.mock import patch
 
 from homeassistant.exceptions import HomeAssistantError
@@ -68,146 +67,116 @@ class TestYaml(unittest.TestCase):
 
     def test_include_yaml(self):
         """Test include yaml."""
-        with tempfile.NamedTemporaryFile() as include_file:
-            include_file.write(b"value")
-            include_file.seek(0)
-            conf = "key: !include {}".format(include_file.name)
+        with patch_yaml_files({'test.yaml': 'value'}):
+            conf = 'key: !include test.yaml'
             with io.StringIO(conf) as file:
                 doc = yaml.yaml.safe_load(file)
                 assert doc["key"] == "value"
 
-    def test_include_dir_list(self):
+    @patch('homeassistant.util.yaml.os.walk')
+    def test_include_dir_list(self, mock_walk):
         """Test include dir list yaml."""
-        with tempfile.TemporaryDirectory() as include_dir:
-            file_1 = tempfile.NamedTemporaryFile(dir=include_dir,
-                                                 suffix=".yaml", delete=False)
-            file_1.write(b"one")
-            file_1.close()
-            file_2 = tempfile.NamedTemporaryFile(dir=include_dir,
-                                                 suffix=".yaml", delete=False)
-            file_2.write(b"two")
-            file_2.close()
-            conf = "key: !include_dir_list {}".format(include_dir)
+        mock_walk.return_value = [['/tmp', [], ['one.yaml', 'two.yaml']]]
+
+        with patch_yaml_files({
+                '/tmp/one.yaml': 'one', '/tmp/two.yaml': 'two'
+        }):
+            conf = "key: !include_dir_list /tmp"
             with io.StringIO(conf) as file:
                 doc = yaml.yaml.safe_load(file)
                 assert sorted(doc["key"]) == sorted(["one", "two"])
 
-    def test_include_dir_list_recursive(self):
+    @patch('homeassistant.util.yaml.os.walk')
+    def test_include_dir_list_recursive(self, mock_walk):
         """Test include dir recursive list yaml."""
-        with tempfile.TemporaryDirectory() as include_dir:
-            file_0 = tempfile.NamedTemporaryFile(dir=include_dir,
-                                                 suffix=".yaml", delete=False)
-            file_0.write(b"zero")
-            file_0.close()
-            temp_dir = tempfile.TemporaryDirectory(dir=include_dir)
-            file_1 = tempfile.NamedTemporaryFile(dir=temp_dir.name,
-                                                 suffix=".yaml", delete=False)
-            file_1.write(b"one")
-            file_1.close()
-            file_2 = tempfile.NamedTemporaryFile(dir=temp_dir.name,
-                                                 suffix=".yaml", delete=False)
-            file_2.write(b"two")
-            file_2.close()
-            conf = "key: !include_dir_list {}".format(include_dir)
+        mock_walk.return_value = [
+            ['/tmp', ['tmp2'], ['zero.yaml']],
+            ['/tmp/tmp2', [], ['one.yaml', 'two.yaml']],
+        ]
+
+        with patch_yaml_files({
+                '/tmp/zero.yaml': 'zero', '/tmp/tmp2/one.yaml': 'one',
+                '/tmp/tmp2/two.yaml': 'two'
+        }):
+            conf = "key: !include_dir_list /tmp"
             with io.StringIO(conf) as file:
                 doc = yaml.yaml.safe_load(file)
                 assert sorted(doc["key"]) == sorted(["zero", "one", "two"])
 
-    def test_include_dir_named(self):
+    @patch('homeassistant.util.yaml.os.walk')
+    def test_include_dir_named(self, mock_walk):
         """Test include dir named yaml."""
-        with tempfile.TemporaryDirectory() as include_dir:
-            file_1 = tempfile.NamedTemporaryFile(dir=include_dir,
-                                                 suffix=".yaml", delete=False)
-            file_1.write(b"one")
-            file_1.close()
-            file_2 = tempfile.NamedTemporaryFile(dir=include_dir,
-                                                 suffix=".yaml", delete=False)
-            file_2.write(b"two")
-            file_2.close()
-            conf = "key: !include_dir_named {}".format(include_dir)
-            correct = {}
-            correct[os.path.splitext(os.path.basename(file_1.name))[0]] = "one"
-            correct[os.path.splitext(os.path.basename(file_2.name))[0]] = "two"
+        mock_walk.return_value = [['/tmp', [], ['first.yaml', 'second.yaml']]]
+
+        with patch_yaml_files({
+                '/tmp/first.yaml': 'one', '/tmp/second.yaml': 'two'
+        }):
+            conf = "key: !include_dir_named /tmp"
+            correct = {'first': 'one', 'second': 'two'}
             with io.StringIO(conf) as file:
                 doc = yaml.yaml.safe_load(file)
                 assert doc["key"] == correct
 
-    def test_include_dir_named_recursive(self):
+    @patch('homeassistant.util.yaml.os.walk')
+    def test_include_dir_named_recursive(self, mock_walk):
         """Test include dir named yaml."""
-        with tempfile.TemporaryDirectory() as include_dir:
-            file_0 = tempfile.NamedTemporaryFile(dir=include_dir,
-                                                 suffix=".yaml", delete=False)
-            file_0.write(b"zero")
-            file_0.close()
-            temp_dir = tempfile.TemporaryDirectory(dir=include_dir)
-            file_1 = tempfile.NamedTemporaryFile(dir=temp_dir.name,
-                                                 suffix=".yaml", delete=False)
-            file_1.write(b"one")
-            file_1.close()
-            file_2 = tempfile.NamedTemporaryFile(dir=temp_dir.name,
-                                                 suffix=".yaml", delete=False)
-            file_2.write(b"two")
-            file_2.close()
-            conf = "key: !include_dir_named {}".format(include_dir)
-            correct = {}
-            correct[os.path.splitext(
-                            os.path.basename(file_0.name))[0]] = "zero"
-            correct[os.path.splitext(os.path.basename(file_1.name))[0]] = "one"
-            correct[os.path.splitext(os.path.basename(file_2.name))[0]] = "two"
+        mock_walk.return_value = [
+            ['/tmp', ['tmp2'], ['first.yaml']],
+            ['/tmp/tmp2', [], ['second.yaml', 'third.yaml']],
+        ]
+
+        with patch_yaml_files({
+                '/tmp/first.yaml': 'one', '/tmp/tmp2/second.yaml': 'two',
+                '/tmp/tmp2/third.yaml': 'three'
+        }):
+            conf = "key: !include_dir_named /tmp"
+            correct = {'first': 'one', 'second': 'two', 'third': 'three'}
             with io.StringIO(conf) as file:
                 doc = yaml.yaml.safe_load(file)
                 assert doc["key"] == correct
 
-    def test_include_dir_merge_list(self):
+    @patch('homeassistant.util.yaml.os.walk')
+    def test_include_dir_merge_list(self, mock_walk):
         """Test include dir merge list yaml."""
-        with tempfile.TemporaryDirectory() as include_dir:
-            file_1 = tempfile.NamedTemporaryFile(dir=include_dir,
-                                                 suffix=".yaml", delete=False)
-            file_1.write(b"- one")
-            file_1.close()
-            file_2 = tempfile.NamedTemporaryFile(dir=include_dir,
-                                                 suffix=".yaml", delete=False)
-            file_2.write(b"- two\n- three")
-            file_2.close()
-            conf = "key: !include_dir_merge_list {}".format(include_dir)
+        mock_walk.return_value = [['/tmp', [], ['first.yaml', 'second.yaml']]]
+
+        with patch_yaml_files({
+                '/tmp/first.yaml': '- one',
+                '/tmp/second.yaml': '- two\n- three'
+        }):
+            conf = "key: !include_dir_merge_list /tmp"
             with io.StringIO(conf) as file:
                 doc = yaml.yaml.safe_load(file)
                 assert sorted(doc["key"]) == sorted(["one", "two", "three"])
 
-    def test_include_dir_merge_list_recursive(self):
+    @patch('homeassistant.util.yaml.os.walk')
+    def test_include_dir_merge_list_recursive(self, mock_walk):
         """Test include dir merge list yaml."""
-        with tempfile.TemporaryDirectory() as include_dir:
-            file_0 = tempfile.NamedTemporaryFile(dir=include_dir,
-                                                 suffix=".yaml", delete=False)
-            file_0.write(b"- zero")
-            file_0.close()
-            temp_dir = tempfile.TemporaryDirectory(dir=include_dir)
-            file_1 = tempfile.NamedTemporaryFile(dir=temp_dir.name,
-                                                 suffix=".yaml", delete=False)
-            file_1.write(b"- one")
-            file_1.close()
-            file_2 = tempfile.NamedTemporaryFile(dir=temp_dir.name,
-                                                 suffix=".yaml", delete=False)
-            file_2.write(b"- two\n- three")
-            file_2.close()
-            conf = "key: !include_dir_merge_list {}".format(include_dir)
+        mock_walk.return_value = [
+            ['/tmp', ['tmp2'], ['first.yaml']],
+            ['/tmp/tmp2', [], ['second.yaml', 'third.yaml']],
+        ]
+
+        with patch_yaml_files({
+                '/tmp/first.yaml': '- one', '/tmp/tmp2/second.yaml': '- two',
+                '/tmp/tmp2/third.yaml': '- three\n- four'
+        }):
+            conf = "key: !include_dir_merge_list /tmp"
             with io.StringIO(conf) as file:
                 doc = yaml.yaml.safe_load(file)
-                assert sorted(doc["key"]) == sorted(["zero", "one", "two",
-                                                     "three"])
+                assert sorted(doc["key"]) == sorted(["one", "two",
+                                                     "three", "four"])
 
-    def test_include_dir_merge_named(self):
+    @patch('homeassistant.util.yaml.os.walk')
+    def test_include_dir_merge_named(self, mock_walk):
         """Test include dir merge named yaml."""
-        with tempfile.TemporaryDirectory() as include_dir:
-            file_1 = tempfile.NamedTemporaryFile(dir=include_dir,
-                                                 suffix=".yaml", delete=False)
-            file_1.write(b"key1: one")
-            file_1.close()
-            file_2 = tempfile.NamedTemporaryFile(dir=include_dir,
-                                                 suffix=".yaml", delete=False)
-            file_2.write(b"key2: two\nkey3: three")
-            file_2.close()
-            conf = "key: !include_dir_merge_named {}".format(include_dir)
+        mock_walk.return_value = [['/tmp', [], ['first.yaml', 'second.yaml']]]
+
+        with patch_yaml_files({
+                '/tmp/first.yaml': 'key1: one',
+                '/tmp/second.yaml': 'key2: two\nkey3: three'
+        }):
+            conf = "key: !include_dir_merge_named /tmp"
             with io.StringIO(conf) as file:
                 doc = yaml.yaml.safe_load(file)
                 assert doc["key"] == {
@@ -216,30 +185,27 @@ class TestYaml(unittest.TestCase):
                     "key3": "three"
                 }
 
-    def test_include_dir_merge_named_recursive(self):
+    @patch('homeassistant.util.yaml.os.walk')
+    def test_include_dir_merge_named_recursive(self, mock_walk):
         """Test include dir merge named yaml."""
-        with tempfile.TemporaryDirectory() as include_dir:
-            file_0 = tempfile.NamedTemporaryFile(dir=include_dir,
-                                                 suffix=".yaml", delete=False)
-            file_0.write(b"key0: zero")
-            file_0.close()
-            temp_dir = tempfile.TemporaryDirectory(dir=include_dir)
-            file_1 = tempfile.NamedTemporaryFile(dir=temp_dir.name,
-                                                 suffix=".yaml", delete=False)
-            file_1.write(b"key1: one")
-            file_1.close()
-            file_2 = tempfile.NamedTemporaryFile(dir=temp_dir.name,
-                                                 suffix=".yaml", delete=False)
-            file_2.write(b"key2: two\nkey3: three")
-            file_2.close()
-            conf = "key: !include_dir_merge_named {}".format(include_dir)
+        mock_walk.return_value = [
+            ['/tmp', ['tmp2'], ['first.yaml']],
+            ['/tmp/tmp2', [], ['second.yaml', 'third.yaml']],
+        ]
+
+        with patch_yaml_files({
+                '/tmp/first.yaml': 'key1: one',
+                '/tmp/tmp2/second.yaml': 'key2: two',
+                '/tmp/tmp2/third.yaml': 'key3: three\nkey4: four'
+        }):
+            conf = "key: !include_dir_merge_named /tmp"
             with io.StringIO(conf) as file:
                 doc = yaml.yaml.safe_load(file)
                 assert doc["key"] == {
-                    "key0": "zero",
                     "key1": "one",
                     "key2": "two",
-                    "key3": "three"
+                    "key3": "three",
+                    "key4": "four"
                 }
 
 FILES = {}


### PR DESCRIPTION
**Description:**
Replacing instances of `tempfile` in tests with `mock_open`

**Related issue (if applicable):** follow-up to #3685 ([Ref comment](https://github.com/home-assistant/home-assistant/pull/3685#issuecomment-251416116))

**Checklist:**

~~If user exposed functionality or configuration variables are added/changed~~ N/A

~~If the code communicates with devices, web services, or third-party tools:~~ N/A

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass** (in progress)

Tentaive list of files to change:
- [x] tests/test_bootstrap.py
- [X] tests/test_config.py
- [X] tests/components/test_init.py
- [x] tests/components/test_panel_custom.py
- [x] tests/components/test_api.py
- [x] tests/components/notify/test_file.py
- [x] tests/components/notify/test_demo.py
- [x] tests/components/camera/test_local_file.py
- [x] tests/helpers/test_config_validation.py
- [x] tests/util/test_package.py
- [x] tests/util/test_yaml.py

Other changes:
- [X] tests/components/mqtt/test_server.py - removed some unused mock parameters (see [this comment](https://github.com/home-assistant/home-assistant/pull/3753#issuecomment-252404073))

The following files are fine the way they are and don't need I/O mocked:
- tests/components/cover/test_command_line.py
- tests/components/switch/test_command_line.py
- tests/components/rollershutter/test_command_line.py
- tests/components/test_shell_command.py
- tests/components/notify/test_command_line.py
