### PR TITLE
Fail when rendering undefined objects in Jinja2 templates

### DIFF
--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -60,7 +60,7 @@ class MqttSensor(Entity):
             """A new MQTT message has been received."""
             if value_template is not None:
                 payload = value_template.render_with_possible_json_value(
-                    payload)
+                    payload, self._state)
             self._state = payload
             self.update_ha_state()
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -402,7 +402,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         """Test if callback is safe."""
         return isinstance(obj, AllStates) or super().is_safe_callable(obj)
 
-ENV = TemplateEnvironment()
+ENV = TemplateEnvironment(undefined=jinja2.StrictUndefined)
 ENV.filters['round'] = forgiving_round
 ENV.filters['multiply'] = multiply
 ENV.filters['timestamp_custom'] = timestamp_custom

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -387,6 +387,13 @@ def timestamp_utc(value):
         return value
 
 
+def fail_when_undefined(value):
+    """Filter to force a failure when the value is undefined."""
+    if isinstance(value, jinja2.Undefined):
+        value()
+    return value
+
+
 def forgiving_float(value):
     """Try to convert value to a float."""
     try:
@@ -402,12 +409,13 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         """Test if callback is safe."""
         return isinstance(obj, AllStates) or super().is_safe_callable(obj)
 
-ENV = TemplateEnvironment(undefined=jinja2.StrictUndefined)
+ENV = TemplateEnvironment()
 ENV.filters['round'] = forgiving_round
 ENV.filters['multiply'] = multiply
 ENV.filters['timestamp_custom'] = timestamp_custom
 ENV.filters['timestamp_local'] = timestamp_local
 ENV.filters['timestamp_utc'] = timestamp_utc
+ENV.filters['is_defined'] = fail_when_undefined
 ENV.globals['float'] = forgiving_float
 ENV.globals['now'] = dt_util.now
 ENV.globals['utcnow'] = dt_util.utcnow

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -206,6 +206,34 @@ class TestHelpersTemplate(unittest.TestCase):
             '-',
             tpl.render_with_possible_json_value('hello', '-'))
 
+    def test_render_with_possible_json_value_with_missing_json_value(self):
+        """Render with possible JSON value with unknown JSON object."""
+        tpl = template.Template('{{ value_json.goodbye }}', self.hass)
+        self.assertEqual(
+            '',
+            tpl.render_with_possible_json_value('{"hello": "world"}'))
+
+    def test_render_with_possible_json_value_valid_with_is_defined(self):
+        """Render with possible JSON value with known JSON object."""
+        tpl = template.Template('{{ value_json.hello|is_defined }}', self.hass)
+        self.assertEqual(
+            'world',
+            tpl.render_with_possible_json_value('{"hello": "world"}'))
+
+    def test_render_with_possible_json_value_undefined_json(self):
+        """Render with possible JSON value with unknown JSON object."""
+        tpl = template.Template('{{ value_json.bye|is_defined }}', self.hass)
+        self.assertEqual(
+            '{"hello": "world"}',
+            tpl.render_with_possible_json_value('{"hello": "world"}'))
+
+    def test_render_with_possible_json_value_undefined_json_error_value(self):
+        """Render with possible JSON value with unknown JSON object."""
+        tpl = template.Template('{{ value_json.bye|is_defined }}', self.hass)
+        self.assertEqual(
+            '',
+            tpl.render_with_possible_json_value('{"hello": "world"}', ''))
+
     def test_raise_exception_on_error(self):
         """Test raising an exception on error."""
         with self.assertRaises(TemplateError):


### PR DESCRIPTION
**Description:**

Add a new 'is_defined' filter to force Jinja2 template rendering to fail on undefined template variables. This allows the caller to provide an alternative result when the rendering fails using the error_value parameter.

This is useful when tracking battery status with Owntracks, because Owntracks periodically sends a keepalive-like message to the topic that does not contain any of the gps coordinate or battery information, which currently results in an empty string instead of the expected value in the web UI.

My first attempt was to use the StrictUndefined class for undefined object on the Jinja2 environment. However this affected all render functions. The second approach is using the 'fail' filter which can be used to trigger a failure when the filtered variable is undefined. The example `configuration.yaml` entry below show how to use it for the previously mentioned check battery from Owntracks updates sensor.

**Related issue (if applicable):** fixes #3834, #2733

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  platform: mqtt
  state_topic: "owntracks/jan/shamu"
  name: "Nexus6 Battery"
  unit_of_measurement: "%"
  value_template: '{{ value_json.batt | is_defined }}'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.

By not successfully rendering unknown objects to an empty string
the caller provided error_value actually gets used.

This allows, for instance, the MQTT sensor to retain its state when an
unexpected or unwanted message (#2733/#3834) is received.
