### PR TITLE
Fixes in TP-Link Switch logging 0 values on init

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -37,7 +37,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
 
-    add_devices([SmartPlugSwitch(SmartPlug(host), name)])
+    add_devices([SmartPlugSwitch(SmartPlug(host), name)], True)
 
 
 class SmartPlugSwitch(SwitchDevice):
@@ -52,18 +52,6 @@ class SmartPlugSwitch(SwitchDevice):
         _LOGGER.debug("Setting up TP-Link Smart Plug HS%i", smartplug.model)
         # Set up emeter cache
         self._emeter_params = {}
-
-        if self._emeter_present:
-            emeter_readings = self.smartplug.get_emeter_realtime()
-
-            self._emeter_params[ATTR_CURRENT_CONSUMPTION] \
-                = "%.1f W" % emeter_readings["power"]
-            self._emeter_params[ATTR_TOTAL_CONSUMPTION] \
-                = "%.2f kW" % emeter_readings["total"]
-            self._emeter_params[ATTR_VOLTAGE] \
-                = "%.2f V" % emeter_readings["voltage"]
-            self._emeter_params[ATTR_CURRENT] \
-                = "%.1f A" % emeter_readings["current"]
 
     @property
     def name(self):

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -53,6 +53,18 @@ class SmartPlugSwitch(SwitchDevice):
         # Set up emeter cache
         self._emeter_params = {}
 
+        if self._emeter_present:
+            emeter_readings = self.smartplug.get_emeter_realtime()
+
+            self._emeter_params[ATTR_CURRENT_CONSUMPTION] \
+                = "%.1f W" % emeter_readings["power"]
+            self._emeter_params[ATTR_TOTAL_CONSUMPTION] \
+                = "%.2f kW" % emeter_readings["total"]
+            self._emeter_params[ATTR_VOLTAGE] \
+                = "%.2f V" % emeter_readings["voltage"]
+            self._emeter_params[ATTR_CURRENT] \
+                = "%.1f A" % emeter_readings["current"]
+
     @property
     def name(self):
         """Return the name of the Smart Plug, if any."""


### PR DESCRIPTION
**Description:**
When the component initializes it would set all devices attributes to zero, unless they are properly initialized with the real world data. This causes problem when connected to influxdb as the voltage graph suddenly has a 0 value.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
If the code communicates with devices, web services, or third-party tools:

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

On init of component the emeter would log to influxdb and possibly other outputs a 0 value, instead of not logging anything.
Polling on component initialize should circumvent that behavior and avoid logging inconsistencies.
