### PR TITLE
Fix log owntrack log flooting

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -142,9 +142,9 @@ def setup_scanner(hass, config, see):
             return data
         if max_gps_accuracy is not None and \
                 convert(data.get('acc'), float, 0.0) > max_gps_accuracy:
-            _LOGGER.warning('Ignoring %s update because expected GPS '
-                            'accuracy %s is not met: %s',
-                            data_type, max_gps_accuracy, payload)
+            _LOGGER.info('Ignoring %s update because expected GPS '
+                         'accuracy %s is not met: %s',
+                         data_type, max_gps_accuracy, payload)
             return None
         if convert(data.get('acc'), float, 1.0) == 0.0:
             _LOGGER.warning('Ignoring %s update because GPS accuracy'
@@ -247,7 +247,7 @@ def setup_scanner(hass, config, see):
                         if (max_gps_accuracy is not None and
                                 data['acc'] > max_gps_accuracy):
                             valid_gps = False
-                            _LOGGER.warning(
+                            _LOGGER.info(
                                 'Ignoring GPS in region exit because expected '
                                 'GPS accuracy %s is not met: %s',
                                 max_gps_accuracy, payload)


### PR DESCRIPTION
**Description:**

I change two message from warning to info. Since gps accuracy is a option and I set that explicit, I don't want to have a warning. This floot my log with none sence stuff.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

