### PR TITLE
fritz: Only report a MAC address if it's really there.

### DIFF
--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -79,7 +79,7 @@ class FritzBoxScanner(object):
         self._update_info()
         active_hosts = []
         for known_host in self.last_results:
-            if known_host['status'] == '1':
+            if known_host['status'] == '1' and known_host.get('mac'):
                 active_hosts.append(known_host['mac'])
         return active_hosts
 


### PR DESCRIPTION
**Description:**
The fritz device_tracker may return `None` as a MAC address, which leads to the following exception:

```
16-10-20 18:59:00 homeassistant.core: BusHandler:Exception doing job
Traceback (most recent call last):
  File "/srv/hass/hass_venv/lib/python3.4/site-packages/homeassistant/core.py", line 1224, in job_handler
    func(*args)
  File "/srv/hass/hass_venv/lib/python3.4/site-packages/homeassistant/components/device_tracker/__init__.py", line 447, in device_tracker_scan
    see_device(mac=mac, host_name=host_name)
  File "/srv/hass/hass_venv/lib/python3.4/site-packages/homeassistant/components/device_tracker/__init__.py", line 216, in see
    raise HomeAssistantError('Neither mac or device id passed in')
homeassistant.exceptions.HomeAssistantError: Neither mac or device id passed in
```

The issue is that the code only checks for `status` being `1` and then assumes that the device is present and has a MAC address.
BUT: This may not be true. The fritz!box supports inbound VPN connections and reports these devices as normal, since they have an IP address and are part of the network, but without MAC address.

The fix is simple: Also check if the `mac` key is filled.

Note: This will suppress VPN devices from the presence detection, but well, they're not really present, are they? A more complete solution one day might be reporting them as being present in a different zone than Home.

**Related issue (if applicable):** I'm guessing, https://gitter.im/home-assistant/home-assistant?at=5677d300b5777fb85ba4eaae is the same issue. Obviously you'd need to have an (active) inbound VPN connection to test it.
