### PR TITLE
Stop GTFS component from overwriting friendly_name

### DIFF
--- a/homeassistant/components/sensor/gtfs.py
+++ b/homeassistant/components/sensor/gtfs.py
@@ -235,9 +235,9 @@ class GTFSDepartureSensor(Entity):
 
             name = '{} {} to {} next departure'
             self._name = self._custom_name or \
-                         name.format(agency.agency_name,
-                                     origin_station.stop_id,
-                                     destination_station.stop_id)
+                             name.format(agency.agency_name,
+                                         origin_station.stop_id,
+                                         destination_station.stop_id)
 
             # Build attributes
             self._attributes = {}

--- a/homeassistant/components/sensor/gtfs.py
+++ b/homeassistant/components/sensor/gtfs.py
@@ -234,10 +234,10 @@ class GTFSDepartureSensor(Entity):
             trip = self._departure['trip']
 
             name = '{} {} to {} next departure'
-            self._name = self._custom_name or \
-                             name.format(agency.agency_name,
-                                         origin_station.stop_id,
-                                         destination_station.stop_id)
+            self._name = (self._custom_name or
+                          name.format(agency.agency_name,
+                                      origin_station.stop_id,
+                                      destination_station.stop_id))
 
             # Build attributes
             self._attributes = {}

--- a/homeassistant/components/sensor/gtfs.py
+++ b/homeassistant/components/sensor/gtfs.py
@@ -185,7 +185,8 @@ class GTFSDepartureSensor(Entity):
         self._pygtfs = pygtfs
         self.origin = origin
         self.destination = destination
-        self._name = name
+        self._custom_name = name
+        self._name = ''
         self._unit_of_measurement = 'min'
         self._state = 0
         self._attributes = {}
@@ -233,7 +234,8 @@ class GTFSDepartureSensor(Entity):
             trip = self._departure['trip']
 
             name = '{} {} to {} next departure'
-            self._name = name.format(agency.agency_name,
+            self._name = self._custom_name or \
+                         name.format(agency.agency_name,
                                      origin_station.stop_id,
                                      destination_station.stop_id)
 


### PR DESCRIPTION
**Description:** The `GTFSDepartureSensor.update()` method always updates `self._name`, overwriting any custom name that may have been passed to the platform in `configuration.yaml`. This is a quick change to correct that behaviour.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

**Example entry for `configuration.yaml` (if applicable):** N/A

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

There's currently no tests for the GTFS component. I'd be happy to assist writing some, but I'm not yet sure how to go about mocking a whole GTFS schema.
