### PR TITLE
Make 'pin' optional for zigbee device config.

### DIFF
--- a/homeassistant/components/zigbee.py
+++ b/homeassistant/components/zigbee.py
@@ -55,7 +55,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
-    vol.Required(CONF_PIN): cv.positive_int,
+    vol.Optional(CONF_PIN): cv.positive_int,
     vol.Optional(CONF_ADDRESS): cv.string,
 }, extra=vol.ALLOW_EXTRA)
 


### PR DESCRIPTION
**Description:**
'pin' should be an optional configuration value since the 'temperature' type of sensor doesn't use a pin.

https://home-assistant.io/components/sensor.zigbee/#temperature-sensor

Sorry I didn't get a chance to check on #3234 but I've only just got back around to updating my version of HA.

**Related issue (if applicable):** #3234 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#1204

**Example entry for `configuration.yaml` (if applicable):**

For example, an XBee directly attached over USB used as a temperature sensor:

``` yaml
- name: Server Room Temperature
  platform: zigbee
  type: temperature
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [n/a] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [n/a] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [n/a] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [n/a] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [n/a] Tests have been added to verify that the new code works.
