### PR TITLE
Added Device Tracker component for Mikrotik Router OS

### DIFF
--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -77,7 +77,7 @@ class MikrotikDeviceScanner(object):
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()
         return [self.last_results[clientkey]['mac'] for clientkey,
-client in self.last_results.items()]
+                client in self.last_results.items()]
 
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 
 from homeassistant.components.device_tracker import DOMAIN, PLATFORM_SCHEMA
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, \
-CONF_PORT
+                                CONF_PORT
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
@@ -141,7 +141,7 @@ class MikrotikDeviceScanner(object):
                 hostname = result.arp[arpkey]['mac-address']
             for leasekey, lease in result.leases.items():
                 if result.leases[leasekey]['mac-address'] == \
-                result.arp[arpkey]['mac-address']:
+                        result.arp[arpkey]['mac-address']:
                     if result.leases[leasekey].get('host-name', None):
                         hostname = result.leases[leasekey]['host-name']
                     else:

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -1,0 +1,153 @@
+"""
+Support for Mikrotik routers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.mikrotik/
+"""
+import logging
+import re
+import socket
+import threading
+import json
+from collections import namedtuple
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import DOMAIN, PLATFORM_SCHEMA
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT
+from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
+
+DEFAULT_USERNAME = 'admin'
+DEFAULT_PORT = 8728
+
+# Return cached results if last scan was less then this time ago.
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
+
+PLATFORM_SCHEMA = vol.All(
+    cv.has_at_least_one_key(CONF_PASSWORD),
+    PLATFORM_SCHEMA.extend({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port
+    }))
+
+
+_LOGGER = logging.getLogger(__name__)
+REQUIREMENTS = ['tikapy==0.2.1']
+
+_LEASES_CMD = '/ip/dhcp-server/lease/print'
+
+_ARP_CMD = '/ip/arp/print'
+
+def get_scanner(hass, config):
+    """Validate the configuration and return an Mikrotik scanner."""
+    scanner = MikrotikDeviceScanner(config[DOMAIN])
+
+    return scanner if scanner.success_init else None
+
+MikrotikResult = namedtuple('MikrotikResult', 'leases arp')
+
+
+class MikrotikDeviceScanner(object):
+    """This class queries a router running Mikrotik RouterOS"""
+
+
+    def __init__(self, config):
+        """Initialize the scanner."""
+        self.host = config[CONF_HOST]
+        self.username = config[CONF_USERNAME]
+        self.password = config[CONF_PASSWORD]
+        self.port = config[CONF_PORT]
+
+        if not self.password:
+            _LOGGER.error('No password specified')
+            self.success_init = False
+            return
+
+        self.lock = threading.Lock()
+
+        self.last_results = {}
+
+        # Test the router is accessible.
+        data = self.get_arp_data()
+        self.success_init = data is not None
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+        return [self.last_results[clientkey]['mac'] for clientkey, client in self.last_results.items()]
+
+    def get_device_name(self, device):
+        """Return the name of the given device or None if we don't know."""
+        if not self.last_results:
+            return None
+        for key, client in self.last_results.items():
+            if self.last_results[key]['mac'] == device:
+                return self.last_results[key]['host']
+        return None
+
+    @Throttle(MIN_TIME_BETWEEN_SCANS)
+    def _update_info(self):
+        """Ensure the information from the Mikrotik router is up to date.
+
+        Return boolean if scanning successful.
+        """
+        if not self.success_init:
+            return False
+
+        with self.lock:
+            _LOGGER.info('Connecting to device')
+            data = self.get_arp_data()
+            if not data:
+                return False
+
+            self.last_results = data
+            return True
+
+    def api_connection(self):
+        """Retrieve data from mikrotik via RouterOS API."""
+        from tikapy import TikapyClient
+
+        host = TikapyClient(self.host, self.port)
+        try:
+            host.login(self.username, self.password)
+        except :
+            _LOGGER.error('Connection refused. Check if is API allowed.')
+            return None
+
+        try:
+
+            leases_result = host.talk([_LEASES_CMD])
+            arp_result = host.talk([_ARP_CMD])
+
+            return MikrotikResult(leases_result, arp_result)
+        except :
+            _LOGGER.error('Unexpected response from router:')
+            return None
+
+    def get_arp_data(self):
+        """Retrieve data from Mikrotik and return parsed result."""
+        result = self.api_connection()
+
+        if not result:
+            return {}
+
+        arps = {}
+        for arpkey, arp in result.arp.items():
+
+            if result.arp[arpkey].get('mac-address', None):
+                hostname = result.arp[arpkey]['mac-address']
+                for leasekey, lease in result.leases.items():
+                    if result.leases[leasekey]['mac-address'] == result.arp[arpkey]['mac-address']:
+                        hostname = result.leases[leasekey]['host-name']
+                arps[result.arp[arpkey]['address']] = {
+                    'ip': result.arp[arpkey]['address'],
+                    'mac': result.arp[arpkey]['mac-address'].upper(),
+                    'host': hostname,
+                    }
+
+
+        return arps

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -77,7 +77,7 @@ class MikrotikDeviceScanner(object):
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()
         return [self.last_results[clientkey]['mac'] for clientkey,
-         client in self.last_results.items()]
+client in self.last_results.items()]
 
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
@@ -92,7 +92,8 @@ class MikrotikDeviceScanner(object):
     def _update_info(self):
         """Ensure the information from the Mikrotik router is up to date.
 
-        Return boolean if scanning successful."""
+        Return boolean if scanning successful.
+        """
         if not self.success_init:
             return False
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -501,6 +501,9 @@ temperusb==1.5.1
 # homeassistant.components.thingspeak
 thingspeak==0.4.0
 
+# homeassistant.components.device_tracker.mikrotik
+tikapy==0.2.1
+
 # homeassistant.components.sensor.transmission
 # homeassistant.components.switch.transmission
 transmissionrpc==0.11


### PR DESCRIPTION
**Description:**
Device tracker component for routers and boards running Mikrotik RouterOS
Connection to device is made through Mikrotik API (It needs to be allowed)

**Example entry for `configuration.yaml` (if applicable):**

``` yaml
device_tracker:
  - platform: mikrotik
    host: 192.168.1.10
    username: hass
    password: hass
    port: 8728
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16)).
- [x] New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51)).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
- [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
