### PR TITLE
Add support for Lutron RadioRA 2 (lights) and Emotiva XMC-1 (media_player)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -160,9 +160,11 @@ omit =
     homeassistant/components/light/hyperion.py
     homeassistant/components/light/lifx.py
     homeassistant/components/light/limitlessled.py
+    homeassistant/components/light/lutron.py
     homeassistant/components/light/osramlightify.py
     homeassistant/components/light/x10.py
     homeassistant/components/lirc.py
+    homeassistant/components/lutron.py
     homeassistant/components/media_player/braviatv.py
     homeassistant/components/media_player/cast.py
     homeassistant/components/media_player/cmus.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -170,6 +170,7 @@ omit =
     homeassistant/components/media_player/cmus.py
     homeassistant/components/media_player/denon.py
     homeassistant/components/media_player/directv.py
+    homeassistant/components/media_player/emotiva.py
     homeassistant/components/media_player/firetv.py
     homeassistant/components/media_player/gpmdp.py
     homeassistant/components/media_player/itunes.py

--- a/homeassistant/components/light/lutron.py
+++ b/homeassistant/components/light/lutron.py
@@ -1,0 +1,90 @@
+"""Support for Lutron lights."""
+import logging
+
+from homeassistant.components.light import ATTR_BRIGHTNESS, Light
+from homeassistant.components.lutron import (
+    LutronDevice, LUTRON_DEVICES, LUTRON_GROUPS, LUTRON_CONTROLLER)
+
+DEPENDENCIES = ['lutron']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Setup Lutron lights."""
+    area_devs = {}
+    devs = []
+    for (area_name, device) in LUTRON_DEVICES['light']:
+        dev = LutronLight(hass, area_name, device, LUTRON_CONTROLLER)
+        area_devs.setdefault(area_name, []).append(dev)
+        devs.append(dev)
+    add_devices_callback(devs)
+
+    for area in area_devs:
+        if area not in LUTRON_GROUPS:
+            continue
+        gr = LUTRON_GROUPS[area]
+        gr.update_tracked_entity_ids(
+            list(gr.tracking) + [dev.entity_id for dev in area_devs[area]])
+
+
+def to_lutron_level(level):
+    """Convert the given HASS light level (0-255) to Lutron (0.0-100.0)."""
+    return float((level * 100) / 255)
+
+
+def to_hass_level(level):
+    """Convert the given Lutron (0.0-100.0) light level to HASS (0-255)."""
+    return int((level * 255) / 100)
+
+
+class LutronLight(LutronDevice, Light):
+    """Representation of a Lutron Light, including dimmable."""
+
+    def __init__(self, hass, area_name, lutron_device, controller):
+        """Initialize the light."""
+        self._prev_brightness = None
+        LutronDevice.__init__(self, hass, area_name, lutron_device, controller)
+
+    @property
+    def brightness(self):
+        """Return the brightness of the light."""
+        new_brightness = to_hass_level(self._lutron_device.last_level())
+        if new_brightness != 0:
+            self._prev_brightness = new_brightness
+        return new_brightness
+
+    def turn_on(self, **kwargs):
+        """Turn the light on."""
+        if ATTR_BRIGHTNESS in kwargs and self._lutron_device.is_dimmable:
+            brightness = kwargs[ATTR_BRIGHTNESS]
+        elif self._prev_brightness == 0:
+            brightness = 255 / 2
+        else:
+            brightness = self._prev_brightness
+        self._prev_brightness = brightness
+        self._lutron_device.level = to_lutron_level(brightness)
+        self.update_ha_state()
+
+    def turn_off(self, **kwargs):
+        """Turn the light off."""
+        self._lutron_device.level = 0
+        self.update_ha_state()
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attr = {}
+        attr['Lutron Integration ID'] = self._lutron_device.id
+        return attr
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._lutron_device.last_level() > 0
+
+    def update(self):
+        """Called by the lutron device callback to update state."""
+        if self._prev_brightness is None:
+            self._prev_brightness = to_hass_level(self._lutron_device.level)

--- a/homeassistant/components/lutron.py
+++ b/homeassistant/components/lutron.py
@@ -1,0 +1,81 @@
+"""
+Component for interacting with a Lutron RadioRA 2 system.
+
+Uses pylutron (http://github.com/thecynic/pylutron).
+"""
+
+import logging
+
+from homeassistant.components import group
+from homeassistant.helpers import discovery
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['https://github.com/thecynic/pylutron/archive/v0.1.0.zip#pylutron==0.1.0']
+
+DOMAIN = "lutron"
+
+# List of component names (string) your component depends upon.
+DEPENDENCIES = ['group', 'light']
+
+_LOGGER = logging.getLogger(__name__)
+
+LUTRON_CONTROLLER = None
+
+LUTRON_DEVICES = {'light': []}
+LUTRON_GROUPS = {}
+
+
+def setup(hass, base_config):
+    """Setup our skeleton component."""
+    global LUTRON_CONTROLLER
+
+    from pylutron import Lutron
+
+    config = base_config.get(DOMAIN)
+    LUTRON_CONTROLLER = Lutron(
+        config['lutron_host'],
+        config['lutron_user'],
+        config['lutron_password']
+    )
+    LUTRON_CONTROLLER.load_xml_db()
+    LUTRON_CONTROLLER.connect()
+    _LOGGER.info("CONNECTED?!")
+
+    # Sort our devices into types
+    for area in LUTRON_CONTROLLER.areas:
+        if area.name not in LUTRON_GROUPS:
+            gr = group.Group(hass, area.name, [])
+            LUTRON_GROUPS[area.name] = gr
+        for output in area.outputs:
+            LUTRON_DEVICES['light'].append((area.name, output))
+
+    for component in ('light',):
+        discovery.load_platform(hass, component, DOMAIN, None, base_config)
+    return True
+
+
+class LutronDevice(Entity):
+    """Representation of a Lutron device entity."""
+
+    def __init__(self, hass, area_name, lutron_device, controller):
+        """Initialize the device."""
+        self._lutron_device = lutron_device
+        self._controller = controller
+        self._area_name = area_name
+
+        self.update()
+        self._controller.subscribe(self._lutron_device, self._update_callback)
+
+    def _update_callback(self, _device):
+        """Callback invoked by pylutron when the device state changes."""
+        self.update_ha_state()
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._lutron_device.name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False

--- a/homeassistant/components/media_player/emotiva.py
+++ b/homeassistant/components/media_player/emotiva.py
@@ -1,0 +1,102 @@
+"""
+Support for Emotiva Receivers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.emotiva/
+"""
+import logging
+
+from homeassistant.components.media_player import (
+    SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE,
+    SUPPORT_VOLUME_STEP, SUPPORT_SELECT_SOURCE, MediaPlayerDevice)
+from homeassistant.const import STATE_OFF, STATE_ON
+
+REQUIREMENTS = ['https://github.com/thecynic/pymotiva/archive/v0.1.0.zip#pymotiva==0.1.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORT_EMOTIVA = SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_STEP | \
+    SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Emotiva platform."""
+    from pymotiva import Emotiva
+
+    add_devices(EmotivaDevice(Emotiva(ip, info))
+                for ip, info in Emotiva.discover())
+
+
+class EmotivaDevice(MediaPlayerDevice):
+    """Representation of an Emotiva device."""
+
+    # pylint: disable=too-many-public-methods, abstract-method
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self, emo):
+        """Initialize the Emotiva Receiver."""
+        self._emo = emo
+        self._emo.connect()
+        self._name = '%s %s' % (self._emo.name, self._emo.model)
+        self._min_volume = -96.0
+        self._max_volume = 11
+
+        self.update()
+        self._emo.set_update_cb(lambda: self.update_ha_state())
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return {True: STATE_ON, False: STATE_OFF}[self._emo.power]
+
+    @property
+    def volume_level(self):
+        """Volume level of the media player (0..1)."""
+        return ((self._emo.volume - self._min_volume) /
+                (self._max_volume - self._min_volume))
+
+    @property
+    def is_volume_muted(self):
+        """Boolean if volume is currently muted."""
+        return self._emo.mute
+
+    @property
+    def source(self):
+        """Return the current input source."""
+        return self._emo.source
+
+    @property
+    def source_list(self):
+        """List of available input sources."""
+        return self._emo.sources
+
+    @property
+    def supported_media_commands(self):
+        """Flag of media commands that are supported."""
+        return SUPPORT_EMOTIVA
+
+    def turn_off(self):
+        """Turn off media player."""
+        self._emo.power = False
+
+    def mute_volume(self, mute):
+        """Mute (true) or unmute (false) media player."""
+        self._emo.mute = mute
+
+    def volume_up(self):
+        self._emo.volume_up()
+
+    def volume_down(self):
+        self._emo.volume_down()
+
+    def turn_on(self):
+        """Turn the media player on."""
+        self._emo.power = True
+
+    def select_source(self, source):
+        """Select input source."""
+        self._emo.source = source

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -207,6 +207,9 @@ https://github.com/robbiet480/pygtfs/archive/00546724e4bbcb3053110d844ca44e22462
 # homeassistant.components.scene.hunterdouglas_powerview
 https://github.com/sander76/powerviewApi/archive/246e782d60d5c0addcc98d7899a0186f9d5640b0.zip#powerviewApi==0.3.15
 
+# homeassistant.components.lutron
+https://github.com/thecynic/pylutron/archive/v0.1.0.zip#pylutron==0.1.0
+
 # homeassistant.components.mysensors
 https://github.com/theolind/pymysensors/archive/8ce98b7fb56f7921a808eb66845ce8b2c455c81e.zip#pymysensors==0.7.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -210,6 +210,9 @@ https://github.com/sander76/powerviewApi/archive/246e782d60d5c0addcc98d7899a0186
 # homeassistant.components.lutron
 https://github.com/thecynic/pylutron/archive/v0.1.0.zip#pylutron==0.1.0
 
+# homeassistant.components.media_player.emotiva
+https://github.com/thecynic/pymotiva/archive/v0.1.0.zip#pymotiva==0.1.0
+
 # homeassistant.components.mysensors
 https://github.com/theolind/pymysensors/archive/8ce98b7fb56f7921a808eb66845ce8b2c455c81e.zip#pymysensors==0.7.1
 


### PR DESCRIPTION
**Description:**
This PR adds support for Lutron RadioRA 2 and Emotiva XMC-1 devices. I've been running with it for a few months now and things seem pretty solid. I'm sure there are issues, so bug reports are welcome.

This is my first PR so let me know if I'm doing anything really wrong :) If you'd like me to split them into 2 separate PRs, I can do that.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
lutron:
  lutron_host: <ip>
  lutron_user: lutron
  lutron_password: integration

media_player:
  platform: emotiva
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
