### PR TITLE
Adds support for Pioneer AVR interface port number

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from datetime import timedelta
 import os
 from urllib.parse import urlparse
+from socket import _GLOBAL_DEFAULT_TIMEOUT
 
 from typing import Any, Union, TypeVar, Callable, Sequence, Dict
 
@@ -304,6 +305,24 @@ def time_zone(value):
         'http://en.wikipedia.org/wiki/List_of_tz_database_time_zones')
 
 weekdays = vol.All(ensure_list, [vol.In(WEEKDAYS)])
+
+
+def socket_timeout(value):
+    """Validate timeout float > 0.0.
+
+    None coerced to socket._GLOBAL_DEFAULT_TIMEOUT bare object.
+    """
+    if value is None:
+        return _GLOBAL_DEFAULT_TIMEOUT
+    else:
+        try:
+            float_value = float(value)
+            if float_value > 0.0:
+                return float_value
+            raise vol.Invalid('Invalid socket timeout value.'
+                              ' float > 0.0 required.')
+        except Exception as _:
+            raise vol.Invalid('Invalid socket timeout: {err}'.format(err=_))
 
 
 # pylint: disable=no-value-for-parameter

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from datetime import timedelta
 import enum
 import os
+from socket import _GLOBAL_DEFAULT_TIMEOUT
 
 import pytest
 import voluptuous as vol
@@ -436,3 +437,22 @@ def test_enum():
         schema('value3')
 
     TestEnum['value1']
+
+
+def test_socket_timeout():
+    """Test socket timeout validator."""
+    TEST_CONF_TIMEOUT = 'timeout'
+
+    schema = vol.Schema(
+        {vol.Required(TEST_CONF_TIMEOUT, default=None): cv.socket_timeout})
+
+    with pytest.raises(vol.Invalid):
+        schema({TEST_CONF_TIMEOUT: 0.0})
+
+    with pytest.raises(vol.Invalid):
+        schema({TEST_CONF_TIMEOUT: -1})
+
+    assert _GLOBAL_DEFAULT_TIMEOUT == schema({TEST_CONF_TIMEOUT:
+                                              None})[TEST_CONF_TIMEOUT]
+
+    assert 1.0 == schema({TEST_CONF_TIMEOUT: 1})[TEST_CONF_TIMEOUT]


### PR DESCRIPTION
**Description:**
Adds a configuration option for the port the AVR listens on. Some devices do not listen on the default port 23 and listen to 8102 instead.

**Related issue (if applicable):** fixes #
https://community.home-assistant.io/t/support-for-pioneer-avr/503
https://community.home-assistant.io/t/pioneer-av-not-working/2393

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#1246

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
# Example configuration.yaml entry
media_player:
  - platform: pioneer
    host: 192.168.0.10
    port: 23
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ n/a] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [n/a] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [n/a] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [n/a] New files were added to `.coveragerc`.

https://community.home-assistant.io/t/support-for-pioneer-avr/503
telnetlib supports a port number so adding port as
an optional config element with a default of 23 resolves this.
