### PR TITLE
No need to catch redundant exceptions

### DIFF
--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/climate.radiotherm/
 """
 import datetime
 import logging
-from urllib.error import URLError
 
 import voluptuous as vol
 
@@ -52,7 +51,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         try:
             tstat = radiotherm.get_thermostat(host)
             tstats.append(RadioThermostat(tstat, hold_temp))
-        except (URLError, OSError):
+        except OSError:
             _LOGGER.exception("Unable to connect to Radio Thermostat: %s",
                               host)
 

--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.panasonic_viera/
 """
 import logging
-import socket
 
 import voluptuous as vol
 
@@ -60,9 +59,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     try:
         remote.get_mute()
-    except (socket.timeout, TimeoutError, OSError):
-        _LOGGER.error('Panasonic Viera TV is not available at %s:%d',
-                      host, port)
+    except OSError as error:
+        _LOGGER.error('Panasonic Viera TV is not available at %s:%d: %s',
+                      host, port, error)
         return False
 
     add_devices([PanasonicVieraTVDevice(name, remote)])
@@ -88,7 +87,7 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
         try:
             self._muted = self._remote.get_mute()
             self._state = STATE_ON
-        except (socket.timeout, TimeoutError, OSError):
+        except OSError:
             self._state = STATE_OFF
             return False
         return True
@@ -98,7 +97,7 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
         try:
             self._remote.send_key(key)
             self._state = STATE_ON
-        except (socket.timeout, TimeoutError, OSError):
+        except OSError:
             self._state = STATE_OFF
             return False
         return True
@@ -120,7 +119,7 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
         try:
             volume = self._remote.get_volume() / 100
             self._state = STATE_ON
-        except (socket.timeout, TimeoutError, OSError):
+        except OSError:
             self._state = STATE_OFF
         return volume
 
@@ -156,7 +155,7 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
         try:
             self._remote.set_volume(volume)
             self._state = STATE_ON
-        except (socket.timeout, TimeoutError, OSError):
+        except OSError:
             self._state = STATE_OFF
 
     def media_play_pause(self):

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.samsungtv/
 """
 import logging
-import socket
 
 import voluptuous as vol
 
@@ -101,8 +100,7 @@ class SamsungTVDevice(MediaPlayerDevice):
             self._state = STATE_ON
             self._remote = None
             return False
-        except (self._remote_class.ConnectionClosed, socket.timeout,
-                TimeoutError, OSError):
+        except (self._remote_class.ConnectionClosed, OSError):
             self._state = STATE_OFF
             self._remote = None
             return False

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -163,7 +163,7 @@ class LogitechMediaServer(object):
 
             return response
 
-        except (OSError, ConnectionError, EOFError) as error:
+        except (OSError, EOFError) as error:
             _LOGGER.error("Could not communicate with %s:%d: %s",
                           self.host,
                           self.port,

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -71,8 +71,8 @@ def load_data(url=None, file=None, username=None, password=None):
         else:
             _LOGGER.warning("Can't load photo no photo found in params!")
 
-    except (OSError, IOError, requests.exceptions.RequestException):
-        _LOGGER.error("Can't load photo into ByteIO")
+    except OSError as error:
+        _LOGGER.error("Can't load photo into ByteIO: %s", error)
 
     return None
 

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -157,7 +157,7 @@ class TelldusLiveData(object):
             response = self._client.request(what, params)
             _LOGGER.debug("got response %s", response)
             return response
-        except (ConnectionError, TimeoutError, OSError) as error:
+        except OSError as error:
             _LOGGER.error("failed to make request to Tellduslive servers: %s",
                           error)
             return None


### PR DESCRIPTION
**Description:**
OSError is an alias for IOException (since Python 3.3) and also the base class for many other exceptions (such as socket.error, ConnectionError, etc) - there is no need to catch redundant exceptions if OSError already present in the except-clause.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.

…ions - no need to catch redundant exceptions if OSError already present in except-clause
