### PR TITLE
Logbook filtering of automations by entity_id

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -280,7 +280,7 @@ class AutomationEntity(ToggleEntity):
         This method is a coroutine.
         """
         if skip_condition or self._cond_func(variables):
-            yield from self._async_action(variables)
+            yield from self._async_action(variables, self.entity_id)
             self._last_triggered = utcnow()
             self.hass.loop.create_task(self.async_update_ha_state())
 
@@ -356,10 +356,11 @@ def _async_get_action(hass, config, name):
     script_obj = script.Script(hass, config, name)
 
     @asyncio.coroutine
-    def action(variables=None):
+    def action(variables=None, entity_id=None):
         """Action to be executed."""
         _LOGGER.info('Executing %s', name)
-        logbook.async_log_entry(hass, name, 'has been triggered', DOMAIN)
+        logbook.async_log_entry(
+            hass, name, 'has been triggered', DOMAIN, entity_id)
         hass.loop.create_task(script_obj.async_run(variables))
 
     return action

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -280,7 +280,7 @@ class AutomationEntity(ToggleEntity):
         This method is a coroutine.
         """
         if skip_condition or self._cond_func(variables):
-            yield from self._async_action(variables, self.entity_id)
+            yield from self._async_action(self.entity_id, variables)
             self._last_triggered = utcnow()
             self.hass.loop.create_task(self.async_update_ha_state())
 
@@ -356,7 +356,7 @@ def _async_get_action(hass, config, name):
     script_obj = script.Script(hass, config, name)
 
     @asyncio.coroutine
-    def action(variables=None, entity_id=None):
+    def action(entity_id, variables):
         """Action to be executed."""
         _LOGGER.info('Executing %s', name)
         logbook.async_log_entry(

--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -257,7 +257,7 @@ def humanify(events):
                     event.time_fired, "Home Assistant", action,
                     domain=HA_DOMAIN)
 
-            elif event.event_type.lower() == EVENT_LOGBOOK_ENTRY:
+            elif event.event_type == EVENT_LOGBOOK_ENTRY:
                 domain = event.data.get(ATTR_DOMAIN)
                 entity_id = event.data.get(ATTR_ENTITY_ID)
                 if domain is None and entity_id is not None:
@@ -290,6 +290,8 @@ def _exclude_events(events, config):
 
     filtered_events = []
     for event in events:
+        domain, entity_id = None, None
+
         if event.event_type == EVENT_STATE_CHANGED:
             to_state = State.from_dict(event.data.get('new_state'))
             # Do not report on new entities
@@ -303,6 +305,12 @@ def _exclude_events(events, config):
 
             domain = to_state.domain
             entity_id = to_state.entity_id
+
+        elif event.event_type == EVENT_LOGBOOK_ENTRY:
+            domain = event.data.get(ATTR_DOMAIN)
+            entity_id = event.data.get(ATTR_ENTITY_ID)
+
+        if domain or entity_id:
             # filter if only excluded is configured for this domain
             if excluded_domains and domain in excluded_domains and \
                     not included_domains:

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -186,6 +186,43 @@ class TestComponentLogbook(unittest.TestCase):
         self.assert_entry(entries[1], pointB, 'blu', domain='sensor',
                           entity_id=entity_id2)
 
+    def test_exclude_automation_events(self):
+        """Test if automation entries can be excluded by entity_id."""
+        name = 'My Automation Rule'
+        message = 'has been triggered'
+        domain = 'automation'
+        entity_id = 'automation.my_automation_rule'
+        entity_id2 = 'automation.my_automation_rule_2'
+        entity_id2 = 'sensor.blu'
+
+        eventA = ha.Event(logbook.EVENT_LOGBOOK_ENTRY, {
+                logbook.ATTR_NAME: name,
+                logbook.ATTR_MESSAGE: message,
+                logbook.ATTR_DOMAIN: domain,
+                logbook.ATTR_ENTITY_ID: entity_id,
+                })
+        eventB = ha.Event(logbook.EVENT_LOGBOOK_ENTRY, {
+                logbook.ATTR_NAME: name,
+                logbook.ATTR_MESSAGE: message,
+                logbook.ATTR_DOMAIN: domain,
+                logbook.ATTR_ENTITY_ID: entity_id2,
+                })
+
+        config = logbook.CONFIG_SCHEMA({
+            ha.DOMAIN: {},
+            logbook.DOMAIN: {logbook.CONF_EXCLUDE: {
+                logbook.CONF_ENTITIES: [entity_id, ]}}})
+        events = logbook._exclude_events((ha.Event(EVENT_HOMEASSISTANT_STOP),
+                                          eventA, eventB), config)
+        entries = list(logbook.humanify(events))
+
+        self.assertEqual(2, len(entries))
+        self.assert_entry(
+            entries[0], name='Home Assistant', message='stopped',
+            domain=ha.DOMAIN)
+        self.assert_entry(
+            entries[1], name=name, domain=domain, entity_id=entity_id2)
+
     def test_include_events_entity(self):
         """Test if events are filtered if entity is included in config."""
         entity_id = 'sensor.bla'


### PR DESCRIPTION
**Description:**
Fixes #3742. Unfortunately, historical logbook entries didn't have entity_id attached, so this will only affect new entries.

**Checklist:**
If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
