### PR TITLE
Maintenance (sensor.bitcoin, sensor.yahoo_finance)

### DIFF
--- a/homeassistant/components/sensor/bitcoin.py
+++ b/homeassistant/components/sensor/bitcoin.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_DISPLAY_OPTIONS
+from homeassistant.const import (CONF_DISPLAY_OPTIONS, ATTR_ATTRIBUTION)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
@@ -19,6 +19,7 @@ REQUIREMENTS = ['blockchain==1.3.3']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_ATTRIBUTION = "Data provided by blockchain.info"
 CONF_CURRENCY = 'currency'
 
 DEFAULT_CURRENCY = 'USD'
@@ -59,7 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Bitcoin sensors."""
+    """Set up the Bitcoin sensors."""
     from blockchain import exchangerates
 
     currency = config.get(CONF_CURRENCY)
@@ -110,6 +111,13 @@ class BitcoinSensor(Entity):
     def icon(self):
         """Return the icon to use in the frontend, if any."""
         return ICON
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return {
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+        }
 
     # pylint: disable=too-many-branches
     def update(self):

--- a/homeassistant/components/sensor/coinmarketcap.py
+++ b/homeassistant/components/sensor/coinmarketcap.py
@@ -46,13 +46,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the CoinMarketCap sensor."""
+    """Set up the CoinMarketCap sensor."""
     currency = config.get(CONF_CURRENCY)
 
     try:
         CoinMarketCapData(currency).update()
     except HTTPError:
-        _LOGGER.warning('Currency "%s" is not available. Using "bitcoin"',
+        _LOGGER.warning("Currency '%s' is not available. Using 'bitcoin'",
                         currency)
         currency = DEFAULT_CURRENCY
 
@@ -95,13 +95,13 @@ class CoinMarketCapSensor(Entity):
         """Return the state attributes of the sensor."""
         return {
             ATTR_24H_VOLUME_USD: self._ticker.get('24h_volume_usd'),
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
             ATTR_AVAILABLE_SUPPLY: self._ticker.get('available_supply'),
             ATTR_MARKET_CAP: self._ticker.get('market_cap_usd'),
             ATTR_PERCENT_CHANGE_24H: self._ticker.get('percent_change_24h'),
             ATTR_PERCENT_CHANGE_7D: self._ticker.get('percent_change_7d'),
             ATTR_SYMBOL: self._ticker.get('symbol'),
             ATTR_TOTAL_SUPPLY: self._ticker.get('total_supply'),
-            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
         }
 
     # pylint: disable=too-many-branches

--- a/homeassistant/components/sensor/yahoo_finance.py
+++ b/homeassistant/components/sensor/yahoo_finance.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, ATTR_ATTRIBUTION
+from homeassistant.const import (CONF_NAME, ATTR_ATTRIBUTION)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
@@ -19,19 +19,19 @@ REQUIREMENTS = ['yahoo-finance==1.3.2']
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_CHANGE = 'Change'
+ATTR_OPEN = 'open'
+ATTR_PREV_CLOSE = 'prev_close'
+
 CONF_ATTRIBUTION = "Stock market information provided by Yahoo! Inc."
 CONF_SYMBOL = 'symbol'
 
-DEFAULT_SYMBOL = 'YHOO'
 DEFAULT_NAME = 'Yahoo Stock'
+DEFAULT_SYMBOL = 'YHOO'
 
 ICON = 'mdi:currency-usd'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
-
-ATTR_CHANGE = 'Change'
-ATTR_OPEN = 'open'
-ATTR_PREV_CLOSE = 'prev_close'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SYMBOL, default=DEFAULT_SYMBOL): cv.string,
@@ -40,7 +40,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Yahoo Finance sensor."""
+    """Set up the Yahoo Finance sensor."""
     name = config.get(CONF_NAME)
     symbol = config.get(CONF_SYMBOL)
 
@@ -81,10 +81,10 @@ class YahooFinanceSensor(Entity):
         """Return the state attributes."""
         if self._state is not None:
             return {
+                ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
                 ATTR_CHANGE: self.data.price_change,
                 ATTR_OPEN: self.data.price_open,
                 ATTR_PREV_CLOSE: self.data.prev_close,
-                ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
             }
 
     @property
@@ -94,7 +94,7 @@ class YahooFinanceSensor(Entity):
 
     def update(self):
         """Get the latest data and updates the states."""
-        _LOGGER.debug('Updating sensor %s - %s', self._name, self._state)
+        _LOGGER.debug("Updating sensor %s - %s", self._name, self._state)
         self.data.update()
         self._state = self.data.state
 


### PR DESCRIPTION
**Description:**
Add attribution to bitcoin sensor and update ordering.

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor: 
  - platform: yahoo_finance
    name: Red Hat Inc.
    symbol: RHT
  - platform: yahoo_finance
    name: Google
    symbol: GOOGL
  - platform: bitcoin
    currency: CHF
    display_options:
      - exchangerate
      - trade_volume_btc
      - miners_revenue_usd
      - btc_mined
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
