### PR TITLE
Handle FreeBSD version in updater component

### DIFF
--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -108,6 +108,8 @@ def get_newest_version(huuid):
         info_object['os_version'] = platform.win32_ver()[0]
     elif platform.system() == 'Darwin':
         info_object['os_version'] = platform.mac_ver()[0]
+    elif platform.system() == 'FreeBSD':
+        info_object['os_version'] = platform.release()
     elif platform.system() == 'Linux':
         import distro
         linux_dist = distro.linux_distribution(full_distribution_name=False)


### PR DESCRIPTION
**Description:**
If you're running home assistant on a FreeBSD system right now the
updater component doesn't know how to return the FreeBSD release being
used. This commit adds the os_version to the payload when running on
FreeBSD so that version info will be tracked as well.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If the code does not interact with devices:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
