### PR TITLE
Include index and instance in object_id of zwave devices

### DIFF
--- a/homeassistant/components/sensor/zwave.py
+++ b/homeassistant/components/sensor/zwave.py
@@ -12,20 +12,6 @@ from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.helpers.entity import Entity
 
 
-FIBARO = 0x010f
-FIBARO_WALL_PLUG = 0x1000
-FIBARO_WALL_PLUG_SENSOR_METER = (FIBARO, FIBARO_WALL_PLUG, 8)
-
-WORKAROUND_IGNORE = 'ignore'
-
-DEVICE_MAPPINGS = {
-    # For some reason Fibaro Wall Plug reports 2 power consumptions.
-    # One value updates as the power consumption changes
-    # and the other does not change.
-    FIBARO_WALL_PLUG_SENSOR_METER: WORKAROUND_IGNORE,
-}
-
-
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup Z-Wave sensors."""
     # Return on empty `discovery_info`. Given you configure HA with:
@@ -45,18 +31,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     # if 1 in groups and (NETWORK.controller.node_id not in
     #                     groups[1].associations):
     #     node.groups[1].add_association(NETWORK.controller.node_id)
-
-    # Make sure that we have values for the key before converting to int
-    if (value.node.manufacturer_id.strip() and
-            value.node.product_id.strip()):
-        specific_sensor_key = (int(value.node.manufacturer_id, 16),
-                               int(value.node.product_id, 16),
-                               value.index)
-
-        # Check workaround mappings for specific devices.
-        if specific_sensor_key in DEVICE_MAPPINGS:
-            if DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_IGNORE:
-                return
 
     # Generic Device mappings
     if node.has_command_class(zwave.const.COMMAND_CLASS_SENSOR_MULTILEVEL):

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -181,8 +181,8 @@ def _object_id(value):
     The object_id contains node_id and value instance id
     to not collide with other entity_ids.
     """
-    object_id = "{}_{}_{}_{}".format(slugify(_value_name(value)),
-                               value.node.node_id, value.index, value.instance)
+    object_id = "{}_{}_{}".format(slugify(_value_name(value)),
+                                  value.node.node_id, value.index)
 
     # Add the instance id if there is more than one instance for the value
     if value.instance > 1:

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -181,7 +181,8 @@ def _object_id(value):
     The object_id contains node_id and value instance id
     to not collide with other entity_ids.
     """
-    object_id = "{}_{}".format(slugify(_value_name(value)), value.node.node_id)
+    object_id = "{}_{}_{}_{}".format(slugify(_value_name(value)),
+                               value.node.node_id, value.index, value.instance)
 
     # Add the instance id if there is more than one instance for the value
     if value.instance > 1:


### PR DESCRIPTION
DO NOT MERGE YET - We should discuss this first.

This includes a backwards incompatible change for zwave entity names!

**Description:**
The current object_ids for zwave devices are insufficient. Multiple endpoints could map to the same id, which results in strange behaviour as can be seen in #3509

**Related issue (if applicable):** fixes #3509, makes PR #3510 obsolete

As noticed first in #1109, different sensor values can map to same object_id. For the Fibaro Wall Plug component, values are reported for  COMMAND_CLASS_SENSOR_MULTILEVEL and COMMAND_CLASS_METER. Only one of them pushes updates.

```
                        <CommandClass id="49" name="COMMAND_CLASS_SENSOR_MULTILEVEL" version="2" innif="true">
                                <Instance index="1" />
                                <Value type="decimal" genre="user" instance="1" index="4" label="Power" units="W" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="0.0" />
                        </CommandClass>
                        <CommandClass id="50" name="COMMAND_CLASS_METER" version="2" request_flags="2" innif="true">
                                <Instance index="1" />
                                <Value type="decimal" genre="user" instance="1" index="0" label="Energy" units="kWh" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="4.98" />
                                <Value type="decimal" genre="user" instance="1" index="8" label="Power" units="W" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="0.0" />
                                <Value type="bool" genre="user" instance="1" index="32" label="Exporting" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="False" />
                                <Value type="button" genre="system" instance="1" index="33" label="Reset" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0" />
                        </CommandClass>
```

The fix for this component (#1109) was straightforward, just ignore the other value.

But unfortunately, things turned out to be not that easy. 

Other energy measurement devices report a "Previous Reading" value (for different units) at the same object_id, which lead to many problems as can be seen in #3509.

``` [...]
                <Value type="decimal" genre="user" instance="2" index="0" label="Energy" units="kWh" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="238.373" />
                <Value type="decimal" genre="user" instance="2" index="1" label="Previous Reading" units="kWh" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="238.372" />
                <Value type="int" genre="user" instance="2" index="2" label="Interval" units="seconds" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="60" />
                <Value type="decimal" genre="user" instance="2" index="8" label="Power" units="W" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="82.115" />
                <Value type="decimal" genre="user" instance="2" index="16" label="Voltage" units="V" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="233.460" />
                <Value type="decimal" genre="user" instance="2" index="17" label="Previous Reading" units="V" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="-0.000" />
                <Value type="int" genre="user" instance="2" index="18" label="Interval" units="seconds" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="3" />
                <Value type="decimal" genre="user" instance="2" index="20" label="Current" units="A" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="0.370" />
                <Value type="decimal" genre="user" instance="2" index="21" label="Previous Reading" units="A" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="0.000" />
                <Value type="int" genre="user" instance="2" index="22" label="Interval" units="seconds" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="16" />
                <Value type="bool" genre="user" instance="2" index="32" label="Exporting" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="False" />
                <Value type="button" genre="system" instance="2" index="33" label="Reset" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0" />
                <Value type="decimal" genre="user" instance="3" index="0" label="Energy" units="kWh" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="1178.821" />
                <Value type="decimal" genre="user" instance="3" index="1" label="Previous Reading" units="kWh" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="1178.814" />
                <Value type="int" genre="user" instance="3" index="2" label="Interval" units="seconds" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="60" />
                <Value type="decimal" genre="user" instance="3" index="8" label="Power" units="W" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="431.699" />
                <Value type="decimal" genre="user" instance="3" index="16" label="Voltage" units="V" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="233.034" />
                <Value type="decimal" genre="user" instance="3" index="20" label="Current" units="A" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="2.155" />
                <Value type="bool" genre="user" instance="3" index="32" label="Exporting" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="False" />
                <Value type="button" genre="system" instance="3" index="33" label="Reset" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0" />
[...]
```

Even if we use a special check for these devices, I stumbled upon another one which has the same issue, a wiDom Energy Driven Switch.
This device has also two different values (this time from different command classes) at the same entitiy_id.

```
        <Manufacturer id="149" name="wiDom">
            <Product type="1214" id="304" name="UME304 Energy Driven Switch" />
        </Manufacturer>
[...]
        <CommandClasses>
            <CommandClass id="49" name="COMMAND_CLASS_SENSOR_MULTILEVEL" version="3" innif="true">
                <Instance index="1" />
                <Value type="decimal" genre="user" instance="1" index="4" label="Power" units="W" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="0.68" />
            </CommandClass>
            <CommandClass id="50" name="COMMAND_CLASS_METER" version="3" request_flags="2" innif="true">
                <Instance index="1" />
[...]
                <Value type="decimal" genre="user" instance="1" index="8" label="Power" units="W" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="0.68" />
[...]
            </CommandClass>
[...]
```

Another issue that shows the same problem is #3673 

Therefore I think we should address the root cause of these problems, and change the way our object_id is generated and always include the `index` in it. Unfortunately this change will be backwards-incompatible.
