### PR TITLE
Device tracker: SNMPv3

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -49,6 +49,7 @@ def get_scanner(hass, config):
 class SnmpScanner(object):
     """Queries any SNMP capable Access Point for connected devices."""
 
+    # pylint: disable=too-many-instance-attributes
     def __init__(self, config):
         """Initialize the scanner."""
         from pysnmp.entity.rfc3413.oneliner import cmdgen

--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -61,10 +61,13 @@ class SnmpScanner(object):
             self.community = cmdgen.CommunityData(config[CONF_COMMUNITY])
         else:
             self.version = 3
-            self.userdata = cmdgen.UsmUserData(config[CONF_COMMUNITY],
-                config[CONF_AUTHKEY], config[CONF_PRIVKEY],
+            self.userdata = cmdgen.UsmUserData(
+                config[CONF_COMMUNITY],
+                config[CONF_AUTHKEY],
+                config[CONF_PRIVKEY],
                 authProtocol=cfg.usmHMACSHAAuthProtocol,
-                privProtocol=cfg.usmAesCfb128Protocol)
+                privProtocol=cfg.usmAesCfb128Protocol
+            )
         self.baseoid = cmdgen.MibVariable(config[CONF_BASEOID])
 
         self.lock = threading.Lock()

--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -57,14 +57,14 @@ class SnmpScanner(object):
 
         self.host = cmdgen.UdpTransportTarget((config[CONF_HOST], 161))
         if config[CONF_AUTHKEY] is None or config[CONF_PRIVKEY] is None:
-          self.version = 1
-          self.community = cmdgen.CommunityData(config[CONF_COMMUNITY])
+            self.version = 1
+            self.community = cmdgen.CommunityData(config[CONF_COMMUNITY])
         else:
-          self.version = 3
-          self.userdata = cmdgen.UsmUserData(config[CONF_COMMUNITY],
-              config[CONF_AUTHKEY], config[CONF_PRIVKEY],
-              authProtocol=cfg.usmHMACSHAAuthProtocol, 
-              privProtocol=cfg.usmAesCfb128Protocol)
+            self.version = 3
+            self.userdata = cmdgen.UsmUserData(config[CONF_COMMUNITY],
+                config[CONF_AUTHKEY], config[CONF_PRIVKEY],
+                authProtocol=cfg.usmHMACSHAAuthProtocol,
+                privProtocol=cfg.usmAesCfb128Protocol)
         self.baseoid = cmdgen.MibVariable(config[CONF_BASEOID])
 
         self.lock = threading.Lock()
@@ -110,11 +110,11 @@ class SnmpScanner(object):
         devices = []
 
         if self.version == 3:
-          errindication, errstatus, errindex, restable = self.snmp.nextCmd(
-              self.userdata, self.host, self.baseoid)
+            errindication, errstatus, errindex, restable = self.snmp.nextCmd(
+                self.userdata, self.host, self.baseoid)
         else:
-          errindication, errstatus, errindex, restable = self.snmp.nextCmd(
-              self.community, self.host, self.baseoid)
+            errindication, errstatus, errindex, restable = self.snmp.nextCmd(
+                self.community, self.host, self.baseoid)
 
         if errindication:
             _LOGGER.error("SNMPLIB error: %s", errindication)


### PR DESCRIPTION
**Description:**
Original SNMP device tracker only supported SNMPv1 where security is non-existent. This PR adds support for SNMPv3 with authorization using SHA and privacy using AES. 

Functionality was tested using Mikrotik router. Component tries to use SNMPv3 if both authkey (key for authentication) and privkey (key for encrypting data) are provided. Otherwise it will revert back to older SNMP version and use only community-string.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
device_tracker:
  - platform: snmp
    host: 192.168.0.1
    community: "community"
    authkey: "pass1234"
    privkey: "pass1234"
    baseoid: 1.3.6.1.2.1.4.22.1.2
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.
