### PR TITLE
Changing import as powerview api did change.

### DIFF
--- a/homeassistant/components/scene/hunterdouglas_powerview.py
+++ b/homeassistant/components/scene/hunterdouglas_powerview.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import generate_entity_id
 _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = [
     'https://github.com/sander76/powerviewApi/'
-    'archive/master.zip#powerviewApi==0.2']
+    'archive/master.zip#powerviewApi==0.3.15']
 
 HUB_ADDRESS = 'address'
 
@@ -20,7 +20,7 @@ HUB_ADDRESS = 'address'
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the powerview scenes stored in a Powerview hub."""
-    import powerview
+    from powerview_api import powerview
 
     hub_address = config.get(HUB_ADDRESS)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -200,7 +200,7 @@ https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f
 https://github.com/robbiet480/pygtfs/archive/00546724e4bbcb3053110d844ca44e2246267dd8.zip#pygtfs==0.1.3
 
 # homeassistant.components.scene.hunterdouglas_powerview
-https://github.com/sander76/powerviewApi/archive/master.zip#powerviewApi==0.2
+https://github.com/sander76/powerviewApi/archive/master.zip#powerviewApi==0.3.15
 
 # homeassistant.components.mysensors
 https://github.com/theolind/pymysensors/archive/8ce98b7fb56f7921a808eb66845ce8b2c455c81e.zip#pymysensors==0.7.1


### PR DESCRIPTION
**Description:**

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
