### PR TITLE
Upgrade sendgrid to 3.6.0

### DIFF
--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -13,7 +13,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import (CONF_API_KEY, CONF_SENDER, CONF_RECIPIENT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['sendgrid==3.4.0']
+REQUIREMENTS = ['sendgrid==3.6.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -438,7 +438,7 @@ schiene==0.17
 scsgate==0.1.0
 
 # homeassistant.components.notify.sendgrid
-sendgrid==3.4.0
+sendgrid==3.6.0
 
 # homeassistant.components.notify.slack
 slacker==0.9.28


### PR DESCRIPTION
## 3.6.0
- Substitutions allow non-strings for values
## 3.5.0
- Allow dict to be passed to add_headers

Tested with the following configuration:

``` yaml
notify:
  - name: sendgrid
    platform: sendgrid
    api_key: !secret sendgrid_api
    sender: you@example.com
    recipient: me@example.com
```

Message sent with "Call Service" but failed (#3138)

``` json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!",
  "title": "Test message"
}
```
