### PR TITLE
Zwave rgb fix

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -223,17 +223,12 @@ class ZwaveColorLight(ZwaveDimmer):
         self._rgb = None
         self._ct = None
 
-        # Here we attempt to find a zwave color value with the same instance
-        # id as the dimmer value. Currently zwave nodes that change colors
-        # only include one dimmer and one color command, but this will
-        # hopefully provide some forward compatibility for new devices that
-        # have multiple color changing elements.
+        # Currently zwave nodes only exist with one color element per node.
         for value_color in value.node.get_rgbbulbs().values():
-            if value.instance == value_color.instance:
-                self._value_color = value_color
+            self._value_color = value_color
 
         if self._value_color is None:
-            raise ValueError("No matching color command found.")
+            raise ValueError("No color command found.")
 
         for value_color_channels in value.node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_SWITCH_COLOR,

--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -115,7 +115,6 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
         zwave.ZWaveDeviceEntity.__init__(self, value, DOMAIN)
         self._brightness = None
         self._state = None
-        self.update_properties()
         self._alt_delay = None
         self._zw098 = None
 
@@ -133,6 +132,8 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
                     _LOGGER.debug("Dimmer delay workaround enabled for node:"
                                   " %s", value.parent_id)
                     self._alt_delay = 1
+
+        self.update_properties()
 
         # Used for value change event handling
         self._refreshing = False


### PR DESCRIPTION
**Description:**
Some of the future proofing I put into the original zwave RGB logic turns out to be problematic for some RGB controllers. (See https://community.home-assistant.io/t/color-issues-with-aeotec-zwave-zw098/2830 ) Since there currently aren't any zwave nodes that implement this, I wiped it for now.

I also rolled in a regression fix for ZW098 bulbs due to a recent commit: 
Commit: https://github.com/home-assistant/home-assistant/commit/8c13d3ed4c9e8e07abb6aca0f2814e118c788199
Fails here: https://github.com/home-assistant/home-assistant/blob/8c13d3ed4c9e8e07abb6aca0f2814e118c788199/homeassistant/components/light/zwave.py#L284
