### PR TITLE
Resolve issue with delay not passing variables to render

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -94,7 +94,7 @@ class Script():
                     delay = vol.All(
                         cv.time_period,
                         cv.positive_timedelta)(
-                            delay.async_render())
+                            delay.async_render(variables))
 
                 self._async_unsub_delay_listener = \
                     async_track_point_in_utc_time(

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -222,7 +222,7 @@ class TestScriptHelper(unittest.TestCase):
                     'hello': '{{ greeting }}',
                 },
             },
-            {'delay': {'seconds': 5}},
+            {'delay': '{{ delay_period }}'},
             {
                 'service': 'test.script',
                 'data_template': {
@@ -233,6 +233,7 @@ class TestScriptHelper(unittest.TestCase):
         script_obj.run({
             'greeting': 'world',
             'greeting2': 'universe',
+            'delay_period': '00:00:05'
         })
 
         self.hass.block_till_done()


### PR DESCRIPTION
**Description:**

Updated the test, however I'm not sure if it's a regression or I was just doing it wrong - but the following resulted in a config validation error;

``` python
script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
            {
                'service': 'test.script',
                'data_template': {
                    'hello': '{{ greeting }}',
                },
            },
            {'delay': {'seconds': '{{ delay_period }}'}},
            {
                'service': 'test.script',
                'data_template': {
                    'hello': '{{ greeting2 }}',
                },
            }]))

        script_obj.run({
            'greeting': 'world',
            'greeting2': 'universe',
            'delay_period': 5
        })
```

**Related issue (if applicable):** fixes #3871 

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
