### PR TITLE
Adding the ability to store icons in known_devices.yaml instead of in…

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -291,6 +291,7 @@ class Device(Entity):
     def __init__(self, hass: HomeAssistantType, consider_home: timedelta,
                  track: bool, dev_id: str, mac: str, name: str=None,
                  picture: str=None, gravatar: str=None,
+                 icon: str=None,
                  hide_if_away: bool=False) -> None:
         """Initialize a device."""
         self.hass = hass
@@ -316,6 +317,9 @@ class Device(Entity):
         else:
             self.config_picture = picture
 
+        # Configured icon
+        self._icon = icon
+
         self.away_hide = hide_if_away
 
     @property
@@ -327,6 +331,11 @@ class Device(Entity):
     def state(self):
         """Return the state of the device."""
         return self._state
+
+    @property
+    def icon(self):
+        """Return the picture of the device."""
+        return self._icon
 
     @property
     def entity_picture(self):
@@ -415,6 +424,7 @@ def load_config(path: str, hass: HomeAssistantType, consider_home: timedelta):
         vol.Optional(CONF_AWAY_HIDE, default=DEFAULT_AWAY_HIDE): cv.boolean,
         vol.Optional('gravatar', default=None): vol.Any(None, cv.string),
         vol.Optional('picture', default=None): vol.Any(None, cv.string),
+        vol.Optional('icon', default=None): vol.Any(None, cv.icon),
         vol.Optional(CONF_CONSIDER_HOME, default=consider_home): vol.All(
             cv.time_period, cv.positive_timedelta)
     })

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -291,8 +291,7 @@ class Device(Entity):
     def __init__(self, hass: HomeAssistantType, consider_home: timedelta,
                  track: bool, dev_id: str, mac: str, name: str=None,
                  picture: str=None, gravatar: str=None,
-                 icon: str=None,
-                 hide_if_away: bool=False) -> None:
+                 icon: str=None, hide_if_away: bool=False) -> None:
         """Initialize a device."""
         self.hass = hass
         self.entity_id = ENTITY_ID_FORMAT.format(dev_id)


### PR DESCRIPTION
**Description:**
Updates the base device_tracker class to read the ICON from the known_devices.yaml instead of the customize.  Keeps all the data items together.

**Related issue (if applicable):** fixes #1237 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1291

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
