### PR TITLE
Config validation error line numbers

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -430,9 +430,10 @@ def log_exception(ex, domain, config, hass=None):
     else:
         message += '{}.'.format(humanize_error(config, ex))
 
-    if hasattr(config, '__line__'):
+    domain_config = config.get(domain, config)
+    if hasattr(domain_config, '__line__'):
         message += " (See {}:{})".format(
-            config.__config_file__, config.__line__ or '?')
+            domain_config.__config_file__, domain_config.__line__ or '?')
 
     if domain != 'homeassistant':
         message += (' Please check the docs at '

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -431,9 +431,9 @@ def log_exception(ex, domain, config, hass=None):
         message += '{}.'.format(humanize_error(config, ex))
 
     domain_config = config.get(domain, config)
-    if hasattr(domain_config, '__line__'):
-        message += " (See {}:{})".format(
-            domain_config.__config_file__, domain_config.__line__ or '?')
+    message += " (See {}:{})".format(
+        getattr(domain_config, '__config_file__', '?'),
+        getattr(domain_config, '__line__', '?'))
 
     if domain != 'homeassistant':
         message += (' Please check the docs at '

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -158,11 +158,14 @@ def _ordered_dict(loader: SafeLineLoader,
 
 
 def _construct_seq(loader, node):
+    """Add line number and file name to Load YAML sequence."""
     obj, = SafeConstructor.construct_yaml_seq(loader, node)
 
     class NodeClass(list):
         """Wrapper class to be able to add attributes on a list."""
+        
         pass
+
     processed = NodeClass(obj)
     setattr(processed, '__config_file__', loader.name)
     setattr(processed, '__line__', node.start_mark.line)

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -163,7 +163,7 @@ def _construct_seq(loader, node):
 
     class NodeClass(list):
         """Wrapper class to be able to add attributes on a list."""
-        
+
         pass
 
     processed = NodeClass(obj)


### PR DESCRIPTION
**Description:**
Config validation errors will show file and line number in log.

Ex:

```
16-10-21 21:18:11 ERROR (Thread-1) [homeassistant.bootstrap] The following platforms contain invalid configuration:  verisure, automation  (please check your configuration)[aias] is an invalid option for [automation]. Check: automation->aias. (See /home/per/.homeassistant/configuration.yaml:103) Please check the docs at https://home-assistant.io/components/automation/
```

I would appreciate some help to test this on a few configurations before we merge.

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
