### PR TITLE
Prevent zwave from firing event at shutdown

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -430,7 +430,8 @@ def setup(hass, config):
         """Stop Z-Wave network."""
         _LOGGER.info("Stopping ZWave network.")
         NETWORK.stop()
-        hass.bus.fire(const.EVENT_NETWORK_STOP)
+        if hass.state == 'RUNNING':
+            hass.bus.fire(const.EVENT_NETWORK_STOP)
 
     def rename_node(service):
         """Rename a node."""


### PR DESCRIPTION
**Description:**
This will prevent zwave from firing an event at shutdown of HomeAssistant.
That lead to a async error traceback.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
Partly #3967 
