### PR TITLE
add dimmer slide control to imported isy lights

### DIFF
--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -71,6 +71,7 @@ class ISYLightDevice(isy.ISYDevice, Light):
 
     @property
     def state_attributes(self):
+        """Flag supported attributes."""
         return {ATTR_BRIGHTNESS: self.value}
 
     @property

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -71,7 +71,7 @@ class ISYLightDevice(isy.ISYDevice, Light):
     @property
     def state_attributes(self):
         return {ATTR_BRIGHTNESS: self.value}
-        
+
     @property
     def supported_features(self):
         """Flag supported features."""

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/light.isy994/
 import logging
 from typing import Callable
 
-from homeassistant.components.light import Light, SUPPORT_BRIGHTNESS
+from homeassistant.components.light import Light, SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS
 import homeassistant.components.isy994 as isy
 from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType
@@ -68,6 +68,10 @@ class ISYLightDevice(isy.ISYDevice, Light):
         if not self._node.on(val=brightness):
             _LOGGER.debug('Unable to turn on light.')
 
+    @property
+    def state_attributes(self):
+        return {ATTR_BRIGHTNESS: self.value}
+        
     @property
     def supported_features(self):
         """Flag supported features."""

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -7,7 +7,8 @@ https://home-assistant.io/components/light.isy994/
 import logging
 from typing import Callable
 
-from homeassistant.components.light import Light, SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS
+from homeassistant.components.light import (
+    Light, SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS)
 import homeassistant.components.isy994 as isy
 from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType


### PR DESCRIPTION
**Description:**
additions to light/isy994.py to add dimmer slide

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

