### PR TITLE
Upgrade psutil to 4.4.2

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==4.4.0']
+REQUIREMENTS = ['psutil==4.4.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -309,7 +309,7 @@ pmsensor==0.3
 proliphix==0.4.0
 
 # homeassistant.components.sensor.systemmonitor
-psutil==4.4.0
+psutil==4.4.2
 
 # homeassistant.components.wink
 pubnub==3.8.2


### PR DESCRIPTION
#4.4.2
- psutil no longer compiles on Solaris.
#4.4.1
- Popen.**del** may cause maximum recursion depth error.

Tested with the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
```
