### PR TITLE
Make services yield

### DIFF
--- a/homeassistant/components/alarm_control_panel/alarmdotcom.py
+++ b/homeassistant/components/alarm_control_panel/alarmdotcom.py
@@ -42,7 +42,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([AlarmDotCom(hass, name, code, username, password)])
 
 
-# pylint: disable=abstract-method
 class AlarmDotCom(alarm.AlarmControlPanel):
     """Represent an Alarm.com status."""
 

--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -50,7 +50,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         )])
 
 
-# pylint: disable=abstract-method
 class ManualAlarm(alarm.AlarmControlPanel):
     """
     Represents an alarm status.

--- a/homeassistant/components/alarm_control_panel/mqtt.py
+++ b/homeassistant/components/alarm_control_panel/mqtt.py
@@ -55,7 +55,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         config.get(CONF_CODE))])
 
 
-# pylint: disable=abstract-method
 class MqttAlarm(alarm.AlarmControlPanel):
     """Representation of a MQTT alarm status."""
 

--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -41,7 +41,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([SimpliSafeAlarm(name, username, password, code)])
 
 
-# pylint: disable=abstract-method
 class SimpliSafeAlarm(alarm.AlarmControlPanel):
     """Representation a SimpliSafe alarm."""
 

--- a/homeassistant/components/alarm_control_panel/verisure.py
+++ b/homeassistant/components/alarm_control_panel/verisure.py
@@ -28,7 +28,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(alarms)
 
 
-# pylint: disable=abstract-method
 class VerisureAlarm(alarm.AlarmControlPanel):
     """Represent a Verisure alarm status."""
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -349,7 +349,7 @@ def _async_process_config(hass, config, component):
             entities.append(entity)
 
     yield from asyncio.gather(*tasks, loop=hass.loop)
-    hass.loop.create_task(component.async_add_entities(entities))
+    yield from component.async_add_entities(entities)
 
     return len(entities) > 0
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -265,7 +265,7 @@ class AutomationEntity(ToggleEntity):
             return
 
         yield from self.async_enable()
-        self.hass.loop.create_task(self.async_update_ha_state())
+        yield from self.async_update_ha_state()
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs) -> None:
@@ -276,8 +276,6 @@ class AutomationEntity(ToggleEntity):
         self._async_detach_triggers()
         self._async_detach_triggers = None
         self._enabled = False
-        # It's important that the update is finished before this method
-        # ends because async_remove depends on it.
         yield from self.async_update_ha_state()
 
     @asyncio.coroutine
@@ -289,7 +287,7 @@ class AutomationEntity(ToggleEntity):
         if skip_condition or self._cond_func(variables):
             yield from self._async_action(self.entity_id, variables)
             self._last_triggered = utcnow()
-            self.hass.loop.create_task(self.async_update_ha_state())
+            yield from self.async_update_ha_state()
 
     @asyncio.coroutine
     def async_remove(self):
@@ -367,7 +365,7 @@ def _async_get_action(hass, config, name):
         _LOGGER.info('Executing %s', name)
         logbook.async_log_entry(
             hass, name, 'has been triggered', DOMAIN, entity_id)
-        hass.loop.create_task(script_obj.async_run(variables))
+        yield from script_obj.async_run(variables)
 
     return action
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -218,7 +218,6 @@ def async_setup(hass, config):
 class AutomationEntity(ToggleEntity):
     """Entity to show status of entity."""
 
-    # pylint: disable=abstract-method
     def __init__(self, name, async_attach_triggers, cond_func, async_action,
                  hidden):
         """Initialize an automation entity."""

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -133,7 +133,7 @@ class Camera(Entity):
 
                 yield from asyncio.sleep(.5)
         finally:
-            self.hass.loop.create_task(response.write_eof())
+            yield from response.write_eof()
 
     @property
     def state(self):

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -87,7 +87,7 @@ class FFmpegCamera(Camera):
                 response.write(data)
         finally:
             self.hass.loop.create_task(stream.close())
-            self.hass.loop.create_task(response.write_eof())
+            yield from response.write_eof()
 
     @property
     def name(self):

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -114,7 +114,7 @@ class GenericCamera(Camera):
                         auth=self._auth
                     )
                     self._last_image = yield from respone.read()
-                    self.hass.loop.create_task(respone.release())
+                    yield from respone.release()
             except asyncio.TimeoutError:
                 _LOGGER.error('Timeout getting camera image')
                 return self._last_image

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -124,7 +124,7 @@ class MjpegCamera(Camera):
                 response.write(data)
         finally:
             self.hass.loop.create_task(stream.release())
-            self.hass.loop.create_task(response.write_eof())
+            yield from response.write_eof()
 
     @property
     def name(self):

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -284,7 +284,7 @@ class SynologyCamera(Camera):
                 response.write(data)
         finally:
             self.hass.loop.create_task(stream.release())
-            self.hass.loop.create_task(response.write_eof())
+            yield from response.write_eof()
 
     @property
     def name(self):

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -72,7 +72,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         schema=SET_FAN_MIN_ON_TIME_SCHEMA)
 
 
-# pylint: disable=abstract-method
 class Thermostat(ClimateDevice):
     """A thermostat class for Ecobee."""
 

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -42,7 +42,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(devices)
 
 
-# pylint: disable=import-error, abstract-method
+# pylint: disable=import-error
 class EQ3BTSmartThermostat(ClimateDevice):
     """Representation of a eQ-3 Bluetooth Smart thermostat."""
 

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -62,7 +62,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         target_temp, ac_mode, min_cycle_duration)])
 
 
-# pylint: disable=abstract-method
 class GenericThermostat(ClimateDevice):
     """Representation of a GenericThermostat device."""
 

--- a/homeassistant/components/climate/heatmiser.py
+++ b/homeassistant/components/climate/heatmiser.py
@@ -56,7 +56,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class HeatmiserV3Thermostat(ClimateDevice):
     """Representation of a HeatmiserV3 thermostat."""
 
-    # pylint: disable=abstract-method
     def __init__(self, heatmiser, device, name, serport):
         """Initialize the thermostat."""
         self.heatmiser = heatmiser

--- a/homeassistant/components/climate/homematic.py
+++ b/homeassistant/components/climate/homematic.py
@@ -36,7 +36,6 @@ def setup_platform(hass, config, add_callback_devices, discovery_info=None):
     )
 
 
-# pylint: disable=abstract-method
 class HMThermostat(homematic.HMDevice, ClimateDevice):
     """Representation of a Homematic thermostat."""
 

--- a/homeassistant/components/climate/honeywell.py
+++ b/homeassistant/components/climate/honeywell.py
@@ -100,7 +100,6 @@ def _setup_us(username, password, config, add_devices):
 class RoundThermostat(ClimateDevice):
     """Representation of a Honeywell Round Connected thermostat."""
 
-    # pylint: disable=abstract-method
     def __init__(self, device, zone_id, master, away_temp):
         """Initialize the thermostat."""
         self.device = device
@@ -197,7 +196,6 @@ class RoundThermostat(ClimateDevice):
             self._is_dhw = False
 
 
-# pylint: disable=abstract-method
 class HoneywellUSThermostat(ClimateDevice):
     """Representation of a Honeywell US Thermostat."""
 

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -30,7 +30,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                  for structure, device in nest.devices()])
 
 
-# pylint: disable=abstract-method
 class NestThermostat(ClimateDevice):
     """Representation of a Nest thermostat."""
 

--- a/homeassistant/components/climate/netatmo.py
+++ b/homeassistant/components/climate/netatmo.py
@@ -54,7 +54,6 @@ def setup_platform(hass, config, add_callback_devices, discovery_info=None):
         return None
 
 
-# pylint: disable=abstract-method
 class NetatmoThermostat(ClimateDevice):
     """Representation a Netatmo thermostat."""
 

--- a/homeassistant/components/climate/proliphix.py
+++ b/homeassistant/components/climate/proliphix.py
@@ -36,7 +36,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([ProliphixThermostat(pdp)])
 
 
-# pylint: disable=abstract-method
 class ProliphixThermostat(ClimateDevice):
     """Representation a Proliphix thermostat."""
 

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -58,7 +58,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(tstats)
 
 
-# pylint: disable=abstract-method
 class RadioThermostat(ClimateDevice):
     """Representation of a Radio Thermostat."""
 

--- a/homeassistant/components/climate/vera.py
+++ b/homeassistant/components/climate/vera.py
@@ -31,7 +31,6 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         device in VERA_DEVICES['climate'])
 
 
-# pylint: disable=abstract-method
 class VeraThermostat(VeraDevice, ClimateDevice):
     """Representation of a Vera Thermostat."""
 

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -69,7 +69,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                   discovery_info, zwave.NETWORK)
 
 
-# pylint: disable=abstract-method
 class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
     """Represents a ZWave Climate device."""
 

--- a/homeassistant/components/cover/homematic.py
+++ b/homeassistant/components/cover/homematic.py
@@ -31,7 +31,6 @@ def setup_platform(hass, config, add_callback_devices, discovery_info=None):
     )
 
 
-# pylint: disable=abstract-method
 class HMCover(homematic.HMDevice, CoverDevice):
     """Represents a Homematic Cover in Home Assistant."""
 

--- a/homeassistant/components/cover/rfxtrx.py
+++ b/homeassistant/components/cover/rfxtrx.py
@@ -40,7 +40,6 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         rfxtrx.RECEIVED_EVT_SUBSCRIBERS.append(cover_update)
 
 
-# pylint: disable=abstract-method
 class RfxtrxCover(rfxtrx.RfxtrxDevice, CoverDevice):
     """Representation of an rfxtrx cover."""
 

--- a/homeassistant/components/cover/rpi_gpio.py
+++ b/homeassistant/components/cover/rpi_gpio.py
@@ -63,7 +63,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(covers)
 
 
-# pylint: disable=abstract-method
 class RPiGPIOCover(CoverDevice):
     """Representation of a Raspberry GPIO cover."""
 

--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -22,7 +22,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         device in VERA_DEVICES['cover'])
 
 
-# pylint: disable=abstract-method
 class VeraCover(VeraDevice, CoverDevice):
     """Represents a Vera Cover in Home Assistant."""
 

--- a/homeassistant/components/emulated_hue.py
+++ b/homeassistant/components/emulated_hue.py
@@ -86,19 +86,19 @@ def setup(hass, yaml_config):
     upnp_listener = UPNPResponderThread(
         config.host_ip_addr, config.listen_port)
 
-    @core.callback
+    @asyncio.coroutine
     def stop_emulated_hue_bridge(event):
         """Stop the emulated hue bridge."""
         upnp_listener.stop()
-        hass.loop.create_task(server.stop())
+        yield from server.stop()
 
-    @core.callback
+    @asyncio.coroutine
     def start_emulated_hue_bridge(event):
         """Start the emulated hue bridge."""
-        hass.loop.create_task(server.start())
         upnp_listener.start()
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,
                                    stop_emulated_hue_bridge)
+        yield from server.start()
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_emulated_hue_bridge)
 

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -196,7 +196,7 @@ def setup(hass, config: dict) -> None:
 class FanEntity(ToggleEntity):
     """Representation of a fan."""
 
-    # pylint: disable=no-self-use, abstract-method
+    # pylint: disable=no-self-use
 
     def set_speed(self: ToggleEntity, speed: str) -> None:
         """Set the speed of the fan."""

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -22,7 +22,7 @@ from aiohttp.web_exceptions import (
     HTTPUnauthorized, HTTPMovedPermanently, HTTPNotModified)
 from aiohttp.web_urldispatcher import StaticRoute
 
-from homeassistant.core import callback, is_callback
+from homeassistant.core import is_callback
 import homeassistant.remote as rem
 from homeassistant import util
 from homeassistant.const import (
@@ -141,16 +141,16 @@ def setup(hass, config):
         trusted_networks=trusted_networks
     )
 
-    @callback
+    @asyncio.coroutine
     def stop_server(event):
         """Callback to stop the server."""
-        hass.loop.create_task(server.stop())
+        yield from server.stop()
 
-    @callback
+    @asyncio.coroutine
     def start_server(event):
         """Callback to start the server."""
-        hass.loop.create_task(server.start())
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_server)
+        yield from server.start()
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_server)
 

--- a/homeassistant/components/input_select.py
+++ b/homeassistant/components/input_select.py
@@ -105,37 +105,40 @@ def async_setup(hass, config):
     if not entities:
         return False
 
-    @callback
+    @asyncio.coroutine
     def async_select_option_service(call):
         """Handle a calls to the input select option service."""
         target_inputs = component.async_extract_from_service(call)
 
-        for input_select in target_inputs:
-            input_select.select_option(call.data[ATTR_OPTION])
+        tasks = [input_select.select_option(call.data[ATTR_OPTION])
+                 for input_select in target_inputs]
+        yield from asyncio.gather(*tasks, loop=hass.loop)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SELECT_OPTION, async_select_option_service,
         schema=SERVICE_SELECT_OPTION_SCHEMA)
 
-    @callback
+    @asyncio.coroutine
     def async_select_next_service(call):
         """Handle a calls to the input select next service."""
         target_inputs = component.async_extract_from_service(call)
 
-        for input_select in target_inputs:
-            input_select.offset_index(1)
+        tasks = [input_select.offset_index(1)
+                 for input_select in target_inputs]
+        yield from asyncio.gather(*tasks, loop=hass.loop)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SELECT_NEXT, async_select_next_service,
         schema=SERVICE_SELECT_NEXT_SCHEMA)
 
-    @callback
+    @asyncio.coroutine
     def async_select_previous_service(call):
         """Handle a calls to the input select previous service."""
         target_inputs = component.async_extract_from_service(call)
 
-        for input_select in target_inputs:
-            input_select.offset_index(-1)
+        tasks = [input_select.offset_index(-1)
+                 for input_select in target_inputs]
+        yield from asyncio.gather(*tasks, loop=hass.loop)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SELECT_PREVIOUS, async_select_previous_service,
@@ -183,18 +186,20 @@ class InputSelect(Entity):
             ATTR_OPTIONS: self._options,
         }
 
-    def select_option(self, option):
+    @asyncio.coroutine
+    def async_select_option(self, option):
         """Select new option."""
         if option not in self._options:
             _LOGGER.warning('Invalid option: %s (possible options: %s)',
                             option, ', '.join(self._options))
             return
         self._current_option = option
-        self.hass.loop.create_task(self.async_update_ha_state())
+        yield from self.async_update_ha_state()
 
-    def offset_index(self, offset):
+    @asyncio.coroutine
+    def async_offset_index(self, offset):
         """Offset current index."""
         current_index = self._options.index(self._current_option)
         new_index = (current_index + offset) % len(self._options)
         self._current_option = self._options[new_index]
-        self.hass.loop.create_task(self.async_update_ha_state())
+        yield from self.async_update_ha_state()

--- a/homeassistant/components/input_select.py
+++ b/homeassistant/components/input_select.py
@@ -9,7 +9,6 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.const import ATTR_ENTITY_ID, CONF_ICON, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity

--- a/homeassistant/components/input_select.py
+++ b/homeassistant/components/input_select.py
@@ -110,7 +110,7 @@ def async_setup(hass, config):
         """Handle a calls to the input select option service."""
         target_inputs = component.async_extract_from_service(call)
 
-        tasks = [input_select.select_option(call.data[ATTR_OPTION])
+        tasks = [input_select.async_select_option(call.data[ATTR_OPTION])
                  for input_select in target_inputs]
         yield from asyncio.gather(*tasks, loop=hass.loop)
 
@@ -123,7 +123,7 @@ def async_setup(hass, config):
         """Handle a calls to the input select next service."""
         target_inputs = component.async_extract_from_service(call)
 
-        tasks = [input_select.offset_index(1)
+        tasks = [input_select.async_offset_index(1)
                  for input_select in target_inputs]
         yield from asyncio.gather(*tasks, loop=hass.loop)
 
@@ -136,7 +136,7 @@ def async_setup(hass, config):
         """Handle a calls to the input select previous service."""
         target_inputs = component.async_extract_from_service(call)
 
-        tasks = [input_select.offset_index(-1)
+        tasks = [input_select.async_offset_index(-1)
                  for input_select in target_inputs]
         yield from asyncio.gather(*tasks, loop=hass.loop)
 

--- a/homeassistant/components/input_slider.py
+++ b/homeassistant/components/input_slider.py
@@ -100,7 +100,7 @@ def async_setup(hass, config):
         """Handle a calls to the input slider services."""
         target_inputs = component.async_extract_from_service(call)
 
-        tasks = [input_slider.select_value(call.data[ATTR_VALUE])
+        tasks = [input_slider.async_select_value(call.data[ATTR_VALUE])
                  for input_slider in target_inputs]
         yield from asyncio.gather(*tasks, loop=hass.loop)
 

--- a/homeassistant/components/input_slider.py
+++ b/homeassistant/components/input_slider.py
@@ -9,7 +9,6 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_UNIT_OF_MEASUREMENT, CONF_ICON, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
@@ -162,7 +161,7 @@ class InputSlider(Entity):
         }
 
     @asyncio.coroutine
-    def asyncio_select_value(self, value):
+    def async_select_value(self, value):
         """Select new value."""
         num_value = float(value)
         if num_value < self._minimum or num_value > self._maximum:

--- a/homeassistant/components/input_slider.py
+++ b/homeassistant/components/input_slider.py
@@ -95,13 +95,14 @@ def async_setup(hass, config):
     if not entities:
         return False
 
-    @callback
+    @asyncio.coroutine
     def async_select_value_service(call):
         """Handle a calls to the input slider services."""
         target_inputs = component.async_extract_from_service(call)
 
-        for input_slider in target_inputs:
-            input_slider.select_value(call.data[ATTR_VALUE])
+        tasks = [input_slider.select_value(call.data[ATTR_VALUE])
+                 for input_slider in target_inputs]
+        yield from asyncio.gather(*tasks, loop=hass.loop)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SELECT_VALUE, async_select_value_service,
@@ -160,7 +161,8 @@ class InputSlider(Entity):
             ATTR_STEP: self._step
         }
 
-    def select_value(self, value):
+    @asyncio.coroutine
+    def asyncio_select_value(self, value):
         """Select new value."""
         num_value = float(value)
         if num_value < self._minimum or num_value > self._maximum:
@@ -168,4 +170,4 @@ class InputSlider(Entity):
                             num_value, self._minimum, self._maximum)
             return
         self._current_value = num_value
-        self.hass.loop.create_task(self.async_update_ha_state())
+        yield from self.async_update_ha_state()

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -265,7 +265,7 @@ def setup(hass, config):
 class Light(ToggleEntity):
     """Representation of a light."""
 
-    # pylint: disable=no-self-use, abstract-method
+    # pylint: disable=no-self-use
 
     @property
     def brightness(self):

--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -4,7 +4,7 @@ Support for LimitlessLED bulbs.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.limitlessled/
 """
-# pylint: disable=abstract-method
+
 import logging
 
 import voluptuous as vol

--- a/homeassistant/components/light/mysensors.py
+++ b/homeassistant/components/light/mysensors.py
@@ -4,7 +4,7 @@ Support for MySensors lights.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.mysensors/
 """
-# pylint: disable=abstract-method
+
 import logging
 
 from homeassistant.components import mysensors

--- a/homeassistant/components/lock/verisure.py
+++ b/homeassistant/components/lock/verisure.py
@@ -27,7 +27,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(locks)
 
 
-# pylint: disable=abstract-method
 class VerisureDoorlock(LockDevice):
     """Representation of a Verisure doorlock."""
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -710,7 +710,7 @@ def _async_fetch_image(hass, url):
             if response.status == 200:
                 content = yield from response.read()
                 content_type = response.headers.get(CONTENT_TYPE_HEADER)
-            hass.loop.create_task(response.release())
+            yield from response.release()
     except asyncio.TimeoutError:
         pass
 

--- a/homeassistant/components/media_player/braviatv.py
+++ b/homeassistant/components/media_player/braviatv.py
@@ -180,7 +180,6 @@ def request_configuration(config, hass, add_devices):
     )
 
 
-# pylint: disable=abstract-method
 class BraviaTVDevice(MediaPlayerDevice):
     """Representation of a Sony Bravia TV."""
 

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -88,7 +88,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class CastDevice(MediaPlayerDevice):
     """Representation of a Cast device on the network."""
 
-    # pylint: disable=abstract-method
     def __init__(self, chromecast):
         """Initialize the Cast device."""
         self.cast = chromecast

--- a/homeassistant/components/media_player/cmus.py
+++ b/homeassistant/components/media_player/cmus.py
@@ -58,7 +58,7 @@ def setup_platform(hass, config, add_devices, discover_info=None):
 class CmusDevice(MediaPlayerDevice):
     """Representation of a running cmus."""
 
-    # pylint: disable=no-member, abstract-method
+    # pylint: disable=no-member
     def __init__(self, server, password, port, name):
         """Initialize the CMUS device."""
         from pycmus import remote

--- a/homeassistant/components/media_player/demo.py
+++ b/homeassistant/components/media_player/demo.py
@@ -42,7 +42,7 @@ class AbstractDemoPlayer(MediaPlayerDevice):
     """A demo media players."""
 
     # We only implement the methods that we support
-    # pylint: disable=abstract-method
+
     def __init__(self, name):
         """Initialize the demo device."""
         self._name = name
@@ -110,7 +110,7 @@ class DemoYoutubePlayer(AbstractDemoPlayer):
     """A Demo media player that only supports YouTube."""
 
     # We only implement the methods that we support
-    # pylint: disable=abstract-method
+
     def __init__(self, name, youtube_id=None, media_title=None):
         """Initialize the demo device."""
         super().__init__(name)
@@ -162,7 +162,7 @@ class DemoMusicPlayer(AbstractDemoPlayer):
     """A Demo media player that only supports YouTube."""
 
     # We only implement the methods that we support
-    # pylint: disable=abstract-method
+
     tracks = [
         ('Technohead', 'I Wanna Be A Hippy (Flamman & Abraxas Radio Mix)'),
         ('Paul Elstak', 'Luv U More'),
@@ -269,7 +269,7 @@ class DemoTVShowPlayer(AbstractDemoPlayer):
     """A Demo media player that only supports YouTube."""
 
     # We only implement the methods that we support
-    # pylint: disable=abstract-method
+
     def __init__(self):
         """Initialize the demo device."""
         super().__init__('Lounge room')

--- a/homeassistant/components/media_player/denon.py
+++ b/homeassistant/components/media_player/denon.py
@@ -45,7 +45,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class DenonDevice(MediaPlayerDevice):
     """Representation of a Denon device."""
 
-    # pylint: disable=abstract-method
     def __init__(self, name, host):
         """Initialize the Denon device."""
         self._name = name

--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -65,7 +65,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class DirecTvDevice(MediaPlayerDevice):
     """Representation of a DirecTV reciever on the network."""
 
-    # pylint: disable=abstract-method
     def __init__(self, name, host, port):
         """Initialize the device."""
         from DirectPy import DIRECTV

--- a/homeassistant/components/media_player/emby.py
+++ b/homeassistant/components/media_player/emby.py
@@ -110,7 +110,7 @@ class EmbyClient(MediaPlayerDevice):
     """Representation of a Emby device."""
 
     # pylint: disable=too-many-arguments, too-many-public-methods,
-    # pylint: disable=abstract-method
+
     def __init__(self, client, device, emby_sessions, update_devices,
                  update_sessions):
         """Initialize the Emby device."""

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -104,7 +104,6 @@ class FireTV(object):
 class FireTVDevice(MediaPlayerDevice):
     """Representation of an Amazon Fire TV device on the network."""
 
-    # pylint: disable=abstract-method
     def __init__(self, host, port, device, name):
         """Initialize the FireTV device."""
         self._firetv = FireTV(host, port, device)

--- a/homeassistant/components/media_player/gpmdp.py
+++ b/homeassistant/components/media_player/gpmdp.py
@@ -170,7 +170,6 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 class GPMDP(MediaPlayerDevice):
     """Representation of a GPMDP."""
 
-    # pylint: disable=abstract-method
     def __init__(self, name, url, code):
         """Initialize the media player."""
         from websocket import create_connection

--- a/homeassistant/components/media_player/itunes.py
+++ b/homeassistant/components/media_player/itunes.py
@@ -153,7 +153,6 @@ class Itunes(object):
         return self._request('PUT', path, {'level': level})
 
 
-# pylint: disable=unused-argument, abstract-method
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the iTunes platform."""
     add_devices([

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -63,7 +63,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class KodiDevice(MediaPlayerDevice):
     """Representation of a XBMC/Kodi device."""
 
-    # pylint: disable=abstract-method
     def __init__(self, name, url, auth=None, turn_off_action=None):
         """Initialize the Kodi device."""
         import jsonrpc_requests

--- a/homeassistant/components/media_player/lg_netcast.py
+++ b/homeassistant/components/media_player/lg_netcast.py
@@ -52,7 +52,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([LgTVDevice(client, config[CONF_NAME])])
 
 
-# pylint: disable=abstract-method
 class LgTVDevice(MediaPlayerDevice):
     """Representation of a LG TV."""
 

--- a/homeassistant/components/media_player/mpchc.py
+++ b/homeassistant/components/media_player/mpchc.py
@@ -43,7 +43,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([MpcHcDevice(name, url)])
 
 
-# pylint: disable=abstract-method
 class MpcHcDevice(MediaPlayerDevice):
     """Representation of a MPC-HC server."""
 

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -77,7 +77,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class MpdDevice(MediaPlayerDevice):
     """Representation of a MPD server."""
 
-    # pylint: disable=no-member, abstract-method
+    # pylint: disable=no-member
     def __init__(self, server, port, location, password):
         """Initialize the MPD device."""
         import mpd

--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -68,7 +68,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class OnkyoDevice(MediaPlayerDevice):
     """Representation of an Onkyo device."""
 
-    # pylint: disable=abstract-method
     def __init__(self, receiver, sources, name=None):
         """Initialize the Onkyo Receiver."""
         self._receiver = receiver

--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -68,7 +68,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     return True
 
 
-# pylint: disable=abstract-method
 class PanasonicVieraTVDevice(MediaPlayerDevice):
     """Representation of a Panasonic Viera TV."""
 

--- a/homeassistant/components/media_player/pandora.py
+++ b/homeassistant/components/media_player/pandora.py
@@ -63,7 +63,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class PandoraMediaPlayer(MediaPlayerDevice):
     """A media player that uses the Pianobar interface to Pandora."""
 
-    # pylint: disable=abstract-method
     def __init__(self, name):
         """Initialize the demo device."""
         MediaPlayerDevice.__init__(self)

--- a/homeassistant/components/media_player/philips_js.py
+++ b/homeassistant/components/media_player/philips_js.py
@@ -50,7 +50,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([PhilipsTV(tvapi, name)])
 
 
-# pylint: disable=abstract-method
 class PhilipsTV(MediaPlayerDevice):
     """Representation of a Philips TV exposing the JointSpace API."""
 

--- a/homeassistant/components/media_player/pioneer.py
+++ b/homeassistant/components/media_player/pioneer.py
@@ -54,7 +54,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class PioneerDevice(MediaPlayerDevice):
     """Representation of a Pioneer device."""
 
-    # pylint: disable=abstract-method
     def __init__(self, name, host, port, timeout):
         """Initialize the Pioneer device."""
         self._name = name

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -60,7 +60,6 @@ def config_from_file(filename, config=None):
             return {}
 
 
-# pylint: disable=abstract-method
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the Plex platform."""
     config = config_from_file(hass.config.path(PLEX_CONFIG_FILE))

--- a/homeassistant/components/media_player/roku.py
+++ b/homeassistant/components/media_player/roku.py
@@ -34,7 +34,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=abstract-method
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Roku platform."""
     hosts = []
@@ -65,7 +64,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RokuDevice(MediaPlayerDevice):
     """Representation of a Roku device on the network."""
 
-    # pylint: disable=abstract-method
     def __init__(self, host):
         """Initialize the Roku device."""
         from roku import Roku

--- a/homeassistant/components/media_player/russound_rnet.py
+++ b/homeassistant/components/media_player/russound_rnet.py
@@ -72,7 +72,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error('Not connected to %s:%s', host, port)
 
 
-# pylint: disable=abstract-method
 class RussoundRNETDevice(MediaPlayerDevice):
     """Representation of a Russound RNET device."""
 

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -56,7 +56,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([SamsungTVDevice(name, remote_config)])
 
 
-# pylint: disable=abstract-method
 class SamsungTVDevice(MediaPlayerDevice):
     """Representation of a Samsung TV."""
 

--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -52,7 +52,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class SnapcastDevice(MediaPlayerDevice):
     """Representation of a Snapcast client device."""
 
-    # pylint: disable=abstract-method
     def __init__(self, client):
         """Initialize the Snapcast device."""
         self._client = client

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -248,7 +248,6 @@ class _ProcessSonosEventQueue():
         self._sonos_device.process_sonos_event(item)
 
 
-# pylint: disable=abstract-method
 class SonosDevice(MediaPlayerDevice):
     """Representation of a Sonos device."""
 

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -174,7 +174,6 @@ class LogitechMediaServer(object):
 class SqueezeBoxDevice(MediaPlayerDevice):
     """Representation of a SqueezeBox device."""
 
-    # pylint: disable=abstract-method
     def __init__(self, lms, player_id):
         """Initialize the SqeezeBox device."""
         super(SqueezeBoxDevice, self).__init__()

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -141,7 +141,6 @@ def request_configuration(host, name, customize, hass, add_devices):
     )
 
 
-# pylint: disable=abstract-method
 class LgWebOSDevice(MediaPlayerDevice):
     """Representation of a LG WebOS TV."""
 

--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -85,7 +85,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class YamahaDevice(MediaPlayerDevice):
     """Representation of a Yamaha device."""
 
-    # pylint: disable=abstract-method
     def __init__(self, name, receiver, source_ignore, source_names):
         """Initialize the Yamaha Receiver."""
         self._receiver = receiver

--- a/homeassistant/components/sensor/lastfm.py
+++ b/homeassistant/components/sensor/lastfm.py
@@ -40,7 +40,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class LastfmSensor(Entity):
     """A class for the Last.fm account."""
 
-    # pylint: disable=abstract-method
     def __init__(self, user, lastfm):
         """Initialize the sensor."""
         self._user = lastfm.get_user(user)

--- a/homeassistant/components/sensor/steam_online.py
+++ b/homeassistant/components/sensor/steam_online.py
@@ -37,7 +37,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class SteamSensor(Entity):
     """A class for the Steam account."""
 
-    # pylint: disable=abstract-method
     def __init__(self, account, steamod):
         """Initialize the sensor."""
         self._steamod = steamod

--- a/homeassistant/components/sensor/supervisord.py
+++ b/homeassistant/components/sensor/supervisord.py
@@ -43,7 +43,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class SupervisorProcessSensor(Entity):
     """Representation of a supervisor-monitored process."""
 
-    # pylint: disable=abstract-method
     def __init__(self, info, server):
         """Initialize the sensor."""
         self._info = info

--- a/homeassistant/components/sensor/twitch.py
+++ b/homeassistant/components/sensor/twitch.py
@@ -42,7 +42,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class TwitchSensor(Entity):
     """Representation of an Twitch channel."""
 
-    # pylint: disable=abstract-method
     def __init__(self, channel):
         """Initialize the sensor."""
         self._channel = channel

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -108,7 +108,7 @@ def setup(hass, config):
 class SwitchDevice(ToggleEntity):
     """Representation of a switch."""
 
-    # pylint: disable=no-self-use, abstract-method
+    # pylint: disable=no-self-use
     @property
     def current_power_mwh(self):
         """Return the current power usage in mWh."""

--- a/homeassistant/components/switch/arest.py
+++ b/homeassistant/components/switch/arest.py
@@ -4,7 +4,7 @@ Support for an exposed aREST RESTful API of a device.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.arest/
 """
-# pylint: disable=abstract-method
+
 import logging
 
 import requests

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -307,15 +307,35 @@ class ToggleEntity(Entity):
 
     def turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
+        run_coroutine_threadsafe(self.async_turn_on(**kwargs),
+                                 self.hass.loop).result()
+
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
+        """Turn the entity on."""
         raise NotImplementedError()
 
     def turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
+        run_coroutine_threadsafe(self.async_turn_off(**kwargs),
+                                 self.hass.loop).result()
+
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
+        """Turn the entity off."""
         raise NotImplementedError()
 
-    def toggle(self, **kwargs) -> None:
-        """Toggle the entity off."""
+    def toggle(self) -> None:
+        """Toggle the entity."""
         if self.is_on:
-            self.turn_off(**kwargs)
+            self.turn_off()
         else:
-            self.turn_on(**kwargs)
+            self.turn_on()
+
+    @asyncio.coroutine
+    def async_toggle(self):
+        """Toggle the entity."""
+        if self.is_on:
+            yield from self.async_turn_off()
+        else:
+            yield from self.async_turn_on()

--- a/pylintrc
+++ b/pylintrc
@@ -12,6 +12,7 @@ reports=no
 # redefined-variable-type - this is Python, we're duck typing!
 # too-many-* - are not enforced for the sake of readability
 # too-few-* - same as too-many-*
+# abstract-method - with intro of async there are always methods missing
 
 disable=
   locally-disabled,
@@ -30,6 +31,7 @@ disable=
   too-many-return-statements,
   too-many-statements,
   too-few-public-methods,
+  abstract-method
 
 [EXCEPTIONS]
 overgeneral-exceptions=Exception,HomeAssistantError


### PR DESCRIPTION
**Description:**
This converts a bunch of services to use `yield from` instead of `hass.loop.create_task`. See #4099 for discussion.

**Related issue (if applicable):** fixes #4099

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

