### PR TITLE
Upgrade slacker to 0.9.28

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     CONF_API_KEY, CONF_USERNAME, CONF_ICON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['slacker==0.9.25']
+REQUIREMENTS = ['slacker==0.9.28']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -438,7 +438,7 @@ scsgate==0.1.0
 sendgrid==3.4.0
 
 # homeassistant.components.notify.slack
-slacker==0.9.25
+slacker==0.9.28
 
 # homeassistant.components.notify.xmpp
 sleekxmpp==1.3.1


### PR DESCRIPTION
## 0.9.28
- Changed the unreads parameter in im.history to False
- Fixed mpim.open method
- Use team.profile.get method for TeamProfile

Tested with the following configuration:

``` yaml
notify:
  - name: slack
    platform: slack
    api_key: !secret slack_api
    default_channel: '#ha'
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```
