### PR TITLE
Upgrade yahoo-finance to 1.3.2

### DIFF
--- a/homeassistant/components/sensor/yahoo_finance.py
+++ b/homeassistant/components/sensor/yahoo_finance.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['yahoo-finance==1.2.1']
+REQUIREMENTS = ['yahoo-finance==1.3.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -543,7 +543,7 @@ xboxapi==0.1.1
 xmltodict==0.10.2
 
 # homeassistant.components.sensor.yahoo_finance
-yahoo-finance==1.2.1
+yahoo-finance==1.3.2
 
 # homeassistant.components.sensor.yweather
 yahooweather==0.8


### PR DESCRIPTION
## 1.3.2
- Fix ImportError: No module named 'urllib2' in Python 3
## 1.3.1
- Fix Creating Share object fails in raw_decode
## 1.2.2
- Change API URL to HTTPS
- Add get_percent_change()
- Add get_name()
- Cleanup

Tested with the following configuration:

``` yaml
sensor:
  - platform: yahoo_finance
    name: Red Hat Inc.
    symbol: RHT
  - platform: yahoo_finance
    name: Google
    symbol: GOOGL
  - platform: yahoo_finance
    name: Yahoo
    symbol: YHOO
```
