### PR TITLE
Add LiteJet (a lighting control system) component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -37,6 +37,9 @@ omit =
     homeassistant/components/isy994.py
     homeassistant/components/*/isy994.py
 
+    homeassistant/components/litejet.py
+    homeassistant/components/*/litejet.py
+
     homeassistant/components/modbus.py
     homeassistant/components/*/modbus.py
 

--- a/homeassistant/components/automation/litejet.py
+++ b/homeassistant/components/automation/litejet.py
@@ -1,5 +1,8 @@
 """
-Offer LiteJet switch based automation rules.
+Trigger an automation when a LiteJet switch is released.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/automation.litejet/
 """
 from datetime import timedelta
 import logging
@@ -7,7 +10,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.const import CONF_PLATFORM, CONF_ENTITY_ID
+from homeassistant.const import CONF_PLATFORM
 import homeassistant.helpers.config_validation as cv
 import homeassistant.components.litejet as litejet
 
@@ -23,16 +26,12 @@ ATTR_NUMBER = 'number'
 TRIGGER_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'litejet',
     vol.Required(CONF_NUMBER): vol.Coerce(int),
-    #vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Required(CONF_FOR, default=timedelta(0)): cv.time_period,
 })
 
 
 def async_trigger(hass, config, action):
     """Listen for events based on configuration."""
-    #entity_id = config.get(CONF_ENTITY_ID)
-    #entity = hass.states.get(entity_id)
-    #number = entity.attributes[ATTR_NUMBER]
     number = config.get(CONF_NUMBER)
     for_time = config.get(CONF_FOR)
 
@@ -42,7 +41,6 @@ def async_trigger(hass, config, action):
         hass.async_run_job(action, {
             'trigger': {
                 'platform': 'litejet',
-                #'entity_id': entity_id,
                 'number': number,
                 'for': for_time
             },

--- a/homeassistant/components/automation/litejet.py
+++ b/homeassistant/components/automation/litejet.py
@@ -4,7 +4,6 @@ Trigger an automation when a LiteJet switch is released.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/automation.litejet/
 """
-from datetime import timedelta
 import logging
 
 import voluptuous as vol
@@ -21,7 +20,7 @@ CONF_NUMBER = 'number'
 
 TRIGGER_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'litejet',
-    vol.Required(CONF_NUMBER): vol.Coerce(int)
+    vol.Required(CONF_NUMBER): cv.positive_int
 })
 
 

--- a/homeassistant/components/automation/litejet.py
+++ b/homeassistant/components/automation/litejet.py
@@ -18,22 +18,19 @@ DEPENDENCIES = ['litejet']
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_FOR = 'for'
 CONF_NUMBER = 'number'
 
 ATTR_NUMBER = 'number'
 
 TRIGGER_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'litejet',
-    vol.Required(CONF_NUMBER): vol.Coerce(int),
-    vol.Required(CONF_FOR, default=timedelta(0)): cv.time_period,
+    vol.Required(CONF_NUMBER): vol.Coerce(int)
 })
 
 
 def async_trigger(hass, config, action):
     """Listen for events based on configuration."""
     number = config.get(CONF_NUMBER)
-    for_time = config.get(CONF_FOR)
 
     @callback
     def call_action():
@@ -41,8 +38,7 @@ def async_trigger(hass, config, action):
         hass.async_run_job(action, {
             'trigger': {
                 'platform': 'litejet',
-                'number': number,
-                'for': for_time
+                'number': number
             },
         })
 

--- a/homeassistant/components/automation/litejet.py
+++ b/homeassistant/components/automation/litejet.py
@@ -1,0 +1,51 @@
+"""
+Offer LiteJet switch based automation rules.
+"""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.const import CONF_PLATFORM, CONF_ENTITY_ID
+import homeassistant.helpers.config_validation as cv
+import homeassistant.components.litejet as litejet
+
+DEPENDENCIES = ['litejet']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_FOR = 'for'
+CONF_NUMBER = 'number'
+
+ATTR_NUMBER = 'number'
+
+TRIGGER_SCHEMA = vol.Schema({
+    vol.Required(CONF_PLATFORM): 'litejet',
+    vol.Required(CONF_NUMBER): vol.Coerce(int),
+    #vol.Required(CONF_ENTITY_ID): cv.entity_id,
+    vol.Required(CONF_FOR, default=timedelta(0)): cv.time_period,
+})
+
+
+def async_trigger(hass, config, action):
+    """Listen for events based on configuration."""
+    #entity_id = config.get(CONF_ENTITY_ID)
+    #entity = hass.states.get(entity_id)
+    #number = entity.attributes[ATTR_NUMBER]
+    number = config.get(CONF_NUMBER)
+    for_time = config.get(CONF_FOR)
+
+    @callback
+    def call_action():
+        """Call action with right context."""
+        hass.async_run_job(action, {
+            'trigger': {
+                'platform': 'litejet',
+                #'entity_id': entity_id,
+                'number': number,
+                'for': for_time
+            },
+        })
+
+    litejet.CONNECTION.on_switch_released(number, call_action)

--- a/homeassistant/components/automation/litejet.py
+++ b/homeassistant/components/automation/litejet.py
@@ -12,15 +12,12 @@ import voluptuous as vol
 from homeassistant.core import callback
 from homeassistant.const import CONF_PLATFORM
 import homeassistant.helpers.config_validation as cv
-import homeassistant.components.litejet as litejet
 
 DEPENDENCIES = ['litejet']
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_NUMBER = 'number'
-
-ATTR_NUMBER = 'number'
 
 TRIGGER_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'litejet',
@@ -37,9 +34,9 @@ def async_trigger(hass, config, action):
         """Call action with right context."""
         hass.async_run_job(action, {
             'trigger': {
-                'platform': 'litejet',
-                'number': number
+                CONF_PLATFORM: 'litejet',
+                CONF_NUMBER: number
             },
         })
 
-    litejet.CONNECTION.on_switch_released(number, call_action)
+    hass.data['litejet_system'].on_switch_released(number, call_action)

--- a/homeassistant/components/light/litejet.py
+++ b/homeassistant/components/light/litejet.py
@@ -47,7 +47,7 @@ class LiteJetLight(Light):
 
     def _on_load_changed(self):
         """Called on a LiteJet thread when a load's state changes."""
-        _LOGGER.info("Updating due to notification for %s", self._name)
+        _LOGGER.debug("Updating due to notification for %s", self._name)
         self._hass.loop.create_task(self.async_update_ha_state(True))
 
     @property

--- a/homeassistant/components/light/litejet.py
+++ b/homeassistant/components/light/litejet.py
@@ -19,12 +19,12 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup lights for the LiteJet platform."""
-    litejet_ = litejet.CONNECTION
+    litejet_ = hass.data['litejet_system']
 
     devices = []
     for i in litejet_.loads():
         name = litejet_.get_load_name(i)
-        if not litejet.is_ignored(name):
+        if not litejet.is_ignored(hass, name):
             devices.append(LiteJetLight(hass, litejet_, i, name))
     add_devices(devices)
 

--- a/homeassistant/components/light/litejet.py
+++ b/homeassistant/components/light/litejet.py
@@ -1,4 +1,10 @@
-"""A single LiteJet light."""
+"""
+Support for LiteJet lights.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.litejet/
+"""
+
 import logging
 
 import homeassistant.components.litejet as litejet

--- a/homeassistant/components/light/litejet.py
+++ b/homeassistant/components/light/litejet.py
@@ -57,21 +57,22 @@ class LiteJetLight(Light):
 
     @property
     def brightness(self):
-        """The light's brightness."""
+        """Return the light's brightness."""
         return self._brightness
 
     @property
     def is_on(self):
-        """Is the light on?"""
+        """Return if the light is on."""
         return self._brightness != 0
 
     @property
     def should_poll(self):
-        """LiteJet lights do not require polling."""
+        """Return that lights do not require polling."""
         return False
 
     @property
     def device_state_attributes(self):
+        """Return the device state attributes."""
         return {
             ATTR_NUMBER: self._index
         }

--- a/homeassistant/components/light/litejet.py
+++ b/homeassistant/components/light/litejet.py
@@ -16,7 +16,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     litejet_ = litejet.CONNECTION
 
     add_devices(LiteJetLight(hass, litejet_, i) for i in litejet_.loads())
-    # add_devices(LiteJetScene(litejet_, i) for i in litejet_.scenes())
 
 
 class LiteJetLight(Light):
@@ -69,9 +68,10 @@ class LiteJetLight(Light):
 
     def turn_on(self, **kwargs):
         """Turn on the light."""
-        # device_brightness = kwargs.get(ATTR_BRIGHTNESS, 255) / 255 * 99
-        # device_rate = 5
-        self._lj.activate_load(self._index)
+        if ATTR_BRIGHTNESS in kwargs:
+            self._lj.activate_load_at(self._index, int(kwargs[ATTR_BRIGHTNESS] / 255 * 99), 0)
+        else:
+            self._lj.activate_load(self._index)
 
     def turn_off(self, **kwargs):
         """Turn off the light."""
@@ -80,38 +80,3 @@ class LiteJetLight(Light):
     def update(self):
         """Retrieve the light's brightness from the LiteJet system."""
         self._brightness = self._lj.get_load_level(self._index) / 99 * 255
-
-
-class LiteJetScene(Light):
-    """Represents a single LiteJet scene."""
-
-    def __init__(self, lj, i):
-        self._lj = lj
-        self._index = i
-        self._on = False
-
-        self._name = "LiteJet "+str(i)+" "+lj.get_scene_name(i)
-
-    @property
-    def name(self):
-        return self._name
-
-    @property
-    def is_on(self):
-        return self._on
-
-    @property
-    def should_poll(self):
-        return False
-
-    def turn_on(self, **kwargs):
-        self._lj.activate_scene(self._index)
-        self._on = True
-
-    def turn_off(self, **kwargs):
-        self._lj.deactivate_scene(self._index)
-        self._on = False
-
-    def update(self):
-        # do nothing
-        return

--- a/homeassistant/components/light/litejet.py
+++ b/homeassistant/components/light/litejet.py
@@ -73,7 +73,8 @@ class LiteJetLight(Light):
     def turn_on(self, **kwargs):
         """Turn on the light."""
         if ATTR_BRIGHTNESS in kwargs:
-            self._lj.activate_load_at(self._index, int(kwargs[ATTR_BRIGHTNESS] / 255 * 99), 0)
+            brightness = int(kwargs[ATTR_BRIGHTNESS] / 255 * 99)
+            self._lj.activate_load_at(self._index, brightness, 0)
         else:
             self._lj.activate_load(self._index)
 

--- a/homeassistant/components/light/litejet.py
+++ b/homeassistant/components/light/litejet.py
@@ -15,20 +15,24 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup lights for the LiteJet platform."""
     litejet_ = litejet.CONNECTION
 
-    add_devices(LiteJetLight(hass, litejet_, i) for i in litejet_.loads())
+    devices = []
+    for i in litejet_.loads():
+        name = litejet_.get_load_name(i)
+        if not litejet.is_ignored(name):
+            devices.append(LiteJetLight(hass, litejet_, i, name))
+    add_devices(devices)
 
 
 class LiteJetLight(Light):
     """Represents a single LiteJet light."""
 
-    def __init__(self, hass, lj, i):
+    def __init__(self, hass, lj, i, name):
         """Initialize a LiteJet light."""
         self._hass = hass
         self._lj = lj
         self._index = i
         self._brightness = 0
-
-        self._name = lj.get_load_name(i)
+        self._name = name
 
         lj.on_load_activated(i, self._on_load_changed)
         lj.on_load_deactivated(i, self._on_load_changed)

--- a/homeassistant/components/light/litejet.py
+++ b/homeassistant/components/light/litejet.py
@@ -6,6 +6,8 @@ from homeassistant.components.light import ATTR_BRIGHTNESS, Light
 
 DEPENDENCIES = ['litejet']
 
+ATTR_NUMBER = 'number'
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -58,6 +60,12 @@ class LiteJetLight(Light):
     def should_poll(self):
         """LiteJet lights do not require polling."""
         return False
+
+    @property
+    def device_state_attributes(self):
+        return {
+            ATTR_NUMBER: self._index
+        }
 
     def turn_on(self, **kwargs):
         """Turn on the light."""

--- a/homeassistant/components/light/litejet.py
+++ b/homeassistant/components/light/litejet.py
@@ -1,0 +1,109 @@
+"""A single LiteJet light."""
+import logging
+
+import homeassistant.components.litejet as litejet
+from homeassistant.components.light import ATTR_BRIGHTNESS, Light
+
+DEPENDENCIES = ['litejet']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup lights for the LiteJet platform."""
+    litejet_ = litejet.CONNECTION
+
+    add_devices(LiteJetLight(hass, litejet_, i) for i in litejet_.loads())
+    # add_devices(LiteJetScene(litejet_, i) for i in litejet_.scenes())
+
+
+class LiteJetLight(Light):
+    """Represents a single LiteJet light."""
+
+    def __init__(self, hass, lj, i):
+        """Initialize a LiteJet light."""
+        self._hass = hass
+        self._lj = lj
+        self._index = i
+        self._brightness = 0
+
+        self._name = lj.get_load_name(i)
+
+        lj.on_load_activated(i, self._on_load_changed)
+        lj.on_load_deactivated(i, self._on_load_changed)
+
+        self.update()
+
+    def _on_load_changed(self):
+        """Called on a LiteJet thread when a load's state changes."""
+        _LOGGER.info("Updating due to notification for %s", self._name)
+        self._hass.loop.create_task(self.async_update_ha_state(True))
+
+    @property
+    def name(self):
+        """The light's name."""
+        return self._name
+
+    @property
+    def brightness(self):
+        """The light's brightness."""
+        return self._brightness
+
+    @property
+    def is_on(self):
+        """Is the light on?"""
+        return self._brightness != 0
+
+    @property
+    def should_poll(self):
+        """LiteJet lights do not require polling."""
+        return False
+
+    def turn_on(self, **kwargs):
+        """Turn on the light."""
+        # device_brightness = kwargs.get(ATTR_BRIGHTNESS, 255) / 255 * 99
+        # device_rate = 5
+        self._lj.activate_load(self._index)
+
+    def turn_off(self, **kwargs):
+        """Turn off the light."""
+        self._lj.deactivate_load(self._index)
+
+    def update(self):
+        """Retrieve the light's brightness from the LiteJet system."""
+        self._brightness = self._lj.get_load_level(self._index) / 99 * 255
+
+
+class LiteJetScene(Light):
+    """Represents a single LiteJet scene."""
+
+    def __init__(self, lj, i):
+        self._lj = lj
+        self._index = i
+        self._on = False
+
+        self._name = "LiteJet "+str(i)+" "+lj.get_scene_name(i)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def is_on(self):
+        return self._on
+
+    @property
+    def should_poll(self):
+        return False
+
+    def turn_on(self, **kwargs):
+        self._lj.activate_scene(self._index)
+        self._on = True
+
+    def turn_off(self, **kwargs):
+        self._lj.deactivate_scene(self._index)
+        self._on = False
+
+    def update(self):
+        # do nothing
+        return

--- a/homeassistant/components/litejet.py
+++ b/homeassistant/components/litejet.py
@@ -12,7 +12,7 @@ import homeassistant.helpers.config_validation as cv
 
 DOMAIN = 'litejet'
 
-REQUIREMENTS = ['pylitejet>=0.1']
+REQUIREMENTS = ['pylitejet==0.1']
 
 CONF_EXCLUDE_NAMES = 'exclude_names'
 CONF_INCLUDE_SWITCHES = 'include_switches'

--- a/homeassistant/components/litejet.py
+++ b/homeassistant/components/litejet.py
@@ -35,5 +35,6 @@ def setup(hass, config):
 
     discovery.load_platform(hass, 'light', DOMAIN, {}, config)
     discovery.load_platform(hass, 'switch', DOMAIN, {}, config)
+    discovery.load_platform(hass, 'scene', DOMAIN, {}, config)
 
     return True

--- a/homeassistant/components/litejet.py
+++ b/homeassistant/components/litejet.py
@@ -1,0 +1,39 @@
+"""Allows the LiteJet lighting system to be controlled by Home Assistant."""
+import logging
+import voluptuous as vol
+
+from homeassistant.helpers import discovery
+from homeassistant.const import CONF_URL
+import homeassistant.helpers.config_validation as cv
+
+DOMAIN = 'litejet'
+
+REQUIREMENTS = ['pylitejet>=0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_URL): cv.string
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+CONNECTION = None
+
+
+def setup(hass, config):
+    """Initializes the LiteJet component."""
+
+    from pylitejet import LiteJet
+
+    global CONNECTION
+
+    url = config[DOMAIN].get(CONF_URL)
+
+    _LOGGER.info('Opening %s"', url)
+    CONNECTION = LiteJet(url)
+
+    discovery.load_platform(hass, 'light', DOMAIN, {}, config)
+    discovery.load_platform(hass, 'switch', DOMAIN, {}, config)
+
+    return True

--- a/homeassistant/components/litejet.py
+++ b/homeassistant/components/litejet.py
@@ -10,15 +10,19 @@ DOMAIN = 'litejet'
 
 REQUIREMENTS = ['pylitejet>=0.1']
 
+CONF_IGNORE = 'ignore'
+
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_URL): cv.string
+        vol.Required(CONF_URL): cv.string,
+        vol.Optional(CONF_IGNORE) : vol.All(cv.ensure_list, [cv.string])
     })
 }, extra=vol.ALLOW_EXTRA)
 
 CONNECTION = None
+CONFIG = None
 
 
 def setup(hass, config):
@@ -26,15 +30,23 @@ def setup(hass, config):
 
     from pylitejet import LiteJet
 
-    global CONNECTION
+    global CONNECTION, CONFIG
 
     url = config[DOMAIN].get(CONF_URL)
 
     _LOGGER.info('Opening %s"', url)
     CONNECTION = LiteJet(url)
+    CONFIG = config[DOMAIN]
 
     discovery.load_platform(hass, 'light', DOMAIN, {}, config)
     discovery.load_platform(hass, 'switch', DOMAIN, {}, config)
     discovery.load_platform(hass, 'scene', DOMAIN, {}, config)
 
     return True
+
+def is_ignored(name):
+    """Determines if a load, switch, or scene should be ignored based on its name."""
+    for prefix in CONFIG.get(CONF_IGNORE, []):
+        if name.startswith(prefix):
+            return True
+    return False

--- a/homeassistant/components/litejet.py
+++ b/homeassistant/components/litejet.py
@@ -1,4 +1,8 @@
-"""Allows the LiteJet lighting system to be controlled by Home Assistant."""
+"""Allows the LiteJet lighting system to be controlled by Home Assistant.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/litejet/
+"""
 import logging
 import voluptuous as vol
 
@@ -10,14 +14,16 @@ DOMAIN = 'litejet'
 
 REQUIREMENTS = ['pylitejet>=0.1']
 
-CONF_IGNORE = 'ignore'
+CONF_EXCLUDE_NAMES = 'exclude_names'
+CONF_INCLUDE_SWITCHES = 'include_switches'
 
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_URL): cv.string,
-        vol.Optional(CONF_IGNORE): vol.All(cv.ensure_list, [cv.string])
+        vol.Optional(CONF_EXCLUDE_NAMES): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_INCLUDE_SWITCHES, default=False): cv.boolean
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -34,12 +40,12 @@ def setup(hass, config):
 
     url = config[DOMAIN].get(CONF_URL)
 
-    _LOGGER.info('Opening %s"', url)
     CONNECTION = LiteJet(url)
     CONFIG = config[DOMAIN]
 
     discovery.load_platform(hass, 'light', DOMAIN, {}, config)
-    discovery.load_platform(hass, 'switch', DOMAIN, {}, config)
+    if config[DOMAIN].get(CONF_INCLUDE_SWITCHES):
+        discovery.load_platform(hass, 'switch', DOMAIN, {}, config)
     discovery.load_platform(hass, 'scene', DOMAIN, {}, config)
 
     return True
@@ -49,7 +55,7 @@ def is_ignored(name):
     """Determines if a load, switch, or scene should be ignored
     based on its name. This is called by each platform during setup.
     """
-    for prefix in CONFIG.get(CONF_IGNORE, []):
+    for prefix in CONFIG.get(CONF_EXCLUDE_NAMES, []):
         if name.startswith(prefix):
             return True
     return False

--- a/homeassistant/components/litejet.py
+++ b/homeassistant/components/litejet.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_URL): cv.string,
-        vol.Optional(CONF_IGNORE) : vol.All(cv.ensure_list, [cv.string])
+        vol.Optional(CONF_IGNORE): vol.All(cv.ensure_list, [cv.string])
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -44,8 +44,11 @@ def setup(hass, config):
 
     return True
 
+
 def is_ignored(name):
-    """Determines if a load, switch, or scene should be ignored based on its name."""
+    """Determines if a load, switch, or scene should be ignored
+    based on its name. This is called by each platform during setup.
+    """
     for prefix in CONFIG.get(CONF_IGNORE, []):
         if name.startswith(prefix):
             return True

--- a/homeassistant/components/litejet.py
+++ b/homeassistant/components/litejet.py
@@ -32,8 +32,7 @@ CONFIG = None
 
 
 def setup(hass, config):
-    """Initializes the LiteJet component."""
-
+    """Initialize the LiteJet component."""
     from pylitejet import LiteJet
 
     global CONNECTION, CONFIG
@@ -52,9 +51,7 @@ def setup(hass, config):
 
 
 def is_ignored(name):
-    """Determines if a load, switch, or scene should be ignored
-    based on its name. This is called by each platform during setup.
-    """
+    """Determine if a load, switch, or scene should be ignored."""
     for prefix in CONFIG.get(CONF_EXCLUDE_NAMES, []):
         if name.startswith(prefix):
             return True

--- a/homeassistant/components/litejet.py
+++ b/homeassistant/components/litejet.py
@@ -27,20 +27,15 @@ CONFIG_SCHEMA = vol.Schema({
     })
 }, extra=vol.ALLOW_EXTRA)
 
-CONNECTION = None
-CONFIG = None
-
 
 def setup(hass, config):
     """Initialize the LiteJet component."""
     from pylitejet import LiteJet
 
-    global CONNECTION, CONFIG
-
     url = config[DOMAIN].get(CONF_URL)
 
-    CONNECTION = LiteJet(url)
-    CONFIG = config[DOMAIN]
+    hass.data['litejet_system'] = LiteJet(url)
+    hass.data['litejet_config'] = config[DOMAIN]
 
     discovery.load_platform(hass, 'light', DOMAIN, {}, config)
     if config[DOMAIN].get(CONF_INCLUDE_SWITCHES):
@@ -50,9 +45,9 @@ def setup(hass, config):
     return True
 
 
-def is_ignored(name):
+def is_ignored(hass, name):
     """Determine if a load, switch, or scene should be ignored."""
-    for prefix in CONFIG.get(CONF_EXCLUDE_NAMES, []):
+    for prefix in hass.data['litejet_config'].get(CONF_EXCLUDE_NAMES, []):
         if name.startswith(prefix):
             return True
     return False

--- a/homeassistant/components/scene/litejet.py
+++ b/homeassistant/components/scene/litejet.py
@@ -1,4 +1,9 @@
-"""A single LiteJet scene."""
+"""
+Support for LiteJet scenes.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/scene.litejet/
+"""
 import logging
 import homeassistant.components.litejet as litejet
 from homeassistant.components.scene import Scene

--- a/homeassistant/components/scene/litejet.py
+++ b/homeassistant/components/scene/litejet.py
@@ -14,18 +14,22 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup scenes for the LiteJet platform."""
     litejet_ = litejet.CONNECTION
 
-    add_devices(LiteJetScene(litejet_, i) for i in litejet_.scenes())
+    devices = []
+    for i in litejet_.scenes():
+        name = litejet_.get_scene_name(i)
+        if not litejet.is_ignored(name):
+            devices.append(LiteJetScene(litejet_, i, name))
+    add_devices(devices)
 
 
 class LiteJetScene(Scene):
     """Represents a single LiteJet scene."""
 
-    def __init__(self, lj, i):
+    def __init__(self, lj, i, name):
         self._lj = lj
         self._index = i
         self._on = False
-
-        self._name = "LiteJet "+str(i)+" "+lj.get_scene_name(i)
+        self._name = name
 
     @property
     def name(self):

--- a/homeassistant/components/scene/litejet.py
+++ b/homeassistant/components/scene/litejet.py
@@ -1,0 +1,46 @@
+"""A single LiteJet scene."""
+import logging
+import homeassistant.components.litejet as litejet
+from homeassistant.components.scene import Scene
+
+DEPENDENCIES = ['litejet']
+
+ATTR_NUMBER = 'number'
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup scenes for the LiteJet platform."""
+    litejet_ = litejet.CONNECTION
+
+    add_devices(LiteJetScene(litejet_, i) for i in litejet_.scenes())
+
+
+class LiteJetScene(Scene):
+    """Represents a single LiteJet scene."""
+
+    def __init__(self, lj, i):
+        self._lj = lj
+        self._index = i
+        self._on = False
+
+        self._name = "LiteJet "+str(i)+" "+lj.get_scene_name(i)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def should_poll(self):
+        return False
+
+    @property
+    def device_state_attributes(self):
+        return {
+            ATTR_NUMBER: self._index
+        }
+ 
+    def activate(self, **kwargs):
+        self._lj.activate_scene(self._index)
+        self._on = True

--- a/homeassistant/components/scene/litejet.py
+++ b/homeassistant/components/scene/litejet.py
@@ -34,7 +34,6 @@ class LiteJetScene(Scene):
         """Initialize the scene."""
         self._lj = lj
         self._index = i
-        self._on = False
         self._name = name
 
     @property
@@ -57,4 +56,3 @@ class LiteJetScene(Scene):
     def activate(self, **kwargs):
         """Activate the scene."""
         self._lj.activate_scene(self._index)
-        self._on = True

--- a/homeassistant/components/scene/litejet.py
+++ b/homeassistant/components/scene/litejet.py
@@ -17,12 +17,12 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup scenes for the LiteJet platform."""
-    litejet_ = litejet.CONNECTION
+    litejet_ = hass.data['litejet_system']
 
     devices = []
     for i in litejet_.scenes():
         name = litejet_.get_scene_name(i)
-        if not litejet.is_ignored(name):
+        if not litejet.is_ignored(hass, name):
             devices.append(LiteJetScene(litejet_, i, name))
     add_devices(devices)
 

--- a/homeassistant/components/scene/litejet.py
+++ b/homeassistant/components/scene/litejet.py
@@ -44,7 +44,7 @@ class LiteJetScene(Scene):
         return {
             ATTR_NUMBER: self._index
         }
- 
+
     def activate(self, **kwargs):
         self._lj.activate_scene(self._index)
         self._on = True

--- a/homeassistant/components/scene/litejet.py
+++ b/homeassistant/components/scene/litejet.py
@@ -31,6 +31,7 @@ class LiteJetScene(Scene):
     """Represents a single LiteJet scene."""
 
     def __init__(self, lj, i, name):
+        """Initialize the scene."""
         self._lj = lj
         self._index = i
         self._on = False
@@ -38,18 +39,22 @@ class LiteJetScene(Scene):
 
     @property
     def name(self):
+        """Return the name of the scene."""
         return self._name
 
     @property
     def should_poll(self):
+        """Return that polling is not necessary."""
         return False
 
     @property
     def device_state_attributes(self):
+        """Return the device-specific state attributes."""
         return {
             ATTR_NUMBER: self._index
         }
 
     def activate(self, **kwargs):
+        """Activate the scene."""
         self._lj.activate_scene(self._index)
         self._on = True

--- a/homeassistant/components/switch/litejet.py
+++ b/homeassistant/components/switch/litejet.py
@@ -1,9 +1,7 @@
 """Creates switches for the switches in the LiteJet lighting system."""
-import voluptuous as vol
 import logging
 import homeassistant.components.litejet as litejet
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.components.switch import SwitchDevice
 
 DEPENDENCIES = ['litejet']
 

--- a/homeassistant/components/switch/litejet.py
+++ b/homeassistant/components/switch/litejet.py
@@ -1,4 +1,9 @@
-"""Creates switches for the switches in the LiteJet lighting system."""
+"""
+Support for LiteJet switch.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.litejet/
+"""
 import logging
 import homeassistant.components.litejet as litejet
 from homeassistant.components.switch import SwitchDevice

--- a/homeassistant/components/switch/litejet.py
+++ b/homeassistant/components/switch/litejet.py
@@ -17,12 +17,12 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the LiteJet switch platform."""
-    litejet_ = litejet.CONNECTION
+    litejet_ = hass.data['litejet_system']
 
     devices = []
     for i in litejet_.button_switches():
         name = litejet_.get_switch_name(i)
-        if not litejet.is_ignored(name):
+        if not litejet.is_ignored(hass, name):
             devices.append(LiteJetSwitch(hass, litejet_, i, name))
     add_devices(devices)
 

--- a/homeassistant/components/switch/litejet.py
+++ b/homeassistant/components/switch/litejet.py
@@ -56,6 +56,12 @@ class LiteJetSwitch(SwitchDevice):
     def should_poll(self):
         return False
 
+    @property
+    def device_state_attributes(self):
+        return {
+            ATTR_NUMBER: self._index
+        }
+
     def turn_on(self, **kwargs):
         self._lj.press_switch(self._index)
 

--- a/homeassistant/components/switch/litejet.py
+++ b/homeassistant/components/switch/litejet.py
@@ -1,0 +1,67 @@
+"""Creates switches for the switches in the LiteJet lighting system."""
+import logging
+import homeassistant.components.litejet as litejet
+from homeassistant.components.switch import SwitchDevice
+
+DEPENDENCIES = ['litejet']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the LiteJet switch platform."""
+    litejet_ = litejet.CONNECTION
+
+    add_devices(LiteJetSwitch(hass, litejet_, i)
+                for i in litejet_.button_switches())
+
+
+class LiteJetSwitch(SwitchDevice):
+    """Represents a single LiteJet switch."""
+
+    def __init__(self, hass, lj, i):
+        """Initialize a LiteJet switch."""
+        self._hass = hass
+        self._lj = lj
+        self._index = i
+        self._state = False
+        self._new_state = None
+
+        self._name = lj.get_switch_name(i)
+
+        lj.on_switch_pressed(i, self._on_switch_pressed)
+        lj.on_switch_released(i, self._on_switch_released)
+
+        self.update()
+
+    def _on_switch_pressed(self):
+        _LOGGER.info("Updating pressed for %s", self._name)
+        self._new_state = True
+        self._hass.loop.create_task(self.async_update_ha_state(True))
+
+    def _on_switch_released(self):
+        _LOGGER.info("Updating released for %s", self._name)
+        self._new_state = False
+        self._hass.loop.create_task(self.async_update_ha_state(True))
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def is_on(self):
+        return self._state
+
+    @property
+    def should_poll(self):
+        return False
+
+    def turn_on(self, **kwargs):
+        self._lj.press_switch(self._index)
+
+    def turn_off(self, **kwargs):
+        self._lj.release_switch(self._index)
+
+    def update(self):
+        if self._new_state is not None:
+            self._state = self._new_state

--- a/homeassistant/components/switch/litejet.py
+++ b/homeassistant/components/switch/litejet.py
@@ -36,7 +36,6 @@ class LiteJetSwitch(SwitchDevice):
         self._lj = lj
         self._index = i
         self._state = False
-        self._new_state = None
         self._name = name
 
         lj.on_switch_pressed(i, self._on_switch_pressed)
@@ -45,14 +44,14 @@ class LiteJetSwitch(SwitchDevice):
         self.update()
 
     def _on_switch_pressed(self):
-        _LOGGER.info("Updating pressed for %s", self._name)
-        self._new_state = True
-        self._hass.loop.create_task(self.async_update_ha_state(True))
+        _LOGGER.debug("Updating pressed for %s", self._name)
+        self._state = True
+        self._hass.loop.create_task(self.async_update_ha_state())
 
     def _on_switch_released(self):
-        _LOGGER.info("Updating released for %s", self._name)
-        self._new_state = False
-        self._hass.loop.create_task(self.async_update_ha_state(True))
+        _LOGGER.debug("Updating released for %s", self._name)
+        self._state = False
+        self._hass.loop.create_task(self.async_update_ha_state())
 
     @property
     def name(self):
@@ -83,8 +82,3 @@ class LiteJetSwitch(SwitchDevice):
     def turn_off(self, **kwargs):
         """Release the switch."""
         self._lj.release_switch(self._index)
-
-    def update(self):
-        """Update the state."""
-        if self._new_state is not None:
-            self._state = self._new_state

--- a/homeassistant/components/switch/litejet.py
+++ b/homeassistant/components/switch/litejet.py
@@ -5,6 +5,8 @@ from homeassistant.components.switch import SwitchDevice
 
 DEPENDENCIES = ['litejet']
 
+ATTR_NUMBER = 'number'
+
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/switch/litejet.py
+++ b/homeassistant/components/switch/litejet.py
@@ -56,28 +56,35 @@ class LiteJetSwitch(SwitchDevice):
 
     @property
     def name(self):
+        """Return the name of the switch."""
         return self._name
 
     @property
     def is_on(self):
+        """Return if the switch is pressed."""
         return self._state
 
     @property
     def should_poll(self):
+        """Return that polling is not necessary."""
         return False
 
     @property
     def device_state_attributes(self):
+        """Return the device-specific state attributes."""
         return {
             ATTR_NUMBER: self._index
         }
 
     def turn_on(self, **kwargs):
+        """Press the switch."""
         self._lj.press_switch(self._index)
 
     def turn_off(self, **kwargs):
+        """Release the switch."""
         self._lj.release_switch(self._index)
 
     def update(self):
+        """Update the state."""
         if self._new_state is not None:
             self._state = self._new_state

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -368,7 +368,7 @@ pyicloud==0.9.1
 pylast==1.6.0
 
 # homeassistant.components.litejet
-pylitejet>=0.1
+pylitejet==0.1
 
 # homeassistant.components.sensor.loopenergy
 pyloopenergy==0.0.15

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -367,6 +367,9 @@ pyicloud==0.9.1
 # homeassistant.components.sensor.lastfm
 pylast==1.6.0
 
+# homeassistant.components.litejet
+pylitejet>=0.1
+
 # homeassistant.components.sensor.loopenergy
 pyloopenergy==0.0.15
 


### PR DESCRIPTION
**Description:**
Add a new LiteJet component and light, switch, scene, and automation platforms for controlling that lighting system.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1361

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
litejet:
  url: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A501JNX3-if00-port0
  exclude_names:
  - 'Button #'
  - 'Scene #'
  - 'Timed Scene #'
  - 'Timed Scene#'
  - 'LV Rel #'
  - 'Fan #'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass** [Note: My test VM is having trouble with a few core async tests, but these tests also fail on the unmodified dev branch.]
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
