### PR TITLE
lg_netcast platform fails to load if no channels defined 

### DIFF
--- a/homeassistant/components/media_player/lg_netcast.py
+++ b/homeassistant/components/media_player/lg_netcast.py
@@ -103,9 +103,11 @@ class LgTVDevice(MediaPlayerDevice):
 
                 channel_list = client.query_data('channel_list')
                 if channel_list:
-                    channel_names = [str(c.find('chname').text) for
-                                     c in channel_list if
-                                     c.find('chname') is not None]
+                    channel_names = []
+                    for channel in channel_list:
+                        channel_name = channel.find('chname')
+                        if channel_name is not None:
+                            channel_names.append(str(channel_name.text))
                     self._sources = dict(zip(channel_names, channel_list))
                     # sort source names by the major channel number
                     source_tuples = [(k, self._sources[k].find('major').text)

--- a/homeassistant/components/media_player/lg_netcast.py
+++ b/homeassistant/components/media_player/lg_netcast.py
@@ -104,7 +104,8 @@ class LgTVDevice(MediaPlayerDevice):
                 channel_list = client.query_data('channel_list')
                 if channel_list:
                     channel_names = [str(c.find('chname').text) for
-                                     c in channel_list]
+                                     c in channel_list if
+                                     c.find('chname') is not None]
                     self._sources = dict(zip(channel_names, channel_list))
                     # sort source names by the major channel number
                     source_tuples = [(k, self._sources[k].find('major').text)


### PR DESCRIPTION
**Description:**
lg_netcast platform fails to load if no channels are defined for some TV models. The TV returns a non empty channel list, but the entries contain no channel info.

**Related issue (if applicable):** fixes #4024

**Checklist:**
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
