### PR TITLE
Add Bbox Router bandwidth as sensors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -226,6 +226,7 @@ omit =
     homeassistant/components/scene/hunterdouglas_powerview.py
     homeassistant/components/sensor/arest.py
     homeassistant/components/sensor/arwn.py
+    homeassistant/components/sensor/bbox.py
     homeassistant/components/sensor/bitcoin.py
     homeassistant/components/sensor/bom.py
     homeassistant/components/sensor/coinmarketcap.py

--- a/homeassistant/components/sensor/bbox.py
+++ b/homeassistant/components/sensor/bbox.py
@@ -1,0 +1,144 @@
+"""
+Support for Bbox Bouygues Modem Routeur.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.bbox/
+"""
+import logging
+from datetime import timedelta
+import requests
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (BANDWIDTH_MEGABITS_SECONDS, CONF_NAME,
+                                 CONF_MONITORED_VARIABLES, ATTR_ATTRIBUTION)
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
+
+# Return cached results if last scan was less then this time ago
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
+
+REQUIREMENTS = ['pybbox==0.0.5-alpha']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ATTRIBUTION = "Powered by Bouygues Telecom"
+DEFAULT_NAME = 'Bbox'
+
+# Sensor types are defined like so:
+# Name, unit, icon
+SENSOR_TYPES = {
+    'down_max_bandwidth': ['Maximum Download Bandwidth',
+                           BANDWIDTH_MEGABITS_SECONDS, 'mdi:download'],
+    'up_max_bandwidth': ['Maximum Upload Bandwidth',
+                         BANDWIDTH_MEGABITS_SECONDS, 'mdi:upload'],
+    'current_down_bandwidth': ['Currently Used Download Bandwidth',
+                               BANDWIDTH_MEGABITS_SECONDS, 'mdi:download'],
+    'current_up_bandwidth': ['Currently Used Upload Bandwidth',
+                             BANDWIDTH_MEGABITS_SECONDS, 'mdi:upload'],
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_MONITORED_VARIABLES):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+# pylint: disable=too-many-arguments
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Bbox sensor."""
+    # Create a data fetcher to support all of the configured sensors. Then make
+    # the first call to init the data.
+    try:
+        bbox_data = BboxData()
+        bbox_data.update()
+    except requests.exceptions.HTTPError as error:
+        _LOGGER.error(error)
+        return False
+
+    name = config.get(CONF_NAME)
+
+    sensors = []
+    for variable in config[CONF_MONITORED_VARIABLES]:
+        sensors.append(BboxSensor(bbox_data, variable, name))
+
+    add_devices(sensors)
+
+
+class BboxSensor(Entity):
+    """Implementation of a Bbox sensor."""
+
+    def __init__(self, bbox_data, sensor_type, name):
+        """Initialize the sensor."""
+        self.client_name = name
+        self.type = sensor_type
+        self._name = SENSOR_TYPES[sensor_type][0]
+        self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+        self._icon = SENSOR_TYPES[sensor_type][2]
+        self.bbox_data = bbox_data
+        self._state = None
+
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{} {}'.format(self.client_name, self._name)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return round(self._state, 2)
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._unit_of_measurement
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+        }
+
+    def update(self):
+        """Get the latest data from Bbox and update the state."""
+        self.bbox_data.update()
+        if self.type == 'down_max_bandwidth':
+            self._state = self.bbox_data.data['rx']['maxBandwidth'] / 1000
+        elif self.type == 'up_max_bandwidth':
+            self._state = self.bbox_data.data['tx']['maxBandwidth'] / 1000
+        elif self.type == 'current_down_bandwidth':
+            self._state = self.bbox_data.data['rx']['bandwidth'] / 1000
+        elif self.type == 'current_up_bandwidth':
+            self._state = self.bbox_data.data['tx']['bandwidth'] / 1000
+
+
+# pylint: disable=too-few-public-methods
+class BboxData(object):
+    """Get data from the Bbox."""
+
+    def __init__(self):
+        """Initialize the data object."""
+        self.data = None
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Get the latest data from the Bbox."""
+        import pybbox
+
+        try:
+            box = pybbox.Bbox()
+            self.data = box.get_ip_stats()
+        except requests.exceptions.HTTPError as error:
+            _LOGGER.error(error)
+            self.data = None
+            return False

--- a/homeassistant/components/sensor/bbox.py
+++ b/homeassistant/components/sensor/bbox.py
@@ -1,5 +1,5 @@
 """
-Support for Bbox Bouygues Modem Routeur.
+Support for Bbox Bouygues Modem Router.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.bbox/
@@ -10,8 +10,8 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (BANDWIDTH_MEGABITS_SECONDS, CONF_NAME,
-                                 CONF_MONITORED_VARIABLES, ATTR_ATTRIBUTION)
+from homeassistant.const import (CONF_NAME, CONF_MONITORED_VARIABLES,
+                                 ATTR_ATTRIBUTION)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
@@ -25,6 +25,9 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_ATTRIBUTION = "Powered by Bouygues Telecom"
 DEFAULT_NAME = 'Bbox'
+
+# Bandwidth units
+BANDWIDTH_MEGABITS_SECONDS = 'Mb/s'  # type: str
 
 # Sensor types are defined like so:
 # Name, unit, icon
@@ -113,13 +116,17 @@ class BboxSensor(Entity):
         """Get the latest data from Bbox and update the state."""
         self.bbox_data.update()
         if self.type == 'down_max_bandwidth':
-            self._state = self.bbox_data.data['rx']['maxBandwidth'] / 1000
+            self._state = round(
+                self.bbox_data.data['rx']['maxBandwidth'] / 1000, 2)
         elif self.type == 'up_max_bandwidth':
-            self._state = self.bbox_data.data['tx']['maxBandwidth'] / 1000
+            self._state = round(
+                self.bbox_data.data['tx']['maxBandwidth'] / 1000, 2)
         elif self.type == 'current_down_bandwidth':
-            self._state = self.bbox_data.data['rx']['bandwidth'] / 1000
+            self._state = round(self.bbox_data.data['rx']['bandwidth'] / 1000,
+                                2)
         elif self.type == 'current_up_bandwidth':
-            self._state = self.bbox_data.data['tx']['bandwidth'] / 1000
+            self._state = round(self.bbox_data.data['tx']['bandwidth'] / 1000,
+                                2)
 
 
 # pylint: disable=too-few-public-methods

--- a/homeassistant/components/sensor/bbox.py
+++ b/homeassistant/components/sensor/bbox.py
@@ -93,7 +93,7 @@ class BboxSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return round(self._state, 2)
+        return self._state
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -228,6 +228,10 @@ VOLUME_MILLILITERS = 'mL'  # type: str
 VOLUME_GALLONS = 'gal'  # type: str
 VOLUME_FLUID_OUNCE = 'fl. oz.'  # type: str
 
+# Bandwidth units
+BANDWIDTH_MEGABITS_SECONDS = 'Mbps'  # type: str
+BANDWIDTH_GIGABITS_SECONDS = 'Gbps'  # type: str
+
 # Mass units
 MASS_GRAMS = 'g'  # type: str
 MASS_KILOGRAMS = 'kg'  # type: str
@@ -385,3 +389,4 @@ VOLUME = 'volume'  # type: str
 TEMPERATURE = 'temperature'  # type: str
 SPEED_MS = 'speed_ms'  # type: str
 ILLUMINANCE = 'illuminance'  # type: str
+BANDWIDTH = 'bandwidth'  # type: str

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -228,10 +228,6 @@ VOLUME_MILLILITERS = 'mL'  # type: str
 VOLUME_GALLONS = 'gal'  # type: str
 VOLUME_FLUID_OUNCE = 'fl. oz.'  # type: str
 
-# Bandwidth units
-BANDWIDTH_MEGABITS_SECONDS = 'Mbps'  # type: str
-BANDWIDTH_GIGABITS_SECONDS = 'Gbps'  # type: str
-
 # Mass units
 MASS_GRAMS = 'g'  # type: str
 MASS_KILOGRAMS = 'kg'  # type: str
@@ -389,4 +385,3 @@ VOLUME = 'volume'  # type: str
 TEMPERATURE = 'temperature'  # type: str
 SPEED_MS = 'speed_ms'  # type: str
 ILLUMINANCE = 'illuminance'  # type: str
-BANDWIDTH = 'bandwidth'  # type: str

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -333,6 +333,7 @@ pyasn1-modules==0.0.8
 pyasn1==0.1.9
 
 # homeassistant.components.device_tracker.bbox
+# homeassistant.components.sensor.bbox
 pybbox==0.0.5-alpha
 
 # homeassistant.components.device_tracker.bluetooth_tracker


### PR DESCRIPTION
**Description:**
Add possibility to monitor max and currently used bandwidth of your xdsl connection for Bbox Routeur

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1292
**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: bbox
    monitored_variables:
      - down_max_bandwidth
      - up_max_bandwidth
      - current_down_bandwidth
      - current_up_bandwidth
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
