### PR TITLE
Change behavior (sensor.random)

### DIFF
--- a/homeassistant/components/sensor/random.py
+++ b/homeassistant/components/sensor/random.py
@@ -70,4 +70,4 @@ class RandomSensor(Entity):
     def async_update(self):
         """Get a new number and updates the states."""
         from random import randrange
-        self._state = randrange(self._minimum, self._maximum)
+        self._state = randrange(self._minimum, self._maximum + 1)


### PR DESCRIPTION
#**Description:**
`random.randrange(10, 20)` will create an integer between from 10 and 19. From my point of view it would be more natural to include 20 as well. The test needed a fix too.

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: random
    name: Random
    min: 0
    max: 20
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

