### PR TITLE
Add service to change visibility of a group

### DIFF
--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -44,6 +44,18 @@ group:
     description: "Reload group configuration."
     fields:
 
+  set_visibility:
+    description: Hide or show a group
+
+    fields:
+      entity_id:
+        description: Name(s) of entities to set value
+        example: 'group.travel'
+
+      visible:
+        description: True if group should be shown or False if it should be hidden.
+        example: True
+
 persistent_notification:
   create:
     description: Show a notification in the frontend

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -86,17 +86,18 @@ class EntityComponent(object):
         discovery.async_listen_platform(
             self.hass, self.domain, component_platform_discovered)
 
-    def extract_from_service(self, service):
+    def extract_from_service(self, service, expand_group=True):
         """Extract all known entities from a service call.
 
         Will return all entities if no entities specified in call.
         Will return an empty list if entities specified but unknown.
         """
         return run_callback_threadsafe(
-            self.hass.loop, self.async_extract_from_service, service
+            self.hass.loop, self.async_extract_from_service, service,
+            expand_group
         ).result()
 
-    def async_extract_from_service(self, service):
+    def async_extract_from_service(self, service, expand_group=True):
         """Extract all known entities from a service call.
 
         Will return all entities if no entities specified in call.
@@ -108,7 +109,7 @@ class EntityComponent(object):
             return list(self.entities.values())
 
         return [self.entities[entity_id] for entity_id
-                in extract_entity_ids(self.hass, service)
+                in extract_entity_ids(self.hass, service, expand_group)
                 if entity_id in self.entities]
 
     @asyncio.coroutine

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -94,7 +94,7 @@ def async_call_from_config(hass, config, blocking=False, variables=None,
         domain, service_name, service_data, blocking)
 
 
-def extract_entity_ids(hass, service_call):
+def extract_entity_ids(hass, service_call, expand_group=True):
     """Helper method to extract a list of entity ids from a service call.
 
     Will convert group entity ids to the entity ids it represents.
@@ -109,7 +109,17 @@ def extract_entity_ids(hass, service_call):
     # Entity ID attr can be a list or a string
     service_ent_id = service_call.data[ATTR_ENTITY_ID]
 
-    if isinstance(service_ent_id, str):
-        return group.expand_entity_ids(hass, [service_ent_id])
+    if expand_group:
 
-    return [ent_id for ent_id in group.expand_entity_ids(hass, service_ent_id)]
+        if isinstance(service_ent_id, str):
+            return group.expand_entity_ids(hass, [service_ent_id])
+
+        return [ent_id for ent_id in
+                group.expand_entity_ids(hass, service_ent_id)]
+
+    else:
+
+        if isinstance(service_ent_id, str):
+            return [service_ent_id]
+
+        return service_ent_id

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -352,3 +352,23 @@ class TestComponentsGroup(unittest.TestCase):
         assert self.hass.states.entity_ids() == ['group.light']
         grp.stop()
         assert self.hass.states.entity_ids() == []
+
+    def test_changing_group_visibility(self):
+        """Test that a group can be hidden and shown."""
+        setup_component(self.hass, 'group', {
+            'group': {
+                'test_group': 'hello.world,sensor.happy'
+            }
+        })
+
+        group_entity_id = group.ENTITY_ID_FORMAT.format('test_group')
+
+        # Hide the group
+        group.set_visibility(self.hass, group_entity_id, False)
+        group_state = self.hass.states.get(group_entity_id)
+        self.assertTrue(group_state.attributes.get(ATTR_HIDDEN))
+
+        # Show it again
+        group.set_visibility(self.hass, group_entity_id, True)
+        group_state = self.hass.states.get(group_entity_id)
+        self.assertIsNone(group_state.attributes.get(ATTR_HIDDEN))

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, Mock
 
 import homeassistant.core as ha
 import homeassistant.loader as loader
+from homeassistant.components import group
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers import discovery
@@ -177,6 +178,20 @@ class TestHelpersEntityComponent(unittest.TestCase):
 
         assert ['test_domain.test_2'] == \
                [ent.entity_id for ent in component.extract_from_service(call)]
+
+    def test_extract_from_service_no_group_expand(self):
+        """Test not expanding a group."""
+        component = EntityComponent(_LOGGER, DOMAIN, self.hass)
+        test_group = group.Group.create_group(
+            self.hass, 'test_group', ['light.Ceiling', 'light.Kitchen'])
+        component.add_entities([test_group])
+
+        call = ha.ServiceCall('test', 'service', {
+            'entity_id': ['group.test_group']
+        })
+
+        extracted = component.extract_from_service(call, expand_group=False)
+        self.assertEqual([test_group], extracted)
 
     def test_setup_loads_platforms(self):
         """Test the loading of the platforms."""

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -153,3 +153,6 @@ class TestServiceHelpers(unittest.TestCase):
 
         self.assertEqual(['light.ceiling', 'light.kitchen'],
                          service.extract_entity_ids(self.hass, call))
+
+        self.assertEqual(['group.test'], service.extract_entity_ids(
+            self.hass, call, expand_group=False))


### PR DESCRIPTION
**Description:**
This pull request adds a new service that makes it possible to hide or show a specific group. Using this together with automations makes it possible to create a view with dynamic behaviour, only showing groups that e.g. are interesting during a specific time of day. Maybe only show commute sensors during weekday mornings, webcams when no one is home or a specific set of light switches when it's getting dark outside?

I'm not sure if this is the best approach, but it works. Please give feedback on this so we can find the best solution 

**Example entry for `configuration.yaml` (if applicable):**
In this example a special sensor is used that reflects certain occasions during a day (just to make the automations simpler). A command_line sensor and a small python script (below) is used to create this sensor (which really should be considered a hack).

An automation triggers when the sensor changes its state and changes visibility of a group (using a script) if it matches a specific state. So, if the sensor matches "work_morning" the group will be visible and when it changes to something else it will be hidden.

``` yaml
group:
  default_view:
    entities:
      - group.work_sensors

  # Only visible when it's time to go to work
  work_sensors:
    name: Time to go to work
    entities:
      - sensor.something1
      - sensor.something2

sensor:
  - platform: command_line
    name: Occasion
    command: "python3 occasion.py"

script:
  group_visibility:
    sequence:
      - service: group.set_visibility
        data_template:
          entity_id: "{{ entity_id }}"
          visible: "{{ is_state(cond, visible_state) }}"

automation:
  - alias: Work morning
    trigger:
      - platform: state
        entity_id: sensor.occasion
      - platform: event
        event_type: homeassistant_start
    action:
      service: script.group_visibility
      data:
        entity_id: group.work_sensors
        cond: sensor.occasion
        visible_state: 'work_morning'
```

Here is an example of the occasion.py-script used above. It basically outputs different states depending on a timespan for a given set of days. As an example, it will output _work_morning_ between 06:00-07:10 monday-friday. Please note that this is not needed, the automation can be written in any way you like (I just found this easier). Also, note that the update frequency of the command line sensor is 90 seconds, so the times specified are estimates.

``` python
#!/usr/bin/env python3
# -*- coding: utf-8 -*-

from datetime import time, datetime

def mk_occasion(name, start, end, days=None):
    s = start.split(':')
    e = end.split(':')
    return {'name' : name,
            'start': time(int(s[0]), int(s[1]), int(s[2])),
            'end'  : time(int(e[0]), int(e[1]), int(e[2])),
            'days' : days}

# Matching is done from top to bottom
OCCASIONS = [
    # More specific occasions
    mk_occasion('work_morning', '06:00:00', '07:10:00', range(5)),

    # General matching
    mk_occasion('weekday', '00:00:00', '23:59:59', range(5)),
    mk_occasion('weekend', '00:00:00', '23:59:59', [5, 6])
]

def get_current_occasion(occasion_list, default_occasion='normal'):
    now = datetime.now()
    for occasion in OCCASIONS:
        if occasion['start'] <= now.time() <= occasion['end'] and \
           (occasion['days'] is None or now.weekday() in occasion['days']):
            return occasion['name']
    return default_occasion

if __name__ == '__main__':
    print(get_current_occasion(OCCASIONS))
```

If a sensor only belongs to one group and that group is hidden, that sensor will "jump" to the top of the web interface. Add the sensor to an additional group if you do not want this to happen.
**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
