### PR TITLE
Added support for Notifications for Android TV / FireTV

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -206,6 +206,7 @@ omit =
     homeassistant/components/notify/llamalab_automate.py
     homeassistant/components/notify/matrix.py
     homeassistant/components/notify/message_bird.py
+    homeassistant/components/notify/nfandroidtv.py
     homeassistant/components/notify/nma.py
     homeassistant/components/notify/pushbullet.py
     homeassistant/components/notify/pushetta.py

--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -103,6 +103,7 @@ def get_service(hass, config):
                                           interrupt,
                                           timeout)
 
+
 # pylint: disable=too-many-instance-attributes
 class NFAndroidTVNotificationService(BaseNotificationService):
     """Notification service for Notifications for Android TV."""
@@ -147,13 +148,15 @@ class NFAndroidTVNotificationService(BaseNotificationService):
                 try:
                     payload[ATTR_DURATION] = "%i" % int(duration)
                 except ValueError:
-                    _LOGGER.warning("Invalid duration-value: %s", str(duration))
+                    _LOGGER.warning("Invalid duration-value: %s",
+                                    str(duration))
             if ATTR_POSITION in data:
                 position = data.get(ATTR_POSITION)
                 if position in POSITIONS:
                     payload[ATTR_POSITION] = "%i" % POSITIONS.get(position)
                 else:
-                    _LOGGER.warning("Invalid position-value: %s", str(position))
+                    _LOGGER.warning("Invalid position-value: %s",
+                                    str(position))
             if ATTR_TRANSPARENCY in data:
                 transparency = data.get(ATTR_TRANSPARENCY)
                 if transparency in TRANSPARENCIES:

--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -1,0 +1,184 @@
+"""
+Notifications for Android TV notification service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.nfandroidtv/
+"""
+import logging
+import requests
+import os
+import voluptuous as vol
+
+from homeassistant.components.notify import (ATTR_TITLE,
+                                             ATTR_TITLE_DEFAULT,
+                                             ATTR_DATA,
+                                             BaseNotificationService,
+                                             PLATFORM_SCHEMA)
+from homeassistant.helpers import config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_IP = 'ip'
+CONF_DURATION = 'duration'
+CONF_POSITION = 'position'
+CONF_TRANSPARENCY = 'transparency'
+CONF_COLOR = 'color'
+CONF_INTERRUPT = 'interrupt'
+CONF_TIMEOUT = 'timeout'
+
+DEFAULT_DURATION = 5
+DEFAULT_POSITION = 'bottom-right'
+DEFAULT_TRANSPARENCY = 'default'
+DEFAULT_COLOR = 'grey'
+DEFAULT_INTERRUPT = False
+DEFAULT_TIMEOUT = 5
+
+ATTR_DURATION = 'duration'
+ATTR_POSITION = 'position'
+ATTR_TRANSPARENCY = 'transparency'
+ATTR_COLOR = 'color'
+ATTR_BKGCOLOR = 'bkgcolor'
+ATTR_INTERRUPT = 'interrupt'
+
+POSITIONS = {
+    "bottom-right": 0,
+    "bottom-left": 1,
+    "top-right": 2,
+    "top-left": 3,
+    "center": 4,
+}
+
+TRANSPARENCIES = {
+    "default": 0,
+    "0%": 1,
+    "25%": 2,
+    "50%": 3,
+    "75%": 4,
+    "100%": 5,
+}
+
+COLORS = {
+    "grey": "#607d8b",
+    "black": "#000000",
+    "indigo": "#303F9F",
+    "green": "#4CAF50",
+    "red": "#F44336",
+    "cyan": "#00BCD4",
+    "teal": "#009688",
+    "amber": "#FFC107",
+    "pink": "#E91E63",
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_IP): cv.string,
+    vol.Optional(CONF_DURATION, default=DEFAULT_DURATION): vol.Coerce(int),
+    vol.Optional(CONF_POSITION, default=DEFAULT_POSITION):
+        vol.In(POSITIONS.keys()),
+    vol.Optional(CONF_TRANSPARENCY, default=DEFAULT_TRANSPARENCY):
+        vol.In(TRANSPARENCIES.keys()),
+    vol.Optional(CONF_COLOR, default=DEFAULT_COLOR):
+        vol.In(COLORS.keys()),
+    vol.Optional(CONF_COLOR, default=DEFAULT_COLOR): cv.string,
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.Coerce(int),
+    vol.Optional(CONF_INTERRUPT, default=DEFAULT_INTERRUPT): cv.boolean,
+})
+
+
+def get_service(hass, config):
+    """Get the Notifications for Android TV notification service."""
+    ip = config.get(CONF_IP)
+    duration = config.get(CONF_DURATION)
+    position = config.get(CONF_POSITION)
+    transparency = config.get(CONF_TRANSPARENCY)
+    color = config.get(CONF_COLOR)
+    interrupt = config.get(CONF_INTERRUPT)
+    timeout = config.get(CONF_TIMEOUT)
+
+    return NFAndroidTVNotificationService(ip,
+                                          duration,
+                                          position,
+                                          transparency,
+                                          color,
+                                          interrupt,
+                                          timeout)
+
+
+# pylint: disable=too-few-public-methods
+class NFAndroidTVNotificationService(BaseNotificationService):
+    """Notification service for Notifications for Android TV."""
+
+    def __init__(self, ip, duration, position, transparency,
+                 color, interrupt, timeout):
+        """Initialize the service."""
+        self._target = "http://%s:7676" % ip
+        self._default_duration = duration
+        self._default_position = position
+        self._default_transparency = transparency
+        self._default_color = color
+        self._default_interrupt = interrupt
+        self._timeout = timeout
+        self._icon_file = os.path.join(os.path.dirname(__file__), "..",
+                                       "frontend",
+                                       "www_static", "icons",
+                                       "favicon-192x192.png")
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to a Android TV device."""
+        _LOGGER.debug("Sending notification to: %s", self._target)
+
+        payload = dict(filename=('icon.png',
+                                 open(self._icon_file, 'rb'),
+                                 'application/octet-stream',
+                                 {'Expires': '0'}), type="0",
+                       title=kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT),
+                       msg=message, duration="%i" % self._default_duration,
+                       position="%i" % POSITIONS.get(self._default_position),
+                       bkgcolor="%s" % COLORS.get(self._default_color),
+                       transparency="%i" % TRANSPARENCIES.get(
+                               self._default_transparency), offset="0",
+                       app=ATTR_TITLE_DEFAULT, force="true",
+                       interrupt="%i" % self._default_interrupt)
+
+        data = kwargs.get(ATTR_DATA)
+        if data:
+            if ATTR_DURATION in data:
+                d = data.get(ATTR_DURATION)
+                try:
+                    payload[ATTR_DURATION] = "%i" % int(d)
+                except ValueError:
+                    _LOGGER.warning("Invalid duration-value: %s", str(d))
+            if ATTR_POSITION in data:
+                p = data.get(ATTR_POSITION)
+                if p in POSITIONS:
+                    payload[ATTR_POSITION] = "%i" % POSITIONS.get(p)
+                else:
+                    _LOGGER.warning("Invalid position-value: %s", str(p))
+            if ATTR_TRANSPARENCY in data:
+                t = data.get(ATTR_TRANSPARENCY)
+                if t in TRANSPARENCIES:
+                    payload[ATTR_TRANSPARENCY] = "%i" % TRANSPARENCIES.get(t)
+                else:
+                    _LOGGER.warning("Invalid transparency-value: %s", str(t))
+            if ATTR_COLOR in data:
+                c = data.get(ATTR_COLOR)
+                if c in COLORS:
+                    payload[ATTR_BKGCOLOR] = "%s" % COLORS.get(c)
+                else:
+                    _LOGGER.warning("Invalid color-value: %s", str(c))
+            if ATTR_INTERRUPT in data:
+                i = data.get(ATTR_INTERRUPT)
+                try:
+                    payload[ATTR_INTERRUPT] = "%i" % cv.boolean(i)
+                except vol.Invalid:
+                    _LOGGER.warning("Invalid interrupt-value: %s", str(i))
+
+        try:
+            _LOGGER.debug("Payload: %s", str(payload))
+            response = requests.post(self._target,
+                                     files=payload,
+                                     timeout=self._timeout)
+            if response.status_code != 200:
+                _LOGGER.error("Error sending message: %s", str(response))
+        except requests.exceptions.ConnectionError as e:
+            _LOGGER.error("Error communicating with %s: %s",
+                          self._target, str(e))

--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_IP = 'ip'
+CONF_IP = 'host'
 CONF_DURATION = 'duration'
 CONF_POSITION = 'position'
 CONF_TRANSPARENCY = 'transparency'

--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -107,6 +107,7 @@ def get_service(hass, config):
 # pylint: disable=too-many-instance-attributes
 class NFAndroidTVNotificationService(BaseNotificationService):
     """Notification service for Notifications for Android TV."""
+
     # pylint: disable=too-many-arguments,too-few-public-methods
     def __init__(self, remoteip, duration, position, transparency,
                  color, interrupt, timeout):


### PR DESCRIPTION
**Description:**
Notification service for [Notifications for Android TV](https://play.google.com/store/apps/details?id=de.cyberdream.androidtv.notifications.google&hl=de) and [Notifications for FireTV](https://play.google.com/store/apps/details?id=de.cyberdream.firenotifications.google).
The app usually consists of the server-part running on a compatible Android TV or FireTV device + a client-app running on an Android smartphone, which publishes its notifications (WhatsApp, incoming calls etc.) to the TV.
With this service we don't need the client running on the smartphone and instead can push our HASS notifications to the TV. The advantage compared to e.g. Kodi notifications is, that these notifications are global in the context of the Android TV device. So they show up even while watching satellite TV or YouTube.
There are some styling-options available. I've decided to allow a default-configuration via configuration.yaml, but also overriding them with the data-attribute of notifications. The parameters (color, transparency etc.) seem to be more "flexible" at first sight, but are actually limited by the server. Only the values within the platform-code work. So we can't set the color to #ff0000 for red, but have to use #4caf50. All those possible values can be seen in the code, and in the end it might even be more user friendly to call the service with `"color":"red"` instead of `"color":"#ff0000"`. Just want to clarify this so reviewers are aware why it's done this way.  
I'll take care of the documentation soon. If you wan't to try it out, here's a fully filled service-data-dict:

``` json
{
"message": "Messagetext",
"title": "My Notification",
"data":{
"position":"center",
"duration":2,
"transparency":"0%",
"color": "red",
"interrupt": 0
}
}
```

Most parameters explain themselves. The `interrupt` one displays a different kind of notification (looks almost the same, but has a border). When set to true (or on, 1, it's cv.boolean), the notification can be dismissed or selected and viewed. According to the App-description this might even stop playback, although that didn't happen to me with YouTube and Netflix.

One further note: the app description refers to premium features for unlimited messages etc. Those limitations only apply to the smartphone app. So when you're just using it for HASS notifications no premium features are required.

**I really dislike me disabeling the too-many-branches check for what I do beginning at line 147, but I'm unsure how I should handle the passed in data more elegantly. Suggestions welcome!**

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1296

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
notify:
- platform: nfandroidtv
  name: Kitchen
  ip: 192.168.1.12
  color: grey
  transparency: 25%
  position: top-left
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
