### PR TITLE
Upgrade python-telegram-bot to 5.1.1

### DIFF
--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['python-telegram-bot==5.1.0']
+REQUIREMENTS = ['python-telegram-bot==5.1.1']
 
 ATTR_PHOTO = 'photo'
 ATTR_DOCUMENT = 'document'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -421,7 +421,7 @@ python-nmap==0.6.1
 python-pushover==0.2
 
 # homeassistant.components.notify.telegram
-python-telegram-bot==5.1.0
+python-telegram-bot==5.1.1
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.3.0


### PR DESCRIPTION
## v5.1.1
- Fix documentation builds on readthedocs

Tested with the following configuration:

``` yaml
notify:
  - platform: telegram
    name: telegram
    api_key: !secret telegram_api
    chat_id: !secret telegram_client
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```
