### PR TITLE
Improve support for Yamaha receiver

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -447,7 +447,7 @@ radiotherm==1.2
 # rpi-rf==0.9.5
 
 # homeassistant.components.media_player.yamaha
-rxv==0.2.0
+rxv==0.3.0
 
 # homeassistant.components.media_player.samsungtv
 samsungctl==0.5.1


### PR DESCRIPTION
**Description:**
This pull request adds support for basic playback functionality like play, pause, stop, next and previous for input sources that support it in the Yamaha receiver. It also adds support for media title, artist and album if the information is available.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
