### PR TITLE
Fixed Fitbit resting heart rate attribute

### DIFF
--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -403,7 +403,7 @@ class FitbitSensor(Entity):
         response = self.client.time_series(self.resource_type, period='7d')
         self._state = response[container][-1].get('value')
         if self.resource_type == 'activities/heart':
-            self._state = response[container][-1].get('restingHeartRate')
+            self._state = response[container][-1].get('value').get('restingHeartRate')
         config_contents = {
             ATTR_ACCESS_TOKEN: self.client.client.token['access_token'],
             ATTR_REFRESH_TOKEN: self.client.client.token['refresh_token'],

--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -359,6 +359,8 @@ class FitbitSensor(Entity):
         pretty_resource = pretty_resource.title()
         if pretty_resource == 'Body Bmi':
             pretty_resource = 'BMI'
+        elif pretty_resource == 'Heart':
+            pretty_resource = 'Resting Heart Rate'
         self._name = pretty_resource
         unit_type = FITBIT_RESOURCES_LIST[self.resource_type]
         if unit_type == "":

--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -405,7 +405,8 @@ class FitbitSensor(Entity):
         response = self.client.time_series(self.resource_type, period='7d')
         self._state = response[container][-1].get('value')
         if self.resource_type == 'activities/heart':
-            self._state = response[container][-1].get('value').get('restingHeartRate')
+            self._state = response[container][-1]. \
+                    get('value').get('restingHeartRate')
         config_contents = {
             ATTR_ACCESS_TOKEN: self.client.client.token['access_token'],
             ATTR_REFRESH_TOKEN: self.client.client.token['refresh_token'],


### PR DESCRIPTION
**Description:**
Fixed Fitbit attribute restingHearRate to return the correct value via API. 

``` python
    In [31]: r['activities-heart'][-1].get('value')
    Out[31]:
    {'customHeartRateZones': [],
     'heartRateZones': [{'caloriesOut': 126.18348,
       'max': 94,
       'min': 30,
       'minutes': 67,
       'name': 'Out of Range'},
      {'caloriesOut': 27.21339,
       'max': 131,
       'min': 94,
       'minutes': 5,
       'name': 'Fat Burn'},
      {'caloriesOut': 0, 'max': 159, 'min': 131, 'minutes': 0, 'name': 'Cardio'},
      {'caloriesOut': 0, 'max': 220, 'min': 159, 'minutes': 0, 'name': 'Peak'}],
     'restingHeartRate': 69}

    In [32]: r['activities-heart'][-1].get('value').get('restingHeartRate')
    Out[32]: 69
```

https://dev.fitbit.com/docs/activity/#get-activity-intraday-time-series

![image](https://cloud.githubusercontent.com/assets/809840/19300237/2fa7873e-9027-11e6-95c6-095e3c548399.png)

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

I'll work and submit another PR with the unittest for fitbit component. 
