### PR TITLE
More async

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -879,10 +879,7 @@ class ServiceRegistry(object):
         self._bus = bus
         self._loop = loop
         self._cur_id = 0
-        run_callback_threadsafe(
-            loop,
-            bus.async_listen, EVENT_CALL_SERVICE, self._event_to_service_call,
-        )
+        self._async_unsub_call_event = None
 
     @property
     def services(self):
@@ -948,6 +945,10 @@ class ServiceRegistry(object):
             self._services[domain][service] = service_obj
         else:
             self._services[domain] = {service: service_obj}
+
+        if self._async_unsub_call_event is None:
+            self._async_unsub_call_event = self._bus.async_listen(
+                EVENT_CALL_SERVICE, self._event_to_service_call)
 
         self._bus.async_fire(
             EVENT_SERVICE_REGISTERED,

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -19,7 +19,6 @@ import urllib.parse
 
 from typing import Optional
 
-import aiohttp
 import requests
 
 import homeassistant.bootstrap as bootstrap
@@ -135,7 +134,7 @@ class HomeAssistant(ha.HomeAssistant):
         self.services = ha.ServiceRegistry(self.bus, self.add_job, self.loop)
         self.states = StateMachine(self.bus, self.loop, self.remote_api)
         self.config = ha.Config()
-        self.websession = aiohttp.ClientSession(loop=self.loop)
+        self._websession = None
 
         self.state = ha.CoreState.not_running
         self.config.api = local_api

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -8,6 +8,7 @@ For more details about the Python API, please refer to the documentation at
 https://home-assistant.io/developers/python_api/
 """
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 import enum
 import json
@@ -18,6 +19,7 @@ import urllib.parse
 
 from typing import Optional
 
+import aiohttp
 import requests
 
 import homeassistant.bootstrap as bootstrap
@@ -124,14 +126,18 @@ class HomeAssistant(ha.HomeAssistant):
         self.remote_api = remote_api
 
         self.loop = loop or asyncio.get_event_loop()
+        self.executor = ThreadPoolExecutor(max_workers=5)
+        self.loop.set_default_executor(self.executor)
+        self.loop.set_exception_handler(self._async_exception_handler)
         self.pool = ha.create_worker_pool()
 
         self.bus = EventBus(remote_api, self)
         self.services = ha.ServiceRegistry(self.bus, self.add_job, self.loop)
         self.states = StateMachine(self.bus, self.loop, self.remote_api)
         self.config = ha.Config()
-        self.state = ha.CoreState.not_running
+        self.websession = aiohttp.ClientSession(loop=self.loop)
 
+        self.state = ha.CoreState.not_running
         self.config.api = local_api
 
     def start(self):

--- a/tests/common.py
+++ b/tests/common.py
@@ -92,26 +92,21 @@ def async_test_home_assistant(loop):
     """Return a Home Assistant object pointing at test config dir."""
     loop._thread_ident = threading.get_ident()
 
-    def get_hass():
-        """Temp while we migrate core HASS over to be async constructors."""
-        hass = ha.HomeAssistant(loop)
+    hass = ha.HomeAssistant(loop)
 
-        hass.config.location_name = 'test home'
-        hass.config.config_dir = get_test_config_dir()
-        hass.config.latitude = 32.87336
-        hass.config.longitude = -117.22743
-        hass.config.elevation = 0
-        hass.config.time_zone = date_util.get_time_zone('US/Pacific')
-        hass.config.units = METRIC_SYSTEM
-        hass.config.skip_pip = True
+    hass.config.location_name = 'test home'
+    hass.config.config_dir = get_test_config_dir()
+    hass.config.latitude = 32.87336
+    hass.config.longitude = -117.22743
+    hass.config.elevation = 0
+    hass.config.time_zone = date_util.get_time_zone('US/Pacific')
+    hass.config.units = METRIC_SYSTEM
+    hass.config.skip_pip = True
 
-        if 'custom_components.test' not in loader.AVAILABLE_COMPONENTS:
-            loader.prepare(hass)
+    if 'custom_components.test' not in loader.AVAILABLE_COMPONENTS:
+        yield from loop.run_in_executor(None, loader.prepare, hass)
 
-        hass.state = ha.CoreState.running
-        return hass
-
-    hass = yield from loop.run_in_executor(None, get_hass)
+    hass.state = ha.CoreState.running
 
     return hass
 


### PR DESCRIPTION
**Description:**
Work in progress in making the initialization of HA all async.
- [x] Move all init things from `hass.start` to `hass.async_start` making `hass.start` a simple wrapper.
- [x] Make HomeAssistant constructor async friendly (-> problem is `ServiceRegistry` constructor)
- [x] Make our [async test fixture](https://github.com/home-assistant/home-assistant/blob/dev/tests/common.py#L96) truly async

**Checklist:**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
