### PR TITLE
Work better with password-protected Squeezebox / LMS servers

### DIFF
--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/media_player.squeezebox/
 import logging
 import telnetlib
 import urllib.parse
-import socket
 
 import voluptuous as vol
 
@@ -41,6 +40,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the squeezebox platform."""
+    import socket
+    
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/media_player.squeezebox/
 import logging
 import telnetlib
 import urllib.parse
+import socket
 
 import voluptuous as vol
 
@@ -50,11 +51,22 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         host = config.get(CONF_HOST)
         port = config.get(CONF_PORT)
 
-    # Only add a media server once
-    if host in KNOWN_DEVICES:
-        return False
-    KNOWN_DEVICES.append(host)
+    # Get IP of host, to prevent duplication of same host (different DNS names)
+    try:
+        ip = socket.gethostbyname(host)
+    except (OSError) as error:
+      _LOGGER.error("Could not communicate with %s:%d: %s", host, port, error)
+      return False
 
+    # Combine it with port to allow multiple servers at the same host
+    key = "{}:{}".format(ip, port)
+
+    # Only add a media server once
+    if key in KNOWN_DEVICES:
+        return False
+    KNOWN_DEVICES.append(key)
+
+    _LOGGER.debug("Creating LMS object for %s", key)
     lms = LogitechMediaServer(host, port, username, password)
 
     if not lms.init_success:
@@ -97,27 +109,9 @@ class LogitechMediaServer(object):
 
     def query(self, *parameters):
         """Send request and await response from server."""
-        try:
-            telnet = telnetlib.Telnet(self.host, self.port)
-            if self._username and self._password:
-                telnet.write('login {username} {password}\n'.format(
-                    username=self._username,
-                    password=self._password).encode('UTF-8'))
-                telnet.read_until(b'\n', timeout=3)
-            message = '{}\n'.format(' '.join(parameters))
-            telnet.write(message.encode('UTF-8'))
-            response = telnet.read_until(b'\n', timeout=3)\
-                             .decode('UTF-8')\
-                             .split(' ')[-1]\
-                             .strip()
-            telnet.write(b'exit\n')
-            return urllib.parse.unquote(response)
-        except (OSError, ConnectionError) as error:
-            _LOGGER.error("Could not communicate with %s:%d: %s",
-                          self.host,
-                          self.port,
-                          error)
-            return None
+        response = urllib.parse.unquote(self.get(' '.join(parameters)))
+
+        return response.split(' ')[-1].strip()
 
     def get_player_status(self, player):
         """Get ithe status of a player."""
@@ -129,26 +123,50 @@ class LogitechMediaServer(object):
         # l (album): Album, including the server's  "(N of M)"
         tags = 'adKl'
         new_status = {}
+        response = self.get('{player} status - 1 tags:{tags}\n'.format(player=player, tags=tags))
+
+        if not response:
+            return {}
+
+        response = response.split(' ')
+
+        for item in response:
+            parts = urllib.parse.unquote(item).partition(':')
+            new_status[parts[0]] = parts[2]
+        return new_status
+
+    def get(self, command):
+        """Abstracts out the telnet connection."""
         try:
             telnet = telnetlib.Telnet(self.host, self.port)
-            telnet.write('{player} status - 1 tags:{tags}\n'.format(
-                player=player,
-                tags=tags
-            ).encode('UTF-8'))
+
+            if self._username and self._password:
+                _LOGGER.debug("Logging in")
+
+                telnet.write('login {username} {password}\n'.format(
+                    username=self._username,
+                    password=self._password).encode('UTF-8'))
+                telnet.read_until(b'\n', timeout=3)
+
+            _LOGGER.debug("About to send message: %s", command)
+            message = '{}\n'.format(command)
+            telnet.write(message.encode('UTF-8'))
+
             response = telnet.read_until(b'\n', timeout=3)\
                              .decode('UTF-8')\
-                             .split(' ')
+
+            #response = urllib.parse.unquote(response)
             telnet.write(b'exit\n')
-            for item in response:
-                parts = urllib.parse.unquote(item).partition(':')
-                new_status[parts[0]] = parts[2]
-        except (OSError, ConnectionError) as error:
+            _LOGGER.debug("Response: %s", response)
+
+            return response
+
+        except (OSError, ConnectionError, EOFError) as error:
             _LOGGER.error("Could not communicate with %s:%d: %s",
                           self.host,
                           self.port,
                           error)
-        return new_status
-
+            return None
 
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-public-methods
@@ -228,11 +246,21 @@ class SqueezeBoxDevice(MediaPlayerDevice):
             media_url = ('/music/current/cover.jpg?player={player}').format(
                 player=self._id)
 
-        base_url = 'http://{server}:{port}/'.format(
-            server=self._lms.host,
-            port=self._lms.http_port)
+        if self._lms._username:
+            base_url = 'http://{username}:{password}@{server}:{port}/'.format(
+                username=self._lms._username,
+                password=self._lms._password,
+                server=self._lms.host,
+                port=self._lms.http_port)
+        else:
+            base_url = 'http://{server}:{port}/'.format(
+                server=self._lms.host,
+                port=self._lms.http_port)
 
-        return urllib.parse.urljoin(base_url, media_url)
+        url = urllib.parse.urljoin(base_url, media_url)
+
+        _LOGGER.debug("Media image url: %s", url)
+        return url
 
     @property
     def media_title(self):
@@ -337,7 +365,7 @@ class SqueezeBoxDevice(MediaPlayerDevice):
         """
         Replace the current play list with the uri.
 
-        Telnet Command Strucutre:
+        Telnet Command Structure:
         <playerid> playlist play <item> <title> <fadeInSecs>
 
         The "playlist play" command puts the specified song URL,
@@ -361,7 +389,7 @@ class SqueezeBoxDevice(MediaPlayerDevice):
         """
         Add a items to the existing playlist.
 
-        Telnet Command Strucutre:
+        Telnet Command Structure:
         <playerid> playlist add <item>
 
         The "playlist add" command adds the specified song URL, playlist or

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -247,8 +247,8 @@ class SqueezeBoxDevice(MediaPlayerDevice):
             media_url = ('/music/current/cover.jpg?player={player}').format(
                 player=self._id)
 
+        # pylint: disable=protected-access
         if self._lms._username:
-            # pylint: disable=protected-access
             base_url = 'http://{username}:{password}@{server}:{port}/'.format(
                 username=self._lms._username,
                 password=self._lms._password,

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -55,8 +55,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         ip = socket.gethostbyname(host)
     except (OSError) as error:
-      _LOGGER.error("Could not communicate with %s:%d: %s", host, port, error)
-      return False
+        _LOGGER.error("Could not communicate with %s:%d: %s", host, port, error)
+        return False
 
     # Combine it with port to allow multiple servers at the same host
     key = "{}:{}".format(ip, port)
@@ -114,7 +114,7 @@ class LogitechMediaServer(object):
         return response.split(' ')[-1].strip()
 
     def get_player_status(self, player):
-        """Get ithe status of a player."""
+        """Get the status of a player."""
         #   (title) : Song title
         # Requested Information
         # a (artist): Artist name 'artist'
@@ -123,7 +123,8 @@ class LogitechMediaServer(object):
         # l (album): Album, including the server's  "(N of M)"
         tags = 'adKl'
         new_status = {}
-        response = self.get('{player} status - 1 tags:{tags}\n'.format(player=player, tags=tags))
+        response = self.get('{player} status - 1 tags:{tags}\n'
+                            .format(player=player, tags=tags))
 
         if not response:
             return {}
@@ -136,7 +137,7 @@ class LogitechMediaServer(object):
         return new_status
 
     def get(self, command):
-        """Abstracts out the telnet connection."""
+        """Abstract out the telnet connection."""
         try:
             telnet = telnetlib.Telnet(self.host, self.port)
 
@@ -155,7 +156,6 @@ class LogitechMediaServer(object):
             response = telnet.read_until(b'\n', timeout=3)\
                              .decode('UTF-8')\
 
-            #response = urllib.parse.unquote(response)
             telnet.write(b'exit\n')
             _LOGGER.debug("Response: %s", response)
 

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -41,7 +41,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the squeezebox platform."""
     import socket
-    
+
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
@@ -54,13 +54,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     # Get IP of host, to prevent duplication of same host (different DNS names)
     try:
-        ip = socket.gethostbyname(host)
+        ipaddr = socket.gethostbyname(host)
     except (OSError) as error:
         _LOGGER.error("Could not communicate with %s:%d: %s", host, port, error)
         return False
 
     # Combine it with port to allow multiple servers at the same host
-    key = "{}:{}".format(ip, port)
+    key = "{}:{}".format(ipaddr, port)
 
     # Only add a media server once
     if key in KNOWN_DEVICES:
@@ -248,6 +248,7 @@ class SqueezeBoxDevice(MediaPlayerDevice):
                 player=self._id)
 
         if self._lms._username:
+            # pylint: disable=protected-access
             base_url = 'http://{username}:{password}@{server}:{port}/'.format(
                 username=self._lms._username,
                 password=self._lms._password,

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -56,7 +56,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         ipaddr = socket.gethostbyname(host)
     except (OSError) as error:
-        _LOGGER.error("Could not communicate with %s:%d: %s", host, port, error)
+        _LOGGER.error("Could not communicate with %s:%d: %s",
+                      host, port, error)
         return False
 
     # Combine it with port to allow multiple servers at the same host
@@ -168,6 +169,7 @@ class LogitechMediaServer(object):
                           self.port,
                           error)
             return None
+
 
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-public-methods


### PR DESCRIPTION
**Description:**
Improve connecting to Squeezebox / Logitech Media Servers that have a username and password. Previously status was not working. Also generates URL with basic auth to get file art. Refactored to only have a single method calling the telent lib. (Should make it easier to convert to the more appropriate JSON interface)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
