### PR TITLE
Fix mysensors overwriting gateway in GATEWAYS

### DIFF
--- a/homeassistant/components/binary_sensor/mysensors.py
+++ b/homeassistant/components/binary_sensor/mysensors.py
@@ -22,7 +22,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    for gateway in mysensors.GATEWAYS.values():
+    gateways = hass.data.get(mysensors.MYSENSORS_GATEWAYS)
+    if not gateways:
+        return
+
+    for gateway in gateways:
         # Define the S_TYPES and V_TYPES that the platform should handle as
         # states. Map them in a dict of lists.
         pres = gateway.const.Presentation

--- a/homeassistant/components/climate/mysensors.py
+++ b/homeassistant/components/climate/mysensors.py
@@ -24,7 +24,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the mysensors climate."""
     if discovery_info is None:
         return
-    for gateway in mysensors.GATEWAYS.values():
+
+    gateways = hass.data.get(mysensors.MYSENSORS_GATEWAYS)
+    if not gateways:
+        return
+
+    for gateway in gateways:
         if float(gateway.protocol_version) < 1.5:
             continue
         pres = gateway.const.Presentation

--- a/homeassistant/components/cover/mysensors.py
+++ b/homeassistant/components/cover/mysensors.py
@@ -18,7 +18,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the mysensors platform for covers."""
     if discovery_info is None:
         return
-    for gateway in mysensors.GATEWAYS.values():
+
+    gateways = hass.data.get(mysensors.MYSENSORS_GATEWAYS)
+    if not gateways:
+        return
+
+    for gateway in gateways:
         pres = gateway.const.Presentation
         set_req = gateway.const.SetReq
         map_sv_types = {

--- a/homeassistant/components/light/mysensors.py
+++ b/homeassistant/components/light/mysensors.py
@@ -31,7 +31,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    for gateway in mysensors.GATEWAYS.values():
+    gateways = hass.data.get(mysensors.MYSENSORS_GATEWAYS)
+    if not gateways:
+        return
+
+    for gateway in gateways:
         # Define the S_TYPES and V_TYPES that the platform should handle as
         # states. Map them in a dict of lists.
         pres = gateway.const.Presentation

--- a/homeassistant/components/sensor/mysensors.py
+++ b/homeassistant/components/sensor/mysensors.py
@@ -20,7 +20,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    for gateway in mysensors.GATEWAYS.values():
+    gateways = hass.data.get(mysensors.MYSENSORS_GATEWAYS)
+    if not gateways:
+        return
+
+    for gateway in gateways:
         # Define the S_TYPES and V_TYPES that the platform should handle as
         # states. Map them in a dict of lists.
         pres = gateway.const.Presentation

--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -34,7 +34,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    for gateway in mysensors.GATEWAYS.values():
+    gateways = hass.data.get(mysensors.MYSENSORS_GATEWAYS)
+    if not gateways:
+        return
+
+    for gateway in gateways:
         # Define the S_TYPES and V_TYPES that the platform should handle as
         # states. Map them in a dict of lists.
         pres = gateway.const.Presentation


### PR DESCRIPTION
**Description:**
GATEWAYS was a dict, so would overwrite item if key was the same. This
would happen when using multiple MQTT gateways, since the device id is
the same (`mqtt`).
- Fix by changing GATEWAYS from dict into list.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
mysensors:
  gateways:
    - device: mqtt
      topic_in_prefix: 'mygateway1-out'
      topic_out_prefix: 'mygateway1-in'
    - device: mqtt
      topic_in_prefix: 'mygateway2-out'
      topic_out_prefix: 'mygateway2-in'
  version: 2.0
```

**Checklist:**
If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
