### PR TITLE
Close event loop to avoid error on exiting HASS

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -159,11 +159,13 @@ class HomeAssistant(object):
         # Register the async start
         self.loop.create_task(self.async_start())
 
+        @callback
         def stop_homeassistant(*args):
             """Stop Home Assistant."""
             self.exit_code = 0
             self.async_add_job(self.async_stop)
 
+        @callback
         def restart_homeassistant(*args):
             """Restart Home Assistant."""
             self.exit_code = RESTART_EXIT_CODE
@@ -205,6 +207,8 @@ class HomeAssistant(object):
         except KeyboardInterrupt:
             self.loop.call_soon(stop_homeassistant)
             self.loop.run_forever()
+        finally:
+            self.loop.close()
 
     @asyncio.coroutine
     def async_start(self):

--- a/tests/common.py
+++ b/tests/common.py
@@ -72,16 +72,16 @@ def get_test_home_assistant(num_threads=None):
     def fake_stop():
         yield None
 
-    def start_hass():
+    @patch.object(ha, 'async_create_timer')
+    @patch.object(ha, 'async_monitor_worker_pool')
+    @patch.object(hass.loop, 'add_signal_handler')
+    @patch.object(hass.loop, 'run_forever')
+    @patch.object(hass.loop, 'close')
+    @patch.object(hass, 'async_stop', return_value=fake_stop())
+    def start_hass(*mocks):
         """Helper to start hass."""
-        with patch.object(hass.loop, 'run_forever', return_value=None):
-            with patch.object(hass, 'async_stop', return_value=fake_stop()):
-                with patch.object(ha, 'async_create_timer', return_value=None):
-                    with patch.object(ha, 'async_monitor_worker_pool',
-                                      return_value=None):
-                        with patch.object(hass.loop, 'add_signal_handler'):
-                            orig_start()
-                            hass.block_till_done()
+        orig_start()
+        hass.block_till_done()
 
     def stop_hass():
         orig_stop()


### PR DESCRIPTION
**Description:**
@pvizeli you were right by wanting to have to close the loop. I was getting errors when quitting HASS locally because not all resources were released.

```
Exception ignored in: <bound method BaseEventLoop.__del__ of <_UnixSelectorEventLoop running=False closed=True debug=False>>
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/asyncio/base_events.py", line 431, in __del__
  File "/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/asyncio/unix_events.py", line 58, in close
  File "/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/asyncio/unix_events.py", line 139, in remove_signal_handler
  File "/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/signal.py", line 47, in signal
TypeError: signal handler must be signal.SIG_IGN, signal.SIG_DFL, or a callable object
```

The trick was to avoid HASS from closing the loop in the tests ([we do it explicitly](https://github.com/home-assistant/home-assistant/blob/dev/tests/common.py#L63)).

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
