### PR TITLE
Fix command line cover template

### DIFF
--- a/homeassistant/components/cover/command_line.py
+++ b/homeassistant/components/cover/command_line.py
@@ -38,7 +38,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for device_name, device_config in devices.items():
         value_template = device_config.get(CONF_VALUE_TEMPLATE)
-        value_template.hass = hass
+        if value_template is not None:
+            value_template.hass = hass
 
         covers.append(
             CommandCover(


### PR DESCRIPTION
The command line cover value template is optional so we
need to check it's not none before assigning hass to it.

Fixes #3649

Signed-off-by: Roi Dayan roi.dayan@gmail.com
