### PR TITLE
changing to `async_generate_entitity_id` as old method was not return…

### DIFF
--- a/homeassistant/components/scene/hunterdouglas_powerview.py
+++ b/homeassistant/components/scene/hunterdouglas_powerview.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/scene.hunterdouglas_powerview/
 import logging
 
 from homeassistant.components.scene import Scene, DOMAIN
-from homeassistant.helpers.entity import generate_entity_id
+from homeassistant.helpers.entity import async_generate_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = [
@@ -49,9 +49,9 @@ class PowerViewScene(Scene):
         self.scene_data = scene_data
         self._sync_room_data(room_data)
         self.entity_id_format = DOMAIN + '.{}'
-        self.entity_id = generate_entity_id(self.entity_id_format,
-                                            str(self.scene_data["id"]),
-                                            hass=hass)
+        self.entity_id = async_generate_entity_id(self.entity_id_format,
+                                                  str(self.scene_data["id"]),
+                                                  hass=hass)
 
     def _sync_room_data(self, room_data):
         """Sync the room data."""


### PR DESCRIPTION
**Description:**


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

…ing anything.