### PR TITLE
Fixed issue #3760, handle X10 unit numbers greater than 9.

### DIFF
--- a/homeassistant/components/light/x10.py
+++ b/homeassistant/components/light/x10.py
@@ -41,7 +41,7 @@ def get_status():
 
 def get_unit_status(code):
     """Get on/off status for given unit."""
-    unit = int(code[1])
+    unit = int(code[1:])
     return get_status()[16 - int(unit)] == '1'
 
 


### PR DESCRIPTION
**Description:**
Added the colon to the string array index to slice all characters past the first one, to handle unit numbers that have more than one digit, any greater than 9.

**Related issue (if applicable):** fixes #3760 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
