### PR TITLE
Fix updater, add new fields

### DIFF
--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -9,6 +9,7 @@ import logging
 import json
 import platform
 import uuid
+import os
 # pylint: disable=no-name-in-module,import-error
 from distutils.version import StrictVersion
 
@@ -92,7 +93,9 @@ def get_newest_version(huuid):
     info_object = {'uuid': huuid, 'version': CURRENT_VERSION,
                    'timezone': dt_util.DEFAULT_TIME_ZONE.zone,
                    'os_name': platform.system(), "arch": platform.machine(),
-                   'python_version': platform.python_version()}
+                   'python_version': platform.python_version(),
+                   'virtualenv': (os.environ.get('VIRTUAL_ENV') is not None),
+                   'docker': False}
 
     if platform.system() == 'Windows':
         info_object['os_version'] = platform.win32_ver()[0]
@@ -103,6 +106,8 @@ def get_newest_version(huuid):
         linux_dist = distro.linux_distribution(full_distribution_name=False)
         info_object['distribution'] = linux_dist[0]
         info_object['os_version'] = linux_dist[1]
+
+        info_object['docker'] = os.path.isfile('/.dockerenv')
 
     if not huuid:
         info_object = {}

--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -63,6 +63,7 @@ def setup(hass, config):
         _LOGGER.warning('Updater not supported in development version')
         return False
 
+    config = config.get(DOMAIN, {})
     huuid = _load_uuid(hass) if config.get(CONF_REPORTING) else None
 
     # Update daily, start 1 hour after startup

--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -106,7 +106,6 @@ def get_newest_version(huuid):
         linux_dist = distro.linux_distribution(full_distribution_name=False)
         info_object['distribution'] = linux_dist[0]
         info_object['os_version'] = linux_dist[1]
-
         info_object['docker'] = os.path.isfile('/.dockerenv')
 
     if not huuid:
@@ -115,6 +114,9 @@ def get_newest_version(huuid):
     try:
         req = requests.post(UPDATER_URL, json=info_object)
         res = req.json()
+        _LOGGER.info(('The latest version is %s. '
+                      'Information submitted includes %s'),
+                     str(res['version']), str(info_object))
         return (res['version'], res['release-notes'])
     except requests.RequestException:
         _LOGGER.exception('Could not contact HASS Update to check for updates')

--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -116,7 +116,7 @@ def get_newest_version(huuid):
         res = req.json()
         _LOGGER.info(('The latest version is %s. '
                       'Information submitted includes %s'),
-                     str(res['version']), str(info_object))
+                     res['version'], info_object)
         return (res['version'], res['release-notes'])
     except requests.RequestException:
         _LOGGER.exception('Could not contact HASS Update to check for updates')

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import os
 
 import requests
+import requests_mock
 
 from homeassistant.bootstrap import setup_component
 from homeassistant.components import updater
@@ -111,3 +112,19 @@ class TestUpdater(unittest.TestCase):
             assert uuid != uuid2
         finally:
             os.remove(path)
+
+    @requests_mock.Mocker()
+    def test_reporting_false_works(self, m):
+        """Test we do not send any data."""
+        m.post(updater.UPDATER_URL,
+               json={'version': '0.15',
+                     'release-notes': 'https://home-assistant.io'})
+
+        response = updater.get_newest_version(None)
+
+        assert response == ('0.15', 'https://home-assistant.io')
+
+        history = m.request_history
+
+        assert len(history) == 1
+        assert history[0].json() == {}


### PR DESCRIPTION
**Description:**
Fix opting out for updater.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
