### PR TITLE
Climate: Avoid setting lists if not present, and possible logging fix

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -368,7 +368,10 @@ class ClimateDevice(Entity):
     @property
     def state(self):
         """Return the current state."""
-        return self.current_operation or STATE_UNKNOWN
+        if self.current_operation:
+            return self.current_operation
+        else:
+            return STATE_UNKNOWN
 
     @property
     def state_attributes(self):
@@ -398,17 +401,20 @@ class ClimateDevice(Entity):
         fan_mode = self.current_fan_mode
         if fan_mode is not None:
             data[ATTR_FAN_MODE] = fan_mode
-            data[ATTR_FAN_LIST] = self.fan_list
+            if self.fan_list:
+                data[ATTR_FAN_LIST] = self.fan_list
 
         operation_mode = self.current_operation
         if operation_mode is not None:
             data[ATTR_OPERATION_MODE] = operation_mode
-            data[ATTR_OPERATION_LIST] = self.operation_list
+            if self.operation_list:
+                data[ATTR_OPERATION_LIST] = self.operation_list
 
         swing_mode = self.current_swing_mode
         if swing_mode is not None:
             data[ATTR_SWING_MODE] = swing_mode
-            data[ATTR_SWING_LIST] = self.swing_list
+            if self.swing_list:
+                data[ATTR_SWING_LIST] = self.swing_list
 
         is_away = self.is_away_mode_on
         if is_away is not None:


### PR DESCRIPTION
**Description:**
This fixes a problem with the dropdown menu for operation/fan/swing appearing empty if the mode is available, but not a list.
Also possible solution for #3409 #3666 because state was not set to unknown. Needs to be tested by someone with the platforms the issue was made. It fixed the logging for the generic_thermostat at my setup.

**Related issue (if applicable):** fixes #
#3409 #3666 and new unsubmitted bug.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
