### PR TITLE
#3829 - Fixed issued LowHighTuple doesn't define __round__ method for Nest Sensor

### DIFF
--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -135,7 +135,7 @@ class NestTempSensor(NestSensor):
         if temp is None:
             return None
 
-        if not isinstance(temp, (int, float)):
+        if isinstance(temp, tuple):
             low, high = temp
             return "%s-%s" % (int(low), int(high))
         else:

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -135,7 +135,11 @@ class NestTempSensor(NestSensor):
         if temp is None:
             return None
 
-        return round(temp, 1)
+        if not isinstance(temp, (int, float)):
+            low, high = temp
+            return "%s-%s" % (int(low), int(high))
+        else:
+            return round(temp, 1)
 
 
 class NestWeatherSensor(NestSensor):


### PR DESCRIPTION
**Description:**
Fixed issue when trying to round LowHighTuple value returned by Nest when operating in range mode. 

``` python
DEBUG:homeassistant.bootstrap:Component nest already set up.
DEBUG:homeassistant.components.sensor.nest:NEST self.device: <Device: downstairs>
DEBUG:homeassistant.components.sensor.nest:NEST self.variable: target
DEBUG:homeassistant.components.sensor.nest:NEST temp: LowHighTuple(low=21.6, high=25.1)
ERROR:homeassistant.components.sensor:Error while setting up platform nest
Traceback (most recent call last):
  File "/home/mdemello/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/helpers/entity_component.py", line 107, in _setup_platform
    discovery_info)
  File "/home/mdemello/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/components/sensor/nest.py", line 71, in setup_platform
    add_devices(sensors)
  File "/home/mdemello/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/helpers/entity_component.py", line 198, in add_entities
    if self.component.add_entity(entity, self):
  File "/home/mdemello/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/helpers/entity_component.py", line 134, in add_entity
    entity.update_ha_state()
  File "/home/mdemello/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/helpers/entity.py", line 170, in update_ha_state
    self.async_update_ha_state(force_refresh), self.hass.loop
  File "/usr/lib64/python3.5/concurrent/futures/_base.py", line 405, in result
    return self.__get_result()
  File "/usr/lib64/python3.5/concurrent/futures/_base.py", line 357, in __get_result
    raise self._exception
  File "/usr/lib64/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
  File "/home/mdemello/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/helpers/entity.py", line 197, in async_update_ha_state
    state = STATE_UNKNOWN if self.state is None else str(self.state)
  File "/home/mdemello/.virtualenvs/home_assistant/lib/python3.5/site-packages/homeassistant/components/sensor/nest.py", line 144, in state
    return round(temp, 1)
TypeError: type LowHighTuple doesn't define __round__ method
```

**Related issue (if applicable):** fixes #3829 

it nicely returns now a string with `low-high` temperatures. 

![screenshot at 2016-10-15 00-52-22](https://cloud.githubusercontent.com/assets/809840/19407550/b8417de0-9273-11e6-8250-b8313cd608d4.png)

![screenshot at 2016-10-15 00-51-08](https://cloud.githubusercontent.com/assets/809840/19407552/bbe698cc-9273-11e6-9e19-c6fb4a0df0bc.png)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
