### PR TITLE
Add again certifi to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ RUN script/build_python_openzwave && \
   ln -sf /usr/src/app/build/python-openzwave/openzwave/config /usr/local/share/python-openzwave/config
 
 COPY requirements_all.txt requirements_all.txt
-# certifi breaks Debian based installs
-RUN pip3 install --no-cache-dir -r requirements_all.txt && pip3 uninstall -y certifi && \
+RUN pip3 install --no-cache-dir -r requirements_all.txt && \
     pip3 install mysqlclient psycopg2 uvloop
 
 # Copy source


### PR DESCRIPTION
Latest versions of certifi (>= 2016.8.31) don't seem to break anything anymore.
This is needed for Telegram to work.

See #2554
