### PR TITLE
0.30.2

### DIFF
--- a/homeassistant/components/device_tracker/volvooncall.py
+++ b/homeassistant/components/device_tracker/volvooncall.py
@@ -14,6 +14,7 @@ import requests
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_point_in_utc_time
 from homeassistant.util.dt import utcnow
+from homeassistant.util import slugify
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
@@ -87,7 +88,7 @@ def setup_scanner(hass, config, see):
         vehicle_url = rel["vehicle"] + '/'
         attributes = query("attributes", vehicle_url)
 
-        dev_id = "volvo_" + attributes["registrationNumber"]
+        dev_id = "volvo_" + slugify(attributes["registrationNumber"])
         host_name = "%s %s/%s" % (attributes["registrationNumber"],
                                   attributes["vehicleType"],
                                   attributes["modelYear"])

--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -353,7 +353,8 @@ def _get_devices(device_type, keys):
                     name = _create_ha_name(
                         name=device.NAME,
                         channel=channel,
-                        param=param
+                        param=param,
+                        count=len(channels)
                     )
                     device_dict = {
                         CONF_PLATFORM: "homematic",
@@ -377,22 +378,22 @@ def _get_devices(device_type, keys):
     return device_arr
 
 
-def _create_ha_name(name, channel, param):
+def _create_ha_name(name, channel, param, count):
     """Generate a unique object name."""
     # HMDevice is a simple device
-    if channel == 1 and param is None:
+    if count == 1 and param is None:
         return name
 
     # Has multiple elements/channels
-    if channel > 1 and param is None:
+    if count > 1 and param is None:
         return "{} {}".format(name, channel)
 
     # With multiple param first elements
-    if channel == 1 and param is not None:
+    if count == 1 and param is not None:
         return "{} {}".format(name, param)
 
     # Multiple param on object with multiple elements
-    if channel > 1 and param is not None:
+    if count > 1 and param is not None:
         return "{} {} {}".format(name, channel, param)
 
 
@@ -599,12 +600,6 @@ class HMDevice(Entity):
         # Set param to uppercase
         if self._state:
             self._state = self._state.upper()
-
-        # Generate name
-        if not self._name:
-            self._name = _create_ha_name(name=self._address,
-                                         channel=self._channel,
-                                         param=self._state)
 
     @property
     def should_poll(self):

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -100,7 +100,7 @@ def setup(hass, config):
                 kwargs[ATTR_TITLE] = title.render()
 
             if targets.get(call.service) is not None:
-                kwargs[ATTR_TARGET] = targets[call.service]
+                kwargs[ATTR_TARGET] = [targets[call.service]]
             else:
                 kwargs[ATTR_TARGET] = call.data.get(ATTR_TARGET)
 

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -101,7 +101,7 @@ def setup(hass, config):
 
             if targets.get(call.service) is not None:
                 kwargs[ATTR_TARGET] = [targets[call.service]]
-            else:
+            elif call.data.get(ATTR_TARGET) is not None:
                 kwargs[ATTR_TARGET] = call.data.get(ATTR_TARGET)
 
             message.hass = hass

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -344,12 +344,15 @@ class HTML5NotificationService(BaseNotificationService):
             # Pick out fields that should go into the notification directly vs
             # into the notification data dictionary.
 
-            for key, val in data.copy().items():
+            data_tmp = {}
+
+            for key, val in data.items():
                 if key in HTML5_SHOWNOTIFICATION_PARAMETERS:
                     payload[key] = val
-                    del data[key]
+                else:
+                    data_tmp[key] = val
 
-            payload[ATTR_DATA] = data
+            payload[ATTR_DATA] = data_tmp
 
         if (payload[ATTR_DATA].get(ATTR_URL) is None and
                 payload.get(ATTR_ACTIONS) is None):

--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -63,6 +63,9 @@ class PushoverNotificationService(BaseNotificationService):
 
         targets = kwargs.get(ATTR_TARGET)
 
+        if not isinstance(targets, list):
+            targets = [targets]
+
         for target in targets:
             if target is not None:
                 data['device'] = target

--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -68,7 +68,10 @@ class SlackNotificationService(BaseNotificationService):
         """Send a message to a user."""
         import slacker
 
-        targets = kwargs.get(ATTR_TARGET, [self._default_channel])
+        if kwargs.get(ATTR_TARGET) is None:
+            targets = [self._default_channel]
+        else:
+            targets = kwargs.get(ATTR_TARGET)
 
         data = kwargs.get('data')
         attachments = data.get('attachments') if data else None

--- a/homeassistant/components/zigbee.py
+++ b/homeassistant/components/zigbee.py
@@ -55,7 +55,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
-    vol.Required(CONF_PIN): cv.positive_int,
+    vol.Optional(CONF_PIN): cv.positive_int,
     vol.Optional(CONF_ADDRESS): cv.string,
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 30
-PATCH_VERSION = '1'
+PATCH_VERSION = '2'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 4, 2)

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -64,7 +64,6 @@ class TestNotifyDemo(unittest.TestCase):
         data = self.events[0].data
         assert {
             'message': 'my message',
-            'target': None,
             'title': 'my title',
             'data': {'hello': 'world'}
         } == data
@@ -92,7 +91,6 @@ data_template:
         self.assertTrue(len(self.events) == 1)
         assert {
             'message': 'Test 123 4',
-            'target': None,
             'data': {
                 'push': {
                     'sound':
@@ -124,7 +122,6 @@ data_template:
         assert {
             'message': 'Test 123 4',
             'title': 'Test',
-            'target': None,
             'data': {
                 'push': {
                     'sound':

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -152,7 +152,7 @@ data_template:
 
         assert {
             'message': 'my message',
-            'target': 'test target id',
+            'target': ['test target id'],
             'title': 'my title',
             'data': {'hello': 'world'}
         } == data


### PR DESCRIPTION
- Handle Volvo's with dashes in their name (@molobrakos)
- Fix some html5 push notification configuration options were discarded after first use (@T3m3z)
- Fix Homematic device name with autodiscovery (@pvizeli)
- Make 'pin' optional for zigbee device config (@flyte)
- Fix when sending a notification to a service with target attached (i.e. `notify.html5_unnamed_device_2`) the target was not submitted to the platform as a list causing iteration over every character in the string. (@robbiet480)
- Fix for Slack targets (@fabaff)
- Fix for Pushover targets (@Nixon506E)

Not releasing this yet as Robbie wanted to get https://github.com/home-assistant/home-assistant/pull/3769 in but it doesn't seem to be ready yet.
