### PR TITLE
Bump proliphix library to 0.4.0

### DIFF
--- a/homeassistant/components/climate/proliphix.py
+++ b/homeassistant/components/climate/proliphix.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, TEMP_FAHRENHEIT, ATTR_TEMPERATURE)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['proliphix==0.3.1']
+REQUIREMENTS = ['proliphix==0.4.0']
 
 ATTR_FAN = 'fan'
 

--- a/homeassistant/components/thermostat/proliphix.py
+++ b/homeassistant/components/thermostat/proliphix.py
@@ -9,7 +9,7 @@ from homeassistant.components.thermostat import (
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, TEMP_FAHRENHEIT)
 
-REQUIREMENTS = ['proliphix==0.3.1']
+REQUIREMENTS = ['proliphix==0.4.0']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -293,7 +293,7 @@ pmsensor==0.3
 
 # homeassistant.components.climate.proliphix
 # homeassistant.components.thermostat.proliphix
-proliphix==0.3.1
+proliphix==0.4.0
 
 # homeassistant.components.sensor.systemmonitor
 psutil==4.3.1


### PR DESCRIPTION
**Description:**

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.

There was a bug in setback setting which is now fixed in 0.4.0. This
ensures that any users have working setback code.
