### PR TITLE
Add ignore option to Z-Wave customize configuration (zwave)

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -31,11 +31,13 @@ CONF_POLLING_INTENSITY = 'polling_intensity'
 CONF_POLLING_INTERVAL = 'polling_interval'
 CONF_USB_STICK_PATH = 'usb_path'
 CONF_CONFIG_PATH = 'config_path'
+CONF_IGNORED = 'ignored'
 
 DEFAULT_CONF_AUTOHEAL = True
 DEFAULT_CONF_USB_STICK_PATH = '/zwaveusbstick'
 DEFAULT_POLLING_INTERVAL = 60000
 DEFAULT_DEBUG = True
+DEFAULT_CONF_IGNORED = False
 DOMAIN = 'zwave'
 
 NETWORK = None
@@ -134,6 +136,7 @@ SET_CONFIG_PARAMETER_SCHEMA = vol.Schema({
 CUSTOMIZE_SCHEMA = vol.Schema({
     vol.Optional(CONF_POLLING_INTENSITY):
         vol.All(cv.positive_int),
+    vol.Optional(CONF_IGNORED, default=DEFAULT_CONF_IGNORED): cv.boolean,
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -324,6 +327,11 @@ def setup(hass, config):
             name = "{}.{}".format(component, _object_id(value))
 
             node_config = customize.get(name, {})
+
+            if node_config.get(CONF_IGNORED):
+                _LOGGER.info("Ignoring device %s", name)
+                return
+
             polling_intensity = convert(
                 node_config.get(CONF_POLLING_INTENSITY), int)
             if polling_intensity:


### PR DESCRIPTION
**Description:**
After #3759, several new devices might be recognized. Some of them might be of no interest to the user, and should be ignored.

This PR adds the "ignored" attribute to the customize section of the zwave configuration

Other components use `blacklist` (InfluxDB), `source_ignore` (media_player.yamaha) or `ignored_zones` (proximity). I think `ignored` fits best.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#1238

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
zwave:
  usb_path: /dev/ttyACM0
  customize:
    sensor.aeotec_home_energy_meter_g2_previous_reading_12_1_3:
        ignored: true

    sensor.aeotec_home_energy_meter_g2_previous_reading_12_1_4:
        ignored: true

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
