### PR TITLE
Converting unit_of_measurement variable to optional, to be consistent with other sensors

### DIFF
--- a/homeassistant/components/sensor/influxdb.py
+++ b/homeassistant/components/sensor/influxdb.py
@@ -40,14 +40,14 @@ REQUIREMENTS = ['influxdb==3.0.0']
 
 _QUERY_SCHEME = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
-    vol.Required(CONF_UNIT_OF_MEASUREMENT): cv.string,
     vol.Required(CONF_MEASUREMENT_NAME): cv.string,
     vol.Required(CONF_WHERE): cv.string,
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     vol.Optional(CONF_DB_NAME, default=DEFAULT_DATABASE): cv.string,
     vol.Optional(CONF_GROUP_FUNCTION, default=DEFAULT_GROUP_FUNCTION):
         cv.string,
-    vol.Optional(CONF_FIELD, default=DEFAULT_FIELD): cv.string,
+    vol.Optional(CONF_FIELD, default=DEFAULT_FIELD): cv.string
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
**Description:**
On the other sensors, unit of measurement is an optional configuration variable. It should be the same for influxdb sensor.

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
