### PR TITLE
Migrate to async (sensor.time_date)

### DIFF
--- a/homeassistant/components/sensor/time_date.py
+++ b/homeassistant/components/sensor/time_date.py
@@ -4,20 +4,21 @@ Support for showing the date and the time.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.time_date/
 """
-import logging
 from datetime import timedelta
+import asyncio
+import logging
 
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_DISPLAY_OPTIONS
-import homeassistant.util.dt as dt_util
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
-TIME_STR_FORMAT = "%H:%M"
+TIME_STR_FORMAT = '%H:%M'
 
 OPTION_TYPES = {
     'time': 'Time',
@@ -34,17 +35,19 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup the Time and Date sensor."""
     if hass.config.time_zone is None:
-        _LOGGER.error("Timezone is not set in Home Assistant config")
+        _LOGGER.error("Timezone is not set in Home Assistant configuration")
         return False
 
     devices = []
     for variable in config[CONF_DISPLAY_OPTIONS]:
         devices.append(TimeDateSensor(variable))
 
-    add_devices(devices)
+    hass.loop.create_task(async_add_devices(devices))
+    return True
 
 
 # pylint: disable=too-few-public-methods
@@ -56,7 +59,7 @@ class TimeDateSensor(Entity):
         self._name = OPTION_TYPES[option_type]
         self.type = option_type
         self._state = None
-        self.update()
+        self.async_update()
 
     @property
     def name(self):
@@ -71,14 +74,15 @@ class TimeDateSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
-        if "date" in self.type and "time" in self.type:
-            return "mdi:calendar-clock"
-        elif "date" in self.type:
-            return "mdi:calendar"
+        if 'date' in self.type and 'time' in self.type:
+            return 'mdi:calendar-clock'
+        elif 'date' in self.type:
+            return 'mdi:calendar'
         else:
-            return "mdi:clock"
+            return 'mdi:clock'
 
-    def update(self):
+    @asyncio.coroutine
+    def async_update(self):
         """Get the latest data and updates the states."""
         time_date = dt_util.utcnow()
         time = dt_util.as_local(time_date).strftime(TIME_STR_FORMAT)
@@ -87,10 +91,9 @@ class TimeDateSensor(Entity):
 
         # Calculate Swatch Internet Time.
         time_bmt = time_date + timedelta(hours=1)
-        delta = timedelta(hours=time_bmt.hour,
-                          minutes=time_bmt.minute,
-                          seconds=time_bmt.second,
-                          microseconds=time_bmt.microsecond)
+        delta = timedelta(
+            hours=time_bmt.hour, minutes=time_bmt.minute,
+            seconds=time_bmt.second, microseconds=time_bmt.microsecond)
         beat = int((delta.seconds + delta.microseconds / 1000000.0) / 86.4)
 
         if self.type == 'time':
@@ -98,9 +101,9 @@ class TimeDateSensor(Entity):
         elif self.type == 'date':
             self._state = date
         elif self.type == 'date_time':
-            self._state = date + ', ' + time
+            self._state = '{}, {}'.format(date, time)
         elif self.type == 'time_date':
-            self._state = time + ', ' + date
+            self._state = '{}, {}'.format(time, date)
         elif self.type == 'time_utc':
             self._state = time_utc
         elif self.type == 'beat':

--- a/homeassistant/components/sensor/time_date.py
+++ b/homeassistant/components/sensor/time_date.py
@@ -46,7 +46,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     for variable in config[CONF_DISPLAY_OPTIONS]:
         devices.append(TimeDateSensor(variable))
 
-    hass.loop.create_task(async_add_devices(devices))
+    hass.loop.create_task(async_add_devices(devices, True))
     return True
 
 
@@ -59,7 +59,6 @@ class TimeDateSensor(Entity):
         self._name = OPTION_TYPES[option_type]
         self.type = option_type
         self._state = None
-        self.async_update()
 
     @property
     def name(self):


### PR DESCRIPTION
**Description:**
Migrate the `time_date` sensor to async.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: time_date
    display_options:
      - 'time'
      - 'date'
      - 'beat'
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] New files were added to `.coveragerc`.
