### PR TITLE
Restore Optional Target Config Attribute (notify.pushover)

### DIFF
--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -63,21 +63,21 @@ class PushoverNotificationService(BaseNotificationService):
 
         targets = kwargs.get(ATTR_TARGET)
 
-	if targets is not None:
-		for target in targets:
-			if target is not None:
-				data['device'] = target
+        if targets is not None:
+            for target in targets:
+                if target is not None:
+                    data['device'] = target
 
-				try:
-					self.pushover.send_message(message, **data)
-				except ValueError as val_err:
-					_LOGGER.error(str(val_err))
-				except RequestError:
-					_LOGGER.exception('Could not send pushover notification')
-	else:
-		try:
-			self.pushover.send_message(message, **data)
-		except ValueError as val_err:
-			_LOGGER.error(str(val_err))
-		except RequestError:
-			_LOGGER.exception('Could not send pushover notification')
+                    try:
+                        self.pushover.send_message(message, **data)
+                    except ValueError as val_err:
+                        _LOGGER.error(str(val_err))
+                    except RequestError:
+                        _LOGGER.exception('Could not send pushover notification')
+        else:
+            try:
+                self.pushover.send_message(message, **data)
+            except ValueError as val_err:
+                _LOGGER.error(str(val_err))
+            except RequestError:
+                _LOGGER.exception('Could not send pushover notification')

--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -63,13 +63,21 @@ class PushoverNotificationService(BaseNotificationService):
 
         targets = kwargs.get(ATTR_TARGET)
 
-        for target in targets:
-            if target is not None:
-                data['device'] = target
+        if targets is not None:
+			for target in targets:
+				if target is not None:
+					data['device'] = target
 
-            try:
-                self.pushover.send_message(message, **data)
-            except ValueError as val_err:
-                _LOGGER.error(str(val_err))
-            except RequestError:
-                _LOGGER.exception('Could not send pushover notification')
+					try:
+						self.pushover.send_message(message, **data)
+					except ValueError as val_err:
+						_LOGGER.error(str(val_err))
+					except RequestError:
+						_LOGGER.exception('Could not send pushover notification')
+		else:
+			try:
+				self.pushover.send_message(message, **data)
+			except ValueError as val_err:
+				_LOGGER.error(str(val_err))
+			except RequestError:
+				_LOGGER.exception('Could not send pushover notification')

--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -63,18 +63,13 @@ class PushoverNotificationService(BaseNotificationService):
 
         targets = kwargs.get(ATTR_TARGET)
 
-        if targets is not None:
-            for target in targets:
-                if target is not None:
-                    data['device'] = target
+        if isinstance(targets, list) is False:
+            targets = [targets]
 
-                    try:
-                        self.pushover.send_message(message, **data)
-                    except ValueError as val_err:
-                        _LOGGER.error(str(val_err))
-                    except RequestError:
-                        _LOGGER.exception('Could not send pushover notification')
-        else:
+        for target in targets:
+            if target is not None:
+                data['device'] = target
+
             try:
                 self.pushover.send_message(message, **data)
             except ValueError as val_err:

--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -63,21 +63,21 @@ class PushoverNotificationService(BaseNotificationService):
 
         targets = kwargs.get(ATTR_TARGET)
 
-        if targets is not None:
-			for target in targets:
-				if target is not None:
-					data['device'] = target
+	if targets is not None:
+		for target in targets:
+			if target is not None:
+				data['device'] = target
 
-					try:
-						self.pushover.send_message(message, **data)
-					except ValueError as val_err:
-						_LOGGER.error(str(val_err))
-					except RequestError:
-						_LOGGER.exception('Could not send pushover notification')
-		else:
-			try:
-				self.pushover.send_message(message, **data)
-			except ValueError as val_err:
-				_LOGGER.error(str(val_err))
-			except RequestError:
-				_LOGGER.exception('Could not send pushover notification')
+				try:
+					self.pushover.send_message(message, **data)
+				except ValueError as val_err:
+					_LOGGER.error(str(val_err))
+				except RequestError:
+					_LOGGER.exception('Could not send pushover notification')
+	else:
+		try:
+			self.pushover.send_message(message, **data)
+		except ValueError as val_err:
+			_LOGGER.error(str(val_err))
+		except RequestError:
+			_LOGGER.exception('Could not send pushover notification')

--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -63,7 +63,7 @@ class PushoverNotificationService(BaseNotificationService):
 
         targets = kwargs.get(ATTR_TARGET)
 
-        if isinstance(targets, list) is False:
+        if not isinstance(targets, list):
             targets = [targets]
 
         for target in targets:


### PR DESCRIPTION
**Description:**

**Related issue (if applicable):** fixes #3778

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
