### PR TITLE
Add zone_ignore option for yamaha.

### DIFF
--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -26,6 +26,7 @@ SUPPORT_YAMAHA = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
 
 CONF_SOURCE_NAMES = 'source_names'
 CONF_SOURCE_IGNORE = 'source_ignore'
+CONF_ZONE_IGNORE = 'zone_ignore'
 
 DEFAULT_NAME = 'Yamaha Receiver'
 
@@ -34,10 +35,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_SOURCE_IGNORE, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_ZONE_IGNORE, default=[]):
+        vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_SOURCE_NAMES, default={}): {cv.string: cv.string},
 })
 
 
+# pylint: disable=too-many-locals
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Yamaha platform."""
     import rxv
@@ -46,6 +50,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     host = config.get(CONF_HOST)
     source_ignore = config.get(CONF_SOURCE_IGNORE)
     source_names = config.get(CONF_SOURCE_NAMES)
+    zone_ignore = config.get(CONF_ZONE_IGNORE) or []
 
     if discovery_info is not None:
         name = discovery_info[0]
@@ -66,9 +71,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         ctrl_url = "http://{}:80/YamahaRemoteControl/ctrl".format(host)
         receivers = rxv.RXV(ctrl_url, name).zone_controllers()
 
-    add_devices(
-        YamahaDevice(name, receiver, source_ignore, source_names)
-        for receiver in receivers)
+    for receiver in receivers:
+        if receiver.zone not in zone_ignore:
+            add_devices([
+                YamahaDevice(name, receiver, source_ignore, source_names)])
 
 
 class YamahaDevice(MediaPlayerDevice):

--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -50,7 +50,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     host = config.get(CONF_HOST)
     source_ignore = config.get(CONF_SOURCE_IGNORE)
     source_names = config.get(CONF_SOURCE_NAMES)
-    zone_ignore = config.get(CONF_ZONE_IGNORE) or []
+    zone_ignore = config.get(CONF_ZONE_IGNORE)
 
     if discovery_info is not None:
         name = discovery_info[0]


### PR DESCRIPTION
We attempt to discover all zones for yamaha receivers. There are times
when users may want to suppress some zones from showing up. When a
Zone isn't actually connected to speakers, or on some newer receivers
where Zone_4 is an HDMI only zone, that doesn't support even basic
media_player UI.

This provide a mechanism for users to do that.

Fixes #4088
