### PR TITLE
Fix name allocation (sensor.yr)

### DIFF
--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -27,7 +27,7 @@ CONF_ATTRIBUTION = "Weather forecast from yr.no, delivered by the Norwegian " \
 # Sensor types are defined like so:
 SENSOR_TYPES = {
     'symbol': ['Symbol', None],
-    'precipitation': ['Condition', 'mm'],
+    'precipitation': ['Precipitation', 'mm'],
     'temperature': ['Temperature', '°C'],
     'windSpeed': ['Wind speed', 'm/s'],
     'windGust': ['Wind gust', 'm/s'],


### PR DESCRIPTION
**Description:**
The monitored condition `precipitation` was named `Condition` in the frontend with an unit of `mm`. As the slug doesn't reflected the actual condition.

**Related issue (if applicable):** fixes [YR.no sensor inconsistency](https://community.home-assistant.io/t/yr-no-sensor-inconsistency/5022)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: yr
    monitored_conditions:
      - temperature
      - symbol
      - precipitation
      - windSpeed
      - pressure
```
