### PR TITLE
If no weather advisories were issued, state should return 0 instead Unknown

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -117,8 +117,11 @@ class WUndergroundSensor(Entity):
             else:
                 return self.rest.data[self._condition]
 
-        if self.rest.alerts and self._condition == 'alerts':
-            return len(self.rest.alerts)
+        if self._condition == 'alerts':
+            if self.rest.alerts:
+                return len(self.rest.alerts)
+            else:
+                return 0
         return STATE_UNKNOWN
 
     @property

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -117,11 +117,10 @@ class WUndergroundSensor(Entity):
             else:
                 return self.rest.data[self._condition]
 
-        if self._condition == 'alerts':
-            if self.rest.alerts:
-                return len(self.rest.alerts)
-            else:
-                return 0
+        if self.rest.alerts and self._condition == 'alerts':
+            return len(self.rest.alerts)
+        else:
+            return 0
         return STATE_UNKNOWN
 
     @property

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -117,10 +117,11 @@ class WUndergroundSensor(Entity):
             else:
                 return self.rest.data[self._condition]
 
-        if self.rest.alerts and self._condition == 'alerts':
-            return len(self.rest.alerts)
-        else:
-            return 0
+        if self._condition == 'alerts':
+            if self.rest.alerts:
+                return len(self.rest.alerts)
+            else:
+                return 0
         return STATE_UNKNOWN
 
     @property


### PR DESCRIPTION
**Description:**
If no weather alerts were issued, the sensor should return 0 instead unknown. 

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- without this patch
  ![image](https://cloud.githubusercontent.com/assets/809840/19674676/a1cfc2ec-9a57-11e6-8ce0-9a84ef509167.png)
- with this patch
  ![image](https://cloud.githubusercontent.com/assets/809840/19674706/d082065e-9a57-11e6-9ef5-5aec87042d19.png)
