### PR TITLE
Disable too-many-*

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -99,8 +99,7 @@ def _async_setup_component(hass: core.HomeAssistant,
 
     This method is a coroutine.
     """
-    # pylint: disable=too-many-return-statements,too-many-branches
-    # pylint: disable=too-many-statements
+    # pylint: disable=too-many-return-statements
     if domain in hass.config.components:
         return True
 
@@ -312,7 +311,6 @@ def async_prepare_setup_platform(hass: core.HomeAssistant, config, domain: str,
     return platform
 
 
-# pylint: disable=too-many-branches, too-many-statements, too-many-arguments
 def from_config_dict(config: Dict[str, Any],
                      hass: Optional[core.HomeAssistant]=None,
                      config_dir: Optional[str]=None,
@@ -352,7 +350,6 @@ def from_config_dict(config: Dict[str, Any],
 
 
 @asyncio.coroutine
-# pylint: disable=too-many-branches, too-many-statements, too-many-arguments
 def async_from_config_dict(config: Dict[str, Any],
                            hass: core.HomeAssistant,
                            config_dir: Optional[str]=None,

--- a/homeassistant/components/alarm_control_panel/alarmdotcom.py
+++ b/homeassistant/components/alarm_control_panel/alarmdotcom.py
@@ -42,7 +42,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([AlarmDotCom(hass, name, code, username, password)])
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 # pylint: disable=abstract-method
 class AlarmDotCom(alarm.AlarmControlPanel):
     """Represent an Alarm.com status."""

--- a/homeassistant/components/alarm_control_panel/envisalink.py
+++ b/homeassistant/components/alarm_control_panel/envisalink.py
@@ -43,7 +43,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class EnvisalinkAlarm(EnvisalinkDevice, alarm.AlarmControlPanel):
     """Representation of an Envisalink-based alarm panel."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, partition_number, alarm_name, code, panic_type, info,
                  controller):
         """Initialize the alarm panel."""

--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -50,7 +50,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         )])
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 # pylint: disable=abstract-method
 class ManualAlarm(alarm.AlarmControlPanel):
     """

--- a/homeassistant/components/alarm_control_panel/mqtt.py
+++ b/homeassistant/components/alarm_control_panel/mqtt.py
@@ -55,7 +55,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         config.get(CONF_CODE))])
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 # pylint: disable=abstract-method
 class MqttAlarm(alarm.AlarmControlPanel):
     """Representation of a MQTT alarm status."""

--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -286,7 +286,6 @@ class AlexaFlashBriefingView(HomeAssistantView):
         self.flash_briefings = copy.deepcopy(flash_briefings)
         template.attach(hass, self.flash_briefings)
 
-    # pylint: disable=too-many-branches
     @callback
     def get(self, request, briefing_id):
         """Handle Alexa Flash Briefing request."""

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -219,7 +219,6 @@ class AutomationEntity(ToggleEntity):
     """Entity to show status of entity."""
 
     # pylint: disable=abstract-method
-    # pylint: disable=too-many-arguments, too-many-instance-attributes
     def __init__(self, name, async_attach_triggers, cond_func, async_action,
                  hidden):
         """Initialize an automation entity."""

--- a/homeassistant/components/binary_sensor/arest.py
+++ b/homeassistant/components/binary_sensor/arest.py
@@ -54,7 +54,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         sensor_class, pin)])
 
 
-# pylint: disable=too-many-instance-attributes, too-many-arguments
 class ArestBinarySensor(BinarySensorDevice):
     """Implement an aREST binary sensor for a pin."""
 
@@ -93,7 +92,6 @@ class ArestBinarySensor(BinarySensorDevice):
         self.arest.update()
 
 
-# pylint: disable=too-few-public-methods
 class ArestData(object):
     """Class for handling the data retrieval for pins."""
 

--- a/homeassistant/components/binary_sensor/command_line.py
+++ b/homeassistant/components/binary_sensor/command_line.py
@@ -53,7 +53,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         value_template)])
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 class CommandBinarySensor(BinarySensorDevice):
     """Represent a command line binary sensor."""
 

--- a/homeassistant/components/binary_sensor/concord232.py
+++ b/homeassistant/components/binary_sensor/concord232.py
@@ -42,7 +42,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=too-many-locals
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Concord232 binary sensor platform."""
     from concord232 import client as concord232_client

--- a/homeassistant/components/binary_sensor/envisalink.py
+++ b/homeassistant/components/binary_sensor/envisalink.py
@@ -35,7 +35,6 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorDevice):
     """Representation of an Envisalink binary sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, zone_number, zone_name, zone_type, info, controller):
         """Initialize the binary_sensor."""
         from pydispatch import dispatcher

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -51,7 +51,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     )])
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 class MqttBinarySensor(BinarySensorDevice):
     """Representation a binary sensor that is updated by MQTT."""
 

--- a/homeassistant/components/binary_sensor/octoprint.py
+++ b/homeassistant/components/binary_sensor/octoprint.py
@@ -58,11 +58,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(devices)
 
 
-# pylint: disable=too-many-instance-attributes
 class OctoPrintBinarySensor(BinarySensorDevice):
     """Representation an OctoPrint binary sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, api, condition, sensor_type, sensor_name, unit,
                  endpoint, group, tool=None):
         """Initialize a new OctoPrint sensor."""

--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -41,7 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-variable, too-many-locals
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the REST binary sensor."""
     name = config.get(CONF_NAME)
@@ -76,7 +75,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         hass, rest, name, sensor_class, value_template)])
 
 
-# pylint: disable=too-many-arguments
 class RestBinarySensor(BinarySensorDevice):
     """Representation of a REST binary sensor."""
 

--- a/homeassistant/components/binary_sensor/rpi_gpio.py
+++ b/homeassistant/components/binary_sensor/rpi_gpio.py
@@ -54,7 +54,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(binary_sensors)
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 class RPiGPIOBinarySensor(BinarySensorDevice):
     """Represent a binary sensor that uses Raspberry Pi GPIO."""
 

--- a/homeassistant/components/binary_sensor/sleepiq.py
+++ b/homeassistant/components/binary_sensor/sleepiq.py
@@ -25,7 +25,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(dev)
 
 
-# pylint: disable=too-many-instance-attributes
 class IsInBedBinarySensor(sleepiq.SleepIQSensor, BinarySensorDevice):
     """Implementation of a SleepIQ presence sensor."""
 

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -70,7 +70,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class BinarySensorTemplate(BinarySensorDevice):
     """A virtual binary sensor that triggers from another sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, device, friendly_name, sensor_class,
                  value_template, entity_ids):
         """Initialize the Template binary sensor."""

--- a/homeassistant/components/binary_sensor/trend.py
+++ b/homeassistant/components/binary_sensor/trend.py
@@ -72,7 +72,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class SensorTrend(BinarySensorDevice):
     """Representation of a trend Sensor."""
 
-    # pylint: disable=too-many-arguments, too-many-instance-attributes
     def __init__(self, hass, device_id, friendly_name,
                  target_entity, attribute, sensor_class, invert):
         """Initialize the sensor."""

--- a/homeassistant/components/bloomsky.py
+++ b/homeassistant/components/bloomsky.py
@@ -33,7 +33,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# pylint: disable=unused-argument,too-few-public-methods
+# pylint: disable=unused-argument
 def setup(hass, config):
     """Setup BloomSky component."""
     api_key = config[DOMAIN][CONF_API_KEY]

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -28,7 +28,6 @@ ENTITY_IMAGE_URL = '/api/camera_proxy/{0}?token={1}'
 
 
 @asyncio.coroutine
-# pylint: disable=too-many-branches
 def async_setup(hass, config):
     """Setup the camera component."""
     component = EntityComponent(

--- a/homeassistant/components/camera/foscam.py
+++ b/homeassistant/components/camera/foscam.py
@@ -36,7 +36,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([FoscamCamera(config)])
 
 
-# pylint: disable=too-many-instance-attributes
 class FoscamCamera(Camera):
     """An implementation of a Foscam IP camera."""
 

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -46,7 +46,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     hass.loop.create_task(async_add_devices([GenericCamera(hass, config)]))
 
 
-# pylint: disable=too-many-instance-attributes
 class GenericCamera(Camera):
     """A generic implementation of an IP camera."""
 

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -58,7 +58,6 @@ def extract_image_from_mjpeg(stream):
             return jpg
 
 
-# pylint: disable=too-many-instance-attributes
 class MjpegCamera(Camera):
     """An implementation of an IP camera that is reachable over a URL."""
 

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -23,7 +23,6 @@ from homeassistant.util.async import run_coroutine_threadsafe
 
 _LOGGER = logging.getLogger(__name__)
 
-#  pylint: disable=too-many-locals
 DEFAULT_NAME = 'Synology Camera'
 DEFAULT_STREAM_ID = '0'
 TIMEOUT = 5
@@ -179,11 +178,9 @@ def get_session_id(hass, username, password, login_url, valid_cert):
     return auth_resp['data']['sid']
 
 
-# pylint: disable=too-many-instance-attributes
 class SynologyCamera(Camera):
     """An implementation of a Synology NAS based IP camera."""
 
-# pylint: disable=too-many-arguments
     def __init__(self, config, camera_id, camera_name,
                  snapshot_path, streaming_path, camera_path, auth_path):
         """Initialize a Synology Surveillance Station camera."""

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -123,7 +123,6 @@ def set_aux_heat(hass, aux_heat, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_SET_AUX_HEAT, data)
 
 
-# pylint: disable=too-many-arguments
 def set_temperature(hass, temperature=None, entity_id=None,
                     target_temp_high=None, target_temp_low=None,
                     operation_mode=None):
@@ -181,7 +180,6 @@ def set_swing_mode(hass, swing_mode, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_SET_SWING_MODE, data)
 
 
-# pylint: disable=too-many-branches
 def setup(hass, config):
     """Setup climate devices."""
     component = EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
@@ -364,7 +362,7 @@ def setup(hass, config):
 class ClimateDevice(Entity):
     """Representation of a climate device."""
 
-    # pylint: disable=too-many-public-methods,no-self-use
+    # pylint: disable=no-self-use
     @property
     def state(self):
         """Return the current state."""

--- a/homeassistant/components/climate/demo.py
+++ b/homeassistant/components/climate/demo.py
@@ -21,11 +21,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     ])
 
 
-# pylint: disable=too-many-arguments, too-many-public-methods
 class DemoClimate(ClimateDevice):
     """Representation of a demo climate device."""
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, name, target_temperature, unit_of_measurement,
                  away, current_temperature, current_fan_mode,
                  target_humidity, current_humidity, current_swing_mode,

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -72,7 +72,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         schema=SET_FAN_MIN_ON_TIME_SCHEMA)
 
 
-# pylint: disable=too-many-public-methods, abstract-method
+# pylint: disable=abstract-method
 class Thermostat(ClimateDevice):
     """A thermostat class for Ecobee."""
 

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -42,7 +42,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(devices)
 
 
-# pylint: disable=too-many-instance-attributes, import-error, abstract-method
+# pylint: disable=import-error, abstract-method
 class EQ3BTSmartThermostat(ClimateDevice):
     """Representation of a eQ-3 Bluetooth Smart thermostat."""
 

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -62,11 +62,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         target_temp, ac_mode, min_cycle_duration)])
 
 
-# pylint: disable=too-many-instance-attributes, abstract-method
+# pylint: disable=abstract-method
 class GenericThermostat(ClimateDevice):
     """Representation of a GenericThermostat device."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, name, heater_entity_id, sensor_entity_id,
                  min_temp, max_temp, target_temp, ac_mode, min_cycle_duration):
         """Initialize the thermostat."""

--- a/homeassistant/components/climate/heatmiser.py
+++ b/homeassistant/components/climate/heatmiser.py
@@ -56,7 +56,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class HeatmiserV3Thermostat(ClimateDevice):
     """Representation of a HeatmiserV3 thermostat."""
 
-    # pylint: disable=too-many-instance-attributes, abstract-method
+    # pylint: disable=abstract-method
     def __init__(self, heatmiser, device, name, serport):
         """Initialize the thermostat."""
         self.heatmiser = heatmiser

--- a/homeassistant/components/climate/honeywell.py
+++ b/homeassistant/components/climate/honeywell.py
@@ -100,7 +100,7 @@ def _setup_us(username, password, config, add_devices):
 class RoundThermostat(ClimateDevice):
     """Representation of a Honeywell Round Connected thermostat."""
 
-    # pylint: disable=too-many-instance-attributes, abstract-method
+    # pylint: disable=abstract-method
     def __init__(self, device, zone_id, master, away_temp):
         """Initialize the thermostat."""
         self.device = device

--- a/homeassistant/components/climate/mysensors.py
+++ b/homeassistant/components/climate/mysensors.py
@@ -37,7 +37,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             map_sv_types, devices, add_devices, MySensorsHVAC))
 
 
-# pylint: disable=too-many-arguments, too-many-public-methods
 class MySensorsHVAC(mysensors.MySensorsDeviceEntity, ClimateDevice):
     """Representation of a MySensorsHVAC hvac."""
 

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -30,7 +30,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                  for structure, device in nest.devices()])
 
 
-# pylint: disable=abstract-method,too-many-public-methods
+# pylint: disable=abstract-method
 class NestThermostat(ClimateDevice):
     """Representation of a Nest thermostat."""
 

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -73,7 +73,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
     """Represents a ZWave Climate device."""
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, value, temp_unit):
         """Initialize the zwave climate device."""
         from openzwave.network import ZWaveNetwork
@@ -121,7 +120,6 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
             self.update_ha_state()
             _LOGGER.debug("Value changed on network %s", value)
 
-    # pylint: disable=too-many-branches
     def update_properties(self):
         """Callback on data change for the registered node/value pair."""
         # Operation Mode

--- a/homeassistant/components/configurator.py
+++ b/homeassistant/components/configurator.py
@@ -34,7 +34,6 @@ STATE_CONFIGURE = 'configure'
 STATE_CONFIGURED = 'configured'
 
 
-# pylint: disable=too-many-arguments
 def request_config(
         hass, name, callback, description=None, description_image=None,
         submit_caption=None, fields=None, link_name=None, link_url=None,
@@ -102,7 +101,6 @@ class Configurator(object):
         hass.services.register(
             DOMAIN, SERVICE_CONFIGURE, self.handle_service_call)
 
-    # pylint: disable=too-many-arguments
     def request_config(
             self, name, callback,
             description, description_image, submit_caption,

--- a/homeassistant/components/cover/command_line.py
+++ b/homeassistant/components/cover/command_line.py
@@ -60,11 +60,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(covers)
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 class CommandCover(CoverDevice):
     """Representation a command line cover."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, name, command_open, command_close, command_stop,
                  command_state, value_template):
         """Initialize the cover."""

--- a/homeassistant/components/cover/demo.py
+++ b/homeassistant/components/cover/demo.py
@@ -20,7 +20,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class DemoCover(CoverDevice):
     """Representation of a demo cover."""
 
-    # pylint: disable=no-self-use, too-many-instance-attributes
+    # pylint: disable=no-self-use
     def __init__(self, hass, name, position=None, tilt_position=None):
         """Initialize the cover."""
         self.hass = hass

--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -67,7 +67,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     )])
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 class MqttCover(CoverDevice):
     """Representation of a cover that can be controlled using MQTT."""
 

--- a/homeassistant/components/cover/rpi_gpio.py
+++ b/homeassistant/components/cover/rpi_gpio.py
@@ -67,7 +67,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiGPIOCover(CoverDevice):
     """Representation of a Raspberry GPIO cover."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, name, relay_pin, state_pin, state_pull_mode,
                  relay_time):
         """Initialize the cover."""

--- a/homeassistant/components/cover/scsgate.py
+++ b/homeassistant/components/cover/scsgate.py
@@ -45,7 +45,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(covers)
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 class SCSGateCover(CoverDevice):
     """Representation of SCSGate cover."""
 

--- a/homeassistant/components/device_sun_light_trigger.py
+++ b/homeassistant/components/device_sun_light_trigger.py
@@ -41,7 +41,6 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# pylint: disable=too-many-locals
 def setup(hass, config):
     """The triggers to turn lights on or off based on device presence."""
     logger = logging.getLogger(__name__)

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -4,8 +4,6 @@ Provide functionality to keep track of devices.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/device_tracker/
 """
-# pylint: disable=too-many-instance-attributes, too-many-arguments
-# pylint: disable=too-many-locals
 import asyncio
 from datetime import timedelta
 import logging
@@ -88,7 +86,6 @@ def is_on(hass: HomeAssistantType, entity_id: str=None):
     return hass.states.is_state(entity, STATE_HOME)
 
 
-# pylint: disable=too-many-arguments
 def see(hass: HomeAssistantType, mac: str=None, dev_id: str=None,
         host_name: str=None, location_name: str=None,
         gps: GPSType=None, gps_accuracy=None,

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -90,9 +90,7 @@ AsusWrtResult = namedtuple('AsusWrtResult', 'neighbors leases arp')
 class AsusWrtDeviceScanner(object):
     """This class queries a router running ASUSWRT firmware."""
 
-    # pylint: disable=too-many-instance-attributes, too-many-branches
     # Eighth attribute needed for mode (AP mode vs router mode)
-
     def __init__(self, config):
         """Initialize the scanner."""
         self.host = config[CONF_HOST]

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -60,8 +60,6 @@ def setup_scanner(hass, config: dict, see):
     return True
 
 
-# pylint: disable=too-many-instance-attributes
-# pylint: disable=too-few-public-methods
 class AutomaticDeviceScanner(object):
     """A class representing an Automatic device."""
 

--- a/homeassistant/components/device_tracker/ddwrt.py
+++ b/homeassistant/components/device_tracker/ddwrt.py
@@ -41,7 +41,6 @@ def get_scanner(hass, config):
         return None
 
 
-# pylint: disable=too-many-instance-attributes
 class DdWrtDeviceScanner(object):
     """This class queries a wireless router running DD-WRT firmware."""
 

--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -38,7 +38,6 @@ def get_scanner(hass, config):
     return scanner if scanner.success_init else None
 
 
-# pylint: disable=too-many-instance-attributes
 class FritzBoxScanner(object):
     """This class queries a FRITZ!Box router."""
 

--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -51,9 +51,9 @@ class LocativeView(HomeAssistantView):
         return res
 
     @asyncio.coroutine
+    # pylint: disable=too-many-return-statements
     def _handle(self, data):
         """Handle locative request."""
-        # pylint: disable=too-many-return-statements
         if 'latitude' not in data or 'longitude' not in data:
             return ('Latitude and longitude not specified.',
                     HTTP_UNPROCESSABLE_ENTITY)

--- a/homeassistant/components/device_tracker/luci.py
+++ b/homeassistant/components/device_tracker/luci.py
@@ -37,7 +37,6 @@ def get_scanner(hass, config):
     return scanner if scanner.success_init else None
 
 
-# pylint: disable=too-many-instance-attributes
 class LuciDeviceScanner(object):
     """This class queries a wireless router running OpenWrt firmware.
 

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -114,10 +114,9 @@ def setup_scanner(hass, config, see):
                             'for topic %s.', topic)
             return None
 
+    # pylint: disable=too-many-return-statements
     def validate_payload(topic, payload, data_type):
         """Validate the OwnTracks payload."""
-        # pylint: disable=too-many-return-statements
-
         try:
             data = json.loads(payload)
         except ValueError:

--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -49,7 +49,6 @@ def get_scanner(hass, config):
 class SnmpScanner(object):
     """Queries any SNMP capable Access Point for connected devices."""
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, config):
         """Initialize the scanner."""
         from pysnmp.entity.rfc3413.oneliner import cmdgen

--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -37,7 +37,6 @@ def get_scanner(hass, config):
     return scanner if scanner.success_init else None
 
 
-# pylint: disable=too-many-instance-attributes
 class UbusDeviceScanner(object):
     """
     This class queries a wireless router running OpenWrt firmware.

--- a/homeassistant/components/digital_ocean.py
+++ b/homeassistant/components/digital_ocean.py
@@ -42,7 +42,6 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# pylint: disable=unused-argument,too-few-public-methods
 def setup(hass, config):
     """Set up the Digital Ocean component."""
     conf = config[DOMAIN]

--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -38,7 +38,6 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# pylint: disable=too-many-branches
 def setup(hass, config):
     """Listen for download events to download files."""
     download_path = config[DOMAIN][CONF_DOWNLOAD_DIR]

--- a/homeassistant/components/dweet.py
+++ b/homeassistant/components/dweet.py
@@ -32,7 +32,6 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# pylint: disable=too-many-locals
 def setup(hass, config):
     """Setup the Dweet.io component."""
     conf = config[DOMAIN]

--- a/homeassistant/components/ecobee.py
+++ b/homeassistant/components/ecobee.py
@@ -86,7 +86,6 @@ def setup_ecobee(hass, network, config):
     discovery.load_platform(hass, 'binary_sensor', DOMAIN, {}, config)
 
 
-# pylint: disable=too-few-public-methods
 class EcobeeData(object):
     """Get the latest data and update the states."""
 

--- a/homeassistant/components/emulated_hue.py
+++ b/homeassistant/components/emulated_hue.py
@@ -105,7 +105,6 @@ def setup(hass, yaml_config):
     return True
 
 
-# pylint: disable=too-few-public-methods
 class Config(object):
     """Holds configuration variables for the emulated hue bridge."""
 

--- a/homeassistant/components/enocean.py
+++ b/homeassistant/components/enocean.py
@@ -56,14 +56,14 @@ class EnOceanDongle:
         """Send a command from the EnOcean dongle."""
         self.__communicator.send(command)
 
-    def _combine_hex(self, data):  # pylint: disable=no-self-use
+    # pylint: disable=no-self-use
+    def _combine_hex(self, data):
         """Combine list of integer values to one big integer."""
         output = 0x00
         for i, j in enumerate(reversed(data)):
             output |= (j << i * 8)
         return output
 
-    # pylint: disable=too-many-branches
     def callback(self, temp):
         """Callback function for EnOcean Device.
 
@@ -112,7 +112,6 @@ class EnOceanDongle:
                         device.value_changed(value)
 
 
-# pylint: disable=too-few-public-methods
 class EnOceanDevice():
     """Parent class for all devices associated with the EnOcean component."""
 

--- a/homeassistant/components/envisalink.py
+++ b/homeassistant/components/envisalink.py
@@ -77,8 +77,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# pylint: disable=unused-argument, too-many-function-args, too-many-locals
-# pylint: disable=too-many-return-statements
+# pylint: disable=unused-argument
 def setup(hass, base_config):
     """Common setup for Envisalink devices."""
     from pyenvisalink import EnvisalinkAlarmPanel

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -86,7 +86,6 @@ def is_on(hass, entity_id: str=None) -> bool:
     return state.attributes[ATTR_SPEED] not in [SPEED_OFF, STATE_UNKNOWN]
 
 
-# pylint: disable=too-many-arguments
 def turn_on(hass, entity_id: str=None, speed: str=None) -> None:
     """Turn all or specified fan on."""
     data = {
@@ -141,7 +140,6 @@ def set_speed(hass, entity_id: str=None, speed: str=None) -> None:
     hass.services.call(DOMAIN, SERVICE_SET_SPEED, data)
 
 
-# pylint: disable=too-many-branches, too-many-locals, too-many-statements
 def setup(hass, config: dict) -> None:
     """Expose fan control via statemachine and services."""
     component = EntityComponent(

--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -110,11 +110,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     )])
 
 
-# pylint: disable=too-many-instance-attributes
 class MqttFan(FanEntity):
     """A MQTT fan component."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, name, topic, templates, qos, retain, payload,
                  speed_list, optimistic):
         """Initialize the MQTT fan."""

--- a/homeassistant/components/feedreader.py
+++ b/homeassistant/components/feedreader.py
@@ -44,7 +44,6 @@ def setup(hass, config):
     return len(feeds) > 0
 
 
-# pylint: disable=too-few-public-methods
 class FeedManager(object):
     """Abstraction over feedparser module."""
 

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -41,7 +41,6 @@ _LOGGER = logging.getLogger(__name__)
 def register_built_in_panel(hass, component_name, sidebar_title=None,
                             sidebar_icon=None, url_path=None, config=None):
     """Register a built-in panel."""
-    # pylint: disable=too-many-arguments
     path = 'panels/ha-panel-{}.html'.format(component_name)
 
     if hass.http.development:
@@ -70,7 +69,6 @@ def register_panel(hass, component_name, path, md5=None, sidebar_title=None,
 
     Warning: this API will probably change. Use at own risk.
     """
-    # pylint: disable=too-many-arguments
     if url_path is None:
         url_path = component_name
 

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -218,7 +218,6 @@ def _async_process_config(hass, config, component):
 class Group(Entity):
     """Track a group of entity ids."""
 
-    # pylint: disable=too-many-instance-attributes, too-many-arguments
     def __init__(self, hass, name, order=None, user_defined=True, icon=None,
                  view=False):
         """Initialize a group.
@@ -240,7 +239,6 @@ class Group(Entity):
         self._visible = True
 
     @staticmethod
-    # pylint: disable=too-many-arguments
     def create_group(hass, name, entity_ids=None, user_defined=True,
                      icon=None, view=False, object_id=None):
         """Initialize a group."""
@@ -251,7 +249,6 @@ class Group(Entity):
 
     @staticmethod
     @asyncio.coroutine
-    # pylint: disable=too-many-arguments
     def async_create_group(hass, name, entity_ids=None, user_defined=True,
                            icon=None, view=False, object_id=None):
         """Initialize a group.
@@ -420,7 +417,6 @@ class Group(Entity):
 
         This method must be run in the event loop.
         """
-        # pylint: disable=too-many-branches
         # To store current states of group entities. Might not be needed.
         states = None
         gr_state = self._state

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -247,7 +247,6 @@ class HistoryPeriodView(HomeAssistantView):
         return self.json(result.values())
 
 
-# pylint: disable=too-few-public-methods
 class Filters(object):
     """Container for the configured include and exclude filters."""
 

--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -183,7 +183,7 @@ def set_value(hass, entity_id, value):
     hass.services.call(DOMAIN, SERVICE_SET_VALUE, data)
 
 
-# pylint: disable=unused-argument,too-many-locals
+# pylint: disable=unused-argument
 def setup(hass, config):
     """Setup the Homematic component."""
     global HOMEMATIC, HOMEMATIC_LINK_DELAY
@@ -271,7 +271,6 @@ def setup(hass, config):
     return True
 
 
-# pylint: disable=too-many-branches
 def _system_callback_handler(hass, config, src, *args):
     """Callback handler."""
     if src == 'newDevices':
@@ -323,7 +322,6 @@ def _get_devices(device_type, keys):
     """Get the Homematic devices."""
     device_arr = []
 
-    # pylint: disable=too-many-nested-blocks
     for key in keys:
         device = HOMEMATIC.devices[key]
         class_name = device.__class__.__name__
@@ -585,7 +583,6 @@ class HMVariable(Entity):
 class HMDevice(Entity):
     """The Homematic device base object."""
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, config):
         """Initialize a generic Homematic device."""
         self._name = config.get(ATTR_NAME)

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -97,7 +97,6 @@ def request_class():
 class HideSensitiveFilter(logging.Filter):
     """Filter API password calls."""
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, hass):
         """Initialize sensitive data filter."""
         super().__init__()
@@ -246,9 +245,6 @@ class HAStaticRoute(StaticRoute):
 
 class HomeAssistantWSGI(object):
     """WSGI server for Home Assistant."""
-
-    # pylint: disable=too-many-instance-attributes, too-many-locals
-    # pylint: disable=too-many-arguments
 
     def __init__(self, hass, development, api_password, ssl_certificate,
                  ssl_key, server_host, server_port, cors_origins,
@@ -405,7 +401,8 @@ class HomeAssistantView(object):
 
         self.hass = hass
 
-    def json(self, result, status_code=200):  # pylint: disable=no-self-use
+    # pylint: disable=no-self-use
+    def json(self, result, status_code=200):
         """Return a JSON response."""
         msg = json.dumps(
             result, sort_keys=True, cls=rem.JSONEncoder).encode('UTF-8')
@@ -417,7 +414,8 @@ class HomeAssistantView(object):
         return self.json({'message': error}, status_code)
 
     @asyncio.coroutine
-    def file(self, request, fil):  # pylint: disable=no-self-use
+    # pylint: disable=no-self-use
+    def file(self, request, fil):
         """Return a file."""
         assert isinstance(fil, str), 'only string paths allowed'
         response = yield from _GZIP_FILE_SENDER.send(request, Path(fil))

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -49,7 +49,6 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# pylint: disable=too-many-locals
 def setup(hass, config):
     """Setup the InfluxDB component."""
     from influxdb import InfluxDBClient, exceptions

--- a/homeassistant/components/input_select.py
+++ b/homeassistant/components/input_select.py
@@ -148,7 +148,6 @@ def async_setup(hass, config):
 class InputSelect(Entity):
     """Representation of a select input."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, object_id, name, state, options, icon):
         """Initialize a select input."""
         self.entity_id = ENTITY_ID_FORMAT.format(object_id)

--- a/homeassistant/components/input_slider.py
+++ b/homeassistant/components/input_slider.py
@@ -114,7 +114,6 @@ def async_setup(hass, config):
 class InputSlider(Entity):
     """Represent an slider."""
 
-    # pylint: disable=too-many-arguments, too-many-instance-attributes
     def __init__(self, object_id, name, state, minimum, maximum, step, icon,
                  unit):
         """Initialize a select input."""

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -93,15 +93,16 @@ def _categorize_nodes(hidden_identifier: str, sensor_identifier: str) -> None:
     NODES = []
     GROUPS = []
 
+    # pylint: disable=no-member
     for (path, node) in ISY.nodes:
         hidden = hidden_identifier in path or hidden_identifier in node.name
         if hidden:
             node.name += hidden_identifier
         if sensor_identifier in path or sensor_identifier in node.name:
             SENSOR_NODES.append(node)
-        elif isinstance(node, PYISY.Nodes.Node):  # pylint: disable=no-member
+        elif isinstance(node, PYISY.Nodes.Node):
             NODES.append(node)
-        elif isinstance(node, PYISY.Nodes.Group):  # pylint: disable=no-member
+        elif isinstance(node, PYISY.Nodes.Group):
             GROUPS.append(node)
 
 
@@ -131,7 +132,6 @@ def _categorize_programs() -> None:
                         PROGRAMS[component].append(program)
 
 
-# pylint: disable=too-many-locals
 def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the ISY 994 platform."""
     isy_config = config.get(DOMAIN)

--- a/homeassistant/components/joaoapps_join.py
+++ b/homeassistant/components/joaoapps_join.py
@@ -27,7 +27,6 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# pylint: disable=too-many-locals
 def register_device(hass, device_id, api_key, name):
     """Method to register services for each join device listed."""
     from pyjoin import (ring_device, set_wallpaper, send_sms,

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -124,7 +124,6 @@ def is_on(hass, entity_id=None):
     return hass.states.is_state(entity_id, STATE_ON)
 
 
-# pylint: disable=too-many-arguments
 def turn_on(hass, entity_id=None, transition=None, brightness=None,
             rgb_color=None, xy_color=None, color_temp=None, white_value=None,
             profile=None, flash=None, effect=None, color_name=None):
@@ -172,7 +171,6 @@ def toggle(hass, entity_id=None, transition=None):
     hass.services.call(DOMAIN, SERVICE_TOGGLE, data)
 
 
-# pylint: disable=too-many-branches, too-many-locals, too-many-statements
 def setup(hass, config):
     """Expose light control via statemachine and services."""
     component = EntityComponent(

--- a/homeassistant/components/light/demo.py
+++ b/homeassistant/components/light/demo.py
@@ -34,7 +34,6 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 class DemoLight(Light):
     """Represenation of a demo light."""
 
-    # pylint: disable=too-many-arguments
     def __init__(
             self, name, state, rgb=None, ct=None, brightness=180,
             xy_color=(.5, .5), white=200):

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -76,7 +76,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class FluxLight(Light):
     """Representation of a Flux light."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, device):
         """Initialize the light."""
         import flux_led

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -199,7 +199,6 @@ def request_configuration(host, hass, add_devices, filename,
 class HueLight(Light):
     """Representation of a Hue light."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, light_id, info, bridge, update_lights,
                  bridge_type, allow_unreachable):
         """Initialize the light."""

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -80,7 +80,6 @@ class LIFX(object):
                 break
         return bulb
 
-    # pylint: disable=too-many-arguments
     def on_device(self, ipaddr, name, power, hue, sat, bri, kel):
         """Initialize the light."""
         bulb = self.find_bulb(ipaddr)
@@ -99,7 +98,6 @@ class LIFX(object):
             bulb.set_color(hue, sat, bri, kel)
             bulb.update_ha_state()
 
-    # pylint: disable=too-many-arguments
     def on_color(self, ipaddr, hue, sat, bri, kel):
         """Initialize the light."""
         bulb = self.find_bulb(ipaddr)
@@ -137,11 +135,9 @@ def convert_rgb_to_hsv(rgb):
             int(brightness * SHORT_MAX)]
 
 
-# pylint: disable=too-many-instance-attributes
 class LIFXLight(Light):
     """Representation of a LIFX light."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, liffy, ipaddr, name, power, hue, saturation, brightness,
                  kelvin):
         """Initialize the light."""

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -101,8 +101,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class MqttLight(Light):
     """MQTT light."""
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes
-    # pylint: disable=too-many-locals,too-many-branches
     def __init__(self, hass, name, topic, templates, qos, retain, payload,
                  optimistic, brightness_scale):
         """Initialize MQTT light."""

--- a/homeassistant/components/light/mqtt_json.py
+++ b/homeassistant/components/light/mqtt_json.py
@@ -85,7 +85,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class MqttJson(Light):
     """Representation of a MQTT JSON light."""
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(self, hass, name, topic, qos, retain,
                  optimistic, brightness, rgb, flash_times):
         """Initialize MQTT JSON light."""

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -78,7 +78,6 @@ class WinkLight(WinkDevice, Light):
         """Flag supported features."""
         return SUPPORT_WINK
 
-    # pylint: disable=too-few-public-methods
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         brightness = kwargs.get(ATTR_BRIGHTNESS)

--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -43,7 +43,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class YeelightLight(Light):
     """Representation of a Yeelight light."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, device):
         """Initialize the light."""
         import pyyeelight

--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -105,7 +105,6 @@ def brightness_state(value):
 class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
     """Representation of a Z-Wave dimmer."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, value):
         """Initialize the light."""
         from openzwave.network import ZWaveNetwork
@@ -263,7 +262,6 @@ class ZwaveColorLight(ZwaveDimmer):
         # Check for the missing color values
         self._get_color_values()
 
-    # pylint: disable=too-many-branches
     def update_properties(self):
         """Update internal properties based on zwave values."""
         super().update_properties()

--- a/homeassistant/components/lock/mqtt.py
+++ b/homeassistant/components/lock/mqtt.py
@@ -58,7 +58,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     )])
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 class MqttLock(LockDevice):
     """Represents a lock that can be toggled using MQTT."""
 

--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -154,7 +154,6 @@ class LogbookView(HomeAssistantView):
 class Entry(object):
     """A human readable version of the log."""
 
-    # pylint: disable=too-many-arguments, too-few-public-methods
     def __init__(self, when=None, name=None, message=None, domain=None,
                  entity_id=None):
         """Initialize the entry."""
@@ -182,7 +181,6 @@ def humanify(events):
      - if 2+ sensor updates in GROUP_BY_MINUTES, show last
      - if home assistant stop and start happen in same minute call it restarted
     """
-    # pylint: disable=too-many-branches
     # Group events in batches of GROUP_BY_MINUTES
     for _, g_events in groupby(
             events,
@@ -288,7 +286,6 @@ def humanify(events):
 
 def _exclude_events(events, config):
     """Get lists of excluded entities and platforms."""
-    # pylint: disable=too-many-branches
     excluded_entities = []
     excluded_domains = []
     included_entities = []
@@ -355,10 +352,10 @@ def _exclude_events(events, config):
     return filtered_events
 
 
+# pylint: disable=too-many-return-statements
 def _entry_message_from_state(domain, state):
     """Convert a state to a message for the logbook."""
     # We pass domain in so we don't have to split entity_id again
-    # pylint: disable=too-many-return-statements
     if domain == 'device_tracker':
         if state.state == STATE_NOT_HOME:
             return 'is away'

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -398,10 +398,8 @@ def setup(hass, config):
 class MediaPlayerDevice(Entity):
     """ABC for media player devices."""
 
-    # pylint: disable=too-many-public-methods,no-self-use
-
+    # pylint: disable=no-self-use
     # Implement these for your media player
-
     @property
     def state(self):
         """State of the player."""

--- a/homeassistant/components/media_player/braviatv.py
+++ b/homeassistant/components/media_player/braviatv.py
@@ -117,7 +117,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     setup_bravia(config, pin, hass, add_devices)
 
 
-# pylint: disable=too-many-branches
 def setup_bravia(config, pin, hass, add_devices):
     """Setup a Sony Bravia TV based on host parameter."""
     host = config.get(CONF_HOST)
@@ -181,8 +180,7 @@ def request_configuration(config, hass, add_devices):
     )
 
 
-# pylint: disable=abstract-method, too-many-public-methods,
-# pylint: disable=too-many-instance-attributes, too-many-arguments
+# pylint: disable=abstract-method
 class BraviaTVDevice(MediaPlayerDevice):
     """Representation of a Sony Bravia TV."""
 

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -89,7 +89,6 @@ class CastDevice(MediaPlayerDevice):
     """Representation of a Cast device on the network."""
 
     # pylint: disable=abstract-method
-    # pylint: disable=too-many-public-methods
     def __init__(self, chromecast):
         """Initialize the Cast device."""
         self.cast = chromecast

--- a/homeassistant/components/media_player/cmus.py
+++ b/homeassistant/components/media_player/cmus.py
@@ -58,7 +58,7 @@ def setup_platform(hass, config, add_devices, discover_info=None):
 class CmusDevice(MediaPlayerDevice):
     """Representation of a running cmus."""
 
-    # pylint: disable=no-member, too-many-public-methods, abstract-method
+    # pylint: disable=no-member, abstract-method
     def __init__(self, server, password, port, name):
         """Initialize the CMUS device."""
         from pycmus import remote

--- a/homeassistant/components/media_player/denon.py
+++ b/homeassistant/components/media_player/denon.py
@@ -45,7 +45,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class DenonDevice(MediaPlayerDevice):
     """Representation of a Denon device."""
 
-    # pylint: disable=too-many-public-methods, abstract-method
+    # pylint: disable=abstract-method
     def __init__(self, name, host):
         """Initialize the Denon device."""
         self._name = name

--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -66,7 +66,6 @@ class DirecTvDevice(MediaPlayerDevice):
     """Representation of a DirecTV reciever on the network."""
 
     # pylint: disable=abstract-method
-    # pylint: disable=too-many-public-methods
     def __init__(self, name, host, port):
         """Initialize the device."""
         from DirectPy import DIRECTV

--- a/homeassistant/components/media_player/gpmdp.py
+++ b/homeassistant/components/media_player/gpmdp.py
@@ -170,8 +170,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 class GPMDP(MediaPlayerDevice):
     """Representation of a GPMDP."""
 
-    # pylint: disable=too-many-public-methods, abstract-method
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=abstract-method
     def __init__(self, name, url, code):
         """Initialize the media player."""
         from websocket import create_connection

--- a/homeassistant/components/media_player/itunes.py
+++ b/homeassistant/components/media_player/itunes.py
@@ -154,7 +154,6 @@ class Itunes(object):
 
 
 # pylint: disable=unused-argument, abstract-method
-# pylint: disable=too-many-instance-attributes
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the iTunes platform."""
     add_devices([
@@ -172,7 +171,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class ItunesDevice(MediaPlayerDevice):
     """Representation of an iTunes API instance."""
 
-    # pylint: disable=too-many-public-methods, too-many-arguments
     def __init__(self, name, host, port, use_ssl, add_devices):
         """Initialize the iTunes device."""
         self._name = name
@@ -353,7 +351,6 @@ class ItunesDevice(MediaPlayerDevice):
 class AirPlayDevice(MediaPlayerDevice):
     """Representation an AirPlay device via an iTunes API instance."""
 
-    # pylint: disable=too-many-public-methods
     def __init__(self, device_id, client):
         """Initialize the AirPlay device."""
         self._id = device_id

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -63,8 +63,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class KodiDevice(MediaPlayerDevice):
     """Representation of a XBMC/Kodi device."""
 
-    # pylint: disable=too-many-public-methods, abstract-method
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=abstract-method
     def __init__(self, name, url, auth=None, turn_off_action=None):
         """Initialize the Kodi device."""
         import jsonrpc_requests

--- a/homeassistant/components/media_player/lg_netcast.py
+++ b/homeassistant/components/media_player/lg_netcast.py
@@ -52,8 +52,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([LgTVDevice(client, config[CONF_NAME])])
 
 
-# pylint: disable=too-many-public-methods, abstract-method
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=abstract-method
 class LgTVDevice(MediaPlayerDevice):
     """Representation of a LG TV."""
 

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -77,7 +77,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class MpdDevice(MediaPlayerDevice):
     """Representation of a MPD server."""
 
-    # pylint: disable=no-member, too-many-public-methods, abstract-method
+    # pylint: disable=no-member, abstract-method
     def __init__(self, server, port, location, password):
         """Initialize the MPD device."""
         import mpd

--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -65,11 +65,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(hosts)
 
 
-# pylint: disable=too-many-instance-attributes
 class OnkyoDevice(MediaPlayerDevice):
     """Representation of an Onkyo device."""
 
-    # pylint: disable=too-many-public-methods, abstract-method
+    # pylint: disable=abstract-method
     def __init__(self, receiver, sources, name=None):
         """Initialize the Onkyo Receiver."""
         self._receiver = receiver

--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -72,7 +72,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class PanasonicVieraTVDevice(MediaPlayerDevice):
     """Representation of a Panasonic Viera TV."""
 
-    # pylint: disable=too-many-public-methods
     def __init__(self, name, remote):
         """Initialize the samsung device."""
         # Save a reference to the imported class

--- a/homeassistant/components/media_player/pandora.py
+++ b/homeassistant/components/media_player/pandora.py
@@ -60,7 +60,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([pandora])
 
 
-# pylint: disable=too-many-instance-attributes
 class PandoraMediaPlayer(MediaPlayerDevice):
     """A media player that uses the Pianobar interface to Pandora."""
 

--- a/homeassistant/components/media_player/pioneer.py
+++ b/homeassistant/components/media_player/pioneer.py
@@ -54,8 +54,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class PioneerDevice(MediaPlayerDevice):
     """Representation of a Pioneer device."""
 
-    # pylint: disable=too-many-public-methods, abstract-method
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=abstract-method
     def __init__(self, name, host, port, timeout):
         """Initialize the Pioneer device."""
         self._name = name

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -83,7 +83,6 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     setup_plexserver(host, token, hass, add_devices_callback)
 
 
-# pylint: disable=too-many-branches
 def setup_plexserver(host, token, hass, add_devices_callback):
     """Setup a plexserver based on host parameter."""
     import plexapi.server
@@ -192,7 +191,7 @@ def request_configuration(host, hass, add_devices_callback):
 class PlexClient(MediaPlayerDevice):
     """Representation of a Plex device."""
 
-    # pylint: disable=too-many-public-methods, attribute-defined-outside-init
+    # pylint: disable=attribute-defined-outside-init
     def __init__(self, device, plex_sessions, update_devices, update_sessions):
         """Initialize the Plex device."""
         from plexapi.utils import NA

--- a/homeassistant/components/media_player/roku.py
+++ b/homeassistant/components/media_player/roku.py
@@ -66,7 +66,6 @@ class RokuDevice(MediaPlayerDevice):
     """Representation of a Roku device on the network."""
 
     # pylint: disable=abstract-method
-    # pylint: disable=too-many-public-methods
     def __init__(self, host):
         """Initialize the Roku device."""
         from roku import Roku

--- a/homeassistant/components/media_player/russound_rnet.py
+++ b/homeassistant/components/media_player/russound_rnet.py
@@ -72,8 +72,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error('Not connected to %s:%s', host, port)
 
 
-# pylint: disable=abstract-method, too-many-public-methods,
-# pylint: disable=too-many-instance-attributes, too-many-arguments
+# pylint: disable=abstract-method
 class RussoundRNETDevice(MediaPlayerDevice):
     """Representation of a Russound RNET device."""
 

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -60,7 +60,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class SamsungTVDevice(MediaPlayerDevice):
     """Representation of a Samsung TV."""
 
-    # pylint: disable=too-many-public-methods
     def __init__(self, name, config):
         """Initialize the Samsung device."""
         from samsungctl import Remote

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -64,7 +64,6 @@ SONOS_SET_TIMER_SCHEMA = SONOS_SCHEMA.extend({
 DEVICES = []
 
 
-# pylint: disable=unused-argument, too-many-locals
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Sonos platform."""
     import soco
@@ -224,12 +223,10 @@ def only_if_coordinator(func):
     return wrapper
 
 
-# pylint: disable=too-many-instance-attributes, too-many-public-methods
 # pylint: disable=abstract-method
 class SonosDevice(MediaPlayerDevice):
     """Representation of a Sonos device."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, player):
         """Initialize the Sonos device."""
         from soco.snapshot import Snapshot

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -171,12 +171,10 @@ class LogitechMediaServer(object):
             return None
 
 
-# pylint: disable=too-many-instance-attributes
-# pylint: disable=too-many-public-methods
 class SqueezeBoxDevice(MediaPlayerDevice):
     """Representation of a SqueezeBox device."""
 
-    # pylint: disable=too-many-arguments, abstract-method
+    # pylint: disable=abstract-method
     def __init__(self, lms, player_id):
         """Initialize the SqeezeBox device."""
         super(SqueezeBoxDevice, self).__init__()

--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -132,10 +132,8 @@ def validate_attributes(config):
 class UniversalMediaPlayer(MediaPlayerDevice):
     """Representation of an universal media player."""
 
-    # pylint: disable=too-many-public-methods
     def __init__(self, hass, name, children, commands, attributes):
         """Initialize the Universal media device."""
-        # pylint: disable=too-many-arguments
         self.hass = hass
         self._name = name
         self._children = children

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -142,11 +142,9 @@ def request_configuration(host, name, customize, hass, add_devices):
 
 
 # pylint: disable=abstract-method
-# pylint: disable=too-many-instance-attributes
 class LgWebOSDevice(MediaPlayerDevice):
     """Representation of a LG WebOS TV."""
 
-    # pylint: disable=too-many-public-methods
     def __init__(self, host, name, customize):
         """Initialize the webos device."""
         from pylgtv import WebOsClient

--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -41,7 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=too-many-locals
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Yamaha platform."""
     import rxv
@@ -80,8 +79,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class YamahaDevice(MediaPlayerDevice):
     """Representation of a Yamaha device."""
 
-    # pylint: disable=too-many-public-methods, abstract-method
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=abstract-method
     def __init__(self, name, receiver, source_ignore, source_names):
         """Initialize the Yamaha Receiver."""
         self._receiver = receiver

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -206,7 +206,6 @@ def _setup_server(hass, config):
 
 def setup(hass, config):
     """Start the MQTT protocol service."""
-    # pylint: disable=too-many-locals
     conf = config.get(DOMAIN, {})
 
     client_id = conf.get(CONF_CLIENT_ID)
@@ -292,7 +291,6 @@ def setup(hass, config):
     return True
 
 
-# pylint: disable=too-many-arguments
 class MQTT(object):
     """Home Assistant MQTT client."""
 

--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -69,7 +69,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-def setup(hass, config):  # pylint: disable=too-many-locals
+def setup(hass, config):
     """Setup the MySensors component."""
     import mysensors.mysensors as mysensors
 
@@ -79,7 +79,6 @@ def setup(hass, config):  # pylint: disable=too-many-locals
     def setup_gateway(device, persistence_file, baud_rate, tcp_port, in_prefix,
                       out_prefix):
         """Return gateway after setup of the gateway."""
-        # pylint: disable=too-many-arguments
         if device == MQTT_COMPONENT:
             if not setup_component(hass, MQTT_COMPONENT, config):
                 return
@@ -201,8 +200,6 @@ def pf_callback_factory(map_sv_types, devices, add_devices, entity_class):
 class GatewayWrapper(object):
     """Gateway wrapper class."""
 
-    # pylint: disable=too-few-public-methods
-
     def __init__(self, gateway, optimistic, device):
         """Setup class attributes on instantiation.
 
@@ -255,8 +252,6 @@ class GatewayWrapper(object):
 
 class MySensorsDeviceEntity(object):
     """Represent a MySensors entity."""
-
-    # pylint: disable=too-many-arguments
 
     def __init__(
             self, gateway, node_id, child_id, name, value_type, child_type):

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -64,7 +64,6 @@ def send_message(hass, message, title=None, data=None):
     hass.services.call(DOMAIN, SERVICE_NOTIFY, info)
 
 
-# pylint: disable=too-many-locals
 def setup(hass, config):
     """Setup the notify services."""
     success = False
@@ -134,7 +133,6 @@ def setup(hass, config):
     return success
 
 
-# pylint: disable=too-few-public-methods
 class BaseNotificationService(object):
     """An abstract class for notification services."""
 

--- a/homeassistant/components/notify/apns.py
+++ b/homeassistant/components/notify/apns.py
@@ -130,8 +130,6 @@ class ApnsDevice(object):
 class ApnsNotificationService(BaseNotificationService):
     """Implement the notification service for the APNS service."""
 
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, hass, app_name, topic, sandbox, cert_file):
         """Initialize APNS application."""
         self.hass = hass

--- a/homeassistant/components/notify/aws_lambda.py
+++ b/homeassistant/components/notify/aws_lambda.py
@@ -62,7 +62,6 @@ def get_service(hass, config):
     return AWSLambda(lambda_client, context)
 
 
-# pylint: disable=too-few-public-methods
 class AWSLambda(BaseNotificationService):
     """Implement the notification service for the AWS Lambda service."""
 

--- a/homeassistant/components/notify/aws_sns.py
+++ b/homeassistant/components/notify/aws_sns.py
@@ -54,7 +54,6 @@ def get_service(hass, config):
     return AWSSNS(sns_client)
 
 
-# pylint: disable=too-few-public-methods
 class AWSSNS(BaseNotificationService):
     """Implement the notification service for the AWS SNS service."""
 

--- a/homeassistant/components/notify/aws_sqs.py
+++ b/homeassistant/components/notify/aws_sqs.py
@@ -53,7 +53,6 @@ def get_service(hass, config):
     return AWSSQS(sqs_client)
 
 
-# pylint: disable=too-few-public-methods
 class AWSSQS(BaseNotificationService):
     """Implement the notification service for the AWS SQS service."""
 

--- a/homeassistant/components/notify/command_line.py
+++ b/homeassistant/components/notify/command_line.py
@@ -29,7 +29,6 @@ def get_service(hass, config):
     return CommandLineNotificationService(command)
 
 
-# pylint: disable=too-few-public-methods
 class CommandLineNotificationService(BaseNotificationService):
     """Implement the notification service for the Command Line service."""
 

--- a/homeassistant/components/notify/demo.py
+++ b/homeassistant/components/notify/demo.py
@@ -14,7 +14,6 @@ def get_service(hass, config):
     return DemoNotificationService(hass)
 
 
-# pylint: disable=too-few-public-methods
 class DemoNotificationService(BaseNotificationService):
     """Implement demo notification service."""
 

--- a/homeassistant/components/notify/ecobee.py
+++ b/homeassistant/components/notify/ecobee.py
@@ -30,7 +30,6 @@ def get_service(hass, config):
     return EcobeeNotificationService(index)
 
 
-# pylint: disable=too-few-public-methods
 class EcobeeNotificationService(BaseNotificationService):
     """Implement the notification service for the Ecobee thermostat."""
 

--- a/homeassistant/components/notify/file.py
+++ b/homeassistant/components/notify/file.py
@@ -33,7 +33,6 @@ def get_service(hass, config):
     return FileNotificationService(hass, filename, timestamp)
 
 
-# pylint: disable=too-few-public-methods
 class FileNotificationService(BaseNotificationService):
     """Implement the notification service for the File service."""
 

--- a/homeassistant/components/notify/free_mobile.py
+++ b/homeassistant/components/notify/free_mobile.py
@@ -29,7 +29,6 @@ def get_service(hass, config):
                                       config[CONF_ACCESS_TOKEN])
 
 
-# pylint: disable=too-few-public-methods
 class FreeSMSNotificationService(BaseNotificationService):
     """Implement a notification service for the Free Mobile SMS service."""
 

--- a/homeassistant/components/notify/gntp.py
+++ b/homeassistant/components/notify/gntp.py
@@ -55,11 +55,9 @@ def get_service(hass, config):
                                    config.get(CONF_PORT))
 
 
-# pylint: disable=too-few-public-methods
 class GNTPNotificationService(BaseNotificationService):
     """Implement the notification service for GNTP."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, app_name, app_icon, hostname, password, port):
         """Initialize the service."""
         import gntp.notifier

--- a/homeassistant/components/notify/group.py
+++ b/homeassistant/components/notify/group.py
@@ -42,7 +42,6 @@ def get_service(hass, config):
     return GroupNotifyPlatform(hass, config.get(CONF_SERVICES))
 
 
-# pylint: disable=too-few-public-methods
 class GroupNotifyPlatform(BaseNotificationService):
     """Implement the notification service for the group notify playform."""
 

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -255,7 +255,6 @@ class HTML5PushCallbackView(HomeAssistantView):
 
     # The following is based on code from Auth0
     # https://auth0.com/docs/quickstart/backend/python
-    # pylint: disable=too-many-return-statements
     def check_authorization_header(self, request):
         """Check the authorization header."""
         import jwt
@@ -320,11 +319,9 @@ class HTML5PushCallbackView(HomeAssistantView):
                           'event': event_payload[ATTR_TYPE]})
 
 
-# pylint: disable=too-few-public-methods
 class HTML5NotificationService(BaseNotificationService):
     """Implement the notification service for HTML5."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, gcm_key, registrations):
         """Initialize the service."""
         self._gcm_key = gcm_key
@@ -338,7 +335,6 @@ class HTML5NotificationService(BaseNotificationService):
             targets[registration] = registration
         return targets
 
-    # pylint: disable=too-many-locals
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
         import jwt

--- a/homeassistant/components/notify/instapush.py
+++ b/homeassistant/components/notify/instapush.py
@@ -60,7 +60,6 @@ def get_service(hass, config):
         config.get(CONF_EVENT), config.get(CONF_TRACKER))
 
 
-# pylint: disable=too-few-public-methods
 class InstapushNotificationService(BaseNotificationService):
     """Implementation of the notification service for Instapush."""
 

--- a/homeassistant/components/notify/ios.py
+++ b/homeassistant/components/notify/ios.py
@@ -55,7 +55,6 @@ def get_service(hass, config):
     return iOSNotificationService()
 
 
-# pylint: disable=too-few-public-methods, too-many-arguments, invalid-name
 class iOSNotificationService(BaseNotificationService):
     """Implement the notification service for iOS."""
 

--- a/homeassistant/components/notify/joaoapps_join.py
+++ b/homeassistant/components/notify/joaoapps_join.py
@@ -39,7 +39,6 @@ def get_service(hass, config):
     return JoinNotificationService(device_id, api_key)
 
 
-# pylint: disable=too-few-public-methods
 class JoinNotificationService(BaseNotificationService):
     """Implement the notification service for Join."""
 

--- a/homeassistant/components/notify/kodi.py
+++ b/homeassistant/components/notify/kodi.py
@@ -41,7 +41,6 @@ def get_service(hass, config):
     )
 
 
-# pylint: disable=too-few-public-methods
 class KODINotificationService(BaseNotificationService):
     """Implement the notification service for Kodi."""
 

--- a/homeassistant/components/notify/llamalab_automate.py
+++ b/homeassistant/components/notify/llamalab_automate.py
@@ -35,7 +35,6 @@ def get_service(hass, config):
     return AutomateNotificationService(secret, recipient, device)
 
 
-# pylint: disable=too-few-public-methods
 class AutomateNotificationService(BaseNotificationService):
     """Implement the notification service for LlamaLab Automate."""
 

--- a/homeassistant/components/notify/matrix.py
+++ b/homeassistant/components/notify/matrix.py
@@ -48,11 +48,9 @@ def get_service(hass, config):
     )
 
 
-# pylint: disable=too-few-public-methods
 class MatrixNotificationService(BaseNotificationService):
     """Wrapper for the MatrixNotificationClient."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, homeserver, default_room, verify_ssl,
                  username, password):
         """Buffer configuration data for send_message."""
@@ -94,7 +92,6 @@ def store_token(mx_id, token):
         handle.write(json.dumps(AUTH_TOKENS))
 
 
-# pylint: disable=too-many-locals, too-many-arguments
 def send_message(message, homeserver, target_rooms, verify_tls,
                  username, password):
     """Do everything thats necessary to send a message to a Matrix room."""

--- a/homeassistant/components/notify/message_bird.py
+++ b/homeassistant/components/notify/message_bird.py
@@ -40,7 +40,6 @@ def get_service(hass, config):
     return MessageBirdNotificationService(config.get(CONF_SENDER), client)
 
 
-# pylint: disable=too-few-public-methods
 class MessageBirdNotificationService(BaseNotificationService):
     """Implement the notification service for MessageBird."""
 

--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -98,11 +98,9 @@ def get_service(hass, config):
         remoteip, duration, position, transparency, color, interrupt, timeout)
 
 
-# pylint: disable=too-many-instance-attributes
 class NFAndroidTVNotificationService(BaseNotificationService):
     """Notification service for Notifications for Android TV."""
 
-    # pylint: disable=too-many-arguments,too-few-public-methods
     def __init__(self, remoteip, duration, position, transparency, color,
                  interrupt, timeout):
         """Initialize the service."""
@@ -117,7 +115,6 @@ class NFAndroidTVNotificationService(BaseNotificationService):
             os.path.dirname(__file__), '..', 'frontend', 'www_static', 'icons',
             'favicon-192x192.png')
 
-    # pylint: disable=too-many-branches
     def send_message(self, message="", **kwargs):
         """Send a message to a Android TV device."""
         _LOGGER.debug("Sending notification to: %s", self._target)

--- a/homeassistant/components/notify/nma.py
+++ b/homeassistant/components/notify/nma.py
@@ -37,7 +37,6 @@ def get_service(hass, config):
     return NmaNotificationService(config[CONF_API_KEY])
 
 
-# pylint: disable=too-few-public-methods
 class NmaNotificationService(BaseNotificationService):
     """Implement the notification service for NMA."""
 

--- a/homeassistant/components/notify/pushbullet.py
+++ b/homeassistant/components/notify/pushbullet.py
@@ -41,7 +41,6 @@ def get_service(hass, config):
     return PushBulletNotificationService(pushbullet)
 
 
-# pylint: disable=too-few-public-methods, too-many-branches
 class PushBulletNotificationService(BaseNotificationService):
     """Implement the notification service for Pushbullet."""
 

--- a/homeassistant/components/notify/pushetta.py
+++ b/homeassistant/components/notify/pushetta.py
@@ -37,7 +37,6 @@ def get_service(hass, config):
         return pushetta_service
 
 
-# pylint: disable=too-few-public-methods
 class PushettaNotificationService(BaseNotificationService):
     """Implement the notification service for Pushetta."""
 

--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -40,7 +40,6 @@ def get_service(hass, config):
         return None
 
 
-# pylint: disable=too-few-public-methods
 class PushoverNotificationService(BaseNotificationService):
     """Implement the notification service for Pushover."""
 

--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -52,7 +52,6 @@ def get_service(hass, config):
         target_param_name)
 
 
-# pylint: disable=too-few-public-methods, too-many-arguments
 class RestNotificationService(BaseNotificationService):
     """Implementation of a notification service for REST."""
 

--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -34,7 +34,6 @@ def get_service(hass, config):
     return SendgridNotificationService(api_key, sender, recipient)
 
 
-# pylint: disable=too-few-public-methods
 class SendgridNotificationService(BaseNotificationService):
     """Implementation the notification service for email via Sendgrid."""
 

--- a/homeassistant/components/notify/simplepush.py
+++ b/homeassistant/components/notify/simplepush.py
@@ -30,7 +30,6 @@ def get_service(hass, config):
     return SimplePushNotificationService(config.get(CONF_DEVICE_KEY))
 
 
-# pylint: disable=too-few-public-methods
 class SimplePushNotificationService(BaseNotificationService):
     """Implementation of the notification service for SimplePush."""
 

--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -45,7 +45,6 @@ def get_service(hass, config):
         return None
 
 
-# pylint: disable=too-few-public-methods
 class SlackNotificationService(BaseNotificationService):
     """Implement the notification service for Slack."""
 

--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -63,11 +63,9 @@ def get_service(hass, config):
         return None
 
 
-# pylint: disable=too-few-public-methods, too-many-instance-attributes
 class MailNotificationService(BaseNotificationService):
     """Implement the notification service for E-Mail messages."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, server, port, sender, starttls, username,
                  password, recipient, debug):
         """Initialize the service."""

--- a/homeassistant/components/notify/syslog.py
+++ b/homeassistant/components/notify/syslog.py
@@ -78,11 +78,9 @@ def get_service(hass, config):
     return SyslogNotificationService(facility, option, priority)
 
 
-# pylint: disable=too-few-public-methods
 class SyslogNotificationService(BaseNotificationService):
     """Implement the syslog notification service."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, facility, option, priority):
         """Initialize the service."""
         self._facility = facility

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -77,7 +77,6 @@ def load_data(url=None, file=None, username=None, password=None):
     return None
 
 
-# pylint: disable=too-few-public-methods
 class TelegramNotificationService(BaseNotificationService):
     """Implement the notification service for Telegram."""
 

--- a/homeassistant/components/notify/telstra.py
+++ b/homeassistant/components/notify/telstra.py
@@ -41,7 +41,6 @@ def get_service(hass, config):
         consumer_key, consumer_secret, phone_number)
 
 
-# pylint: disable=too-few-public-methods, too-many-arguments
 class TelstraNotificationService(BaseNotificationService):
     """Implementation of a notification service for the Telstra SMS API."""
 

--- a/homeassistant/components/notify/twilio_sms.py
+++ b/homeassistant/components/notify/twilio_sms.py
@@ -40,7 +40,6 @@ def get_service(hass, config):
                                         config[CONF_FROM_NUMBER])
 
 
-# pylint: disable=too-few-public-methods
 class TwilioSMSNotificationService(BaseNotificationService):
     """Implement the notification service for the Twilio SMS service."""
 

--- a/homeassistant/components/notify/twitter.py
+++ b/homeassistant/components/notify/twitter.py
@@ -37,7 +37,6 @@ def get_service(hass, config):
     )
 
 
-# pylint: disable=too-few-public-methods
 class TwitterNotificationService(BaseNotificationService):
     """Implementation of a notification service for the Twitter service."""
 

--- a/homeassistant/components/notify/webostv.py
+++ b/homeassistant/components/notify/webostv.py
@@ -43,7 +43,6 @@ def get_service(hass, config):
     return LgWebOSNotificationService(client)
 
 
-# pylint: disable=too-few-public-methods
 class LgWebOSNotificationService(BaseNotificationService):
     """Implement the notification service for LG WebOS TV."""
 

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -39,7 +39,6 @@ def get_service(hass, config):
         config.get('tls'))
 
 
-# pylint: disable=too-few-public-methods
 class XmppNotificationService(BaseNotificationService):
     """Implement the notification service for Jabber (XMPP)."""
 

--- a/homeassistant/components/nuimo_controller.py
+++ b/homeassistant/components/nuimo_controller.py
@@ -51,7 +51,7 @@ def setup(hass, config):
     return True
 
 
-class NuimoLogger(object):  # pylint: disable=too-few-public-methods
+class NuimoLogger(object):
     """Handle Nuimo Controller event callbacks."""
 
     def __init__(self, hass, name):
@@ -94,7 +94,8 @@ class NuimoThread(threading.Thread):
             self._nuimo.disconnect()
             self._nuimo = None
 
-    def stop(self, event):  # pylint: disable=unused-argument
+    # pylint: disable=unused-argument
+    def stop(self, event):
         """Terminate Thread by unsetting flag."""
         _LOGGER.debug('Stopping thread for Nuimo %s', self._mac)
         self._hass_is_running = False
@@ -169,14 +170,17 @@ HOMEASSIST_LOGO = (
 class DiscoveryLogger(object):
     """Handle Nuimo Discovery callbacks."""
 
-    def discovery_started(self):  # pylint: disable=no-self-use
+    # pylint: disable=no-self-use
+    def discovery_started(self):
         """Discovery startet."""
         _LOGGER.info("started discovery")
 
-    def discovery_finished(self):  # pylint: disable=no-self-use
+    # pylint: disable=no-self-use
+    def discovery_finished(self):
         """Discovery finished."""
         _LOGGER.info("finished discovery")
 
-    def controller_added(self, nuimo):  # pylint: disable=no-self-use
+    # pylint: disable=no-self-use
+    def controller_added(self, nuimo):
         """Controller found."""
         _LOGGER.info("added Nuimo: %s", nuimo)

--- a/homeassistant/components/openalpr.py
+++ b/homeassistant/components/openalpr.py
@@ -117,7 +117,6 @@ def restart(hass, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_RESTART, data)
 
 
-# pylint: disable=too-many-locals
 def setup(hass, config):
     """Setup the OpenAlpr component."""
     engine = config[DOMAIN].get(CONF_ENGINE)
@@ -291,7 +290,6 @@ class OpenalprDevice(Entity):
 class OpenalprDeviceFFmpeg(OpenalprDevice):
     """Represent a openalpr device object for processing stream/images."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, name, interval, api, input_source,
                  extra_arguments=None):
         """Init image processing."""
@@ -362,7 +360,6 @@ class OpenalprDeviceFFmpeg(OpenalprDevice):
 class OpenalprDeviceImage(OpenalprDevice):
     """Represent a openalpr device object for processing stream/images."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, name, interval, api, input_source,
                  username=None, password=None):
         """Init image processing."""
@@ -403,7 +400,6 @@ class OpenalprDeviceImage(OpenalprDevice):
         self._next = time() + self._interval
 
 
-# pylint: disable=too-few-public-methods
 class OpenalprApi(object):
     """OpenAlpr api class."""
 
@@ -417,7 +413,6 @@ class OpenalprApi(object):
         raise NotImplementedError()
 
 
-# pylint: disable=too-few-public-methods
 class OpenalprApiCloud(OpenalprApi):
     """Use the cloud openalpr api to parse licences plate."""
 

--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -87,11 +87,9 @@ def setup(hass, config):
     return True
 
 
-# pylint: disable=too-many-instance-attributes
 class Proximity(Entity):
     """Representation of a Proximity."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, zone_friendly_name, dist_to, dir_of_travel,
                  nearest, ignored_zones, proximity_devices, tolerance,
                  proximity_zone, unit_of_measurement):
@@ -130,7 +128,6 @@ class Proximity(Entity):
             ATTR_NEAREST: self.nearest,
         }
 
-    # pylint: disable=too-many-branches,too-many-statements,too-many-locals
     def check_proximity_state_change(self, entity, old_state, new_state):
         """Function to perform the proximity checking."""
         entity_name = new_state.name

--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -117,7 +117,6 @@ class QSLight(QSToggleEntity, Light):
         return SUPPORT_QWIKSWITCH
 
 
-# pylint: disable=too-many-locals
 def setup(hass, config):
     """Setup the QSUSB component."""
     from pyqwikswitch import (QSUsb, CMD_BUTTONS, QS_NAME, QS_ID, QS_CMD,

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -153,7 +153,6 @@ def log_error(e: Exception, retry_wait: Optional[float]=0,
 class Recorder(threading.Thread):
     """A threaded recorder class."""
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, hass: HomeAssistant, purge_days: int, uri: str) -> None:
         """Initialize the recorder."""
         threading.Thread.__init__(self)

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -20,7 +20,6 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Events(Base):  # type: ignore
-    # pylint: disable=too-few-public-methods
     """Event history data."""
 
     __tablename__ = 'events'
@@ -55,7 +54,6 @@ class Events(Base):  # type: ignore
 
 
 class States(Base):   # type: ignore
-    # pylint: disable=too-few-public-methods
     """State change history."""
 
     __tablename__ = 'states'
@@ -115,7 +113,6 @@ class States(Base):   # type: ignore
 
 
 class RecorderRuns(Base):   # type: ignore
-    # pylint: disable=too-few-public-methods
     """Representation of recorder run."""
 
     __tablename__ = 'recorder_runs'

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -279,7 +279,6 @@ class RfxtrxDevice(Entity):
     """Represents a Rfxtrx device.
 
     Contains the common logic for Rfxtrx lights and switches.
-
     """
 
     def __init__(self, name, event, datas, signal_repetitions):
@@ -327,7 +326,6 @@ class RfxtrxDevice(Entity):
         self.update_ha_state()
 
     def _send_command(self, command, brightness=0):
-        # pylint: disable=too-many-return-statements,too-many-branches
         if not self._event:
             return
 

--- a/homeassistant/components/script.py
+++ b/homeassistant/components/script.py
@@ -122,7 +122,6 @@ def setup(hass, config):
 class ScriptEntity(ToggleEntity):
     """Representation of a script entity."""
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, hass, object_id, name, sequence):
         """Initialize the script."""
         self.entity_id = ENTITY_ID_FORMAT.format(object_id)

--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -44,7 +44,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=too-many-locals
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the aREST sensor."""
     resource = config.get(CONF_RESOURCE)
@@ -108,7 +107,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(dev)
 
 
-# pylint: disable=too-many-instance-attributes, too-many-arguments
 class ArestSensor(Entity):
     """Implementation of an aREST sensor for exposed variables."""
 
@@ -163,7 +161,6 @@ class ArestSensor(Entity):
         return self.arest.available
 
 
-# pylint: disable=too-few-public-methods
 class ArestData(object):
     """The Class for handling the data retrieval for variables."""
 

--- a/homeassistant/components/sensor/bbox.py
+++ b/homeassistant/components/sensor/bbox.py
@@ -48,7 +48,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=too-many-arguments
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Bbox sensor."""
     # Create a data fetcher to support all of the configured sensors. Then make
@@ -128,7 +127,6 @@ class BboxSensor(Entity):
                                 2)
 
 
-# pylint: disable=too-few-public-methods
 class BboxData(object):
     """Get data from the Bbox."""
 

--- a/homeassistant/components/sensor/bitcoin.py
+++ b/homeassistant/components/sensor/bitcoin.py
@@ -78,7 +78,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(dev)
 
 
-# pylint: disable=too-few-public-methods
 class BitcoinSensor(Entity):
     """Representation of a Bitcoin sensor."""
 
@@ -119,7 +118,6 @@ class BitcoinSensor(Entity):
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
         }
 
-    # pylint: disable=too-many-branches
     def update(self):
         """Get the latest data and updates the states."""
         self.data.update()

--- a/homeassistant/components/sensor/bom.py
+++ b/homeassistant/components/sensor/bom.py
@@ -145,7 +145,6 @@ class BOMCurrentSensor(Entity):
         self.rest.update()
 
 
-# pylint: disable=too-few-public-methods
 class BOMCurrentData(object):
     """Get data from BOM."""
 

--- a/homeassistant/components/sensor/coinmarketcap.py
+++ b/homeassistant/components/sensor/coinmarketcap.py
@@ -59,7 +59,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([CoinMarketCapSensor(CoinMarketCapData(currency))])
 
 
-# pylint: disable=too-few-public-methods
 class CoinMarketCapSensor(Entity):
     """Representation of a CoinMarketCap sensor."""
 
@@ -104,7 +103,6 @@ class CoinMarketCapSensor(Entity):
             ATTR_TOTAL_SUPPLY: self._ticker.get('total_supply'),
         }
 
-    # pylint: disable=too-many-branches
     def update(self):
         """Get the latest data and updates the states."""
         self.data.update()

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -46,7 +46,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([CommandSensor(hass, data, name, unit, value_template)])
 
 
-# pylint: disable=too-many-arguments
 class CommandSensor(Entity):
     """Representation of a sensor that is using shell commands."""
 
@@ -89,7 +88,6 @@ class CommandSensor(Entity):
             self._state = value
 
 
-# pylint: disable=too-few-public-methods
 class CommandSensorData(object):
     """The class for handling the data retrieval."""
 

--- a/homeassistant/components/sensor/currencylayer.py
+++ b/homeassistant/components/sensor/currencylayer.py
@@ -101,11 +101,9 @@ class CurrencylayerSensor(Entity):
                 value['{}{}'.format(self._base, self._quote)], 4)
 
 
-# pylint: disable=too-few-public-methods
 class CurrencylayerData(object):
     """Get data from Currencylayer.org."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, resource, parameters):
         """Initialize the data object."""
         self._resource = resource

--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -90,7 +90,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=too-many-arguments
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Dark Sky sensor."""
     # Validate the configuration
@@ -128,7 +127,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(sensors)
 
 
-# pylint: disable=too-few-public-methods
 class DarkSkySensor(Entity):
     """Implementation of a Dark Sky sensor."""
 
@@ -186,7 +184,6 @@ class DarkSkySensor(Entity):
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
         }
 
-    # pylint: disable=too-many-branches,too-many-statements
     def update(self):
         """Get the latest data from Dark Sky and updates the states."""
         # Call the API for new forecast data. Each sensor will re-trigger this
@@ -259,7 +256,6 @@ def convert_to_camel(data):
 class DarkSkyData(object):
     """Get the latest data from Darksky."""
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, api_key, latitude, longitude, units, interval):
         """Initialize the data object."""
         self._api_key = api_key

--- a/homeassistant/components/sensor/deutsche_bahn.py
+++ b/homeassistant/components/sensor/deutsche_bahn.py
@@ -40,7 +40,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([DeutscheBahnSensor(start, destination)])
 
 
-# pylint: disable=too-few-public-methods
 class DeutscheBahnSensor(Entity):
     """Implementation of a Deutsche Bahn sensor."""
 
@@ -81,7 +80,6 @@ class DeutscheBahnSensor(Entity):
             self._state += " + {}".format(self.data.connections[0]['delay'])
 
 
-# pylint: disable=too-few-public-methods
 class SchieneData(object):
     """Pull data from the bahn.de web page."""
 

--- a/homeassistant/components/sensor/dht.py
+++ b/homeassistant/components/sensor/dht.py
@@ -80,7 +80,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(dev)
 
 
-# pylint: disable=too-few-public-methods
 class DHTSensor(Entity):
     """Implementation of the DHT sensor."""
 

--- a/homeassistant/components/sensor/dte_energy_bridge.py
+++ b/homeassistant/components/sensor/dte_energy_bridge.py
@@ -35,7 +35,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([DteEnergyBridgeSensor(ip_address, name)])
 
 
-# pylint: disable=too-many-instance-attributes
 class DteEnergyBridgeSensor(Entity):
     """Implementation of a DTE Energy Bridge sensor."""
 

--- a/homeassistant/components/sensor/dweet.py
+++ b/homeassistant/components/sensor/dweet.py
@@ -60,7 +60,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([DweetSensor(hass, dweet, name, value_template, unit)])
 
 
-# pylint: disable=too-many-arguments
 class DweetSensor(Entity):
     """Representation of a Dweet sensor."""
 
@@ -100,7 +99,6 @@ class DweetSensor(Entity):
         self.dweet.update()
 
 
-# pylint: disable=too-few-public-methods
 class DweetData(object):
     """The class for handling the data retrieval."""
 

--- a/homeassistant/components/sensor/efergy.py
+++ b/homeassistant/components/sensor/efergy.py
@@ -63,11 +63,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(dev)
 
 
-# pylint: disable=too-many-instance-attributes
 class EfergySensor(Entity):
     """Implementation of an Efergy sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, sensor_type, app_token, utc_offset, period, currency):
         """Initialize the sensor."""
         self._name = SENSOR_TYPES[sensor_type][0]

--- a/homeassistant/components/sensor/emoncms.py
+++ b/homeassistant/components/sensor/emoncms.py
@@ -61,7 +61,6 @@ def get_id(sensorid, feedtag, feedname, feedid, feeduserid):
         sensorid, feedtag, feedname, feedid, feeduserid)
 
 
-# pylint: disable=too-many-locals
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Emoncms sensor."""
     apikey = config.get(CONF_API_KEY)
@@ -106,11 +105,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(sensors)
 
 
-# pylint: disable=too-many-instance-attributes
 class EmonCmsSensor(Entity):
     """Implementation of an Emoncms sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, data, name, value_template,
                  unit_of_measurement, sensorid, elem):
         """Initialize the sensor."""
@@ -188,7 +185,6 @@ class EmonCmsSensor(Entity):
             self._state = round(float(elem["value"]), DECIMALS)
 
 
-# pylint: disable=too-few-public-methods
 class EmonCmsData(object):
     """The class for handling the data retrieval."""
 

--- a/homeassistant/components/sensor/fastdotcom.py
+++ b/homeassistant/components/sensor/fastdotcom.py
@@ -49,7 +49,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     hass.services.register(DOMAIN, 'update_fastdotcom', update)
 
 
-# pylint: disable=too-few-public-methods
 class SpeedtestSensor(Entity):
     """Implementation of a FAst.com sensor."""
 

--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -213,8 +213,6 @@ def request_oauth_completion(hass):
         submit_caption="I have authorized Fitbit."
     )
 
-# pylint: disable=too-many-locals
-
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Fitbit sensor."""
@@ -348,7 +346,6 @@ class FitbitAuthCallbackView(HomeAssistantView):
         return html_response
 
 
-# pylint: disable=too-few-public-methods
 class FitbitSensor(Entity):
     """Implementation of a Fitbit sensor."""
 
@@ -400,7 +397,6 @@ class FitbitSensor(Entity):
         """Icon to use in the frontend, if any."""
         return ICON
 
-    # pylint: disable=too-many-branches
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data from the Fitbit API and update the states."""

--- a/homeassistant/components/sensor/fixer.py
+++ b/homeassistant/components/sensor/fixer.py
@@ -58,7 +58,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([ExchangeRateSensor(data, name, target)])
 
 
-# pylint: disable=too-few-public-methods
 class ExchangeRateSensor(Entity):
     """Representation of a Exchange sensor."""
 

--- a/homeassistant/components/sensor/fritzbox_callmonitor.py
+++ b/homeassistant/components/sensor/fritzbox_callmonitor.py
@@ -56,7 +56,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return True
 
 
-# pylint: disable=too-few-public-methods
 class FritzBoxCallSensor(Entity):
     """Implementation of a Fritz!Box call monitor."""
 
@@ -95,7 +94,6 @@ class FritzBoxCallSensor(Entity):
         return self._attributes
 
 
-# pylint: disable=too-few-public-methods
 class FritzBoxCallMonitor(object):
     """Event listener to monitor calls on the Fritz!Box."""
 

--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -104,7 +104,7 @@ class GlancesSensor(Entity):
         """Return the unit the value is expressed in."""
         return self._unit_of_measurement
 
-    # pylint: disable=too-many-branches, too-many-return-statements
+    # pylint: disable=too-many-return-statements
     @property
     def state(self):
         """Return the state of the resources."""

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -82,7 +82,6 @@ def convert_time_to_utc(timestr):
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the Google travel time platform."""
-    # pylint: disable=too-many-locals
     def run_setup(event):
         """Delay the setup until Home Assistant is fully initialized.
 
@@ -120,11 +119,9 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
 
 
-# pylint: disable=too-many-instance-attributes
 class GoogleTravelTimeSensor(Entity):
     """Representation of a Google travel time sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, name, api_key, origin, destination, options):
         """Initialize the sensor."""
         self._hass = hass

--- a/homeassistant/components/sensor/gtfs.py
+++ b/homeassistant/components/sensor/gtfs.py
@@ -41,7 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=too-many-locals
 def get_next_departure(sched, start_station_id, end_station_id):
     """Get the next departure for the given schedule."""
     origin_station = sched.stops_by_id(start_station_id)[0]
@@ -176,7 +175,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([GTFSDepartureSensor(gtfs, name, origin, destination)])
 
 
-# pylint: disable=too-many-instance-attributes,too-few-public-methods
 class GTFSDepartureSensor(Entity):
     """Implementation of an GTFS departures sensor."""
 

--- a/homeassistant/components/sensor/hp_ilo.py
+++ b/homeassistant/components/sensor/hp_ilo.py
@@ -141,7 +141,6 @@ class HpIloSensor(Entity):
             self._state = ilo_data
 
 
-# pylint: disable=too-few-public-methods
 class HpIloData(object):
     """Gets the latest data from HP ILO."""
 

--- a/homeassistant/components/sensor/imap.py
+++ b/homeassistant/components/sensor/imap.py
@@ -47,7 +47,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class ImapSensor(Entity):
     """Representation of an IMAP sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, name, user, password, server, port):
         """Initialize the sensor."""
         self._name = name or user

--- a/homeassistant/components/sensor/imap_email_content.py
+++ b/homeassistant/components/sensor/imap_email_content.py
@@ -130,8 +130,6 @@ class EmailReader:
 class EmailContentSensor(Entity):
     """Representation of an EMail sensor."""
 
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-instance-attributes
     def __init__(self,
                  hass,
                  email_reader,

--- a/homeassistant/components/sensor/influxdb.py
+++ b/homeassistant/components/sensor/influxdb.py
@@ -156,7 +156,6 @@ class InfluxSensor(Entity):
         self._state = value
 
 
-# pylint: disable=too-few-public-methods
 class InfluxSensorData(object):
     """Class for handling the data retrieval."""
 

--- a/homeassistant/components/sensor/knx.py
+++ b/homeassistant/components/sensor/knx.py
@@ -84,7 +84,7 @@ def update_and_define_min_max(config, minimum_default,
     return minimum_value, maximum_value
 
 
-class KNXSensorBaseClass():  # pylint: disable=too-few-public-methods
+class KNXSensorBaseClass():
     """Sensor Base Class for all KNX Sensors."""
 
     _unit_of_measurement = None
@@ -107,7 +107,6 @@ class KNXSensorFloatClass(KNXGroupAddress, KNXSensorBaseClass):
     Defined in KNX 3.7.2 - 3.10
     """
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, config, unit_of_measurement, minimum_sensor_value,
                  maximum_sensor_value):
         """Initialize a KNX Float Sensor."""

--- a/homeassistant/components/sensor/lastfm.py
+++ b/homeassistant/components/sensor/lastfm.py
@@ -40,7 +40,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class LastfmSensor(Entity):
     """A class for the Last.fm account."""
 
-    # pylint: disable=abstract-method, too-many-instance-attributes
+    # pylint: disable=abstract-method
     def __init__(self, user, lastfm):
         """Initialize the sensor."""
         self._user = lastfm.get_user(user)

--- a/homeassistant/components/sensor/linux_battery.py
+++ b/homeassistant/components/sensor/linux_battery.py
@@ -63,7 +63,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([LinuxBatterySensor(name, battery_id)])
 
 
-# pylint: disable=too-few-public-methods
 class LinuxBatterySensor(Entity):
     """Representation of a Linux Battery sensor."""
 

--- a/homeassistant/components/sensor/loopenergy.py
+++ b/homeassistant/components/sensor/loopenergy.py
@@ -90,11 +90,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(sensors)
 
 
-# pylint: disable=too-many-instance-attributes
 class LoopEnergyDevice(Entity):
     """Implementation of an Loop Energy base sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, controller):
         """Initialize the sensor."""
         self._state = None
@@ -126,11 +124,9 @@ class LoopEnergyDevice(Entity):
         self.update_ha_state(True)
 
 
-# pylint: disable=too-many-instance-attributes
 class LoopEnergyElec(LoopEnergyDevice):
     """Implementation of an Loop Energy Electricity sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, controller):
         """Initialize the sensor."""
         super(LoopEnergyElec, self).__init__(controller)
@@ -142,11 +138,9 @@ class LoopEnergyElec(LoopEnergyDevice):
         self._state = round(self._controller.electricity_useage, 2)
 
 
-# pylint: disable=too-many-instance-attributes
 class LoopEnergyGas(LoopEnergyDevice):
     """Implementation of an Loop Energy Gas sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, controller):
         """Initialize the sensor."""
         super(LoopEnergyGas, self).__init__(controller)

--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -87,7 +87,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class MiFloraSensor(Entity):
     """Implementing the MiFlora sensor."""
 
-    # pylint: disable=too-many-instance-attributes,too-many-arguments
     def __init__(self, poller, parameter, name, unit, force_update, median):
         """Initialize the sensor."""
         self.poller = poller

--- a/homeassistant/components/sensor/min_max.py
+++ b/homeassistant/components/sensor/min_max.py
@@ -58,7 +58,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([MinMaxSensor(hass, entity_ids, name, sensor_type)])
 
 
-# pylint: disable=too-many-instance-attributes
 class MinMaxSensor(Entity):
     """Representation of a min/max sensor."""
 

--- a/homeassistant/components/sensor/modbus.py
+++ b/homeassistant/components/sensor/modbus.py
@@ -58,7 +58,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class ModbusRegisterSensor(Entity):
     """Modbus resgister sensor."""
 
-    # pylint: disable=too-many-instance-attributes, too-many-arguments
     def __init__(self, name, slave, register, unit_of_measurement, count,
                  scale, offset, precision):
         """Initialize the modbus register sensor."""

--- a/homeassistant/components/sensor/mold_indicator.py
+++ b/homeassistant/components/sensor/mold_indicator.py
@@ -55,11 +55,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         indoor_humidity_sensor, calib_factor)])
 
 
-# pylint: disable=too-many-instance-attributes
 class MoldIndicator(Entity):
     """Represents a MoldIndication sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, name, indoor_temp_sensor, outdoor_temp_sensor,
                  indoor_humidity_sensor, calib_factor):
         """Initialize the sensor."""

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -42,7 +42,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     )])
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 class MqttSensor(Entity):
     """Representation of a sensor that can be updated using MQTT."""
 

--- a/homeassistant/components/sensor/mqtt_room.py
+++ b/homeassistant/components/sensor/mqtt_room.py
@@ -67,7 +67,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     )])
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 class MQTTRoomSensor(Entity):
     """Representation of a room sensor that is updated via MQTT."""
 

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -89,7 +89,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(dev)
 
 
-# pylint: disable=too-few-public-methods
 class NetAtmoSensor(Entity):
     """Implementation of a Netatmo sensor."""
 
@@ -134,9 +133,6 @@ class NetAtmoSensor(Entity):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement
 
-    # pylint: disable=too-many-branches
-    # Fix for pylint too many statements error
-    # pylint: disable=too-many-statements
     def update(self):
         """Get the latest data from NetAtmo API and updates the states."""
         self.netatmo_data.update()

--- a/homeassistant/components/sensor/neurio_energy.py
+++ b/homeassistant/components/sensor/neurio_energy.py
@@ -52,11 +52,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([NeurioEnergy(api_key, api_secret, name, sensor_id)])
 
 
-# pylint: disable=too-many-instance-attributes
 class NeurioEnergy(Entity):
     """Implementation of an Neurio energy."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, api_key, api_secret, name, sensor_id):
         """Initialize the sensor."""
         self._name = name

--- a/homeassistant/components/sensor/nzbget.py
+++ b/homeassistant/components/sensor/nzbget.py
@@ -48,7 +48,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument, too-many-locals
+# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the NZBGet sensors."""
     host = config.get(CONF_HOST)

--- a/homeassistant/components/sensor/octoprint.py
+++ b/homeassistant/components/sensor/octoprint.py
@@ -71,11 +71,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(devices)
 
 
-# pylint: disable=too-many-instance-attributes
 class OctoPrintSensor(Entity):
     """Representation of an OctoPrint sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, api, condition, sensor_type, sensor_name, unit,
                  endpoint, group, tool=None):
         """Initialize a new OctoPrint sensor."""

--- a/homeassistant/components/sensor/openexchangerates.py
+++ b/homeassistant/components/sensor/openexchangerates.py
@@ -93,11 +93,9 @@ class OpenexchangeratesSensor(Entity):
         self._state = round(value[str(self._quote)], 4)
 
 
-# pylint: disable=too-few-public-methods
 class OpenexchangeratesData(object):
     """Get data from Openexchangerates.org."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, resource, parameters, quote):
         """Initialize the data object."""
         self._resource = resource

--- a/homeassistant/components/sensor/openweathermap.py
+++ b/homeassistant/components/sensor/openweathermap.py
@@ -84,7 +84,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(dev)
 
 
-# pylint: disable=too-few-public-methods
 class OpenWeatherMapSensor(Entity):
     """Implementation of an OpenWeatherMap sensor."""
 
@@ -121,7 +120,6 @@ class OpenWeatherMapSensor(Entity):
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
         }
 
-    # pylint: disable=too-many-branches
     def update(self):
         """Get the latest data from OWM and updates the states."""
         self.owa_client.update()

--- a/homeassistant/components/sensor/pilight.py
+++ b/homeassistant/components/sensor/pilight.py
@@ -41,7 +41,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     )])
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 class PilightSensor(Entity):
     """Representation of a sensor that can be updated using pilight."""
 

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -55,7 +55,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class PlexSensor(Entity):
     """Representation of a Plex now playing sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, name, plex_url, plex_user, plex_password, plex_server):
         """Initialize the sensor."""
         from plexapi.utils import NA

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -41,7 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-variable, too-many-locals
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the RESTful sensor."""
     name = config.get(CONF_NAME)
@@ -74,7 +73,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([RestSensor(hass, rest, name, unit, value_template)])
 
 
-# pylint: disable=too-many-arguments
 class RestSensor(Entity):
     """Implementation of a REST sensor."""
 
@@ -117,7 +115,6 @@ class RestSensor(Entity):
         self._state = value
 
 
-# pylint: disable=too-few-public-methods
 class RestData(object):
     """Class for handling the data retrieval."""
 

--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -29,7 +29,6 @@ PLATFORM_SCHEMA = vol.Schema({
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the RFXtrx platform."""
-    # pylint: disable=too-many-locals
     from RFXtrx import SensorEvent
     sensors = []
     for packet_id, entity_info in config[CONF_DEVICES].items():

--- a/homeassistant/components/sensor/sabnzbd.py
+++ b/homeassistant/components/sensor/sabnzbd.py
@@ -50,7 +50,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument, too-many-locals
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the SABnzbd sensors."""
     from pysabnzbd import SabnzbdApi, SabnzbdApiException

--- a/homeassistant/components/sensor/scrape.py
+++ b/homeassistant/components/sensor/scrape.py
@@ -35,7 +35,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=too-many-locals
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Web scrape sensor."""
     name = config.get(CONF_NAME)
@@ -61,11 +60,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     ])
 
 
-# pylint: disable=too-many-instance-attributes
 class ScrapeSensor(Entity):
     """Representation of a web scrape sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, rest, name, select, value_template, unit):
         """Initialize a web scrape sensor."""
         self.rest = rest

--- a/homeassistant/components/sensor/sleepiq.py
+++ b/homeassistant/components/sensor/sleepiq.py
@@ -25,7 +25,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(dev)
 
 
-# pylint: disable=too-few-public-methods, too-many-instance-attributes
 class SleepNumberSensor(sleepiq.SleepIQSensor):
     """Implementation of a SleepIQ sensor."""
 

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -40,7 +40,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=too-many-locals
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the SNMP sensor."""
     from pysnmp.hlapi import (getCmd, CommunityData, SnmpEngine,
@@ -104,7 +103,6 @@ class SnmpSensor(Entity):
 class SnmpData(object):
     """Get the latest data and update the states."""
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, host, port, community, baseoid):
         """Initialize the data object."""
         self._host = host

--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -72,7 +72,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     hass.services.register(DOMAIN, 'update_speedtest', update)
 
 
-# pylint: disable=too-few-public-methods
 class SpeedtestSensor(Entity):
     """Implementation of a speedtest.net sensor."""
 

--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -50,7 +50,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([StatisticsSensor(hass, entity_id, name, sampling_size)])
 
 
-# pylint: disable=too-many-instance-attributes
 class StatisticsSensor(Entity):
     """Representation of a Statistics sensor."""
 

--- a/homeassistant/components/sensor/swiss_hydrological_data.py
+++ b/homeassistant/components/sensor/swiss_hydrological_data.py
@@ -71,7 +71,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([SwissHydrologicalDataSensor(name, data)])
 
 
-# pylint: disable=too-few-public-methods
 class SwissHydrologicalDataSensor(Entity):
     """Implementation of an Swiss hydrological sensor."""
 
@@ -138,7 +137,6 @@ class SwissHydrologicalDataSensor(Entity):
         """Icon to use in the frontend, if any."""
         return ICON
 
-    # pylint: disable=too-many-branches
     def update(self):
         """Get the latest data and update the states."""
         self.data.update()
@@ -149,7 +147,6 @@ class SwissHydrologicalDataSensor(Entity):
                 self._state = self.data.measurings['03']['current']
 
 
-# pylint: disable=too-few-public-methods
 class HydrologicalData(object):
     """The Class for handling the data retrieval."""
 

--- a/homeassistant/components/sensor/swiss_public_transport.py
+++ b/homeassistant/components/sensor/swiss_public_transport.py
@@ -65,7 +65,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([SwissPublicTransportSensor(data, journey, name)])
 
 
-# pylint: disable=too-few-public-methods
 class SwissPublicTransportSensor(Entity):
     """Implementation of an Swiss public transport sensor."""
 
@@ -106,7 +105,6 @@ class SwissPublicTransportSensor(Entity):
         """Icon to use in the frontend, if any."""
         return ICON
 
-    # pylint: disable=too-many-branches
     def update(self):
         """Get the latest data from opendata.ch and update the states."""
         self.data.update()
@@ -117,7 +115,6 @@ class SwissPublicTransportSensor(Entity):
             pass
 
 
-# pylint: disable=too-few-public-methods
 class PublicTransportData(object):
     """The Class for handling the data retrieval."""
 

--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -94,7 +94,6 @@ class SystemMonitorSensor(Entity):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement
 
-    # pylint: disable=too-many-branches
     def update(self):
         """Get the latest system information."""
         import psutil

--- a/homeassistant/components/sensor/ted5000.py
+++ b/homeassistant/components/sensor/ted5000.py
@@ -89,7 +89,6 @@ class Ted5000Sensor(Entity):
         self._gateway.update()
 
 
-# pylint: disable=too-few-public-methods
 class Ted5000Gateway(object):
     """The class for handling the data retrieval."""
 

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -68,7 +68,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class SensorTemplate(Entity):
     """Representation of a Template Sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, device_id, friendly_name, unit_of_measurement,
                  state_template, entity_ids):
         """Initialize the sensor."""

--- a/homeassistant/components/sensor/time_date.py
+++ b/homeassistant/components/sensor/time_date.py
@@ -47,7 +47,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(devices)
 
 
-# pylint: disable=too-few-public-methods
 class TimeDateSensor(Entity):
     """Implementation of a Time and Date sensor."""
 

--- a/homeassistant/components/sensor/torque.py
+++ b/homeassistant/components/sensor/torque.py
@@ -69,7 +69,6 @@ class TorqueReceiveDataView(HomeAssistantView):
     url = API_PATH
     name = 'api:torque'
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, email, vehicle, sensors, add_devices):
         """Initialize a Torque view."""
         super().__init__(hass)

--- a/homeassistant/components/sensor/uber.py
+++ b/homeassistant/components/sensor/uber.py
@@ -64,7 +64,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(dev)
 
 
-# pylint: disable=too-few-public-methods
 class UberSensor(Entity):
     """Implementation of an Uber sensor."""
 
@@ -154,7 +153,6 @@ class UberSensor(Entity):
         """Icon to use in the frontend, if any."""
         return ICON
 
-    # pylint: disable=too-many-branches
     def update(self):
         """Get the latest data from the Uber API and update the states."""
         self.data.update()
@@ -171,11 +169,9 @@ class UberSensor(Entity):
                 self._state = 0
 
 
-# pylint: disable=too-few-public-methods
 class UberEstimate(object):
     """The class for handling the time and price estimate."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, session, start_latitude, start_longitude,
                  end_latitude=None, end_longitude=None):
         """Initialize the UberEstimate object."""

--- a/homeassistant/components/sensor/vasttrafik.py
+++ b/homeassistant/components/sensor/vasttrafik.py
@@ -62,7 +62,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class VasttrafikDepartureSensor(Entity):
     """Implementation of a Vasttrafik Departure Sensor."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, planner, name, departure, heading, delay):
         """Initialize the sensor."""
         self._planner = planner

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -165,7 +165,6 @@ class WUndergroundSensor(Entity):
             self.rest.update()
 
 
-# pylint: disable=too-few-public-methods
 class WUndergroundData(object):
     """Get data from WUnderground."""
 

--- a/homeassistant/components/sensor/xbox_live.py
+++ b/homeassistant/components/sensor/xbox_live.py
@@ -45,7 +45,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
 
-# pylint: disable=too-many-instance-attributes
 class XboxSensor(Entity):
     """A class for the Xbox account."""
 

--- a/homeassistant/components/sensor/yahoo_finance.py
+++ b/homeassistant/components/sensor/yahoo_finance.py
@@ -48,7 +48,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([YahooFinanceSensor(name, data, symbol)])
 
 
-# pylint: disable=too-few-public-methods
 class YahooFinanceSensor(Entity):
     """Representation of a Yahoo Finance sensor."""
 

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -75,7 +75,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(dev)
 
 
-# pylint: disable=too-many-instance-attributes
 class YrSensor(Entity):
     """Representation of an Yr.no sensor."""
 
@@ -164,7 +163,6 @@ class YrSensor(Entity):
                 break
 
 
-# pylint: disable=too-few-public-methods
 class YrData(object):
     """Get the latest data and updates the states."""
 

--- a/homeassistant/components/sensor/yweather.py
+++ b/homeassistant/components/sensor/yweather.py
@@ -97,7 +97,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(dev)
 
 
-# pylint: disable=too-many-instance-attributes
 class YahooWeatherSensor(Entity):
     """Implementation of an Yahoo! weather sensor."""
 
@@ -179,7 +178,6 @@ class YahooWeatherSensor(Entity):
             self._state = self._data.yahoo.Atmosphere["visibility"]
 
 
-# pylint: disable=too-few-public-methods
 class YahooWeatherData(object):
     """Handle yahoo api object and limit updates."""
 

--- a/homeassistant/components/sleepiq.py
+++ b/homeassistant/components/sleepiq.py
@@ -75,7 +75,6 @@ def setup(hass, config):
     return True
 
 
-# pylint: disable=too-few-public-methods
 class SleepIQData(object):
     """Gets the latest data from SleepIQ."""
 
@@ -95,7 +94,6 @@ class SleepIQData(object):
         self.beds = {bed.bed_id: bed for bed in beds}
 
 
-# pylint: disable=too-few-public-methods, too-many-instance-attributes
 class SleepIQSensor(Entity):
     """Implementation of a SleepIQ sensor."""
 

--- a/homeassistant/components/switch/anel_pwrctrl.py
+++ b/homeassistant/components/switch/anel_pwrctrl.py
@@ -110,7 +110,6 @@ class PwrCtrlSwitch(SwitchDevice):
         self._port.off()
 
 
-# pylint: disable=too-few-public-methods
 class PwrCtrlDevice(object):
     """Device representation for per device throttling."""
 

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -60,11 +60,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(switches)
 
 
-# pylint: disable=too-many-instance-attributes
 class CommandSwitch(SwitchDevice):
     """Representation a switch that can be toggled using shell commands."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, name, command_on, command_off,
                  command_state, value_template):
         """Initialize the switch."""

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -102,11 +102,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     hass.services.register(DOMAIN, name + '_update', update)
 
 
-# pylint: disable=too-many-instance-attributes
 class FluxSwitch(SwitchDevice):
     """Representation of a Flux switch."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, name, hass, state, lights, start_time, stop_time,
                  start_colortemp, sunset_colortemp, stop_colortemp,
                  brightness, mode):
@@ -150,7 +148,6 @@ class FluxSwitch(SwitchDevice):
         self._state = False
         self.update_ha_state()
 
-    # pylint: disable=too-many-locals
     def flux_update(self, now=None):
         """Update all the lights using flux."""
         if now is None:

--- a/homeassistant/components/switch/hikvisioncam.py
+++ b/homeassistant/components/switch/hikvisioncam.py
@@ -33,8 +33,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=too-many-arguments
-# pylint: disable=too-many-instance-attributes
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup Hikvision camera."""
     import hikvision.api

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -43,7 +43,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class ModbusCoilSwitch(ToggleEntity):
     """Representation of a Modbus switch."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, name, slave, coil):
         """Initialize the switch."""
         self._name = name

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -54,7 +54,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     )])
 
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 class MqttSwitch(SwitchDevice):
     """Representation of a switch that can be toggled using MQTT."""
 

--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -37,7 +37,6 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 class PilightSwitch(SwitchDevice):
     """Representation of a pilight switch."""
 
-    # pylint: disable=too-many-arguments, too-many-instance-attributes
     def __init__(self, hass, name, code_on, code_off,
                  code_on_receive, code_off_receive):
         """Initialize the switch."""

--- a/homeassistant/components/switch/pulseaudio_loopback.py
+++ b/homeassistant/components/switch/pulseaudio_loopback.py
@@ -141,7 +141,6 @@ class PAServer():
             return -1
 
 
-# pylint: disable=too-many-arguments
 class PALoopbackSwitch(SwitchDevice):
     """Representation the presence or absence of a PA loopback module."""
 

--- a/homeassistant/components/switch/rest.py
+++ b/homeassistant/components/switch/rest.py
@@ -65,13 +65,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             hass, name, resource, body_on, body_off, is_on_template, timeout)])
 
 
-# pylint: disable=too-many-arguments
 class RestSwitch(SwitchDevice):
     """Representation of a switch that can be toggled using REST."""
 
-    # pylint: disable=too-many-instance-attributes
-    def __init__(self, hass, name, resource, body_on, body_off, is_on_template,
-                 timeout):
+    def __init__(self, hass, name, resource, body_on, body_off,
+                 is_on_template, timeout):
         """Initialize the REST switch."""
         self._state = None
         self._hass = hass

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -68,7 +68,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiRFSwitch(SwitchDevice):
     """Representation of a GPIO RF switch."""
 
-    # pylint: disable=too-many-arguments, too-many-instance-attributes
     def __init__(self, hass, name, rfdevice, protocol, pulselength,
                  code_on, code_off):
         """Initialize the switch."""

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -77,7 +77,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class SwitchTemplate(SwitchDevice):
     """Representation of a Template switch."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, device_id, friendly_name, state_template,
                  on_action, off_action, entity_ids):
         """Initialize the Template switch."""

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -93,9 +93,9 @@ def setup(hass, base_config):
     return True
 
 
+# pylint: disable=too-many-return-statements
 def map_vera_device(vera_device, remap):
     """Map vera  classes to HA types."""
-    # pylint: disable=too-many-return-statements
     import pyvera as veraApi
     if isinstance(vera_device, veraApi.VeraDimmer):
         return 'light'

--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -63,7 +63,6 @@ def setup(hass, config):
     return True
 
 
-# pylint: disable=too-many-instance-attributes
 class VerisureHub(object):
     """A Verisure hub wrapper class."""
 

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -36,7 +36,7 @@ def setup(hass, config):
     return True
 
 
-# pylint: disable=no-member, no-self-use, too-many-return-statements
+# pylint: disable=no-member, no-self-use
 class WeatherEntity(Entity):
     """ABC for a weather data."""
 

--- a/homeassistant/components/weather/demo.py
+++ b/homeassistant/components/weather/demo.py
@@ -33,7 +33,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     ])
 
 
-# pylint: disable=too-many-arguments
 class DemoWeather(WeatherEntity):
     """Representation of a weather condition."""
 

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -70,7 +70,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         name, data, hass.config.units.temperature_unit)])
 
 
-# pylint: disable=too-few-public-methods
 class OpenWeatherMapWeather(WeatherEntity):
     """Implementation of an OpenWeatherMap sensor."""
 
@@ -131,7 +130,6 @@ class OpenWeatherMapWeather(WeatherEntity):
         """Return the attribution."""
         return ATTRIBUTION
 
-    # pylint: disable=too-many-branches
     def update(self):
         """Get the latest data from OWM and updates the states."""
         self._owm.update()

--- a/homeassistant/components/zone.py
+++ b/homeassistant/components/zone.py
@@ -117,7 +117,6 @@ def async_setup(hass, config):
 class Zone(Entity):
     """Representation of a Zone."""
 
-    # pylint: disable=too-many-arguments, too-many-instance-attributes
     def __init__(self, hass, name, latitude, longitude, radius, icon, passive):
         """Initialize the zone."""
         self.hass = hass

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -260,7 +260,6 @@ def async_process_ha_core_config(hass, config):
 
     This method is a coroutine.
     """
-    # pylint: disable=too-many-branches
     config = CORE_CONFIG_SCHEMA(config)
     hac = hass.config
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -128,8 +128,6 @@ class JobPriority(util.OrderedEnum):
 class HomeAssistant(object):
     """Root object of the Home Assistant home automation."""
 
-    # pylint: disable=too-many-instance-attributes
-
     def __init__(self, loop=None):
         """Initialize new Home Assistant object."""
         self.loop = loop or asyncio.get_event_loop()
@@ -364,7 +362,6 @@ class EventOrigin(enum.Enum):
 
 
 class Event(object):
-    # pylint: disable=too-few-public-methods
     """Represents an event within the Bus."""
 
     __slots__ = ['event_type', 'data', 'origin', 'time_fired']
@@ -581,7 +578,6 @@ class State(object):
     __slots__ = ['entity_id', 'state', 'attributes',
                  'last_changed', 'last_updated']
 
-    # pylint: disable=too-many-arguments
     def __init__(self, entity_id, state, attributes=None, last_changed=None,
                  last_updated=None):
         """Initialize a new state."""
@@ -824,7 +820,6 @@ class StateMachine(object):
         self._bus.async_fire(EVENT_STATE_CHANGED, event_data)
 
 
-# pylint: disable=too-few-public-methods
 class Service(object):
     """Represents a callable service."""
 
@@ -848,7 +843,6 @@ class Service(object):
         }
 
 
-# pylint: disable=too-few-public-methods
 class ServiceCall(object):
     """Represents a call to a service."""
 
@@ -906,7 +900,6 @@ class ServiceRegistry(object):
         """
         return service.lower() in self._services.get(domain.lower(), [])
 
-    # pylint: disable=too-many-arguments
     def register(self, domain, service, service_func, description=None,
                  schema=None):
         """
@@ -1091,7 +1084,6 @@ class ServiceRegistry(object):
 class Config(object):
     """Configuration settings for Home Assistant."""
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self):
         """Initialize a new config object."""
         self.latitude = None  # type: Optional[float]

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -131,7 +131,6 @@ def async_or_from_config(config: ConfigType, config_validation: bool=True):
 or_from_config = _threaded_factory(async_or_from_config)
 
 
-# pylint: disable=too-many-arguments
 def numeric_state(hass: HomeAssistant, entity, below=None, above=None,
                   value_template=None, variables=None):
     """Test a numeric state condition."""

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -23,8 +23,6 @@ DEFAULT_SCAN_INTERVAL = 15
 class EntityComponent(object):
     """Helper class that will help a component manage its entities."""
 
-    # pylint: disable=too-many-instance-attributes
-    # pylint: disable=too-many-arguments
     def __init__(self, logger, domain, hass,
                  scan_interval=DEFAULT_SCAN_INTERVAL, group_name=None):
         """Initialize an entity component."""
@@ -274,7 +272,6 @@ class EntityComponent(object):
 class EntityPlatform(object):
     """Keep track of entities for a single platform and stay in loop."""
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, component, scan_interval, entity_namespace):
         """Initalize the entity platform."""
         self.component = component

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -203,7 +203,6 @@ def async_track_sunset(hass, action, offset=None):
 track_sunset = threaded_listener_factory(async_track_sunset)
 
 
-# pylint: disable=too-many-arguments
 def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
                                 hour=None, minute=None, second=None,
                                 local=False):
@@ -248,7 +247,6 @@ def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
 track_utc_time_change = threaded_listener_factory(async_track_utc_time_change)
 
 
-# pylint: disable=too-many-arguments
 def async_track_time_change(hass, action, year=None, month=None, day=None,
                             hour=None, minute=None, second=None):
     """Add a listener that will fire if UTC time matches a pattern."""

--- a/homeassistant/helpers/event_decorators.py
+++ b/homeassistant/helpers/event_decorators.py
@@ -46,7 +46,6 @@ def track_sunset(offset=None):
     return track_sunset_decorator
 
 
-# pylint: disable=too-many-arguments
 def track_time_change(year=None, month=None, day=None, hour=None, minute=None,
                       second=None):
     """Decorator factory to track time changes."""
@@ -60,7 +59,6 @@ def track_time_change(year=None, month=None, day=None, hour=None, minute=None,
     return track_time_change_decorator
 
 
-# pylint: disable=too-many-arguments
 def track_utc_time_change(year=None, month=None, day=None, hour=None,
                           minute=None, second=None):
     """Decorator factory to track time changes."""

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -36,7 +36,6 @@ def call_from_config(hass: HomeAssistant, config: ConfigType,
 class Script():
     """Representation of a script."""
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, hass: HomeAssistant, sequence, name: str=None,
                  change_listener=None) -> None:
         """Initialize the script."""

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -77,7 +77,6 @@ SERVICE_TO_STATE = {
 }
 
 
-# pylint: disable=too-few-public-methods, attribute-defined-outside-init
 class AsyncTrackStates(object):
     """
     Record the time when the with-block is entered.
@@ -93,6 +92,7 @@ class AsyncTrackStates(object):
         self.hass = hass
         self.states = []
 
+    # pylint: disable=attribute-defined-outside-init
     def __enter__(self):
         """Record time from which to track changes."""
         self.now = dt_util.utcnow()

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1,5 +1,4 @@
 """Template helper methods for rendering strings with HA data."""
-# pylint: disable=too-few-public-methods
 import json
 import logging
 import re

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -40,7 +40,7 @@ _LOGGER = logging.getLogger(__name__)
 class APIStatus(enum.Enum):
     """Represent API status."""
 
-    # pylint: disable=no-init,invalid-name,too-few-public-methods
+    # pylint: disable=no-init, invalid-name
     OK = "ok"
     INVALID_PASSWORD = "invalid_password"
     CANNOT_CONNECT = "cannot_connect"
@@ -54,7 +54,6 @@ class APIStatus(enum.Enum):
 class API(object):
     """Object to pass around Home Assistant API location and credentials."""
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, host: str, api_password: Optional[str]=None,
                  port: Optional[int]=None, use_ssl: bool=False) -> None:
         """Initalize the API."""
@@ -114,7 +113,7 @@ class API(object):
 class HomeAssistant(ha.HomeAssistant):
     """Home Assistant that forwards work."""
 
-    # pylint: disable=super-init-not-called,too-many-instance-attributes
+    # pylint: disable=super-init-not-called
     def __init__(self, remote_api, local_api=None, loop=None):
         """Initalize the forward instance."""
         if not remote_api.validate_api():
@@ -150,7 +149,8 @@ class HomeAssistant(ha.HomeAssistant):
                     'Unable to setup local API to receive events')
 
         self.state = ha.CoreState.starting
-        ha._async_create_timer(self)  # pylint: disable=protected-access
+        # pylint: disable=protected-access
+        ha._async_create_timer(self)
 
         self.bus.fire(ha.EVENT_HOMEASSISTANT_START,
                       origin=ha.EventOrigin.remote)
@@ -186,7 +186,6 @@ class HomeAssistant(ha.HomeAssistant):
 class EventBus(ha.EventBus):
     """EventBus implementation that forwards fire_event to remote API."""
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, api, hass):
         """Initalize the eventbus."""
         super().__init__(hass)
@@ -300,7 +299,7 @@ class StateMachine(ha.StateMachine):
 class JSONEncoder(json.JSONEncoder):
     """JSONEncoder that supports Home Assistant objects."""
 
-    # pylint: disable=too-few-public-methods,method-hidden
+    # pylint: disable=method-hidden
     def default(self, obj):
         """Convert Home Assistant objects.
 

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -56,7 +56,6 @@ def color(the_color, *args, reset=None):
         raise ValueError("Invalid color {} in {}".format(str(k), the_color))
 
 
-# pylint: disable=too-many-locals, too-many-branches
 def run(script_args: List) -> int:
     """Handle ensure config commandline script."""
     parser = argparse.ArgumentParser(
@@ -160,12 +159,14 @@ def check(config_path):
         'secret_cache': OrderedDict(),
     }
 
-    def mock_load(filename):  # pylint: disable=unused-variable
+    # pylint: disable=unused-variable
+    def mock_load(filename):
         """Mock hass.util.load_yaml to save config files."""
         res['yaml_files'][filename] = True
         return MOCKS['load'][1](filename)
 
-    def mock_get(comp_name):  # pylint: disable=unused-variable
+    # pylint: disable=unused-variable
+    def mock_get(comp_name):
         """Mock hass.loader.get_component to replace setup & setup_platform."""
         def mock_setup(*kwargs):
             """Mock setup, only record the component name & config."""
@@ -196,7 +197,8 @@ def check(config_path):
 
         return module
 
-    def mock_secrets(ldr, node):  # pylint: disable=unused-variable
+    # pylint: disable=unused-variable
+    def mock_secrets(ldr, node):
         """Mock _get_secrets."""
         try:
             val = MOCKS['secrets'][1](ldr, node)

--- a/homeassistant/scripts/db_migrator.py
+++ b/homeassistant/scripts/db_migrator.py
@@ -23,7 +23,6 @@ def ts_to_dt(timestamp: Optional[float]) -> Optional[datetime]:
 
 # Based on code at
 # http://stackoverflow.com/questions/3173320/text-progress-bar-in-the-console
-# pylint: disable=too-many-arguments
 def print_progress(iteration: int, total: int, prefix: str='', suffix: str='',
                    decimals: int=2, bar_length: int=68) -> None:
     """Print progress bar.
@@ -49,7 +48,7 @@ def print_progress(iteration: int, total: int, prefix: str='', suffix: str='',
 
 def run(script_args: List) -> int:
     """The actual script body."""
-    # pylint: disable=too-many-locals,invalid-name,too-many-statements
+    # pylint: disable=invalid-name
     from sqlalchemy import create_engine
     from sqlalchemy.orm import sessionmaker
     from homeassistant.components.recorder import models

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -193,7 +193,8 @@ class OrderedSet(MutableSet):
             yield curr[0]
             curr = curr[1]
 
-    def pop(self, last=True):  # pylint: disable=arguments-differ
+    # pylint: disable=arguments-differ
+    def pop(self, last=True):
         """Pop element of the end of the set.
 
         Set last=False to pop from the beginning.
@@ -240,7 +241,6 @@ class Throttle(object):
     Adds a datetime attribute `last_call` to the method.
     """
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, min_time, limit_no_throttle=None):
         """Initialize the throttle."""
         self.min_time = min_time
@@ -307,7 +307,6 @@ class Throttle(object):
 class ThreadPool(object):
     """A priority queue-based thread pool."""
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, job_handler, worker_count=0):
         """Initialize the pool.
 
@@ -416,7 +415,6 @@ class ThreadPool(object):
 class PriorityQueueItem(object):
     """Holds a priority and a value. Used within PriorityQueue."""
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, priority, item):
         """Initialize the queue."""
         self.priority = priority

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -169,7 +169,6 @@ def parse_time(time_str):
 
 # Found in this gist: https://gist.github.com/zhangsen/1199964
 def get_age(date: dt.datetime) -> str:
-    # pylint: disable=too-many-return-statements
     """
     Take a datetime and return its "age" as a string.
 

--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -80,7 +80,7 @@ def elevation(latitude, longitude):
 # Author: https://github.com/maurycyp
 # Source: https://github.com/maurycyp/vincenty
 # License: https://github.com/maurycyp/vincenty/blob/master/LICENSE
-# pylint: disable=too-many-locals, invalid-name, unused-variable
+# pylint: disable=invalid-name, unused-variable
 def vincenty(point1: Tuple[float, float], point2: Tuple[float, float],
              miles: bool=False) -> Optional[float]:
     """

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -64,7 +64,6 @@ def is_valid_unit(unit: str, unit_type: str) -> bool:
 class UnitSystem(object):
     """A container for units of measure."""
 
-    # pylint: disable=too-many-arguments
     def __init__(self: object, name: str, temperature: str, length: str,
                  volume: str, mass: str) -> None:
         """Initialize the unit system object."""

--- a/pylintrc
+++ b/pylintrc
@@ -5,11 +5,14 @@ reports=no
 # locally-disabled - it spams too much
 # duplicate-code - unavoidable
 # cyclic-import - doesn't test if both import on load
-# abstract-class-little-used - Prevents from setting right foundation
+# abstract-class-little-used - prevents from setting right foundation
 # abstract-class-not-used - is flaky, should not show up but does
 # unused-argument - generic callbacks and setup methods create a lot of warnings
 # global-statement - used for the on-demand requirement installation
 # redefined-variable-type - this is Python, we're duck typing!
+# too-many-* - are not enforced for the sake of readability
+# too-few-* - same as too-many-*
+
 disable=
   locally-disabled,
   duplicate-code,
@@ -18,7 +21,14 @@ disable=
   abstract-class-not-used,
   unused-argument,
   global-statement,
-  redefined-variable-type
+  redefined-variable-type,
+  too-many-arguments,
+  too-many-branches,
+  too-many-instance-attributes,
+  too-many-locals,
+  too-many-public-methods,
+  too-many-statements,
+  too-few-public-methods,
 
 [EXCEPTIONS]
 overgeneral-exceptions=Exception,HomeAssistantError

--- a/tests/common.py
+++ b/tests/common.py
@@ -223,7 +223,7 @@ def mock_mqtt_component(hass):
 class MockModule(object):
     """Representation of a fake module."""
 
-    # pylint: disable=invalid-name,too-few-public-methods,too-many-arguments
+    # pylint: disable=invalid-name
     def __init__(self, domain=None, dependencies=None, setup=None,
                  requirements=None, config_schema=None, platform_schema=None):
         """Initialize the mock module."""
@@ -248,7 +248,7 @@ class MockModule(object):
 class MockPlatform(object):
     """Provide a fake platform."""
 
-    # pylint: disable=invalid-name,too-few-public-methods
+    # pylint: disable=invalid-name
     def __init__(self, setup_platform=None, dependencies=None,
                  platform_schema=None):
         """Initialize the platform."""

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the device tracker component."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access
 import logging
 import unittest
 from unittest.mock import call, patch
@@ -30,12 +30,14 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     hass = None  # HomeAssistant
     yaml_devices = None  # type: str
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.yaml_devices = self.hass.config.path(device_tracker.YAML_DEVICES)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         try:
             os.remove(self.yaml_devices)
@@ -56,7 +58,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
         self.assertFalse(device_tracker.is_on(self.hass, entity_id))
 
-    def test_reading_broken_yaml_config(self):  # pylint: disable=no-self-use
+    # pylint: disable=no-self-use
+    def test_reading_broken_yaml_config(self):
         """Test when known devices contains invalid data."""
         files = {'empty.yaml': '',
                  'nodict.yaml': '100',
@@ -101,9 +104,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         self.assertEqual(device.away_hide, config.away_hide)
         self.assertEqual(device.consider_home, config.consider_home)
 
+    # pylint: disable=invalid-name
     @patch('homeassistant.components.device_tracker._LOGGER.warning')
-    def test_track_with_duplicate_mac_dev_id(self, mock_warning):  \
-            # pylint: disable=invalid-name
+    def test_track_with_duplicate_mac_dev_id(self, mock_warning):
         """Test adding duplicate MACs or device IDs to DeviceTracker."""
         devices = [
             device_tracker.Device(self.hass, True, True, 'my_device', 'AB:01',
@@ -138,8 +141,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
                                         TEST_PLATFORM))
 
-    def test_adding_unknown_device_to_config(self): \
-            # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def test_adding_unknown_device_to_config(self):
         """Test the adding of unknown devices to configuration file."""
         scanner = get_component('device_tracker.test').SCANNER
         scanner.reset()
@@ -303,8 +306,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         self.assertEqual(mock_see.call_count, 1)
         self.assertEqual(mock_see.call_args, call(**params))
 
-    def test_not_write_duplicate_yaml_keys(self): \
-            # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def test_not_write_duplicate_yaml_keys(self):
         """Test that the device tracker will not generate invalid YAML."""
         self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
                                         TEST_PLATFORM))
@@ -318,7 +321,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
                                             timedelta(seconds=0))
         assert len(config) == 2
 
-    def test_not_allow_invalid_dev_id(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def test_not_allow_invalid_dev_id(self):
         """Test that the device tracker will not allow invalid dev ids."""
         self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
                                         TEST_PLATFORM))

--- a/tests/components/device_tracker/test_locative.py
+++ b/tests/components/device_tracker/test_locative.py
@@ -26,9 +26,10 @@ def _url(data=None):
     return "{}{}locative?{}".format(HTTP_BASE_URL, const.URL_API, data)
 
 
-def setUpModule():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def setUpModule():
     """Initalize a Home Assistant server."""
-    global hass    # pylint: disable=invalid-name
+    global hass
 
     hass = get_test_home_assistant()
     bootstrap.setup_component(hass, http.DOMAIN, {

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -242,12 +242,10 @@ class BaseMQTT(unittest.TestCase):
         self.assertEqual(state.attributes.get('gps_accuracy'), accuracy)
 
 
-# pylint: disable=too-many-public-methods
 class TestDeviceTrackerOwnTracks(BaseMQTT):
     """Test the OwnTrack sensor."""
 
     # pylint: disable=invalid-name
-
     def setup_method(self, _):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -1,5 +1,5 @@
 """The tests for the demo light component."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import unittest
 
 from homeassistant.bootstrap import setup_component
@@ -13,14 +13,16 @@ ENTITY_LIGHT = 'light.bed_light'
 class TestDemoClimate(unittest.TestCase):
     """Test the demo climate hvac."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.assertTrue(setup_component(self.hass, light.DOMAIN, {'light': {
             'platform': 'demo',
         }}))
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the Light component."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import unittest
 import os
 
@@ -16,11 +16,13 @@ from tests.common import mock_service, get_test_home_assistant
 class TestLight(unittest.TestCase):
     """Test the light module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -1,5 +1,5 @@
 """The tests for the Cast Media player platform."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import unittest
 from unittest.mock import patch
 

--- a/tests/components/sensor/test_pilight.py
+++ b/tests/components/sensor/test_pilight.py
@@ -17,7 +17,8 @@ def fire_pilight_message(protocol, data):
     HASS.bus.fire(pilight.EVENT, message)
 
 
-def setup_function():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def setup_function():
     """Initialize a Home Assistant server."""
     global HASS
 
@@ -25,7 +26,8 @@ def setup_function():   # pylint: disable=invalid-name
     HASS.config.components = ['pilight']
 
 
-def teardown_function():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def teardown_function():
     """Stop the Home Assistant server."""
     HASS.stop()
 

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -31,7 +31,6 @@ ALERT_MESSAGE = 'This is a test alert message'
 
 def mocked_requests_get(*args, **kwargs):
     """Mock requests.get invocations."""
-    # pylint: disable=too-few-public-methods
     class MockResponse:
         """Class to represent a mocked response."""
 

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the Switch component."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import unittest
 
 from homeassistant.bootstrap import setup_component
@@ -13,7 +13,8 @@ from tests.common import get_test_home_assistant
 class TestSwitch(unittest.TestCase):
     """Test the switch module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         platform = loader.get_component('switch.test')
@@ -22,7 +23,8 @@ class TestSwitch(unittest.TestCase):
         self.switch_1, self.switch_2, self.switch_3 = \
             platform.DEVICES
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -1,5 +1,5 @@
 """The tests for the Alexa component."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access
 import json
 import time
 import datetime
@@ -36,7 +36,8 @@ NPR_NEWS_MP3_URL = "https://pd.npr.org/anon.npr-mp3/npr/news/newscast.mp3"
 STATIC_TIME = datetime.datetime.utcfromtimestamp(1476129102)
 
 
-def setUpModule():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def setUpModule():
     """Initialize a Home Assistant server for testing this module."""
     global hass
 
@@ -117,7 +118,8 @@ def setUpModule():   # pylint: disable=invalid-name
     time.sleep(0.05)
 
 
-def tearDownModule():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def tearDownModule():
     """Stop the Home Assistant server."""
     hass.stop()
 

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -1,5 +1,5 @@
 """The tests for the Home Assistant API component."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access
 import asyncio
 from contextlib import closing
 import json
@@ -32,7 +32,8 @@ def _url(path=""):
     return HTTP_BASE_URL + path
 
 
-def setUpModule():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def setUpModule():
     """Initialize a Home Assistant server."""
     global hass
 
@@ -52,7 +53,8 @@ def setUpModule():   # pylint: disable=invalid-name
     time.sleep(0.05)
 
 
-def tearDownModule():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def tearDownModule():
     """Stop the Home Assistant server."""
     hass.stop()
 

--- a/tests/components/test_configurator.py
+++ b/tests/components/test_configurator.py
@@ -1,5 +1,5 @@
 """The tests for the Configurator component."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import unittest
 
 import homeassistant.components.configurator as configurator
@@ -11,11 +11,13 @@ from tests.common import get_test_home_assistant
 class TestConfigurator(unittest.TestCase):
     """Test the Configurator component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -1,5 +1,5 @@
 """The tests for the Conversation component."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import unittest
 from unittest.mock import patch
 
@@ -15,7 +15,8 @@ from tests.common import get_test_home_assistant, assert_setup_component
 class TestConversation(unittest.TestCase):
     """Test the conversation component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.ent_id = 'light.kitchen_lights'
         self.hass = get_test_home_assistant(3)
@@ -28,7 +29,8 @@ class TestConversation(unittest.TestCase):
                 conversation.DOMAIN: {}
             }))
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_device_sun_light_trigger.py
+++ b/tests/components/test_device_sun_light_trigger.py
@@ -1,5 +1,5 @@
 """The tests device sun light trigger component."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import os
 import unittest
 
@@ -19,7 +19,8 @@ KNOWN_DEV_YAML_PATH = os.path.join(get_test_config_dir(),
                                    device_tracker.YAML_DEVICES)
 
 
-def setUpModule():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def setUpModule():
     """Write a device tracker known devices file to be used."""
     device_tracker.update_config(
         KNOWN_DEV_YAML_PATH, 'device_1', device_tracker.Device(
@@ -32,7 +33,8 @@ def setUpModule():   # pylint: disable=invalid-name
             picture='http://example.com/dev2.jpg'))
 
 
-def tearDownModule():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def tearDownModule():
     """Remove device tracker known devices file."""
     os.remove(KNOWN_DEV_YAML_PATH)
 

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -1,5 +1,5 @@
 """The tests for Home Assistant frontend."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access
 import re
 import time
 import unittest
@@ -25,7 +25,8 @@ def _url(path=""):
     return HTTP_BASE_URL + path
 
 
-def setUpModule():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def setUpModule():
     """Initialize a Home Assistant server."""
     global hass
 
@@ -45,7 +46,8 @@ def setUpModule():   # pylint: disable=invalid-name
     time.sleep(0.05)
 
 
-def tearDownModule():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def tearDownModule():
     """Stop everything that was started."""
     hass.stop()
     frontend.PANELS = {}

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -1,5 +1,5 @@
 """The tests for the Group components."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access
 from collections import OrderedDict
 import unittest
 from unittest.mock import patch
@@ -16,11 +16,13 @@ from tests.common import get_test_home_assistant
 class TestComponentsGroup(unittest.TestCase):
     """Test Group component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -1,5 +1,5 @@
 """The tests the History component."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access
 from datetime import timedelta
 import unittest
 from unittest.mock import patch, sentinel
@@ -16,11 +16,13 @@ from tests.common import (
 class TestComponentHistory(unittest.TestCase):
     """Test History component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_http.py
+++ b/tests/components/test_http.py
@@ -1,5 +1,5 @@
 """The tests for the Home Assistant HTTP component."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access
 import logging
 import time
 from ipaddress import ip_network
@@ -64,7 +64,8 @@ def setUpModule():
     time.sleep(0.05)
 
 
-def tearDownModule():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def tearDownModule():
     """Stop the Home Assistant server."""
     hass.stop()
 

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -1,5 +1,5 @@
 """The testd for Core components."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access
 import asyncio
 import unittest
 from unittest.mock import patch, Mock
@@ -21,7 +21,8 @@ from tests.common import (
 class TestComponentsCore(unittest.TestCase):
     """Test homeassistant.components module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.assertTrue(run_coroutine_threadsafe(
@@ -31,7 +32,8 @@ class TestComponentsCore(unittest.TestCase):
         self.hass.states.set('light.Bowl', STATE_ON)
         self.hass.states.set('light.Ceiling', STATE_OFF)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_input_boolean.py
+++ b/tests/components/test_input_boolean.py
@@ -1,5 +1,5 @@
 """The tests for the input_boolean component."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import unittest
 import logging
 
@@ -17,11 +17,13 @@ _LOGGER = logging.getLogger(__name__)
 class TestInputBoolean(unittest.TestCase):
     """Test the input boolean module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_input_select.py
+++ b/tests/components/test_input_select.py
@@ -1,5 +1,5 @@
 """The tests for the Input select component."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import unittest
 
 from tests.common import get_test_home_assistant
@@ -14,11 +14,13 @@ from homeassistant.const import (
 class TestInputSelect(unittest.TestCase):
     """Test the input select component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_input_slider.py
+++ b/tests/components/test_input_slider.py
@@ -1,5 +1,5 @@
 """The tests for the Input slider component."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import unittest
 
 from tests.common import get_test_home_assistant
@@ -11,11 +11,13 @@ from homeassistant.components.input_slider import (DOMAIN, select_value)
 class TestInputSlider(unittest.TestCase):
     """Test the input slider component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -1,5 +1,5 @@
 """The tests for the logbook component."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access
 from datetime import timedelta
 import unittest
 from unittest.mock import patch

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -1,5 +1,5 @@
 """The tests for the Rfxtrx component."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import unittest
 
 import pytest

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -1,5 +1,5 @@
 """The tests for the Script component."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import unittest
 
 from homeassistant.bootstrap import setup_component
@@ -14,12 +14,14 @@ ENTITY_ID = 'script.test'
 class TestScriptComponent(unittest.TestCase):
     """Test the Script component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.components.append('group')
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_sun.py
+++ b/tests/components/test_sun.py
@@ -1,5 +1,5 @@
 """The tests for the Sun component."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import unittest
 from unittest.mock import patch
 from datetime import timedelta, datetime
@@ -15,11 +15,13 @@ from tests.common import get_test_home_assistant
 class TestSun(unittest.TestCase):
     """Test the sun module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1,5 +1,5 @@
 """Test the entity helper."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access
 import asyncio
 from unittest.mock import MagicMock
 

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -1,5 +1,5 @@
 """The tests for the Entity component helper."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access
 from collections import OrderedDict
 import logging
 import unittest

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -1,6 +1,5 @@
 """Test event helpers."""
-# pylint: disable=protected-access,too-many-public-methods
-# pylint: disable=too-few-public-methods
+# pylint: disable=protected-access
 import asyncio
 import unittest
 from datetime import datetime, timedelta
@@ -28,11 +27,13 @@ from tests.common import get_test_home_assistant
 class TestEventHelpers(unittest.TestCase):
     """Test the Home Assistant event helpers."""
 
-    def setUp(self):     # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/helpers/test_event_decorators.py
+++ b/tests/helpers/test_event_decorators.py
@@ -1,6 +1,5 @@
 """Test event decorator helpers."""
-# pylint: disable=protected-access,too-many-public-methods
-# pylint: disable=too-few-public-methods
+# pylint: disable=protected-access
 import unittest
 from datetime import datetime, timedelta
 
@@ -20,7 +19,8 @@ from tests.common import get_test_home_assistant
 class TestEventDecoratorHelpers(unittest.TestCase):
     """Test the Home Assistant event helpers."""
 
-    def setUp(self):     # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.states.set("light.Bowl", "on")
@@ -28,7 +28,8 @@ class TestEventDecoratorHelpers(unittest.TestCase):
 
         event_decorators.HASS = self.hass
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
         event_decorators.HASS = None

--- a/tests/helpers/test_init.py
+++ b/tests/helpers/test_init.py
@@ -1,5 +1,5 @@
 """Test component helpers."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access
 from collections import OrderedDict
 import unittest
 
@@ -11,11 +11,13 @@ from tests.common import get_test_home_assistant
 class TestHelpers(unittest.TestCase):
     """Tests homeassistant.helpers module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Init needed objects."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/helpers/test_location.py
+++ b/tests/helpers/test_location.py
@@ -1,5 +1,4 @@
 """Tests Home Assistant location helpers."""
-# pylint: disable=too-many-public-methods
 import unittest
 
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1,5 +1,5 @@
 """The tests for the Script component."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 from datetime import timedelta
 from unittest import mock
 import unittest
@@ -18,11 +18,13 @@ ENTITY_ID = 'script.test'
 class TestScriptHelper(unittest.TestCase):
     """Test the Script component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1,5 +1,4 @@
 """Test Home Assistant template helper methods."""
-# pylint: disable=too-many-public-methods
 import unittest
 from unittest.mock import patch
 
@@ -22,14 +21,16 @@ from tests.common import get_test_home_assistant
 class TestHelpersTemplate(unittest.TestCase):
     """Test the Template."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup the tests."""
         self.hass = get_test_home_assistant()
         self.hass.config.units = UnitSystem('custom', TEMP_CELSIUS,
                                             LENGTH_METERS, VOLUME_LITERS,
                                             MASS_GRAMS)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down stuff we started."""
         self.hass.stop()
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,5 +1,5 @@
 """Test the bootstrapping."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 from unittest import mock
 import threading
 import logging
@@ -26,7 +26,6 @@ class TestBootstrap:
     backup_cache = None
 
     # pylint: disable=invalid-name, no-self-use
-
     def setup_method(self, method):
         """Setup the test."""
         self.backup_cache = loader._COMPONENT_CACHE

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 """Test config utils."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import os
 import unittest
 import unittest.mock as mock
@@ -35,11 +35,13 @@ def create_file(path):
 class TestConfig(unittest.TestCase):
     """Test the configutils."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Initialize a test Home Assistant instance."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Clean up."""
         dt_util.DEFAULT_TIME_ZONE = ORIG_TIMEZONE
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,5 @@
 """Test to verify that Home Assistant core works."""
-# pylint: disable=protected-access,too-many-public-methods
-# pylint: disable=too-few-public-methods
+# pylint: disable=protected-access
 import asyncio
 import unittest
 from unittest.mock import patch, MagicMock
@@ -89,11 +88,13 @@ def test_async_run_job_delegates_non_async():
 class TestHomeAssistant(unittest.TestCase):
     """Test the Home Assistant core classes."""
 
-    def setUp(self):     # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant(0)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 
@@ -163,13 +164,15 @@ class TestEvent(unittest.TestCase):
 class TestEventBus(unittest.TestCase):
     """Test EventBus methods."""
 
-    def setUp(self):     # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.bus = self.hass.bus
         self.bus.listen('test_event', lambda x: len)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down stuff we started."""
         self.hass.stop()
 
@@ -360,14 +363,16 @@ class TestState(unittest.TestCase):
 class TestStateMachine(unittest.TestCase):
     """Test State machine methods."""
 
-    def setUp(self):    # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant(0)
         self.states = self.hass.states
         self.states.set("light.Bowl", "on")
         self.states.set("switch.AC", "off")
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down stuff we started."""
         self.hass.stop()
 
@@ -485,13 +490,15 @@ class TestServiceCall(unittest.TestCase):
 class TestServiceRegistry(unittest.TestCase):
     """Test ServicerRegistry methods."""
 
-    def setUp(self):     # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.services = self.hass.services
         self.services.register("Test_Domain", "TEST_SERVICE", lambda x: None)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down stuff we started."""
         self.hass.stop()
 
@@ -572,7 +579,8 @@ class TestServiceRegistry(unittest.TestCase):
 class TestConfig(unittest.TestCase):
     """Test configuration methods."""
 
-    def setUp(self):     # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.config = ha.Config()
         self.assertIsNone(self.config.config_dir)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,5 +1,5 @@
 """Test to verify that we can load components."""
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=protected-access
 import unittest
 
 import homeassistant.loader as loader
@@ -11,11 +11,13 @@ from tests.common import get_test_home_assistant, MockModule
 class TestLoader(unittest.TestCase):
     """Test the loader module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def setUp(self):
         """Setup tests."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,5 +1,5 @@
 """Test Home Assistant remote methods and classes."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access
 import asyncio
 import threading
 import time
@@ -16,11 +16,11 @@ import homeassistant.util.dt as dt_util
 from tests.common import (
     get_test_instance_port, get_test_home_assistant, get_test_config_dir)
 
-API_PASSWORD = "test1234"
+API_PASSWORD = 'test1234'
 MASTER_PORT = get_test_instance_port()
 SLAVE_PORT = get_test_instance_port()
 BROKEN_PORT = get_test_instance_port()
-HTTP_BASE_URL = "http://127.0.0.1:{}".format(MASTER_PORT)
+HTTP_BASE_URL = 'http://127.0.0.1:{}'.format(MASTER_PORT)
 
 HA_HEADERS = {HTTP_HEADER_HA_AUTH: API_PASSWORD}
 
@@ -28,12 +28,13 @@ broken_api = remote.API('127.0.0.1', "bladiebla")
 hass, slave, master_api = None, None, None
 
 
-def _url(path=""):
+def _url(path=''):
     """Helper method to generate URLs."""
     return HTTP_BASE_URL + path
 
 
-def setUpModule():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def setUpModule():
     """Initalization of a Home Assistant server and Slave instance."""
     global hass, slave, master_api
 
@@ -52,13 +53,13 @@ def setUpModule():   # pylint: disable=invalid-name
     hass.start()
     time.sleep(0.05)
 
-    master_api = remote.API("127.0.0.1", API_PASSWORD, MASTER_PORT)
+    master_api = remote.API('127.0.0.1', API_PASSWORD, MASTER_PORT)
 
     # Start slave
     loop = asyncio.new_event_loop()
 
     # FIXME: should not be a daemon
-    threading.Thread(name="SlaveThread", daemon=True,
+    threading.Thread(name='SlaveThread', daemon=True,
                      target=loop.run_forever).start()
 
     slave = remote.HomeAssistant(master_api, loop=loop)
@@ -73,7 +74,8 @@ def setUpModule():   # pylint: disable=invalid-name
         slave.start()
 
 
-def tearDownModule():   # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+def tearDownModule():
     """Stop the Home Assistant server and slave."""
     slave.stop()
     hass.stop()
@@ -94,7 +96,7 @@ class TestRemoteMethods(unittest.TestCase):
         self.assertEqual(
             remote.APIStatus.INVALID_PASSWORD,
             remote.validate_api(
-                remote.API("127.0.0.1", API_PASSWORD + "A", MASTER_PORT)))
+                remote.API('127.0.0.1', API_PASSWORD + 'A', MASTER_PORT)))
 
         self.assertEqual(
             remote.APIStatus.CANNOT_CONNECT, remote.validate_api(broken_api))

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -1,5 +1,4 @@
 """Test Home Assistant date util methods."""
-# pylint: disable=too-many-public-methods
 import unittest
 from datetime import datetime, timedelta
 

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -1,5 +1,4 @@
 """Test Home Assistant util methods."""
-# pylint: disable=too-many-public-methods
 import unittest
 from unittest.mock import patch
 from datetime import datetime, timedelta

--- a/tests/util/test_location.py
+++ b/tests/util/test_location.py
@@ -1,5 +1,4 @@
 """Test Home Assistant location util methods."""
-# pylint: disable=too-many-public-methods
 from unittest import TestCase
 from unittest.mock import patch
 

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -12,7 +12,7 @@ from tests.common import get_test_config_dir, patch_yaml_files
 
 class TestYaml(unittest.TestCase):
     """Test util.yaml loader."""
-    # pylint: disable=no-self-use,invalid-name
+    # pylint: disable=no-self-use, invalid-name
 
     def test_simple_list(self):
         """Test simple list."""
@@ -254,7 +254,7 @@ def load_yaml(fname, string):
         return load_yaml_config_file(fname)
 
 
-class FakeKeyring():  # pylint: disable=too-few-public-methods
+class FakeKeyring():
     """Fake a keyring class."""
 
     def __init__(self, secrets_dict):
@@ -270,7 +270,7 @@ class FakeKeyring():  # pylint: disable=too-few-public-methods
 
 class TestSecrets(unittest.TestCase):
     """Test the secrets parameter in the yaml utility."""
-    # pylint: disable=protected-access,invalid-name
+    # pylint: disable=protected-access, invalid-name
 
     def setUp(self):  # pylint: disable=invalid-name
         """Create & load secrets file."""
@@ -295,7 +295,8 @@ class TestSecrets(unittest.TestCase):
                                '  password: !secret comp1_pw\n'
                                '')
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    def tearDown(self):
         """Clean up secrets."""
         yaml.clear_secret_cache()
         FILES.clear()


### PR DESCRIPTION
**Description:**
Disable too-many-\* for pylint.
- [x] too-many-locals
- [x] too-many-instance-attributes
- [x] too-many-arguments
- [x] too-many-branches
- [x] too-many-public-methods

**Related issue (if applicable):** fixes #4090

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
