### PR TITLE
Clean up some async stuff

### DIFF
--- a/homeassistant/components/nuimo_controller.py
+++ b/homeassistant/components/nuimo_controller.py
@@ -79,8 +79,7 @@ class NuimoThread(threading.Thread):
         self._name = name
         self._hass_is_running = True
         self._nuimo = None
-        self._listener = hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP,
-                                              self.stop)
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, self.stop)
 
     def run(self):
         """Setup connection or be idle."""
@@ -99,8 +98,6 @@ class NuimoThread(threading.Thread):
         """Terminate Thread by unsetting flag."""
         _LOGGER.debug('Stopping thread for Nuimo %s', self._mac)
         self._hass_is_running = False
-        self._hass.bus.remove_listener(EVENT_HOMEASSISTANT_STOP,
-                                       self._listener)
 
     def _attach(self):
         """Create a nuimo object from mac address or discovery."""

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -239,7 +239,7 @@ class HomeAssistant(object):
     def async_add_job(self, target: Callable[..., None], *args: Any):
         """Add a job from within the eventloop.
 
-        Async friendly.
+        This method must be run in the event loop.
 
         target: target to call.
         args: parameters for method to call.
@@ -255,7 +255,7 @@ class HomeAssistant(object):
     def async_run_job(self, target: Callable[..., None], *args: Any):
         """Run a job from within the event loop.
 
-        Async friendly.
+        This method must be run in the event loop.
 
         target: target to call.
         args: parameters for method to call.
@@ -543,7 +543,6 @@ class EventBus(object):
         @callback
         def onetime_listener(event):
             """Remove listener from eventbus and then fire listener."""
-            _LOGGER.debug("BLA")
             if hasattr(onetime_listener, 'run'):
                 return
             # Set variable so that we will never run twice.
@@ -703,7 +702,10 @@ class StateMachine(object):
 
     @callback
     def async_entity_ids(self, domain_filter=None):
-        """List of entity ids that are being tracked."""
+        """List of entity ids that are being tracked.
+
+        This method must be run in the event loop.
+        """
         if domain_filter is None:
             return list(self._states.keys())
 
@@ -906,7 +908,10 @@ class ServiceRegistry(object):
 
     @callback
     def async_services(self):
-        """Dict with per domain a list of available services."""
+        """Dict with per domain a list of available services.
+
+        This method must be run in the event loop.
+        """
         return {domain: {key: value.as_dict() for key, value
                          in self._services[domain].items()}
                 for domain in self._services}

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -143,7 +143,7 @@ class HomeAssistant(ha.HomeAssistant):
                     'Unable to setup local API to receive events')
 
         self.state = ha.CoreState.starting
-        ha.async_create_timer(self)
+        ha._async_create_timer(self)  # pylint: disable=protected-access
 
         self.bus.fire(ha.EVENT_HOMEASSISTANT_START,
                       origin=ha.EventOrigin.remote)

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -124,9 +124,9 @@ class HomeAssistant(ha.HomeAssistant):
         self.remote_api = remote_api
 
         self.loop = loop or asyncio.get_event_loop()
-        self.pool = pool = ha.create_worker_pool()
+        self.pool = ha.create_worker_pool()
 
-        self.bus = EventBus(remote_api, pool, self.loop)
+        self.bus = EventBus(remote_api, self)
         self.services = ha.ServiceRegistry(self.bus, self.add_job, self.loop)
         self.states = StateMachine(self.bus, self.loop, self.remote_api)
         self.config = ha.Config()
@@ -180,9 +180,9 @@ class EventBus(ha.EventBus):
     """EventBus implementation that forwards fire_event to remote API."""
 
     # pylint: disable=too-few-public-methods
-    def __init__(self, api, pool, loop):
+    def __init__(self, api, hass):
         """Initalize the eventbus."""
-        super().__init__(pool, loop)
+        super().__init__(hass)
         self._api = api
 
     def fire(self, event_type, event_data=None, origin=ha.EventOrigin.local):

--- a/tests/common.py
+++ b/tests/common.py
@@ -76,8 +76,8 @@ def get_test_home_assistant(num_threads=None):
         """Fake stop."""
         yield None
 
-    @patch.object(ha, 'async_create_timer')
-    @patch.object(ha, 'async_monitor_worker_pool')
+    @patch.object(ha, '_async_create_timer')
+    @patch.object(ha, '_async_monitor_worker_pool')
     @patch.object(hass.loop, 'add_signal_handler')
     @patch.object(hass.loop, 'run_forever')
     @patch.object(hass.loop, 'close')

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -145,14 +145,14 @@ class TestAPI(unittest.TestCase):
         requests.post(_url(const.URL_API_STATES_ENTITY.format("test.test")),
                       data=json.dumps({"state": "not_to_be_set"}),
                       headers=HA_HEADERS)
-        hass.bus._pool.block_till_done()
+        hass.block_till_done()
         self.assertEqual(0, len(events))
 
         requests.post(_url(const.URL_API_STATES_ENTITY.format("test.test")),
                       data=json.dumps({"state": "not_to_be_set",
                                        "force_update": True}),
                       headers=HA_HEADERS)
-        hass.bus._pool.block_till_done()
+        hass.block_till_done()
         self.assertEqual(1, len(events))
 
     # pylint: disable=invalid-name

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -69,7 +69,7 @@ def setUpModule():   # pylint: disable=invalid-name
         {http.DOMAIN: {http.CONF_API_PASSWORD: API_PASSWORD,
                        http.CONF_SERVER_PORT: SLAVE_PORT}})
 
-    with patch.object(ha, 'async_create_timer', return_value=None):
+    with patch.object(ha, '_async_create_timer', return_value=None):
         slave.start()
 
 


### PR DESCRIPTION
**Description:**
- EventBus.listen_once was not correctly handling the different types of functions. This has been corrected.
- ServiceRegistry.async_call was incorrectly annotated as a callback (should be a coroutine)
- Updated some docs to add that methods are async friendly.
- Made `async_create_timer` and `async_monitor_pool` private by prefixing with underscore
- Remove deprecated `EventBus.remove_listener`

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
