### PR TITLE
Add support for Neato Connected robot as a switch

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -292,6 +292,7 @@ omit =
     homeassistant/components/switch/edimax.py
     homeassistant/components/switch/hikvisioncam.py
     homeassistant/components/switch/mystrom.py
+    homeassistant/components/switch/neato.py
     homeassistant/components/switch/netio.py
     homeassistant/components/switch/orvibo.py
     homeassistant/components/switch/pulseaudio_loopback.py

--- a/homeassistant/components/switch/neato.py
+++ b/homeassistant/components/switch/neato.py
@@ -103,12 +103,13 @@ class NeatoConnectedSwitch(ToggleEntity):
     @property
     def state(self):
         """Return the state."""
-        if not self._state or \
-           ( not self._state['availableCommands']['start'] and \
+        if not self._state:
+            return STATE_UNAVAILABLE
+        if not self._state['availableCommands']['start'] and \
            not self._state['availableCommands']['stop'] and \
            not self._state['availableCommands']['pause'] and \
            not self._state['availableCommands']['resume'] and \
-           not self._state['availableCommands']['goToBase'] ):
+           not self._state['availableCommands']['goToBase']:
             return STATE_UNAVAILABLE
         return STATE_ON if self.is_on else STATE_OFF
 

--- a/homeassistant/components/switch/neato.py
+++ b/homeassistant/components/switch/neato.py
@@ -1,0 +1,137 @@
+"""
+Support for Neato Connected Vaccums.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.neato/
+"""
+import time
+import logging
+from datetime import timedelta
+from urllib.error import HTTPError
+
+import voluptuous as vol
+
+from homeassistant.const import (CONF_PASSWORD, CONF_USERNAME, STATE_OFF,
+                                 STATE_ON, STATE_UNAVAILABLE)
+from homeassistant.helpers.entity import ToggleEntity
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['https://github.com/jabesq/pybotvac/archive/v0.0.1.zip'
+                '#pybotvac==0.0.1']
+
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
+MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
+
+MIN_TIME_TO_WAIT = timedelta(seconds=10)
+MIN_TIME_TO_LOCK_UPDATE = 10
+
+SWITCH_TYPES = {
+    'clean': ['Clean']
+}
+
+DOMAIN = 'neato'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Neato platform."""
+    from pybotvac import Account
+
+    try:
+        auth = Account(config[CONF_USERNAME], config[CONF_PASSWORD])
+    except HTTPError:
+        _LOGGER.error("Unable to connect to Neato API")
+        return False
+
+    dev = []
+    for robot in auth.robots:
+        for type_name in SWITCH_TYPES:
+            dev.append(NeatoConnectedSwitch(robot, type_name))
+    add_devices(dev)
+
+
+class NeatoConnectedSwitch(ToggleEntity):
+    """ThinkingCleaner Switch (dock, clean, find me)."""
+
+    def __init__(self, robot, switch_type):
+        """Initialize the Neato Connected switch."""
+        self.type = switch_type
+        self.robot = robot
+        self.lock = False
+        self.last_lock_time = None
+        self.graceful_state = False
+
+    def lock_update(self):
+        """Lock the update since TC clean takes some time to update."""
+        if self.is_update_locked():
+            return
+        self.lock = True
+        self.last_lock_time = time.time()
+
+    def reset_update_lock(self):
+        """Reset the update lock."""
+        self.lock = False
+        self.last_lock_time = None
+
+    def set_graceful_lock(self, state):
+        """Set the graceful state."""
+        self.graceful_state = state
+        self.reset_update_lock()
+        self.lock_update()
+
+    def is_update_locked(self):
+        """Check if the update method is locked."""
+        if self.last_lock_time is None:
+            return False
+
+        if time.time() - self.last_lock_time >= MIN_TIME_TO_LOCK_UPDATE:
+            self.last_lock_time = None
+            return False
+
+        return True
+
+    @property
+    def state(self):
+        """Return the state."""
+        State = self.robot.state
+        if not State['availableCommands']['start'] and \
+           not State['availableCommands']['stop'] and \
+           not State['availableCommands']['pause'] and \
+           not State['availableCommands']['resume'] and \
+           not State['availableCommands']['goToBase']:
+            return STATE_UNAVAILABLE
+        return STATE_ON if self.is_on else STATE_OFF
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self.robot.name + ' ' + SWITCH_TYPES[self.type][0]
+
+    @property
+    def is_on(self):
+        State = self.robot.state
+        """Return true if device is on."""
+        if self.is_update_locked():
+            return self.graceful_state
+        if State['action'] == 1 and State['state'] == 2:
+            return True
+        return False
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        self.set_graceful_lock(True)
+        self.robot.start_cleaning()
+
+    def turn_off(self, **kwargs):
+        """Turn the device off. (Return Robot to base)"""
+        self.robot.pause_cleaning()
+        time.sleep(1)
+        self.robot.send_to_base()

--- a/homeassistant/components/switch/neato.py
+++ b/homeassistant/components/switch/neato.py
@@ -117,8 +117,8 @@ class NeatoConnectedSwitch(ToggleEntity):
 
     @property
     def is_on(self):
-        State = self.robot.state
         """Return true if device is on."""
+        State = self.robot.state
         if self.is_update_locked():
             return self.graceful_state
         if State['action'] == 1 and State['state'] == 2:

--- a/homeassistant/components/switch/neato.py
+++ b/homeassistant/components/switch/neato.py
@@ -136,4 +136,10 @@ class NeatoConnectedSwitch(ToggleEntity):
         self.robot.send_to_base()
 
     def update(self):
-        self._state = self.robot.state
+        """Refresh Robot state from Neato API."""
+        try:
+            self._state = self.robot.state
+        except HTTPError:
+            _LOGGER.error("Unable to retrieve to Robot State.")
+            self._state = None
+            return False

--- a/homeassistant/components/switch/neato.py
+++ b/homeassistant/components/switch/neato.py
@@ -8,6 +8,7 @@ import time
 import logging
 from datetime import timedelta
 from urllib.error import HTTPError
+from requests.exceptions import HTTPError as req_HTTPError
 
 import voluptuous as vol
 
@@ -102,11 +103,12 @@ class NeatoConnectedSwitch(ToggleEntity):
     @property
     def state(self):
         """Return the state."""
-        if not self._state['availableCommands']['start'] and \
+        if not self._state or \
+           ( not self._state['availableCommands']['start'] and \
            not self._state['availableCommands']['stop'] and \
            not self._state['availableCommands']['pause'] and \
            not self._state['availableCommands']['resume'] and \
-           not self._state['availableCommands']['goToBase']:
+           not self._state['availableCommands']['goToBase'] ):
             return STATE_UNAVAILABLE
         return STATE_ON if self.is_on else STATE_OFF
 
@@ -139,7 +141,7 @@ class NeatoConnectedSwitch(ToggleEntity):
         """Refresh Robot state from Neato API."""
         try:
             self._state = self.robot.state
-        except HTTPError:
+        except req_HTTPError:
             _LOGGER.error("Unable to retrieve to Robot State.")
             self._state = None
             return False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -186,6 +186,9 @@ https://github.com/gadgetreactor/pyHS100/archive/ef85f939fd5b07064a0f34dfa673fa7
 # homeassistant.components.netatmo
 https://github.com/jabesq/netatmo-api-python/archive/v0.6.0.zip#lnetatmo==0.6.0
 
+# homeassistant.components.switch.neato
+https://github.com/jabesq/pybotvac/archive/v0.0.1.zip#pybotvac==0.0.1
+
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
 


### PR DESCRIPTION
**Description:**
Add support for Neato Botvac Connected robot as a switch (https://www.neatorobotics.com/robot-vacuum/botvac-connected-series/botvac-connected/)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1261

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
switch:
    platform: neato
    username: USERNAME
    password: PASSWORD
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
