### PR TITLE
Introducing hass.data

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -141,6 +141,8 @@ class HomeAssistant(object):
         self.services = ServiceRegistry(self.bus, self.add_job, self.loop)
         self.states = StateMachine(self.bus, self.loop)
         self.config = Config()  # type: Config
+        # This is a dictionary that any component can store any data on.
+        self.data = {}
         self.state = CoreState.not_running
         self.exit_code = None
         self._websession = None

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -113,9 +113,10 @@ def async_load_platform(hass, component, platform, discovered=None,
     This method is a coroutine.
     """
     did_lock = False
-    if hasattr(hass, 'setup_lock') and hass.setup_lock.locked():
+    setup_lock = hass.data.get('setup_lock')
+    if setup_lock and setup_lock.locked():
         did_lock = True
-        yield from hass.setup_lock.acquire()
+        yield from setup_lock.acquire()
 
     try:
         # No need to fire event if we could not setup component
@@ -123,7 +124,7 @@ def async_load_platform(hass, component, platform, discovered=None,
             hass, component, hass_config)
     finally:
         if did_lock:
-            hass.setup_lock.release()
+            setup_lock.release()
 
     if not res:
         return

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -134,9 +134,11 @@ class HomeAssistant(ha.HomeAssistant):
         self.services = ha.ServiceRegistry(self.bus, self.add_job, self.loop)
         self.states = StateMachine(self.bus, self.loop, self.remote_api)
         self.config = ha.Config()
-        self._websession = None
-
+        # This is a dictionary that any component can store any data on.
+        self.data = {}
         self.state = ha.CoreState.not_running
+        self.exit_code = None
+        self._websession = None
         self.config.api = local_api
 
     def start(self):

--- a/tests/helpers/test_discovery.py
+++ b/tests/helpers/test_discovery.py
@@ -138,7 +138,7 @@ class TestHelpersDiscovery:
 
         # We wait for the setup_lock to finish
         run_coroutine_threadsafe(
-            self.hass.setup_lock.acquire(), self.hass.loop).result()
+            self.hass.data['setup_lock'].acquire(), self.hass.loop).result()
 
         self.hass.block_till_done()
 


### PR DESCRIPTION
This PR introduces a new property `hass.data` that is a dictionary that is meant for components and platforms to store data. This might either be data that they want to share with other pieces of code (ie an instance of a bridge/hub) or something they want to store but not share with everyone (ie the homeassistant.loader cache).

I was researching the recent test flakiness when I noticed it was caused by a global that didn't get reset. I then remembered the [aiohttp data sharing docs](http://aiohttp.readthedocs.io/en/stable/web.html#aiohttp-web-data-sharing) and decided to do a similar thing for us. They actually go a step further and have their Application class extend `dict`. I am not sure how I feel about doing that for Home Assistant.

The eventual goal would be to kill all globals used for data storage.
