### PR TITLE
Adding ssl option to zoneminder

### DIFF
--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    CONF_PATH, CONF_HOST, CONF_PASSWORD, CONF_USERNAME)
+    CONF_PATH, CONF_HOST, CONF_SSL, CONF_PASSWORD, CONF_USERNAME)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,6 +26,7 @@ DOMAIN = 'zoneminder'
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_SSL, default=False): cv.boolean,
         vol.Optional(CONF_PATH, default="/zm/"): cv.string,
         vol.Optional(CONF_USERNAME): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string
@@ -42,7 +43,12 @@ def setup(hass, config):
     ZM = {}
 
     conf = config[DOMAIN]
-    url = urljoin("http://" + conf[CONF_HOST], conf[CONF_PATH])
+    if conf[CONF_SSL]:
+        schema = "https"
+    else:
+        schema = "http"
+
+    url = urljoin(schema + "://" + conf[CONF_HOST], conf[CONF_PATH])
     username = conf.get(CONF_USERNAME, None)
     password = conf.get(CONF_PASSWORD, None)
 


### PR DESCRIPTION
**Description:**
Configures zoneminder to use SSL if necessary.

**Related issue (if applicable):** fixes @a214n 's issue at https://github.com/home-assistant/home-assistant/pull/3795

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/1339

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
# Example configuration.yaml entry
zoneminder:
  host: ZM_HOST
  path: ZM_PATH
  ssl: False
  username: USERNAME
  password: PASSWORD
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
