### PR TITLE
check the services of a bluetooth device

### DIFF
--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -77,7 +77,8 @@ def setup_scanner(hass, config, see):
             for mac in devs_to_track:
                 _LOGGER.debug("Scanning " + mac)
                 result = bluetooth.lookup_name(mac, timeout=5)
-                if not result:
+                tempresult = bluetooth.find_service(address=mac)
+                if not result or not tempresult:
                     # Could not lookup device name
                     continue
                 see_device((mac, result))


### PR DESCRIPTION
**Description:**
This adds a check to find the services of a bluetooth device. By doing this, the component actually connects to a bluetooth device. If there are no services found, the device isn't in range.
This solves the issue that paired devices are always found as 'home'. At least, that's on Windows, I'm not sure if this is also the case on other OS's.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
