### PR TITLE
Fixed statsd stopping if state is not numeric or only attributes changed

### DIFF
--- a/homeassistant/components/statsd.py
+++ b/homeassistant/components/statsd.py
@@ -76,7 +76,6 @@ def setup(hass, config):
                     sample_rate
                 )
 
-
             # Send attribute values
             for key, value in states.items():
                 if isinstance(value, (float, int)):

--- a/homeassistant/components/statsd.py
+++ b/homeassistant/components/statsd.py
@@ -66,10 +66,10 @@ def setup(hass, config):
 
         states = dict(state.attributes)
 
-        _LOGGER.debug('Sending %s.%s', state.entity_id, _state)
+        _LOGGER.debug('Sending %s', state.entity_id)
 
         if show_attribute_flag is True:
-            if _state is not None:
+            if isinstance(_state, (float, int)):
                 statsd_client.gauge(
                     "%s.state" % state.entity_id,
                     _state,
@@ -84,7 +84,8 @@ def setup(hass, config):
                     statsd_client.gauge(stat, value, sample_rate)
 
         else:
-            statsd_client.gauge(state.entity_id, _state, sample_rate)
+            if isinstance(_state, (float, int)):
+                statsd_client.gauge(state.entity_id, _state, sample_rate)
 
         # Increment the count
         statsd_client.incr(state.entity_id, rate=sample_rate)

--- a/homeassistant/components/statsd.py
+++ b/homeassistant/components/statsd.py
@@ -61,18 +61,21 @@ def setup(hass, config):
         try:
             _state = state_helper.state_as_number(state)
         except ValueError:
-            return
+            # Set the state to none and continue for any numeric attributes.
+            _state = None
 
         states = dict(state.attributes)
 
         _LOGGER.debug('Sending %s.%s', state.entity_id, _state)
 
         if show_attribute_flag is True:
-            statsd_client.gauge(
-                "%s.state" % state.entity_id,
-                _state,
-                sample_rate
-            )
+            if _state is not None:
+                statsd_client.gauge(
+                    "%s.state" % state.entity_id,
+                    _state,
+                    sample_rate
+                )
+
 
             # Send attribute values
             for key, value in states.items():

--- a/tests/components/test_statsd.py
+++ b/tests/components/test_statsd.py
@@ -114,7 +114,7 @@ class TestStatsd(unittest.TestCase):
             handler_method(mock.MagicMock(data={
                 'new_state': ha.State('domain.test', invalid, {})}))
             self.assertFalse(mock_client.return_value.gauge.called)
-            self.assertFalse(mock_client.return_value.incr.called)
+            self.assertTrue(mock_client.return_value.incr.called)
 
     @mock.patch('statsd.StatsClient')
     def test_event_listener_attr_details(self, mock_client):
@@ -162,4 +162,4 @@ class TestStatsd(unittest.TestCase):
             handler_method(mock.MagicMock(data={
                 'new_state': ha.State('domain.test', invalid, {})}))
             self.assertFalse(mock_client.return_value.gauge.called)
-            self.assertFalse(mock_client.return_value.incr.called)
+            self.assertTrue(mock_client.return_value.incr.called)


### PR DESCRIPTION
**Description:**
If an attribute is changed but not the state the EVENT_STATE_CHANGE still gets fired but statsd would ignore it. It will now accept non numeric states or attribute changes only and update the counter and gauges appropriately.
