### PR TITLE
Upgrade psutil to 4.4.0

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==4.3.1']
+REQUIREMENTS = ['psutil==4.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,7 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the System sensors."""
+    """Set up the system monitor sensors."""
     dev = []
     for resource in config[CONF_RESOURCES]:
         if 'arg' not in resource:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -312,7 +312,7 @@ pmsensor==0.3
 proliphix==0.4.0
 
 # homeassistant.components.sensor.systemmonitor
-psutil==4.3.1
+psutil==4.4.0
 
 # homeassistant.components.wink
 pubnub==3.8.2


### PR DESCRIPTION
#4.4.0
## Enhancements
- [Windows] net_if_addrs() returns also the netmask.
- [Linux] virtual_memory()'s 'available' and 'used' values are more   precise and match "free" cmdline utility.  "available" also takes into account LCX containers preventing "available" to overflow "total".
- procinfo.py script has been updated and provides a lot more info.
## Bug fixes
- [OSX] possibly fix Process.memory_maps() segfault (critical!).
- [OSX] Process.status() may erroneously return "running" for zombie processes.
- [Windows] Process.open_files() returns and empty list on Windows 10.
- [Linux] cpu_affinity; fix possible double close and use of unopened socket.
- [Windows] Handle race condition inside psutil_net_connections.
- ValueError is raised if a negative integer is passed to cpu_percent() functions.
- [Linux] Process.cpu_affinity([-1]) raise SystemError with no error set; now ValueError is raised.
- 906_: [BSD] disk_partitions(all=False) returned an empty list. Now the
  argument is ignored and all partitions are always returned.
- [FreeBSD] Process.exe() may fail with OSError(ENOENT).
- [OSX, BSD] different process methods could errounesuly mask the real error for high-privileged PIDs and raise NoSuchProcess and AccessDenied instead of OSError and RuntimeError.
- [OSX] Process open_files() and connections() methods may raise OSError with no exception set if process is gone.
- [OSX] fix many compilation warnings.

Tested with the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
```
