### PR TITLE
Support for Bluetooth LE controlled mipow color lamp

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -172,6 +172,7 @@ omit =
     homeassistant/components/light/hyperion.py
     homeassistant/components/light/lifx.py
     homeassistant/components/light/limitlessled.py
+    homeassistant/components/light/mipow.py
     homeassistant/components/light/osramlightify.py
     homeassistant/components/light/x10.py
     homeassistant/components/lirc.py

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -67,7 +67,8 @@ ATTR_EFFECT = "effect"
 EFFECT_COLORLOOP = "colorloop"
 EFFECT_RANDOM = "random"
 EFFECT_WHITE = "white"
-
+EFFECT_CANDLE = "candle"
+EFFECT_RAINBOW = "rainbow"
 LIGHT_PROFILES_FILE = "light_profiles.csv"
 
 PROP_TO_ATTR = {

--- a/homeassistant/components/light/mipow.py
+++ b/homeassistant/components/light/mipow.py
@@ -1,5 +1,6 @@
 """
 Support for mipow lights.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.mipow/
 """
@@ -28,7 +29,6 @@ class Mipow(Light):
 
     def __init__(self, serial, name=None):
         """Initialize the light."""
-
         if name is not None:
             self._name = name
         else:
@@ -84,8 +84,7 @@ class Mipow(Light):
             self._adapter = adapter
             self._connection = self._adapter.connect(self._serial)
             return self._connection
-            
-            
+
     @property
     def should_poll(self):
         """Polling needed."""
@@ -98,45 +97,41 @@ class Mipow(Light):
 
     @property
     def rgb_color(self):
-        # Get device status from gattools
+# Get device status from gattools
         self._connection = self.connect()
 
         device_status = self._connection.char_read("0000fffc-0000-1000-8000-00805f9b34fb")
 
-        #Convert byte array into int list
+#Convert byte array into int list
         device_colors = [x for x in device_status]
 
-        # Remove first element as it's the brightness
+# Remove first element as it's the brightness
         device_colors.pop(0)
 
-        # Assign to instance for later use
+# Assign to instance for later use
         self._rgb_color = device_colors
 
-        # Disconnect
 
-        # Return list for ha use
+# Return list for ha use
         return self._rgb_color
     @property
     def rgb_bright(self):
-        # Get device status from gattools
+# Get device status from gattools
         self._connection = self.connect()
 
         device_status = self._connection.char_read("0000fffc-0000-1000-8000-00805f9b34fb")
 
-        #Convert byte array into int list
+#Convert byte array into int list
         device_bright = [x for x in device_status]
 
-        # Remove first element as it's the brightness
+# Remove first element as it's the brightness
         device_bright.pop()
         device_bright.pop()
         device_bright.pop()
-        # Assign to instance for later use
+# Assign to instance for later use
         self._rgb_bright = device_bright
 
-        # Disconnect
-        #connection.disconnect()
-
-        # Return list for ha use
+# Return list for ha use
         return self._rgb_bright
     @property
     def brightness(self):
@@ -148,14 +143,12 @@ class Mipow(Light):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        #adapter = self._start_adapter()
         self._connection = self.connect()
 
         if ATTR_BRIGHTNESS in kwargs and ATTR_RGB_COLOR in kwargs and not ATTR_FLASH in kwargs:
             self._rgb_color = [x for x in kwargs[ATTR_RGB_COLOR]]
             brgb = [kwargs[ATTR_BRIGHTNESS], self._rgb_color[0], self._rgb_color[1], self._rgb_color[2]]
 
-            #self._rgb_color = [255, 255, 255]
             self._connection.char_write_handle(0x0025, brgb)
         elif ATTR_RGB_COLOR in kwargs and not ATTR_BRIGHTNESS in kwargs and not ATTR_FLASH in kwargs:
             self._rgb_color = [x for x in kwargs[ATTR_RGB_COLOR]]
@@ -166,19 +159,18 @@ class Mipow(Light):
 
             self._connection.char_write_handle(0x0025, brgb)
         elif ATTR_BRIGHTNESS in kwargs and not ATTR_RGB_COLOR in kwargs and not ATTR_FLASH in kwargs:
-            brgb = [kwargs[ATTR_BRIGHTNESS], 0,0,0]
+            brgb = [kwargs[ATTR_BRIGHTNESS], 0, 0, 0]
             self._rgb_color = [255, 255, 255]
             self._connection.char_write_handle(0x0025, brgb)
         effect = kwargs.get(ATTR_EFFECT)
         if effect == EFFECT_RAINBOW:
-                val = bytearray([0x00,0x00,0x00,0x00,0x02,0x00,0x14,0x00])
+                val = bytearray([0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x14, 0x00])
                 self._connection.char_write_handle(0x0023, val)
         if effect == EFFECT_CANDLE:
-                val = bytearray([0x00,0x00,0x00,0x00,0x02,0x00,0x14,0x00])
+                val = bytearray([0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x14, 0x00])
                 self._connection.char_write_handle(0x0023, val)
         if ATTR_FLASH in kwargs and ATTR_RGB_COLOR in kwargs:
                 self._rgb_color = [x for x in kwargs[ATTR_RGB_COLOR]]
-                
                 bri = 0
                 red = self._rgb_color[0]
                 green = self._rgb_color[1]
@@ -189,19 +181,16 @@ class Mipow(Light):
                 if flash == FLASH_SHORT:
                     speed = 0x00
                 mode = 00
-                val = bytearray([bri,red,green,blue,mode,0x00,speed,0x00])
-                
-                
+                val = bytearray([bri, red, green, blue, mode, 0x00, speed, 0x00])
                 self._connection.char_write_handle(0x0023, val)
         elif not self.is_on:
-            
+
             self._connection.char_write_handle(0x0025, [255, 0, 0, 0])
-            
-        #connection.disconnect()
+
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
         self._connection = self.connect()
-        self._connection.char_write_handle(0x0025, [00,00,00,00])
+        self._connection.char_write_handle(0x0025, [00, 00, 00, 00])
 
 

--- a/homeassistant/components/light/mipow.py
+++ b/homeassistant/components/light/mipow.py
@@ -1,0 +1,207 @@
+"""
+Support for mipow lights.
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.mipow/
+"""
+
+import logging
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATTR_EFFECT, EFFECT_RAINBOW, EFFECT_CANDLE, ATTR_FLASH, FLASH_LONG, FLASH_SHORT, Light)
+from homeassistant.loader import get_component
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['pygatt==3.0.0']
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Add device specified by serial number."""
+    import pygatt
+    serial = config['serial']
+    name = config.get('name')
+    bulb = Mipow(serial, name)
+
+    add_devices_callback([bulb])
+
+
+class Mipow(Light):
+    """Representation of a mipow light."""
+
+    def __init__(self, serial, name=None):
+        """Initialize the light."""
+
+        if name is not None:
+            self._name = name
+        else:
+            self._name = serial
+
+        self._serial = serial
+        self._adapter = None
+        self._connection = None
+        try:
+            self.update()
+        except:
+            self._rgb_color = [0, 0, 0]
+            self._rgb_bright = [0]
+
+    def update(self):
+        """Read back the device state."""
+        self._rgb_color = self.rgb_color
+        self._rgb_bright = self.rgb_bright
+
+    def _start_adapter(self):
+        if self._adapter is not None:
+            self._adapter.stop()
+
+        adapter = pygatt.backends.GATTToolBackend()
+        adapter.start()
+
+        self._adapter = adapter
+
+        return adapter
+
+    def _stop_adapter(self):
+        self._adapter.stop()
+        
+
+    def isconnected(self):
+        if device._connected == True:
+            if adapter.address == self._serial:
+                return True
+        else:
+            return False
+    def connect(self):
+        
+        if self._connection is not None:
+            if self._connection._connected:
+                return self._connection
+        else:
+            if self._adapter is not None:
+                self._adapter.stop()
+
+            adapter = pygatt.backends.GATTToolBackend()
+            adapter.start()
+
+            self._adapter = adapter
+            self._connection = self._adapter.connect(self._serial)
+            return self._connection
+            
+            
+    @property
+    def should_poll(self):
+        """Polling needed."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the light."""
+        return self._name
+
+    @property
+    def rgb_color(self):
+        # Get device status from gattools
+        self._connection = self.connect()
+
+        device_status = self._connection.char_read("0000fffc-0000-1000-8000-00805f9b34fb")
+
+        #Convert byte array into int list
+        device_colors = [x for x in device_status]
+
+        # Remove first element as it's the brightness
+        device_colors.pop(0)
+
+        # Assign to instance for later use
+        self._rgb_color = device_colors
+
+        # Disconnect
+
+        # Return list for ha use
+        return self._rgb_color
+    @property
+    def rgb_bright(self):
+        # Get device status from gattools
+        self._connection = self.connect()
+
+        device_status = self._connection.char_read("0000fffc-0000-1000-8000-00805f9b34fb")
+
+        #Convert byte array into int list
+        device_bright = [x for x in device_status]
+
+        # Remove first element as it's the brightness
+        device_bright.pop()
+        device_bright.pop()
+        device_bright.pop()
+        # Assign to instance for later use
+        self._rgb_bright = device_bright
+
+        # Disconnect
+        #connection.disconnect()
+
+        # Return list for ha use
+        return self._rgb_bright
+    @property
+    def brightness(self):
+        return self._rgb_bright
+    @property
+    def is_on(self):
+        """Check whether any of the LEDs colors are non-zero."""
+        return sum(self._rgb_color)+sum(self._rgb_bright) > 0
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        #adapter = self._start_adapter()
+        self._connection = self.connect()
+
+        if ATTR_BRIGHTNESS in kwargs and ATTR_RGB_COLOR in kwargs and not ATTR_FLASH in kwargs:
+            self._rgb_color = [x for x in kwargs[ATTR_RGB_COLOR]]
+            brgb = [kwargs[ATTR_BRIGHTNESS], self._rgb_color[0], self._rgb_color[1], self._rgb_color[2]]
+
+            #self._rgb_color = [255, 255, 255]
+            self._connection.char_write_handle(0x0025, brgb)
+        elif ATTR_RGB_COLOR in kwargs and not ATTR_BRIGHTNESS in kwargs and not ATTR_FLASH in kwargs:
+            self._rgb_color = [x for x in kwargs[ATTR_RGB_COLOR]]
+            brgb = [0]
+            brgb.append(self._rgb_color[0])
+            brgb.append(self._rgb_color[1])
+            brgb.append(self._rgb_color[2])
+
+            self._connection.char_write_handle(0x0025, brgb)
+        elif ATTR_BRIGHTNESS in kwargs and not ATTR_RGB_COLOR in kwargs and not ATTR_FLASH in kwargs:
+            brgb = [kwargs[ATTR_BRIGHTNESS], 0,0,0]
+            self._rgb_color = [255, 255, 255]
+            self._connection.char_write_handle(0x0025, brgb)
+        effect = kwargs.get(ATTR_EFFECT)
+        if effect == EFFECT_RAINBOW:
+                val = bytearray([0x00,0x00,0x00,0x00,0x02,0x00,0x14,0x00])
+                self._connection.char_write_handle(0x0023, val)
+        if effect == EFFECT_CANDLE:
+                val = bytearray([0x00,0x00,0x00,0x00,0x02,0x00,0x14,0x00])
+                self._connection.char_write_handle(0x0023, val)
+        if ATTR_FLASH in kwargs and ATTR_RGB_COLOR in kwargs:
+                self._rgb_color = [x for x in kwargs[ATTR_RGB_COLOR]]
+                
+                bri = 0
+                red = self._rgb_color[0]
+                green = self._rgb_color[1]
+                blue = self._rgb_color[2]
+                flash = kwargs.get(ATTR_FLASH)
+                if flash == FLASH_LONG:
+                    speed = 0x14
+                if flash == FLASH_SHORT:
+                    speed = 0x00
+                mode = 00
+                val = bytearray([bri,red,green,blue,mode,0x00,speed,0x00])
+                
+                
+                self._connection.char_write_handle(0x0023, val)
+        elif not self.is_on:
+            
+            self._connection.char_write_handle(0x0025, [255, 0, 0, 0])
+            
+        #connection.disconnect()
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        self._connection = self.connect()
+        self._connection.char_write_handle(0x0025, [00,00,00,00])
+
+

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -295,7 +295,8 @@ pexpect==4.0.1
 
 # homeassistant.components.light.hue
 phue==0.8
-
+# homeassistant.components.light.mipow
+pygatt==3.0.0
 # homeassistant.components.pilight
 pilight==0.1.1
 


### PR DESCRIPTION
**Description:**
Controlling mipow color bulb with BT LE

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
light:
  platform: mipow
  name: room
  serial: '55:37:4B:12:AC:E6'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
