### PR TITLE
Upgrade python-digitalocean to 1.10.0

### DIFF
--- a/homeassistant/components/digital_ocean.py
+++ b/homeassistant/components/digital_ocean.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-digitalocean==1.9.0']
+REQUIREMENTS = ['python-digitalocean==1.10.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 # pylint: disable=unused-argument,too-few-public-methods
 def setup(hass, config):
-    """Setup the Digital Ocean component."""
+    """Set up the Digital Ocean component."""
     conf = config[DOMAIN]
     access_token = conf.get(CONF_ACCESS_TOKEN)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -377,7 +377,7 @@ pyserial==3.1.1
 pysnmp==4.3.2
 
 # homeassistant.components.digital_ocean
-python-digitalocean==1.9.0
+python-digitalocean==1.10.0
 
 # homeassistant.components.sensor.darksky
 python-forecastio==1.3.5


### PR DESCRIPTION
## 1.10.0
- Tags support
- Better pagination support
- Human readable classes
- general bug fixes

Tested with the following configuration:

``` yaml
digital_ocean:
  access_token: !secret do_api

switch:
  - platform: digital_ocean
    droplets:
      - 'fedora-512mb-nyc2-02'
      - 'coreos-512mb-nyc2-02'
```
