### PR TITLE
Fix HTTP serving a single static file

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -328,8 +328,8 @@ class HomeAssistantWSGI(object):
         @asyncio.coroutine
         def serve_file(request):
             """Redirect to location."""
-            yield from _GZIP_FILE_SENDER.send(request, filepath)
-            return
+            res = yield from _GZIP_FILE_SENDER.send(request, filepath)
+            return res
 
         # aiohttp supports regex matching for variables. Using that as temp
         # to work around cache busting MD5.


### PR DESCRIPTION
**Description:**

Requesting static files that were registered on a file-basis with Home Assistant would trigger this exception in the logs (but the file would still be served):

```
16-10-29 13:15:20 ERROR (MainThread) [aiohttp.web] Error handling request
Traceback (most recent call last):
  File "/Users/paulus/dev/python/home-assistant/lib/python3.5/site-packages/aiohttp/server.py", line 261, in start
    yield from self.handle_request(message, payload)
  File "/Users/paulus/dev/python/home-assistant/lib/python3.5/site-packages/aiohttp/web.py", line 93, in handle_request
    match_info.handler, type(resp), self._middlewares)
AssertionError: Handler <function HomeAssistantWSGI.register_static_path.<locals>.serve_file at 0x101afc268> should return response instance, got <class 'NoneType'> [middlewares []]
```

Example URL that triggered it:

```
http://localhost:8123/frontend/panels/dev-event-550bf85345c454274a40d15b2795a002.html
```

**Related issue (if applicable):** fixes #4072
