### PR TITLE
Fix vera climate units

### DIFF
--- a/homeassistant/components/climate/vera.py
+++ b/homeassistant/components/climate/vera.py
@@ -8,7 +8,10 @@ import logging
 
 from homeassistant.util import convert
 from homeassistant.components.climate import ClimateDevice
-from homeassistant.const import TEMP_FAHRENHEIT, ATTR_TEMPERATURE
+from homeassistant.const import (
+    TEMP_FAHRENHEIT,
+    TEMP_CELSIUS,
+    ATTR_TEMPERATURE)
 
 from homeassistant.components.vera import (
     VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
@@ -95,7 +98,13 @@ class VeraThermostat(VeraDevice, ClimateDevice):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        return TEMP_FAHRENHEIT
+        vera_temp_units = (
+            self.vera_device.vera_controller.temperature_units)
+
+        if vera_temp_units == 'F':
+            return TEMP_FAHRENHEIT
+
+        return TEMP_CELSIUS
 
     @property
     def current_temperature(self):


### PR DESCRIPTION
**Description:**
Gets the units from the vera controller - rather than assuming Fahrenheit.

I can't test this as I don't have a vera thermostat so @tyfoon @snizzleorg @rcloran  could one of you check this works?

**Related issue (if applicable):** fixes #3936

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**

``` yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [ ] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
