### PR TITLE
Sonos volume and mute state fallback

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -356,12 +356,6 @@ class SonosDevice(MediaPlayerDevice):
 
         if is_available:
 
-            if self._queue is None or self._player_volume is None:
-                self._player_volume = self._player.volume
-
-            if self._queue is None or self._player_volume_muted is None:
-                self._player_volume_muted = self._player.mute
-
             track_info = None
             if self._last_avtransport_event:
                 variables = self._last_avtransport_event.variables
@@ -384,6 +378,8 @@ class SonosDevice(MediaPlayerDevice):
                         'duration': variables.get('current_track_duration')
                     }
             else:
+                self._player_volume = self._player.volume
+                self._player_volume_muted = self._player.mute
                 transport_info = self._player.get_current_transport_info()
                 self._status = transport_info.get('current_transport_state')
 


### PR DESCRIPTION
**Description:**

If the update events from the speaker fail to reach HA for some reason, we now correctly fall-back to reading volume and mute state directly from the speakers.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
