### PR TITLE
Zwave Cover: Prevent multiple instances of device being initialzed

### DIFF
--- a/homeassistant/components/cover/zwave.py
+++ b/homeassistant/components/cover/zwave.py
@@ -32,17 +32,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     node = zwave.NETWORK.nodes[discovery_info[zwave.const.ATTR_NODE_ID]]
     value = node.values[discovery_info[zwave.const.ATTR_VALUE_ID]]
 
-    if node.has_command_class(zwave.const.COMMAND_CLASS_SWITCH_MULTILEVEL) \
-            and value.index == 0:
+    if (value.command_class == zwave.const.COMMAND_CLASS_SWITCH_MULTILEVEL
+            and value.index == 0):
         value.set_change_verified(False)
         add_devices([ZwaveRollershutter(value)])
-    elif node.has_command_class(zwave.const.COMMAND_CLASS_SWITCH_BINARY) or \
-            node.has_command_class(zwave.const.COMMAND_CLASS_BARRIER_OPERATOR):
-        if value.type != zwave.const.TYPE_BOOL and \
-           value.genre != zwave.const.GENRE_USER:
-            return
-        value.set_change_verified(False)
-        add_devices([ZwaveGarageDoor(value)])
+    elif value.node.specific == zwave.const.GENERIC_TYPE_ENTRY_CONTROL:
+        if (value.command_class == zwave.const.COMMAND_CLASS_SWITCH_BINARY or
+                value.command_class ==
+                zwave.const.COMMAND_CLASS_BARRIER_OPERATOR):
+            if (value.type != zwave.const.TYPE_BOOL and
+                    value.genre != zwave.const.GENRE_USER):
+                return
+            value.set_change_verified(False)
+            add_devices([ZwaveGarageDoor(value)])
     else:
         return
 


### PR DESCRIPTION

**Description:**
This prevents multiple instances of a device to be initialized to cover.
Brought to my attention by @robbiet480 
Before this patch, all the value.index where initialized as an entity.