### PR TITLE
Allow multiple symbols (sensor.yahoo_finance)

### DIFF
--- a/homeassistant/components/sensor/yahoo_finance.py
+++ b/homeassistant/components/sensor/yahoo_finance.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_NAME, ATTR_ATTRIBUTION)
+from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
@@ -24,37 +24,45 @@ ATTR_OPEN = 'open'
 ATTR_PREV_CLOSE = 'prev_close'
 
 CONF_ATTRIBUTION = "Stock market information provided by Yahoo! Inc."
-CONF_SYMBOL = 'symbol'
+CONF_SYMBOLS = 'symbols'
 
 DEFAULT_NAME = 'Yahoo Stock'
 DEFAULT_SYMBOL = 'YHOO'
 
 ICON = 'mdi:currency-usd'
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_SYMBOL, default=DEFAULT_SYMBOL): cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_SYMBOLS, default=[DEFAULT_SYMBOL]):
+        vol.All(cv.ensure_list, [cv.string]),
 })
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Yahoo Finance sensor."""
-    name = config.get(CONF_NAME)
-    symbol = config.get(CONF_SYMBOL)
+    from yahoo_finance import Share
 
-    data = YahooFinanceData(name, symbol)
-    add_devices([YahooFinanceSensor(name, data, symbol)])
+    symbols = config.get(CONF_SYMBOLS)
+
+    dev = []
+    for symbol in symbols:
+        if Share(symbol).get_price() is None:
+            _LOGGER.warning("Symbol %s unknown", symbol)
+            break
+        data = YahooFinanceData(symbol)
+        dev.append(YahooFinanceSensor(data, symbol))
+
+    add_devices(dev)
 
 
 # pylint: disable=too-few-public-methods
 class YahooFinanceSensor(Entity):
     """Representation of a Yahoo Finance sensor."""
 
-    def __init__(self, name, data, symbol):
+    def __init__(self, data, symbol):
         """Initialize the sensor."""
-        self._name = name
+        self._name = symbol
         self.data = data
         self._symbol = symbol
         self._state = None
@@ -102,17 +110,16 @@ class YahooFinanceSensor(Entity):
 class YahooFinanceData(object):
     """Get data from Yahoo Finance."""
 
-    def __init__(self, name, symbol):
+    def __init__(self, symbol):
         """Initialize the data object."""
         from yahoo_finance import Share
 
-        self._name = name
         self._symbol = symbol
         self.state = None
         self.price_change = None
         self.price_open = None
         self.prev_close = None
-        self.stock = Share(symbol)
+        self.stock = Share(self._symbol)
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/tests/components/sensor/test_yahoo_finance.py
+++ b/tests/components/sensor/test_yahoo_finance.py
@@ -11,10 +11,13 @@ from tests.common import (
 
 VALID_CONFIG = {
     'platform': 'yahoo_finance',
-    'symbol': 'YHOO'
+    'symbols': [
+        'YHOO',
+    ]
 }
 
 
+# pylint: disable=invalid-name
 class TestYahooFinanceSetup(unittest.TestCase):
     """Test the Yahoo Finance platform."""
 
@@ -29,13 +32,13 @@ class TestYahooFinanceSetup(unittest.TestCase):
 
     @patch('yahoo_finance.Base._request',
            return_value=json.loads(load_fixture('yahoo_finance.json')))
-    def test_default_setup(self, m):  # pylint: disable=invalid-name
+    def test_default_setup(self, mock_request):
         """Test the default setup."""
         with assert_setup_component(1, sensor.DOMAIN):
             assert setup_component(self.hass, sensor.DOMAIN, {
                 'sensor': VALID_CONFIG})
 
-        state = self.hass.states.get('sensor.yahoo_stock')
-        self.assertEqual("41.69", state.attributes.get('open'))
-        self.assertEqual("41.79", state.attributes.get('prev_close'))
-        self.assertEqual("YHOO", state.attributes.get('unit_of_measurement'))
+        state = self.hass.states.get('sensor.yhoo')
+        self.assertEqual('41.69', state.attributes.get('open'))
+        self.assertEqual('41.79', state.attributes.get('prev_close'))
+        self.assertEqual('YHOO', state.attributes.get('unit_of_measurement'))


### PR DESCRIPTION
**Description:**
Allow multiple stocks.

**Related issue (if applicable):** fixes #4105

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1362

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: yahoo_finance
    symbols:
      - RHT
      - GOOG
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] Tests have been added to verify that the new code works.
