### PR TITLE
WIP: Add zwave entities after node queries complete

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -276,6 +276,7 @@ def setup(hass, config):
             print("SIGNAL *****", signal)
             if value and signal in (ZWaveNetwork.SIGNAL_VALUE_CHANGED,
                                     ZWaveNetwork.SIGNAL_VALUE_ADDED,
+                                    ZWaveNetwork.SIGNAL_NODE_QUERIES_COMPLETE,
                                     ZWaveNetwork.SIGNAL_SCENE_EVENT,
                                     ZWaveNetwork.SIGNAL_NODE_EVENT,
                                     ZWaveNetwork.SIGNAL_AWAKE_NODES_QUERIED,
@@ -286,8 +287,13 @@ def setup(hass, config):
 
         dispatcher.connect(log_all, weak=False)
 
-    def value_added(node, value):
-        """Called when a value is added to a node on the network."""
+    def node_queries_complete(node):
+        """Called when a node has been fully queried for the network."""
+        for value in node.get_values().values():
+            add_node_value(node, value)
+
+    def add_node_value(node, value):
+        """Called after a node is added on the network for each node value."""
         for (component,
              generic_device_class,
              specific_device_class,
@@ -381,7 +387,8 @@ def setup(hass, config):
         hass.bus.fire(const.EVENT_NETWORK_COMPLETE)
 
     dispatcher.connect(
-        value_added, ZWaveNetwork.SIGNAL_VALUE_ADDED, weak=False)
+        node_queries_complete, ZWaveNetwork.SIGNAL_NODE_QUERIES_COMPLETE,
+        weak=False)
     dispatcher.connect(
         scene_activated, ZWaveNetwork.SIGNAL_SCENE_EVENT, weak=False)
     dispatcher.connect(


### PR DESCRIPTION
**Description:**
Currently, home assistant is listening for the openzwave node VALUE_ADDED signal, at which point it creates the corresponding entity for that value. In this pull request, home assistant waits for the NODE_QUERIES_COMPLETE signal before creating any entities tied to that node.

The motivation for this change is the issue here: https://community.home-assistant.io/t/color-issues-with-aeotec-zwave-zw098/2830/14 Because the zwave color bulbs require interaction between two command classes, they are tied to multiple zwave values for that node. In the current implementation, if the color value is added first, it is present when the multilevel value is added, and home-assistant initializes the color bulb entity properly. However, if the multilevel value is added first, the color value isn't present when the entity is created, and the error presents itself.

I'm also fairly certain that with this change there will be other race conditions in the zwave platform that suddenly disappear, since entities will only initialize once the node is in a known good condition, instead of part way through initialization.

**Discussion:**
I marked this PR as a WIP, since there is a behavior change that needs to be discussed. In the current zwave implementation, the VALUE_ADDED signal is generated when parsing the zwcfg xml file, and entities are created for the whole network. In this new PR, entities are only created for online nodes, meaning that a completely disconnected node has no entities created until it comes online. It would be possible to listen for the Notification - Node Dead signal to add these nodes; however, this would introduce the additional complication of ensuring entities are only created once for each node. I'd like to get some feedback on the impact from other devs, and in either case I'd hope to get some testing from others with more extensive zwave networks.
