### PR TITLE
Add discovery notify support and mysensors notify

### DIFF
--- a/homeassistant/components/binary_sensor/mysensors.py
+++ b/homeassistant/components/binary_sensor/mysensors.py
@@ -47,7 +47,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
         devices = {}
         gateway.platform_callbacks.append(mysensors.pf_callback_factory(
-            map_sv_types, devices, add_devices, MySensorsBinarySensor))
+            map_sv_types, devices, MySensorsBinarySensor, add_devices))
 
 
 class MySensorsBinarySensor(

--- a/homeassistant/components/climate/mysensors.py
+++ b/homeassistant/components/climate/mysensors.py
@@ -39,7 +39,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         }
         devices = {}
         gateway.platform_callbacks.append(mysensors.pf_callback_factory(
-            map_sv_types, devices, add_devices, MySensorsHVAC))
+            map_sv_types, devices, MySensorsHVAC, add_devices))
 
 
 class MySensorsHVAC(mysensors.MySensorsDeviceEntity, ClimateDevice):

--- a/homeassistant/components/cover/mysensors.py
+++ b/homeassistant/components/cover/mysensors.py
@@ -35,7 +35,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             })
         devices = {}
         gateway.platform_callbacks.append(mysensors.pf_callback_factory(
-            map_sv_types, devices, add_devices, MySensorsCover))
+            map_sv_types, devices, MySensorsCover, add_devices))
 
 
 class MySensorsCover(mysensors.MySensorsDeviceEntity, CoverDevice):

--- a/homeassistant/components/light/mysensors.py
+++ b/homeassistant/components/light/mysensors.py
@@ -58,7 +58,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             })
         devices = {}
         gateway.platform_callbacks.append(mysensors.pf_callback_factory(
-            map_sv_types, devices, add_devices, device_class_map))
+            map_sv_types, devices, device_class_map, add_devices))
 
 
 class MySensorsLight(mysensors.MySensorsDeviceEntity, Light):

--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -172,7 +172,7 @@ def setup(hass, config):
     return True
 
 
-def pf_callback_factory(map_sv_types, devices, add_devices, entity_class):
+def pf_callback_factory(map_sv_types, devices, entity_class, add_devices=None):
     """Return a new callback for the platform."""
     def mysensors_callback(gateway, node_id):
         """Callback for mysensors platform."""
@@ -187,7 +187,10 @@ def pf_callback_factory(map_sv_types, devices, add_devices, entity_class):
                         value_type not in map_sv_types[child.type]:
                     continue
                 if key in devices:
-                    devices[key].update_ha_state(True)
+                    if add_devices:
+                        devices[key].update_ha_state(True)
+                    else:
+                        devices[key].update()
                     continue
                 name = '{} {} {}'.format(
                     gateway.sensors[node_id].sketch_name, node_id, child.id)
@@ -197,11 +200,12 @@ def pf_callback_factory(map_sv_types, devices, add_devices, entity_class):
                     device_class = entity_class
                 devices[key] = device_class(
                     gateway, node_id, child.id, name, value_type, child.type)
-
-                _LOGGER.info('Adding new devices: %s', devices[key])
-                add_devices([devices[key]])
-                if key in devices:
+                if add_devices:
+                    _LOGGER.info('Adding new devices: %s', devices[key])
+                    add_devices([devices[key]])
                     devices[key].update_ha_state(True)
+                else:
+                    devices[key].update()
     return mysensors_callback
 
 

--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -9,10 +9,10 @@ import socket
 
 import voluptuous as vol
 
-from homeassistant.bootstrap import setup_component
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import (ATTR_BATTERY_LEVEL, CONF_OPTIMISTIC,
-                                 EVENT_HOMEASSISTANT_START,
+from homeassistant.bootstrap import setup_component
+from homeassistant.const import (ATTR_BATTERY_LEVEL, CONF_NAME,
+                                 CONF_OPTIMISTIC, EVENT_HOMEASSISTANT_START,
                                  EVENT_HOMEASSISTANT_STOP, STATE_OFF, STATE_ON)
 from homeassistant.helpers import discovery
 from homeassistant.loader import get_component
@@ -168,6 +168,9 @@ def setup(hass, config):
     for component in ['sensor', 'switch', 'light', 'binary_sensor', 'climate',
                       'cover']:
         discovery.load_platform(hass, component, DOMAIN, {}, config)
+
+    discovery.load_platform(
+        hass, 'notify', DOMAIN, {CONF_NAME: DOMAIN}, config)
 
     return True
 

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -136,7 +136,8 @@ def setup(hass, config):
 
     for platform, p_config in config_per_platform(config, DOMAIN):
         if not setup_notify_platform(platform, p_config):
-            return False
+            _LOGGER.error("Failed to set up platform %s", platform)
+            continue
 
     def platform_discovered(platform, info):
         """Callback to load a platform."""

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -14,7 +14,7 @@ import homeassistant.bootstrap as bootstrap
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config import load_yaml_config_file
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
-from homeassistant.helpers import config_per_platform
+from homeassistant.helpers import config_per_platform, discovery
 from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,27 +66,31 @@ def send_message(hass, message, title=None, data=None):
 
 def setup(hass, config):
     """Setup the notify services."""
-    success = False
-
     descriptions = load_yaml_config_file(
         os.path.join(os.path.dirname(__file__), 'services.yaml'))
 
     targets = {}
 
-    for platform, p_config in config_per_platform(config, DOMAIN):
+    def setup_notify_platform(platform, p_config=None, discovery_info=None):
+        """Set up a notify platform."""
+        if p_config is None:
+            p_config = {}
+        if discovery_info is not None:
+            p_config = discovery_info
+
         notify_implementation = bootstrap.prepare_setup_platform(
             hass, config, DOMAIN, platform)
 
         if notify_implementation is None:
             _LOGGER.error("Unknown notification service specified")
-            continue
+            return False
 
         notify_service = notify_implementation.get_service(hass, p_config)
 
         if notify_service is None:
             _LOGGER.error("Failed to initialize notification service %s",
                           platform)
-            continue
+            return False
 
         def notify_message(notify_service, call):
             """Handle sending notification message service calls."""
@@ -127,9 +131,20 @@ def setup(hass, config):
         hass.services.register(
             DOMAIN, platform_name_slug, service_call_handler,
             descriptions.get(SERVICE_NOTIFY), schema=NOTIFY_SERVICE_SCHEMA)
-        success = True
 
-    return success
+        return True
+
+    for platform, p_config in config_per_platform(config, DOMAIN):
+        if not setup_notify_platform(platform, p_config):
+            return False
+
+    def platform_discovered(platform, info):
+        """Callback to load a platform."""
+        setup_notify_platform(platform, discovery_info=info)
+
+    discovery.listen_platform(hass, DOMAIN, platform_discovered)
+
+    return True
 
 
 class BaseNotificationService(object):

--- a/homeassistant/components/notify/apns.py
+++ b/homeassistant/components/notify/apns.py
@@ -11,17 +11,26 @@ import voluptuous as vol
 from homeassistant.helpers.event import track_state_change
 from homeassistant.config import load_yaml_config_file
 from homeassistant.components.notify import (
-    ATTR_TARGET, ATTR_DATA, BaseNotificationService)
+    ATTR_TARGET, ATTR_DATA, BaseNotificationService, PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import template as template_helper
 
 DOMAIN = "apns"
 APNS_DEVICES = "apns.yaml"
+CONF_CERTFILE = "cert_file"
+CONF_TOPIC = "topic"
 DEVICE_TRACKER_DOMAIN = "device_tracker"
 SERVICE_REGISTER = "apns_register"
 
 ATTR_PUSH_ID = "push_id"
 ATTR_NAME = "name"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_CERTFILE): cv.string,
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_TOPIC): cv.string,
+})
 
 REGISTER_SERVICE_SCHEMA = vol.Schema({
     vol.Required(ATTR_PUSH_ID): cv.string,
@@ -37,19 +46,8 @@ def get_service(hass, config):
         os.path.join(os.path.dirname(__file__), 'services.yaml'))
 
     name = config.get("name")
-    if name is None:
-        logging.error("Name must be specified.")
-        return None
-
     cert_file = config.get('cert_file')
-    if cert_file is None:
-        logging.error("Certificate must be specified.")
-        return None
-
     topic = config.get('topic')
-    if topic is None:
-        logging.error("Topic must be specified.")
-        return None
 
     sandbox = bool(config.get('sandbox', False))
 

--- a/homeassistant/components/notify/mysensors.py
+++ b/homeassistant/components/notify/mysensors.py
@@ -8,8 +8,6 @@ from homeassistant.components import mysensors
 from homeassistant.components.notify import (ATTR_TARGET,
                                              BaseNotificationService)
 
-DEPENDENCIES = ['mysensors']
-
 
 def get_service(hass, config):
     """Get the MySensors notification service."""

--- a/homeassistant/components/notify/mysensors.py
+++ b/homeassistant/components/notify/mysensors.py
@@ -1,0 +1,60 @@
+"""
+MySensors notification service.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/notify.mysensors/
+"""
+from homeassistant.components import mysensors
+from homeassistant.components.notify import (ATTR_TARGET,
+                                             BaseNotificationService)
+
+DEPENDENCIES = ['mysensors']
+
+
+def get_service(hass, config):
+    """Get the MySensors notification service."""
+    platform_devices = []
+    for gateway in mysensors.GATEWAYS.values():
+        pres = gateway.const.Presentation
+        set_req = gateway.const.SetReq
+        map_sv_types = {
+            pres.S_INFO: [set_req.V_TEXT],
+        }
+        devices = {}
+        gateway.platform_callbacks.append(mysensors.pf_callback_factory(
+            map_sv_types, devices, MySensorsNotificationDevice))
+        platform_devices.append(devices)
+    return MySensorsNotificationService(platform_devices)
+
+
+class MySensorsNotificationDevice(mysensors.MySensorsDeviceEntity):
+    """Represent a MySensors Notification device."""
+
+    def send_msg(self, msg):
+        """Send a message."""
+        for sub_msg in [msg[i:i + 25] for i in range(0, len(msg), 25)]:
+            # Max mysensors payload is 25 bytes.
+            self.gateway.set_child_value(
+                self.node_id, self.child_id, self.value_type, sub_msg)
+
+
+class MySensorsNotificationService(BaseNotificationService):
+    """Implement MySensors notification service."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, platform_devices):
+        """Initialize the service."""
+        self.platform_devices = platform_devices
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to a user."""
+        target_devices = kwargs.get(ATTR_TARGET)
+        devices = [
+            device for gw_devs in self.platform_devices
+            for device in gw_devs.values()
+            if target_devices is None or
+            device.name in target_devices]
+
+        for device in devices:
+            device.send_msg(message)

--- a/homeassistant/components/notify/mysensors.py
+++ b/homeassistant/components/notify/mysensors.py
@@ -14,7 +14,11 @@ DEPENDENCIES = ['mysensors']
 def get_service(hass, config):
     """Get the MySensors notification service."""
     platform_devices = []
-    for gateway in mysensors.GATEWAYS.values():
+    gateways = hass.data.get(mysensors.MYSENSORS_GATEWAYS)
+    if not gateways:
+        return
+
+    for gateway in gateways:
         pres = gateway.const.Presentation
         set_req = gateway.const.SetReq
         map_sv_types = {
@@ -24,6 +28,7 @@ def get_service(hass, config):
         gateway.platform_callbacks.append(mysensors.pf_callback_factory(
             map_sv_types, devices, MySensorsNotificationDevice))
         platform_devices.append(devices)
+
     return MySensorsNotificationService(platform_devices)
 
 

--- a/homeassistant/components/sensor/mysensors.py
+++ b/homeassistant/components/sensor/mysensors.py
@@ -83,7 +83,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
         devices = {}
         gateway.platform_callbacks.append(mysensors.pf_callback_factory(
-            map_sv_types, devices, add_devices, MySensorsSensor))
+            map_sv_types, devices, MySensorsSensor, add_devices))
 
 
 class MySensorsSensor(mysensors.MySensorsDeviceEntity, Entity):

--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -89,7 +89,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
         devices = {}
         gateway.platform_callbacks.append(mysensors.pf_callback_factory(
-            map_sv_types, devices, add_devices, device_class_map))
+            map_sv_types, devices, device_class_map, add_devices))
         platform_devices.append(devices)
 
     def send_ir_code_service(service):

--- a/tests/common.py
+++ b/tests/common.py
@@ -399,7 +399,7 @@ def assert_setup_component(count, domain=None):
 
     Use as a context manager aroung bootstrap.setup_component
         with assert_setup_component(0) as result_config:
-            setup_component(hass, start_config, domain)
+            setup_component(hass, domain, start_config)
             # using result_config is optional
     """
     config = {}

--- a/tests/components/notify/test_apns.py
+++ b/tests/components/notify/test_apns.py
@@ -29,43 +29,6 @@ class TestApns(unittest.TestCase):
 
         self.assertTrue(notify.setup(hass, config))
 
-    def test_apns_setup_missing_name(self):
-        """Test setup with missing name."""
-        config = {
-            'notify': {
-                'platform': 'apns',
-                'sandbox': 'True',
-                'topic': 'testapp.appname',
-                'cert_file': 'test_app.pem'
-            }
-        }
-        hass = get_test_home_assistant()
-        self.assertFalse(notify.setup(hass, config))
-
-    def test_apns_setup_missing_certificate(self):
-        """Test setup with missing name."""
-        config = {
-            'notify': {
-                'platform': 'apns',
-                'topic': 'testapp.appname',
-                'name': 'test_app'
-            }
-        }
-        hass = get_test_home_assistant()
-        self.assertFalse(notify.setup(hass, config))
-
-    def test_apns_setup_missing_topic(self):
-        """Test setup with missing topic."""
-        config = {
-            'notify': {
-                'platform': 'apns',
-                'cert_file': 'test_app.pem',
-                'name': 'test_app'
-            }
-        }
-        hass = get_test_home_assistant()
-        self.assertFalse(notify.setup(hass, config))
-
     def test_register_new_device(self):
         """Test registering a new device with a name."""
         config = {

--- a/tests/components/notify/test_command_line.py
+++ b/tests/components/notify/test_command_line.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.notify as notify
-from tests.common import get_test_home_assistant
+from tests.common import assert_setup_component, get_test_home_assistant
 
 
 class TestCommandLine(unittest.TestCase):
@@ -31,12 +31,14 @@ class TestCommandLine(unittest.TestCase):
 
     def test_bad_config(self):
         """Test set up the platform with bad/missing configuration."""
-        self.assertFalse(setup_component(self.hass, notify.DOMAIN, {
-            'notify': {
-                'name': 'test',
-                'platform': 'bad_platform',
-            }
-        }))
+        # Platform should not be set up, but component should be set up.
+        with assert_setup_component(0):
+            self.assertTrue(setup_component(self.hass, notify.DOMAIN, {
+                'notify': {
+                    'name': 'test',
+                    'platform': 'bad_platform',
+                    }
+                }))
 
     def test_command_line_output(self):
         """Test the command line output."""

--- a/tests/components/notify/test_command_line.py
+++ b/tests/components/notify/test_command_line.py
@@ -29,17 +29,6 @@ class TestCommandLine(unittest.TestCase):
                 'command': 'echo $(cat); exit 1',
             }})
 
-    def test_bad_config(self):
-        """Test set up the platform with bad/missing configuration."""
-        # Platform should not be set up, but component should be set up.
-        with assert_setup_component(0):
-            self.assertTrue(setup_component(self.hass, notify.DOMAIN, {
-                'notify': {
-                    'name': 'test',
-                    'platform': 'bad_platform',
-                    }
-                }))
-
     def test_command_line_output(self):
         """Test the command line output."""
         with tempfile.TemporaryDirectory() as tempdirname:

--- a/tests/components/notify/test_file.py
+++ b/tests/components/notify/test_file.py
@@ -25,8 +25,9 @@ class TestNotifyFile(unittest.TestCase):
 
     def test_bad_config(self):
         """Test set up the platform with bad/missing config."""
+        # Platform should not be set up, but component should be set up.
         with assert_setup_component(0):
-            assert not setup_component(self.hass, notify.DOMAIN, {
+            assert setup_component(self.hass, notify.DOMAIN, {
                 'notify': {
                     'name': 'test',
                     'platform': 'file',
@@ -42,8 +43,8 @@ class TestNotifyFile(unittest.TestCase):
 
         m_open = mock_open()
         with patch(
-                'homeassistant.components.notify.file.open',
-                m_open, create=True
+            'homeassistant.components.notify.file.open',
+            m_open, create=True
         ):
             filename = 'mock_file'
             message = 'one, two, testing, testing'

--- a/tests/components/notify/test_file.py
+++ b/tests/components/notify/test_file.py
@@ -23,17 +23,6 @@ class TestNotifyFile(unittest.TestCase):
         """"Stop down everything that was started."""
         self.hass.stop()
 
-    def test_bad_config(self):
-        """Test set up the platform with bad/missing config."""
-        # Platform should not be set up, but component should be set up.
-        with assert_setup_component(0):
-            assert setup_component(self.hass, notify.DOMAIN, {
-                'notify': {
-                    'name': 'test',
-                    'platform': 'file',
-                },
-            })
-
     @patch('homeassistant.components.notify.file.os.stat')
     @patch('homeassistant.util.dt.utcnow')
     def test_notify_file(self, mock_utcnow, mock_stat):


### PR DESCRIPTION
**Description:**
- Add support for discovery setup for notify component platforms.
- Make add_devices optional in mysensors platform callback function.
- Use new argument structure for all existing mysensors platforms.
- Add mysensors notify platform.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
mysensors:
  gateways:
    - device: '/dev/ttyACM0'
  version: 2.0
```

**Checklist:**
If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
