### PR TITLE
Catch all errors when doing mqtt message unicode-decode.

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -401,7 +401,7 @@ class MQTT(object):
         """Message received callback."""
         try:
             payload = msg.payload.decode('utf-8')
-        except AttributeError:
+        except:
             _LOGGER.error("Illegal utf-8 unicode payload from "
                           "MQTT topic: %s, Payload: %s", msg.topic,
                           msg.payload)

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -401,7 +401,7 @@ class MQTT(object):
         """Message received callback."""
         try:
             payload = msg.payload.decode('utf-8')
-        except:
+        except (AttributeError, UnicodeDecodeError):
             _LOGGER.error("Illegal utf-8 unicode payload from "
                           "MQTT topic: %s, Payload: %s", msg.topic,
                           msg.payload)


### PR DESCRIPTION
**Description:**

Previous error handling of msg.payload.decode only trapped AttributeErrors. There are other exceptions thrown when an illegal payload is decoded.  This change traps all exceptions of a decode operation.  
