### PR TITLE
Sonos improvements

### DIFF
--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -19,6 +19,16 @@ class socoDiscoverMock():
         return {SoCoMock('192.0.2.1')}
 
 
+class AvTransportMock():
+    """Mock class for the avTransport property on soco.SoCo object."""
+    def __init__(self):
+        pass
+
+    def GetMediaInfo(self, _):
+        return {'CurrentURI': '',
+                'CurrentURIMetaData': ''}
+
+
 class SoCoMock():
     """Mock class for the soco.SoCo object."""
 
@@ -26,6 +36,7 @@ class SoCoMock():
         """Initialize soco object."""
         self.ip_address = ip
         self.is_visible = True
+        self.avTransport = AvTransportMock()
 
     def get_speaker_info(self):
         """Return a dict with various data points about the speaker."""


### PR DESCRIPTION
**Description:**

Sonos improvements:
- media_\* properties delegate to coordinator if speaker is a slave
- media_image_url and media_title now works for radio streams
- source selection/list takes speaker model into account
- commands on slaves delegate to coordinator where appropriate.

My first pull request, be gentle :)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
