### PR TITLE
Lazy initialise the worker pool

### DIFF
--- a/homeassistant/components/sensor/zigbee.py
+++ b/homeassistant/components/sensor/zigbee.py
@@ -12,7 +12,6 @@ import voluptuous as vol
 from homeassistant.components import zigbee
 from homeassistant.components.zigbee import PLATFORM_SCHEMA
 from homeassistant.const import TEMP_CELSIUS
-from homeassistant.core import JobPriority
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,8 +55,7 @@ class ZigBeeTemperatureSensor(Entity):
         self._config = config
         self._temp = None
         # Get initial state
-        hass.pool.add_job(
-            JobPriority.EVENT_STATE, (self.update_ha_state, True))
+        hass.add_job(self.update_ha_state, True)
 
     @property
     def name(self):

--- a/homeassistant/components/zigbee.py
+++ b/homeassistant/components/zigbee.py
@@ -433,7 +433,7 @@ class ZigBeeAnalogIn(Entity):
         subscribe(hass, handle_frame)
 
         # Get initial state
-        hass.pool.add_job(self.update_ha_state, True)
+        hass.add_job(self.update_ha_state, True)
 
     @property
     def name(self):

--- a/homeassistant/components/zigbee.py
+++ b/homeassistant/components/zigbee.py
@@ -13,7 +13,6 @@ import voluptuous as vol
 
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP, CONF_DEVICE, CONF_NAME, CONF_PIN)
-from homeassistant.core import JobPriority
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers import config_validation as cv
 
@@ -308,8 +307,7 @@ class ZigBeeDigitalIn(Entity):
         subscribe(hass, handle_frame)
 
         # Get initial state
-        hass.pool.add_job(
-            JobPriority.EVENT_STATE, (self.update_ha_state, True))
+        hass.add_job(self.update_ha_state, True)
 
     @property
     def name(self):
@@ -435,8 +433,7 @@ class ZigBeeAnalogIn(Entity):
         subscribe(hass, handle_frame)
 
         # Get initial state
-        hass.pool.add_job(
-            JobPriority.EVENT_STATE, (self.update_ha_state, True))
+        hass.pool.add_job(self.update_ha_state, True)
 
     @property
     def name(self):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -197,6 +197,8 @@ class HomeAssistant(object):
         target: target to call.
         args: parameters for method to call.
         """
+        if self.pool is None:
+            run_callback_threadsafe(self.pool, self.async_init_pool).result()
         self.pool.add_job((target,) + args)
 
     @callback
@@ -215,7 +217,7 @@ class HomeAssistant(object):
         else:
             if self.pool is None:
                 self.async_init_pool()
-            self.add_job(target, *args)
+            self.pool.add_job((target,) + args)
 
     @callback
     def async_run_job(self, target: Callable[..., None], *args: Any) -> None:

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -319,7 +319,7 @@ class ThreadPool(object):
         self._job_handler = job_handler
 
         self.worker_count = 0
-        self._work_queue = queue.PriorityQueue()
+        self._work_queue = queue.Queue()
         self.current_jobs = []
         self._quit_task = object()
 
@@ -349,24 +349,24 @@ class ThreadPool(object):
         if not self.running:
             raise RuntimeError("ThreadPool not running")
 
-        self._work_queue.put(PriorityQueueItem(0, self._quit_task))
+        self._work_queue.put(self._quit_task)
 
         self.worker_count -= 1
 
-    def add_job(self, priority, job):
+    def add_job(self, job):
         """Add a job to the queue."""
         if not self.running:
             raise RuntimeError("ThreadPool not running")
 
-        self._work_queue.put(PriorityQueueItem(priority, job))
+        self._work_queue.put(job)
 
     def add_many_jobs(self, jobs):
         """Add a list of jobs to the queue."""
         if not self.running:
             raise RuntimeError("ThreadPool not running")
 
-        for priority, job in jobs:
-            self._work_queue.put(PriorityQueueItem(priority, job))
+        for job in jobs:
+            self._work_queue.put(job)
 
     def block_till_done(self):
         """Block till current work is done."""
@@ -392,7 +392,7 @@ class ThreadPool(object):
         """Handle jobs for the thread pool."""
         while True:
             # Get new item from work_queue
-            job = self._work_queue.get().item
+            job = self._work_queue.get()
 
             if job is self._quit_task:
                 self._work_queue.task_done()
@@ -410,16 +410,3 @@ class ThreadPool(object):
 
             # Tell work_queue the task is done
             self._work_queue.task_done()
-
-
-class PriorityQueueItem(object):
-    """Holds a priority and a value. Used within PriorityQueue."""
-
-    def __init__(self, priority, item):
-        """Initialize the queue."""
-        self.priority = priority
-        self.item = item
-
-    def __lt__(self, other):
-        """Return the ordering."""
-        return self.priority < other.priority

--- a/tests/common.py
+++ b/tests/common.py
@@ -36,6 +36,7 @@ def get_test_home_assistant():
     loop = asyncio.new_event_loop()
 
     hass = loop.run_until_complete(async_test_home_assistant(loop))
+    hass.allow_pool = True
 
     # FIXME should not be a daemon. Means hass.stop() not called in teardown
     stop_event = threading.Event()
@@ -94,7 +95,7 @@ def async_test_home_assistant(loop):
 
     hass.state = ha.CoreState.running
 
-    hass.allow_pool = True
+    hass.allow_pool = False
     orig_init = hass.async_init_pool
 
     @ha.callback

--- a/tests/common.py
+++ b/tests/common.py
@@ -31,18 +31,11 @@ def get_test_config_dir(*add_path):
     return os.path.join(os.path.dirname(__file__), "testing_config", *add_path)
 
 
-def get_test_home_assistant(num_threads=None):
+def get_test_home_assistant():
     """Return a Home Assistant object pointing at test config dir."""
     loop = asyncio.new_event_loop()
 
-    if num_threads:
-        orig_num_threads = ha.MIN_WORKER_THREAD
-        ha.MIN_WORKER_THREAD = num_threads
-
     hass = loop.run_until_complete(async_test_home_assistant(loop))
-
-    if num_threads:
-        ha.MIN_WORKER_THREAD = orig_num_threads
 
     # FIXME should not be a daemon. Means hass.stop() not called in teardown
     stop_event = threading.Event()

--- a/tests/common.py
+++ b/tests/common.py
@@ -225,7 +225,8 @@ class MockModule(object):
 
     # pylint: disable=invalid-name
     def __init__(self, domain=None, dependencies=None, setup=None,
-                 requirements=None, config_schema=None, platform_schema=None):
+                 requirements=None, config_schema=None, platform_schema=None,
+                 async_setup=None):
         """Initialize the mock module."""
         self.DOMAIN = domain
         self.DEPENDENCIES = dependencies or []
@@ -238,8 +239,15 @@ class MockModule(object):
         if platform_schema is not None:
             self.PLATFORM_SCHEMA = platform_schema
 
+        if async_setup is not None:
+            self.async_setup = async_setup
+
     def setup(self, hass, config):
-        """Setup the component."""
+        """Setup the component.
+
+        We always define this mock because MagicMock setups will be seen by the
+        executor as a coroutine, raising an exception.
+        """
         if self._setup is not None:
             return self._setup(hass, config)
         return True

--- a/tests/common.py
+++ b/tests/common.py
@@ -108,6 +108,19 @@ def async_test_home_assistant(loop):
 
     hass.state = ha.CoreState.running
 
+    hass.allow_pool = True
+    orig_init = hass.async_init_pool
+
+    @ha.callback
+    def mock_async_init_pool():
+        """Prevent worker pool from being initialized."""
+        if hass.allow_pool:
+            orig_init()
+        else:
+            assert False, 'Thread pool not allowed. Set hass.allow_pool = True'
+
+    hass.async_init_pool = mock_async_init_pool
+
     return hass
 
 

--- a/tests/components/camera/test_generic.py
+++ b/tests/components/camera/test_generic.py
@@ -8,6 +8,7 @@ from homeassistant.bootstrap import setup_component
 @asyncio.coroutine
 def test_fetching_url(aioclient_mock, hass, test_client):
     """Test that it fetches the given url."""
+    hass.allow_pool = True
     aioclient_mock.get('http://example.com', text='hello world')
 
     def setup_platform():
@@ -39,6 +40,7 @@ def test_fetching_url(aioclient_mock, hass, test_client):
 @asyncio.coroutine
 def test_limit_refetch(aioclient_mock, hass, test_client):
     """Test that it fetches the given url."""
+    hass.allow_pool = True
     aioclient_mock.get('http://example.com/5a', text='hello world')
     aioclient_mock.get('http://example.com/10a', text='hello world')
     aioclient_mock.get('http://example.com/15a', text='hello planet')

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -14,6 +14,8 @@ from tests.common import assert_setup_component, mock_http_component
 @asyncio.coroutine
 def test_loading_file(hass, test_client):
     """Test that it loads image from disk."""
+    hass.allow_pool = True
+
     @mock.patch('os.path.isfile', mock.Mock(return_value=True))
     @mock.patch('os.access', mock.Mock(return_value=True))
     def setup_platform():

--- a/tests/components/climate/test_demo.py
+++ b/tests/components/climate/test_demo.py
@@ -86,7 +86,7 @@ class TestDemoClimate(unittest.TestCase):
         self.assertEqual(24.0, state.attributes.get('target_temp_high'))
         climate.set_temperature(self.hass, target_temp_high=25,
                                 target_temp_low=20, entity_id=ENTITY_ECOBEE)
-        self.hass.pool.block_till_done()
+        self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_ECOBEE)
         self.assertEqual(None, state.attributes.get('temperature'))
         self.assertEqual(20.0, state.attributes.get('target_temp_low'))
@@ -102,7 +102,7 @@ class TestDemoClimate(unittest.TestCase):
         climate.set_temperature(self.hass, temperature=None,
                                 entity_id=ENTITY_ECOBEE, target_temp_low=None,
                                 target_temp_high=None)
-        self.hass.pool.block_till_done()
+        self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_ECOBEE)
         self.assertEqual(None, state.attributes.get('temperature'))
         self.assertEqual(21.0, state.attributes.get('target_temp_low'))

--- a/tests/components/cover/test_rfxtrx.py
+++ b/tests/components/cover/test_rfxtrx.py
@@ -15,7 +15,7 @@ class TestCoverRfxtrx(unittest.TestCase):
 
     def setUp(self):
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(0)
+        self.hass = get_test_home_assistant()
         self.hass.config.components = ['rfxtrx']
 
     def tearDown(self):

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -30,7 +30,7 @@ class TestDemoClimate(unittest.TestCase):
         """Test light state attributes."""
         light.turn_on(
             self.hass, ENTITY_LIGHT, xy_color=(.4, .6), brightness=25)
-        self.hass.pool.block_till_done()
+        self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_LIGHT)
         self.assertTrue(light.is_on(self.hass, ENTITY_LIGHT))
         self.assertEqual((.4, .6), state.attributes.get(light.ATTR_XY_COLOR))
@@ -40,21 +40,21 @@ class TestDemoClimate(unittest.TestCase):
         light.turn_on(
             self.hass, ENTITY_LIGHT, rgb_color=(251, 252, 253),
             white_value=254)
-        self.hass.pool.block_till_done()
+        self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_LIGHT)
         self.assertEqual(254, state.attributes.get(light.ATTR_WHITE_VALUE))
         self.assertEqual(
             (251, 252, 253), state.attributes.get(light.ATTR_RGB_COLOR))
         light.turn_on(self.hass, ENTITY_LIGHT, color_temp=400)
-        self.hass.pool.block_till_done()
+        self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_LIGHT)
         self.assertEqual(400, state.attributes.get(light.ATTR_COLOR_TEMP))
 
     def test_turn_off(self):
         """Test light turn off method."""
         light.turn_on(self.hass, ENTITY_LIGHT)
-        self.hass.pool.block_till_done()
+        self.hass.block_till_done()
         self.assertTrue(light.is_on(self.hass, ENTITY_LIGHT))
         light.turn_off(self.hass, ENTITY_LIGHT)
-        self.hass.pool.block_till_done()
+        self.hass.block_till_done()
         self.assertFalse(light.is_on(self.hass, ENTITY_LIGHT))

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -15,7 +15,7 @@ class TestLightRfxtrx(unittest.TestCase):
 
     def setUp(self):
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(0)
+        self.hass = get_test_home_assistant()
         self.hass.config.components = ['rfxtrx']
 
     def tearDown(self):

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -21,7 +21,7 @@ class TestMQTT(unittest.TestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(1)
+        self.hass = get_test_home_assistant()
         mock_mqtt_component(self.hass)
         self.calls = []
 
@@ -217,7 +217,7 @@ class TestMQTTCallbacks(unittest.TestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(1)
+        self.hass = get_test_home_assistant()
         # mock_mqtt_component(self.hass)
 
         with mock.patch('paho.mqtt.client.Client'):

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -111,7 +111,7 @@ class TestNotifyDemo(unittest.TestCase):
         }
 
         script.call_from_config(self.hass, conf)
-        self.hass.pool.block_till_done()
+        self.hass.block_till_done()
         self.assertTrue(len(self.events) == 1)
         assert {
             'message': 'Test 123 4',

--- a/tests/components/sensor/test_imap_email_content.py
+++ b/tests/components/sensor/test_imap_email_content.py
@@ -178,7 +178,7 @@ class EmailContentSensor(unittest.TestCase):
         sensor.entity_id = "sensor.emailtest"
         sensor.update()
 
-        self.hass.pool.block_till_done()
+        self.hass.block_till_done()
         states_received.wait(5)
 
         self.assertEqual("Test Message", states[0].state)

--- a/tests/components/sensor/test_random.py
+++ b/tests/components/sensor/test_random.py
@@ -33,4 +33,4 @@ class TestRandomSensor(unittest.TestCase):
         state = self.hass.states.get('sensor.test')
 
         self.assertLessEqual(int(state.state), config['sensor']['maximum'])
-        self.assertGreater(int(state.state), config['sensor']['minimum'])
+        self.assertGreaterEqual(int(state.state), config['sensor']['minimum'])

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -16,7 +16,7 @@ class TestSensorRfxtrx(unittest.TestCase):
 
     def setUp(self):
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(0)
+        self.hass = get_test_home_assistant()
         self.hass.config.components = ['rfxtrx']
 
     def tearDown(self):

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -15,7 +15,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def setUp(self):
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(0)
+        self.hass = get_test_home_assistant()
         self.hass.config.components = ['rfxtrx']
 
     def tearDown(self):

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -19,7 +19,7 @@ class TestConversation(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.ent_id = 'light.kitchen_lights'
-        self.hass = get_test_home_assistant(3)
+        self.hass = get_test_home_assistant()
         self.hass.states.set(self.ent_id, 'on')
         self.assertTrue(run_coroutine_threadsafe(
             core_components.async_setup(self.hass, {}), self.hass.loop

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -17,7 +17,7 @@ class TestInfluxDB(unittest.TestCase):
 
     def setUp(self):
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(2)
+        self.hass = get_test_home_assistant()
         self.handler_method = None
         self.hass.bus.listen = mock.Mock()
 

--- a/tests/components/test_logentries.py
+++ b/tests/components/test_logentries.py
@@ -15,7 +15,7 @@ class TestLogentries(unittest.TestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(2)
+        self.hass = get_test_home_assistant()
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""

--- a/tests/components/test_logger.py
+++ b/tests/components/test_logger.py
@@ -16,7 +16,7 @@ class TestUpdater(unittest.TestCase):
 
     def setUp(self):
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(2)
+        self.hass = get_test_home_assistant()
         self.log_config = {'logger':
                            {'default': 'warning', 'logs': {'test': 'info'}}}
 

--- a/tests/components/test_splunk.py
+++ b/tests/components/test_splunk.py
@@ -14,7 +14,7 @@ class TestSplunk(unittest.TestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(2)
+        self.hass = get_test_home_assistant()
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""

--- a/tests/components/test_statsd.py
+++ b/tests/components/test_statsd.py
@@ -17,7 +17,7 @@ class TestStatsd(unittest.TestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(2)
+        self.hass = get_test_home_assistant()
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -91,7 +91,7 @@ class TestHomeAssistant(unittest.TestCase):
     # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(0)
+        self.hass = get_test_home_assistant()
 
     # pylint: disable=invalid-name
     def tearDown(self):
@@ -372,7 +372,7 @@ class TestStateMachine(unittest.TestCase):
     # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant(0)
+        self.hass = get_test_home_assistant()
         self.states = self.hass.states
         self.states.set("light.Bowl", "on")
         self.states.set("switch.AC", "off")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -653,8 +653,9 @@ class TestWorkerPool(unittest.TestCase):
         def register_call(_):
             calls.append(1)
 
-        pool.add_job(ha.JobPriority.EVENT_DEFAULT, (malicious_job, None))
-        pool.add_job(ha.JobPriority.EVENT_DEFAULT, (register_call, None))
+        pool.add_job((malicious_job, None))
+        pool.block_till_done()
+        pool.add_job((register_call, None))
         pool.block_till_done()
         self.assertEqual(1, len(calls))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -56,7 +56,7 @@ def test_async_add_job_add_threaded_job_to_pool(mock_iscoro):
     ha.HomeAssistant.async_add_job(hass, job)
     assert len(hass.loop.call_soon.mock_calls) == 0
     assert len(hass.loop.create_task.mock_calls) == 0
-    assert len(hass.add_job.mock_calls) == 1
+    assert len(hass.pool.add_job.mock_calls) == 1
 
 
 def test_async_run_job_calls_callback():


### PR DESCRIPTION
This will lazy initialise the worker pool. This should make startup slightly faster, including for our tests 💃 

On top of that it will now raise if the thread pool is used in a test while depending on the `hass` fixture. If you want to allow the pool, set `hass.allow_pool = True`. Set it to `False` to disallow the pool when you're using `get_test_home_assistant`.

Passing in a thread count to `get_test_home_assistant` has been removed as most of the times it wasn't used anymore as things take place inside asyncio now.

Because of these changes we no longer need our thread pool to be a priority queue as we are just enqueueing most things in asyncio and we do not have any priority there. So I have removed all the priority stuff from our thread pool and core.