### PR TITLE
Adds energy monitoring capabilities to the TP-Link HS110

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -12,8 +12,8 @@ from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_HOST, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['https://github.com/kirichkov/pyHS100/archive/'
-                '6e1fedb08ee475a1b8a882a51aa09241e78ac7e8.zip#pyHS100==0.2.0']
+REQUIREMENTS = ['https://github.com/GadgetReactor/pyHS100/archive/'
+                '1f771b7d8090a91c6a58931532e42730b021cbde.zip#pyHS100==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -77,7 +77,7 @@ class SmartPlugSwitch(SwitchDevice):
         return self._emeter_params
 
     def update(self):
-        """Update the TP-Link switch's state"""
+        """Update the TP-Link switch's state."""
         self._state = self.smartplug.state
 
         if self._emeter_present:

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -12,12 +12,17 @@ from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_HOST, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['https://github.com/gadgetreactor/pyHS100/archive/'
-                'ef85f939fd5b07064a0f34dfa673fa7d6140bd95.zip#pyHS100==0.1.2']
+REQUIREMENTS = ['https://github.com/kirichkov/pyHS100/archive/'
+                '6e1fedb08ee475a1b8a882a51aa09241e78ac7e8.zip#pyHS100==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'TPLink Switch HS100'
+
+ATTR_CURRENT_CONSUMPTION = 'Current consumption'
+ATTR_TOTAL_CONSUMPTION = 'Total consumption'
+ATTR_VOLTAGE = 'Voltage'
+ATTR_CURRENT = 'Current'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -60,3 +65,27 @@ class SmartPlugSwitch(SwitchDevice):
     def turn_off(self):
         """Turn the switch off."""
         self.smartplug.state = 'OFF'
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the device."""
+        _LOGGER.debug("Updating TP-Link energy meter data")
+
+        emeter_readings = self.smartplug.get_emeter_realtime()
+
+        if emeter_readings is False:
+            return {}
+
+        current_consumption = "%.1f W" % emeter_readings["power"]
+        current = "%.1f A" % emeter_readings["current"]
+        voltage = "%.2f V" % emeter_readings["voltage"]
+        total_consumption = "%.2f kW" % emeter_readings["total"]
+
+        attrs = {
+            ATTR_CURRENT_CONSUMPTION: current_consumption,
+            ATTR_TOTAL_CONSUMPTION: total_consumption,
+            ATTR_VOLTAGE: voltage,
+            ATTR_CURRENT: current
+        }
+
+        return attrs

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -144,6 +144,9 @@ hikvision==0.4
 # homeassistant.components.light.flux_led
 https://github.com/Danielhiversen/flux_led/archive/0.7.zip#flux_led==0.8
 
+# homeassistant.components.switch.tplink
+https://github.com/GadgetReactor/pyHS100/archive/1f771b7d8090a91c6a58931532e42730b021cbde.zip#pyHS100==0.2.0
+
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.3.5.zip#pyW215==0.3.5
 
@@ -181,9 +184,6 @@ https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad591540925
 
 # homeassistant.components.qwikswitch
 https://github.com/kellerza/pyqwikswitch/archive/v0.4.zip#pyqwikswitch==0.4
-
-# homeassistant.components.switch.tplink
-https://github.com/kirichkov/pyHS100/archive/6e1fedb08ee475a1b8a882a51aa09241e78ac7e8.zip#pyHS100==0.2.0
 
 # homeassistant.components.media_player.russound_rnet
 https://github.com/laf/russound/archive/0.1.6.zip#russound==0.1.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -173,9 +173,6 @@ https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.
 # homeassistant.components.device_tracker.fritz
 # https://github.com/deisi/fritzconnection/archive/b5c14515e1c8e2652b06b6316a7f3913df942841.zip#fritzconnection==0.4.6
 
-# homeassistant.components.switch.tplink
-https://github.com/gadgetreactor/pyHS100/archive/ef85f939fd5b07064a0f34dfa673fa7d6140bd95.zip#pyHS100==0.1.2
-
 # homeassistant.components.netatmo
 https://github.com/jabesq/netatmo-api-python/archive/v0.6.0.zip#lnetatmo==0.6.0
 
@@ -184,6 +181,9 @@ https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad591540925
 
 # homeassistant.components.qwikswitch
 https://github.com/kellerza/pyqwikswitch/archive/v0.4.zip#pyqwikswitch==0.4
+
+# homeassistant.components.switch.tplink
+https://github.com/kirichkov/pyHS100/archive/6e1fedb08ee475a1b8a882a51aa09241e78ac7e8.zip#pyHS100==0.2.0
 
 # homeassistant.components.media_player.russound_rnet
 https://github.com/laf/russound/archive/0.1.6.zip#russound==0.1.6


### PR DESCRIPTION
**Description:**
Adds energy monitoring to the TP-Link HS110 Smart switches

**Related issue (if applicable):**

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
  - platform: tplink
    host: IP_ADRRESS
```

No changes to the configuration are needed. The updated module should automatically detect whether the switch's model and determine whether energy monitoring is available (HS110) or not (HS100)

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [-] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

Energy monitoring works only on the HS110 model
