### PR TITLE
Wrap found target in list

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -100,7 +100,7 @@ def setup(hass, config):
                 kwargs[ATTR_TITLE] = title.render()
 
             if targets.get(call.service) is not None:
-                kwargs[ATTR_TARGET] = targets[call.service]
+                kwargs[ATTR_TARGET] = [targets[call.service]]
             else:
                 kwargs[ATTR_TARGET] = call.data.get(ATTR_TARGET)
 

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -152,7 +152,7 @@ data_template:
 
         assert {
             'message': 'my message',
-            'target': 'test target id',
+            'target': ['test target id'],
             'title': 'my title',
             'data': {'hello': 'world'}
         } == data


### PR DESCRIPTION
Fixes an issue where when sending a notification to a service with target attached (i.e. `notify.html5_unnamed_device_2`) the target was not submitted to the platform as a list causing iteration over every character in the string.

Thanks to @sgauche for finding this.
