### PR TITLE
Upgrade pyowm to 2.5.0

### DIFF
--- a/homeassistant/components/sensor/openweathermap.py
+++ b/homeassistant/components/sensor/openweathermap.py
@@ -17,7 +17,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyowm==2.4.0']
+REQUIREMENTS = ['pyowm==2.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -174,12 +174,12 @@ class WeatherData(object):
         """Get the latest data from OpenWeatherMap."""
         obs = self.owm.weather_at_coords(self.latitude, self.longitude)
         if obs is None:
-            _LOGGER.warning('Failed to fetch data from OWM')
+            _LOGGER.warning("Failed to fetch data from OpenWeatherMap")
             return
 
         self.data = obs.get_weather()
 
         if self.forecast == 1:
-            obs = self.owm.three_hours_forecast_at_coords(self.latitude,
-                                                          self.longitude)
+            obs = self.owm.three_hours_forecast_at_coords(
+                self.latitude, self.longitude)
             self.fc_data = obs.get_forecast()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -361,7 +361,7 @@ pynetio==0.1.6
 pynx584==0.2
 
 # homeassistant.components.sensor.openweathermap
-pyowm==2.4.0
+pyowm==2.5.0
 
 # homeassistant.components.switch.acer_projector
 pyserial==3.1.1


### PR DESCRIPTION
## 2.5.0
- New features:
  - [Air Pollution data API endpoints](https://github.com/csparpa/pyowm/wiki/Air-Pollution-endpoints): `OWM25.coindex_around_coords`, `OWM25.ozone_around_coords`
  - [UV data endpoint](https://github.com/csparpa/pyowm/wiki/Ultra-Violet-endpoint): `OWM25.uvindex_around_coords`
- Bugfixes:
  - fixed `OWM25.is_API_online` method (was not working)
  - more robust support for querying data on Unicode place names
  - Enhancements: now datetime objects across all library are timezone-aware

**Related issue (if applicable):** fixes #3526

Tested with the following configuration:

``` yaml
sensor:
  - platform: openweathermap
    api_key: !secret owm_api
    forecast: 0
    monitored_conditions:
      - weather
      - temperature
      - wind_speed
      - humidity
      - pressure
```
