### PR TITLE
rpi_rf protocol should be an int

### DIFF
--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -28,7 +28,7 @@ SWITCH_SCHEMA = vol.Schema({
     vol.Required(CONF_CODE_OFF): cv.positive_int,
     vol.Required(CONF_CODE_ON): cv.positive_int,
     vol.Optional(CONF_PULSELENGTH): cv.positive_int,
-    vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL): cv.string,
+    vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL): cv.positive_int,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
**Description:**
_Use voluptuous for Pi RF Switch_ broke my switches. Looks like rpi_rf is expecting protocol to be an int not a string.

In the current dev I am getting the following traceback. This PR corrects the problem.

``` bash
Traceback (most recent call last):
  File "/home/pi/.virtualenvs/hass_dev/lib/python3.4/site-packages/homeassistant-0.31.0.dev0-py3.4.egg/homeassistant/core.py", line 1224, in job_handler
    func(*args)
  File "/home/pi/.virtualenvs/hass_dev/lib/python3.4/site-packages/homeassistant-0.31.0.dev0-py3.4.egg/homeassistant/core.py", line 1087, in execute_service
    service_handler.func(service_call)
  File "/home/pi/.virtualenvs/hass_dev/lib/python3.4/site-packages/homeassistant-0.31.0.dev0-py3.4.egg/homeassistant/components/switch/__init__.py", line 84, in handle_switch_service
    switch.turn_on()
  File "/home/pi/.virtualenvs/hass_dev/lib/python3.4/site-packages/homeassistant-0.31.0.dev0-py3.4.egg/homeassistant/components/switch/rpi_rf.py", line 109, in turn_on
    if self._send_code(self._code_on, self._protocol, self._pulselength):
  File "/home/pi/.virtualenvs/hass_dev/lib/python3.4/site-packages/homeassistant-0.31.0.dev0-py3.4.egg/homeassistant/components/switch/rpi_rf.py", line 102, in _send_code
    res = self._rfdevice.tx_code(code, protocol, pulselength)
  File "/home/pi/.virtualenvs/hass_dev/config/deps/rpi_rf/rpi_rf.py", line 107, in tx_code
    return self.tx_bin(rawcode)
  File "/home/pi/.virtualenvs/hass_dev/config/deps/rpi_rf/rpi_rf.py", line 115, in tx_bin
    if not self.tx_l0():
  File "/home/pi/.virtualenvs/hass_dev/config/deps/rpi_rf/rpi_rf.py", line 127, in tx_l0
    if not 0 < self.tx_proto < len(PROTOCOLS):
TypeError: unorderable types: int() < str()
```

**Related issue (if applicable):** fixes #3817 

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
