### PR TITLE
Async bootstrap / component init

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -1,11 +1,10 @@
 """Provides methods to bootstrap a home assistant instance."""
-
+import asyncio
 import logging
 import logging.handlers
 import os
 import sys
 from collections import defaultdict
-from threading import RLock
 
 from types import ModuleType
 from typing import Any, Optional, Dict
@@ -19,6 +18,8 @@ import homeassistant.config as conf_util
 import homeassistant.core as core
 import homeassistant.loader as loader
 import homeassistant.util.package as pkg_util
+from homeassistant.util.async import (
+    run_coroutine_threadsafe, run_callback_threadsafe)
 from homeassistant.util.yaml import clear_secret_cache
 from homeassistant.const import EVENT_COMPONENT_LOADED, PLATFORM_FORMAT
 from homeassistant.exceptions import HomeAssistantError
@@ -26,7 +27,6 @@ from homeassistant.helpers import (
     event_decorators, service, config_per_platform, extract_domain_configs)
 
 _LOGGER = logging.getLogger(__name__)
-_SETUP_LOCK = RLock()
 _CURRENT_SETUP = []
 
 ATTR_COMPONENT = 'component'
@@ -39,11 +39,22 @@ _PERSISTENT_VALIDATION = set()
 def setup_component(hass: core.HomeAssistant, domain: str,
                     config: Optional[Dict]=None) -> bool:
     """Setup a component and all its dependencies."""
+    return run_coroutine_threadsafe(
+        async_setup_component(hass, domain, config), loop=hass.loop).result()
+
+
+@asyncio.coroutine
+def async_setup_component(hass: core.HomeAssistant, domain: str,
+                          config: Optional[Dict]=None) -> bool:
+    """Setup a component and all its dependencies.
+
+    This method need to run in a executor.
+    """
     if domain in hass.config.components:
         _LOGGER.debug('Component %s already set up.', domain)
         return True
 
-    _ensure_loader_prepared(hass)
+    yield from hass.loop.run_in_executor(None, _ensure_loader_prepared, hass)
 
     if config is None:
         config = defaultdict(dict)
@@ -55,7 +66,8 @@ def setup_component(hass: core.HomeAssistant, domain: str,
         return False
 
     for component in components:
-        if not _setup_component(hass, component, config):
+        res = yield from _async_setup_component(hass, component, config)
+        if not res:
             _LOGGER.error('Component %s failed to setup', component)
             return False
 
@@ -64,7 +76,11 @@ def setup_component(hass: core.HomeAssistant, domain: str,
 
 def _handle_requirements(hass: core.HomeAssistant, component,
                          name: str) -> bool:
-    """Install the requirements for a component."""
+    """Install the requirements for a component.
+
+    Asyncio don't support file operation jet.
+    This method need to run in a executor.
+    """
     if hass.config.skip_pip or not hasattr(component, 'REQUIREMENTS'):
         return True
 
@@ -77,65 +93,82 @@ def _handle_requirements(hass: core.HomeAssistant, component,
     return True
 
 
-def _setup_component(hass: core.HomeAssistant, domain: str, config) -> bool:
-    """Setup a component for Home Assistant."""
+@asyncio.coroutine
+def _async_setup_component(hass: core.HomeAssistant,
+                           domain: str, config) -> bool:
+    """Setup a component for Home Assistant.
+
+    This method is a coroutine.
+    """
     # pylint: disable=too-many-return-statements,too-many-branches
     # pylint: disable=too-many-statements
     if domain in hass.config.components:
         return True
 
-    with _SETUP_LOCK:
-        # It might have been loaded while waiting for lock
-        if domain in hass.config.components:
-            return True
+    if domain in _CURRENT_SETUP:
+        _LOGGER.error('Attempt made to setup %s during setup of %s',
+                      domain, domain)
+        return False
 
-        if domain in _CURRENT_SETUP:
-            _LOGGER.error('Attempt made to setup %s during setup of %s',
-                          domain, domain)
+    config = yield from async_prepare_setup_component(hass, config, domain)
+
+    if config is None:
+        return False
+
+    component = loader.get_component(domain)
+    _CURRENT_SETUP.append(domain)
+
+    try:
+        if hasattr(component, 'async_setup'):
+            result = yield from component.async_setup(hass, config)
+        else:
+            result = yield from hass.loop.run_in_executor(
+                None, component.setup, hass, config)
+
+        if result is False:
+            _LOGGER.error('component %s failed to initialize', domain)
             return False
-
-        config = prepare_setup_component(hass, config, domain)
-
-        if config is None:
+        elif result is not True:
+            _LOGGER.error('component %s did not return boolean if setup '
+                          'was successful. Disabling component.', domain)
+            loader.set_component(domain, None)
             return False
+    except Exception:  # pylint: disable=broad-except
+        _LOGGER.exception('Error during setup of component %s', domain)
+        return False
+    finally:
+        _CURRENT_SETUP.remove(domain)
 
-        component = loader.get_component(domain)
-        _CURRENT_SETUP.append(domain)
+    hass.config.components.append(component.DOMAIN)
 
-        try:
-            result = component.setup(hass, config)
-            if result is False:
-                _LOGGER.error('component %s failed to initialize', domain)
-                return False
-            elif result is not True:
-                _LOGGER.error('component %s did not return boolean if setup '
-                              'was successful. Disabling component.', domain)
-                loader.set_component(domain, None)
-                return False
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception('Error during setup of component %s', domain)
-            return False
-        finally:
-            _CURRENT_SETUP.remove(domain)
+    # Assumption: if a component does not depend on groups
+    # it communicates with devices
+    if 'group' not in getattr(component, 'DEPENDENCIES', []) and \
+       hass.pool.worker_count <= 10:
+        hass.pool.add_worker()
 
-        hass.config.components.append(component.DOMAIN)
+    hass.bus.async_fire(
+        EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: component.DOMAIN}
+    )
 
-        # Assumption: if a component does not depend on groups
-        # it communicates with devices
-        if 'group' not in getattr(component, 'DEPENDENCIES', []) and \
-           hass.pool.worker_count <= 10:
-            hass.pool.add_worker()
-
-        hass.bus.fire(
-            EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: component.DOMAIN}
-        )
-
-        return True
+    return True
 
 
 def prepare_setup_component(hass: core.HomeAssistant, config: dict,
                             domain: str):
     """Prepare setup of a component and return processed config."""
+    return run_coroutine_threadsafe(
+        async_prepare_setup_component(hass, config, domain), loop=hass.loop
+    ).result()
+
+
+@asyncio.coroutine
+def async_prepare_setup_component(hass: core.HomeAssistant, config: dict,
+                                  domain: str):
+    """Prepare setup of a component and return processed config.
+
+    This method is a coroutine.
+    """
     # pylint: disable=too-many-return-statements
     component = loader.get_component(domain)
     missing_deps = [dep for dep in getattr(component, 'DEPENDENCIES', [])
@@ -151,7 +184,7 @@ def prepare_setup_component(hass: core.HomeAssistant, config: dict,
         try:
             config = component.CONFIG_SCHEMA(config)
         except vol.Invalid as ex:
-            log_exception(ex, domain, config, hass)
+            async_log_exception(ex, domain, config, hass)
             return None
 
     elif hasattr(component, 'PLATFORM_SCHEMA'):
@@ -161,7 +194,7 @@ def prepare_setup_component(hass: core.HomeAssistant, config: dict,
             try:
                 p_validated = component.PLATFORM_SCHEMA(p_config)
             except vol.Invalid as ex:
-                log_exception(ex, domain, config, hass)
+                async_log_exception(ex, domain, config, hass)
                 continue
 
             # Not all platform components follow same pattern for platforms
@@ -171,8 +204,8 @@ def prepare_setup_component(hass: core.HomeAssistant, config: dict,
                 platforms.append(p_validated)
                 continue
 
-            platform = prepare_setup_platform(hass, config, domain,
-                                              p_name)
+            platform = yield from async_prepare_setup_platform(
+                hass, config, domain, p_name)
 
             if platform is None:
                 continue
@@ -180,10 +213,11 @@ def prepare_setup_component(hass: core.HomeAssistant, config: dict,
             # Validate platform specific schema
             if hasattr(platform, 'PLATFORM_SCHEMA'):
                 try:
+                    # pylint: disable=no-member
                     p_validated = platform.PLATFORM_SCHEMA(p_validated)
                 except vol.Invalid as ex:
-                    log_exception(ex, '{}.{}'.format(domain, p_name),
-                                  p_validated, hass)
+                    async_log_exception(ex, '{}.{}'.format(domain, p_name),
+                                        p_validated, hass)
                     continue
 
             platforms.append(p_validated)
@@ -195,7 +229,9 @@ def prepare_setup_component(hass: core.HomeAssistant, config: dict,
                   if key not in filter_keys}
         config[domain] = platforms
 
-    if not _handle_requirements(hass, component, domain):
+    res = yield from hass.loop.run_in_executor(
+        None, _handle_requirements, hass, component, domain)
+    if not res:
         return None
 
     return config
@@ -204,7 +240,21 @@ def prepare_setup_component(hass: core.HomeAssistant, config: dict,
 def prepare_setup_platform(hass: core.HomeAssistant, config, domain: str,
                            platform_name: str) -> Optional[ModuleType]:
     """Load a platform and makes sure dependencies are setup."""
-    _ensure_loader_prepared(hass)
+    return run_coroutine_threadsafe(
+        async_prepare_setup_platform(hass, config, domain, platform_name),
+        loop=hass.loop
+    ).result()
+
+
+@asyncio.coroutine
+def async_prepare_setup_platform(hass: core.HomeAssistant, config, domain: str,
+                                 platform_name: str) \
+                                 -> Optional[ModuleType]:
+    """Load a platform and makes sure dependencies are setup.
+
+    This method is a coroutine.
+    """
+    yield from hass.loop.run_in_executor(None, _ensure_loader_prepared, hass)
 
     platform_path = PLATFORM_FORMAT.format(domain, platform_name)
 
@@ -218,7 +268,7 @@ def prepare_setup_platform(hass: core.HomeAssistant, config, domain: str,
         message = ('Unable to find the following platforms: ' +
                    ', '.join(list(_PERSISTENT_PLATFORMS)) +
                    '(please check your configuration)')
-        persistent_notification.create(
+        persistent_notification.async_create(
             hass, message, 'Invalid platforms', 'platform_errors')
         return None
 
@@ -228,14 +278,17 @@ def prepare_setup_platform(hass: core.HomeAssistant, config, domain: str,
 
     # Load dependencies
     for component in getattr(platform, 'DEPENDENCIES', []):
-        if not setup_component(hass, component, config):
+        res = yield from async_setup_component(hass, component, config)
+        if not res:
             _LOGGER.error(
                 'Unable to prepare setup for platform %s because '
                 'dependency %s could not be initialized', platform_path,
                 component)
             return None
 
-    if not _handle_requirements(hass, platform, platform_path):
+    res = yield from hass.loop.run_in_executor(
+        None, _handle_requirements, hass, platform, platform_path)
+    if not res:
         return None
 
     return platform
@@ -261,25 +314,68 @@ def from_config_dict(config: Dict[str, Any],
             hass.config.config_dir = config_dir
             mount_local_lib_path(config_dir)
 
+    # async loop allready running
+    if hass.loop.is_running():
+        return run_coroutine_threadsafe(async_from_config_dict(
+            config, hass, config_dir, enable_log, verbose, skip_pip
+        ), hass.loop).result()
+
+    @asyncio.coroutine
+    def _async_init_from_config_dict(future):
+        try:
+            re_hass = yield from async_from_config_dict(
+                config, hass, config_dir, enable_log, verbose, skip_pip,
+                log_rotate_days)
+            future.set_result(re_hass)
+        # pylint: disable=broad-except
+        except Exception as exc:
+            future.set_exception(exc)
+
+    # run task
+    future = asyncio.Future()
+    asyncio.Task(_async_init_from_config_dict(future), loop=hass.loop)
+    hass.loop.run_until_complete(future)
+
+    return future.result()
+
+
+@asyncio.coroutine
+# pylint: disable=too-many-branches, too-many-statements, too-many-arguments
+def async_from_config_dict(config: Dict[str, Any],
+                           hass: core.HomeAssistant,
+                           config_dir: Optional[str]=None,
+                           enable_log: bool=True,
+                           verbose: bool=False,
+                           skip_pip: bool=False,
+                           log_rotate_days: Any=None) \
+                           -> Optional[core.HomeAssistant]:
+    """Try to configure Home Assistant from a config dict.
+
+    Dynamically loads required components and its dependencies.
+    This method is a coroutine.
+    """
     core_config = config.get(core.DOMAIN, {})
 
     try:
-        conf_util.process_ha_core_config(hass, core_config)
+        yield from conf_util.async_process_ha_core_config(hass, core_config)
     except vol.Invalid as ex:
-        log_exception(ex, 'homeassistant', core_config, hass)
+        async_log_exception(ex, 'homeassistant', core_config, hass)
         return None
 
-    conf_util.process_ha_config_upgrade(hass)
+    yield from hass.loop.run_in_executor(
+        None, conf_util.process_ha_config_upgrade, hass)
 
     if enable_log:
-        enable_logging(hass, verbose, log_rotate_days)
+        yield from hass.loop.run_in_executor(
+            None, enable_logging, hass, verbose, log_rotate_days)
 
     hass.config.skip_pip = skip_pip
     if skip_pip:
         _LOGGER.warning('Skipping pip installation of required modules. '
                         'This may cause issues.')
 
-    _ensure_loader_prepared(hass)
+    yield from hass.loop.run_in_executor(
+        None, _ensure_loader_prepared, hass)
 
     # Make a copy because we are mutating it.
     # Convert it to defaultdict so components can always have config dict
@@ -291,29 +387,25 @@ def from_config_dict(config: Dict[str, Any],
     components = set(key.split(' ')[0] for key in config.keys()
                      if key != core.DOMAIN)
 
-    # Setup in a thread to avoid blocking
-    def component_setup():
-        """Set up a component."""
-        if not core_components.setup(hass, config):
-            _LOGGER.error('Home Assistant core failed to initialize. '
-                          'Further initialization aborted.')
-            return hass
+    # setup components
+    # pylint: disable=not-an-iterable
+    res = yield from core_components.async_setup(hass, config)
+    if not res:
+        _LOGGER.error('Home Assistant core failed to initialize. '
+                      'Further initialization aborted.')
+        return hass
 
-        persistent_notification.setup(hass, config)
+    yield from persistent_notification.async_setup(hass, config)
 
-        _LOGGER.info('Home Assistant core initialized')
+    _LOGGER.info('Home Assistant core initialized')
 
-        # Give event decorators access to HASS
-        event_decorators.HASS = hass
-        service.HASS = hass
+    # Give event decorators access to HASS
+    event_decorators.HASS = hass
+    service.HASS = hass
 
-        # Setup the components
-        for domain in loader.load_order_components(components):
-            _setup_component(hass, domain, config)
-
-    hass.loop.run_until_complete(
-        hass.loop.run_in_executor(None, component_setup)
-    )
+    # Setup the components
+    for domain in loader.load_order_components(components):
+        yield from _async_setup_component(hass, domain, config)
 
     return hass
 
@@ -336,22 +428,64 @@ def from_config_file(config_path: str,
     hass.config.config_dir = config_dir
     mount_local_lib_path(config_dir)
 
-    enable_logging(hass, verbose, log_rotate_days)
+    # async loop allready running
+    if hass.loop.is_running():
+        return run_coroutine_threadsafe(async_from_config_file(
+            config_path, hass, verbose, skip_pip, log_rotate_days
+        ), hass.loop).result()
+
+    @asyncio.coroutine
+    def _async_init_from_config_file(future):
+        try:
+            re_hass = yield from async_from_config_file(
+                config_path, hass, verbose, skip_pip, log_rotate_days)
+            future.set_result(re_hass)
+        # pylint: disable=broad-except
+        except Exception as exc:
+            future.set_exception(exc)
+
+    # run task
+    future = asyncio.Future()
+    asyncio.Task(_async_init_from_config_file(future), loop=hass.loop)
+    hass.loop.run_until_complete(future)
+
+    return future.result()
+
+
+@asyncio.coroutine
+def async_from_config_file(config_path: str,
+                           hass: core.HomeAssistant,
+                           verbose: bool=False,
+                           skip_pip: bool=True,
+                           log_rotate_days: Any=None):
+    """Read the configuration file and try to start all the functionality.
+
+    Will add functionality to 'hass' parameter.
+    This method is a coroutine.
+    """
+    yield from hass.loop.run_in_executor(
+        None, enable_logging, hass, verbose, log_rotate_days)
 
     try:
-        config_dict = conf_util.load_yaml_config_file(config_path)
+        config_dict = yield from hass.loop.run_in_executor(
+            None, conf_util.load_yaml_config_file, config_path)
     except HomeAssistantError:
         return None
     finally:
         clear_secret_cache()
 
-    return from_config_dict(config_dict, hass, enable_log=False,
-                            skip_pip=skip_pip)
+    hass = yield from async_from_config_dict(
+        config_dict, hass, enable_log=False, skip_pip=skip_pip)
+    return hass
 
 
 def enable_logging(hass: core.HomeAssistant, verbose: bool=False,
                    log_rotate_days=None) -> None:
-    """Setup the logging."""
+    """Setup the logging.
+
+    Asyncio don't support file operation jet.
+    This method need to run in a executor.
+    """
     logging.basicConfig(level=logging.INFO)
     fmt = ("%(log_color)s%(asctime)s %(levelname)s (%(threadName)s) "
            "[%(name)s] %(message)s%(reset)s")
@@ -408,21 +542,34 @@ def enable_logging(hass: core.HomeAssistant, verbose: bool=False,
 
 
 def _ensure_loader_prepared(hass: core.HomeAssistant) -> None:
-    """Ensure Home Assistant loader is prepared."""
+    """Ensure Home Assistant loader is prepared.
+
+    Asyncio don't support file operation jet.
+    This method need to run in a executor.
+    """
     if not loader.PREPARED:
         loader.prepare(hass)
 
 
-def log_exception(ex, domain, config, hass=None):
+def log_exception(ex, domain, config, hass):
     """Generate log exception for config validation."""
+    run_callback_threadsafe(
+        hass.loop, async_log_exception, ex, domain, config, hass).result()
+
+
+@core.callback
+def async_log_exception(ex, domain, config, hass):
+    """Generate log exception for config validation.
+
+    Need to run in a async loop.
+    """
     message = 'Invalid config for [{}]: '.format(domain)
-    if hass is not None:
-        _PERSISTENT_VALIDATION.add(domain)
-        message = ('The following platforms contain invalid configuration:  ' +
-                   ', '.join(list(_PERSISTENT_VALIDATION)) +
-                   '  (please check your configuration)')
-        persistent_notification.create(
-            hass, message, 'Invalid config', 'invalid_config')
+    _PERSISTENT_VALIDATION.add(domain)
+    message = ('The following platforms contain invalid configuration:  ' +
+               ', '.join(list(_PERSISTENT_VALIDATION)) +
+               '  (please check your configuration)')
+    persistent_notification.async_create(
+        hass, message, 'Invalid config', 'invalid_config')
 
     if 'extra keys not allowed' in ex.error_message:
         message += '[{}] is an invalid option for [{}]. Check: {}->{}.'\
@@ -444,7 +591,10 @@ def log_exception(ex, domain, config, hass=None):
 
 
 def mount_local_lib_path(config_dir: str) -> str:
-    """Add local library to Python Path."""
+    """Add local library to Python Path.
+
+    Async friendly.
+    """
     deps_dir = os.path.join(config_dir, 'deps')
     if deps_dir not in sys.path:
         sys.path.insert(0, os.path.join(config_dir, 'deps'))

--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -83,7 +83,7 @@ def reload_core_config(hass):
 @asyncio.coroutine
 def async_setup(hass, config):
     """Setup general services related to Home Assistant."""
-    @asyncio.coroutine
+    @ha.callback
     def handle_turn_service(service):
         """Method to handle calls to homeassistant.turn_on/off."""
         entity_ids = extract_entity_ids(hass, service)
@@ -114,8 +114,8 @@ def async_setup(hass, config):
             # ent_ids is a generator, convert it to a list.
             data[ATTR_ENTITY_ID] = list(ent_ids)
 
-            yield from hass.services.async_call(
-                domain, service.service, data, blocking)
+            hass.loop.create_task(hass.services.async_call(
+                domain, service.service, data, blocking))
 
     hass.services.async_register(
         ha.DOMAIN, SERVICE_TURN_OFF, handle_turn_service)

--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -7,6 +7,7 @@ Component design guidelines:
   format "<DOMAIN>.<OBJECT_ID>".
 - Each component should publish services only under its own domain.
 """
+import asyncio
 import itertools as it
 import logging
 
@@ -79,8 +80,10 @@ def reload_core_config(hass):
     hass.services.call(ha.DOMAIN, SERVICE_RELOAD_CORE_CONFIG)
 
 
-def setup(hass, config):
+@asyncio.coroutine
+def async_setup(hass, config):
     """Setup general services related to Home Assistant."""
+    @asyncio.coroutine
     def handle_turn_service(service):
         """Method to handle calls to homeassistant.turn_on/off."""
         entity_ids = extract_entity_ids(hass, service)
@@ -111,27 +114,32 @@ def setup(hass, config):
             # ent_ids is a generator, convert it to a list.
             data[ATTR_ENTITY_ID] = list(ent_ids)
 
-            hass.services.call(domain, service.service, data, blocking)
+            yield from hass.services.async_call(
+                domain, service.service, data, blocking)
 
-    hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, handle_turn_service)
-    hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, handle_turn_service)
-    hass.services.register(ha.DOMAIN, SERVICE_TOGGLE, handle_turn_service)
+    hass.services.async_register(
+        ha.DOMAIN, SERVICE_TURN_OFF, handle_turn_service)
+    hass.services.async_register(
+        ha.DOMAIN, SERVICE_TURN_ON, handle_turn_service)
+    hass.services.async_register(
+        ha.DOMAIN, SERVICE_TOGGLE, handle_turn_service)
 
+    @asyncio.coroutine
     def handle_reload_config(call):
         """Service handler for reloading core config."""
         from homeassistant.exceptions import HomeAssistantError
         from homeassistant import config as conf_util
 
         try:
-            path = conf_util.find_config_file(hass.config.config_dir)
-            conf = conf_util.load_yaml_config_file(path)
+            conf = yield from conf_util.async_hass_config_yaml(hass)
         except HomeAssistantError as err:
             _LOGGER.error(err)
             return
 
-        conf_util.process_ha_core_config(hass, conf.get(ha.DOMAIN) or {})
+        yield from conf_util.async_process_ha_core_config(
+            hass, conf.get(ha.DOMAIN) or {})
 
-    hass.services.register(ha.DOMAIN, SERVICE_RELOAD_CORE_CONFIG,
-                           handle_reload_config)
+    hass.services.async_register(
+        ha.DOMAIN, SERVICE_RELOAD_CORE_CONFIG, handle_reload_config)
 
     return True

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -114,7 +114,7 @@ def setup(hass: HomeAssistantType, config: ConfigType):
     try:
         conf = config.get(DOMAIN, [])
     except vol.Invalid as ex:
-        log_exception(ex, DOMAIN, config)
+        log_exception(ex, DOMAIN, config, hass)
         return False
     else:
         conf = conf[0] if len(conf) > 0 else {}
@@ -431,7 +431,7 @@ def load_config(path: str, hass: HomeAssistantType, consider_home: timedelta):
                 device = dev_schema(device)
                 device['dev_id'] = cv.slugify(dev_id)
             except vol.Invalid as exp:
-                log_exception(exp, dev_id, devices)
+                log_exception(exp, dev_id, devices, hass)
             else:
                 result.append(Device(hass, **device))
         return result

--- a/homeassistant/components/persistent_notification.py
+++ b/homeassistant/components/persistent_notification.py
@@ -10,12 +10,13 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity import generate_entity_id
+from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.util import slugify
 from homeassistant.config import load_yaml_config_file
-from homeassistant.util.async import run_coroutine_threadsafe
+from homeassistant.util.async import run_callback_threadsafe
 
 DOMAIN = 'persistent_notification'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
@@ -38,12 +39,12 @@ _LOGGER = logging.getLogger(__name__)
 
 def create(hass, message, title=None, notification_id=None):
     """Generate a notification."""
-    run_coroutine_threadsafe(
-        async_create(hass, message, title, notification_id), hass.loop
+    run_callback_threadsafe(
+        hass.loop, async_create, hass, message, title, notification_id
     ).result()
 
 
-@asyncio.coroutine
+@callback
 def async_create(hass, message, title=None, notification_id=None):
     """Generate a notification."""
     data = {
@@ -54,11 +55,14 @@ def async_create(hass, message, title=None, notification_id=None):
         ] if value is not None
     }
 
-    yield from hass.services.async_call(DOMAIN, SERVICE_CREATE, data)
+    hass.loop.create_task(
+        hass.services.async_call(DOMAIN, SERVICE_CREATE, data))
 
 
-def setup(hass, config):
+@asyncio.coroutine
+def async_setup(hass, config):
     """Setup the persistent notification component."""
+    @callback
     def create_service(call):
         """Handle a create notification service call."""
         title = call.data.get(ATTR_TITLE)
@@ -68,13 +72,13 @@ def setup(hass, config):
         if notification_id is not None:
             entity_id = ENTITY_ID_FORMAT.format(slugify(notification_id))
         else:
-            entity_id = generate_entity_id(ENTITY_ID_FORMAT, DEFAULT_OBJECT_ID,
-                                           hass=hass)
+            entity_id = async_generate_entity_id(
+                ENTITY_ID_FORMAT, DEFAULT_OBJECT_ID, hass=hass)
         attr = {}
         if title is not None:
             try:
                 title.hass = hass
-                title = title.render()
+                title = title.async_render()
             except TemplateError as ex:
                 _LOGGER.error('Error rendering title %s: %s', title, ex)
                 title = title.template
@@ -83,17 +87,19 @@ def setup(hass, config):
 
         try:
             message.hass = hass
-            message = message.render()
+            message = message.async_render()
         except TemplateError as ex:
             _LOGGER.error('Error rendering message %s: %s', message, ex)
             message = message.template
 
-        hass.states.set(entity_id, message, attr)
+        hass.states.async_set(entity_id, message, attr)
 
-    descriptions = load_yaml_config_file(
-        os.path.join(os.path.dirname(__file__), 'services.yaml'))
-    hass.services.register(DOMAIN, SERVICE_CREATE, create_service,
-                           descriptions[DOMAIN][SERVICE_CREATE],
-                           SCHEMA_SERVICE_CREATE)
+    descriptions = yield from hass.loop.run_in_executor(
+        None, load_yaml_config_file, os.path.join(
+            os.path.dirname(__file__), 'services.yaml')
+    )
+    hass.services.async_register(DOMAIN, SERVICE_CREATE, create_service,
+                                 descriptions[DOMAIN][SERVICE_CREATE],
+                                 SCHEMA_SERVICE_CREATE)
 
     return True

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -56,7 +56,10 @@ def async_generate_entity_id(entity_id_format: str, name: Optional[str],
 
 
 def set_customize(customize: Dict[str, Any]) -> None:
-    """Overwrite all current customize settings."""
+    """Overwrite all current customize settings.
+
+    Async friendly.
+    """
     global _OVERWRITE
 
     _OVERWRITE = {key.lower(): val for key, val in customize.items()}

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -40,7 +40,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def prepare(hass: 'HomeAssistant'):
-    """Prepare the loading of components."""
+    """Prepare the loading of components.
+
+    Asyncio don't support file operation jet.
+    This method need to run in a executor.
+    """
     global PREPARED  # pylint: disable=global-statement
 
     # Load the built-in components
@@ -81,14 +85,20 @@ def prepare(hass: 'HomeAssistant'):
 
 
 def set_component(comp_name: str, component: ModuleType) -> None:
-    """Set a component in the cache."""
+    """Set a component in the cache.
+
+    Async friendly.
+    """
     _check_prepared()
 
     _COMPONENT_CACHE[comp_name] = component
 
 
 def get_platform(domain: str, platform: str) -> Optional[ModuleType]:
-    """Try to load specified platform."""
+    """Try to load specified platform.
+
+    Async friendly.
+    """
     return get_component(PLATFORM_FORMAT.format(domain, platform))
 
 
@@ -97,6 +107,8 @@ def get_component(comp_name) -> Optional[ModuleType]:
 
     Looks in config dir first, then built-in components.
     Only returns it if also found to be valid.
+
+    Async friendly.
     """
     if comp_name in _COMPONENT_CACHE:
         return _COMPONENT_CACHE[comp_name]
@@ -166,6 +178,8 @@ def load_order_components(components: Sequence[str]) -> OrderedSet:
     - Will ensure that all components that do not directly depend on
       the group component will be loaded before the group component.
     - returns an OrderedSet load order.
+
+    Async friendly.
     """
     _check_prepared()
 
@@ -192,13 +206,18 @@ def load_order_component(comp_name: str) -> OrderedSet:
 
     Raises HomeAssistantError if a circular dependency is detected.
     Returns an empty list if component could not be loaded.
+
+    Async friendly.
     """
     return _load_order_component(comp_name, OrderedSet(), set())
 
 
 def _load_order_component(comp_name: str, load_order: OrderedSet,
                           loading: Set) -> OrderedSet:
-    """Recursive function to get load order of components."""
+    """Recursive function to get load order of components.
+
+    Async friendly.
+    """
     component = get_component(comp_name)
 
     # If None it does not exist, error already thrown by get_component.
@@ -235,7 +254,10 @@ def _load_order_component(comp_name: str, load_order: OrderedSet,
 
 
 def _check_prepared() -> None:
-    """Issue a warning if loader.prepare() has never been called."""
+    """Issue a warning if loader.prepare() has never been called.
+
+    Async friendly.
+    """
     if not PREPARED:
         _LOGGER.warning((
             "You did not call loader.prepare() yet. "

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -26,8 +26,8 @@ MOCKS = {
     'load*': ("homeassistant.config.load_yaml", yaml.load_yaml),
     'get': ("homeassistant.loader.get_component", loader.get_component),
     'secrets': ("homeassistant.util.yaml._secret_yaml", yaml._secret_yaml),
-    'except': ("homeassistant.bootstrap.log_exception",
-               bootstrap.log_exception)
+    'except': ("homeassistant.bootstrap.async_log_exception",
+               bootstrap.async_log_exception)
 }
 SILENCE = (
     'homeassistant.bootstrap.clear_secret_cache',
@@ -150,6 +150,7 @@ def run(script_args: List) -> int:
     return 0
 
 
+
 def check(config_path):
     """Perform a check by mocking hass load functions."""
     res = {
@@ -185,8 +186,14 @@ def check(config_path):
         # Test if platform/component and overwrite setup
         if '.' in comp_name:
             module.setup_platform = mock_setup
+
+            if hasattr(module, 'async_setup_platform'):
+                del module.async_setup_platform
         else:
             module.setup = mock_setup
+
+            if hasattr(module, 'async_setup'):
+                del module.async_setup
 
         return module
 

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -150,7 +150,6 @@ def run(script_args: List) -> int:
     return 0
 
 
-
 def check(config_path):
     """Perform a check by mocking hass load functions."""
     res = {

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -23,7 +23,10 @@ DATETIME_RE = re.compile(
 
 
 def set_default_time_zone(time_zone: dt.tzinfo) -> None:
-    """Set a default time zone to be used when none is specified."""
+    """Set a default time zone to be used when none is specified.
+
+    Async friendly.
+    """
     global DEFAULT_TIME_ZONE  # pylint: disable=global-statement
 
     # NOTE: Remove in the future in favour of typing

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -36,7 +36,10 @@ def set_default_time_zone(time_zone: dt.tzinfo) -> None:
 
 
 def get_time_zone(time_zone_str: str) -> Optional[dt.tzinfo]:
-    """Get time zone from string. Return None if unable to determine."""
+    """Get time zone from string. Return None if unable to determine.
+
+    Async friendly.
+    """
     try:
         return pytz.timezone(time_zone_str)
     except pytz.exceptions.UnknownTimeZoneError:

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -49,7 +49,10 @@ def load_yaml(fname: str) -> Union[List, Dict]:
 
 
 def clear_secret_cache() -> None:
-    """Clear the secret cache."""
+    """Clear the secret cache.
+
+    Async friendly.
+    """
     __SECRET_CACHE.clear()
 
 

--- a/tests/components/automation/test_event.py
+++ b/tests/components/automation/test_event.py
@@ -1,7 +1,7 @@
 """The tests for the Event automation."""
 import unittest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.automation as automation
 
 from tests.common import get_test_home_assistant
@@ -28,7 +28,7 @@ class TestAutomationEvent(unittest.TestCase):
 
     def test_if_fires_on_event(self):
         """Test the firing of events."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',
@@ -53,7 +53,7 @@ class TestAutomationEvent(unittest.TestCase):
 
     def test_if_fires_on_event_with_data(self):
         """Test the firing of events with data."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',
@@ -73,7 +73,7 @@ class TestAutomationEvent(unittest.TestCase):
 
     def test_if_not_fires_if_event_data_not_matches(self):
         """Test firing of event if no match."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -359,37 +359,25 @@ class TestAutomation(unittest.TestCase):
 
         automation.toggle(self.hass, entity_id)
         self.hass.block_till_done()
+
+        assert automation.is_on(self.hass, entity_id)
         self.hass.bus.fire('test_event')
         self.hass.block_till_done()
         assert len(self.calls) == 2
 
-        assert automation.is_on(self.hass, entity_id)
-        self.hass.bus.fire('test_event')
+        automation.trigger(self.hass, entity_id)
         self.hass.block_till_done()
         assert len(self.calls) == 3
 
-        automation.trigger(self.hass, entity_id)
-        self.hass.block_till_done()
-        self.hass.bus.fire('test_event')
-        self.hass.block_till_done()
-        assert len(self.calls) == 5
-
         automation.turn_off(self.hass, entity_id)
         self.hass.block_till_done()
-        self.hass.bus.fire('test_event')
-        self.hass.block_till_done()
         automation.trigger(self.hass, entity_id)
         self.hass.block_till_done()
-        self.hass.bus.fire('test_event')
-        self.hass.block_till_done()
-        assert len(self.calls) == 6
+        assert len(self.calls) == 4
 
         automation.turn_on(self.hass, entity_id)
         self.hass.block_till_done()
-        self.hass.bus.fire('test_event')
-        self.hass.block_till_done()
         assert automation.is_on(self.hass, entity_id)
-        assert len(self.calls) == 7
 
     @patch('homeassistant.config.load_yaml_config_file', autospec=True,
            return_value={

--- a/tests/components/automation/test_mqtt.py
+++ b/tests/components/automation/test_mqtt.py
@@ -1,7 +1,7 @@
 """The tests for the MQTT automation."""
 import unittest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.automation as automation
 from tests.common import (
     mock_mqtt_component, fire_mqtt_message, get_test_home_assistant)
@@ -28,7 +28,7 @@ class TestAutomationMQTT(unittest.TestCase):
 
     def test_if_fires_on_topic_match(self):
         """Test if message is fired on topic match."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'mqtt',
@@ -58,7 +58,7 @@ class TestAutomationMQTT(unittest.TestCase):
 
     def test_if_fires_on_topic_and_payload_match(self):
         """Test if message is fired on topic and payload match."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'mqtt',
@@ -77,7 +77,7 @@ class TestAutomationMQTT(unittest.TestCase):
 
     def test_if_not_fires_on_topic_but_no_payload_match(self):
         """Test if message is not fired on topic but no payload."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'mqtt',

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -1,7 +1,7 @@
 """The tests for numeric state automation."""
 import unittest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.automation as automation
 
 from tests.common import get_test_home_assistant
@@ -28,7 +28,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_if_fires_on_entity_change_below(self):
         """"Test the firing with changed entity."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -58,7 +58,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.hass.states.set('test.entity', 11)
         self.hass.block_till_done()
 
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -81,7 +81,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.hass.states.set('test.entity', 9)
         self.hass.block_till_done()
 
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -101,7 +101,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_if_fires_on_entity_change_above(self):
         """"Test the firing with changed entity."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -124,7 +124,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.hass.states.set('test.entity', 9)
         self.hass.block_till_done()
 
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -148,7 +148,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.hass.states.set('test.entity', 11)
         self.hass.block_till_done()
 
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -168,7 +168,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_if_fires_on_entity_change_below_range(self):
         """"Test the firing with changed entity."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -188,7 +188,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_if_fires_on_entity_change_below_above_range(self):
         """"Test the firing with changed entity."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -211,7 +211,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.hass.states.set('test.entity', 11)
         self.hass.block_till_done()
 
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -235,7 +235,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.hass.states.set('test.entity', 11)
         self.hass.block_till_done()
 
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -256,7 +256,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_if_not_fires_if_entity_not_match(self):
         """"Test if not fired with non matching entity."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -275,7 +275,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_if_fires_on_entity_change_below_with_attribute(self):
         """"Test attributes change."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -294,7 +294,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_if_not_fires_on_entity_change_not_below_with_attribute(self):
         """"Test attributes."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -313,7 +313,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_if_fires_on_attribute_change_with_attribute_below(self):
         """"Test attributes change."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -333,7 +333,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_if_not_fires_on_attribute_change_with_attribute_not_below(self):
         """"Test attributes change."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -353,7 +353,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_if_not_fires_on_entity_change_with_attribute_below(self):
         """"Test attributes change."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -373,7 +373,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_if_not_fires_on_entity_change_with_not_attribute_below(self):
         """"Test attributes change."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -393,7 +393,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_fires_on_attr_change_with_attribute_below_and_multiple_attr(self):
         """"Test attributes change."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -414,7 +414,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_template_list(self):
         """"Test template list."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -436,7 +436,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_template_string(self):
         """"Test template string."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -469,7 +469,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
     def test_not_fires_on_attr_change_with_attr_not_below_multiple_attr(self):
         """"Test if not fired changed attributes."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'numeric_state',
@@ -492,7 +492,7 @@ class TestAutomationNumericState(unittest.TestCase):
         """"Test if action."""
         entity_id = 'domain.test_entity'
         test_state = 10
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -3,11 +3,12 @@ import unittest
 from datetime import timedelta
 from unittest.mock import patch
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 import homeassistant.util.dt as dt_util
 import homeassistant.components.automation as automation
 
-from tests.common import fire_time_changed, get_test_home_assistant
+from tests.common import (
+    fire_time_changed, get_test_home_assistant, assert_setup_component)
 
 
 class TestAutomationState(unittest.TestCase):
@@ -34,7 +35,7 @@ class TestAutomationState(unittest.TestCase):
         self.hass.states.set('test.entity', 'hello')
         self.hass.block_till_done()
 
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'state',
@@ -67,7 +68,7 @@ class TestAutomationState(unittest.TestCase):
 
     def test_if_fires_on_entity_change_with_from_filter(self):
         """Test for firing on entity change with filter."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'state',
@@ -86,7 +87,7 @@ class TestAutomationState(unittest.TestCase):
 
     def test_if_fires_on_entity_change_with_to_filter(self):
         """Test for firing on entity change with no filter."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'state',
@@ -105,7 +106,7 @@ class TestAutomationState(unittest.TestCase):
 
     def test_if_fires_on_entity_change_with_state_filter(self):
         """Test for firing on entity change with state filter."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'state',
@@ -124,7 +125,7 @@ class TestAutomationState(unittest.TestCase):
 
     def test_if_fires_on_entity_change_with_both_filters(self):
         """Test for firing if both filters are a non match."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'state',
@@ -144,7 +145,7 @@ class TestAutomationState(unittest.TestCase):
 
     def test_if_not_fires_if_to_filter_not_match(self):
         """Test for not firing if to filter is not a match."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'state',
@@ -166,7 +167,7 @@ class TestAutomationState(unittest.TestCase):
         """Test for not firing if from filter is not a match."""
         self.hass.states.set('test.entity', 'bye')
 
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'state',
@@ -186,7 +187,7 @@ class TestAutomationState(unittest.TestCase):
 
     def test_if_not_fires_if_entity_not_match(self):
         """Test for not firing if entity is not matching."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'state',
@@ -206,7 +207,7 @@ class TestAutomationState(unittest.TestCase):
         """Test for to action."""
         entity_id = 'domain.test_entity'
         test_state = 'new_state'
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',
@@ -237,68 +238,72 @@ class TestAutomationState(unittest.TestCase):
 
     def test_if_fails_setup_if_to_boolean_value(self):
         """Test for setup failure for boolean to."""
-        assert not _setup_component(self.hass, automation.DOMAIN, {
-            automation.DOMAIN: {
-                'trigger': {
-                    'platform': 'state',
-                    'entity_id': 'test.entity',
-                    'to': True,
-                },
-                'action': {
-                    'service': 'homeassistant.turn_on',
-                }
-            }})
+        with assert_setup_component(0):
+            assert not setup_component(self.hass, automation.DOMAIN, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'state',
+                        'entity_id': 'test.entity',
+                        'to': True,
+                    },
+                    'action': {
+                        'service': 'homeassistant.turn_on',
+                    }
+                }})
 
     def test_if_fails_setup_if_from_boolean_value(self):
         """Test for setup failure for boolean from."""
-        assert not _setup_component(self.hass, automation.DOMAIN, {
-            automation.DOMAIN: {
-                'trigger': {
-                    'platform': 'state',
-                    'entity_id': 'test.entity',
-                    'from': True,
-                },
-                'action': {
-                    'service': 'homeassistant.turn_on',
-                }
-            }})
+        with assert_setup_component(0):
+            assert not setup_component(self.hass, automation.DOMAIN, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'state',
+                        'entity_id': 'test.entity',
+                        'from': True,
+                    },
+                    'action': {
+                        'service': 'homeassistant.turn_on',
+                    }
+                }})
 
     def test_if_fails_setup_bad_for(self):
         """Test for setup failure for bad for."""
-        assert not _setup_component(self.hass, automation.DOMAIN, {
-            automation.DOMAIN: {
-                'trigger': {
-                    'platform': 'state',
-                    'entity_id': 'test.entity',
-                    'to': 'world',
-                    'for': {
-                        'invalid': 5
+        with assert_setup_component(0):
+            assert not setup_component(self.hass, automation.DOMAIN, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'state',
+                        'entity_id': 'test.entity',
+                        'to': 'world',
+                        'for': {
+                            'invalid': 5
+                        },
                     },
-                },
-                'action': {
-                    'service': 'homeassistant.turn_on',
-                }
-            }})
+                    'action': {
+                        'service': 'homeassistant.turn_on',
+                    }
+                }})
 
     def test_if_fails_setup_for_without_to(self):
         """Test for setup failures for missing to."""
-        assert not _setup_component(self.hass, automation.DOMAIN, {
-            automation.DOMAIN: {
-                'trigger': {
-                    'platform': 'state',
-                    'entity_id': 'test.entity',
-                    'for': {
-                        'seconds': 5
+        with assert_setup_component(0):
+            assert not setup_component(self.hass, automation.DOMAIN, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'state',
+                        'entity_id': 'test.entity',
+                        'for': {
+                            'seconds': 5
+                        },
                     },
-                },
-                'action': {
-                    'service': 'homeassistant.turn_on',
-                }
-            }})
+                    'action': {
+                        'service': 'homeassistant.turn_on',
+                    }
+                }})
 
     def test_if_not_fires_on_entity_change_with_for(self):
         """Test for not firing on entity change with for."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'state',
@@ -324,7 +329,7 @@ class TestAutomationState(unittest.TestCase):
 
     def test_if_fires_on_entity_change_with_for(self):
         """Test for firing on entity change with for."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'state',
@@ -353,7 +358,7 @@ class TestAutomationState(unittest.TestCase):
         with patch('homeassistant.core.dt_util.utcnow') as mock_utcnow:
             mock_utcnow.return_value = point1
             self.hass.states.set('test.entity', 'on')
-            assert _setup_component(self.hass, automation.DOMAIN, {
+            assert setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'event',
@@ -384,32 +389,34 @@ class TestAutomationState(unittest.TestCase):
 
     def test_if_fails_setup_for_without_time(self):
         """Test for setup failure if no time is provided."""
-        assert not _setup_component(self.hass, automation.DOMAIN, {
-            automation.DOMAIN: {
-                'trigger': {
-                    'platform': 'event',
-                    'event_type': 'bla'
-                },
-                'condition': {
-                    'platform': 'state',
-                    'entity_id': 'test.entity',
-                    'state': 'on',
-                    'for': {},
-                },
-                'action': {'service': 'test.automation'},
-            }})
+        with assert_setup_component(0):
+            assert not setup_component(self.hass, automation.DOMAIN, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'event',
+                        'event_type': 'bla'
+                    },
+                    'condition': {
+                        'platform': 'state',
+                        'entity_id': 'test.entity',
+                        'state': 'on',
+                        'for': {},
+                    },
+                    'action': {'service': 'test.automation'},
+                }})
 
     def test_if_fails_setup_for_without_entity(self):
         """Test for setup failure if no entity is provided."""
-        assert not _setup_component(self.hass, automation.DOMAIN, {
-            automation.DOMAIN: {
-                'trigger': {'event_type': 'bla'},
-                'condition': {
-                    'platform': 'state',
-                    'state': 'on',
-                    'for': {
-                        'seconds': 5
+        with assert_setup_component(0):
+            assert not setup_component(self.hass, automation.DOMAIN, {
+                automation.DOMAIN: {
+                    'trigger': {'event_type': 'bla'},
+                    'condition': {
+                        'platform': 'state',
+                        'state': 'on',
+                        'for': {
+                            'seconds': 5
+                        },
                     },
-                },
-                'action': {'service': 'test.automation'},
-            }})
+                    'action': {'service': 'test.automation'},
+                }})

--- a/tests/components/automation/test_sun.py
+++ b/tests/components/automation/test_sun.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import unittest
 from unittest.mock import patch
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import sun
 import homeassistant.components.automation as automation
 import homeassistant.util.dt as dt_util
@@ -42,7 +42,7 @@ class TestAutomationSun(unittest.TestCase):
 
         with patch('homeassistant.util.dt.utcnow',
                    return_value=now):
-            _setup_component(self.hass, automation.DOMAIN, {
+            setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'sun',
@@ -81,7 +81,7 @@ class TestAutomationSun(unittest.TestCase):
 
         with patch('homeassistant.util.dt.utcnow',
                    return_value=now):
-            _setup_component(self.hass, automation.DOMAIN, {
+            setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'sun',
@@ -108,7 +108,7 @@ class TestAutomationSun(unittest.TestCase):
 
         with patch('homeassistant.util.dt.utcnow',
                    return_value=now):
-            _setup_component(self.hass, automation.DOMAIN, {
+            setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'sun',
@@ -142,7 +142,7 @@ class TestAutomationSun(unittest.TestCase):
 
         with patch('homeassistant.util.dt.utcnow',
                    return_value=now):
-            _setup_component(self.hass, automation.DOMAIN, {
+            setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'sun',
@@ -165,7 +165,7 @@ class TestAutomationSun(unittest.TestCase):
             sun.STATE_ATTR_NEXT_RISING: '2015-09-16T14:00:00Z',
         })
 
-        _setup_component(self.hass, automation.DOMAIN, {
+        setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',
@@ -201,7 +201,7 @@ class TestAutomationSun(unittest.TestCase):
             sun.STATE_ATTR_NEXT_RISING: '2015-09-16T14:00:00Z',
         })
 
-        _setup_component(self.hass, automation.DOMAIN, {
+        setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',
@@ -237,7 +237,7 @@ class TestAutomationSun(unittest.TestCase):
             sun.STATE_ATTR_NEXT_RISING: '2015-09-16T14:00:00Z',
         })
 
-        _setup_component(self.hass, automation.DOMAIN, {
+        setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',
@@ -274,7 +274,7 @@ class TestAutomationSun(unittest.TestCase):
             sun.STATE_ATTR_NEXT_RISING: '2015-09-16T14:00:00Z',
         })
 
-        _setup_component(self.hass, automation.DOMAIN, {
+        setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',
@@ -312,7 +312,7 @@ class TestAutomationSun(unittest.TestCase):
             sun.STATE_ATTR_NEXT_SETTING: '2015-09-16T15:00:00Z',
         })
 
-        _setup_component(self.hass, automation.DOMAIN, {
+        setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',
@@ -358,7 +358,7 @@ class TestAutomationSun(unittest.TestCase):
             sun.STATE_ATTR_NEXT_SETTING: '2015-09-16T17:30:00Z',
         })
 
-        _setup_component(self.hass, automation.DOMAIN, {
+        setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -1,10 +1,10 @@
 """The tests for the Template automation."""
 import unittest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.automation as automation
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, assert_setup_component
 
 
 class TestAutomationTemplate(unittest.TestCase):
@@ -29,7 +29,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_fires_on_change_bool(self):
         """Test for firing on boolean change."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
@@ -54,7 +54,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_fires_on_change_str(self):
         """Test for firing on change."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
@@ -72,7 +72,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_fires_on_change_str_crazy(self):
         """Test for firing on change."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
@@ -90,7 +90,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_not_fires_on_change_bool(self):
         """Test for not firing on boolean change."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
@@ -108,7 +108,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_not_fires_on_change_str(self):
         """Test for not firing on string change."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
@@ -126,7 +126,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_not_fires_on_change_str_crazy(self):
         """Test for not firing on string change."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
@@ -144,7 +144,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_fires_on_no_change(self):
         """Test for firing on no change."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
@@ -165,7 +165,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_fires_on_two_change(self):
         """Test for firing on two changes."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
@@ -189,7 +189,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_fires_on_change_with_template(self):
         """Test for firing on change with template."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
@@ -207,7 +207,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_not_fires_on_change_with_template(self):
         """Test for not firing on change with template."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
@@ -228,7 +228,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_fires_on_change_with_template_advanced(self):
         """Test for firing on change with template advanced."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
@@ -262,7 +262,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_fires_on_no_change_with_template_advanced(self):
         """Test for firing on no change with template advanced."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
@@ -290,7 +290,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_fires_on_change_with_template_2(self):
         """Test for firing on change with template."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
@@ -332,7 +332,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_action(self):
         """Test for firing if action."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',
@@ -365,21 +365,22 @@ class TestAutomationTemplate(unittest.TestCase):
 
     def test_if_fires_on_change_with_bad_template(self):
         """Test for firing on change with bad template."""
-        assert not _setup_component(self.hass, automation.DOMAIN, {
-            automation.DOMAIN: {
-                'trigger': {
-                    'platform': 'template',
-                    'value_template': '{{ ',
-                },
-                'action': {
-                    'service': 'test.automation'
+        with assert_setup_component(0):
+            assert not setup_component(self.hass, automation.DOMAIN, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'template',
+                        'value_template': '{{ ',
+                    },
+                    'action': {
+                        'service': 'test.automation'
+                    }
                 }
-            }
-        })
+            })
 
     def test_if_fires_on_change_with_bad_template_2(self):
         """Test for firing on change with bad template."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -3,11 +3,12 @@ from datetime import timedelta
 import unittest
 from unittest.mock import patch
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 import homeassistant.util.dt as dt_util
 import homeassistant.components.automation as automation
 
-from tests.common import fire_time_changed, get_test_home_assistant
+from tests.common import (
+    fire_time_changed, get_test_home_assistant, assert_setup_component)
 
 
 class TestAutomationTime(unittest.TestCase):
@@ -30,7 +31,7 @@ class TestAutomationTime(unittest.TestCase):
 
     def test_if_fires_when_hour_matches(self):
         """Test for firing if hour is matching."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'time',
@@ -55,7 +56,7 @@ class TestAutomationTime(unittest.TestCase):
 
     def test_if_fires_when_minute_matches(self):
         """Test for firing if minutes are matching."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'time',
@@ -74,7 +75,7 @@ class TestAutomationTime(unittest.TestCase):
 
     def test_if_fires_when_second_matches(self):
         """Test for firing if seconds are matching."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'time',
@@ -93,7 +94,7 @@ class TestAutomationTime(unittest.TestCase):
 
     def test_if_fires_when_all_matches(self):
         """Test for firing if everything matches."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'time',
@@ -115,7 +116,7 @@ class TestAutomationTime(unittest.TestCase):
 
     def test_if_fires_periodic_seconds(self):
         """Test for firing periodically every second."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'time',
@@ -135,7 +136,7 @@ class TestAutomationTime(unittest.TestCase):
 
     def test_if_fires_periodic_minutes(self):
         """Test for firing periodically every minute."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'time',
@@ -155,7 +156,7 @@ class TestAutomationTime(unittest.TestCase):
 
     def test_if_fires_periodic_hours(self):
         """Test for firing periodically every hour."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'time',
@@ -175,7 +176,7 @@ class TestAutomationTime(unittest.TestCase):
 
     def test_if_fires_using_after(self):
         """Test for firing after."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'time',
@@ -200,16 +201,17 @@ class TestAutomationTime(unittest.TestCase):
 
     def test_if_not_working_if_no_values_in_conf_provided(self):
         """Test for failure if no configuration."""
-        assert not _setup_component(self.hass, automation.DOMAIN, {
-            automation.DOMAIN: {
-                'trigger': {
-                    'platform': 'time',
-                },
-                'action': {
-                    'service': 'test.automation'
+        with assert_setup_component(0):
+            assert not setup_component(self.hass, automation.DOMAIN, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'time',
+                    },
+                    'action': {
+                        'service': 'test.automation'
+                    }
                 }
-            }
-        })
+            })
 
         fire_time_changed(self.hass, dt_util.utcnow().replace(
             hour=5, minute=0, second=0))
@@ -222,18 +224,19 @@ class TestAutomationTime(unittest.TestCase):
 
         This should break the before rule.
         """
-        assert not _setup_component(self.hass, automation.DOMAIN, {
-            automation.DOMAIN: {
-                'trigger': {
-                    'platform': 'time',
-                    'after': 3605,
-                    # Total seconds. Hour = 3600 second
-                },
-                'action': {
-                    'service': 'test.automation'
+        with assert_setup_component(0):
+            assert not setup_component(self.hass, automation.DOMAIN, {
+                automation.DOMAIN: {
+                    'trigger': {
+                        'platform': 'time',
+                        'after': 3605,
+                        # Total seconds. Hour = 3600 second
+                    },
+                    'action': {
+                        'service': 'test.automation'
+                    }
                 }
-            }
-        })
+            })
 
         fire_time_changed(self.hass, dt_util.utcnow().replace(
             hour=1, minute=0, second=5))
@@ -243,7 +246,7 @@ class TestAutomationTime(unittest.TestCase):
 
     def test_if_action_before(self):
         """Test for if action before."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',
@@ -278,7 +281,7 @@ class TestAutomationTime(unittest.TestCase):
 
     def test_if_action_after(self):
         """Test for if action after."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',
@@ -313,7 +316,7 @@ class TestAutomationTime(unittest.TestCase):
 
     def test_if_action_one_weekday(self):
         """Test for if action with one weekday."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',
@@ -349,7 +352,7 @@ class TestAutomationTime(unittest.TestCase):
 
     def test_if_action_list_weekday(self):
         """Test for action with a list of weekdays."""
-        assert _setup_component(self.hass, automation.DOMAIN, {
+        assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'event',

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -1,7 +1,7 @@
 """The tests for the  MQTT binary sensor platform."""
 import unittest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.binary_sensor as binary_sensor
 from tests.common import mock_mqtt_component, fire_mqtt_message
 from homeassistant.const import (STATE_OFF, STATE_ON)
@@ -24,7 +24,7 @@ class TestSensorMQTT(unittest.TestCase):
     def test_setting_sensor_value_via_mqtt_message(self):
         """Test the setting of the value via MQTT."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, binary_sensor.DOMAIN, {
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
             binary_sensor.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -50,7 +50,7 @@ class TestSensorMQTT(unittest.TestCase):
     def test_valid_sensor_class(self):
         """Test the setting of a valid sensor class."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, binary_sensor.DOMAIN, {
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
             binary_sensor.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -65,7 +65,7 @@ class TestSensorMQTT(unittest.TestCase):
     def test_invalid_sensor_class(self):
         """Test the setting of an invalid sensor class."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, binary_sensor.DOMAIN, {
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
             binary_sensor.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',

--- a/tests/components/binary_sensor/test_nx584.py
+++ b/tests/components/binary_sensor/test_nx584.py
@@ -8,6 +8,8 @@ from nx584 import client as nx584_client
 from homeassistant.components.binary_sensor import nx584
 from homeassistant.bootstrap import setup_component
 
+from tests.common import get_test_home_assistant
+
 
 class StopMe(Exception):
     """Stop helper."""
@@ -20,6 +22,7 @@ class TestNX584SensorSetup(unittest.TestCase):
 
     def setUp(self):
         """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
         self._mock_client = mock.patch.object(nx584_client, 'Client')
         self._mock_client.start()
 
@@ -35,6 +38,7 @@ class TestNX584SensorSetup(unittest.TestCase):
 
     def tearDown(self):
         """Stop everything that was started."""
+        self.hass.stop()
         self._mock_client.stop()
 
     @mock.patch('homeassistant.components.binary_sensor.nx584.NX584Watcher')
@@ -42,14 +46,13 @@ class TestNX584SensorSetup(unittest.TestCase):
     def test_setup_defaults(self, mock_nx, mock_watcher):
         """Test the setup with no configuration."""
         add_devices = mock.MagicMock()
-        hass = mock.MagicMock()
         config = {
             'host': nx584.DEFAULT_HOST,
             'port': nx584.DEFAULT_PORT,
             'exclude_zones': [],
             'zone_types': {},
             }
-        self.assertTrue(nx584.setup_platform(hass, config, add_devices))
+        self.assertTrue(nx584.setup_platform(self.hass, config, add_devices))
         mock_nx.assert_has_calls(
              [mock.call(zone, 'opening') for zone in self.fake_zones])
         self.assertTrue(add_devices.called)
@@ -69,8 +72,7 @@ class TestNX584SensorSetup(unittest.TestCase):
             'zone_types': {3: 'motion'},
             }
         add_devices = mock.MagicMock()
-        hass = mock.MagicMock()
-        self.assertTrue(nx584.setup_platform(hass, config, add_devices))
+        self.assertTrue(nx584.setup_platform(self.hass, config, add_devices))
         mock_nx.assert_has_calls([
             mock.call(self.fake_zones[0], 'opening'),
             mock.call(self.fake_zones[2], 'motion'),
@@ -84,9 +86,8 @@ class TestNX584SensorSetup(unittest.TestCase):
 
     def _test_assert_graceful_fail(self, config):
         """Test the failing."""
-        hass = add_devices = mock.MagicMock()
-        self.assertFalse(setup_component(hass, 'binary_sensor.nx584', config))
-        self.assertFalse(add_devices.called)
+        self.assertFalse(setup_component(
+            self.hass, 'binary_sensor.nx584', config))
 
     def test_setup_bad_config(self):
         """Test the setup with bad configuration."""
@@ -113,8 +114,8 @@ class TestNX584SensorSetup(unittest.TestCase):
     def test_setup_no_zones(self):
         """Test the setup with no zones."""
         nx584_client.Client.return_value.list_zones.return_value = []
-        hass = add_devices = mock.MagicMock()
-        self.assertTrue(nx584.setup_platform(hass, {}, add_devices))
+        add_devices = mock.MagicMock()
+        self.assertTrue(nx584.setup_platform(self.hass, {}, add_devices))
         self.assertFalse(add_devices.called)
 
 

--- a/tests/components/cover/test_rfxtrx.py
+++ b/tests/components/cover/test_rfxtrx.py
@@ -3,7 +3,7 @@ import unittest
 
 import pytest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
 
 from tests.common import get_test_home_assistant
@@ -28,7 +28,7 @@ class TestCoverRfxtrx(unittest.TestCase):
 
     def test_valid_config(self):
         """Test configuration."""
-        self.assertTrue(_setup_component(self.hass, 'cover', {
+        self.assertTrue(setup_component(self.hass, 'cover', {
             'cover': {'platform': 'rfxtrx',
                       'automatic_add': True,
                       'devices':
@@ -39,7 +39,7 @@ class TestCoverRfxtrx(unittest.TestCase):
 
     def test_invalid_config_capital_letters(self):
         """Test configuration."""
-        self.assertFalse(_setup_component(self.hass, 'cover', {
+        self.assertFalse(setup_component(self.hass, 'cover', {
             'cover': {'platform': 'rfxtrx',
                       'automatic_add': True,
                       'devices':
@@ -51,7 +51,7 @@ class TestCoverRfxtrx(unittest.TestCase):
 
     def test_invalid_config_extra_key(self):
         """Test configuration."""
-        self.assertFalse(_setup_component(self.hass, 'cover', {
+        self.assertFalse(setup_component(self.hass, 'cover', {
             'cover': {'platform': 'rfxtrx',
                       'automatic_add': True,
                       'invalid_key': 'afda',
@@ -64,7 +64,7 @@ class TestCoverRfxtrx(unittest.TestCase):
 
     def test_invalid_config_capital_packetid(self):
         """Test configuration."""
-        self.assertFalse(_setup_component(self.hass, 'cover', {
+        self.assertFalse(setup_component(self.hass, 'cover', {
             'cover': {'platform': 'rfxtrx',
                       'automatic_add': True,
                       'devices':
@@ -76,7 +76,7 @@ class TestCoverRfxtrx(unittest.TestCase):
 
     def test_invalid_config_missing_packetid(self):
         """Test configuration."""
-        self.assertFalse(_setup_component(self.hass, 'cover', {
+        self.assertFalse(setup_component(self.hass, 'cover', {
             'cover': {'platform': 'rfxtrx',
                       'automatic_add': True,
                       'devices':
@@ -87,14 +87,14 @@ class TestCoverRfxtrx(unittest.TestCase):
 
     def test_default_config(self):
         """Test with 0 cover."""
-        self.assertTrue(_setup_component(self.hass, 'cover', {
+        self.assertTrue(setup_component(self.hass, 'cover', {
             'cover': {'platform': 'rfxtrx',
                       'devices': {}}}))
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
 
     def test_one_cover(self):
         """Test with 1 cover."""
-        self.assertTrue(_setup_component(self.hass, 'cover', {
+        self.assertTrue(setup_component(self.hass, 'cover', {
             'cover': {'platform': 'rfxtrx',
                       'devices':
                           {'0b1400cd0213c7f210010f51': {
@@ -117,7 +117,7 @@ class TestCoverRfxtrx(unittest.TestCase):
 
     def test_several_covers(self):
         """Test with 3 covers."""
-        self.assertTrue(_setup_component(self.hass, 'cover', {
+        self.assertTrue(setup_component(self.hass, 'cover', {
             'cover': {'platform': 'rfxtrx',
                       'signal_repetitions': 3,
                       'devices':
@@ -145,7 +145,7 @@ class TestCoverRfxtrx(unittest.TestCase):
 
     def test_discover_covers(self):
         """Test with discovery of covers."""
-        self.assertTrue(_setup_component(self.hass, 'cover', {
+        self.assertTrue(setup_component(self.hass, 'cover', {
             'cover': {'platform': 'rfxtrx',
                       'automatic_add': True,
                       'devices': {}}}))
@@ -183,7 +183,7 @@ class TestCoverRfxtrx(unittest.TestCase):
 
     def test_discover_cover_noautoadd(self):
         """Test with discovery of cover when auto add is False."""
-        self.assertTrue(_setup_component(self.hass, 'cover', {
+        self.assertTrue(setup_component(self.hass, 'cover', {
             'cover': {'platform': 'rfxtrx',
                       'automatic_add': False,
                       'devices': {}}}))

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import logging
 import os
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.const import CONF_PLATFORM
 
@@ -42,7 +42,7 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
             dev_id = 'paulus'
             topic = '/location/paulus'
             self.hass.config.components = ['mqtt', 'zone']
-            assert _setup_component(self.hass, device_tracker.DOMAIN, {
+            assert setup_component(self.hass, device_tracker.DOMAIN, {
                 device_tracker.DOMAIN: {
                     CONF_PLATFORM: 'mqtt',
                     'devices': {dev_id: topic}
@@ -58,7 +58,7 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
         location = 'work'
 
         self.hass.config.components = ['mqtt', 'zone']
-        assert _setup_component(self.hass, device_tracker.DOMAIN, {
+        assert setup_component(self.hass, device_tracker.DOMAIN, {
             device_tracker.DOMAIN: {
                 CONF_PLATFORM: 'mqtt',
                 'devices': {dev_id: topic}

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -30,7 +30,7 @@ light:
 import json
 import unittest
 
-from homeassistant.bootstrap import _setup_component, setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.light as light
 from tests.common import (
@@ -67,7 +67,7 @@ class TestLightMQTTJSON(unittest.TestCase):
             # pylint: disable=invalid-name
         """Test if there is no color and brightness if they aren't defined."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, light.DOMAIN, {
+        assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
                 'name': 'test',
@@ -93,7 +93,7 @@ class TestLightMQTTJSON(unittest.TestCase):
             # pylint: disable=invalid-name
         """Test the controlling of the state via topic."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, light.DOMAIN, {
+        assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
                 'name': 'test',
@@ -153,7 +153,7 @@ class TestLightMQTTJSON(unittest.TestCase):
             # pylint: disable=invalid-name
         """Test the sending of command in optimistic mode."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, light.DOMAIN, {
+        assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
                 'name': 'test',
@@ -209,7 +209,7 @@ class TestLightMQTTJSON(unittest.TestCase):
             # pylint: disable=invalid-name
         """Test for flash length being sent when included."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, light.DOMAIN, {
+        assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
                 'name': 'test',
@@ -251,7 +251,7 @@ class TestLightMQTTJSON(unittest.TestCase):
     def test_transition(self):
         """Test for transition time being sent when included."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, light.DOMAIN, {
+        assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
                 'name': 'test',
@@ -293,7 +293,7 @@ class TestLightMQTTJSON(unittest.TestCase):
             # pylint: disable=invalid-name
         """Test that invalid color/brightness values are ignored."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, light.DOMAIN, {
+        assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
                 'name': 'test',

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -3,7 +3,7 @@ import unittest
 
 import pytest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
 
 from tests.common import get_test_home_assistant
@@ -28,7 +28,7 @@ class TestLightRfxtrx(unittest.TestCase):
 
     def test_valid_config(self):
         """Test configuration."""
-        self.assertTrue(_setup_component(self.hass, 'light', {
+        self.assertTrue(setup_component(self.hass, 'light', {
             'light': {'platform': 'rfxtrx',
                       'automatic_add': True,
                       'devices':
@@ -36,7 +36,7 @@ class TestLightRfxtrx(unittest.TestCase):
                                'name': 'Test',
                                rfxtrx_core.ATTR_FIREEVENT: True}}}}))
 
-        self.assertTrue(_setup_component(self.hass, 'light', {
+        self.assertTrue(setup_component(self.hass, 'light', {
             'light': {'platform': 'rfxtrx',
                       'automatic_add': True,
                       'devices':
@@ -47,7 +47,7 @@ class TestLightRfxtrx(unittest.TestCase):
 
     def test_invalid_config(self):
         """Test configuration."""
-        self.assertFalse(_setup_component(self.hass, 'light', {
+        self.assertFalse(setup_component(self.hass, 'light', {
             'light': {'platform': 'rfxtrx',
                       'automatic_add': True,
                       'invalid_key': 'afda',
@@ -59,14 +59,14 @@ class TestLightRfxtrx(unittest.TestCase):
 
     def test_default_config(self):
         """Test with 0 switches."""
-        self.assertTrue(_setup_component(self.hass, 'light', {
+        self.assertTrue(setup_component(self.hass, 'light', {
             'light': {'platform': 'rfxtrx',
                       'devices': {}}}))
         self.assertEqual(0, len(rfxtrx_core.RFX_DEVICES))
 
     def test_old_config(self):
         """Test with 1 light."""
-        self.assertTrue(_setup_component(self.hass, 'light', {
+        self.assertTrue(setup_component(self.hass, 'light', {
             'light': {'platform': 'rfxtrx',
                       'devices':
                       {'123efab1': {
@@ -110,7 +110,7 @@ class TestLightRfxtrx(unittest.TestCase):
 
     def test_one_light(self):
         """Test with 1 light."""
-        self.assertTrue(_setup_component(self.hass, 'light', {
+        self.assertTrue(setup_component(self.hass, 'light', {
             'light': {'platform': 'rfxtrx',
                       'devices':
                       {'0b1100cd0213c7f210010f51': {
@@ -179,7 +179,7 @@ class TestLightRfxtrx(unittest.TestCase):
 
     def test_several_lights(self):
         """Test with 3 lights."""
-        self.assertTrue(_setup_component(self.hass, 'light', {
+        self.assertTrue(setup_component(self.hass, 'light', {
             'light': {'platform': 'rfxtrx',
                       'signal_repetitions': 3,
                       'devices':
@@ -212,7 +212,7 @@ class TestLightRfxtrx(unittest.TestCase):
 
     def test_discover_light(self):
         """Test with discovery of lights."""
-        self.assertTrue(_setup_component(self.hass, 'light', {
+        self.assertTrue(setup_component(self.hass, 'light', {
             'light': {'platform': 'rfxtrx',
                       'automatic_add': True,
                       'devices': {}}}))
@@ -265,7 +265,7 @@ class TestLightRfxtrx(unittest.TestCase):
 
     def test_discover_light_noautoadd(self):
         """Test with discover of light when auto add is False."""
-        self.assertTrue(_setup_component(self.hass, 'light', {
+        self.assertTrue(setup_component(self.hass, 'light', {
             'light': {'platform': 'rfxtrx',
                       'automatic_add': False,
                       'devices': {}}}))

--- a/tests/components/lock/test_mqtt.py
+++ b/tests/components/lock/test_mqtt.py
@@ -1,7 +1,7 @@
 """The tests for the MQTT lock platform."""
 import unittest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED,
                                  ATTR_ASSUMED_STATE)
 import homeassistant.components.lock as lock
@@ -24,7 +24,7 @@ class TestLockMQTT(unittest.TestCase):
     def test_controlling_state_via_topic(self):
         """Test the controlling state via topic."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, lock.DOMAIN, {
+        assert setup_component(self.hass, lock.DOMAIN, {
             lock.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -54,7 +54,7 @@ class TestLockMQTT(unittest.TestCase):
     def test_sending_mqtt_commands_and_optimistic(self):
         """Test the sending MQTT commands in optimistic mode."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, lock.DOMAIN, {
+        assert setup_component(self.hass, lock.DOMAIN, {
             lock.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -88,7 +88,7 @@ class TestLockMQTT(unittest.TestCase):
     def test_controlling_state_via_topic_and_json_message(self):
         """Test the controlling state via topic and JSON message."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, lock.DOMAIN, {
+        assert setup_component(self.hass, lock.DOMAIN, {
             lock.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -6,7 +6,7 @@ import socket
 
 import voluptuous as vol
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.mqtt as mqtt
 from homeassistant.const import (
     EVENT_CALL_SERVICE, ATTR_DOMAIN, ATTR_SERVICE, EVENT_HOMEASSISTANT_START,
@@ -52,7 +52,7 @@ class TestMQTT(unittest.TestCase):
         with mock.patch('homeassistant.components.mqtt.MQTT',
                         side_effect=socket.error()):
             self.hass.config.components = []
-            assert not _setup_component(self.hass, mqtt.DOMAIN, {
+            assert not setup_component(self.hass, mqtt.DOMAIN, {
                 mqtt.DOMAIN: {
                     mqtt.CONF_BROKER: 'test-broker',
                 }
@@ -62,7 +62,7 @@ class TestMQTT(unittest.TestCase):
         """Test for setup failure if connection to broker is missing."""
         with mock.patch('paho.mqtt.client.Client'):
             self.hass.config.components = []
-            assert _setup_component(self.hass, mqtt.DOMAIN, {
+            assert setup_component(self.hass, mqtt.DOMAIN, {
                 mqtt.DOMAIN: {
                     mqtt.CONF_BROKER: 'test-broker',
                     mqtt.CONF_PROTOCOL: 3.1,
@@ -222,7 +222,7 @@ class TestMQTTCallbacks(unittest.TestCase):
 
         with mock.patch('paho.mqtt.client.Client'):
             self.hass.config.components = []
-            assert _setup_component(self.hass, mqtt.DOMAIN, {
+            assert setup_component(self.hass, mqtt.DOMAIN, {
                 mqtt.DOMAIN: {
                     mqtt.CONF_BROKER: 'mock-broker',
                 }

--- a/tests/components/mqtt/test_server.py
+++ b/tests/components/mqtt/test_server.py
@@ -1,7 +1,7 @@
 """The tests for the MQTT component embedded server."""
 from unittest.mock import Mock, MagicMock, patch
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.mqtt as mqtt
 
 from tests.common import get_test_home_assistant
@@ -29,7 +29,7 @@ class TestMQTT:
         password = 'super_secret'
 
         self.hass.config.api = MagicMock(api_password=password)
-        assert _setup_component(self.hass, mqtt.DOMAIN, {})
+        assert setup_component(self.hass, mqtt.DOMAIN, {})
         assert mock_mqtt.called
         assert mock_mqtt.mock_calls[0][1][5] == 'homeassistant'
         assert mock_mqtt.mock_calls[0][1][6] == password
@@ -38,7 +38,7 @@ class TestMQTT:
 
         self.hass.config.components = ['http']
         self.hass.config.api = MagicMock(api_password=None)
-        assert _setup_component(self.hass, mqtt.DOMAIN, {})
+        assert setup_component(self.hass, mqtt.DOMAIN, {})
         assert mock_mqtt.called
         assert mock_mqtt.mock_calls[0][1][5] is None
         assert mock_mqtt.mock_calls[0][1][6] is None
@@ -54,6 +54,7 @@ class TestMQTT:
         mock_gather.side_effect = BrokerException
 
         self.hass.config.api = MagicMock(api_password=None)
-        assert not _setup_component(self.hass, mqtt.DOMAIN, {
+
+        assert not setup_component(self.hass, mqtt.DOMAIN, {
             mqtt.DOMAIN: {mqtt.CONF_EMBEDDED: {}}
         })

--- a/tests/components/notify/test_file.py
+++ b/tests/components/notify/test_file.py
@@ -8,9 +8,8 @@ import homeassistant.components.notify as notify
 from homeassistant.components.notify import (
     ATTR_TITLE_DEFAULT)
 import homeassistant.util.dt as dt_util
-from homeassistant.bootstrap import _setup_component
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, assert_setup_component
 
 
 class TestNotifyFile(unittest.TestCase):
@@ -26,12 +25,13 @@ class TestNotifyFile(unittest.TestCase):
 
     def test_bad_config(self):
         """Test set up the platform with bad/missing config."""
-        self.assertFalse(_setup_component(self.hass, notify.DOMAIN, {
-            'notify': {
-                'name': 'test',
-                'platform': 'file',
-            },
-        }))
+        with assert_setup_component(0):
+            assert not setup_component(self.hass, notify.DOMAIN, {
+                'notify': {
+                    'name': 'test',
+                    'platform': 'file',
+                },
+            })
 
     @patch('homeassistant.components.notify.file.os.stat')
     @patch('homeassistant.util.dt.utcnow')

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -6,7 +6,7 @@ import unittest
 
 from homeassistant.const import MATCH_ALL
 from homeassistant.components import recorder
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from tests.common import get_test_home_assistant
 
 
@@ -17,7 +17,7 @@ class TestRecorder(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         db_uri = 'sqlite://'  # In memory DB
-        _setup_component(self.hass, recorder.DOMAIN, {
+        setup_component(self.hass, recorder.DOMAIN, {
             recorder.DOMAIN: {recorder.CONF_DB_URL: db_uri}})
         self.hass.start()
         recorder._verify_instance()

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -1,7 +1,7 @@
 """The tests for the MQTT sensor platform."""
 import unittest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 import homeassistant.components.sensor as sensor
 from tests.common import mock_mqtt_component, fire_mqtt_message
 
@@ -23,7 +23,7 @@ class TestSensorMQTT(unittest.TestCase):
     def test_setting_sensor_value_via_mqtt_message(self):
         """Test the setting of the value via MQTT."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, sensor.DOMAIN, {
+        assert setup_component(self.hass, sensor.DOMAIN, {
             sensor.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -43,7 +43,7 @@ class TestSensorMQTT(unittest.TestCase):
     def test_setting_sensor_value_via_mqtt_json_message(self):
         """Test the setting of the value via MQTT with JSON playload."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, sensor.DOMAIN, {
+        assert setup_component(self.hass, sensor.DOMAIN, {
             sensor.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -3,7 +3,7 @@ import unittest
 
 import pytest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.const import TEMP_CELSIUS
 
@@ -29,7 +29,7 @@ class TestSensorRfxtrx(unittest.TestCase):
 
     def test_default_config(self):
         """Test with 0 sensor."""
-        self.assertTrue(_setup_component(self.hass, 'sensor', {
+        self.assertTrue(setup_component(self.hass, 'sensor', {
             'sensor': {'platform': 'rfxtrx',
                        'devices':
                            {}}}))
@@ -37,7 +37,7 @@ class TestSensorRfxtrx(unittest.TestCase):
 
     def test_old_config_sensor(self):
         """Test with 1 sensor."""
-        self.assertTrue(_setup_component(self.hass, 'sensor', {
+        self.assertTrue(setup_component(self.hass, 'sensor', {
             'sensor': {'platform': 'rfxtrx',
                        'devices':
                            {'sensor_0502': {
@@ -53,7 +53,7 @@ class TestSensorRfxtrx(unittest.TestCase):
 
     def test_one_sensor(self):
         """Test with 1 sensor."""
-        self.assertTrue(_setup_component(self.hass, 'sensor', {
+        self.assertTrue(setup_component(self.hass, 'sensor', {
             'sensor': {'platform': 'rfxtrx',
                        'devices':
                            {'0a52080705020095220269': {
@@ -68,7 +68,7 @@ class TestSensorRfxtrx(unittest.TestCase):
 
     def test_one_sensor_no_datatype(self):
         """Test with 1 sensor."""
-        self.assertTrue(_setup_component(self.hass, 'sensor', {
+        self.assertTrue(setup_component(self.hass, 'sensor', {
             'sensor': {'platform': 'rfxtrx',
                        'devices':
                            {'0a52080705020095220269': {
@@ -88,7 +88,7 @@ class TestSensorRfxtrx(unittest.TestCase):
 
     def test_several_sensors(self):
         """Test with 3 sensors."""
-        self.assertTrue(_setup_component(self.hass, 'sensor', {
+        self.assertTrue(setup_component(self.hass, 'sensor', {
                 'sensor': {'platform': 'rfxtrx',
                            'devices':
                                {'0a52080705020095220269': {
@@ -124,7 +124,7 @@ class TestSensorRfxtrx(unittest.TestCase):
 
     def test_discover_sensor(self):
         """Test with discovery of sensor."""
-        self.assertTrue(_setup_component(self.hass, 'sensor', {
+        self.assertTrue(setup_component(self.hass, 'sensor', {
             'sensor': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'devices': {}}}))
@@ -182,7 +182,7 @@ class TestSensorRfxtrx(unittest.TestCase):
 
     def test_discover_sensor_noautoadd(self):
         """Test with discover of sensor when auto add is False."""
-        self.assertTrue(_setup_component(self.hass, 'sensor', {
+        self.assertTrue(setup_component(self.hass, 'sensor', {
             'sensor': {'platform': 'rfxtrx',
                        'automatic_add': False,
                        'devices': {}}}))
@@ -209,7 +209,7 @@ class TestSensorRfxtrx(unittest.TestCase):
 
     def test_update_of_sensors(self):
         """Test with 3 sensors."""
-        self.assertTrue(_setup_component(self.hass, 'sensor', {
+        self.assertTrue(setup_component(self.hass, 'sensor', {
                 'sensor': {'platform': 'rfxtrx',
                            'devices':
                                {'0a52080705020095220269': {

--- a/tests/components/sensor/test_yr.py
+++ b/tests/components/sensor/test_yr.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from unittest.mock import patch
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 import homeassistant.util.dt as dt_util
 from tests.common import get_test_home_assistant, load_fixture
 
@@ -28,7 +28,7 @@ class TestSensorYr:
 
         with patch('homeassistant.components.sensor.yr.dt_util.utcnow',
                    return_value=now):
-                assert _setup_component(self.hass, 'sensor', {
+                assert setup_component(self.hass, 'sensor', {
                                 'sensor': {'platform': 'yr',
                                            'elevation': 0}})
 
@@ -46,7 +46,7 @@ class TestSensorYr:
 
         with patch('homeassistant.components.sensor.yr.dt_util.utcnow',
                    return_value=now):
-            assert _setup_component(self.hass, 'sensor', {
+            assert setup_component(self.hass, 'sensor', {
                                     'sensor': {'platform': 'yr',
                                                'elevation': 0,
                                                'monitored_conditions': [

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -1,7 +1,7 @@
 """The tests for the MQTT switch platform."""
 import unittest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.switch as switch
 from tests.common import (
@@ -23,7 +23,7 @@ class TestSensorMQTT(unittest.TestCase):
     def test_controlling_state_via_topic(self):
         """Test the controlling state via topic."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, switch.DOMAIN, {
+        assert setup_component(self.hass, switch.DOMAIN, {
             switch.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -53,7 +53,7 @@ class TestSensorMQTT(unittest.TestCase):
     def test_sending_mqtt_commands_and_optimistic(self):
         """Test the sending MQTT commands in optimistic mode."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, switch.DOMAIN, {
+        assert setup_component(self.hass, switch.DOMAIN, {
             switch.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
@@ -87,7 +87,7 @@ class TestSensorMQTT(unittest.TestCase):
     def test_controlling_state_via_topic_and_json_message(self):
         """Test the controlling state via topic and JSON message."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, switch.DOMAIN, {
+        assert setup_component(self.hass, switch.DOMAIN, {
             switch.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -3,7 +3,7 @@ import unittest
 
 import pytest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
 
 from tests.common import get_test_home_assistant
@@ -28,7 +28,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def test_valid_config(self):
         """Test configuration."""
-        self.assertTrue(_setup_component(self.hass, 'switch', {
+        self.assertTrue(setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'devices':
@@ -39,7 +39,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def test_valid_config_int_device_id(self):
         """Test configuration."""
-        self.assertTrue(_setup_component(self.hass, 'switch', {
+        self.assertTrue(setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'devices':
@@ -49,7 +49,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
                             }}}))
 
     def test_invalid_config1(self):
-        self.assertFalse(_setup_component(self.hass, 'switch', {
+        self.assertFalse(setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'devices':
@@ -61,7 +61,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def test_invalid_config2(self):
         """Test configuration."""
-        self.assertFalse(_setup_component(self.hass, 'switch', {
+        self.assertFalse(setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'invalid_key': 'afda',
@@ -73,7 +73,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
                             }}}))
 
     def test_invalid_config3(self):
-        self.assertFalse(_setup_component(self.hass, 'switch', {
+        self.assertFalse(setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'devices':
@@ -85,7 +85,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def test_invalid_config4(self):
         """Test configuration."""
-        self.assertFalse(_setup_component(self.hass, 'switch', {
+        self.assertFalse(setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'devices':
@@ -96,7 +96,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def test_default_config(self):
         """Test with 0 switches."""
-        self.assertTrue(_setup_component(self.hass, 'switch', {
+        self.assertTrue(setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'devices':
                            {}}}))
@@ -104,7 +104,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def test_old_config(self):
         """Test with 1 switch."""
-        self.assertTrue(_setup_component(self.hass, 'switch', {
+        self.assertTrue(setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'devices':
                            {'123efab1': {
@@ -132,7 +132,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def test_one_switch(self):
         """Test with 1 switch."""
-        self.assertTrue(_setup_component(self.hass, 'switch', {
+        self.assertTrue(setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'devices':
                            {'0b1100cd0213c7f210010f51': {
@@ -170,7 +170,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def test_several_switches(self):
         """Test with 3 switches."""
-        self.assertTrue(_setup_component(self.hass, 'switch', {
+        self.assertTrue(setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'signal_repetitions': 3,
                        'devices':
@@ -203,7 +203,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def test_discover_switch(self):
         """Test with discovery of switches."""
-        self.assertTrue(_setup_component(self.hass, 'switch', {
+        self.assertTrue(setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'devices': {}}}))
@@ -253,7 +253,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def test_discover_switch_noautoadd(self):
         """Test with discovery of switch when auto add is False."""
-        self.assertTrue(_setup_component(self.hass, 'switch', {
+        self.assertTrue(setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'automatic_add': False,
                        'devices': {}}}))

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -7,8 +7,9 @@ from homeassistant.bootstrap import setup_component
 import homeassistant.components as core_components
 from homeassistant.components import conversation
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.util.async import run_coroutine_threadsafe
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, assert_setup_component
 
 
 class TestConversation(unittest.TestCase):
@@ -19,9 +20,13 @@ class TestConversation(unittest.TestCase):
         self.ent_id = 'light.kitchen_lights'
         self.hass = get_test_home_assistant(3)
         self.hass.states.set(self.ent_id, 'on')
-        self.assertTrue(core_components.setup(self.hass, {}))
-        self.assertTrue(setup_component(self.hass, conversation.DOMAIN, {
-            conversation.DOMAIN: {}}))
+        self.assertTrue(run_coroutine_threadsafe(
+            core_components.async_setup(self.hass, {}), self.hass.loop
+        ).result())
+        with assert_setup_component(0):
+            self.assertTrue(setup_component(self.hass, conversation.DOMAIN, {
+                conversation.DOMAIN: {}
+            }))
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""

--- a/tests/components/test_emulated_hue.py
+++ b/tests/components/test_emulated_hue.py
@@ -318,6 +318,7 @@ class TestEmulatedHueExposedByDefault(unittest.TestCase):
             light.DOMAIN, const.SERVICE_TURN_OFF,
             {const.ATTR_ENTITY_ID: 'light.ceiling_lights'},
             blocking=True)
+        self.hass.block_till_done()
 
         ceiling_lights = self.hass.states.get('light.ceiling_lights')
         self.assertEqual(ceiling_lights.state, STATE_OFF)
@@ -345,6 +346,7 @@ class TestEmulatedHueExposedByDefault(unittest.TestCase):
             BRIDGE_URL_BASE.format(
                 '/api/username/lights/{}'.format(entity_id)), timeout=5)
 
+        self.hass.block_till_done()
         self.assertEqual(result.status_code, expected_status)
 
         if expected_status == 200:
@@ -370,6 +372,8 @@ class TestEmulatedHueExposedByDefault(unittest.TestCase):
 
         result = requests.put(
             url, data=json.dumps(data), timeout=5, headers=req_headers)
+
+        self.hass.block_till_done()
         return result
 
 

--- a/tests/components/test_emulated_hue.py
+++ b/tests/components/test_emulated_hue.py
@@ -13,6 +13,7 @@ from homeassistant.components import emulated_hue, http, light
 from homeassistant.const import STATE_ON, STATE_OFF
 from homeassistant.components.emulated_hue import (
     HUE_API_STATE_ON, HUE_API_STATE_BRI)
+from homeassistant.util.async import run_coroutine_threadsafe
 
 from tests.common import get_test_instance_port, get_test_home_assistant
 
@@ -28,7 +29,9 @@ def setup_hass_instance(emulated_hue_config):
     hass = get_test_home_assistant()
 
     # We need to do this to get access to homeassistant/turn_(on,off)
-    core_components.setup(hass, {core.DOMAIN: {}})
+    run_coroutine_threadsafe(
+        core_components.async_setup(hass, {core.DOMAIN: {}}), hass.loop
+    ).result()
 
     bootstrap.setup_component(
         hass, http.DOMAIN,

--- a/tests/components/test_emulated_hue.py
+++ b/tests/components/test_emulated_hue.py
@@ -318,7 +318,6 @@ class TestEmulatedHueExposedByDefault(unittest.TestCase):
             light.DOMAIN, const.SERVICE_TURN_OFF,
             {const.ATTR_ENTITY_ID: 'light.ceiling_lights'},
             blocking=True)
-        self.hass.block_till_done()
 
         ceiling_lights = self.hass.states.get('light.ceiling_lights')
         self.assertEqual(ceiling_lights.state, STATE_OFF)
@@ -346,7 +345,6 @@ class TestEmulatedHueExposedByDefault(unittest.TestCase):
             BRIDGE_URL_BASE.format(
                 '/api/username/lights/{}'.format(entity_id)), timeout=5)
 
-        self.hass.block_till_done()
         self.assertEqual(result.status_code, expected_status)
 
         if expected_status == 200:
@@ -373,7 +371,6 @@ class TestEmulatedHueExposedByDefault(unittest.TestCase):
         result = requests.put(
             url, data=json.dumps(data), timeout=5, headers=req_headers)
 
-        self.hass.block_till_done()
         return result
 
 

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -1,13 +1,14 @@
 """The tests for the InfluxDB component."""
 import unittest
 from unittest import mock
-from unittest.mock import patch
 
 import influxdb as influx_client
 
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.influxdb as influxdb
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
+
+from tests.common import get_test_home_assistant
 
 
 @mock.patch('influxdb.InfluxDBClient')
@@ -16,9 +17,13 @@ class TestInfluxDB(unittest.TestCase):
 
     def setUp(self):
         """Setup things to be run when tests are started."""
-        self.hass = mock.MagicMock()
-        self.hass.pool.worker_count = 2
+        self.hass = get_test_home_assistant(2)
         self.handler_method = None
+        self.hass.bus.listen = mock.Mock()
+
+    def tearDown(self):
+        """Clear data."""
+        self.hass.stop()
 
     def test_setup_config_full(self, mock_client):
         """Test the setup with full configuration."""
@@ -61,8 +66,6 @@ class TestInfluxDB(unittest.TestCase):
 
         assert setup_component(self.hass, influxdb.DOMAIN, config)
 
-    @patch('homeassistant.components.persistent_notification.create',
-           mock.MagicMock())
     def test_setup_missing_password(self, mock_client):
         """Test the setup with existing username and missing password."""
         config = {

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -111,7 +111,7 @@ class TestComponentsCore(unittest.TestCase):
 
     @patch('homeassistant.config.os.path.isfile', Mock(return_value=True))
     @patch('homeassistant.components._LOGGER.error')
-    @patch('homeassistant.config.process_ha_core_config')
+    @patch('homeassistant.config.async_process_ha_core_config')
     def test_reload_core_with_wrong_conf(self, mock_process, mock_error):
         """Test reload core conf service."""
         files = {

--- a/tests/components/test_logentries.py
+++ b/tests/components/test_logentries.py
@@ -7,9 +7,19 @@ from homeassistant.bootstrap import setup_component
 import homeassistant.components.logentries as logentries
 from homeassistant.const import STATE_ON, STATE_OFF, EVENT_STATE_CHANGED
 
+from tests.common import get_test_home_assistant
+
 
 class TestLogentries(unittest.TestCase):
     """Test the Logentries component."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant(2)
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
 
     def test_setup_config_full(self):
         """Test setup with all data."""
@@ -18,12 +28,11 @@ class TestLogentries(unittest.TestCase):
                 'token': 'secret',
             }
         }
-        hass = mock.MagicMock()
-        hass.pool.worker_count = 2
-        self.assertTrue(setup_component(hass, logentries.DOMAIN, config))
-        self.assertTrue(hass.bus.listen.called)
+        self.hass.bus.listen = mock.MagicMock()
+        self.assertTrue(setup_component(self.hass, logentries.DOMAIN, config))
+        self.assertTrue(self.hass.bus.listen.called)
         self.assertEqual(EVENT_STATE_CHANGED,
-                         hass.bus.listen.call_args_list[0][0][0])
+                         self.hass.bus.listen.call_args_list[0][0][0])
 
     def test_setup_config_defaults(self):
         """Test setup with defaults."""
@@ -32,12 +41,11 @@ class TestLogentries(unittest.TestCase):
                 'token': 'token',
             }
         }
-        hass = mock.MagicMock()
-        hass.pool.worker_count = 2
-        self.assertTrue(setup_component(hass, logentries.DOMAIN, config))
-        self.assertTrue(hass.bus.listen.called)
+        self.hass.bus.listen = mock.MagicMock()
+        self.assertTrue(setup_component(self.hass, logentries.DOMAIN, config))
+        self.assertTrue(self.hass.bus.listen.called)
         self.assertEqual(EVENT_STATE_CHANGED,
-                         hass.bus.listen.call_args_list[0][0][0])
+                         self.hass.bus.listen.call_args_list[0][0][0])
 
     def _setup(self, mock_requests):
         """Test the setup."""
@@ -49,8 +57,7 @@ class TestLogentries(unittest.TestCase):
                 'token': 'token'
             }
         }
-        self.hass = mock.MagicMock()
-        self.hass.pool.worker_count = 2
+        self.hass.bus.listen = mock.MagicMock()
         setup_component(self.hass, logentries.DOMAIN, config)
         self.handler_method = self.hass.bus.listen.call_args_list[0][0][1]
 

--- a/tests/components/test_logger.py
+++ b/tests/components/test_logger.py
@@ -2,10 +2,11 @@
 from collections import namedtuple
 import logging
 import unittest
-from unittest.mock import MagicMock
 
 from homeassistant.bootstrap import setup_component
 from homeassistant.components import logger
+
+from tests.common import get_test_home_assistant
 
 RECORD = namedtuple('record', ('name', 'levelno'))
 
@@ -15,18 +16,18 @@ class TestUpdater(unittest.TestCase):
 
     def setUp(self):
         """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant(2)
         self.log_config = {'logger':
                            {'default': 'warning', 'logs': {'test': 'info'}}}
 
     def tearDown(self):
         """Stop everything that was started."""
         del logging.root.handlers[-1]
+        self.hass.stop()
 
     def test_logger_setup(self):
         """Use logger to create a logging filter."""
-        hass = MagicMock()
-        hass.pool.worker_count = 2
-        setup_component(hass, logger.DOMAIN, self.log_config)
+        setup_component(self.hass, logger.DOMAIN, self.log_config)
 
         self.assertTrue(len(logging.root.handlers) > 0)
         handler = logging.root.handlers[-1]
@@ -39,9 +40,7 @@ class TestUpdater(unittest.TestCase):
 
     def test_logger_test_filters(self):
         """Test resulting filter operation."""
-        hass = MagicMock()
-        hass.pool.worker_count = 2
-        setup_component(hass, logger.DOMAIN, self.log_config)
+        setup_component(self.hass, logger.DOMAIN, self.log_config)
 
         log_filter = logging.root.handlers[-1].filters[0]
 

--- a/tests/components/test_panel_custom.py
+++ b/tests/components/test_panel_custom.py
@@ -10,7 +10,8 @@ from homeassistant.components import panel_custom
 from tests.common import get_test_home_assistant
 
 
-@patch('homeassistant.components.frontend.setup', return_value=True)
+@patch('homeassistant.components.frontend.setup',
+       autospec=True, return_value=True)
 class TestPanelCustom(unittest.TestCase):
     """Test the panel_custom component."""
 

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -4,7 +4,7 @@ import unittest
 
 import pytest
 
-from homeassistant.bootstrap import _setup_component
+from homeassistant.bootstrap import setup_component
 from homeassistant.components import rfxtrx as rfxtrx
 from tests.common import get_test_home_assistant
 
@@ -27,14 +27,14 @@ class TestRFXTRX(unittest.TestCase):
 
     def test_default_config(self):
         """Test configuration."""
-        self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
+        self.assertTrue(setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
                 'device': '/dev/serial/by-id/usb' +
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
                 'dummy': True}
         }))
 
-        self.assertTrue(_setup_component(self.hass, 'sensor', {
+        self.assertTrue(setup_component(self.hass, 'sensor', {
             'sensor': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'devices': {}}}))
@@ -43,7 +43,7 @@ class TestRFXTRX(unittest.TestCase):
 
     def test_valid_config(self):
         """Test configuration."""
-        self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
+        self.assertTrue(setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
                 'device': '/dev/serial/by-id/usb' +
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
@@ -51,7 +51,7 @@ class TestRFXTRX(unittest.TestCase):
 
         self.hass.config.components.remove('rfxtrx')
 
-        self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
+        self.assertTrue(setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
                 'device': '/dev/serial/by-id/usb' +
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
@@ -60,11 +60,11 @@ class TestRFXTRX(unittest.TestCase):
 
     def test_invalid_config(self):
         """Test configuration."""
-        self.assertFalse(_setup_component(self.hass, 'rfxtrx', {
+        self.assertFalse(setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {}
         }))
 
-        self.assertFalse(_setup_component(self.hass, 'rfxtrx', {
+        self.assertFalse(setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
                 'device': '/dev/serial/by-id/usb' +
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
@@ -72,13 +72,13 @@ class TestRFXTRX(unittest.TestCase):
 
     def test_fire_event(self):
         """Test fire event."""
-        self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
+        self.assertTrue(setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
                 'device': '/dev/serial/by-id/usb' +
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
                 'dummy': True}
         }))
-        self.assertTrue(_setup_component(self.hass, 'switch', {
+        self.assertTrue(setup_component(self.hass, 'switch', {
             'switch': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'devices':
@@ -116,13 +116,13 @@ class TestRFXTRX(unittest.TestCase):
 
     def test_fire_event_sensor(self):
         """Test fire event."""
-        self.assertTrue(_setup_component(self.hass, 'rfxtrx', {
+        self.assertTrue(setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
                 'device': '/dev/serial/by-id/usb' +
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
                 'dummy': True}
         }))
-        self.assertTrue(_setup_component(self.hass, 'sensor', {
+        self.assertTrue(setup_component(self.hass, 'sensor', {
             'sensor': {'platform': 'rfxtrx',
                        'automatic_add': True,
                        'devices':

--- a/tests/components/test_sleepiq.py
+++ b/tests/components/test_sleepiq.py
@@ -65,11 +65,11 @@ class TestSleepIQ(unittest.TestCase):
         """Test the setup when no login is configured."""
         conf = self.config.copy()
         del conf['sleepiq']['username']
-        assert not bootstrap._setup_component(self.hass, sleepiq.DOMAIN, conf)
+        assert not bootstrap.setup_component(self.hass, sleepiq.DOMAIN, conf)
 
     def test_setup_component_no_password(self):
         """Test the setup when no password is configured."""
         conf = self.config.copy()
         del conf['sleepiq']['password']
 
-        assert not bootstrap._setup_component(self.hass, sleepiq.DOMAIN, conf)
+        assert not bootstrap.setup_component(self.hass, sleepiq.DOMAIN, conf)

--- a/tests/components/test_splunk.py
+++ b/tests/components/test_splunk.py
@@ -6,9 +6,19 @@ from homeassistant.bootstrap import setup_component
 import homeassistant.components.splunk as splunk
 from homeassistant.const import STATE_ON, STATE_OFF, EVENT_STATE_CHANGED
 
+from tests.common import get_test_home_assistant
+
 
 class TestSplunk(unittest.TestCase):
     """Test the Splunk component."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant(2)
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
 
     def test_setup_config_full(self):
         """Test setup with all data."""
@@ -21,12 +31,11 @@ class TestSplunk(unittest.TestCase):
             }
         }
 
-        hass = mock.MagicMock()
-        hass.pool.worker_count = 2
-        self.assertTrue(setup_component(hass, splunk.DOMAIN, config))
-        self.assertTrue(hass.bus.listen.called)
+        self.hass.bus.listen = mock.MagicMock()
+        self.assertTrue(setup_component(self.hass, splunk.DOMAIN, config))
+        self.assertTrue(self.hass.bus.listen.called)
         self.assertEqual(EVENT_STATE_CHANGED,
-                         hass.bus.listen.call_args_list[0][0][0])
+                         self.hass.bus.listen.call_args_list[0][0][0])
 
     def test_setup_config_defaults(self):
         """Test setup with defaults."""
@@ -37,12 +46,11 @@ class TestSplunk(unittest.TestCase):
             }
         }
 
-        hass = mock.MagicMock()
-        hass.pool.worker_count = 2
-        self.assertTrue(setup_component(hass, splunk.DOMAIN, config))
-        self.assertTrue(hass.bus.listen.called)
+        self.hass.bus.listen = mock.MagicMock()
+        self.assertTrue(setup_component(self.hass, splunk.DOMAIN, config))
+        self.assertTrue(self.hass.bus.listen.called)
         self.assertEqual(EVENT_STATE_CHANGED,
-                         hass.bus.listen.call_args_list[0][0][0])
+                         self.hass.bus.listen.call_args_list[0][0][0])
 
     def _setup(self, mock_requests):
         """Test the setup."""
@@ -57,8 +65,7 @@ class TestSplunk(unittest.TestCase):
             }
         }
 
-        self.hass = mock.MagicMock()
-        self.hass.pool.worker_count = 2
+        self.hass.bus.listen = mock.MagicMock()
         setup_component(self.hass, splunk.DOMAIN, config)
         self.handler_method = self.hass.bus.listen.call_args_list[0][0][1]
 

--- a/tests/components/test_statsd.py
+++ b/tests/components/test_statsd.py
@@ -9,9 +9,19 @@ import homeassistant.core as ha
 import homeassistant.components.statsd as statsd
 from homeassistant.const import (STATE_ON, STATE_OFF, EVENT_STATE_CHANGED)
 
+from tests.common import get_test_home_assistant
+
 
 class TestStatsd(unittest.TestCase):
     """Test the StatsD component."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant(2)
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
 
     def test_invalid_config(self):
         """Test configuration with defaults."""
@@ -37,18 +47,17 @@ class TestStatsd(unittest.TestCase):
                 'prefix': 'foo',
             }
         }
-        hass = mock.MagicMock()
-        hass.pool.worker_count = 2
-        self.assertTrue(setup_component(hass, statsd.DOMAIN, config))
+        self.hass.bus.listen = mock.MagicMock()
+        self.assertTrue(setup_component(self.hass, statsd.DOMAIN, config))
         self.assertEqual(mock_connection.call_count, 1)
         self.assertEqual(
             mock_connection.call_args,
             mock.call(host='host', port=123, prefix='foo')
         )
 
-        self.assertTrue(hass.bus.listen.called)
+        self.assertTrue(self.hass.bus.listen.called)
         self.assertEqual(EVENT_STATE_CHANGED,
-                         hass.bus.listen.call_args_list[0][0][0])
+                         self.hass.bus.listen.call_args_list[0][0][0])
 
     @mock.patch('statsd.StatsClient')
     def test_statsd_setup_defaults(self, mock_connection):
@@ -62,15 +71,14 @@ class TestStatsd(unittest.TestCase):
         config['statsd'][statsd.CONF_PORT] = statsd.DEFAULT_PORT
         config['statsd'][statsd.CONF_PREFIX] = statsd.DEFAULT_PREFIX
 
-        hass = mock.MagicMock()
-        hass.pool.worker_count = 2
-        self.assertTrue(setup_component(hass, statsd.DOMAIN, config))
+        self.hass.bus.listen = mock.MagicMock()
+        self.assertTrue(setup_component(self.hass, statsd.DOMAIN, config))
         self.assertEqual(mock_connection.call_count, 1)
         self.assertEqual(
             mock_connection.call_args,
             mock.call(host='host', port=8125, prefix='hass')
         )
-        self.assertTrue(hass.bus.listen.called)
+        self.assertTrue(self.hass.bus.listen.called)
 
     @mock.patch('statsd.StatsClient')
     def test_event_listener_defaults(self, mock_client):
@@ -83,11 +91,10 @@ class TestStatsd(unittest.TestCase):
 
         config['statsd'][statsd.CONF_RATE] = statsd.DEFAULT_RATE
 
-        hass = mock.MagicMock()
-        hass.pool.worker_count = 2
-        setup_component(hass, statsd.DOMAIN, config)
-        self.assertTrue(hass.bus.listen.called)
-        handler_method = hass.bus.listen.call_args_list[0][0][1]
+        self.hass.bus.listen = mock.MagicMock()
+        setup_component(self.hass, statsd.DOMAIN, config)
+        self.assertTrue(self.hass.bus.listen.called)
+        handler_method = self.hass.bus.listen.call_args_list[0][0][1]
 
         valid = {'1': 1,
                  '1.0': 1.0,
@@ -128,11 +135,10 @@ class TestStatsd(unittest.TestCase):
 
         config['statsd'][statsd.CONF_RATE] = statsd.DEFAULT_RATE
 
-        hass = mock.MagicMock()
-        hass.pool.worker_count = 2
-        setup_component(hass, statsd.DOMAIN, config)
-        self.assertTrue(hass.bus.listen.called)
-        handler_method = hass.bus.listen.call_args_list[0][0][1]
+        self.hass.bus.listen = mock.MagicMock()
+        setup_component(self.hass, statsd.DOMAIN, config)
+        self.assertTrue(self.hass.bus.listen.called)
+        handler_method = self.hass.bus.listen.call_args_list[0][0][1]
 
         valid = {'1': 1,
                  '1.0': 1.0,

--- a/tests/helpers/test_discovery.py
+++ b/tests/helpers/test_discovery.py
@@ -127,4 +127,4 @@ class TestHelpersDiscovery:
         assert 'test_component' in self.hass.config.components
         assert 'switch' in self.hass.config.components
         assert len(component_calls) == 1
-        assert len(platform_calls) == 2
+        assert len(platform_calls) == 1

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import homeassistant.core as ha
 import homeassistant.components as core_components
 from homeassistant.const import (SERVICE_TURN_ON, SERVICE_TURN_OFF)
+from homeassistant.util.async import run_coroutine_threadsafe
 from homeassistant.util import dt as dt_util
 from homeassistant.helpers import state
 from homeassistant.const import (
@@ -63,7 +64,8 @@ class TestStateHelpers(unittest.TestCase):
     def setUp(self):     # pylint: disable=invalid-name
         """Run when tests are started."""
         self.hass = get_test_home_assistant()
-        core_components.setup(self.hass, {})
+        run_coroutine_threadsafe(core_components.async_setup(
+            self.hass, {}), self.hass.loop).result()
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop when tests are finished."""

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -5,8 +5,6 @@ import os
 import unittest
 from unittest.mock import patch
 
-import pytest
-
 import homeassistant.scripts.check_config as check_config
 from tests.common import patch_yaml_files, get_test_config_dir
 
@@ -47,13 +45,11 @@ def tearDownModule(self):  # pylint: disable=invalid-name
         os.remove(path)
 
 
-@pytest.mark.skipif("os.environ.get('check_config') != 'RUN'")
-@patch('asyncio.get_event_loop', return_value=asyncio.new_event_loop())
 class TestCheckConfig(unittest.TestCase):
     """Tests for the homeassistant.scripts.check_config module."""
 
     # pylint: disable=no-self-use,invalid-name
-    def test_config_platform_valid(self, mock_get_loop):
+    def test_config_platform_valid(self):
         """Test a valid platform setup."""
         files = {
             'light.yaml': BASE_CONFIG + 'light:\n  platform: demo',
@@ -69,7 +65,7 @@ class TestCheckConfig(unittest.TestCase):
                 'yaml_files': ['.../light.yaml']
             }, res)
 
-    def test_config_component_platform_fail_validation(self, mock_get_loop):
+    def test_config_component_platform_fail_validation(self):
         """Test errors if component & platform not found."""
         files = {
             'component.yaml': BASE_CONFIG + 'http:\n  password: err123',
@@ -107,7 +103,7 @@ class TestCheckConfig(unittest.TestCase):
             self.assertDictEqual({}, res['secrets'])
             self.assertListEqual(['.../platform.yaml'], res['yaml_files'])
 
-    def test_component_platform_not_found(self, mock_get_loop):
+    def test_component_platform_not_found(self):
         """Test errors if component or platform not found."""
         files = {
             'badcomponent.yaml': BASE_CONFIG + 'beer:',
@@ -134,7 +130,7 @@ class TestCheckConfig(unittest.TestCase):
             self.assertDictEqual({}, res['secrets'])
             self.assertListEqual(['.../badplatform.yaml'], res['yaml_files'])
 
-    def test_secrets(self, mock_get_loop):
+    def test_secrets(self):
         """Test secrets config checking method."""
         files = {
             get_test_config_dir('secret.yaml'): (

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -5,6 +5,8 @@ import os
 import unittest
 from unittest.mock import patch
 
+import pytest
+
 import homeassistant.scripts.check_config as check_config
 from tests.common import patch_yaml_files, get_test_config_dir
 
@@ -45,6 +47,7 @@ def tearDownModule(self):  # pylint: disable=invalid-name
         os.remove(path)
 
 
+@pytest.mark.skipif("os.environ.get('check_config') != 'RUN'")
 @patch('asyncio.get_event_loop', return_value=asyncio.new_event_loop())
 class TestCheckConfig(unittest.TestCase):
     """Tests for the homeassistant.scripts.check_config module."""

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -53,7 +53,9 @@ class TestCheckConfig(unittest.TestCase):
         # this ensures we have one.
         try:
             asyncio.get_event_loop()
-        except RuntimeError:
+        except (RuntimeError, AssertionError):
+            # Py35: RuntimeError
+            # Py34: AssertionError
             asyncio.set_event_loop(asyncio.new_event_loop())
 
     # pylint: disable=no-self-use,invalid-name

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 import os
 import unittest
-from unittest.mock import patch
 
 import homeassistant.scripts.check_config as check_config
 from tests.common import patch_yaml_files, get_test_config_dir
@@ -47,6 +46,15 @@ def tearDownModule(self):  # pylint: disable=invalid-name
 
 class TestCheckConfig(unittest.TestCase):
     """Tests for the homeassistant.scripts.check_config module."""
+
+    def setUp(self):
+        """Prepare the test."""
+        # Somewhere in the tests our event loop gets killed,
+        # this ensures we have one.
+        try:
+            asyncio.get_event_loop()
+        except RuntimeError:
+            asyncio.set_event_loop(asyncio.new_event_loop())
 
     # pylint: disable=no-self-use,invalid-name
     def test_config_platform_valid(self):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -48,11 +48,10 @@ class TestBootstrap:
     @mock.patch(
         # prevent .HA_VERISON file from being written
         'homeassistant.bootstrap.conf_util.process_ha_config_upgrade',
-        mock.Mock()
-    )
+        autospec=True)
     @mock.patch('homeassistant.util.location.detect_location_info',
-                return_value=None)
-    def test_from_config_file(self, mock_detect):
+                autospec=True, return_value=None)
+    def test_from_config_file(self, mock_upgrade, mock_detect):
         """Test with configuration file."""
         components = ['browser', 'conversation', 'script']
         files = {
@@ -94,28 +93,33 @@ class TestBootstrap:
         loader.set_component(
             'comp_conf', MockModule('comp_conf', config_schema=config_schema))
 
-        assert not bootstrap._setup_component(self.hass, 'comp_conf', {})
+        with assert_setup_component(0):
+            assert not bootstrap.setup_component(self.hass, 'comp_conf', {})
 
-        assert not bootstrap._setup_component(self.hass, 'comp_conf', {
-            'comp_conf': None
-        })
+        with assert_setup_component(0):
+            assert not bootstrap.setup_component(self.hass, 'comp_conf', {
+                'comp_conf': None
+            })
 
-        assert not bootstrap._setup_component(self.hass, 'comp_conf', {
-            'comp_conf': {}
-        })
+        with assert_setup_component(0):
+            assert not bootstrap.setup_component(self.hass, 'comp_conf', {
+                'comp_conf': {}
+            })
 
-        assert not bootstrap._setup_component(self.hass, 'comp_conf', {
-            'comp_conf': {
-                'hello': 'world',
-                'invalid': 'extra',
-            }
-        })
+        with assert_setup_component(0):
+            assert not bootstrap.setup_component(self.hass, 'comp_conf', {
+                'comp_conf': {
+                    'hello': 'world',
+                    'invalid': 'extra',
+                }
+            })
 
-        assert bootstrap._setup_component(self.hass, 'comp_conf', {
-            'comp_conf': {
-                'hello': 'world',
-            }
-        })
+        with assert_setup_component(1):
+            assert bootstrap.setup_component(self.hass, 'comp_conf', {
+                'comp_conf': {
+                    'hello': 'world',
+                }
+            })
 
     def test_validate_platform_config(self):
         """Test validating platform configuration."""
@@ -130,7 +134,7 @@ class TestBootstrap:
             'platform_conf.whatever', MockPlatform('whatever'))
 
         with assert_setup_component(0):
-            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+            assert bootstrap.setup_component(self.hass, 'platform_conf', {
                 'platform_conf': {
                     'hello': 'world',
                     'invalid': 'extra',
@@ -140,7 +144,7 @@ class TestBootstrap:
         self.hass.config.components.remove('platform_conf')
 
         with assert_setup_component(1):
-            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+            assert bootstrap.setup_component(self.hass, 'platform_conf', {
                 'platform_conf': {
                     'platform': 'whatever',
                     'hello': 'world',
@@ -153,7 +157,7 @@ class TestBootstrap:
         self.hass.config.components.remove('platform_conf')
 
         with assert_setup_component(0):
-            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+            assert bootstrap.setup_component(self.hass, 'platform_conf', {
                 'platform_conf': {
                     'platform': 'not_existing',
                     'hello': 'world',
@@ -163,7 +167,7 @@ class TestBootstrap:
         self.hass.config.components.remove('platform_conf')
 
         with assert_setup_component(1):
-            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+            assert bootstrap.setup_component(self.hass, 'platform_conf', {
                 'platform_conf': {
                     'platform': 'whatever',
                     'hello': 'world',
@@ -173,7 +177,7 @@ class TestBootstrap:
         self.hass.config.components.remove('platform_conf')
 
         with assert_setup_component(1):
-            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+            assert bootstrap.setup_component(self.hass, 'platform_conf', {
                 'platform_conf': [{
                     'platform': 'whatever',
                     'hello': 'world',
@@ -184,13 +188,13 @@ class TestBootstrap:
 
         # Any falsey platform config will be ignored (None, {}, etc)
         with assert_setup_component(0) as config:
-            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+            assert bootstrap.setup_component(self.hass, 'platform_conf', {
                 'platform_conf': None
             })
             assert 'platform_conf' in self.hass.config.components
             assert not config['platform_conf']  # empty
 
-            assert bootstrap._setup_component(self.hass, 'platform_conf', {
+            assert bootstrap.setup_component(self.hass, 'platform_conf', {
                 'platform_conf': {}
             })
             assert 'platform_conf' in self.hass.config.components
@@ -235,10 +239,9 @@ class TestBootstrap:
             """Setup the component."""
             result.append(bootstrap.setup_component(self.hass, 'comp'))
 
-        with bootstrap._SETUP_LOCK:
-            thread = threading.Thread(target=setup_component)
-            thread.start()
-            self.hass.config.components.append('comp')
+        thread = threading.Thread(target=setup_component)
+        thread.start()
+        self.hass.config.components.append('comp')
 
         thread.join()
 
@@ -250,19 +253,19 @@ class TestBootstrap:
         deps = ['non_existing']
         loader.set_component('comp', MockModule('comp', dependencies=deps))
 
-        assert not bootstrap._setup_component(self.hass, 'comp', {})
+        assert not bootstrap.setup_component(self.hass, 'comp', {})
         assert 'comp' not in self.hass.config.components
 
-        self.hass.config.components.append('non_existing')
+        loader.set_component('non_existing', MockModule('non_existing'))
 
-        assert bootstrap._setup_component(self.hass, 'comp', {})
+        assert bootstrap.setup_component(self.hass, 'comp', {})
 
     def test_component_failing_setup(self):
         """Test component that fails setup."""
         loader.set_component(
             'comp', MockModule('comp', setup=lambda hass, config: False))
 
-        assert not bootstrap._setup_component(self.hass, 'comp', {})
+        assert not bootstrap.setup_component(self.hass, 'comp', {})
         assert 'comp' not in self.hass.config.components
 
     def test_component_exception_setup(self):
@@ -273,7 +276,7 @@ class TestBootstrap:
 
         loader.set_component('comp', MockModule('comp', setup=exception_setup))
 
-        assert not bootstrap._setup_component(self.hass, 'comp', {})
+        assert not bootstrap.setup_component(self.hass, 'comp', {})
         assert 'comp' not in self.hass.config.components
 
     def test_home_assistant_core_config_validation(self):
@@ -316,7 +319,7 @@ class TestBootstrap:
             'valid': True,
         }, extra=vol.PREVENT_EXTRA)
 
-        mock_setup = mock.MagicMock()
+        mock_setup = mock.MagicMock(spec_set=True)
 
         loader.set_component(
             'switch.platform_a',

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -282,12 +282,11 @@ class TestBootstrap:
     def test_home_assistant_core_config_validation(self):
         """Test if we pass in wrong information for HA conf."""
         # Extensive HA conf validation testing is done in test_config.py
-        hass = get_test_home_assistant()
         assert None is bootstrap.from_config_dict({
             'homeassistant': {
                 'latitude': 'some string'
             }
-        }, hass=hass)
+        })
 
     def test_component_setup_with_validation_and_dependency(self):
         """Test all config is passed to dependencies."""


### PR DESCRIPTION
**Description:**

Now run all bootstrap stuff after create the hass object in the event loop.

~~Memo:
The `check_config` script run now not so good as befor. I think after we merged it, we should fix it until next release.~~

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
