### PR TITLE
Relaxes the configuration options for influxdb

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -25,8 +25,6 @@ CONF_TAGS = 'tags'
 DEFAULT_DATABASE = 'home_assistant'
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 8086
-DEFAULT_USERNAME = ''
-DEFAULT_PASSWORD = ''
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = False
 DOMAIN = 'influxdb'
@@ -35,8 +33,8 @@ TIMEOUT = 5
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
-        vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
-        vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+        vol.Inclusive(CONF_USERNAME, 'authentication'): cv.string,
+        vol.Inclusive(CONF_PASSWORD, 'authentication'): cv.string,
         vol.Optional(CONF_BLACKLIST, default=[]):
             vol.All(cv.ensure_list, [cv.entity_id]),
         vol.Optional(CONF_DB_NAME, default=DEFAULT_DATABASE): cv.string,

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -25,6 +25,8 @@ CONF_TAGS = 'tags'
 DEFAULT_DATABASE = 'home_assistant'
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 8086
+DEFAULT_USERNAME = ''
+DEFAULT_PASSWORD = ''
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = False
 DOMAIN = 'influxdb'
@@ -33,8 +35,8 @@ TIMEOUT = 5
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+        vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
         vol.Optional(CONF_BLACKLIST, default=[]):
             vol.All(cv.ensure_list, [cv.entity_id]),
         vol.Optional(CONF_DB_NAME, default=DEFAULT_DATABASE): cv.string,

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -70,8 +70,6 @@ class TestInfluxDB(unittest.TestCase):
 
         assert not setup_component(self.hass, influxdb.DOMAIN, config)
 
-        
-
     def test_setup_query_fail(self, mock_client):
         """Test the setup for query failures."""
         config = {

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -52,6 +52,26 @@ class TestInfluxDB(unittest.TestCase):
         self.assertEqual(EVENT_STATE_CHANGED,
                          self.hass.bus.listen.call_args_list[0][0][0])
 
+    def test_setup_minimal_config(self, mock_client):
+        """Tests the setup with minimal configuration."""
+        config = {
+            'influxdb': {}
+        }
+
+        assert setup_component(self.hass, influxdb.DOMAIN, config)
+
+    def test_setup_missing_password(self, mock_client):
+        """Test the setup with existing username and missing password."""
+        config = {
+            'influxdb': {
+                'username': 'user'
+            }
+        }
+
+        assert not setup_component(self.hass, influxdb.DOMAIN, config)
+
+        
+
     def test_setup_query_fail(self, mock_client):
         """Test the setup for query failures."""
         config = {

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -1,5 +1,4 @@
 """The tests for the InfluxDB component."""
-import copy
 import unittest
 from unittest import mock
 

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -53,19 +53,6 @@ class TestInfluxDB(unittest.TestCase):
         self.assertEqual(EVENT_STATE_CHANGED,
                          self.hass.bus.listen.call_args_list[0][0][0])
 
-    def test_setup_missing_keys(self, mock_client):
-        """Test the setup with missing keys."""
-        config = {
-            'influxdb': {
-                'username': 'user',
-                'password': 'pass',
-            }
-        }
-        for missing in config['influxdb'].keys():
-            config_copy = copy.deepcopy(config)
-            del config_copy['influxdb'][missing]
-            assert not setup_component(self.hass, influxdb.DOMAIN, config_copy)
-
     def test_setup_query_fail(self, mock_client):
         """Test the setup for query failures."""
         config = {


### PR DESCRIPTION
**Description:**
Influxdb configuration schema incorrectly set username and password as required options. Default installations of influxdb do not require authentication

**Related issue (if applicable):** fixes #3613

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#1242

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
influxdb:
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

By default influxdb allows unauthenticated access
Home Assistant required at least username and password to be present to properly submit data to InfluxDB.
I've removed the completely the test for checking missing keys, as the minimal configuration should work without any additional configuration options
