### PR TITLE
ZWave: Add association service

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -132,12 +132,12 @@ SET_CONFIG_PARAMETER_SCHEMA = vol.Schema({
     vol.Required(const.ATTR_CONFIG_VALUE): vol.Coerce(int),
     vol.Optional(const.ATTR_CONFIG_SIZE): vol.Coerce(int)
 })
-ASSOCIATION_SCHEMA = vol.Schema({
+CHANGE_ASSOCIATION_SCHEMA = vol.Schema({
     vol.Required(const.ATTR_ASSOCIATION): cv.string,
     vol.Required(const.ATTR_NODE_ID): vol.Coerce(int),
     vol.Required(const.ATTR_TARGET_NODE_ID): vol.Coerce(int),
     vol.Required(const.ATTR_GROUP): vol.Coerce(int),
-    vol.Optional(const.ATTR_INSTANCE): vol.Coerce(int)
+    vol.Optional(const.ATTR_INSTANCE, default=0x00): vol.Coerce(int)
 })
 
 CUSTOMIZE_SCHEMA = vol.Schema({
@@ -453,13 +453,13 @@ def setup(hass, config):
         _LOGGER.info("Setting config parameter %s on Node %s "
                      "with value %s and size=%s", param, node_id, value, size)
 
-    def association(service):
-        """Add a association in the zwave network."""
+    def change_association(service):
+        """Changes an association in the zwave network."""
         association_type = service.data.get(const.ATTR_ASSOCIATION)
         node_id = service.data.get(const.ATTR_NODE_ID)
         target_node_id = service.data.get(const.ATTR_TARGET_NODE_ID)
         group = service.data.get(const.ATTR_GROUP)
-        instance = service.data.get(const.ATTR_INSTANCE, 0x00)
+        instance = service.data.get(const.ATTR_INSTANCE)
 
         node = ZWaveGroup(group, NETWORK, node_id)
         if association_type == 'add':
@@ -538,11 +538,11 @@ def setup(hass, config):
                                descriptions[
                                    const.SERVICE_SET_CONFIG_PARAMETER],
                                schema=SET_CONFIG_PARAMETER_SCHEMA)
-        hass.services.register(DOMAIN, const.SERVICE_ASSOCIATION,
-                               association,
+        hass.services.register(DOMAIN, const.SERVICE_CHANGE_ASSOCIATION,
+                               change_association,
                                descriptions[
-                                   const.SERVICE_ASSOCIATION],
-                               schema=ASSOCIATION_SCHEMA)
+                                   const.SERVICE_CHANGE_ASSOCIATION],
+                               schema=CHANGE_ASSOCIATION_SCHEMA)
 
     # Setup autoheal
     if autoheal:

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -454,7 +454,7 @@ def setup(hass, config):
                      "with value %s and size=%s", param, node_id, value, size)
 
     def change_association(service):
-        """Changes an association in the zwave network."""
+        """Change an association in the zwave network."""
         association_type = service.data.get(const.ATTR_ASSOCIATION)
         node_id = service.data.get(const.ATTR_NODE_ID)
         target_node_id = service.data.get(const.ATTR_TARGET_NODE_ID)

--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -15,7 +15,7 @@ ATTR_CONFIG_SIZE = "size"
 ATTR_CONFIG_VALUE = "value"
 NETWORK_READY_WAIT_SECS = 30
 
-SERVICE_ASSOCIATION = "add_association"
+SERVICE_CHANGE_ASSOCIATION = "change_association"
 SERVICE_ADD_NODE = "add_node"
 SERVICE_ADD_NODE_SECURE = "add_node_secure"
 SERVICE_REMOVE_NODE = "remove_node"

--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -2,6 +2,7 @@
 
 ATTR_NODE_ID = "node_id"
 ATTR_TARGET_NODE_ID = "target_node_id"
+ATTR_ASSOCIATION = "association"
 ATTR_INSTANCE = "instance"
 ATTR_GROUP = "group"
 ATTR_VALUE_ID = "value_id"
@@ -14,8 +15,7 @@ ATTR_CONFIG_SIZE = "size"
 ATTR_CONFIG_VALUE = "value"
 NETWORK_READY_WAIT_SECS = 30
 
-SERVICE_ADD_ASSOCIATION = "add_association"
-SERVICE_REMOVE_ASSOCIATION = "remove_association"
+SERVICE_ASSOCIATION = "add_association"
 SERVICE_ADD_NODE = "add_node"
 SERVICE_ADD_NODE_SECURE = "add_node_secure"
 SERVICE_REMOVE_NODE = "remove_node"

--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -1,6 +1,9 @@
 """Z-Wave Constants."""
 
 ATTR_NODE_ID = "node_id"
+ATTR_TARGET_NODE_ID = "target_node_id"
+ATTR_INSTANCE = "instance"
+ATTR_GROUP = "group"
 ATTR_VALUE_ID = "value_id"
 ATTR_OBJECT_ID = "object_id"
 ATTR_NAME = "name"
@@ -11,6 +14,8 @@ ATTR_CONFIG_SIZE = "size"
 ATTR_CONFIG_VALUE = "value"
 NETWORK_READY_WAIT_SECS = 30
 
+SERVICE_ADD_ASSOCIATION = "add_association"
+SERVICE_REMOVE_ASSOCIATION = "remove_association"
 SERVICE_ADD_NODE = "add_node"
 SERVICE_ADD_NODE_SECURE = "add_node_secure"
 SERVICE_REMOVE_NODE = "remove_node"

--- a/homeassistant/components/zwave/services.yaml
+++ b/homeassistant/components/zwave/services.yaml
@@ -1,6 +1,8 @@
-add_association:
+association:
   description: Add a association in the Z-Wave network.
   fields:
+    association:
+      description: Specify add or remove assosication
     node_id:
       description: Node id of the node to set association for.
     target_node_id:

--- a/homeassistant/components/zwave/services.yaml
+++ b/homeassistant/components/zwave/services.yaml
@@ -1,3 +1,15 @@
+add_association:
+  description: Add a association in the Z-Wave network.
+  fields:
+    node_id:
+      description: Node id of the node to set association for.
+    target_node_id:
+      description: Node id of the node to associate to.
+    group:
+      description: Group number to set association for.
+    instance:
+      description: (Optional) Instance of association. Defaults to 0.
+
 add_node:
   description: Add a new node to the Z-Wave network. Refer to OZW.log for details.
 
@@ -9,6 +21,18 @@ cancel_command:
 
 heal_network:
   description: Start a Z-Wave network heal. This might take a while and will slow down the Z-Wave network greatly while it is being processed. Refer to OZW.log for details.
+
+remove_association:
+  description: Remove a association in the Z-Wave network.
+  fields:
+    node_id:
+      description: Node id of the node to remove association for.
+    target_node_id:
+      description: Node id of the target node to remove association for.
+    group:
+      description: Group number to remove association for.
+    instance:
+      description: (Optional) Instance of association. Defaults to 0.
 
 remove_node:
   description: Remove a node from the Z-Wave network. Refer to OZW.log for details.

--- a/homeassistant/components/zwave/services.yaml
+++ b/homeassistant/components/zwave/services.yaml
@@ -1,5 +1,5 @@
-association:
-  description: Add a association in the Z-Wave network.
+change_association:
+  description: Change an association in the Z-Wave network.
   fields:
     association:
       description: Specify add or remove assosication
@@ -23,18 +23,6 @@ cancel_command:
 
 heal_network:
   description: Start a Z-Wave network heal. This might take a while and will slow down the Z-Wave network greatly while it is being processed. Refer to OZW.log for details.
-
-remove_association:
-  description: Remove a association in the Z-Wave network.
-  fields:
-    node_id:
-      description: Node id of the node to remove association for.
-    target_node_id:
-      description: Node id of the target node to remove association for.
-    group:
-      description: Group number to remove association for.
-    instance:
-      description: (Optional) Instance of association. Defaults to 0.
 
 remove_node:
   description: Remove a node from the Z-Wave network. Refer to OZW.log for details.


### PR DESCRIPTION
**Description:**
Adds a service to HomeAssistant to set associations in the zwave network

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1252
