### PR TITLE
Wunderground sensor with alerts exceeds API limits

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -25,8 +25,8 @@ _LOGGER = logging.getLogger(__name__)
 CONF_ATTRIBUTION = "Data provided by the WUnderground weather service"
 CONF_PWS_ID = 'pws_id'
 
-MIN_TIME_BETWEEN_UPDATES_ALERTS = timedelta(seconds=900)
-MIN_TIME_BETWEEN_UPDATES_OBSERVATION = timedelta(seconds=300)
+MIN_TIME_BETWEEN_UPDATES_ALERTS = timedelta(minutes=15)
+MIN_TIME_BETWEEN_UPDATES_OBSERVATION = timedelta(minutes=5)
 
 # Sensor types are defined like: Name, units
 SENSOR_TYPES = {

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -25,7 +25,8 @@ _LOGGER = logging.getLogger(__name__)
 CONF_ATTRIBUTION = "Data provided by the WUnderground weather service"
 CONF_PWS_ID = 'pws_id'
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=300)
+MIN_TIME_BETWEEN_UPDATES_ALERTS = timedelta(seconds=900)
+MIN_TIME_BETWEEN_UPDATES_OBSERVATION = timedelta(seconds=300)
 
 # Sensor types are defined like: Name, units
 SENSOR_TYPES = {
@@ -187,7 +188,7 @@ class WUndergroundData(object):
 
         return url + '.json'
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    @Throttle(MIN_TIME_BETWEEN_UPDATES_OBSERVATION)
     def update(self):
         """Get the latest data from WUnderground."""
         try:
@@ -202,7 +203,7 @@ class WUndergroundData(object):
             self.data = None
             raise
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    @Throttle(MIN_TIME_BETWEEN_UPDATES_ALERTS)
     def update_alerts(self):
         """Get the latest alerts data from WUnderground."""
         try:


### PR DESCRIPTION
**Description:**

Fixes issue #4067 - Wunderground sensor with alerts exceeds API limits

To avoid hitting the max limit of 500 calls per day, this patch keeps weather conditions being updated each 5 minutes and weather alerts each 15 minutes.

This formula will result the following:

```
       conditions -> 300 seconds ->   5 minutes -> 12 req/h -> 288 req/day
       alerts     -> 900 seconds -> 15 minutes ->   4 req/h -> 96 req/day
```

**Related issue (if applicable):** fixes #4067

**Checklist:**
- [x] Documentation added/updated in [home-assistant.github.io]https://github.com/home-assistant/home-assistant.github.io/pull/1337)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
