### PR TITLE
Bugfix/frontend group urls

### DIFF
--- a/tests/components/device_tracker/test_locative.py
+++ b/tests/components/device_tracker/test_locative.py
@@ -1,5 +1,4 @@
 """The tests the for Locative device tracker platform."""
-import time
 import unittest
 from unittest.mock import patch
 
@@ -46,7 +45,6 @@ def setUpModule():
     })
 
     hass.start()
-    time.sleep(0.05)
 
 
 def tearDownModule():   # pylint: disable=invalid-name

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -9,7 +9,6 @@ import homeassistant.components.media_player as mp
 import homeassistant.components.http as http
 
 import requests
-import time
 
 from tests.common import get_test_home_assistant, get_test_instance_port
 
@@ -254,7 +253,6 @@ class TestMediaPlayerWeb(unittest.TestCase):
         })
 
         self.hass.start()
-        time.sleep(0.05)
 
     def tearDown(self):
         """Stop everything that was started."""

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -1,7 +1,6 @@
 """The tests for the Alexa component."""
 # pylint: disable=protected-access
 import json
-import time
 import datetime
 import unittest
 
@@ -115,7 +114,6 @@ def setUpModule():
     })
 
     hass.start()
-    time.sleep(0.05)
 
 
 # pylint: disable=invalid-name

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -3,7 +3,6 @@
 import asyncio
 from contextlib import closing
 import json
-import time
 import unittest
 from unittest.mock import Mock, patch
 
@@ -50,7 +49,6 @@ def setUpModule():
     bootstrap.setup_component(hass, 'api')
 
     hass.start()
-    time.sleep(0.05)
 
 
 # pylint: disable=invalid-name

--- a/tests/components/test_emulated_hue.py
+++ b/tests/components/test_emulated_hue.py
@@ -1,5 +1,4 @@
 """The tests for the emulated Hue component."""
-import time
 import json
 
 import unittest
@@ -43,7 +42,6 @@ def setup_hass_instance(emulated_hue_config):
 def start_hass_instance(hass):
     """Start the Home Assistant instance to test."""
     hass.start()
-    time.sleep(0.05)
 
 
 class TestEmulatedHue(unittest.TestCase):

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -1,7 +1,6 @@
 """The tests for Home Assistant frontend."""
 # pylint: disable=protected-access
 import re
-import time
 import unittest
 
 import requests
@@ -32,9 +31,6 @@ def setUpModule():
 
     hass = get_test_home_assistant()
 
-    hass.bus.listen('test_event', lambda _: _)
-    hass.states.set('test.test', 'a_state')
-
     assert bootstrap.setup_component(
         hass, http.DOMAIN,
         {http.DOMAIN: {http.CONF_API_PASSWORD: API_PASSWORD,
@@ -43,7 +39,6 @@ def setUpModule():
     assert bootstrap.setup_component(hass, 'frontend')
 
     hass.start()
-    time.sleep(0.05)
 
 
 # pylint: disable=invalid-name

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -58,7 +58,6 @@ class TestFrontend(unittest.TestCase):
     def test_frontend_and_static(self):
         """Test if we can get the frontend."""
         req = requests.get(_url(""))
-
         self.assertEqual(200, req.status_code)
 
         # Test we can retrieve frontend.js
@@ -67,9 +66,7 @@ class TestFrontend(unittest.TestCase):
             req.text)
 
         self.assertIsNotNone(frontendjs)
-
         req = requests.get(_url(frontendjs.groups(0)[0]))
-
         self.assertEqual(200, req.status_code)
 
     def test_404(self):
@@ -79,3 +76,15 @@ class TestFrontend(unittest.TestCase):
     def test_we_cannot_POST_to_root(self):
         """Test that POST is not allow to root."""
         self.assertEqual(405, requests.post(_url("")).status_code)
+
+    def test_states_routes(self):
+        """All served by index."""
+        req = requests.get(_url("/states"))
+        self.assertEqual(200, req.status_code)
+
+        req = requests.get(_url("/states/group.non_existing"))
+        self.assertEqual(404, req.status_code)
+
+        hass.states.set('group.existing', 'on', {'view': True})
+        req = requests.get(_url("/states/group.existing"))
+        self.assertEqual(200, req.status_code)

--- a/tests/components/test_http.py
+++ b/tests/components/test_http.py
@@ -1,7 +1,6 @@
 """The tests for the Home Assistant HTTP component."""
 # pylint: disable=protected-access
 import logging
-import time
 from ipaddress import ip_network
 from unittest.mock import patch
 
@@ -61,7 +60,6 @@ def setUpModule():
         for trusted_network in TRUSTED_NETWORKS]
 
     hass.start()
-    time.sleep(0.05)
 
 
 # pylint: disable=invalid-name

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -2,7 +2,6 @@
 # pylint: disable=protected-access
 import asyncio
 import threading
-import time
 import unittest
 from unittest.mock import patch
 
@@ -51,7 +50,6 @@ def setUpModule():
     bootstrap.setup_component(hass, 'api')
 
     hass.start()
-    time.sleep(0.05)
 
     master_api = remote.API('127.0.0.1', API_PASSWORD, MASTER_PORT)
 


### PR DESCRIPTION
**Description:**
The IndexView would incorrectly serve a 404 when loading a page for a view, ie `/states/group.upstairs`.

**Related issue (if applicable):** fixes #4124

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
