### PR TITLE
Test for Worldclock sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -286,7 +286,6 @@ omit =
     homeassistant/components/sensor/twitch.py
     homeassistant/components/sensor/uber.py
     homeassistant/components/sensor/vasttrafik.py
-    homeassistant/components/sensor/worldclock.py
     homeassistant/components/sensor/xbox_live.py
     homeassistant/components/sensor/yweather.py
     homeassistant/components/switch/acer_projector.py

--- a/homeassistant/components/sensor/worldclock.py
+++ b/homeassistant/components/sensor/worldclock.py
@@ -17,8 +17,10 @@ import homeassistant.helpers.config_validation as cv
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Worldclock Sensor'
+
 ICON = 'mdi:clock'
-TIME_STR_FORMAT = "%H:%M"
+
+TIME_STR_FORMAT = '%H:%M'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_TIME_ZONE): cv.time_zone,
@@ -27,7 +29,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Worldclock sensor."""
+    """Setup the World clock sensor."""
     name = config.get(CONF_NAME)
     time_zone = dt_util.get_time_zone(config.get(CONF_TIME_ZONE))
 
@@ -35,7 +37,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class WorldClockSensor(Entity):
-    """Representation of a Worldclock sensor."""
+    """Representation of a World clock sensor."""
 
     def __init__(self, time_zone, name):
         """Initialize the sensor."""

--- a/tests/components/sensor/test_worldclock.py
+++ b/tests/components/sensor/test_worldclock.py
@@ -1,0 +1,36 @@
+"""The test for the World clock sensor platform."""
+import unittest
+
+from homeassistant.bootstrap import setup_component
+from tests.common import get_test_home_assistant
+import homeassistant.util.dt as dt_util
+
+
+class TestWorldClockSensor(unittest.TestCase):
+    """Test the World clock sensor."""
+
+    def setUp(self):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.time_zone = dt_util.get_time_zone('America/New_York')
+
+        config = {
+            'sensor': {
+                'platform': 'worldclock',
+                'time_zone': 'America/New_York',
+            }
+        }
+
+        self.assertTrue(setup_component(self.hass, 'sensor', config))
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_time(self):
+        """Test the time at a different location."""
+        state = self.hass.states.get('sensor.worldclock_sensor')
+        assert state is not None
+
+        assert state.state == dt_util.now(
+            time_zone=self.time_zone).strftime('%H:%M')


### PR DESCRIPTION
**Description:**
Add a test (#3695) for the Worldclock sensor. 

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: worldclock
    time_zone: America/New_York
```

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
