### PR TITLE
Universal source list

### DIFF
--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -119,7 +119,7 @@ def validate_attributes(config):
     elif not isinstance(config[CONF_ATTRS], dict):
         _LOGGER.warning(
             'Universal Media Player (%s) specified attributes '
-        'not dict in config. They will be ignored.',
+            'not dict in config. They will be ignored.',
             config[CONF_NAME])
         config[CONF_ATTRS] = {}
 
@@ -184,7 +184,8 @@ class UniversalMediaPlayer(MediaPlayerDevice):
 
         if allow_override and service_name in self._cmds:
             call_from_config(
-                self.hass, self._cmds[service_name], variables=service_data, blocking=True)
+                self.hass, self._cmds[service_name],
+                variables=service_data, blocking=True)
             return
 
         active_child = self._child_state

--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -183,14 +183,8 @@ class UniversalMediaPlayer(MediaPlayerDevice):
             service_data = {}
 
         if allow_override and service_name in self._cmds:
-            if service_data:
-                call_config = self._cmds[service_name]
-                call_config[ATTR_DATA].update(service_data)
-            else:
-                call_config = self._cmds[service_name]
-
             call_from_config(
-                self.hass, self._cmds[service_name], blocking=True)
+                self.hass, self._cmds[service_name], variables=service_data, blocking=True)
             return
 
         active_child = self._child_state

--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -183,9 +183,14 @@ class UniversalMediaPlayer(MediaPlayerDevice):
             service_data = {}
 
         if allow_override and service_name in self._cmds:
-            service_data[ATTR_ENTITY_ID] = self._cmds[service_name][ATTR_DATA][ATTR_ENTITY_ID]
-            self.hass.services.call(DOMAIN, service_name, service_data,
-                                    blocking=True)
+            if service_data:
+                call_config = self._cmds[service_name]
+                call_config[ATTR_DATA].update(service_data)
+            else:
+                call_config = self._cmds[service_name]
+
+            call_from_config(
+                self.hass, self._cmds[service_name], blocking=True)
             return
 
         active_child = self._child_state

--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -183,10 +183,6 @@ class UniversalMediaPlayer(MediaPlayerDevice):
             service_data = {}
 
         if allow_override and service_name in self._cmds:
-            print(service_name)
-            print(self._cmds)
-            print(self._cmds[service_name][ATTR_DATA])
-            print(self._cmds[service_name][ATTR_DATA][ATTR_ENTITY_ID])
             service_data[ATTR_ENTITY_ID] = self._cmds[service_name][ATTR_DATA][ATTR_ENTITY_ID]
             self.hass.services.call(DOMAIN, service_name, service_data,
                                     blocking=True)

--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -14,7 +14,7 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_TYPE, ATTR_MEDIA_DURATION, ATTR_MEDIA_EPISODE,
     ATTR_MEDIA_PLAYLIST, ATTR_MEDIA_SEASON, ATTR_MEDIA_SEEK_POSITION,
     ATTR_MEDIA_SERIES_TITLE, ATTR_MEDIA_TITLE, ATTR_MEDIA_TRACK,
-    ATTR_MEDIA_VOLUME_LEVEL, ATTR_MEDIA_VOLUME_MUTED,
+    ATTR_MEDIA_VOLUME_LEVEL, ATTR_MEDIA_VOLUME_MUTED, ATTR_INPUT_SOURCE_LIST,
     ATTR_SUPPORTED_MEDIA_COMMANDS, DOMAIN, SERVICE_PLAY_MEDIA,
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP, SUPPORT_SELECT_SOURCE, SUPPORT_CLEAR_PLAYLIST,
@@ -325,6 +325,11 @@ class UniversalMediaPlayer(MediaPlayerDevice):
     def current_source(self):
         """"Return the current input source of the device."""
         return self._child_attr(ATTR_INPUT_SOURCE)
+
+    @property
+    def source_list(self):
+        """List of available input sources."""
+        return self._child_attr(ATTR_INPUT_SOURCE_LIST)
 
     @property
     def supported_media_commands(self):

--- a/tests/components/media_player/test_universal.py
+++ b/tests/components/media_player/test_universal.py
@@ -145,11 +145,11 @@ class TestMediaPlayer(unittest.TestCase):
         self.hass.states.set(self.mock_state_switch_id, STATE_OFF)
 
         self.mock_volume_id = input_slider.ENTITY_ID_FORMAT.format(
-                                'volume_level')
+            'volume_level')
         self.hass.states.set(self.mock_volume_id, 0)
 
         self.mock_source_list_id = input_select.ENTITY_ID_FORMAT.format(
-                                     'source_list')
+            'source_list')
         self.hass.states.set(self.mock_source_list_id, ['dvd', 'htpc'])
 
         self.mock_source_id = input_select.ENTITY_ID_FORMAT.format('source')

--- a/tests/components/media_player/test_universal.py
+++ b/tests/components/media_player/test_universal.py
@@ -5,6 +5,8 @@ import unittest
 from homeassistant.const import (
     STATE_OFF, STATE_ON, STATE_UNKNOWN, STATE_PLAYING, STATE_PAUSED)
 import homeassistant.components.switch as switch
+import homeassistant.components.input_slider as input_slider
+import homeassistant.components.input_select as input_select
 import homeassistant.components.media_player as media_player
 import homeassistant.components.media_player.universal as universal
 
@@ -142,6 +144,15 @@ class TestMediaPlayer(unittest.TestCase):
         self.mock_state_switch_id = switch.ENTITY_ID_FORMAT.format('state')
         self.hass.states.set(self.mock_state_switch_id, STATE_OFF)
 
+        self.mock_volume_id = input_slider.ENTITY_ID_FORMAT.format('volume_level')
+        self.hass.states.set(self.mock_volume_id, 0)
+
+        self.mock_source_list_id = input_select.ENTITY_ID_FORMAT.format('source_list')
+        self.hass.states.set(self.mock_source_list_id, ['dvd', 'htpc'])
+
+        self.mock_source_id = input_select.ENTITY_ID_FORMAT.format('source')
+        self.hass.states.set(self.mock_source_id, 'dvd')
+
         self.config_children_only = {
             'name': 'test', 'platform': 'universal',
             'children': [media_player.ENTITY_ID_FORMAT.format('mock1'),
@@ -153,6 +164,9 @@ class TestMediaPlayer(unittest.TestCase):
                          media_player.ENTITY_ID_FORMAT.format('mock2')],
             'attributes': {
                 'is_volume_muted': self.mock_mute_switch_id,
+                'volume_level': self.mock_volume_id,
+                'source': self.mock_source_id,
+                'source_list': self.mock_source_list_id,
                 'state': self.mock_state_switch_id
             }
         }
@@ -405,6 +419,42 @@ class TestMediaPlayer(unittest.TestCase):
         ump.update()
         self.assertTrue(ump.is_volume_muted)
 
+    def test_source_list_children_and_attr(self):
+        """Test source list property w/ children and attrs."""
+        config = self.config_children_and_attr
+        universal.validate_config(config)
+
+        ump = universal.UniversalMediaPlayer(self.hass, **config)
+
+        self.assertEqual("['dvd', 'htpc']", ump.source_list)
+
+        self.hass.states.set(self.mock_source_list_id, ['dvd', 'htpc', 'game'])
+        self.assertEqual("['dvd', 'htpc', 'game']", ump.source_list)
+
+    def test_source_children_and_attr(self):
+        """Test source property w/ children and attrs."""
+        config = self.config_children_and_attr
+        universal.validate_config(config)
+
+        ump = universal.UniversalMediaPlayer(self.hass, **config)
+
+        self.assertEqual('dvd', ump.source)
+
+        self.hass.states.set(self.mock_source_id, 'htpc')
+        self.assertEqual('htpc', ump.source)
+
+    def test_volume_level_children_and_attr(self):
+        """Test volume level property w/ children and attrs."""
+        config = self.config_children_and_attr
+        universal.validate_config(config)
+
+        ump = universal.UniversalMediaPlayer(self.hass, **config)
+
+        self.assertEqual('0', ump.volume_level)
+
+        self.hass.states.set(self.mock_volume_id, 100)
+        self.assertEqual('100', ump.volume_level)
+
     def test_is_volume_muted_children_and_attr(self):
         """Test is volume muted property w/ children and attrs."""
         config = self.config_children_and_attr
@@ -443,18 +493,20 @@ class TestMediaPlayer(unittest.TestCase):
         config['commands']['volume_up'] = 'test'
         config['commands']['volume_down'] = 'test'
         config['commands']['volume_mute'] = 'test'
+        config['commands']['volume_set'] = 'test'
+        config['commands']['select_source'] = 'test'
 
         ump = universal.UniversalMediaPlayer(self.hass, **config)
         ump.entity_id = media_player.ENTITY_ID_FORMAT.format(config['name'])
         ump.update()
 
-        self.mock_mp_1._supported_media_commands = universal.SUPPORT_VOLUME_SET
         self.mock_mp_1._state = STATE_PLAYING
         self.mock_mp_1.update_ha_state()
         ump.update()
 
         check_flags = universal.SUPPORT_TURN_ON | universal.SUPPORT_TURN_OFF \
-            | universal.SUPPORT_VOLUME_STEP | universal.SUPPORT_VOLUME_MUTE
+            | universal.SUPPORT_VOLUME_STEP | universal.SUPPORT_VOLUME_MUTE \
+            | universal.SUPPORT_SELECT_SOURCE
 
         self.assertEqual(check_flags, ump.supported_media_commands)
 

--- a/tests/components/media_player/test_universal.py
+++ b/tests/components/media_player/test_universal.py
@@ -144,10 +144,12 @@ class TestMediaPlayer(unittest.TestCase):
         self.mock_state_switch_id = switch.ENTITY_ID_FORMAT.format('state')
         self.hass.states.set(self.mock_state_switch_id, STATE_OFF)
 
-        self.mock_volume_id = input_slider.ENTITY_ID_FORMAT.format('volume_level')
+        self.mock_volume_id = input_slider.ENTITY_ID_FORMAT.format(
+                                'volume_level')
         self.hass.states.set(self.mock_volume_id, 0)
 
-        self.mock_source_list_id = input_select.ENTITY_ID_FORMAT.format('source_list')
+        self.mock_source_list_id = input_select.ENTITY_ID_FORMAT.format(
+                                     'source_list')
         self.hass.states.set(self.mock_source_list_id, ['dvd', 'htpc'])
 
         self.mock_source_id = input_select.ENTITY_ID_FORMAT.format('source')


### PR DESCRIPTION
**Description:**

The goal of this PR is to expand the list of attributes/commands supported by the Universal Media Player. 

Added commands:
Volume set
source select

Added attributes:
current source
volume level

My test case is a media center with one receiver and two child devices. The goal is to send the volume/source commands to the receiver. Once this is stable, I feel that it will reduce the need for splitting off receivers. This PR is a work in progress. Tests need updating.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
