### PR TITLE
Async speedup add_device callback

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -306,7 +306,8 @@ class EntityPlatform(object):
     @asyncio.coroutine
     def _async_process_entity(self, new_entity):
         """Add entities to StateMachine."""
-        if yield from self.component.async_add_entity(entity, self):
+        ret = yield from self.component.async_add_entity(entity, self)
+        if ret:
             self.platform_entities.append(entity)
 
     @asyncio.coroutine

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -306,9 +306,9 @@ class EntityPlatform(object):
     @asyncio.coroutine
     def _async_process_entity(self, new_entity):
         """Add entities to StateMachine."""
-        ret = yield from self.component.async_add_entity(entity, self)
+        ret = yield from self.component.async_add_entity(new_entity, self)
         if ret:
-            self.platform_entities.append(entity)
+            self.platform_entities.append(new_entity)
 
     @asyncio.coroutine
     def async_reset(self):

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -289,11 +289,9 @@ class EntityPlatform(object):
 
         This method must be run in the event loop.
         """
-        for entity in new_entities:
-            ret = yield from self.component.async_add_entity(entity, self)
-            if ret:
-                self.platform_entities.append(entity)
+        tasks = [self._async_process_entity(entity) for entity in new_entities]
 
+        yield from asyncio.gather(*tasks, loop=self.component.hass.loop)
         yield from self.component.async_update_group()
 
         if self._async_unsub_polling is not None or \
@@ -304,6 +302,12 @@ class EntityPlatform(object):
         self._async_unsub_polling = async_track_utc_time_change(
             self.component.hass, self._update_entity_states,
             second=range(0, 60, self.scan_interval))
+
+    @asyncio.coroutine
+    def _async_process_entity(self, new_entity):
+        """Add entities to StateMachine."""
+        if yield from self.component.async_add_entity(entity, self):
+            self.platform_entities.append(entity)
 
     @asyncio.coroutine
     def async_reset(self):


### PR DESCRIPTION
**Description:**

Speed up add_device callback with pararell device adding.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
