### PR TITLE
Upgrade SoCo to 0.12

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
 from homeassistant.config import load_yaml_config_file
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['SoCo==0.11.1']
+REQUIREMENTS = ['SoCo==0.12']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -23,7 +23,7 @@ PyMata==2.13
 # RPi.GPIO==0.6.1
 
 # homeassistant.components.media_player.sonos
-SoCo==0.11.1
+SoCo==0.12
 
 # homeassistant.components.notify.twitter
 TwitterAPI==2.4.2


### PR DESCRIPTION
**Description:**

If the code communicates with devices, web services, or third-party tools:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

Full Changelog: https://github.com/SoCo/SoCo/releases/tag/v0.12

Backwards Compatability changes:
-   Dropped support for Python 3.2
-  Methods relating to the music library (get_artists, get_album_artists, get_albums and others) have been moved to the music_library module. Instead of device.get_album_artists(), please now use device.music_library.get_album_artists() etc. Old code will continue to work for the moment, but will raise deprecation warnings
-  Made a hard deprecation of the Spotify plugin since the API it relied on has been deprecated and it therefore no longer worked
-  Dropped pylint checks for Python 2.6
