### PR TITLE
Add Bbox Modem Routeur for device tracker

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -127,6 +127,7 @@ omit =
     homeassistant/components/device_tracker/actiontec.py
     homeassistant/components/device_tracker/aruba.py
     homeassistant/components/device_tracker/asuswrt.py
+    homeassistant/components/device_tracker/bbox.py
     homeassistant/components/device_tracker/bluetooth_tracker.py
     homeassistant/components/device_tracker/bluetooth_le_tracker.py
     homeassistant/components/device_tracker/bt_home_hub_5.py

--- a/homeassistant/components/device_tracker/bbox.py
+++ b/homeassistant/components/device_tracker/bbox.py
@@ -1,0 +1,82 @@
+"""
+Support for French FAI Bouygues Bbox routers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.bbox/
+"""
+from collections import namedtuple
+import logging
+from datetime import timedelta
+import homeassistant.util.dt as dt_util
+from homeassistant.components.device_tracker import DOMAIN
+from homeassistant.util import Throttle
+
+# Return cached results if last scan was less then this time ago
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=60)
+
+_LOGGER = logging.getLogger(__name__)
+REQUIREMENTS = ['pybbox==0.0.5-alpha']
+
+
+def get_scanner(hass, config):
+    """Validate the configuration and return a Bbox scanner."""
+    scanner = BboxDeviceScanner(config[DOMAIN])
+
+    return scanner if scanner.success_init else None
+
+
+Device = namedtuple('Device', ['mac', 'name', 'ip', 'last_update'])
+
+
+class BboxDeviceScanner(object):
+    """This class scans for devices connected to the bbox."""
+
+    def __init__(self, config):
+        """Initialize the scanner."""
+        self.last_results = []  # type: List[Device]
+
+        self.success_init = self._update_info()
+        _LOGGER.info('Bbox scanner initialized')
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+
+        return [device.mac for device in self.last_results]
+
+    def get_device_name(self, mac):
+        """Return the name of the given device or None if we don't know."""
+        filter_named = [device.name for device in self.last_results if
+                        device.mac == mac]
+
+        if filter_named:
+            return filter_named[0]
+        else:
+            return None
+
+    @Throttle(MIN_TIME_BETWEEN_SCANS)
+    def _update_info(self):
+        """Check the bbox for devices.
+
+        Returns boolean if scanning successful.
+        """
+        _LOGGER.info('Scanning')
+
+        import pybbox
+
+        box = pybbox.Bbox()
+        result = box.get_all_connected_devices()
+
+        now = dt_util.now()
+        last_results = []
+        for device in result:
+            if device['active'] != 1:
+                continue
+            last_results.append(
+                Device(device['macaddress'], device['hostname'],
+                       device['ipaddress'], now))
+
+        self.last_results = last_results
+
+        _LOGGER.info('Bbox scan successful')
+        return True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,6 +6,7 @@ pip>=7.0.0
 jinja2>=2.8
 voluptuous==0.9.2
 typing>=3,<4
+pybbox
 
 # homeassistant.components.nuimo_controller
 --only-binary=all git+https://github.com/getSenic/nuimo-linux-python#nuimo==1.0.0
@@ -318,6 +319,9 @@ pyasn1-modules==0.0.8
 
 # homeassistant.components.notify.xmpp
 pyasn1==0.1.9
+
+# homeassistant.components.device_tracker.bbox
+pybbox==0.0.5-alpha
 
 # homeassistant.components.device_tracker.bluetooth_tracker
 # pybluez==0.22


### PR DESCRIPTION
**Description:**
Add the bbox modem routeur to the device tracker. This is a set top box from one of the main French Internet Provider

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
device_tracker:
  - platform: bbox
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [ x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ x] New files were added to `.coveragerc`.
