### PR TITLE
adding support for multiple inputs to nmap tracking module

### DIFF
--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -120,7 +120,8 @@ class NmapDeviceScanner(object):
             options += ' --exclude {}'.format(','.join(exclude_hosts))
 
         try:
-            result = scanner.scan(hosts=' '.join(self.hosts), arguments=options)
+            result = scanner.scan(hosts=' '.join(self.hosts),
+                                  arguments=options)
         except PortScannerError:
             return False
 

--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -30,7 +30,7 @@ CONF_EXCLUDE = 'exclude'
 REQUIREMENTS = ['python-nmap==0.6.1']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOSTS): cv.string,
+    vol.Required(CONF_HOSTS): cv.ensure_list,
     vol.Required(CONF_HOME_INTERVAL, default=0): cv.positive_int,
     vol.Optional(CONF_EXCLUDE, default=[]):
         vol.All(cv.ensure_list, vol.Length(min=1))
@@ -120,7 +120,7 @@ class NmapDeviceScanner(object):
             options += ' --exclude {}'.format(','.join(exclude_hosts))
 
         try:
-            result = scanner.scan(hosts=self.hosts, arguments=options)
+            result = scanner.scan(hosts=' '.join(self.hosts), arguments=options)
         except PortScannerError:
             return False
 


### PR DESCRIPTION
**Description:**

Changing the nmap module's `hosts` configuration from a string to a list. This lets us have more than one input, which is useful for providing specific IPs to monitor, rather than entire subnets.

Example new config:

```
- platform: nmap_tracker
  hosts:
    - 192.168.1.3
    - 10.10.2.180
```

The running nmap process looks like this:

`nmap -oX - 192.168.1.3 10.10.2.180 -F --host-timeout 5s`

This still works with the a classic config like:

```
- platform: nmap_tracker
  hosts: 10.10.2.0/24
```

Which runs the process:

`nmap -oX - 10.10.2.0/24 -sP --host-timeout 5s`

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully.
