### PR TITLE
Use async_render_* and fix config validation (binary_sensor.rest)

### DIFF
--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.rest/
 """
 import logging
-import json
 
 import voluptuous as vol
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
@@ -30,7 +29,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.url,
     vol.Optional(CONF_AUTHENTICATION):
         vol.In([HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]),
-    vol.Optional(CONF_HEADERS): cv.string,
+    vol.Optional(CONF_HEADERS): {cv.string: cv.string},
     vol.Optional(CONF_METHOD, default=DEFAULT_METHOD): vol.In(['POST', 'GET']),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
@@ -52,7 +51,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     verify_ssl = config.get(CONF_VERIFY_SSL)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
-    headers = json.loads(config.get(CONF_HEADERS, '{}'))
+    headers = config.get(CONF_HEADERS)
     sensor_class = config.get(CONF_SENSOR_CLASS)
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
@@ -70,7 +69,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     rest.update()
 
     if rest.data is None:
-        _LOGGER.error('Unable to fetch REST data')
+        _LOGGER.error("Unable to fetch REST data from %s", resource)
         return False
 
     add_devices([RestBinarySensor(
@@ -109,8 +108,8 @@ class RestBinarySensor(BinarySensorDevice):
             return False
 
         if self._value_template is not None:
-            response = self._value_template.render_with_possible_json_value(
-                self.rest.data, False)
+            response = self._value_template.\
+                async_render_with_possible_json_value(self.rest.data, False)
 
         try:
             return bool(int(response))


### PR DESCRIPTION
**Description:**
Switching to `async_render_with_possible_json_value()` seems to solve the blocking issue. Also, include a fix for `voluptuous`.

**Related issue (if applicable):** fixes #3833

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
binary_sensor:
  - platform: rest
    resource: http://127.0.0.1:5000/binary_sensor1
    method: GET
    name: REST Tester 1
    sensor_class: Light
    value_template: '{{ value_json.state1 }}'
    headers:
      Content-Type: application/json
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
