### PR TITLE
Prevent Verisure cam to delete a file when it is None

### DIFF
--- a/homeassistant/components/camera/verisure.py
+++ b/homeassistant/components/camera/verisure.py
@@ -89,6 +89,8 @@ class VerisureSmartcam(Camera):
 
     def delete_image(self, event):
         """Delete an old image."""
+        if not self._image_id:
+            return
         remove_image = os.path.join(self._directory_path,
                                     '{}{}'.format(
                                         self._image_id,

--- a/homeassistant/components/camera/verisure.py
+++ b/homeassistant/components/camera/verisure.py
@@ -74,12 +74,8 @@ class VerisureSmartcam(Camera):
         hub.my_pages.smartcam.download_image(self._device_id,
                                              new_image_id,
                                              self._directory_path)
-        if self._image_id:
-            _LOGGER.debug('Old image_id=%s', self._image_id)
-            self.delete_image(self)
-
-        else:
-            _LOGGER.debug('No old image, only new %s', new_image_id)
+        _LOGGER.debug('Old image_id=%s', self._image_id)
+        self.delete_image(self)
 
         self._image_id = new_image_id
         self._image = os.path.join(self._directory_path,
@@ -89,14 +85,16 @@ class VerisureSmartcam(Camera):
 
     def delete_image(self, event):
         """Delete an old image."""
-        if not self._image_id:
-            return
         remove_image = os.path.join(self._directory_path,
                                     '{}{}'.format(
                                         self._image_id,
                                         '.jpg'))
-        _LOGGER.debug('Deleting old image %s', remove_image)
-        os.remove(remove_image)
+        try:
+            os.remove(remove_image)
+            _LOGGER.debug('Deleting old image %s', remove_image)
+        except OSError as error:
+            if error.errno != 2:
+                raise
 
     @property
     def name(self):

--- a/homeassistant/components/camera/verisure.py
+++ b/homeassistant/components/camera/verisure.py
@@ -4,6 +4,7 @@ Camera that loads a picture from a local file.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/camera.verisure/
 """
+import errno
 import logging
 import os
 
@@ -93,7 +94,7 @@ class VerisureSmartcam(Camera):
             os.remove(remove_image)
             _LOGGER.debug('Deleting old image %s', remove_image)
         except OSError as error:
-            if error.errno != 2:
+            if error.errno != errno.ENOENT:
                 raise
 
     @property


### PR DESCRIPTION
**Description:**
If there is no file at HomAssistant shutdown the camera should not try do delete it.
