### PR TITLE
Add Map support for Locative component

### DIFF
--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -76,11 +76,15 @@ class LocativeView(HomeAssistantView):
         device = data['device'].replace('-', '')
         location_name = data['id'].lower()
         direction = data['trigger']
+        
+        kwargs = {
+           'dev_id': device,
+           'location_name': location_name,
+           'gps': (data['latitude'], data['longitude'])
+        }
 
         if direction == 'enter':
-            yield from self.hass.loop.run_in_executor(
-                None, partial(self.see, dev_id=device,
-                              location_name=location_name))
+            self.see(**kwargs)
             return 'Setting location to {}'.format(location_name)
 
         elif direction == 'exit':
@@ -88,9 +92,8 @@ class LocativeView(HomeAssistantView):
                 '{}.{}'.format(DOMAIN, device))
 
             if current_state is None or current_state.state == location_name:
-                yield from self.hass.loop.run_in_executor(
-                    None, partial(self.see, dev_id=device,
-                                  location_name=STATE_NOT_HOME))
+                kwargs['location_home'] = STATE_NOT_HOME
+                self.see(**kwargs)
                 return 'Setting location to not home'
             else:
                 # Ignore the message if it is telling us to exit a zone that we
@@ -104,6 +107,7 @@ class LocativeView(HomeAssistantView):
             # In the app, a test message can be sent. Just return something to
             # the user to let them know that it works.
             return 'Received test message.'
+
 
         else:
             _LOGGER.error('Received unidentified message from Locative: %s',

--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -5,10 +5,11 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.locative/
 """
 import asyncio
-from functools import partial
 import logging
 
-from homeassistant.const import HTTP_UNPROCESSABLE_ENTITY, STATE_NOT_HOME
+from homeassistant.const import (ATTR_LATITUDE, ATTR_LONGITUDE,
+                                 STATE_NOT_HOME,
+                                 HTTP_UNPROCESSABLE_ENTITY)
 from homeassistant.components.http import HomeAssistantView
 # pylint: disable=unused-import
 from homeassistant.components.device_tracker import (  # NOQA
@@ -80,7 +81,7 @@ class LocativeView(HomeAssistantView):
         kwargs = {
            'dev_id': device,
            'location_name': location_name,
-           'gps': (data['latitude'], data['longitude'])
+           'gps': (data[ATTR_LATITUDE], data[ATTR_LONGITUDE])
         }
 
         if direction == 'enter':

--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -84,7 +84,7 @@ class LocativeView(HomeAssistantView):
             yield from self.hass.loop.run_in_executor(
                 None, partial(self.see, dev_id=device,
                               location_name=location_name,
-                              gps=(data[ATTR_LATITUDE], data[ATTR_LONGITUDE])))
+                              gps=gps_location))
             return 'Setting location to {}'.format(location_name)
 
         elif direction == 'exit':


### PR DESCRIPTION
**Description:**
The Locative App on the mobile is sending an HTTP request to the
server where also the GPS location is sent.
But the GPS location was not passed to the event device_tracker.see.

Use the passed GPS location from Locative and pass it to the
device_tracker.see event.

With this the device is then also shown on the HA Map component.
