### PR TITLE
Fix blocking/stack trace with empty list

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -296,6 +296,10 @@ class EntityPlatform(object):
         tasks = [self._async_process_entity(entity, update_before_add)
                  for entity in new_entities]
 
+        # handle empty list from component/platform
+        if not tasks:
+            return
+
         yield from asyncio.gather(*tasks, loop=self.component.hass.loop)
         yield from self.component.async_update_group()
 


### PR DESCRIPTION
**Description:**

I had see that some component and platform don't check if device list is emtpy and that could make a stacktrace and in some case block gather for ever. I think we should check that on add_entities and don't need to make on ever platform.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

