### PR TITLE
fix mistake in see service for the attributes

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -103,7 +103,7 @@ def see(hass: HomeAssistantType, mac: str=None, dev_id: str=None,
              (ATTR_GPS_ACCURACY, gps_accuracy),
              (ATTR_BATTERY, battery)) if value is not None}
     if attributes:
-        for key, value in attributes:
+        for key, value in attributes.items():
             data[key] = value
     hass.services.call(DOMAIN, SERVICE_SEE, data)
 

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -103,8 +103,7 @@ def see(hass: HomeAssistantType, mac: str=None, dev_id: str=None,
              (ATTR_GPS_ACCURACY, gps_accuracy),
              (ATTR_BATTERY, battery)) if value is not None}
     if attributes:
-        for key, value in attributes.items():
-            data[key] = value
+        data[ATTR_ATTRIBUTES] = attributes
     hass.services.call(DOMAIN, SERVICE_SEE, data)
 
 

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -283,7 +283,10 @@ class TestComponentsDeviceTracker(unittest.TestCase):
             'dev_id': 'some_device',
             'host_name': 'example.com',
             'location_name': 'Work',
-            'gps': [.3, .8]
+            'gps': [.3, .8],
+            'attributes': {
+                'test': 'test'
+            }
         }
         device_tracker.see(self.hass, **params)
         self.hass.block_till_done()


### PR DESCRIPTION
**Description:**
This mistake created errors when you try to add attributes to the see service. This fixes it.

This error is thrown:

```
16-10-24 13:50:22 custom_components.icloud3: ICLOUDTRACKER: device ipadsharon gevonden, roep see service op met attributes {'low_power_mode': False, 'account_name': 'sharon', 'battery_status': 'NotCharging', 'interval': 1, 'device_status': 'offline'}
16-10-24 13:50:22 homeassistant.core: BusHandler:Exception doing job
Traceback (most recent call last):
  File "C:\python3\lib\site-packages\homeassistant-0.32.0.dev0-py3.4.egg\homeassistant\core.py", line 1221, in job_handler
    func(*args)
  File "C:\Users\de_va\AppData\Roaming\.homeassistant\custom_components\icloud3.py", line 267, in keep_alive
    self.update_device(devicename)
  File "C:\Users\de_va\AppData\Roaming\.homeassistant\custom_components\icloud3.py", line 383, in update_device
    attributes=attrs)
  File "C:\python3\lib\site-packages\homeassistant-0.32.0.dev0-py3.4.egg\homeassistant\components\device_tracker\__init__.py", line 106, in see
    for key, value in attributes:
ValueError: too many values to unpack (expected 2)
```

when using this code (a bit simplified):

```
        attrs = {}
        interval = self._intervals.get(devicename, 1)
        if ((currentminutes % interval == 0) or
              (interval > 10 and currentminutes % interval in [2, 4])):
          status = device.status(DEVICESTATUSSET)
          self._devicestatuscode = status['deviceStatus']
          if self._devicestatuscode == '200':
            attrs[ATTR_DEVICESTATUS] = 'online'
          lowpowermode = status['lowPowerMode']
          attrs[ATTR_LOWPOWERMODE] = lowpowermode
          batterystatus = status['batteryStatus']
          attrs[ATTR_BATTERYSTATUS] = batterystatus
          attrs[ATTR_INTERVAL] = interval
          attrs[ATTR_ACCOUNTNAME] = self.accountname
          battery = status['batteryLevel']*100
          location = status['location']
          if location:
            accuracy = location['horizontalAccuracy']
            _LOGGER.info('ICLOUDTRACKER: device %s gevonden, roep see service op met attributes %s', devicename, attrs)
            see(hass=self.hass, dev_id=dev_id, host_name=status['name'], gps=(location['latitude'], location['longitude']), battery=battery,
                gps_accuracy=accuracy, attributes=attrs)
```
