### PR TITLE
Upgrade cherrypy to 8.1.2

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -28,7 +28,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components import persistent_notification
 
 DOMAIN = 'http'
-REQUIREMENTS = ('cherrypy==8.1.0', 'static3==0.7.0', 'Werkzeug==0.11.11')
+REQUIREMENTS = ('cherrypy==8.1.2', 'static3==0.7.0', 'Werkzeug==0.11.11')
 
 CONF_API_PASSWORD = 'api_password'
 CONF_SERVER_HOST = 'server_host'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -58,7 +58,7 @@ boto3==1.3.1
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
-cherrypy==8.1.0
+cherrypy==8.1.2
 
 # homeassistant.components.sensor.coinmarketcap
 coinmarketcap==2.0.1


### PR DESCRIPTION
## 8.1.2
- Fix install error on Windows using pip
## 8.1.1
- Handle errors thrown by `ssl_module: 'builtin'` when client opens connection to HTTPS port using HTTP.
- Fix regression introduced in v6.1.0 where environment construction for WSGIGateway_u0 was passing one parameter and not two.
- Other miscellaneous fixes.

As this is a critical component, feedback is needed. Please feel free to check your OS off the list if it works or leave a comment. Thanks.
### Setup
- [x] Installation on Fedora/CentOS
- [ ] Installation on Debian/Ubuntu/Rasbian/Armbian
- [x] Installation on OS X
- [ ] Installation on Windows
### Runtime
- [x] Runing on Fedora/CentOS
- [ ] Running on Debian/Ubuntu/Rasbian/Armbian
- [x] Running on OS X
- [ ] Running on Windows
