### PR TITLE
Introduce a send_delay for pilight component

### DIFF
--- a/homeassistant/components/pilight.py
+++ b/homeassistant/components/pilight.py
@@ -5,10 +5,16 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/pilight/
 """
 import logging
+import functools
 import socket
+import threading
+
+from datetime import timedelta
 
 import voluptuous as vol
 
+from homeassistant.helpers.event import track_point_in_utc_time
+from homeassistant.util import dt as dt_util
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, CONF_HOST, CONF_PORT,
@@ -103,3 +109,58 @@ def setup(hass, config):
     pilight_client.set_callback(handle_received_code)
 
     return True
+
+
+# pylint: disable=too-few-public-methods
+class CallRateDelayThrottle(object):
+    """Helper class to provide service call rate throttling.
+
+    This class provides a decorator to decorate service methods that need
+    to be throttled to not exceed a certain call rate per second.
+    One instance can be used on multiple service methods to archive
+    an overall throttling.
+
+    As this uses track_point_in_utc_time to schedule delayed executions
+    it should not block the mainloop.
+    """
+
+    def __init__(self, hass, delay_seconds: float):
+        """Initialize the delay handler."""
+        self._delay = timedelta(seconds=max(0.0, delay_seconds))
+        self._queue = []
+        self._active = False
+        self._lock = threading.Lock()
+        self._next_ts = dt_util.utcnow()
+        self._schedule = functools.partial(track_point_in_utc_time, hass)
+
+    def limited(self, method):
+        """Decorator to delay calls on a certain method."""
+        @functools.wraps(method)
+        def decorated(*args, **kwargs):
+            """The decorated function."""
+            if self._delay.total_seconds() == 0.0:
+                method(*args, **kwargs)
+                return
+
+            def action(event):
+                """The action wrapper that gets scheduled."""
+                method(*args, **kwargs)
+
+                with self._lock:
+                    self._next_ts = dt_util.utcnow() + self._delay
+
+                    if len(self._queue) == 0:
+                        self._active = False
+                    else:
+                        next_action = self._queue.pop(0)
+                        self._schedule(next_action, self._next_ts)
+
+            with self._lock:
+                if self._active:
+                    self._queue.append(action)
+                else:
+                    self._active = True
+                    schedule_ts = max(dt_util.utcnow(), self._next_ts)
+                    self._schedule(action, schedule_ts)
+
+        return decorated

--- a/tests/components/test_pilight.py
+++ b/tests/components/test_pilight.py
@@ -70,7 +70,7 @@ class TestPilight(unittest.TestCase):
     @patch('homeassistant.components.pilight._LOGGER.error')
     def test_connection_failed_error(self, mock_error):
         """Try to connect at 127.0.0.1:5000 with socket error."""
-        with assert_setup_component(3):
+        with assert_setup_component(4):
             with patch('pilight.pilight.Client',
                        side_effect=socket.error) as mock_client:
                 self.assertFalse(setup_component(
@@ -82,7 +82,7 @@ class TestPilight(unittest.TestCase):
     @patch('homeassistant.components.pilight._LOGGER.error')
     def test_connection_timeout_error(self, mock_error):
         """Try to connect at 127.0.0.1:5000 with socket timeout."""
-        with assert_setup_component(3):
+        with assert_setup_component(4):
             with patch('pilight.pilight.Client',
                        side_effect=socket.timeout) as mock_client:
                 self.assertFalse(setup_component(
@@ -96,7 +96,7 @@ class TestPilight(unittest.TestCase):
     @patch('tests.components.test_pilight._LOGGER.error')
     def test_send_code_no_protocol(self, mock_pilight_error, mock_error):
         """Try to send data without protocol information, should give error."""
-        with assert_setup_component(3):
+        with assert_setup_component(4):
             self.assertTrue(setup_component(
                 self.hass, pilight.DOMAIN, {pilight.DOMAIN: {}}))
 
@@ -115,7 +115,7 @@ class TestPilight(unittest.TestCase):
     @patch('tests.components.test_pilight._LOGGER.error')
     def test_send_code(self, mock_pilight_error):
         """Try to send proper data."""
-        with assert_setup_component(3):
+        with assert_setup_component(4):
             self.assertTrue(setup_component(
                 self.hass, pilight.DOMAIN, {pilight.DOMAIN: {}}))
 
@@ -134,7 +134,7 @@ class TestPilight(unittest.TestCase):
     @patch('homeassistant.components.pilight._LOGGER.error')
     def test_send_code_fail(self, mock_pilight_error):
         """Check IOError exception error message."""
-        with assert_setup_component(3):
+        with assert_setup_component(4):
             with patch('pilight.pilight.Client.send_code',
                        side_effect=IOError):
                 self.assertTrue(setup_component(
@@ -154,7 +154,7 @@ class TestPilight(unittest.TestCase):
     @patch('tests.components.test_pilight._LOGGER.error')
     def test_start_stop(self, mock_pilight_error):
         """Check correct startup and stop of pilight daemon."""
-        with assert_setup_component(3):
+        with assert_setup_component(4):
             self.assertTrue(setup_component(
                 self.hass, pilight.DOMAIN, {pilight.DOMAIN: {}}))
 
@@ -178,7 +178,7 @@ class TestPilight(unittest.TestCase):
     @patch('homeassistant.core._LOGGER.info')
     def test_receive_code(self, mock_info):
         """Check if code receiving via pilight daemon works."""
-        with assert_setup_component(3):
+        with assert_setup_component(4):
             self.assertTrue(setup_component(
                 self.hass, pilight.DOMAIN, {pilight.DOMAIN: {}}))
 
@@ -201,7 +201,7 @@ class TestPilight(unittest.TestCase):
     @patch('homeassistant.core._LOGGER.info')
     def test_whitelist_exact_match(self, mock_info):
         """Check whitelist filter with matched data."""
-        with assert_setup_component(3):
+        with assert_setup_component(4):
             whitelist = {
                 'protocol': [PilightDaemonSim.test_message['protocol']],
                 'uuid': [PilightDaemonSim.test_message['uuid']],
@@ -229,7 +229,7 @@ class TestPilight(unittest.TestCase):
     @patch('homeassistant.core._LOGGER.info')
     def test_whitelist_partial_match(self, mock_info):
         """Check whitelist filter with partially matched data, should work."""
-        with assert_setup_component(3):
+        with assert_setup_component(4):
             whitelist = {
                 'protocol': [PilightDaemonSim.test_message['protocol']],
                 'id': [PilightDaemonSim.test_message['message']['id']]}
@@ -255,7 +255,7 @@ class TestPilight(unittest.TestCase):
     @patch('homeassistant.core._LOGGER.info')
     def test_whitelist_or_match(self, mock_info):
         """Check whitelist filter with several subsection, should work."""
-        with assert_setup_component(3):
+        with assert_setup_component(4):
             whitelist = {
                 'protocol': [PilightDaemonSim.test_message['protocol'],
                              'other_protocoll'],
@@ -282,7 +282,7 @@ class TestPilight(unittest.TestCase):
     @patch('homeassistant.core._LOGGER.info')
     def test_whitelist_no_match(self, mock_info):
         """Check whitelist filter with unmatched data, should not work."""
-        with assert_setup_component(3):
+        with assert_setup_component(4):
             whitelist = {
                 'protocol': ['wrong_protocoll'],
                 'id': [PilightDaemonSim.test_message['message']['id']]}


### PR DESCRIPTION
**Description:**
This fixes an issue with pilight used with the [pilight USB Nano](https://github.com/pilight/pilight-usb-nano). If such a device is used, you need delays between sending codes to the transmitter. Otherwise it will skip random codes to transmit. This condition of mass-transmit is hit for example if a group of switches is turned off or on. Without a delay, random devices will fail to switch.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1325

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
# Example configuration.yaml entry
pilight: 
  host: 127.0.0.1
  port: 5000
  send_delay: 0.4
  whitelist:  # optional
    protocol:
      - daycom
      - intertechno
    id:
      - 42
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

If pilight is used with a "pilight USB Nano" between the daemon and the
hardware, we must use a delay between sending multiple signals.
Otherwise the hardware will just skip random codes. We hit this
condition for example, if we switch a group of pilight switches on or
off. Without the delay, random switch signals will not be transmitted by
the RF transmitter.

As this seems not necessary, if the transmitter is directly connected
via GPIO, we introduce a optional configuration to set the delay.
