### PR TITLE
Yamaha zones

### DIFF
--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -10,16 +10,18 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import (
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
-    SUPPORT_SELECT_SOURCE, MediaPlayerDevice, PLATFORM_SCHEMA)
+    SUPPORT_SELECT_SOURCE, SUPPORT_PLAY_MEDIA,
+    MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_NAME, CONF_HOST, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['rxv==0.1.11']
+REQUIREMENTS = ['rxv==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_YAMAHA = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
-                 SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE
+                 SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE | \
+                 SUPPORT_PLAY_MEDIA
 
 CONF_SOURCE_NAMES = 'source_names'
 CONF_SOURCE_IGNORE = 'source_ignore'
@@ -45,11 +47,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     source_names = config.get(CONF_SOURCE_NAMES)
 
     if host is None:
-        receivers = rxv.find()
+        receivers = []
+        for recv in rxv.find():
+            receivers.extend(recv.zone_controllers())
     else:
-        receivers = \
-            [rxv.RXV("http://{}:80/YamahaRemoteControl/ctrl".format(host),
-                     name)]
+        ctrl_url = "http://{}:80/YamahaRemoteControl/ctrl".format(host)
+        receivers = rxv.RXV(ctrl_url, name).zone_controllers()
 
     add_devices(
         YamahaDevice(name, receiver, source_ignore, source_names)
@@ -74,6 +77,7 @@ class YamahaDevice(MediaPlayerDevice):
         self._reverse_mapping = None
         self.update()
         self._name = name
+        self._zone = receiver.zone
 
     def update(self):
         """Get the latest details from the device."""
@@ -104,7 +108,11 @@ class YamahaDevice(MediaPlayerDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        return self._name
+        name = self._name
+        if self._zone != "Main_Zone":
+            # Zone will be one of Main_Zone, Zone_2, Zone_3
+            name += " " + self._zone.replace('_', ' ')
+        return name
 
     @property
     def state(self):
@@ -158,3 +166,14 @@ class YamahaDevice(MediaPlayerDevice):
     def select_source(self, source):
         """Select input source."""
         self._receiver.input = self._reverse_mapping.get(source, source)
+
+    def play_media(self, media_type, media_id, **kwargs):
+        """Play media from an ID.
+
+        This exposes a pass through for various input sources in the
+        Yamaha to direct play certain kinds of media. media_type is
+        treated as the input type that we are setting, and media id is
+        specific to it.
+        """
+        if media_type == "NET_RADIO":
+            self._receiver.net_radio(media_id)

--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 from homeassistant.components.media_player import (
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_SELECT_SOURCE, SUPPORT_PLAY_MEDIA,
+    MEDIA_TYPE_MUSIC,
     MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_NAME, CONF_HOST, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
@@ -175,5 +176,26 @@ class YamahaDevice(MediaPlayerDevice):
         treated as the input type that we are setting, and media id is
         specific to it.
         """
-        if media_type == "NET_RADIO":
+        if media_type == "NET RADIO":
             self._receiver.net_radio(media_id)
+
+    @property
+    def media_content_type(self):
+        """Return the media content type."""
+        if self.source == "NET RADIO":
+            return MEDIA_TYPE_MUSIC
+
+    @property
+    def media_title(self):
+        """Return the media title.
+
+        This will vary by input source, as they provide different
+        information in metadata.
+
+        """
+        if self.source == "NET RADIO":
+            info = self._receiver.play_status()
+            if info.song:
+                return "%s: %s" % (info.station, info.song)
+            else:
+                return info.station

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -436,7 +436,7 @@ radiotherm==1.2
 # rpi-rf==0.9.5
 
 # homeassistant.components.media_player.yamaha
-rxv==0.1.11
+rxv==0.2.0
 
 # homeassistant.components.media_player.samsungtv
 samsungctl==0.5.1


### PR DESCRIPTION
**Description:**

Many yamaha receivers support > 1 zone. This creates a media player component per zone, which allows the zones to be independently powered / volume controlled. It also builds in some facilities to handle the net radio source better (display when playing, and providing a way to direct set them). 

**Related issue (if applicable):** fixes #1704

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
