### PR TITLE
Downgrade Docker Python to 3.4 to re-enable Bluetooth Device Tracker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.4
 MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
 
 VOLUME /config


### PR DESCRIPTION
**Description:** There is a bug affecting the Bluetooth device tracker and Python versions 3.5+. The Docker image was upgraded to Python 3.5 in #3430

Now, with the Bluetooth device tracker enabled, the following error is raised by Home Assistant

```
homeassistant.components.device_tracker: Error setting up platform bluetooth_tracker
Traceback (most recent call last):
  File "/usr/src/app/homeassistant/components/device_tracker/__init__.py", line 148, in setup_platform
    if not platform.setup_scanner(hass, p_config, tracker.see):
  File "/usr/src/app/homeassistant/components/device_tracker/bluetooth_tracker.py", line 61, in setup_scanner
    for dev in discover_devices():
  File "/usr/src/app/homeassistant/components/device_tracker/bluetooth_tracker.py", line 39, in discover_devices
    lookup_class=False)
  File "/config/deps/bluetooth/bluez.py", line 26, in discover_devices
    device_id = _bt.hci_get_route()
OSError: [Errno 97] Address family not supported by protocol
```

**Related issue (if applicable):** https://bugs.python.org/issue27929

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
device_tracker:
  - platform: bluetooth_tracker
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
