### PR TITLE
Select next and previous of input select

### DIFF
--- a/homeassistant/components/input_select.py
+++ b/homeassistant/components/input_select.py
@@ -31,6 +31,18 @@ SERVICE_SELECT_OPTION_SCHEMA = vol.Schema({
     vol.Required(ATTR_OPTION): cv.string,
 })
 
+SERVICE_SELECT_NEXT = 'select_next'
+
+SERVICE_SELECT_NEXT_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+})
+
+SERVICE_SELECT_PREVIOUS = 'select_previous'
+
+SERVICE_SELECT_PREVIOUS_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+})
+
 
 def _cv_input_select(cfg):
     """Config validation helper for input select (Voluptuous)."""
@@ -53,10 +65,24 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: {
 
 
 def select_option(hass, entity_id, option):
-    """Set input_select to False."""
+    """Set value of input_select."""
     hass.services.call(DOMAIN, SERVICE_SELECT_OPTION, {
         ATTR_ENTITY_ID: entity_id,
         ATTR_OPTION: option,
+    })
+
+
+def select_next(hass, entity_id):
+    """Set next value of input_select."""
+    hass.services.call(DOMAIN, SERVICE_SELECT_NEXT, {
+        ATTR_ENTITY_ID: entity_id,
+    })
+
+
+def select_previous(hass, entity_id):
+    """Set previous value of input_select."""
+    hass.services.call(DOMAIN, SERVICE_SELECT_PREVIOUS, {
+        ATTR_ENTITY_ID: entity_id,
     })
 
 
@@ -77,7 +103,7 @@ def setup(hass, config):
         return False
 
     def select_option_service(call):
-        """Handle a calls to the input select services."""
+        """Handle a calls to the input select option service."""
         target_inputs = component.extract_from_service(call)
 
         for input_select in target_inputs:
@@ -86,6 +112,28 @@ def setup(hass, config):
     hass.services.register(DOMAIN, SERVICE_SELECT_OPTION,
                            select_option_service,
                            schema=SERVICE_SELECT_OPTION_SCHEMA)
+
+    def select_next_service(call):
+        """Handle a calls to the input select next service."""
+        target_inputs = component.extract_from_service(call)
+
+        for input_select in target_inputs:
+            input_select.offset_index(1)
+
+    hass.services.register(DOMAIN, SERVICE_SELECT_NEXT,
+                           select_next_service,
+                           schema=SERVICE_SELECT_NEXT_SCHEMA)
+
+    def select_previous_service(call):
+        """Handle a calls to the input select previous service."""
+        target_inputs = component.extract_from_service(call)
+
+        for input_select in target_inputs:
+            input_select.offset_index(-1)
+
+    hass.services.register(DOMAIN, SERVICE_SELECT_PREVIOUS,
+                           select_previous_service,
+                           schema=SERVICE_SELECT_PREVIOUS_SCHEMA)
 
     component.add_entities(entities)
 
@@ -138,4 +186,11 @@ class InputSelect(Entity):
                             option, ', '.join(self._options))
             return
         self._current_option = option
+        self.update_ha_state()
+
+    def offset_index(self, offset):
+        """Offset current index."""
+        current_index = self._options.index(self._current_option)
+        new_index = (current_index + offset) % len(self._options)
+        self._current_option = self._options[new_index]
         self.update_ha_state()

--- a/tests/components/test_input_select.py
+++ b/tests/components/test_input_select.py
@@ -6,7 +6,7 @@ from tests.common import get_test_home_assistant
 
 from homeassistant.bootstrap import setup_component
 from homeassistant.components.input_select import (
-    ATTR_OPTIONS, DOMAIN, select_option)
+    ATTR_OPTIONS, DOMAIN, select_option, select_next, select_previous)
 from homeassistant.const import (
     ATTR_ICON, ATTR_FRIENDLY_NAME)
 
@@ -66,6 +66,66 @@ class TestInputSelect(unittest.TestCase):
 
         state = self.hass.states.get(entity_id)
         self.assertEqual('another option', state.state)
+
+    def test_select_next(self):
+        """Test select_next methods."""
+        self.assertTrue(
+            setup_component(self.hass, DOMAIN, {DOMAIN: {
+                'test_1': {
+                    'options': [
+                        'first option',
+                        'middle option',
+                        'last option',
+                    ],
+                    'initial': 'middle option',
+                },
+            }}))
+        entity_id = 'input_select.test_1'
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual('middle option', state.state)
+
+        select_next(self.hass, entity_id)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual('last option', state.state)
+
+        select_next(self.hass, entity_id)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual('first option', state.state)
+
+    def test_select_previous(self):
+        """Test select_previous methods."""
+        self.assertTrue(
+            setup_component(self.hass, DOMAIN, {DOMAIN: {
+                'test_1': {
+                    'options': [
+                        'first option',
+                        'middle option',
+                        'last option',
+                    ],
+                    'initial': 'middle option',
+                },
+            }}))
+        entity_id = 'input_select.test_1'
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual('middle option', state.state)
+
+        select_previous(self.hass, entity_id)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual('first option', state.state)
+
+        select_previous(self.hass, entity_id)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual('last option', state.state)
 
     def test_config_options(self):
         """Test configuration options."""


### PR DESCRIPTION
**Description:**
Services to select next and select previous of an input_select. 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
automation:                                                                                                     
  - alias: Switch to next radio station                                                                         
    trigger:                                                                                                    
      - platform: state                                                                                         
        entity_id: switch.remote_next                                                                           
    action:                                                                                                     
      - service: input_select.select_next                                                                       
        entity_id: input_select.radio_station                                                                   
  - alias: Switch to previous radio station                                                                     
    trigger:                                                                                                    
      - platform: state                                                                                         
        entity_id: switch.remote_previous                                                                       
    action:                                                                                                     
      - service: input_select.select_previous                                                                   
        entity_id: input_select.radio_station     
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
