### PR TITLE
Use voluptuous for Universal media player

### DIFF
--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -57,7 +57,7 @@ COMMAND_SCHEMA = vol.Schema({
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_CHILDREN, default=[]):
-        vol.All(cv.ensure_list, [cv.string]),
+        vol.All(cv.ensure_list, [cv.entity_ids]),
     vol.Optional(CONF_COMMANDS, default={}):
         vol.Schema({vol.All(cv.string, vol.In(COMMANDS)): COMMAND_SCHEMA}),
     vol.Optional(CONF_ATTRS, default={}):


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
media_player:
  - platform: universal
    name: MEDIA_PLAYER_NAME
    children:
      - media_player.CHILD_1_ID
      - media_player.CHILD_2_ID
    commands:
      turn_on:
        service: SERVICE
        data: SERVICE_DATA
      turn_off:
        service: SERVICE
        data: SERVICE_DATA
      volume_up:
        service: SERVICE
        data: SERVICE_DATA
      volume_down:
        service: SERVICE
        data: SERVICE_DATA
      volume_mute:
        service: SERVICE
        data: SERVICE_DATA
    attributes:
      is_volume_muted: ENTITY_ID|ATTRIBUTE
      state: ENTITY_ID|ATTRIBUTE
```

At the moment the a lot of tests are failing. Perhaps somebody can give me a hint for the fix.
