### PR TITLE
manifest.json

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -27,7 +27,6 @@ MANIFEST_JSON = {
     "icons": [],
     "lang": "en-US",
     "name": "Home Assistant",
-    "orientation": "any",
     "short_name": "Assistant",
     "start_url": "/",
     "theme_color": "#03A9F4"


### PR DESCRIPTION
**Description:**
The new HTML5 notification added an "orientation: any" setting to manifest.json. On Android, including an orientation setting causes the web app to ignore the device's screen orientation lock, causing problems when I'm lazy and trying to use Home Assistant in bed while I'm lying on my side.

I propose removing the orientation setting so that the web app respects whatever orientation setting the user may have on their device.

