### PR TITLE
PVOutput sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -280,6 +280,7 @@ omit =
     homeassistant/components/sensor/openweathermap.py
     homeassistant/components/sensor/pi_hole.py
     homeassistant/components/sensor/plex.py
+    homeassistant/components/sensor/pvoutput.py
     homeassistant/components/sensor/sabnzbd.py
     homeassistant/components/sensor/scrape.py
     homeassistant/components/sensor/serial_pm.py

--- a/homeassistant/components/sensor/pvoutput.py
+++ b/homeassistant/components/sensor/pvoutput.py
@@ -1,0 +1,121 @@
+"""
+Support for getting collected information from PVOutput.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.pvoutput/
+"""
+import logging
+from collections import namedtuple
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.components.sensor.rest import RestData
+from homeassistant.const import (
+    ATTR_TEMPERATURE, CONF_API_KEY, CONF_NAME, STATE_UNKNOWN)
+
+_LOGGER = logging.getLogger(__name__)
+_ENDPOINT = 'http://pvoutput.org/service/r2/getstatus.jsp'
+
+ATTR_DATE = 'date'
+ATTR_TIME = 'time'
+ATTR_ENERGY_GENERATION = 'energy_generation'
+ATTR_POWER_GENERATION = 'power_generation'
+ATTR_ENERGY_CONSUMPTION = 'energy_consumption'
+ATTR_POWER_CONSUMPTION = 'power_consumption'
+ATTR_EFFICIENCY = 'efficiency'
+ATTR_VOLTAGE = 'voltage'
+
+CONF_SYSTEM_ID = 'system_id'
+
+DEFAULT_METHOD = 'GET'
+DEFAULT_NAME = 'PVOutput'
+DEFAULT_VERIFY_SSL = True
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Required(CONF_SYSTEM_ID): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the PVOutput sensor."""
+    name = config.get(CONF_NAME)
+    api_key = config.get(CONF_API_KEY)
+    system_id = config.get(CONF_SYSTEM_ID)
+    method = 'GET'
+    payload = None
+    auth = None
+    headers = {
+        'X-Pvoutput-Apikey': api_key,
+        'X-Pvoutput-SystemId': system_id,
+    }
+    verify_ssl = DEFAULT_VERIFY_SSL
+
+    rest = RestData(method, _ENDPOINT, auth, headers, payload, verify_ssl)
+    rest.update()
+
+    if rest.data is None:
+        _LOGGER.error("Unable to fetch data from PVOutput")
+        return False
+
+    add_devices([PvoutputSensor(rest, name)])
+
+
+# pylint: disable=no-member
+class PvoutputSensor(Entity):
+    """Representation of a PVOutput sensor."""
+
+    def __init__(self, rest, name):
+        """Initialize a PVOutput sensor."""
+        self.rest = rest
+        self._name = name
+        self.pvcoutput = False
+        self.status = namedtuple(
+            'status', [ATTR_DATE, ATTR_TIME, ATTR_ENERGY_GENERATION,
+                       ATTR_POWER_GENERATION, ATTR_ENERGY_CONSUMPTION,
+                       ATTR_POWER_CONSUMPTION, ATTR_EFFICIENCY,
+                       ATTR_TEMPERATURE, ATTR_VOLTAGE])
+
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        if self.pvcoutput is not None:
+            return self.pvcoutput.energy_generation
+        else:
+            return STATE_UNKNOWN
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the Pi-Hole."""
+        if self.pvcoutput is not None:
+            return {
+                ATTR_DATE: self.pvcoutput.date,
+                ATTR_TIME: self.pvcoutput.time,
+                ATTR_POWER_GENERATION: self.pvcoutput.power_generation,
+                ATTR_ENERGY_CONSUMPTION: self.pvcoutput.energy_consumption,
+                ATTR_POWER_CONSUMPTION: self.pvcoutput.power_consumption,
+                ATTR_EFFICIENCY: self.pvcoutput.efficiency,
+                ATTR_TEMPERATURE: self.pvcoutput.temperature,
+                ATTR_VOLTAGE: self.pvcoutput.voltage,
+            }
+
+    def update(self):
+        """Get the latest data from the PVOutput API and updates the state."""
+        try:
+            self.rest.update()
+            self.pvcoutput = self.status._make(self.rest.data.split(','))
+        except TypeError:
+            self.pvcoutput = None
+            _LOGGER.error(
+                "Unable to fetch data from PVOutput. %s", self.rest.data)

--- a/homeassistant/components/sensor/pvoutput.py
+++ b/homeassistant/components/sensor/pvoutput.py
@@ -30,9 +30,7 @@ ATTR_VOLTAGE = 'voltage'
 
 CONF_SYSTEM_ID = 'system_id'
 
-DEFAULT_METHOD = 'GET'
 DEFAULT_NAME = 'PVOutput'
-DEFAULT_VERIFY_SSL = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
@@ -42,18 +40,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the PVOutput sensor."""
+    """Set up the PVOutput sensor."""
     name = config.get(CONF_NAME)
     api_key = config.get(CONF_API_KEY)
     system_id = config.get(CONF_SYSTEM_ID)
     method = 'GET'
-    payload = None
-    auth = None
+    payload = verify_ssl = auth = None
     headers = {
         'X-Pvoutput-Apikey': api_key,
         'X-Pvoutput-SystemId': system_id,
     }
-    verify_ssl = DEFAULT_VERIFY_SSL
 
     rest = RestData(method, _ENDPOINT, auth, headers, payload, verify_ssl)
     rest.update()
@@ -100,8 +96,6 @@ class PvoutputSensor(Entity):
         """Return the state attributes of the Pi-Hole."""
         if self.pvcoutput is not None:
             return {
-                ATTR_DATE: self.pvcoutput.date,
-                ATTR_TIME: self.pvcoutput.time,
                 ATTR_POWER_GENERATION: self.pvcoutput.power_generation,
                 ATTR_ENERGY_CONSUMPTION: self.pvcoutput.energy_consumption,
                 ATTR_POWER_CONSUMPTION: self.pvcoutput.power_consumption,

--- a/homeassistant/components/sensor/pvoutput.py
+++ b/homeassistant/components/sensor/pvoutput.py
@@ -31,6 +31,7 @@ ATTR_VOLTAGE = 'voltage'
 CONF_SYSTEM_ID = 'system_id'
 
 DEFAULT_NAME = 'PVOutput'
+DEFAULT_VERIFY_SSL = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
@@ -45,7 +46,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     api_key = config.get(CONF_API_KEY)
     system_id = config.get(CONF_SYSTEM_ID)
     method = 'GET'
-    payload = verify_ssl = auth = None
+    payload = auth = None
+    verify_ssl = DEFAULT_VERIFY_SSL
     headers = {
         'X-Pvoutput-Apikey': api_key,
         'X-Pvoutput-SystemId': system_id,


### PR DESCRIPTION
**Description:**
This sensor is gathering information from [PVOutput](http://pvoutput.org/). PVOutput is a free service for sharing, comparing and monitoring live solar photovoltaic (PV) and energy consumption data.

[Joost](https://community.home-assistant.io/users/joostman/activity) provided the necessary details to make this basic PVOutput sensor possible.

**Related issue (if applicable):** fixes [PVoutput plugin for HASS](https://community.home-assistant.io/t/pvoutput-plugin-for-hass/5760/3)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1406

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: pvoutput
    system_id: !secret pvcoutput_system_id
    api_key: !secret pvcoutput_api
    scan_interval: 120
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

