### PR TITLE
Support for media_position property on media_player

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -459,7 +459,7 @@ class MediaPlayerDevice(Entity):
     def media_position_updated_at(self):
         """When was the position of the current playing media valid.
 
-        Returns value from time.time()."""
+        Returns value from homeassistant.util.dt.utcnow()."""
         return None
 
     @property

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -459,7 +459,8 @@ class MediaPlayerDevice(Entity):
     def media_position_updated_at(self):
         """When was the position of the current playing media valid.
 
-        Returns value from homeassistant.util.dt.utcnow()."""
+        Returns value from homeassistant.util.dt.utcnow().
+        """
         return None
 
     @property

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -58,6 +58,7 @@ ATTR_MEDIA_SEEK_POSITION = 'seek_position'
 ATTR_MEDIA_CONTENT_ID = 'media_content_id'
 ATTR_MEDIA_CONTENT_TYPE = 'media_content_type'
 ATTR_MEDIA_DURATION = 'media_duration'
+ATTR_MEDIA_POSITION = 'media_position'
 ATTR_MEDIA_TITLE = 'media_title'
 ATTR_MEDIA_ARTIST = 'media_artist'
 ATTR_MEDIA_ALBUM_NAME = 'media_album_name'
@@ -119,6 +120,7 @@ ATTR_TO_PROPERTY = [
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_DURATION,
+    ATTR_MEDIA_POSITION,
     ATTR_MEDIA_TITLE,
     ATTR_MEDIA_ARTIST,
     ATTR_MEDIA_ALBUM_NAME,
@@ -444,6 +446,11 @@ class MediaPlayerDevice(Entity):
     @property
     def media_duration(self):
         """Duration of current playing media in seconds."""
+        return None
+
+    @property
+    def media_position(self):
+        """Position of current playing media in seconds."""
         return None
 
     @property

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -59,6 +59,7 @@ ATTR_MEDIA_CONTENT_ID = 'media_content_id'
 ATTR_MEDIA_CONTENT_TYPE = 'media_content_type'
 ATTR_MEDIA_DURATION = 'media_duration'
 ATTR_MEDIA_POSITION = 'media_position'
+ATTR_MEDIA_POSITION_UPDATED_AT = 'media_position_updated_at'
 ATTR_MEDIA_TITLE = 'media_title'
 ATTR_MEDIA_ARTIST = 'media_artist'
 ATTR_MEDIA_ALBUM_NAME = 'media_album_name'
@@ -121,6 +122,7 @@ ATTR_TO_PROPERTY = [
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_DURATION,
     ATTR_MEDIA_POSITION,
+    ATTR_MEDIA_POSITION_UPDATED_AT,
     ATTR_MEDIA_TITLE,
     ATTR_MEDIA_ARTIST,
     ATTR_MEDIA_ALBUM_NAME,
@@ -451,6 +453,13 @@ class MediaPlayerDevice(Entity):
     @property
     def media_position(self):
         """Position of current playing media in seconds."""
+        return None
+
+    @property
+    def media_position_updated_at(self):
+        """When was the position of the current playing media valid.
+
+        Returns value from time.time()."""
         return None
 
     @property

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -431,7 +431,6 @@ class SonosDevice(MediaPlayerDevice):
                     media_image_url = None
 
                 elif is_radio_stream:
-                    media_position = None
                     media_image_url = self._format_media_image_url(
                         current_media_uri
                     )

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -503,14 +503,27 @@ class SonosDevice(MediaPlayerDevice):
                         position_info.get("RelTime")
                     )
 
-                    if rel_time is None or \
-                       self._media_position is None or \
-                       abs(self._media_position + \
-                           time.time() - \
-                           self._media_position_updated_at - \
-                           rel_time) > 1.5:
+                    # player no longer reports position?
+                    update_media_position = rel_time is None and \
+                        self._media_position is not None
 
-                        # update media_position
+                    # player started reporting position?
+                    update_media_position |= rel_time is not None and \
+                        self._media_position is None
+
+                    # position changed?
+                    if rel_time is not None and \
+                       self._media_position is not None:
+
+                        calculated_position = \
+                            self._media_position + \
+                            time.time() - \
+                            self._media_position_updated_at
+
+                        update_media_position = \
+                            abs(calculated_position - rel_time) > 1.5
+
+                    if update_media_position:
                         media_position = rel_time
                         media_position_updated_at = time.time()
                     else:

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -8,7 +8,6 @@ import datetime
 import logging
 from os import path
 import socket
-import time
 import urllib
 import voluptuous as vol
 
@@ -21,6 +20,7 @@ from homeassistant.const import (
     STATE_IDLE, STATE_PAUSED, STATE_PLAYING, STATE_OFF, ATTR_ENTITY_ID)
 from homeassistant.config import load_yaml_config_file
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util.dt import utcnow
 
 REQUIREMENTS = ['SoCo==0.12']
 
@@ -515,17 +515,19 @@ class SonosDevice(MediaPlayerDevice):
                     if rel_time is not None and \
                        self._media_position is not None:
 
+                        time_diff = utcnow() - self._media_position_updated_at
+                        time_diff = time_diff.total_seconds()
+
                         calculated_position = \
                             self._media_position + \
-                            time.time() - \
-                            self._media_position_updated_at
+                            time_diff
 
                         update_media_position = \
                             abs(calculated_position - rel_time) > 1.5
 
                     if update_media_position:
                         media_position = rel_time
-                        media_position_updated_at = time.time()
+                        media_position_updated_at = utcnow()
                     else:
                         # don't update media_position (don't want unneeded
                         # state transitions)
@@ -702,7 +704,7 @@ class SonosDevice(MediaPlayerDevice):
     def media_position_updated_at(self):
         """When was the position of the current playing media valid.
 
-        Returns value from time.time()."""
+        Returns value from homeassistant.util.dt.utcnow()."""
         if self._coordinator:
             return self._coordinator.media_position_updated_at
         else:

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -703,7 +703,8 @@ class SonosDevice(MediaPlayerDevice):
     def media_position_updated_at(self):
         """When was the position of the current playing media valid.
 
-        Returns value from homeassistant.util.dt.utcnow()."""
+        Returns value from homeassistant.util.dt.utcnow().
+        """
         if self._coordinator:
             return self._coordinator.media_position_updated_at
         else:


### PR DESCRIPTION
**Description:**

This adds a new property `media_position` to media_player and provides an implementation for the sonos media player.

The purpose of this is to be able to show the playback progress of media in the UI.

A PR with changes to home-assistant-polymer is also coming up. 

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

