### PR TITLE
Updated Emulated_Hue to send request info as variables to scripts

### DIFF
--- a/homeassistant/components/emulated_hue.py
+++ b/homeassistant/components/emulated_hue.py
@@ -18,7 +18,7 @@ from homeassistant import util, core
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, SERVICE_TURN_OFF, SERVICE_TURN_ON,
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
-    STATE_ON, HTTP_BAD_REQUEST, HTTP_NOT_FOUND,
+    STATE_ON, STATE_OFF, HTTP_BAD_REQUEST, HTTP_NOT_FOUND,
 )
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_SUPPORTED_FEATURES, SUPPORT_BRIGHTNESS
@@ -317,7 +317,16 @@ class HueLightsView(HomeAssistantView):
         # Construct what we need to send to the service
         data = {ATTR_ENTITY_ID: entity_id}
 
-        if brightness is not None:
+        # If the requested entity is a script add some variables
+        if entity.domain.lower() == "script":
+            data['variables'] = {
+                'requested_state': STATE_ON if result else STATE_OFF
+            }
+
+            if brightness is not None:
+                data['variables']['requested_level'] = brightness
+
+        elif brightness is not None:
             data[ATTR_BRIGHTNESS] = brightness
 
         if entity.domain.lower() in config.off_maps_to_on_domains:
@@ -401,6 +410,13 @@ def parse_hue_api_put_light_body(request_json, entity):
 
             report_brightness = True
             result = (brightness > 0)
+        elif entity.domain.lower() == "script":
+            # Convert 0-255 to 0-100
+            level = int(request_json[HUE_API_STATE_BRI]) / 255 * 100
+
+            brightness = round(level)
+            report_brightness = True
+            result = True
 
     return (result, brightness) if report_brightness else (result, None)
 

--- a/tests/components/test_emulated_hue.py
+++ b/tests/components/test_emulated_hue.py
@@ -6,7 +6,7 @@ import requests
 
 from homeassistant import bootstrap, const, core
 import homeassistant.components as core_components
-from homeassistant.components import emulated_hue, http, light
+from homeassistant.components import emulated_hue, http, light, script
 from homeassistant.const import STATE_ON, STATE_OFF
 from homeassistant.components.emulated_hue import (
     HUE_API_STATE_ON, HUE_API_STATE_BRI)
@@ -129,6 +129,27 @@ class TestEmulatedHueExposedByDefault(unittest.TestCase):
             ]
         })
 
+        bootstrap.setup_component(cls.hass, script.DOMAIN, {
+            'script': {
+                'flash_kitchen': {
+                    'sequence': [
+                        {
+                            'service': 'light.turn_off',
+                            'data': {
+                                'entity_id': 'light.kitchen_lights'
+                            }
+                        },
+                        {
+                            'service': 'light.turn_on',
+                            'data': {
+                                'entity_id': 'light.kitchen_lights'
+                            }
+                        }
+                    ]
+                }
+            }
+        })
+
         start_hass_instance(cls.hass)
 
         # Kitchen light is explicitly excluded from being exposed
@@ -138,6 +159,14 @@ class TestEmulatedHueExposedByDefault(unittest.TestCase):
         cls.hass.states.set(
             kitchen_light_entity.entity_id, kitchen_light_entity.state,
             attributes=attrs)
+
+        # Expose the script
+        script_entity = cls.hass.states.get('script.flash_kitchen')
+        attrs = dict(script_entity.attributes)
+        attrs[emulated_hue.ATTR_EMULATED_HUE] = True
+        cls.hass.states.set(
+            script_entity.entity_id, script_entity.state, attributes=attrs
+        )
 
     @classmethod
     def tearDownClass(cls):
@@ -157,6 +186,7 @@ class TestEmulatedHueExposedByDefault(unittest.TestCase):
         # Make sure the lights we added to the config are there
         self.assertTrue('light.ceiling_lights' in result_json)
         self.assertTrue('light.bed_light' in result_json)
+        self.assertTrue('script.flash_kitchen' in result_json)
         self.assertTrue('light.kitchen_lights' not in result_json)
 
     def test_get_light_state(self):
@@ -230,6 +260,40 @@ class TestEmulatedHueExposedByDefault(unittest.TestCase):
         kitchen_result = self.perform_put_light_state(
             'light.kitchen_light', True)
         self.assertEqual(kitchen_result.status_code, 404)
+
+    def test_put_light_state_script(self):
+        """Test the seeting of light states."""
+        # Turn the bedroom light on first
+        self.hass.services.call(
+            light.DOMAIN, const.SERVICE_TURN_ON,
+            {const.ATTR_ENTITY_ID: 'script.flash_kitchen',
+             light.ATTR_BRIGHTNESS: 153},
+            blocking=True)
+
+        # Go through the API to turn it off
+        url = BRIDGE_URL_BASE.format(
+            '/api/username/lights/{}/state'.format('script.flash_kitchen'))
+
+        req_headers = {'Content-Type': 'application/json'}
+
+        # Send Off state and brightness
+        data = {
+            HUE_API_STATE_ON: False,
+            HUE_API_STATE_BRI: 52
+        }
+
+        script_result = requests.put(
+            url,
+            data=json.dumps(data),
+            timeout=5,
+            headers=req_headers
+        )
+
+        script_result_json = script_result.json()
+        print(script_result_json)
+
+        self.assertEqual(script_result.status_code, 200)
+        self.assertEqual(len(script_result_json), 2)
 
     def test_put_with_form_urlencoded_content_type(self):
         """Test the form with urlencoded content."""

--- a/tests/components/test_emulated_hue.py
+++ b/tests/components/test_emulated_hue.py
@@ -1,5 +1,4 @@
 """The tests for the emulated Hue component."""
-import time
 import json
 
 import unittest
@@ -258,7 +257,7 @@ class TestEmulatedHueExposedByDefault(unittest.TestCase):
         self.assertEqual(kitchen_result.status_code, 404)
 
     def test_put_light_state_script(self):
-        """Test the seeting of script variables."""
+        """Test the setting of script variables."""
         # Turn the kitchen light off first
         self.hass.services.call(
             light.DOMAIN, const.SERVICE_TURN_OFF,
@@ -277,8 +276,8 @@ class TestEmulatedHueExposedByDefault(unittest.TestCase):
         self.assertEqual(script_result.status_code, 200)
         self.assertEqual(len(script_result_json), 2)
 
-        # Sleep for short time so script has time to complete
-        time.sleep(.01)
+        # Wait until script is complete before continuing
+        self.hass.block_till_done()
 
         kitchen_light = self.hass.states.get('light.kitchen_lights')
         self.assertEqual(kitchen_light.state, 'on')

--- a/tests/components/test_emulated_hue.py
+++ b/tests/components/test_emulated_hue.py
@@ -1,4 +1,5 @@
 """The tests for the emulated Hue component."""
+import time
 import json
 
 import unittest


### PR DESCRIPTION
**The Problem**
When using emulated_hue there are some requests in the command that we already know. However those are not exposed to any scripts that could of been called.

**My Solution**
I have updated it to get the requested state (on|off) and the requested level(0-100) and pass them into scripts as variables. This allows a single script to be used for turn on and turn off as well as passing in a value 0-100.

The original behavior for treating off as on for scripts is still in place and the service called is not changed. Only difference is if the entity is a script then it will add the actual requested command to the script as variables.

**Alexa commands parsed**
1. Alexa, turn {requested_state} {entity_name} at {requested_level}% 
2. Alexa, set {entity_name} to {requested_level}%
- Using this will send the "on" requested_state by default
