### PR TITLE
Update python-lirc to 1.2.3

### DIFF
--- a/homeassistant/components/lirc.py
+++ b/homeassistant/components/lirc.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP, EVENT_HOMEASSISTANT_START)
 
-REQUIREMENTS = ['python-lirc==1.2.1']
+REQUIREMENTS = ['python-lirc==1.2.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -380,7 +380,7 @@ python-forecastio==1.3.5
 python-hpilo==3.8
 
 # homeassistant.components.lirc
-# python-lirc==1.2.1
+# python-lirc==1.2.3
 
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5


### PR DESCRIPTION
**Description:**
Upgrade to python-lirc 1.2.3, which fixes blocking of hass when lirc platform is enabled

**Related issue (if applicable):** fixes #2306

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
lirc:
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [X] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [X] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
