### PR TITLE
Bugfix sonos

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -64,7 +64,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         player = soco.SoCo(discovery_info)
 
         # if device allready exists by config
-        if player.uid in [device.player_uid for device in DEVICES]:
+        if player.uid in DEVICES:
             return True
 
         if player.is_visible:
@@ -218,8 +218,8 @@ class SonosDevice(MediaPlayerDevice):
         self.update_ha_state(True)
 
     @property
-    def player_uid(self):
-        """A unique identifier."""
+    def unique_id(self):
+        """Return an unique ID."""
         return self._player.uid
 
     @property

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -62,7 +62,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if discovery_info:
         # if device allready maped by config
-        if not DEVICES:
+        if DEVICES:
             return True
 
         player = soco.SoCo(discovery_info)

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -61,6 +61,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     global DEVICES
 
     if discovery_info:
+        # if device allready maped by config
+        if not DEVICES:
+            return True
+
         player = soco.SoCo(discovery_info)
         if player.is_visible:
             device = SonosDevice(hass, player)

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -66,7 +66,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         # if device allready exists by config
         if player.uid in [device.player_uid for device in DEVICES]:
             return True
-            
+
         if player.is_visible:
             device = SonosDevice(hass, player)
             add_devices([device])

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -61,11 +61,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     global DEVICES
 
     if discovery_info:
-        # if device allready maped by config
-        if DEVICES:
-            return True
-
         player = soco.SoCo(discovery_info)
+
+        # if device allready exists by config
+        if player.uid in [device.player_uid for device in DEVICES]:
+            return True
+            
         if player.is_visible:
             device = SonosDevice(hass, player)
             add_devices([device])
@@ -215,6 +216,11 @@ class SonosDevice(MediaPlayerDevice):
     def update_sonos(self, now):
         """Update state, called by track_utc_time_change."""
         self.update_ha_state(True)
+
+    @property
+    def player_uid(self):
+        """A unique identifier."""
+        return self._player.uid
 
     @property
     def name(self):

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -67,6 +67,10 @@ class SoCoMock():
         """Cause the speaker to separate itself from other speakers."""
         return
 
+    def uid(self):
+        """Return a player uid."""
+        return "RINCON_XXXXXXXXXXXXXXXXX"
+
 
 class TestSonosMediaPlayer(unittest.TestCase):
     """Test the media_player module."""


### PR DESCRIPTION
**Description:**

I change the sonos from internal wlan to home wireless and have now the same problem, that if I use 

```
media_player:
  - platform: sonos
```

will it discover by config and later with autodiscovery. So I have the same device twice.

**Related issue (if applicable):** fixes #3317
