### PR TITLE
Handle IPv6 in zeroconf

### DIFF
--- a/homeassistant/components/zeroconf.py
+++ b/homeassistant/components/zeroconf.py
@@ -40,9 +40,16 @@ def setup(hass, config):
         'requires_api_password': requires_api_password,
     }
 
-    info = ServiceInfo(ZEROCONF_TYPE, zeroconf_name,
-                       socket.inet_aton(hass.config.api.host),
-                       hass.config.api.port, 0, 0, params)
+    try:
+        info = ServiceInfo(ZEROCONF_TYPE, zeroconf_name,
+                           socket.inet_pton(
+                               socket.AF_INET, hass.config.api.host),
+                           hass.config.api.port, 0, 0, params)
+    except socket.error:
+        info = ServiceInfo(ZEROCONF_TYPE, zeroconf_name,
+                           socket.inet_pton(
+                               socket.AF_INET6, hass.config.api.host),
+                           hass.config.api.port, 0, 0, params)
 
     zeroconf.register_service(info)
 


### PR DESCRIPTION
**Description:** If the API host is an IPv6 address, inet_aton will fail.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
