### PR TITLE
Speed up Sonos tests

### DIFF
--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -1,4 +1,5 @@
 """The tests for the Demo Media player platform."""
+import socket
 import unittest
 import soco.snapshot
 from unittest import mock
@@ -113,7 +114,8 @@ class TestSonosMediaPlayer(unittest.TestCase):
         self.hass.stop()
 
     @mock.patch('soco.SoCo', new=SoCoMock)
-    def test_ensure_setup_discovery(self):
+    @mock.patch('socket.create_connection', side_effect=socket.error())
+    def test_ensure_setup_discovery(self, *args):
         """Test a single device using the autodiscovery provided by HASS."""
         sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
 
@@ -122,7 +124,8 @@ class TestSonosMediaPlayer(unittest.TestCase):
         self.assertEqual(sonos.DEVICES[0].name, 'Kitchen')
 
     @mock.patch('soco.SoCo', new=SoCoMock)
-    def test_ensure_setup_config(self):
+    @mock.patch('socket.create_connection', side_effect=socket.error())
+    def test_ensure_setup_config(self, *args):
         """Test a single address config'd by the HASS config file."""
         sonos.setup_platform(self.hass,
                              {'hosts': '192.0.2.1'},
@@ -134,15 +137,17 @@ class TestSonosMediaPlayer(unittest.TestCase):
 
     @mock.patch('soco.SoCo', new=SoCoMock)
     @mock.patch.object(soco, 'discover', new=socoDiscoverMock.discover)
-    def test_ensure_setup_sonos_discovery(self):
+    @mock.patch('socket.create_connection', side_effect=socket.error())
+    def test_ensure_setup_sonos_discovery(self, *args):
         """Test a single device using the autodiscovery provided by Sonos."""
         sonos.setup_platform(self.hass, {}, mock.MagicMock())
         self.assertEqual(len(sonos.DEVICES), 1)
         self.assertEqual(sonos.DEVICES[0].name, 'Kitchen')
 
     @mock.patch('soco.SoCo', new=SoCoMock)
+    @mock.patch('socket.create_connection', side_effect=socket.error())
     @mock.patch.object(SoCoMock, 'partymode')
-    def test_sonos_group_players(self, partymodeMock):
+    def test_sonos_group_players(self, partymodeMock, *args):
         """Ensuring soco methods called for sonos_group_players service."""
         sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
         device = sonos.DEVICES[-1]
@@ -152,8 +157,9 @@ class TestSonosMediaPlayer(unittest.TestCase):
         self.assertEqual(partymodeMock.call_args, mock.call())
 
     @mock.patch('soco.SoCo', new=SoCoMock)
+    @mock.patch('socket.create_connection', side_effect=socket.error())
     @mock.patch.object(SoCoMock, 'unjoin')
-    def test_sonos_unjoin(self, unjoinMock):
+    def test_sonos_unjoin(self, unjoinMock, *args):
         """Ensuring soco methods called for sonos_unjoin service."""
         sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
         device = sonos.DEVICES[-1]
@@ -163,8 +169,9 @@ class TestSonosMediaPlayer(unittest.TestCase):
         self.assertEqual(unjoinMock.call_args, mock.call())
 
     @mock.patch('soco.SoCo', new=SoCoMock)
+    @mock.patch('socket.create_connection', side_effect=socket.error())
     @mock.patch.object(SoCoMock, 'set_sleep_timer')
-    def test_sonos_set_sleep_timer(self, set_sleep_timerMock):
+    def test_sonos_set_sleep_timer(self, set_sleep_timerMock, *args):
         """Ensuring soco methods called for sonos_set_sleep_timer service."""
         sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
         device = sonos.DEVICES[-1]
@@ -172,8 +179,9 @@ class TestSonosMediaPlayer(unittest.TestCase):
         set_sleep_timerMock.assert_called_once_with(30)
 
     @mock.patch('soco.SoCo', new=SoCoMock)
+    @mock.patch('socket.create_connection', side_effect=socket.error())
     @mock.patch.object(SoCoMock, 'set_sleep_timer')
-    def test_sonos_clear_sleep_timer(self, set_sleep_timerMock):
+    def test_sonos_clear_sleep_timer(self, set_sleep_timerMock, *args):
         """Ensuring soco methods called for sonos_clear_sleep_timer service."""
         sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
         device = sonos.DEVICES[-1]
@@ -181,8 +189,9 @@ class TestSonosMediaPlayer(unittest.TestCase):
         set_sleep_timerMock.assert_called_once_with(None)
 
     @mock.patch('soco.SoCo', new=SoCoMock)
+    @mock.patch('socket.create_connection', side_effect=socket.error())
     @mock.patch.object(soco.snapshot.Snapshot, 'snapshot')
-    def test_sonos_snapshot(self, snapshotMock):
+    def test_sonos_snapshot(self, snapshotMock, *args):
         """Ensuring soco methods called for sonos_snapshot service."""
         sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
         device = sonos.DEVICES[-1]
@@ -192,8 +201,9 @@ class TestSonosMediaPlayer(unittest.TestCase):
         self.assertEqual(snapshotMock.call_args, mock.call())
 
     @mock.patch('soco.SoCo', new=SoCoMock)
+    @mock.patch('socket.create_connection', side_effect=socket.error())
     @mock.patch.object(soco.snapshot.Snapshot, 'restore')
-    def test_sonos_restore(self, restoreMock):
+    def test_sonos_restore(self, restoreMock, *args):
         """Ensuring soco methods called for sonos_restor service."""
         sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
         device = sonos.DEVICES[-1]


### PR DESCRIPTION
**Description:**

Tests were running slow after #4063 due to having to wait for a socket timeout.