### PR TITLE
Media player BraviaTv : Try to connect only if tv is not in off state.

### DIFF
--- a/homeassistant/components/media_player/braviatv.py
+++ b/homeassistant/components/media_player/braviatv.py
@@ -221,7 +221,8 @@ class BraviaTVDevice(MediaPlayerDevice):
     def update(self):
         """Update TV info."""
         if not self._braviarc.is_connected():
-            self._braviarc.connect(self._pin, CLIENTID_PREFIX, NICKNAME)
+            if self._braviarc.get_power_status() != 'off':
+                self._braviarc.connect(self._pin, CLIENTID_PREFIX, NICKNAME)
             if not self._braviarc.is_connected():
                 return
 


### PR DESCRIPTION
**Description:**

When HA is restart with the TV in off state there was error log every 10s until the TV is set ON.
This patch only to try to connect when TV is ON (the check of TV is ON do not log message)

No documentation change.
No new depencies.
No new files

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
