### PR TITLE
* Apply @dale3h's corrected delta time change to support future value…

### DIFF
--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -183,7 +183,7 @@ def get_age(date: dt.datetime) -> str:
         """Return quotient and remaining."""
         return first // second, first % second
 
-    delta = now() - date
+    delta = now() - date if now() > date else date - now()
     day = delta.days
     second = delta.seconds
 


### PR DESCRIPTION
This change makes for relative_time to work correctly with future values as well as past values...  allowing `{{ relative_time(now().strptime((states.sun.sun.attributes.next_setting[:-6].replace('T',' ')+states.sun.sun.attributes.next_setting[-6:].replace(':',''))|timestamp_custom('%Y-%m-%d %H:%M:%S%z'), '%Y-%m-%d %H:%M:%S%z')) }}` to return a value other than "12 months" 

There is some discussion about this in #3950
