### PR TITLE
Use port instead of url (litejet)

### DIFF
--- a/homeassistant/components/light/litejet.py
+++ b/homeassistant/components/light/litejet.py
@@ -4,7 +4,6 @@ Support for LiteJet lights.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.litejet/
 """
-
 import logging
 
 import homeassistant.components.litejet as litejet
@@ -18,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup lights for the LiteJet platform."""
+    """Set up lights for the LiteJet platform."""
     litejet_ = hass.data['litejet_system']
 
     devices = []
@@ -30,7 +29,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class LiteJetLight(Light):
-    """Represents a single LiteJet light."""
+    """Representation of a single LiteJet light."""
 
     def __init__(self, hass, lj, i, name):
         """Initialize a LiteJet light."""

--- a/homeassistant/components/litejet.py
+++ b/homeassistant/components/litejet.py
@@ -4,24 +4,25 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/litejet/
 """
 import logging
+
 import voluptuous as vol
 
 from homeassistant.helpers import discovery
-from homeassistant.const import CONF_URL
+from homeassistant.const import CONF_PORT
 import homeassistant.helpers.config_validation as cv
 
-DOMAIN = 'litejet'
-
 REQUIREMENTS = ['pylitejet==0.1']
+
+_LOGGER = logging.getLogger(__name__)
 
 CONF_EXCLUDE_NAMES = 'exclude_names'
 CONF_INCLUDE_SWITCHES = 'include_switches'
 
-_LOGGER = logging.getLogger(__name__)
+DOMAIN = 'litejet'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_URL): cv.string,
+        vol.Required(CONF_PORT): cv.string,
         vol.Optional(CONF_EXCLUDE_NAMES): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_INCLUDE_SWITCHES, default=False): cv.boolean
     })
@@ -32,7 +33,7 @@ def setup(hass, config):
     """Initialize the LiteJet component."""
     from pylitejet import LiteJet
 
-    url = config[DOMAIN].get(CONF_URL)
+    url = config[DOMAIN].get(CONF_PORT)
 
     hass.data['litejet_system'] = LiteJet(url)
     hass.data['litejet_config'] = config[DOMAIN]

--- a/homeassistant/components/scene/litejet.py
+++ b/homeassistant/components/scene/litejet.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/scene.litejet/
 """
 import logging
+
 import homeassistant.components.litejet as litejet
 from homeassistant.components.scene import Scene
 
@@ -16,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup scenes for the LiteJet platform."""
+    """Set up scenes for the LiteJet platform."""
     litejet_ = hass.data['litejet_system']
 
     devices = []
@@ -28,7 +29,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class LiteJetScene(Scene):
-    """Represents a single LiteJet scene."""
+    """Representation of a single LiteJet scene."""
 
     def __init__(self, lj, i, name):
         """Initialize the scene."""

--- a/homeassistant/components/switch/litejet.py
+++ b/homeassistant/components/switch/litejet.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.litejet/
 """
 import logging
+
 import homeassistant.components.litejet as litejet
 from homeassistant.components.switch import SwitchDevice
 
@@ -16,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the LiteJet switch platform."""
+    """Set up the LiteJet switch platform."""
     litejet_ = hass.data['litejet_system']
 
     devices = []
@@ -28,7 +29,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class LiteJetSwitch(SwitchDevice):
-    """Represents a single LiteJet switch."""
+    """Representation of a single LiteJet switch."""
 
     def __init__(self, hass, lj, i, name):
         """Initialize a LiteJet switch."""


### PR DESCRIPTION
**Description:**
Use `port` for the serial port and not `url`. As we do in other platforms/components which are using a serial interface to communicate.

**Example entry for `configuration.yaml` (if applicable):**
```yaml
litejet:
  port: /dev/serial/by-id/THE-PATH-OF-YOUR-SERIAL-PORT
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

