### PR TITLE
Cache condition in helpers.Script

### DIFF
--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -311,8 +311,7 @@ class TestScriptHelper(unittest.TestCase):
         assert len(script_obj._config_cache) == 1
 
     def test_all_conditions_cached(self):
-        """Test that in a script with multiple conditions, all the conditions
-         get cached."""
+        """Test that multiple conditions get cached."""
         event = 'test_event'
         events = []
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1,6 +1,7 @@
 """The tests for the Script component."""
 # pylint: disable=too-many-public-methods,protected-access
 from datetime import timedelta
+from unittest import mock
 import unittest
 
 # Otherwise can't test just this file (import order issue)
@@ -279,3 +280,63 @@ class TestScriptHelper(unittest.TestCase):
         script_obj.run()
         self.hass.block_till_done()
         assert len(events) == 3
+
+    @mock.patch('homeassistant.helpers.script.condition.async_from_config')
+    def test_condition_created_once(self, async_from_config):
+        """Test that the conditions do not get created multiple times."""
+        event = 'test_event'
+        events = []
+
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        self.hass.states.set('test.entity', 'hello')
+
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
+            {'event': event},
+            {
+                'condition': 'template',
+                'value_template': '{{ states.test.entity.state == "hello" }}',
+            },
+            {'event': event},
+        ]))
+
+        script_obj.run()
+        script_obj.run()
+        self.hass.block_till_done()
+        assert async_from_config.call_count == 1
+        assert len(script_obj._config_cache) == 1
+
+    def test_all_conditions_cached(self):
+        """Test that in a script with multiple conditions, all the conditions
+         get cached."""
+        event = 'test_event'
+        events = []
+
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        self.hass.states.set('test.entity', 'hello')
+
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
+            {'event': event},
+            {
+                'condition': 'template',
+                'value_template': '{{ states.test.entity.state == "hello" }}',
+            },
+            {
+                'condition': 'template',
+                'value_template': '{{ states.test.entity.state != "hello" }}',
+            },
+            {'event': event},
+        ]))
+
+        script_obj.run()
+        self.hass.block_till_done()
+        assert len(script_obj._config_cache) == 2


### PR DESCRIPTION
**Description:**

Implementing this as part of Hacktoberfest. The pull-request adds some caching so that we don't always re-create the conditions in the scripts.

The caching is a simple in-memory, per-instance dictionary.
We use `__str__` to format cache keys.

This naive implementation has some disadvantages (e.g., we won't be able to cache two conditions that contain references to distinct-but-equivalent object instances and we don't have any control over the size of the condition cache), but for most simple use-cases the approach should be good enough.

**Related issue:** fixes #3629

**Checklist:**
- [x] Local tests with `tox` run successfully.
- [x] Tests have been added to verify that the new code works.
