### PR TITLE
Async version of Yr.no

### DIFF
--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -4,9 +4,11 @@ Support for Yr.no weather service.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.yr/
 """
+import asyncio
 import logging
 
-import requests
+from aiohttp.web import HTTPException
+
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -15,7 +17,10 @@ from homeassistant.const import (
     CONF_LATITUDE, CONF_LONGITUDE, CONF_ELEVATION, CONF_MONITORED_CONDITIONS,
     ATTR_ATTRIBUTION)
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import (
+    async_track_point_in_utc_time, async_track_time_change)
 from homeassistant.util import dt as dt_util
+
 
 REQUIREMENTS = ['xmltodict==0.10.2']
 
@@ -43,8 +48,8 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=[]):
-        [vol.In(SENSOR_TYPES.keys())],
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=['symbol']): vol.All(
+        cv.ensure_list, vol.Length(min=1), [vol.In(SENSOR_TYPES.keys())]),
     vol.Optional(CONF_LATITUDE): cv.latitude,
     vol.Optional(CONF_LONGITUDE): cv.longitude,
     vol.Optional(CONF_ELEVATION): vol.Coerce(int),
@@ -63,32 +68,25 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     coordinates = dict(lat=latitude, lon=longitude, msl=elevation)
 
-    weather = YrData(coordinates)
-
     dev = []
     for sensor_type in config[CONF_MONITORED_CONDITIONS]:
-        dev.append(YrSensor(sensor_type, weather))
+        dev.append(YrSensor(sensor_type))
 
-    # add symbol as default sensor
-    if len(dev) == 0:
-        dev.append(YrSensor("symbol", weather))
     add_devices(dev)
+
+    YrData(hass, coordinates, dev)
 
 
 class YrSensor(Entity):
     """Representation of an Yr.no sensor."""
 
-    def __init__(self, sensor_type, weather):
+    def __init__(self, sensor_type):
         """Initialize the sensor."""
         self.client_name = 'yr'
         self._name = SENSOR_TYPES[sensor_type][0]
         self.type = sensor_type
         self._state = None
-        self._weather = weather
         self._unit_of_measurement = SENSOR_TYPES[self.type][1]
-        self._update = None
-
-        self.update()
 
     @property
     def name(self):
@@ -99,6 +97,11 @@ class YrSensor(Entity):
     def state(self):
         """Return the state of the device."""
         return self._state
+
+    @property
+    def should_poll(self):  # pylint: disable=no-self-use
+        """No polling needed."""
+        return False
 
     @property
     def entity_picture(self):
@@ -120,78 +123,88 @@ class YrSensor(Entity):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement
 
-    def update(self):
-        """Get the latest data from yr.no and updates the states."""
-        now = dt_util.utcnow()
-        # Check if data should be updated
-        if self._update is not None and now <= self._update:
-            return
-
-        self._weather.update()
-
-        # Find sensor
-        for time_entry in self._weather.data['product']['time']:
-            valid_from = dt_util.parse_datetime(time_entry['@from'])
-            valid_to = dt_util.parse_datetime(time_entry['@to'])
-
-            loc_data = time_entry['location']
-
-            if self.type not in loc_data or now >= valid_to:
-                continue
-
-            self._update = valid_to
-
-            if self.type == 'precipitation' and valid_from < now:
-                self._state = loc_data[self.type]['@value']
-                break
-            elif self.type == 'symbol' and valid_from < now:
-                self._state = loc_data[self.type]['@number']
-                break
-            elif self.type in ('temperature', 'pressure', 'humidity',
-                               'dewpointTemperature'):
-                self._state = loc_data[self.type]['@value']
-                break
-            elif self.type in ('windSpeed', 'windGust'):
-                self._state = loc_data[self.type]['@mps']
-                break
-            elif self.type == 'windDirection':
-                self._state = float(loc_data[self.type]['@deg'])
-                break
-            elif self.type in ('fog', 'cloudiness', 'lowClouds',
-                               'mediumClouds', 'highClouds'):
-                self._state = loc_data[self.type]['@percent']
-                break
-
 
 class YrData(object):
     """Get the latest data and updates the states."""
 
-    def __init__(self, coordinates):
+    def __init__(self, hass, coordinates, devices):
         """Initialize the data object."""
         self._url = 'http://api.yr.no/weatherapi/locationforecast/1.9/?' \
             'lat={lat};lon={lon};msl={msl}'.format(**coordinates)
 
         self._nextrun = None
+        self.devices = devices
         self.data = {}
-        self.update()
+        self.hass = hass
+        async_track_time_change(self.hass, self.async_update, second=0,
+                                minute=0, hour=3)
 
-    def update(self):
+        hass.loop.create_task(self.async_update())
+
+    @asyncio.coroutine
+    def async_update(self):
         """Get the latest data from yr.no."""
-        # Check if new will be available
-        if self._nextrun is not None and dt_util.utcnow() <= self._nextrun:
-            return
+        resp = yield from self.hass.websession.get(self._url, timeout=30)
         try:
-            with requests.Session() as sess:
-                response = sess.get(self._url)
-        except requests.RequestException:
+            if resp.status != 200:
+                return
+            _text = (yield from resp.text())
+        except asyncio.TimeoutError:
             return
-        if response.status_code != 200:
+        except HTTPException:
+            resp.close()
             return
-        data = response.text
+        finally:
+            self.hass.loop.create_task(resp.release())
+            # ? yield from resp.release()
 
         import xmltodict
-        self.data = xmltodict.parse(data)['weatherdata']
+        self.data = xmltodict.parse(_text)['weatherdata']
         model = self.data['meta']['model']
         if '@nextrun' not in model:
             model = model[0]
         self._nextrun = dt_util.parse_datetime(model['@nextrun'])
+
+        # Schedule next execution
+        async_track_point_in_utc_time(
+            self.hass, self.async_update, self._nextrun)
+
+        now = dt_util.utcnow()
+
+        # Update all devices
+        for dev in self.devices:
+            # Find sensor
+            for time_entry in self.data['product']['time']:
+                valid_from = dt_util.parse_datetime(time_entry['@from'])
+                valid_to = dt_util.parse_datetime(time_entry['@to'])
+
+                loc_data = time_entry['location']
+
+                if dev.type not in loc_data or now >= valid_to:
+                    continue
+
+                if dev.type == 'precipitation' and valid_from < now:
+                    new_state = loc_data[dev.type]['@value']
+                    break
+                elif dev.type == 'symbol' and valid_from < now:
+                    new_state = loc_data[dev.type]['@number']
+                    break
+                elif dev.type in ('temperature', 'pressure', 'humidity',
+                                  'dewpointTemperature'):
+                    new_state = loc_data[dev.type]['@value']
+                    break
+                elif dev.type in ('windSpeed', 'windGust'):
+                    new_state = loc_data[dev.type]['@mps']
+                    break
+                elif dev.type == 'windDirection':
+                    new_state = float(loc_data[dev.type]['@deg'])
+                    break
+                elif dev.type in ('fog', 'cloudiness', 'lowClouds',
+                                  'mediumClouds', 'highClouds'):
+                    new_state = loc_data[dev.type]['@percent']
+                    break
+
+            # pylint: disable=protected-access
+            if new_state != dev._state:
+                dev._state = new_state
+                yield from dev.async_update_ha_state()

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -150,15 +150,17 @@ class YrData(object):
             with async_timeout.timeout(10, loop=self.hass.loop):
                 resp = yield from self.hass.websession.get(self._url)
             if resp.status != 200:
-                return try_again('{} returned {}'
-                                 .format(self._url, resp.status))
+                try_again('{} returned {}'.format(self._url, resp.status))
+                return
             text = yield from resp.text()
             self.hass.loop.create_task(resp.release())
         except asyncio.TimeoutError as err:
-            return try_again(err)
+            try_again(err)
+            return
         except HTTPException as err:
             resp.close()
-            return try_again(err)
+            try_again(err)
+            return
 
         try:
             import xmltodict
@@ -168,7 +170,8 @@ class YrData(object):
                 model = model[0]
             next_run = dt_util.parse_datetime(model['@nextrun'])
         except (ExpatError, IndexError) as err:
-            return try_again(err)
+            try_again(err)
+            return
 
         # Schedule next execution
         async_track_point_in_utc_time(self.hass, self.async_update, next_run)

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -72,10 +72,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     dev = []
     for sensor_type in config[CONF_MONITORED_CONDITIONS]:
         dev.append(YrSensor(sensor_type))
+    yield from async_add_devices(dev)
 
     weather = YrData(hass, coordinates, dev)
-    tasks = [async_add_devices(dev), weather.async_update()]
-    yield from asyncio.gather(*tasks, loop=hass.loop)
+    yield from weather.async_update()
 
 
 class YrSensor(Entity):
@@ -148,8 +148,7 @@ class YrData(object):
 
         try:
             with async_timeout.timeout(10, loop=self.hass.loop):
-                resp = yield from self.hass.websession.get(
-                    self._url, timeout=30)
+                resp = yield from self.hass.websession.get(self._url)
             if resp.status != 200:
                 return try_again('{} returned {}'
                                  .format(self._url, resp.status))

--- a/pylintrc
+++ b/pylintrc
@@ -5,14 +5,11 @@ reports=no
 # locally-disabled - it spams too much
 # duplicate-code - unavoidable
 # cyclic-import - doesn't test if both import on load
-# abstract-class-little-used - prevents from setting right foundation
+# abstract-class-little-used - Prevents from setting right foundation
 # abstract-class-not-used - is flaky, should not show up but does
 # unused-argument - generic callbacks and setup methods create a lot of warnings
 # global-statement - used for the on-demand requirement installation
 # redefined-variable-type - this is Python, we're duck typing!
-# too-many-* - are not enforced for the sake of readability
-# too-few-* - same as too-many-*
-
 disable=
   locally-disabled,
   duplicate-code,
@@ -22,13 +19,7 @@ disable=
   unused-argument,
   global-statement,
   redefined-variable-type,
-  too-many-arguments,
-  too-many-branches,
-  too-many-instance-attributes,
-  too-many-locals,
-  too-many-public-methods,
-  too-many-statements,
-  too-few-public-methods,
+  unused-variable
 
 [EXCEPTIONS]
 overgeneral-exceptions=Exception,HomeAssistantError

--- a/pylintrc
+++ b/pylintrc
@@ -5,11 +5,14 @@ reports=no
 # locally-disabled - it spams too much
 # duplicate-code - unavoidable
 # cyclic-import - doesn't test if both import on load
-# abstract-class-little-used - Prevents from setting right foundation
+# abstract-class-little-used - prevents from setting right foundation
 # abstract-class-not-used - is flaky, should not show up but does
 # unused-argument - generic callbacks and setup methods create a lot of warnings
 # global-statement - used for the on-demand requirement installation
 # redefined-variable-type - this is Python, we're duck typing!
+# too-many-* - are not enforced for the sake of readability
+# too-few-* - same as too-many-*
+
 disable=
   locally-disabled,
   duplicate-code,
@@ -19,7 +22,14 @@ disable=
   unused-argument,
   global-statement,
   redefined-variable-type,
-  unused-variable
+  too-many-arguments,
+  too-many-branches,
+  too-many-instance-attributes,
+  too-many-locals,
+  too-many-public-methods,
+  too-many-return-statements,
+  too-many-statements,
+  too-few-public-methods,
 
 [EXCEPTIONS]
 overgeneral-exceptions=Exception,HomeAssistantError

--- a/tests/components/sensor/test_yr.py
+++ b/tests/components/sensor/test_yr.py
@@ -1,77 +1,76 @@
 """The tests for the Yr sensor platform."""
+import asyncio
 from datetime import datetime
 from unittest.mock import patch
 
 from homeassistant.bootstrap import setup_component
 import homeassistant.util.dt as dt_util
-from tests.common import get_test_home_assistant, load_fixture
+from tests.common import assert_setup_component, load_fixture
 
 
-class TestSensorYr:
-    """Test the Yr sensor."""
+NOW = datetime(2016, 6, 9, 1, tzinfo=dt_util.UTC)
 
-    def setup_method(self):
-        """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.hass.config.latitude = 32.87336
-        self.hass.config.longitude = 117.22743
 
-    def teardown_method(self):
-        """Stop everything that was started."""
-        self.hass.stop()
+def _setup_platform(hass, config):
+    """Setup a yr platform."""
+    hass.allow_pool = True
 
-    def test_default_setup(self, requests_mock):
-        """Test the default setup."""
-        requests_mock.get('http://api.yr.no/weatherapi/locationforecast/1.9/',
-                          text=load_fixture('yr.no.json'))
-        now = datetime(2016, 6, 9, 1, tzinfo=dt_util.UTC)
-
+    def _setup():
+        """Setup the platform."""
         with patch('homeassistant.components.sensor.yr.dt_util.utcnow',
-                   return_value=now):
-                assert setup_component(self.hass, 'sensor', {
-                                'sensor': {'platform': 'yr',
-                                           'elevation': 0}})
+                   return_value=NOW), assert_setup_component(1):
+            setup_component(hass, 'sensor', {'sensor': config})
+    return _setup
 
-        state = self.hass.states.get('sensor.yr_symbol')
 
-        assert '3' == state.state
-        assert state.state.isnumeric()
-        assert state.attributes.get('unit_of_measurement') is None
+@asyncio.coroutine
+def test_default_setup(hass, aioclient_mock):
+    """Test the default setup."""
+    aioclient_mock.get('http://api.yr.no/weatherapi/locationforecast/1.9/',
+                       text=load_fixture('yr.no.json'))
+    config = {'platform': 'yr',
+              'elevation': 0}
+    yield from hass.loop.run_in_executor(None, _setup_platform(hass, config))
 
-    def test_custom_setup(self, requests_mock):
-        """Test a custom setup."""
-        requests_mock.get('http://api.yr.no/weatherapi/locationforecast/1.9/',
-                          text=load_fixture('yr.no.json'))
-        now = datetime(2016, 6, 9, 1, tzinfo=dt_util.UTC)
+    state = hass.states.get('sensor.yr_symbol')
 
-        with patch('homeassistant.components.sensor.yr.dt_util.utcnow',
-                   return_value=now):
-            assert setup_component(self.hass, 'sensor', {
-                                    'sensor': {'platform': 'yr',
-                                               'elevation': 0,
-                                               'monitored_conditions': [
-                                                   'pressure',
-                                                   'windDirection',
-                                                   'humidity',
-                                                   'fog',
-                                                   'windSpeed']}})
+    assert state.state == '3'
+    assert state.state.isnumeric()
+    assert state.attributes.get('unit_of_measurement') is None
 
-        state = self.hass.states.get('sensor.yr_pressure')
-        assert 'hPa' == state.attributes.get('unit_of_measurement')
-        assert '1009.3' == state.state
 
-        state = self.hass.states.get('sensor.yr_wind_direction')
-        assert '°' == state.attributes.get('unit_of_measurement')
-        assert '103.6' == state.state
+@asyncio.coroutine
+def test_custom_setup(hass, aioclient_mock):
+    """Test a custom setup."""
+    aioclient_mock.get('http://api.yr.no/weatherapi/locationforecast/1.9/',
+                       text=load_fixture('yr.no.json'))
 
-        state = self.hass.states.get('sensor.yr_humidity')
-        assert '%' == state.attributes.get('unit_of_measurement')
-        assert '55.5' == state.state
+    config = {'platform': 'yr',
+              'elevation': 0,
+              'monitored_conditions': [
+                  'pressure',
+                  'windDirection',
+                  'humidity',
+                  'fog',
+                  'windSpeed']}
+    yield from hass.loop.run_in_executor(None, _setup_platform(hass, config))
 
-        state = self.hass.states.get('sensor.yr_fog')
-        assert '%' == state.attributes.get('unit_of_measurement')
-        assert '0.0' == state.state
+    state = hass.states.get('sensor.yr_pressure')
+    assert state.attributes.get('unit_of_measurement') == 'hPa'
+    assert state.state == '1009.3'
 
-        state = self.hass.states.get('sensor.yr_wind_speed')
-        assert 'm/s', state.attributes.get('unit_of_measurement')
-        assert '3.5' == state.state
+    state = hass.states.get('sensor.yr_wind_direction')
+    assert state.attributes.get('unit_of_measurement') == '°'
+    assert state.state == '103.6'
+
+    state = hass.states.get('sensor.yr_humidity')
+    assert state.attributes.get('unit_of_measurement') == '%'
+    assert state.state == '55.5'
+
+    state = hass.states.get('sensor.yr_fog')
+    assert state.attributes.get('unit_of_measurement') == '%'
+    assert state.state == '0.0'
+
+    state = hass.states.get('sensor.yr_wind_speed')
+    assert state.attributes.get('unit_of_measurement') == 'm/s'
+    assert state.state == '3.5'

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -16,7 +16,7 @@ class AiohttpClientMocker:
         self.mock_calls = []
 
     def request(self, method, url, *,
-                auth=None,  # pylint: disable=unused-variable
+                auth=None,
                 status=200,
                 text=None,
                 content=None,
@@ -58,7 +58,7 @@ class AiohttpClientMocker:
         return len(self.mock_calls)
 
     @asyncio.coroutine
-    def match_request(self, method, url, *, auth=None, timeout=None): \
+    def match_request(self, method, url, *, auth=None): \
             # pylint: disable=unused-variable
         """Match a request against pre-registered requests."""
         for response in self._mocks:
@@ -77,10 +77,8 @@ class AiohttpClientMockResponse:
         """Initialize a fake response."""
         self.method = method
         self._url = url
-        try:
-            self._url_parts = urlparse(url.lower())
-        except AttributeError:
-            self._url_parts = None
+        self._url_parts = urlparse(url.lower()) \
+            if isinstance(url, str) else None
         self.status = status
         self.response = response
 

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -57,7 +57,7 @@ class AiohttpClientMocker:
         return len(self.mock_calls)
 
     @asyncio.coroutine
-    def match_request(self, method, url, *, auth=None):
+    def match_request(self, method, url, *, auth=None, **kwargs):
         """Match a request against pre-registered requests."""
         for response in self._mocks:
             if response.match_request(method, url):
@@ -80,7 +80,7 @@ class AiohttpClientMockResponse:
 
     def match_request(self, method, url):
         """Test if response answers request."""
-        return method == self.method and url == self.url
+        return method == self.method and url.startswith(self.url)
 
     @asyncio.coroutine
     def read(self):


### PR DESCRIPTION
**Description:**
Async version of yr.no. Continue work of #3597

The logic of the YrSensor / YrData changed:
- In the past, Each sensor(YrSensor) called the datastore (YrData), which would update the data if the last result expired.
- With the new logic, Yr.data is scheduled to execute on _nexttime and pushes the new data updates to the sensors (YrSensor)


**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: yr
    monitored_conditions:
      - temperature
      - symbol
      - precipitation
      - windSpeed
```

**Checklist:**


If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] No new dependencies 
  - [x] Tests have been added to verify that the new code works.
