### PR TITLE
Use voluptuous for Pi RF Switch

### DIFF
--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -4,51 +4,65 @@ Allows to configure a switch using a 433MHz module via GPIO on a Raspberry Pi.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.rpi_rf/
 """
-
 import logging
 
-from homeassistant.components.switch import SwitchDevice
+import voluptuous as vol
+
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_NAME, CONF_SWITCHES)
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['rpi-rf==0.9.5']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_CODE_OFF = 'code_off'
+CONF_CODE_ON = 'code_on'
+CONF_GPIO = 'gpio'
+CONF_PROTOCOL = 'protocol'
+CONF_PULSELENGTH = 'pulselength'
+
+DEFAULT_PROTOCOL = 1
+
+SWITCH_SCHEMA = vol.Schema({
+    vol.Required(CONF_CODE_OFF): cv.positive_int,
+    vol.Required(CONF_CODE_ON): cv.positive_int,
+    vol.Optional(CONF_PULSELENGTH): cv.positive_int,
+    vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL): cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_GPIO): cv.positive_int,
+    vol.Required(CONF_SWITCHES): vol.Schema({cv.string: SWITCH_SCHEMA}),
+})
+
 
 # pylint: disable=unused-argument, import-error
-def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return switches controlled by a generic RF device via GPIO."""
     import rpi_rf
 
-    gpio = config.get('gpio')
-    if not gpio:
-        _LOGGER.error("No GPIO specified")
-        return False
-
+    gpio = config.get(CONF_GPIO)
     rfdevice = rpi_rf.RFDevice(gpio)
+    switches = config.get(CONF_SWITCHES)
 
-    switches = config.get('switches', {})
     devices = []
     for dev_name, properties in switches.items():
-        if not properties.get('code_on'):
-            _LOGGER.error("%s: code_on not specified", dev_name)
-            continue
-        if not properties.get('code_off'):
-            _LOGGER.error("%s: code_off not specified", dev_name)
-            continue
-
         devices.append(
             RPiRFSwitch(
                 hass,
-                properties.get('name', dev_name),
+                properties.get(CONF_NAME, dev_name),
                 rfdevice,
-                properties.get('protocol', None),
-                properties.get('pulselength', None),
-                properties.get('code_on'),
-                properties.get('code_off')))
+                properties.get(CONF_PROTOCOL),
+                properties.get(CONF_PULSELENGTH),
+                properties.get(CONF_CODE_ON),
+                properties.get(CONF_CODE_OFF)
+            )
+        )
     if devices:
         rfdevice.enable_tx()
 
-    add_devices_callback(devices)
+    add_devices(devices)
 
 
 class RPiRFSwitch(SwitchDevice):
@@ -84,10 +98,10 @@ class RPiRFSwitch(SwitchDevice):
 
     def _send_code(self, code, protocol, pulselength):
         """Send the code with a specified pulselength."""
-        _LOGGER.info('Sending code: %s', code)
+        _LOGGER.info("Sending code: %s", code)
         res = self._rfdevice.tx_code(code, protocol, pulselength)
         if not res:
-            _LOGGER.error('Sending code %s failed', code)
+            _LOGGER.error("Sending code %s failed", code)
         return res
 
     def turn_on(self):


### PR DESCRIPTION
**Description:**
Migration of the configuration check to `voluptuous`.

**Related issue (if applicable):** fixes [127528299](https://www.pivotaltracker.com/story/show/127528299)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
  - platform: rpi_rf
    gpio: 17
    switches:
      bedroom_light:
        code_on: 1234567
        code_off: 1234568
      ambilight:
        pulselength: 200
        code_on: 987654
        code_off: 133742
      living_room_light:
        protocol: 5
        code_on: 654321
        code_off: 654320
```
