### PR TITLE
Random number sensor

### DIFF
--- a/homeassistant/components/sensor/random.py
+++ b/homeassistant/components/sensor/random.py
@@ -1,0 +1,73 @@
+"""
+Support for showing random numbers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.random/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (CONF_NAME, CONF_MINIMUM, CONF_MAXIMUM)
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'Random Sensor'
+DEFAULT_MIN = 0
+DEFAULT_MAX = 20
+
+ICON = 'mdi:hanger'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_MAXIMUM, default=DEFAULT_MAX): cv.positive_int,
+    vol.Optional(CONF_MINIMUM, default=DEFAULT_MIN): cv.positive_int,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Setup the Random number sensor."""
+    name = config.get(CONF_NAME)
+    minimum = config.get(CONF_MINIMUM)
+    maximum = config.get(CONF_MAXIMUM)
+
+    hass.loop.create_task(async_add_devices(
+        [RandomSensor(name, minimum, maximum)], True))
+    return True
+
+
+class RandomSensor(Entity):
+    """Representation of a Random number sensor."""
+
+    def __init__(self, name, minimum, maximum):
+        """Initialize the sensor."""
+        self._name = name
+        self._minimum = minimum
+        self._maximum = maximum
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return ICON
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Get a new number and updates the states."""
+        from random import randrange
+        self._state = randrange(self._minimum, self._maximum)

--- a/tests/components/sensor/test_random.py
+++ b/tests/components/sensor/test_random.py
@@ -1,0 +1,36 @@
+"""The test for the random number sensor platform."""
+import unittest
+
+from homeassistant.bootstrap import setup_component
+
+from tests.common import get_test_home_assistant
+
+
+class TestRandomSensor(unittest.TestCase):
+    """Test the Random number sensor."""
+
+    def setup_method(self, method):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_random_sensor(self):
+        """Test the Randowm number sensor."""
+        config = {
+            'sensor': {
+                'platform': 'random',
+                'name': 'test',
+                'minimum': 10,
+                'maximum': 20,
+            }
+        }
+
+        assert setup_component(self.hass, 'sensor', config)
+
+        state = self.hass.states.get('sensor.test')
+
+        self.assertLessEqual(int(state.state), config['sensor']['maximum'])
+        self.assertGreater(int(state.state), config['sensor']['minimum'])


### PR DESCRIPTION
**Description:**
The `random` sensor only create new numerical values with every update run. For me it's a simple helper while working on HA but I think that it can be useful for others too. No need to use an `input_slider` to generate values.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1376

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
sensor:
  - platform: random
    name: Random
    minimum: 0
    maximum: 20
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
