### PR TITLE
Upgrade dnspython3 to 1.15.0

### DIFF
--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -14,10 +14,11 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_PASSWORD, CONF_SENDER, CONF_RECIPIENT
 
 REQUIREMENTS = ['sleekxmpp==1.3.1',
-                'dnspython3==1.14.0',
+                'dnspython3==1.15.0',
                 'pyasn1==0.1.9',
                 'pyasn1-modules==0.0.8']
 
+_LOGGER = logging.getLogger(__name__)
 
 CONF_TLS = 'tls'
 
@@ -27,9 +28,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RECIPIENT): cv.string,
     vol.Optional(CONF_TLS, default=True): cv.boolean,
 })
-
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def get_service(hass, config):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -70,7 +70,7 @@ colorlog>2.1,<3
 directpy==0.1
 
 # homeassistant.components.notify.xmpp
-dnspython3==1.14.0
+dnspython3==1.15.0
 
 # homeassistant.components.dweet
 # homeassistant.components.sensor.dweet


### PR DESCRIPTION
## 1.15.0
- IDNA 2008 support is now available if the "idna" module has been installed and IDNA 2008 is requested.  The default IDNA behavior is still IDNA 2003.  The new IDNA codec mechanism is currently only useful for direct calls to dns.name.from_text() or dns.name.from_unicode(), but in future releases it will be deployed throughout dnspython, e.g. so that you can read a masterfile with an IDNA 2008 codec in force.
- By default, dns.name.to_unicode() is not strict about which version of IDNA the input complies with.  Strictness can be requested by using one of the strict IDNA codecs.
- Add AVC RR support.
- Some problems with newlines in various output modes have been addressed.
- dns.name.to_text() now returns text and not bytes on Python 3.x 
- More miscellaneous fixes for the Python 2/3 codeline merge.

Tested with the following configuration:

``` yaml
notify:
  - platform: xmpp
    name: jabber
    sender: sender@swissjabber.org
    password: !secret xmpp_password
    recipient: recipient@swissjabber.org
```

Message sent with "Call Service" :

``` json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!",
  "title": "Test message"
}
```
