### PR TITLE
Add templates for color in mqtt_json light

### DIFF
--- a/homeassistant/components/light/mqtt_json.py
+++ b/homeassistant/components/light/mqtt_json.py
@@ -26,10 +26,21 @@ DOMAIN = 'mqtt_json'
 
 DEPENDENCIES = ['mqtt']
 
+CONF_RGB_VALUE_TEMPLATE = 'rgb_value_template'
+CONF_RGB_SET_TEMPLATE = 'rgb_set_template'
+
 DEFAULT_NAME = 'MQTT JSON Light'
 DEFAULT_OPTIMISTIC = False
 DEFAULT_BRIGHTNESS = False
 DEFAULT_RGB = False
+DEFAULT_RGB_VALUE_TEMPLATE = cv.template('{{ value_json.color.r }},'
+                                         '{{ value_json.color.g }},'
+                                         '{{ value_json.color.b }}')
+DEFAULT_RGB_SET_TEMPLATE = cv.template('{"color": {'
+                                       '"r": {{ value_json.r }}, '
+                                       '"g": {{ value_json.g }}, '
+                                       '"b": {{ value_json.b }}}'
+                                       '}')
 DEFAULT_FLASH_TIME_SHORT = 2
 DEFAULT_FLASH_TIME_LONG = 10
 
@@ -50,6 +61,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
     vol.Optional(CONF_BRIGHTNESS, default=DEFAULT_BRIGHTNESS): cv.boolean,
     vol.Optional(CONF_RGB, default=DEFAULT_RGB): cv.boolean,
+    vol.Optional(CONF_RGB_VALUE_TEMPLATE, default=DEFAULT_RGB_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_RGB_SET_TEMPLATE, default=DEFAULT_RGB_SET_TEMPLATE): cv.template,
     vol.Optional(CONF_FLASH_TIME_SHORT, default=DEFAULT_FLASH_TIME_SHORT):
         cv.positive_int,
     vol.Optional(CONF_FLASH_TIME_LONG, default=DEFAULT_FLASH_TIME_LONG):
@@ -68,6 +81,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 CONF_COMMAND_TOPIC
             )
         },
+        {
+            CONF_RGB_VALUE_TEMPLATE: config.get(CONF_RGB_VALUE_TEMPLATE),
+            CONF_RGB_SET_TEMPLATE: config.get(CONF_RGB_SET_TEMPLATE)
+        },
         config.get(CONF_QOS),
         config.get(CONF_RETAIN),
         config.get(CONF_OPTIMISTIC),
@@ -85,7 +102,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class MqttJson(Light):
     """Representation of a MQTT JSON light."""
 
-    def __init__(self, hass, name, topic, qos, retain,
+    def __init__(self, hass, name, topic, templates, qos, retain,
                  optimistic, brightness, rgb, flash_times):
         """Initialize MQTT JSON light."""
         self._hass = hass
@@ -107,6 +124,14 @@ class MqttJson(Light):
 
         self._flash_times = flash_times
 
+        self._templates = {}
+        for key, tpl in list(templates.items()):
+            if tpl is None:
+                self._templates[key] = lambda value: value
+            else:
+                tpl.hass = hass
+                self._templates[key] = tpl.render_with_possible_json_value
+
         def state_received(topic, payload, qos):
             """A new MQTT message has been received."""
             values = json.loads(payload)
@@ -118,11 +143,8 @@ class MqttJson(Light):
 
             if self._rgb is not None:
                 try:
-                    red = int(values['color']['r'])
-                    green = int(values['color']['g'])
-                    blue = int(values['color']['b'])
-
-                    self._rgb = [red, green, blue]
+                    self._rgb = [int(val) for val in
+                                 self._templates[CONF_RGB_VALUE_TEMPLATE](payload).split(',')]
                 except KeyError:
                     pass
                 except ValueError:
@@ -179,11 +201,11 @@ class MqttJson(Light):
         message = {'state': 'ON'}
 
         if ATTR_RGB_COLOR in kwargs:
-            message['color'] = {
+            message.update(json.loads(self._templates[CONF_RGB_SET_TEMPLATE](json.dumps({
                 'r': kwargs[ATTR_RGB_COLOR][0],
                 'g': kwargs[ATTR_RGB_COLOR][1],
                 'b': kwargs[ATTR_RGB_COLOR][2]
-            }
+            }))))
 
             if self._optimistic:
                 self._rgb = kwargs[ATTR_RGB_COLOR]

--- a/homeassistant/components/light/mqtt_json.py
+++ b/homeassistant/components/light/mqtt_json.py
@@ -128,11 +128,8 @@ class MqttJson(Light):
 
         self._templates = {}
         for key, tpl in list(templates.items()):
-            if tpl is None:
-                self._templates[key] = lambda value: value
-            else:
-                tpl.hass = hass
-                self._templates[key] = tpl.render_with_possible_json_value
+            tpl.hass = hass
+            self._templates[key] = tpl.render_with_possible_json_value
 
         def state_received(topic, payload, qos):
             """A new MQTT message has been received."""

--- a/homeassistant/components/light/mqtt_json.py
+++ b/homeassistant/components/light/mqtt_json.py
@@ -127,7 +127,7 @@ class MqttJson(Light):
         self._flash_times = flash_times
 
         self._templates = {}
-        for key, tpl in list(templates.items()):
+        for key, tpl in templates.items():
             tpl.hass = hass
             self._templates[key] = tpl.render_with_possible_json_value
 

--- a/homeassistant/components/light/mqtt_json.py
+++ b/homeassistant/components/light/mqtt_json.py
@@ -61,8 +61,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
     vol.Optional(CONF_BRIGHTNESS, default=DEFAULT_BRIGHTNESS): cv.boolean,
     vol.Optional(CONF_RGB, default=DEFAULT_RGB): cv.boolean,
-    vol.Optional(CONF_RGB_VALUE_TEMPLATE, default=DEFAULT_RGB_VALUE_TEMPLATE): cv.template,
-    vol.Optional(CONF_RGB_SET_TEMPLATE, default=DEFAULT_RGB_SET_TEMPLATE): cv.template,
+    vol.Optional(CONF_RGB_VALUE_TEMPLATE, default=DEFAULT_RGB_VALUE_TEMPLATE):
+        cv.template,
+    vol.Optional(CONF_RGB_SET_TEMPLATE, default=DEFAULT_RGB_SET_TEMPLATE):
+        cv.template,
     vol.Optional(CONF_FLASH_TIME_SHORT, default=DEFAULT_FLASH_TIME_SHORT):
         cv.positive_int,
     vol.Optional(CONF_FLASH_TIME_LONG, default=DEFAULT_FLASH_TIME_LONG):
@@ -144,7 +146,8 @@ class MqttJson(Light):
             if self._rgb is not None:
                 try:
                     self._rgb = [int(val) for val in
-                                 self._templates[CONF_RGB_VALUE_TEMPLATE](payload).split(',')]
+                                 self._templates[CONF_RGB_VALUE_TEMPLATE](
+                                     payload).split(',')]
                 except KeyError:
                     pass
                 except ValueError:
@@ -201,11 +204,13 @@ class MqttJson(Light):
         message = {'state': 'ON'}
 
         if ATTR_RGB_COLOR in kwargs:
-            message.update(json.loads(self._templates[CONF_RGB_SET_TEMPLATE](json.dumps({
-                'r': kwargs[ATTR_RGB_COLOR][0],
-                'g': kwargs[ATTR_RGB_COLOR][1],
-                'b': kwargs[ATTR_RGB_COLOR][2]
-            }))))
+            message.update(json.loads(self._templates[CONF_RGB_SET_TEMPLATE](
+                json.dumps({
+                    'r': kwargs[ATTR_RGB_COLOR][0],
+                    'g': kwargs[ATTR_RGB_COLOR][1],
+                    'b': kwargs[ATTR_RGB_COLOR][2]
+                })
+            )))
 
             if self._optimistic:
                 self._rgb = kwargs[ATTR_RGB_COLOR]

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -149,6 +149,40 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertEqual([125, 125, 125],
                          light_state.attributes.get('rgb_color'))
 
+    def test_controlling_color_with_templates_via_topic(self): \
+            # pylint: disable=invalid-name
+        """Test the controlling of the color with templates via topic."""
+        self.hass.config.components = ['mqtt']
+        assert _setup_component(self.hass, light.DOMAIN, {
+            light.DOMAIN: {
+                'platform': 'mqtt_json',
+                'name': 'test',
+                'state_topic': 'test_light_rgb',
+                'command_topic': 'test_light_rgb/set',
+                'brightness': True,
+                'rgb': True,
+                'rgb_value_template': '{{ value_json.color[0] }},{{ value_json.color[1] }},{{ value_json.color[2] }}',
+                'rgb_set_template': '{"color": [{{ value_json.r }},{{ value_json.g}},{{ value_json.b }}]}',
+                'qos': '0'
+            }
+        })
+
+        state = self.hass.states.get('light.test')
+        self.assertEqual(STATE_OFF, state.state)
+        self.assertIsNone(state.attributes.get('rgb_color'))
+        self.assertIsNone(state.attributes.get('brightness'))
+        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+
+        # Set to a custom color using [r, g, b] list format
+        fire_mqtt_message(self.hass, 'test_light_rgb',
+                          '{"state":"ON",'
+                          '"color":[41,42,43],'
+                          '"brightness":255}')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('light.test')
+        self.assertEqual([41, 42, 43], state.attributes.get('rgb_color'))
+
     def test_sending_mqtt_commands_and_optimistic(self): \
             # pylint: disable=invalid-name
         """Test the sending of command in optimistic mode."""

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -153,7 +153,7 @@ class TestLightMQTTJSON(unittest.TestCase):
             # pylint: disable=invalid-name
         """Test the controlling of the color with templates via topic."""
         self.hass.config.components = ['mqtt']
-        assert _setup_component(self.hass, light.DOMAIN, {
+        assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
                 'name': 'test',

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -161,8 +161,14 @@ class TestLightMQTTJSON(unittest.TestCase):
                 'command_topic': 'test_light_rgb/set',
                 'brightness': True,
                 'rgb': True,
-                'rgb_value_template': '{{ value_json.color[0] }},{{ value_json.color[1] }},{{ value_json.color[2] }}',
-                'rgb_set_template': '{"color": [{{ value_json.r }},{{ value_json.g}},{{ value_json.b }}]}',
+                'rgb_value_template': '{{ value_json.color[0] }},'
+                                      '{{ value_json.color[1] }},'
+                                      '{{ value_json.color[2] }}',
+                'rgb_set_template': '{"color":['
+                                    '{{ value_json.r }},'
+                                    '{{ value_json.g }},'
+                                    '{{ value_json.b }}'
+                                    ']}',
                 'qos': '0'
             }
         })

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -153,25 +153,26 @@ class TestLightMQTTJSON(unittest.TestCase):
             # pylint: disable=invalid-name
         """Test the controlling of the color with templates via topic."""
         self.hass.config.components = ['mqtt']
-        assert setup_component(self.hass, light.DOMAIN, {
-            light.DOMAIN: {
-                'platform': 'mqtt_json',
-                'name': 'test',
-                'state_topic': 'test_light_rgb',
-                'command_topic': 'test_light_rgb/set',
-                'brightness': True,
-                'rgb': True,
-                'rgb_value_template': '{{ value_json.color[0] }},'
-                                      '{{ value_json.color[1] }},'
-                                      '{{ value_json.color[2] }}',
-                'rgb_set_template': '{"color":['
-                                    '{{ value_json.r }},'
-                                    '{{ value_json.g }},'
-                                    '{{ value_json.b }}'
-                                    ']}',
-                'qos': '0'
-            }
-        })
+        with assert_setup_component(1):
+            assert setup_component(self.hass, light.DOMAIN, {
+                light.DOMAIN: {
+                    'platform': 'mqtt_json',
+                    'name': 'test',
+                    'state_topic': 'test_light_rgb',
+                    'command_topic': 'test_light_rgb/set',
+                    'brightness': True,
+                    'rgb': True,
+                    'rgb_value_template': '{{ value_json.color[0] }},'
+                                          '{{ value_json.color[1] }},'
+                                          '{{ value_json.color[2] }}',
+                    'rgb_set_template': '{"color":['
+                                        '{{ value_json.r }},'
+                                        '{{ value_json.g }},'
+                                        '{{ value_json.b }}'
+                                        ']}',
+                    'qos': '0'
+                }
+            })
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)


### PR DESCRIPTION
**Description:** Add templates for color in mqtt_json light
This allows for more custom JSON format for color. Changes are fully backward compatible.

**Related issue (if applicable):** discussion on #2777

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1302

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
light:
  - platform: mqtt_json
    name: mqtt_json_light_1
    state_topic: "home/rgb1"
    command_topic: "home/rgb1/set"
    brightness: true
    rgb: true
    rgb_value_template: "{{ value_json.color.r }},{{ value_json.color.g }},{{ value_json.color.b }}"
    rgb_set_template: '{"color": [{{ value_json.r }},{{ value_json.g}},{{ value_json.b }}]}'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
