### PR TITLE
EntityComponent.add_entities now converts generators to a list

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -283,7 +283,7 @@ class EntityPlatform(object):
     def add_entities(self, new_entities, update_before_add=False):
         """Add entities for a single platform."""
         run_coroutine_threadsafe(
-            self.async_add_entities(new_entities, update_before_add),
+            self.async_add_entities(list(new_entities), update_before_add),
             self.component.hass.loop
         ).result()
 


### PR DESCRIPTION
**Description:**
We allow platforms to pass any iterable to EntityComponent.add_entities. However, with our transition to async we will now only iterate over this generator inside an async context. This causes unpredictable behavior as the original author of the platform might not have been even aware there is such a thing as async.

This PR will convert the iterable of new entities to a list before processing it in async land.

**Related issue (if applicable):** fixes #4112

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

