### PR TITLE
Adding timer setting functionality to sonos component

### DIFF
--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -185,3 +185,14 @@ sonos_restore:
     entity_id:
       description: Name(s) of entites that will be restored. Platform dependent.
       example: 'media_player.living_room_sonos'
+
+sonos_set_sleep_timer:
+  description: Set a Sonos timer
+
+  fields:
+    entity_id:
+      description: Name(s) of entites that will have a timer set.
+      example: 'media_player.living_room_sonos'
+    sleep_time:
+      description: Number of seconds to set the timer
+      example: '900'

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -196,3 +196,11 @@ sonos_set_sleep_timer:
     sleep_time:
       description: Number of seconds to set the timer
       example: '900'
+
+sonos_clear_sleep_timer:
+  description: Clear a Sonos timer
+
+  fields:
+    entity_id:
+      description: Name(s) of entites that will have the timer cleared.
+      example: 'media_player.living_room_sonos'

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -41,13 +41,21 @@ SERVICE_GROUP_PLAYERS = 'sonos_group_players'
 SERVICE_UNJOIN = 'sonos_unjoin'
 SERVICE_SNAPSHOT = 'sonos_snapshot'
 SERVICE_RESTORE = 'sonos_restore'
+SERVICE_SET_TIMER = 'sonos_set_sleep_timer'
 
 SUPPORT_SOURCE_LINEIN = 'Line-in'
 SUPPORT_SOURCE_TV = 'TV'
 SUPPORT_SOURCE_RADIO = 'Radio'
 
+# Service call validation schemas
+ATTR_SLEEP_TIME = 'sleep_time'
+
 SONOS_SCHEMA = vol.Schema({
     ATTR_ENTITY_ID: cv.entity_ids,
+})
+
+SONOS_SET_TIMER_SCHEMA = SONOS_SCHEMA.extend({
+    vol.Required(ATTR_SLEEP_TIME): cv.positive_int,
 })
 
 # List of devices that have been registered
@@ -126,6 +134,11 @@ def register_services(hass):
                            descriptions.get(SERVICE_RESTORE),
                            schema=SONOS_SCHEMA)
 
+    hass.services.register(DOMAIN, SERVICE_SET_TIMER,
+                           _set_sleep_timer_service,
+                           descriptions.get(SERVICE_SET_TIMER),
+                           schema=SONOS_SET_TIMER_SCHEMA)
+
 
 def _apply_service(service, service_func, *service_func_args):
     """Internal func for applying a service."""
@@ -160,6 +173,13 @@ def _snapshot_service(service):
 def _restore_service(service):
     """Restore a snapshot."""
     _apply_service(service, SonosDevice.restore)
+
+
+def _set_sleep_timer_service(service):
+    """Set a timer."""
+    _apply_service(service,
+                   SonosDevice.set_sleep_timer,
+                   service.data[ATTR_SLEEP_TIME])
 
 
 def only_if_coordinator(func):
@@ -439,6 +459,16 @@ class SonosDevice(MediaPlayerDevice):
     def restore(self):
         """Restore snapshot for the player."""
         self.soco_snapshot.restore(True)
+
+    @only_if_coordinator
+    def set_sleep_timer(self, sleep_time):
+        """Set the timer on the player."""
+        if sleep_time != '':
+            if int(sleep_time) > 86399:
+                raise ValueError("Can only set timers less than one day")
+        else:
+            sleep_time = None
+        self._player.set_sleep_timer(sleep_time)
 
     @property
     def available(self):

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -63,6 +63,10 @@ class SoCoMock():
         """Cause the speaker to join all other speakers in the network."""
         return
 
+    def set_sleep_timer(self, sleep_time_seconds):
+        """Set/clear the sleep timer."""
+        return
+
     def unjoin(self):
         """Cause the speaker to separate itself from other speakers."""
         return
@@ -142,6 +146,15 @@ class TestSonosMediaPlayer(unittest.TestCase):
         device.unjoin()
         self.assertEqual(unjoinMock.call_count, 1)
         self.assertEqual(unjoinMock.call_args, mock.call())
+
+    @mock.patch('soco.SoCo', new=SoCoMock)
+    @mock.patch.object(SoCoMock, 'set_sleep_timer')
+    def test_sonos_set_sleep_timer(self, set_sleep_timerMock):
+        """Ensuring soco methods called for sonos_set_sleep_timer service."""
+        sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
+        device = sonos.DEVICES[-1]
+        device.set_sleep_timer(30)
+        set_sleep_timerMock.assert_called_once_with(30)
 
     @mock.patch('soco.SoCo', new=SoCoMock)
     @mock.patch.object(soco.snapshot.Snapshot, 'snapshot')

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -27,6 +27,10 @@ class SoCoMock():
         self.ip_address = ip
         self.is_visible = True
 
+    def clear_sleep_timer(self):
+        """Clear the sleep timer."""
+        return
+
     def get_speaker_info(self):
         """Return a dict with various data points about the speaker."""
         return {'serial_number': 'B8-E9-37-BO-OC-BA:2',
@@ -64,7 +68,7 @@ class SoCoMock():
         return
 
     def set_sleep_timer(self, sleep_time_seconds):
-        """Set/clear the sleep timer."""
+        """Set the sleep timer."""
         return
 
     def unjoin(self):
@@ -155,6 +159,15 @@ class TestSonosMediaPlayer(unittest.TestCase):
         device = sonos.DEVICES[-1]
         device.set_sleep_timer(30)
         set_sleep_timerMock.assert_called_once_with(30)
+
+    @mock.patch('soco.SoCo', new=SoCoMock)
+    @mock.patch.object(SoCoMock, 'set_sleep_timer')
+    def test_sonos_clear_sleep_timer(self, set_sleep_timerMock):
+        """Ensuring soco methods called for sonos_clear_sleep_timer service."""
+        sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
+        device = sonos.DEVICES[-1]
+        device.set_sleep_timer(None)
+        set_sleep_timerMock.assert_called_once_with(None)
 
     @mock.patch('soco.SoCo', new=SoCoMock)
     @mock.patch.object(soco.snapshot.Snapshot, 'snapshot')


### PR DESCRIPTION
Sleep timers can be used with Sonos to configure a speaker (or set of speakers) to taper down the volume to 0 and stop music after a specific number of seconds. Also, if you want your speakers to gracefully taper down immediately, you can pass it 0 seconds.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1273

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`. (Truth be told: I edited the single relevant line)
- [ ] New files were added to `.coveragerc`. (I think we're not doing coveragerc for sonos)
