### PR TITLE
Add discovery for yamaha component

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.helpers.discovery import load_platform, discover
 
-REQUIREMENTS = ['netdisco==0.7.2']
+REQUIREMENTS = ['netdisco==0.7.5']
 
 DOMAIN = 'discovery'
 
@@ -33,6 +33,7 @@ SERVICE_HANDLERS = {
     'plex_mediaserver': ('media_player', 'plex'),
     'roku': ('media_player', 'roku'),
     'sonos': ('media_player', 'sonos'),
+    'yamaha': ('media_player', 'yamaha'),
     'logitech_mediaserver': ('media_player', 'squeezebox'),
     'directv': ('media_player', 'directv'),
 }

--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -47,7 +47,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     source_ignore = config.get(CONF_SOURCE_IGNORE)
     source_names = config.get(CONF_SOURCE_NAMES)
 
-    if host is None:
+    if discovery_info is not None:
+        name = discovery_info[0]
+        model = discovery_info[1]
+        ctrl_url = discovery_info[2]
+        desc_url = discovery_info[3]
+        receivers = rxv.RXV(
+            ctrl_url,
+            model_name=model,
+            friendly_name=name,
+            unit_desc_url=desc_url).zone_controllers()
+        _LOGGER.info("Receivers: %s", receivers)
+    elif host is None:
         receivers = []
         for recv in rxv.find():
             receivers.extend(recv.zone_controllers())
@@ -73,8 +84,8 @@ class YamahaDevice(MediaPlayerDevice):
         self._pwstate = STATE_OFF
         self._current_source = None
         self._source_list = None
-        self._source_ignore = source_ignore
-        self._source_names = source_names
+        self._source_ignore = source_ignore or []
+        self._source_names = source_names or {}
         self._reverse_mapping = None
         self.update()
         self._name = name

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -271,7 +271,7 @@ mficlient==0.3.0
 miflora==0.1.9
 
 # homeassistant.components.discovery
-netdisco==0.7.2
+netdisco==0.7.5
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.2.10


### PR DESCRIPTION
**Description:**

Adds discovery for yamaha

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.

This uses the discovery code from netdisco/ha to discover yamaha
receivers. The old discovery code remains if discovery is turned of in
HA, at least for now. Though it probably is worth turning that off in
the future.
