### PR TITLE
Hotfix for Netatmo discovery

### DIFF
--- a/homeassistant/components/binary_sensor/netatmo.py
+++ b/homeassistant/components/binary_sensor/netatmo.py
@@ -49,10 +49,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import lnetatmo
     try:
         data = WelcomeData(netatmo.NETATMO_AUTH, home)
+        if data.get_camera_names() == []:
+            return None
     except lnetatmo.NoDevice:
-        return None
-
-    if data.get_camera_names() == []:
         return None
 
     sensors = config.get(CONF_MONITORED_CONDITIONS, SENSOR_TYPES)

--- a/homeassistant/components/camera/netatmo.py
+++ b/homeassistant/components/camera/netatmo.py
@@ -36,15 +36,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import lnetatmo
     try:
         data = WelcomeData(netatmo.NETATMO_AUTH, home)
+        for camera_name in data.get_camera_names():
+            if CONF_CAMERAS in config:
+                if config[CONF_CAMERAS] != [] and \
+                   camera_name not in config[CONF_CAMERAS]:
+                    continue
+            add_devices([WelcomeCamera(data, camera_name, home)])
     except lnetatmo.NoDevice:
         return None
-
-    for camera_name in data.get_camera_names():
-        if CONF_CAMERAS in config:
-            if config[CONF_CAMERAS] != [] and \
-               camera_name not in config[CONF_CAMERAS]:
-                continue
-        add_devices([WelcomeCamera(data, camera_name, home)])
 
 
 class WelcomeCamera(Camera):

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -65,20 +65,26 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     data = NetAtmoData(netatmo.NETATMO_AUTH, config.get(CONF_STATION, None))
 
     dev = []
-    if CONF_MODULES in config:
-        # Iterate each module
-        for module_name, monitored_conditions in config[CONF_MODULES].items():
-            # Test if module exist """
-            if module_name not in data.get_module_names():
-                _LOGGER.error('Module name: "%s" not found', module_name)
-                continue
-            # Only create sensor for monitored """
-            for variable in monitored_conditions:
-                dev.append(NetAtmoSensor(data, module_name, variable))
-    else:
-        for module_name in data.get_module_names():
-            for variable in data.station_data.monitoredConditions(module_name):
-                dev.append(NetAtmoSensor(data, module_name, variable))
+    import lnetatmo
+    try:
+        if CONF_MODULES in config:
+            # Iterate each module
+            for module_name, monitored_conditions in\
+                    config[CONF_MODULES].items():
+                # Test if module exist """
+                if module_name not in data.get_module_names():
+                    _LOGGER.error('Module name: "%s" not found', module_name)
+                    continue
+                # Only create sensor for monitored """
+                for variable in monitored_conditions:
+                    dev.append(NetAtmoSensor(data, module_name, variable))
+        else:
+            for module_name in data.get_module_names():
+                for variable in\
+                        data.station_data.monitoredConditions(module_name):
+                    dev.append(NetAtmoSensor(data, module_name, variable))
+    except lnetatmo.NoDevice:
+        return None
 
     add_devices(dev)
 


### PR DESCRIPTION
**Description:**
Hotfix for the Netatmo discovery as it now uses by all netatmo devices (sensor, binary sensor and camera). 

**Related issue (if applicable):** fixes #2601 and full error log seen during PR #3836 

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
