### PR TITLE
Zwave climate, add operating state to attributes

### DIFF
--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -188,7 +188,7 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
         for value in (self._node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_THERMOSTAT_OPERATING_STATE)
                       .values()):
-            value.data = self._operating_state
+            self._operating_state = value.data
 
     @property
     def should_poll(self):

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -84,6 +84,7 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
         self._current_temperature = None
         self._current_operation = None
         self._operation_list = None
+        self._operating_state = None
         self._current_fan_mode = None
         self._fan_list = None
         self._current_swing_mode = None
@@ -120,6 +121,7 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
             self.update_ha_state()
             _LOGGER.debug("Value changed on network %s", value)
 
+    # pylint: disable=too-many-branches
     def update_properties(self):
         """Callback on data change for the registered node/value pair."""
         # Operation Mode
@@ -182,6 +184,11 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
             _LOGGER.debug("Device can't set setpoint based on operation mode."
                           " Defaulting to index=1")
             self._target_temperature = int(value.data)
+        # Operating state
+        for value in (self._node.get_values(
+                class_id=zwave.const.COMMAND_CLASS_THERMOSTAT_OPERATING_STATE)
+                      .values()):
+            value.data = self._operating_state
 
     @property
     def should_poll(self):
@@ -323,3 +330,13 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
                    value.index == 33:
                     value.data = bytes(swing_mode, 'utf-8')
                     break
+
+    @property
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
+        if self._operating_state:
+            return {
+                "operating_state": self._operating_state,
+            }
+        else:
+            return {}


### PR DESCRIPTION
**Description:**
Add a attribute to zwave climate to store COMMAND_CLASS_THERMOSTAT_OPERATING_STATE
`operating_state`

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://community.home-assistant.io/t/climate-component-add-support-for-current-operating-state/5085
