### PR TITLE
Add support for verisure file camera.

### DIFF
--- a/homeassistant/components/camera/verisure.py
+++ b/homeassistant/components/camera/verisure.py
@@ -59,7 +59,7 @@ class VerisureSmartcam(Camera):
         """Check the contents of the image list."""
         hub.update_smartcam_imagelist()
         if (self._device_id not in hub.smartcam_dict or
-             not hub.smartcam_dict[self._device_id]):
+                not hub.smartcam_dict[self._device_id]):
             return
         images = hub.smartcam_dict[self._device_id]
         new_image_id = images[0]

--- a/homeassistant/components/camera/verisure.py
+++ b/homeassistant/components/camera/verisure.py
@@ -15,8 +15,6 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_NAME = 'Verisure File'
-
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Camera."""
@@ -29,33 +27,29 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if not smartcam_dict:
         return False
     device_id = list(smartcam_dict.keys())
-    file_path = os.path.join(hass.config.config_dir)
+    directory_path = hass.config.config_dir
     if not os.access(file_path, os.R_OK):
-        _LOGGER.error("file path %s is not readable", file_path)
+        _LOGGER.error("file path %s is not readable", directory_path)
         return False
     for device_id in smartcam_dict:
-        add_devices([VerisureFile(device_id, file_path, smartcam_dict)])
+        add_devices([VerisureFile(device_id, directory_path, smartcam_dict)])
 
 
 # pylint: disable=too-many-instance-attributes
 class VerisureFile(Camera):
     """Local camera."""
 
-    def __init__(self, device_id, file_path, smartcam_dict):
+    def __init__(self, device_id, directory_path, smartcam_dict):
         """Initialize Verisure File Camera component."""
         super().__init__()
 
         self._delete_image = None
-        self._device_id = device_id
-        self._file_path = file_path
-        self._new_image_id = None
-        self._image_id = None
+        self._directory_path = directory_path
         self._image = None
         self._smartcam_dict = smartcam_dict
         self._smartcam_old_dict = {}
-        self._images = []
-        _LOGGER.debug('self._smartcam_dict=%s, self._file_path=%s',
-                      self._smartcam_dict, self._file_path)
+        _LOGGER.debug('self._smartcam_dict=%s, self._directory_path=%s',
+                      self._smartcam_dict, self._directory_path)
 
     def camera_image(self):
         """Return image response."""
@@ -70,42 +64,40 @@ class VerisureFile(Camera):
         if self._smartcam_old_dict == self._smartcam_dict:
             _LOGGER.debug('old and new dict is equal')
             return
-        else:
-            for self._device_id in self._smartcam_dict:
-                self._images = list(self._smartcam_dict.items())
-                self._new_image_id = self._images[0][1][0]
-                _LOGGER.debug('self._device_id=%s, self._images=%s, '
-                              'self._new_image_id=%s', self._device_id,
-                              self._images, self._new_image_id)
-                if self._new_image_id == '-1' or \
-                   self._image_id == self._new_image_id:
-                    _LOGGER.debug('The image is the same, or loading image_id')
-                    return
-                else:
-                    _LOGGER.debug('Download new image %s', self._new_image_id)
-                    hub.my_pages.smartcam.download_image(self._device_id,
-                                                         self._new_image_id,
-                                                         self._file_path)
-                    self._smartcam_old_dict = self._smartcam_dict
-                    if self._image_id:
-                        _LOGGER.debug('self._image_id=%s', self._image_id)
-                        self._delete_image = os.path.join(self._file_path,
-                                                          '{}{}'.format(
-                                                              self._image_id,
-                                                              '.jpg'))
-                        _LOGGER.debug('Deleting %s', self._delete_image)
-                        os.remove(self._delete_image)
-                        self._image_id = self._new_image_id
-                        self._image = os.path.join(self._file_path,
-                                                   '{}{}'.format(
-                                                       self._image_id,
-                                                       '.jpg'))
-                    else:
-                        self._image = os.path.join(self._file_path,
-                                                   '{}{}'.format(
-                                                       self._new_image_id,
-                                                       '.jpg'))
-                        self._image_id = self._new_image_id
+        for self._device_id in self._smartcam_dict:
+            self._images = list(self._smartcam_dict.items())
+            self._new_image_id = self._images[0][1][0]
+            _LOGGER.debug('self._device_id=%s, self._images=%s, '
+                          'self._new_image_id=%s', self._device_id,
+                          self._images, self._new_image_id)
+            if (self._new_image_id == '-1' or
+                self._image_id == self._new_image_id):
+                _LOGGER.debug('The image is the same, or loading image_id')
+                return
+            _LOGGER.debug('Download new image %s', self._new_image_id)
+            hub.my_pages.smartcam.download_image(self._device_id,
+                                                 self._new_image_id,
+                                                 self._directory_path)
+            self._smartcam_old_dict = self._smartcam_dict
+            if self._image_id:
+                _LOGGER.debug('self._image_id=%s', self._image_id)
+                self._delete_image = os.path.join(self._directory_path,
+                                                 '{}{}'.format(
+                                                      self._image_id,
+                                                      '.jpg'))
+                _LOGGER.debug('Deleting %s', self._delete_image)
+                os.remove(self._delete_image)
+                self._image_id = self._new_image_id
+                self._image = os.path.join(self._directory_path,
+                                           '{}{}'.format(
+                                               self._image_id,
+                                               '.jpg'))
+            else:
+                self._image = os.path.join(self._directory_path,
+                                           '{}{}'.format(
+                                              self._new_image_id,
+                                              '.jpg'))
+                self._image_id = self._new_image_id
 
     @Throttle(timedelta(seconds=30))
     def update_imagelist(self):

--- a/homeassistant/components/camera/verisure.py
+++ b/homeassistant/components/camera/verisure.py
@@ -1,0 +1,119 @@
+"""
+Camera that loads a picture from a local file.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/camera.verisure/
+"""
+import logging
+import os
+
+from datetime import timedelta
+from homeassistant.components.camera import Camera
+from homeassistant.components.verisure import HUB as hub
+from homeassistant.components.verisure import CONF_SMARTCAM
+from homeassistant.util import Throttle
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'Verisure File'
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Camera."""
+    if not int(hub.config.get(CONF_SMARTCAM, 1)):
+        return False
+    smartcam_dict = {}
+    _LOGGER.debug('loading initial smartcam dict')
+    smartcam_dict = hub.my_pages.smartcam.get_imagelist()
+    _LOGGER.debug('smartcam_dict=%s', smartcam_dict)
+    if not smartcam_dict:
+        return False
+    device_id = list(smartcam_dict.keys())
+    file_path = os.path.join(hass.config.config_dir)
+    if not os.access(file_path, os.R_OK):
+        _LOGGER.error("file path %s is not readable", file_path)
+        return False
+    for device_id in smartcam_dict:
+        add_devices([VerisureFile(device_id, file_path, smartcam_dict)])
+
+
+# pylint: disable=too-many-instance-attributes
+class VerisureFile(Camera):
+    """Local camera."""
+
+    def __init__(self, device_id, file_path, smartcam_dict):
+        """Initialize Verisure File Camera component."""
+        super().__init__()
+
+        self._delete_image = None
+        self._device_id = device_id
+        self._file_path = file_path
+        self._new_image_id = None
+        self._image_id = None
+        self._image = None
+        self._smartcam_dict = smartcam_dict
+        self._smartcam_old_dict = {}
+        self._images = []
+        _LOGGER.debug('self._smartcam_dict=%s, self._file_path=%s',
+                      self._smartcam_dict, self._file_path)
+
+    def camera_image(self):
+        """Return image response."""
+        self.check_imagelist()
+        _LOGGER.debug('trying to open %s', self._image)
+        with open(self._image, 'rb') as file:
+            return file.read()
+
+    def check_imagelist(self):
+        """Check the contents of the image list."""
+        self.update_imagelist()
+        if self._smartcam_old_dict == self._smartcam_dict:
+            _LOGGER.debug('old and new dict is equal')
+            return
+        else:
+            for self._device_id in self._smartcam_dict:
+                self._images = list(self._smartcam_dict.items())
+                self._new_image_id = self._images[0][1][0]
+                _LOGGER.debug('self._device_id=%s, self._images=%s, '
+                              'self._new_image_id=%s', self._device_id,
+                              self._images, self._new_image_id)
+                if self._new_image_id == '-1' or \
+                   self._image_id == self._new_image_id:
+                    _LOGGER.debug('The image is the same, or loading image_id')
+                    return
+                else:
+                    _LOGGER.debug('Download new image %s', self._new_image_id)
+                    hub.my_pages.smartcam.download_image(self._device_id,
+                                                         self._new_image_id,
+                                                         self._file_path)
+                    self._smartcam_old_dict = self._smartcam_dict
+                    if self._image_id:
+                        _LOGGER.debug('self._image_id=%s', self._image_id)
+                        self._delete_image = os.path.join(self._file_path,
+                                                          '{}{}'.format(
+                                                              self._image_id,
+                                                              '.jpg'))
+                        _LOGGER.debug('Deleting %s', self._delete_image)
+                        os.remove(self._delete_image)
+                        self._image_id = self._new_image_id
+                        self._image = os.path.join(self._file_path,
+                                                   '{}{}'.format(
+                                                       self._image_id,
+                                                       '.jpg'))
+                    else:
+                        self._image = os.path.join(self._file_path,
+                                                   '{}{}'.format(
+                                                       self._new_image_id,
+                                                       '.jpg'))
+                        self._image_id = self._new_image_id
+
+    @Throttle(timedelta(seconds=30))
+    def update_imagelist(self):
+        """Update the imagelist for the camera."""
+        _LOGGER.debug('Running update imagelist')
+        self._smartcam_dict = hub.my_pages.smartcam.get_imagelist()
+
+    @property
+    def name(self):
+        """Return the name of this camera."""
+        return self._device_id

--- a/homeassistant/components/camera/verisure.py
+++ b/homeassistant/components/camera/verisure.py
@@ -20,36 +20,31 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Camera."""
     if not int(hub.config.get(CONF_SMARTCAM, 1)):
         return False
-    smartcam_dict = {}
-    _LOGGER.debug('loading initial smartcam dict')
-    smartcam_dict = hub.my_pages.smartcam.get_imagelist()
-    _LOGGER.debug('smartcam_dict=%s', smartcam_dict)
-    if not smartcam_dict:
-        return False
-    device_id = list(smartcam_dict.keys())
     directory_path = hass.config.config_dir
-    if not os.access(file_path, os.R_OK):
+    if not os.access(directory_path, os.R_OK):
         _LOGGER.error("file path %s is not readable", directory_path)
         return False
-    for device_id in smartcam_dict:
-        add_devices([VerisureFile(device_id, directory_path, smartcam_dict)])
+    hub.update_smartcam()
+    smartcams = []
+    smartcams.extend([
+        VerisureSmartcam(value.deviceLabel, directory_path)
+        for value in hub.smartcam_status.values()])
+    add_devices(smartcams)
 
 
-# pylint: disable=too-many-instance-attributes
-class VerisureFile(Camera):
+class VerisureSmartcam(Camera):
     """Local camera."""
 
-    def __init__(self, device_id, directory_path, smartcam_dict):
+    def __init__(self, device_id, directory_path):
         """Initialize Verisure File Camera component."""
         super().__init__()
 
         self._delete_image = None
+        self._device_id = device_id
         self._directory_path = directory_path
         self._image = None
-        self._smartcam_dict = smartcam_dict
-        self._smartcam_old_dict = {}
-        _LOGGER.debug('self._smartcam_dict=%s, self._directory_path=%s',
-                      self._smartcam_dict, self._directory_path)
+        self._image_id = None
+        self._smartcam_dict = {}
 
     def camera_image(self):
         """Return image response."""
@@ -60,52 +55,51 @@ class VerisureFile(Camera):
 
     def check_imagelist(self):
         """Check the contents of the image list."""
-        self.update_imagelist()
-        if self._smartcam_old_dict == self._smartcam_dict:
-            _LOGGER.debug('old and new dict is equal')
+        if not self.update_imagelist():
             return
-        for self._device_id in self._smartcam_dict:
-            self._images = list(self._smartcam_dict.items())
-            self._new_image_id = self._images[0][1][0]
-            _LOGGER.debug('self._device_id=%s, self._images=%s, '
-                          'self._new_image_id=%s', self._device_id,
-                          self._images, self._new_image_id)
-            if (self._new_image_id == '-1' or
-                self._image_id == self._new_image_id):
-                _LOGGER.debug('The image is the same, or loading image_id')
-                return
-            _LOGGER.debug('Download new image %s', self._new_image_id)
-            hub.my_pages.smartcam.download_image(self._device_id,
-                                                 self._new_image_id,
-                                                 self._directory_path)
-            self._smartcam_old_dict = self._smartcam_dict
-            if self._image_id:
-                _LOGGER.debug('self._image_id=%s', self._image_id)
-                self._delete_image = os.path.join(self._directory_path,
-                                                 '{}{}'.format(
-                                                      self._image_id,
-                                                      '.jpg'))
-                _LOGGER.debug('Deleting %s', self._delete_image)
-                os.remove(self._delete_image)
-                self._image_id = self._new_image_id
-                self._image = os.path.join(self._directory_path,
-                                           '{}{}'.format(
-                                               self._image_id,
-                                               '.jpg'))
-            else:
-                self._image = os.path.join(self._directory_path,
-                                           '{}{}'.format(
-                                              self._new_image_id,
-                                              '.jpg'))
-                self._image_id = self._new_image_id
+
+        images = self._smartcam_dict[self._device_id]
+        new_image_id = images[0]
+        _LOGGER.debug('self._device_id=%s, self._images=%s, '
+                      'self._new_image_id=%s', self._device_id,
+                      images, new_image_id)
+        if (new_image_id == '-1' or
+                self._image_id == new_image_id):
+            _LOGGER.debug('The image is the same, or loading image_id')
+            return
+        _LOGGER.debug('Download new image %s', new_image_id)
+        hub.my_pages.smartcam.download_image(self._device_id,
+                                             new_image_id,
+                                             self._directory_path)
+        if self._image_id:
+            _LOGGER.debug('Old image_id=%s', self._image_id)
+            delete_image = os.path.join(self._directory_path,
+                                        '{}{}'.format(
+                                            self._image_id,
+                                            '.jpg'))
+            _LOGGER.debug('Deleting old image %s', delete_image)
+            os.remove(delete_image)
+            self._image_id = new_image_id
+            self._image = os.path.join(self._directory_path,
+                                       '{}{}'.format(
+                                           self._image_id,
+                                           '.jpg'))
+        else:
+            _LOGGER.debug('No old image, only new %s', new_image_id)
+            self._image = os.path.join(self._directory_path,
+                                       '{}{}'.format(
+                                           new_image_id,
+                                           '.jpg'))
+            self._image_id = new_image_id
 
     @Throttle(timedelta(seconds=30))
     def update_imagelist(self):
         """Update the imagelist for the camera."""
         _LOGGER.debug('Running update imagelist')
         self._smartcam_dict = hub.my_pages.smartcam.get_imagelist()
+        return True
 
     @property
     def name(self):
         """Return the name of this camera."""
-        return self._device_id
+        return hub.smartcam_status[self._device_id].location

--- a/homeassistant/components/camera/verisure.py
+++ b/homeassistant/components/camera/verisure.py
@@ -58,11 +58,8 @@ class VerisureSmartcam(Camera):
     def check_imagelist(self):
         """Check the contents of the image list."""
         hub.update_smartcam_imagelist()
-        try:
-            if (self._device_id not in hub.smartcam_dict or
-                    not hub.smartcam_dict[self._device_id]):
-                return
-        except KeyError:
+        if (self._device_id not in hub.smartcam_dict or
+             not hub.smartcam_dict[self._device_id]):
             return
         images = hub.smartcam_dict[self._device_id]
         new_image_id = images[0]

--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -149,7 +149,7 @@ class VerisureHub(object):
         """Update the imagelist for the camera."""
         _LOGGER.debug('Running update imagelist')
         self.smartcam_dict = self.my_pages.smartcam.get_imagelist()
-        return self.smartcam_dict
+        _LOGGER.debug('New dict: %s', self.smartcam_dict)
 
     @property
     def available(self):

--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -27,7 +27,7 @@ CONF_LOCKS = 'locks'
 CONF_MOUSE = 'mouse'
 CONF_SMARTPLUGS = 'smartplugs'
 CONF_THERMOMETERS = 'thermometers'
-
+CONF_SMARTCAM = 'smartcam'
 DOMAIN = 'verisure'
 
 HUB = None
@@ -43,6 +43,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_MOUSE, default=True): cv.boolean,
         vol.Optional(CONF_SMARTPLUGS, default=True): cv.boolean,
         vol.Optional(CONF_THERMOMETERS, default=True): cv.boolean,
+        vol.Optional(CONF_SMARTCAM, default=True): cv.boolean,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -55,7 +56,8 @@ def setup(hass, config):
     if not HUB.login():
         return False
 
-    for component in ('sensor', 'switch', 'alarm_control_panel', 'lock'):
+    for component in ('sensor', 'switch', 'alarm_control_panel', 'lock',
+                      'camera'):
         discovery.load_platform(hass, component, DOMAIN, {}, config)
 
     return True

--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -75,6 +75,7 @@ class VerisureHub(object):
         self.mouse_status = {}
         self.smartplug_status = {}
         self.smartcam_status = {}
+        self.smartcam_dict = {}
 
         self.config = domain_config
         self._verisure = verisure
@@ -142,6 +143,13 @@ class VerisureHub(object):
         self.update_component(
             self.my_pages.smartcam.get,
             self.smartcam_status)
+
+    @Throttle(timedelta(seconds=30))
+    def update_smartcam_imagelist(self):
+        """Update the imagelist for the camera."""
+        _LOGGER.debug('Running update imagelist')
+        self.smartcam_dict = self.my_pages.smartcam.get_imagelist()
+        return self.smartcam_dict
 
     @property
     def available(self):

--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -74,6 +74,7 @@ class VerisureHub(object):
         self.climate_status = {}
         self.mouse_status = {}
         self.smartplug_status = {}
+        self.smartcam_status = {}
 
         self.config = domain_config
         self._verisure = verisure
@@ -134,6 +135,13 @@ class VerisureHub(object):
         self.update_component(
             self.my_pages.smartplug.get,
             self.smartplug_status)
+
+    @Throttle(timedelta(seconds=30))
+    def update_smartcam(self):
+        """Update the status of the smartcam."""
+        self.update_component(
+            self.my_pages.smartcam.get,
+            self.smartcam_status)
 
     @property
     def available(self):


### PR DESCRIPTION
**Description:**
This adds support for Verisure file camera.
This is a so called SmartCam providing still images to the user from within your home.
This platform will download a list of available images, and compare to the last known list, and display the newest. It automatically deletes the old image if a new is downloaded.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
verisure:
  username:
  password:
  smartcam: True
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
