### PR TITLE
Add web scrape sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -255,6 +255,7 @@ omit =
     homeassistant/components/sensor/plex.py
     homeassistant/components/sensor/rest.py
     homeassistant/components/sensor/sabnzbd.py
+    homeassistant/components/sensor/scrape.py
     homeassistant/components/sensor/serial_pm.py
     homeassistant/components/sensor/snmp.py
     homeassistant/components/sensor/speedtest.py

--- a/homeassistant/components/sensor/scrape.py
+++ b/homeassistant/components/sensor/scrape.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.components.sensor.rest import RestData
 from homeassistant.const import (
     CONF_NAME, CONF_RESOURCE, CONF_UNIT_OF_MEASUREMENT, STATE_UNKNOWN,
-    CONF_VALUE_TEMPLATE,CONF_VERIFY_SSL)
+    CONF_VALUE_TEMPLATE, CONF_VERIFY_SSL)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/sensor/scrape.py
+++ b/homeassistant/components/sensor/scrape.py
@@ -1,0 +1,113 @@
+"""
+Support for getting data from websites with scraping.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.scrape/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.components.sensor.rest import RestData
+from homeassistant.const import (
+    CONF_NAME, CONF_RESOURCE, CONF_UNIT_OF_MEASUREMENT, STATE_UNKNOWN)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['beautifulsoup4==4.5.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_SELECT = 'select'
+CONF_ELEMENT = 'element'
+CONF_BEFORE = 'before'
+CONF_AFTER = 'after'
+
+DEFAULT_NAME = 'Web scrape'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_RESOURCE): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Required(CONF_SELECT): cv.string,
+    vol.Optional(CONF_ELEMENT, default=0): cv.positive_int,
+    vol.Optional(CONF_BEFORE, default=0): cv.positive_int,
+    vol.Optional(CONF_AFTER, default=99999): cv.positive_int,
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+})
+
+
+# pylint: disable=too-many-locals
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Web scrape sensor."""
+    name = config.get(CONF_NAME)
+    resource = config.get(CONF_RESOURCE)
+    method = 'GET'
+    payload = auth = headers = None
+    verify_ssl = True
+    select = config.get(CONF_SELECT)
+    element = config.get(CONF_ELEMENT)
+    before = config.get(CONF_BEFORE)
+    after = config.get(CONF_AFTER)
+    unit = config.get(CONF_UNIT_OF_MEASUREMENT)
+
+    rest = RestData(method, resource, auth, headers, payload, verify_ssl)
+    rest.update()
+
+    if rest.data is None:
+        _LOGGER.error("Unable to fetch data from %s", resource)
+        return False
+
+    add_devices([
+        ScrapeSensor(rest, name, select, element, before, after, unit)
+    ])
+
+
+# pylint: disable=too-many-instance-attributes
+class ScrapeSensor(Entity):
+    """Representation of a web scrape sensor."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, rest, name, select, element, before, after, unit):
+        """Initialize a web scrape sensor."""
+        self.rest = rest
+        self._name = name
+        self._state = STATE_UNKNOWN
+        self._select = select
+        self._element = element
+        self._before = before
+        self._after = after
+        self._unit_of_measurement = unit
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self._unit_of_measurement
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    def update(self):
+        """Get the latest data from the source and updates the state."""
+        self.rest.update()
+
+        from bs4 import BeautifulSoup
+
+        raw_data = BeautifulSoup(self.rest.data, 'html.parser')
+        _LOGGER.debug(raw_data)
+        data = raw_data.select(self._select)
+        _LOGGER.error(data)
+
+        try:
+            self._state = data[self._element].text[self._before:self._after]
+        except TypeError:
+            _LOGGER.warning("Unable to extract a value")
+            self._state = STATE_UNKNOWN

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -41,6 +41,9 @@ astral==1.2
 # homeassistant.components.sensor.linux_battery
 batinfo==0.3
 
+# homeassistant.components.sensor.scrape
+beautifulsoup4==4.5.1
+
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.8
 


### PR DESCRIPTION
**Description:**
The web scrape sensor is built on top of the REST sensor, allows one to retrieve a whole website, and to extract a value. Its limited features can't compete with a specialized tool like [scrapy](https://scrapy.org/) but as a last resort it could be helpful. There are samples available in the [docs PR](https://github.com/home-assistant/home-assistant.github.io/pull/1220/files#diff-ff5112f34cb71624c6d2390d45117b45R38) with a bit of context (below you find the entries for the `configuration.yaml` file) and a [Jupyter notebook](https://github.com/home-assistant/home-assistant-notebooks/pull/4) is showing some details. 

**Related issue (if applicable):** fixes [Web page parsing or web scraping sensor](https://community.home-assistant.io/t/web-page-parsing-or-web-scraping-sensor-for-specific-numbers-values-text-etc/4841)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#1220

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: scrape
    resource: https://home-assistant.io
    name: Release
    select: ".current-version h1"
    value_template: '{{ value.split(":")[1] }}'
  - platform: scrape
    resource: https://home-assistant.io/components/
    name: Home Assistant impl.
    select: 'a[href="#all"]'
    value_template: '{{ value.split("(")[1].split(")")[0] }}'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
