### PR TITLE
Removing calls to mock.assert_called_once_with

### DIFF
--- a/tests/components/binary_sensor/test_nx584.py
+++ b/tests/components/binary_sensor/test_nx584.py
@@ -53,7 +53,10 @@ class TestNX584SensorSetup(unittest.TestCase):
         mock_nx.assert_has_calls(
              [mock.call(zone, 'opening') for zone in self.fake_zones])
         self.assertTrue(add_devices.called)
-        nx584_client.Client.assert_called_once_with('http://localhost:5007')
+        self.assertEqual(nx584_client.Client.call_count, 1)
+        self.assertEqual(
+            nx584_client.Client.call_args, mock.call('http://localhost:5007')
+        )
 
     @mock.patch('homeassistant.components.binary_sensor.nx584.NX584Watcher')
     @mock.patch('homeassistant.components.binary_sensor.nx584.NX584ZoneSensor')
@@ -73,7 +76,10 @@ class TestNX584SensorSetup(unittest.TestCase):
             mock.call(self.fake_zones[2], 'motion'),
             ])
         self.assertTrue(add_devices.called)
-        nx584_client.Client.assert_called_once_with('http://foo:123')
+        self.assertEqual(nx584_client.Client.call_count, 1)
+        self.assertEqual(
+            nx584_client.Client.call_args, mock.call('http://foo:123')
+        )
         self.assertTrue(mock_watcher.called)
 
     def _test_assert_graceful_fail(self, config):
@@ -174,7 +180,8 @@ class TestNX584Watcher(unittest.TestCase):
         def run(fake_process):
             fake_process.side_effect = StopMe
             self.assertRaises(StopMe, watcher._run)
-            fake_process.assert_called_once_with(fake_events[0])
+            self.assertEqual(fake_process.call_count, 1)
+            self.assertEqual(fake_process.call_args, mock.call(fake_events[0]))
 
         run()
         self.assertEqual(3, client.get_events.call_count)

--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -44,9 +44,17 @@ class TestBinarySensorTemplate(unittest.TestCase):
         add_devices = mock.MagicMock()
         result = template.setup_platform(self.hass, config, add_devices)
         self.assertTrue(result)
-        mock_template.assert_called_once_with(
-            self.hass, 'test', 'virtual thingy', 'motion', tpl, 'test')
-        add_devices.assert_called_once_with([mock_template.return_value])
+        self.assertEqual(mock_template.call_count, 1)
+        self.assertEqual(
+            mock_template.call_args,
+            mock.call(
+                self.hass, 'test', 'virtual thingy', 'motion', tpl, 'test'
+            )
+        )
+        self.assertEqual(add_devices.call_count, 1)
+        self.assertEqual(
+            add_devices.call_args, mock.call([mock_template.return_value])
+        )
 
     def test_setup_no_sensors(self):
         """"Test setup with no sensors."""

--- a/tests/components/camera/test_uvc.py
+++ b/tests/components/camera/test_uvc.py
@@ -54,7 +54,10 @@ class TestUVCSetup(unittest.TestCase):
 
         assert setup_component(self.hass, 'camera', {'camera': config})
 
-        mock_remote.assert_called_once_with('foo', 123, 'secret')
+        self.assertEqual(mock_remote.call_count, 1)
+        self.assertEqual(
+            mock_remote.call_args, mock.call('foo', 123, 'secret')
+        )
         mock_uvc.assert_has_calls([
             mock.call(mock_remote.return_value, 'id1', 'Front'),
             mock.call(mock_remote.return_value, 'id2', 'Back'),
@@ -79,7 +82,10 @@ class TestUVCSetup(unittest.TestCase):
 
         assert setup_component(self.hass, 'camera', {'camera': config})
 
-        mock_remote.assert_called_once_with('foo', 7080, 'secret')
+        self.assertEqual(mock_remote.call_count, 1)
+        self.assertEqual(
+            mock_remote.call_args, mock.call('foo', 7080, 'secret')
+        )
         mock_uvc.assert_has_calls([
             mock.call(mock_remote.return_value, 'id1', 'Front'),
             mock.call(mock_remote.return_value, 'id2', 'Back'),
@@ -104,7 +110,10 @@ class TestUVCSetup(unittest.TestCase):
 
         assert setup_component(self.hass, 'camera', {'camera': config})
 
-        mock_remote.assert_called_once_with('foo', 7080, 'secret')
+        self.assertEqual(mock_remote.call_count, 1)
+        self.assertEqual(
+            mock_remote.call_args, mock.call('foo', 7080, 'secret')
+        )
         mock_uvc.assert_has_calls([
             mock.call(mock_remote.return_value, 'one', 'Front'),
             mock.call(mock_remote.return_value, 'two', 'Back'),
@@ -173,8 +182,12 @@ class TestUVC(unittest.TestCase):
         """"Test the login."""
         mock_store.return_value.get_camera_password.return_value = 'seekret'
         self.uvc._login()
-        mock_camera.assert_called_once_with('host-a', 'admin', 'seekret')
-        mock_camera.return_value.login.assert_called_once_with()
+        self.assertEqual(mock_camera.call_count, 1)
+        self.assertEqual(
+            mock_camera.call_args, mock.call('host-a', 'admin', 'seekret')
+        )
+        self.assertEqual(mock_camera.return_value.login.call_count, 1)
+        self.assertEqual(mock_camera.return_value.login.call_args, mock.call())
 
     @mock.patch('uvcclient.store.get_info_store')
     @mock.patch('uvcclient.camera.UVCCameraClient')
@@ -183,8 +196,12 @@ class TestUVC(unittest.TestCase):
         mock_store.return_value.get_camera_password.return_value = 'seekret'
         self.nvr.server_version = (3, 1, 3)
         self.uvc._login()
-        mock_camera.assert_called_once_with('host-a', 'admin', 'seekret')
-        mock_camera.return_value.login.assert_called_once_with()
+        self.assertEqual(mock_camera.call_count, 1)
+        self.assertEqual(
+            mock_camera.call_args, mock.call('host-a', 'admin', 'seekret')
+        )
+        self.assertEqual(mock_camera.return_value.login.call_count, 1)
+        self.assertEqual(mock_camera.return_value.login.call_args, mock.call())
 
     @mock.patch('uvcclient.store.get_info_store')
     @mock.patch('uvcclient.camera.UVCCameraClientV320')
@@ -192,8 +209,12 @@ class TestUVC(unittest.TestCase):
         """"Test the login with no password."""
         mock_store.return_value.get_camera_password.return_value = None
         self.uvc._login()
-        mock_camera.assert_called_once_with('host-a', 'admin', 'ubnt')
-        mock_camera.return_value.login.assert_called_once_with()
+        self.assertEqual(mock_camera.call_count, 1)
+        self.assertEqual(
+            mock_camera.call_args, mock.call('host-a', 'admin', 'ubnt')
+        )
+        self.assertEqual(mock_camera.return_value.login.call_count, 1)
+        self.assertEqual(mock_camera.return_value.login.call_args, mock.call())
 
     @mock.patch('uvcclient.store.get_info_store')
     @mock.patch('uvcclient.camera.UVCCameraClientV320')
@@ -216,8 +237,12 @@ class TestUVC(unittest.TestCase):
 
         mock_camera.reset_mock()
         self.uvc._login()
-        mock_camera.assert_called_once_with('host-b', 'admin', 'ubnt')
-        mock_camera.return_value.login.assert_called_once_with()
+        self.assertEqual(mock_camera.call_count, 1)
+        self.assertEqual(
+            mock_camera.call_args, mock.call('host-b', 'admin', 'ubnt')
+        )
+        self.assertEqual(mock_camera.return_value.login.call_count, 1)
+        self.assertEqual(mock_camera.return_value.login.call_args, mock.call())
 
     @mock.patch('uvcclient.store.get_info_store')
     @mock.patch('uvcclient.camera.UVCCameraClientV320')
@@ -232,7 +257,8 @@ class TestUVC(unittest.TestCase):
         with mock.patch.object(self.uvc, '_login') as mock_login:
             mock_login.return_value = False
             self.assertEqual(None, self.uvc.camera_image())
-            mock_login.assert_called_once_with()
+            self.assertEqual(mock_login.call_count, 1)
+            self.assertEqual(mock_login.call_args, mock.call())
 
     def test_camera_image_logged_in(self):
         """"Test the login state."""
@@ -262,7 +288,8 @@ class TestUVC(unittest.TestCase):
         self.uvc._camera.get_snapshot.side_effect = fake_snapshot
         with mock.patch.object(self.uvc, '_login') as mock_login:
             self.assertEqual('image', self.uvc.camera_image())
-            mock_login.assert_called_once_with()
+            self.assertEqual(mock_login.call_count, 1)
+            self.assertEqual(mock_login.call_args, mock.call())
             self.assertEqual([], responses)
 
     def test_camera_image_reauths_only_once(self):
@@ -271,4 +298,5 @@ class TestUVC(unittest.TestCase):
         self.uvc._camera.get_snapshot.side_effect = camera.CameraAuthError
         with mock.patch.object(self.uvc, '_login') as mock_login:
             self.assertRaises(camera.CameraAuthError, self.uvc.camera_image)
-            mock_login.assert_called_once_with()
+            self.assertEqual(mock_login.call_count, 1)
+            self.assertEqual(mock_login.call_args, mock.call())

--- a/tests/components/climate/test_honeywell.py
+++ b/tests/components/climate/test_honeywell.py
@@ -62,7 +62,8 @@ class TestHoneywell(unittest.TestCase):
 
         result = honeywell.setup_platform(hass, config, add_devices)
         self.assertTrue(result)
-        mock_sc.assert_called_once_with('user', 'pass')
+        self.assertEqual(mock_sc.call_count, 1)
+        self.assertEqual(mock_sc.call_args, mock.call('user', 'pass'))
         mock_ht.assert_has_calls([
             mock.call(mock_sc.return_value, devices_1[0]),
             mock.call(mock_sc.return_value, devices_2[0]),
@@ -174,9 +175,13 @@ class TestHoneywell(unittest.TestCase):
         hass = mock.MagicMock()
         add_devices = mock.MagicMock()
         self.assertTrue(honeywell.setup_platform(hass, config, add_devices))
-        mock_evo.assert_called_once_with('user', 'pass')
-        mock_evo.return_value.temperatures.assert_called_once_with(
-            force_refresh=True)
+        self.assertEqual(mock_evo.call_count, 1)
+        self.assertEqual(mock_evo.call_args, mock.call('user', 'pass'))
+        self.assertEqual(mock_evo.return_value.temperatures.call_count, 1)
+        self.assertEqual(
+            mock_evo.return_value.temperatures.call_args,
+            mock.call(force_refresh=True)
+        )
         mock_round.assert_has_calls([
             mock.call(mock_evo.return_value, 'foo', True, 20.0),
             mock.call(mock_evo.return_value, 'bar', False, 20.0),
@@ -280,17 +285,26 @@ class TestHoneywellRound(unittest.TestCase):
         self.assertFalse(self.round1.is_away_mode_on)
         self.round1.turn_away_mode_on()
         self.assertTrue(self.round1.is_away_mode_on)
-        self.device.set_temperature.assert_called_once_with('House', 16)
+        self.assertEqual(self.device.set_temperature.call_count, 1)
+        self.assertEqual(
+            self.device.set_temperature.call_args, mock.call('House', 16)
+        )
 
         self.device.set_temperature.reset_mock()
         self.round1.turn_away_mode_off()
         self.assertFalse(self.round1.is_away_mode_on)
-        self.device.cancel_temp_override.assert_called_once_with('House')
+        self.assertEqual(self.device.cancel_temp_override.call_count, 1)
+        self.assertEqual(
+            self.device.cancel_temp_override.call_args, mock.call('House')
+        )
 
     def test_set_temperature(self):
         """Test setting the temperature."""
         self.round1.set_temperature(temperature=25)
-        self.device.set_temperature.assert_called_once_with('House', 25)
+        self.assertEqual(self.device.set_temperature.call_count, 1)
+        self.assertEqual(
+            self.device.set_temperature.call_args, mock.call('House', 25)
+        )
 
     def test_set_operation_mode(self: unittest.TestCase) -> None:
         """Test setting the system operation."""

--- a/tests/components/cover/test_command_line.py
+++ b/tests/components/cover/test_command_line.py
@@ -40,7 +40,10 @@ class TestCommandCover(unittest.TestCase):
             mock_run.return_value = b' foo bar '
             result = self.rs._query_state_value('runme')
             self.assertEqual('foo bar', result)
-            mock_run.assert_called_once_with('runme', shell=True)
+            self.assertEqual(mock_run.call_count, 1)
+            self.assertEqual(
+                mock_run.call_args, mock.call('runme', shell=True)
+            )
 
     def test_state_value(self):
         """Test with state value."""

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -79,7 +79,8 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
 
         conf_dict[DOMAIN][CONF_MODE] = 'router'
         conf_dict[DOMAIN][CONF_PROTOCOL] = 'ssh'
-        asuswrt_mock.assert_called_once_with(conf_dict[DOMAIN])
+        self.assertEqual(asuswrt_mock.call_count, 1)
+        self.assertEqual(asuswrt_mock.call_args, mock.call(conf_dict[DOMAIN]))
 
     @mock.patch(
         'homeassistant.components.device_tracker.asuswrt.AsusWrtDeviceScanner',
@@ -101,7 +102,8 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
 
         conf_dict[DOMAIN][CONF_MODE] = 'router'
         conf_dict[DOMAIN][CONF_PROTOCOL] = 'ssh'
-        asuswrt_mock.assert_called_once_with(conf_dict[DOMAIN])
+        self.assertEqual(asuswrt_mock.call_count, 1)
+        self.assertEqual(asuswrt_mock.call_args, mock.call(conf_dict[DOMAIN]))
 
     def test_ssh_login_with_pub_key(self):
         """Test that login is done with pub_key when configured to."""
@@ -122,8 +124,11 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         self.addCleanup(update_mock.stop)
         asuswrt = device_tracker.asuswrt.AsusWrtDeviceScanner(conf_dict)
         asuswrt.ssh_connection()
-        ssh.login.assert_called_once_with('fake_host', 'fake_user',
-                                          ssh_key=FAKEFILE)
+        self.assertEqual(ssh.login.call_count, 1)
+        self.assertEqual(
+            ssh.login.call_args,
+            mock.call('fake_host', 'fake_user', ssh_key=FAKEFILE)
+        )
 
     def test_ssh_login_with_password(self):
         """Test that login is done with password when configured to."""
@@ -144,8 +149,11 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         self.addCleanup(update_mock.stop)
         asuswrt = device_tracker.asuswrt.AsusWrtDeviceScanner(conf_dict)
         asuswrt.ssh_connection()
-        ssh.login.assert_called_once_with('fake_host', 'fake_user',
-                                          password='fake_pass')
+        self.assertEqual(ssh.login.call_count, 1)
+        self.assertEqual(
+            ssh.login.call_args,
+            mock.call('fake_host', 'fake_user', password='fake_pass')
+        )
 
     def test_ssh_login_without_password_or_pubkey(self):  \
             # pylint: disable=invalid-name

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access,too-many-public-methods
 import logging
 import unittest
-from unittest.mock import patch
+from unittest.mock import call, patch
 from datetime import datetime, timedelta
 import os
 
@@ -288,7 +288,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         device_tracker.see(self.hass, **params)
         self.hass.block_till_done()
         assert mock_see.call_count == 1
-        mock_see.assert_called_once_with(**params)
+        self.assertEqual(mock_see.call_count, 1)
+        self.assertEqual(mock_see.call_args, call(**params))
 
         mock_see.reset_mock()
         params['dev_id'] += chr(233)  # e' acute accent from icloud
@@ -296,7 +297,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         device_tracker.see(self.hass, **params)
         self.hass.block_till_done()
         assert mock_see.call_count == 1
-        mock_see.assert_called_once_with(**params)
+        self.assertEqual(mock_see.call_count, 1)
+        self.assertEqual(mock_see.call_args, call(**params))
 
     def test_not_write_duplicate_yaml_keys(self): \
             # pylint: disable=invalid-name

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -27,9 +27,16 @@ class TestUnifiScanner(unittest.TestCase):
         }
         result = unifi.get_scanner(None, config)
         self.assertEqual(mock_scanner.return_value, result)
-        mock_ctrl.assert_called_once_with('localhost', 'foo', 'password',
-                                          8443, 'v4', 'default')
-        mock_scanner.assert_called_once_with(mock_ctrl.return_value)
+        self.assertEqual(mock_ctrl.call_count, 1)
+        self.assertEqual(
+            mock_ctrl.call_args,
+            mock.call('localhost', 'foo', 'password', 8443, 'v4', 'default')
+        )
+        self.assertEqual(mock_scanner.call_count, 1)
+        self.assertEqual(
+            mock_scanner.call_args,
+            mock.call(mock_ctrl.return_value)
+        )
 
     @mock.patch('homeassistant.components.device_tracker.unifi.UnifiScanner')
     @mock.patch.object(controller, 'Controller')
@@ -47,9 +54,16 @@ class TestUnifiScanner(unittest.TestCase):
         }
         result = unifi.get_scanner(None, config)
         self.assertEqual(mock_scanner.return_value, result)
-        mock_ctrl.assert_called_once_with('myhost', 'foo', 'password',
-                                          123, 'v4', 'abcdef01')
-        mock_scanner.assert_called_once_with(mock_ctrl.return_value)
+        self.assertEqual(mock_ctrl.call_count, 1)
+        self.assertEqual(
+            mock_ctrl.call_args,
+            mock.call('myhost', 'foo', 'password', 123, 'v4', 'abcdef01')
+        )
+        self.assertEqual(mock_scanner.call_count, 1)
+        self.assertEqual(
+            mock_scanner.call_args,
+            mock.call(mock_ctrl.return_value)
+        )
 
     def test_config_error(self):
         """Test for configuration errors."""
@@ -94,7 +108,8 @@ class TestUnifiScanner(unittest.TestCase):
         ]
         ctrl.get_clients.return_value = fake_clients
         unifi.UnifiScanner(ctrl)
-        ctrl.get_clients.assert_called_once_with()
+        self.assertEqual(ctrl.get_clients.call_count, 1)
+        self.assertEqual(ctrl.get_clients.call_args, mock.call())
 
     def test_scanner_update_error(self):  # pylint: disable=no-self-use
         """Test the scanner update for error."""

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -125,7 +125,8 @@ class TestSonosMediaPlayer(unittest.TestCase):
         device = sonos.DEVICES[-1]
         partymodeMock.return_value = True
         device.group_players()
-        partymodeMock.assert_called_once_with()
+        self.assertEqual(partymodeMock.call_count, 1)
+        self.assertEqual(partymodeMock.call_args, mock.call())
 
     @mock.patch('soco.SoCo', new=SoCoMock)
     @mock.patch.object(SoCoMock, 'unjoin')
@@ -135,7 +136,8 @@ class TestSonosMediaPlayer(unittest.TestCase):
         device = sonos.DEVICES[-1]
         unjoinMock.return_value = True
         device.unjoin()
-        unjoinMock.assert_called_once_with()
+        self.assertEqual(unjoinMock.call_count, 1)
+        self.assertEqual(unjoinMock.call_args, mock.call())
 
     @mock.patch('soco.SoCo', new=SoCoMock)
     @mock.patch.object(soco.snapshot.Snapshot, 'snapshot')
@@ -145,7 +147,8 @@ class TestSonosMediaPlayer(unittest.TestCase):
         device = sonos.DEVICES[-1]
         snapshotMock.return_value = True
         device.snapshot()
-        snapshotMock.assert_called_once_with()
+        self.assertEqual(snapshotMock.call_count, 1)
+        self.assertEqual(snapshotMock.call_args, mock.call())
 
     @mock.patch('soco.SoCo', new=SoCoMock)
     @mock.patch.object(soco.snapshot.Snapshot, 'restore')
@@ -155,4 +158,5 @@ class TestSonosMediaPlayer(unittest.TestCase):
         device = sonos.DEVICES[-1]
         restoreMock.return_value = True
         device.restore()
-        restoreMock.assert_called_once_with(True)
+        self.assertEqual(restoreMock.call_count, 1)
+        self.assertEqual(restoreMock.call_args, mock.call(True))

--- a/tests/components/rollershutter/test_command_line.py
+++ b/tests/components/rollershutter/test_command_line.py
@@ -41,7 +41,10 @@ class TestCommandRollerShutter(unittest.TestCase):
             mock_run.return_value = b' foo bar '
             result = self.rs._query_state_value('runme')
             self.assertEqual('foo bar', result)
-            mock_run.assert_called_once_with('runme', shell=True)
+            self.assertEqual(mock_run.call_count, 1)
+            self.assertEqual(
+                mock_run.call_args, mock.call('runme', shell=True)
+            )
 
     def test_state_value(self):
         """Test with state value."""

--- a/tests/components/sensor/test_mfi.py
+++ b/tests/components/sensor/test_mfi.py
@@ -71,8 +71,13 @@ class TestMfiSensorSetup(unittest.TestCase):
         config = dict(self.GOOD_CONFIG)
         del config[self.THING]['port']
         assert setup_component(self.hass, self.COMPONENT.DOMAIN, config)
-        mock_client.assert_called_once_with(
-            'foo', 'user', 'pass', port=6443, use_tls=True, verify=True)
+        self.assertEqual(mock_client.call_count, 1)
+        self.assertEqual(
+            mock_client.call_args,
+            mock.call(
+                'foo', 'user', 'pass', port=6443, use_tls=True, verify=True
+            )
+        )
 
     @mock.patch('mficlient.client.MFiClient')
     def test_setup_with_port(self, mock_client):
@@ -80,8 +85,13 @@ class TestMfiSensorSetup(unittest.TestCase):
         config = dict(self.GOOD_CONFIG)
         config[self.THING]['port'] = 6123
         assert setup_component(self.hass, self.COMPONENT.DOMAIN, config)
-        mock_client.assert_called_once_with(
-            'foo', 'user', 'pass', port=6123, use_tls=True, verify=True)
+        self.assertEqual(mock_client.call_count, 1)
+        self.assertEqual(
+            mock_client.call_args,
+            mock.call(
+                'foo', 'user', 'pass', port=6123, use_tls=True, verify=True
+            )
+        )
 
     @mock.patch('mficlient.client.MFiClient')
     def test_setup_with_tls_disabled(self, mock_client):
@@ -91,8 +101,13 @@ class TestMfiSensorSetup(unittest.TestCase):
         config[self.THING]['ssl'] = False
         config[self.THING]['verify_ssl'] = False
         assert setup_component(self.hass, self.COMPONENT.DOMAIN, config)
-        mock_client.assert_called_once_with(
-            'foo', 'user', 'pass', port=6080, use_tls=False, verify=False)
+        self.assertEqual(mock_client.call_count, 1)
+        self.assertEqual(
+            mock_client.call_args,
+            mock.call(
+                'foo', 'user', 'pass', port=6080, use_tls=False, verify=False
+            )
+        )
 
     @mock.patch('mficlient.client.MFiClient')
     @mock.patch('homeassistant.components.sensor.mfi.MfiSensor')
@@ -180,4 +195,5 @@ class TestMfiSensor(unittest.TestCase):
     def test_update(self):
         """Test the update."""
         self.sensor.update()
-        self.port.refresh.assert_called_once_with()
+        self.assertEqual(self.port.refresh.call_count, 1)
+        self.assertEqual(self.port.refresh.call_args, mock.call())

--- a/tests/components/switch/test_mfi.py
+++ b/tests/components/switch/test_mfi.py
@@ -65,7 +65,8 @@ class TestMfiSwitch(unittest.TestCase):
     def test_update(self):
         """Test update."""
         self.switch.update()
-        self.port.refresh.assert_called_once_with()
+        self.assertEqual(self.port.refresh.call_count, 1)
+        self.assertEqual(self.port.refresh.call_args, mock.call())
 
     def test_update_with_target_state(self):
         """Test update with target state."""
@@ -82,13 +83,15 @@ class TestMfiSwitch(unittest.TestCase):
     def test_turn_on(self):
         """Test turn_on."""
         self.switch.turn_on()
-        self.port.control.assert_called_once_with(True)
+        self.assertEqual(self.port.control.call_count, 1)
+        self.assertEqual(self.port.control.call_args, mock.call(True))
         self.assertTrue(self.switch._target_state)
 
     def test_turn_off(self):
         """Test turn_off."""
         self.switch.turn_off()
-        self.port.control.assert_called_once_with(False)
+        self.assertEqual(self.port.control.call_count, 1)
+        self.assertEqual(self.port.control.call_args, mock.call(False))
         self.assertFalse(self.switch._target_state)
 
     def test_current_power_mwh(self):

--- a/tests/components/test_graphite.py
+++ b/tests/components/test_graphite.py
@@ -29,7 +29,11 @@ class TestGraphite(unittest.TestCase):
     def test_setup(self, mock_socket):
         """Test setup."""
         assert setup_component(self.hass, graphite.DOMAIN, {'graphite': {}})
-        mock_socket.assert_called_once_with(socket.AF_INET, socket.SOCK_STREAM)
+        self.assertEqual(mock_socket.call_count, 1)
+        self.assertEqual(
+            mock_socket.call_args,
+            mock.call(socket.AF_INET, socket.SOCK_STREAM)
+        )
 
     @patch('socket.socket')
     @patch('homeassistant.components.graphite.GraphiteFeeder')
@@ -44,8 +48,15 @@ class TestGraphite(unittest.TestCase):
         }
 
         self.assertTrue(setup_component(self.hass, graphite.DOMAIN, config))
-        mock_gf.assert_called_once_with(self.hass, 'foo', 123, 'me')
-        mock_socket.assert_called_once_with(socket.AF_INET, socket.SOCK_STREAM)
+        self.assertEqual(mock_gf.call_count, 1)
+        self.assertEqual(
+            mock_gf.call_args, mock.call(self.hass, 'foo', 123, 'me')
+        )
+        self.assertEqual(mock_socket.call_count, 1)
+        self.assertEqual(
+            mock_socket.call_args,
+            mock.call(socket.AF_INET, socket.SOCK_STREAM)
+        )
 
     @patch('socket.socket')
     @patch('homeassistant.components.graphite.GraphiteFeeder')
@@ -60,7 +71,11 @@ class TestGraphite(unittest.TestCase):
 
         self.assertTrue(setup_component(self.hass, graphite.DOMAIN, config))
         self.assertTrue(mock_gf.called)
-        mock_socket.assert_called_once_with(socket.AF_INET, socket.SOCK_STREAM)
+        self.assertEqual(mock_socket.call_count, 1)
+        self.assertEqual(
+            mock_socket.call_args,
+            mock.call(socket.AF_INET, socket.SOCK_STREAM)
+        )
 
     def test_subscribe(self):
         """Test the subscription."""
@@ -70,26 +85,34 @@ class TestGraphite(unittest.TestCase):
             mock.call(EVENT_HOMEASSISTANT_START, gf.start_listen),
             mock.call(EVENT_HOMEASSISTANT_STOP, gf.shutdown),
         ])
-        fake_hass.bus.listen.assert_called_once_with(
-            EVENT_STATE_CHANGED, gf.event_listener)
+        self.assertEqual(fake_hass.bus.listen.call_count, 1)
+        self.assertEqual(
+            fake_hass.bus.listen.call_args,
+            mock.call(EVENT_STATE_CHANGED, gf.event_listener)
+        )
 
     def test_start(self):
         """Test the start."""
         with mock.patch.object(self.gf, 'start') as mock_start:
             self.gf.start_listen('event')
-            mock_start.assert_called_once_with()
+            self.assertEqual(mock_start.call_count, 1)
+            self.assertEqual(mock_start.call_args, mock.call())
 
     def test_shutdown(self):
         """Test the shutdown."""
         with mock.patch.object(self.gf, '_queue') as mock_queue:
             self.gf.shutdown('event')
-            mock_queue.put.assert_called_once_with(self.gf._quit_object)
+            self.assertEqual(mock_queue.put.call_count, 1)
+            self.assertEqual(
+                mock_queue.put.call_args, mock.call(self.gf._quit_object)
+            )
 
     def test_event_listener(self):
         """Test the event listener."""
         with mock.patch.object(self.gf, '_queue') as mock_queue:
             self.gf.event_listener('foo')
-            mock_queue.put.assert_called_once_with('foo')
+            self.assertEqual(mock_queue.put.call_count, 1)
+            self.assertEqual(mock_queue.put.call_args, mock.call('foo'))
 
     @patch('time.time')
     def test_report_attributes(self, mock_time):
@@ -164,21 +187,32 @@ class TestGraphite(unittest.TestCase):
     def test_send_to_graphite(self, mock_socket):
         """Test the sending of data."""
         self.gf._send_to_graphite('foo')
-        mock_socket.assert_called_once_with(socket.AF_INET,
-                                            socket.SOCK_STREAM)
+        self.assertEqual(mock_socket.call_count, 1)
+        self.assertEqual(
+            mock_socket.call_args,
+            mock.call(socket.AF_INET, socket.SOCK_STREAM)
+        )
         sock = mock_socket.return_value
-        sock.connect.assert_called_once_with(('foo', 123))
-        sock.sendall.assert_called_once_with('foo'.encode('ascii'))
-        sock.send.assert_called_once_with('\n'.encode('ascii'))
-        sock.close.assert_called_once_with()
+        self.assertEqual(sock.connect.call_count, 1)
+        self.assertEqual(sock.connect.call_args, mock.call(('foo', 123)))
+        self.assertEqual(sock.sendall.call_count, 1)
+        self.assertEqual(
+            sock.sendall.call_args, mock.call('foo'.encode('ascii'))
+        )
+        self.assertEqual(sock.send.call_count, 1)
+        self.assertEqual(sock.send.call_args, mock.call('\n'.encode('ascii')))
+        self.assertEqual(sock.close.call_count, 1)
+        self.assertEqual(sock.close.call_args, mock.call())
 
     def test_run_stops(self):
         """Test the stops."""
         with mock.patch.object(self.gf, '_queue') as mock_queue:
             mock_queue.get.return_value = self.gf._quit_object
             self.assertEqual(None, self.gf.run())
-            mock_queue.get.assert_called_once_with()
-            mock_queue.task_done.assert_called_once_with()
+            self.assertEqual(mock_queue.get.call_count, 1)
+            self.assertEqual(mock_queue.get.call_args, mock.call())
+            self.assertEqual(mock_queue.task_done.call_count, 1)
+            self.assertEqual(mock_queue.task_done.call_args, mock.call())
 
     def test_run(self):
         """Test the running."""
@@ -204,6 +238,8 @@ class TestGraphite(unittest.TestCase):
                 self.gf.run()
                 # Twice for two events, once for the stop
                 self.assertEqual(3, mock_queue.task_done.call_count)
-                mock_r.assert_called_once_with(
-                    'entity',
-                    event.data['new_state'])
+                self.assertEqual(mock_r.call_count, 1)
+                self.assertEqual(
+                    mock_r.call_args,
+                    mock.call('entity', event.data['new_state'])
+                )

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -131,7 +131,13 @@ class TestInfluxDB(unittest.TestCase):
                 },
             }]
             self.handler_method(event)
-            mock_client.return_value.write_points.assert_called_once_with(body)
+            self.assertEqual(
+                mock_client.return_value.write_points.call_count, 1
+            )
+            self.assertEqual(
+                mock_client.return_value.write_points.call_args,
+                mock.call(body)
+            )
             mock_client.return_value.write_points.reset_mock()
 
     def test_event_listener_no_units(self, mock_client):
@@ -162,7 +168,13 @@ class TestInfluxDB(unittest.TestCase):
                 },
             }]
             self.handler_method(event)
-            mock_client.return_value.write_points.assert_called_once_with(body)
+            self.assertEqual(
+                mock_client.return_value.write_points.call_count, 1
+            )
+            self.assertEqual(
+                mock_client.return_value.write_points.call_args,
+                mock.call(body)
+            )
             mock_client.return_value.write_points.reset_mock()
 
     def test_event_listener_fail_write(self, mock_client):
@@ -205,8 +217,13 @@ class TestInfluxDB(unittest.TestCase):
             }]
             self.handler_method(event)
             if state_state == 1:
-                mock_client.return_value.write_points.assert_called_once_with(
-                    body)
+                self.assertEqual(
+                    mock_client.return_value.write_points.call_count, 1
+                )
+                self.assertEqual(
+                    mock_client.return_value.write_points.call_args,
+                    mock.call(body)
+                )
             else:
                 self.assertFalse(mock_client.return_value.write_points.called)
             mock_client.return_value.write_points.reset_mock()
@@ -236,8 +253,13 @@ class TestInfluxDB(unittest.TestCase):
             }]
             self.handler_method(event)
             if entity_id == 'ok':
-                mock_client.return_value.write_points.assert_called_once_with(
-                    body)
+                self.assertEqual(
+                    mock_client.return_value.write_points.call_count, 1
+                )
+                self.assertEqual(
+                    mock_client.return_value.write_points.call_args,
+                    mock.call(body)
+                )
             else:
                 self.assertFalse(mock_client.return_value.write_points.called)
             mock_client.return_value.write_points.reset_mock()

--- a/tests/components/test_logentries.py
+++ b/tests/components/test_logentries.py
@@ -84,6 +84,9 @@ class TestLogentries(unittest.TestCase):
                        'logs/token',
                        'event': body}
             self.handler_method(event)
-            self.mock_post.assert_called_once_with(
-                payload['host'], data=payload, timeout=10)
+            self.assertEqual(self.mock_post.call_count, 1)
+            self.assertEqual(
+                self.mock_post.call_args,
+                mock.call(payload['host'], data=payload, timeout=10)
+            )
             self.mock_post.reset_mock()

--- a/tests/components/test_splunk.py
+++ b/tests/components/test_splunk.py
@@ -94,7 +94,12 @@ class TestSplunk(unittest.TestCase):
             payload = {'host': 'http://host:8088/services/collector/event',
                        'event': body}
             self.handler_method(event)
-            self.mock_post.assert_called_once_with(
-                payload['host'], data=payload,
-                headers={'Authorization': 'Splunk secret'})
+            self.assertEqual(self.mock_post.call_count, 1)
+            self.assertEqual(
+                self.mock_post.call_args,
+                mock.call(
+                    payload['host'], data=payload,
+                    headers={'Authorization': 'Splunk secret'}
+                )
+            )
             self.mock_post.reset_mock()

--- a/tests/components/test_statsd.py
+++ b/tests/components/test_statsd.py
@@ -40,10 +40,11 @@ class TestStatsd(unittest.TestCase):
         hass = mock.MagicMock()
         hass.pool.worker_count = 2
         self.assertTrue(setup_component(hass, statsd.DOMAIN, config))
-        mock_connection.assert_called_once_with(
-            host='host',
-            port=123,
-            prefix='foo')
+        self.assertEqual(mock_connection.call_count, 1)
+        self.assertEqual(
+            mock_connection.call_args,
+            mock.call(host='host', port=123, prefix='foo')
+        )
 
         self.assertTrue(hass.bus.listen.called)
         self.assertEqual(EVENT_STATE_CHANGED,
@@ -64,10 +65,11 @@ class TestStatsd(unittest.TestCase):
         hass = mock.MagicMock()
         hass.pool.worker_count = 2
         self.assertTrue(setup_component(hass, statsd.DOMAIN, config))
-        mock_connection.assert_called_once_with(
-            host='host',
-            port=8125,
-            prefix='hass')
+        self.assertEqual(mock_connection.call_count, 1)
+        self.assertEqual(
+            mock_connection.call_args,
+            mock.call(host='host', port=8125, prefix='hass')
+        )
         self.assertTrue(hass.bus.listen.called)
 
     @mock.patch('statsd.StatsClient')
@@ -101,8 +103,11 @@ class TestStatsd(unittest.TestCase):
 
             mock_client.return_value.gauge.reset_mock()
 
-            mock_client.return_value.incr.assert_called_once_with(
-                state.entity_id, rate=statsd.DEFAULT_RATE)
+            self.assertEqual(mock_client.return_value.incr.call_count, 1)
+            self.assertEqual(
+                mock_client.return_value.incr.call_args,
+                mock.call(state.entity_id, rate=statsd.DEFAULT_RATE)
+            )
             mock_client.return_value.incr.reset_mock()
 
         for invalid in ('foo', '', object):
@@ -146,8 +151,11 @@ class TestStatsd(unittest.TestCase):
 
             mock_client.return_value.gauge.reset_mock()
 
-            mock_client.return_value.incr.assert_called_once_with(
-                state.entity_id, rate=statsd.DEFAULT_RATE)
+            self.assertEqual(mock_client.return_value.incr.call_count, 1)
+            self.assertEqual(
+                mock_client.return_value.incr.call_args,
+                mock.call(state.entity_id, rate=statsd.DEFAULT_RATE)
+            )
             mock_client.return_value.incr.reset_mock()
 
         for invalid in ('foo', '', object):

--- a/tests/components/thermostat/test_honeywell.py
+++ b/tests/components/thermostat/test_honeywell.py
@@ -52,7 +52,8 @@ class TestHoneywell(unittest.TestCase):
         self.assertFalse(result)
         result = honeywell.setup_platform(hass, config, add_devices)
         self.assertTrue(result)
-        mock_sc.assert_called_once_with('user', 'pass')
+        self.assertEqual(mock_sc.call_count, 1)
+        self.assertEqual(mock_sc.call_args, mock.call('user', 'pass'))
         mock_ht.assert_has_calls([
             mock.call(mock_sc.return_value, devices_1[0]),
             mock.call(mock_sc.return_value, devices_2[0]),
@@ -164,9 +165,13 @@ class TestHoneywell(unittest.TestCase):
         hass = mock.MagicMock()
         add_devices = mock.MagicMock()
         self.assertTrue(honeywell.setup_platform(hass, config, add_devices))
-        mock_evo.assert_called_once_with('user', 'pass')
-        mock_evo.return_value.temperatures.assert_called_once_with(
-            force_refresh=True)
+        self.assertEqual(mock_evo.call_count, 1)
+        self.assertEqual(mock_evo.call_args, mock.call('user', 'pass'))
+        self.assertEqual(mock_evo.return_value.temperatures.call_count, 1)
+        self.assertEqual(
+            mock_evo.return_value.temperatures.call_args,
+            mock.call(force_refresh=True)
+        )
         mock_round.assert_has_calls([
             mock.call(mock_evo.return_value, 'foo', True, 20),
             mock.call(mock_evo.return_value, 'bar', False, 20),
@@ -265,17 +270,26 @@ class TestHoneywellRound(unittest.TestCase):
         self.assertFalse(self.round1.is_away_mode_on)
         self.round1.turn_away_mode_on()
         self.assertTrue(self.round1.is_away_mode_on)
-        self.device.set_temperature.assert_called_once_with('House', 16)
+        self.assertEqual(self.device.set_temperature.call_count, 1)
+        self.assertEqual(
+            self.device.set_temperature.call_args, mock.call('House', 16)
+        )
 
         self.device.set_temperature.reset_mock()
         self.round1.turn_away_mode_off()
         self.assertFalse(self.round1.is_away_mode_on)
-        self.device.cancel_temp_override.assert_called_once_with('House')
+        self.assertEqual(self.device.cancel_temp_override.call_count, 1)
+        self.assertEqual(
+            self.device.cancel_temp_override.call_args, mock.call('House')
+        )
 
     def test_set_temperature(self):
         """Test setting the temperature."""
         self.round1.set_temperature(25)
-        self.device.set_temperature.assert_called_once_with('House', 25)
+        self.assertEqual(self.device.set_temperature.call_count, 1)
+        self.assertEqual(
+            self.device.set_temperature.call_args, mock.call('House', 25)
+        )
 
     def test_set_hvac_mode(self: unittest.TestCase) -> None:
         """Test setting the system operation."""


### PR DESCRIPTION
**Description:**
If a mock's assert_called_once_with method is misspelled (e.g. asert_called_once_with) then the test will appear as passing.  Therefore, this commit removes all instances of assert_called_once_with calls and replaces them with two assertions:

```
    self.assertEqual(mock.call_count, 1)
    self.assertEqual(mock.call_args, mock.call(call_args))
```

Ref [pull request review comment](https://github.com/home-assistant/home-assistant/pull/3753#pullrequestreview-3414940).

**Checklist:**

~~If user exposed functionality or configuration variables are added/changed:~~ N/A

~~If the code communicates with devices, web services, or third-party tools:~~ N/A

If the code does not interact with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

Files requiring modification:
- [X] tests/components/cover/test_command_line.py
- [X] tests/components/switch/test_mfi.py
- [X] tests/components/rollershutter/test_command_line.py
- [X] tests/components/test_splunk.py
- [X] tests/components/thermostat/test_honeywell.py
- [X] tests/components/test_influxdb.py
- [X] tests/components/device_tracker/test_init.py
- [X] tests/components/device_tracker/test_asuswrt.py
- [X] tests/components/device_tracker/test_unifi.py
- [X] tests/components/test_statsd.py
- [X] tests/components/test_logentries.py
- [X] tests/components/test_graphite.py
- [X] tests/components/media_player/test_sonos.py
- [X] tests/components/sensor/test_mfi.py
- [X] tests/components/binary_sensor/test_template.py
- [X] tests/components/binary_sensor/test_nx584.py
- [X] tests/components/climate/test_honeywell.py
- [X] tests/components/camera/test_uvc.py
