### PR TITLE
Influxdb sensor state set to unknown if query return no points

### DIFF
--- a/homeassistant/components/sensor/influxdb.py
+++ b/homeassistant/components/sensor/influxdb.py
@@ -173,8 +173,8 @@ class InfluxSensorData(object):
 
         points = list(self.influx.query(self.query).get_points())
         if len(points) == 0:
-            _LOGGER.info('Query returned no points, sensor state set'
-                         ' to UNKNOWN : %s', self.query)
+            _LOGGER.warning('Query returned no points, sensor state set'
+                            ' to UNKNOWN : %s', self.query)
             self.value = None
         else:
             if len(points) > 1:

--- a/homeassistant/components/sensor/influxdb.py
+++ b/homeassistant/components/sensor/influxdb.py
@@ -173,9 +173,11 @@ class InfluxSensorData(object):
 
         points = list(self.influx.query(self.query).get_points())
         if len(points) == 0:
-            _LOGGER.error('Query returned no points : %s', self.query)
-            return
-        if len(points) > 1:
-            _LOGGER.warning('Query returned multiple points, only first one'
-                            ' shown : %s', self.query)
-        self.value = points[0].get('value')
+            _LOGGER.info('Query returned no points, sensor state set'
+                         ' to UNKNOWN : %s', self.query)
+            self.value = None
+        else:
+            if len(points) > 1:
+                _LOGGER.warning('Query returned multiple points, only first'
+                                ' one shown : %s', self.query)
+            self.value = points[0].get('value')


### PR DESCRIPTION
**Description:**
With this modification, the sensor state is set to unknown if there are no points return by query. The previous behavior was to keep the last known value, which can be misleading.

Use case : I have some sensors that write directly to the database. One of them was down, and I haven't catch it until a restart of home assistant.

I'm not sure of the right level for the log message when there are no points. I have settle to info.
