### PR TITLE
Disabled too-few-public-methods

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -45,8 +45,7 @@ def monkey_patch_asyncio():
     See https://bugs.python.org/issue26617 for details of the Python
     bug.
     """
-    # pylint: disable=no-self-use, too-few-public-methods, protected-access
-    # pylint: disable=bare-except
+    # pylint: disable=no-self-use, protected-access, bare-except
     import asyncio.tasks
 
     class IgnoreCalls:

--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -166,7 +166,7 @@ def setup(hass, config):
 class GzipFileSender(FileSender):
     """FileSender class capable of sending gzip version if available."""
 
-    # pylint: disable=invalid-name, too-few-public-methods
+    # pylint: disable=invalid-name
 
     development = False
 

--- a/homeassistant/components/logger.py
+++ b/homeassistant/components/logger.py
@@ -40,7 +40,7 @@ CONFIG_SCHEMA = vol.Schema({
 class HomeAssistantLogFilter(logging.Filter):
     """A log filter."""
 
-    # pylint: disable=no-init,too-few-public-methods
+    # pylint: disable=no-init
     def __init__(self, logfilter):
         """Initialize the filter."""
         super().__init__()

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -234,7 +234,6 @@ def _parse_timespan(timespan):
             reversed(timespan.split(':'))))
 
 
-# pylint: disable=too-few-public-methods
 class _ProcessSonosEventQueue():
     """Queue like object for dispatching sonos events."""
 

--- a/homeassistant/components/pilight.py
+++ b/homeassistant/components/pilight.py
@@ -120,7 +120,6 @@ def setup(hass, config):
     return True
 
 
-# pylint: disable=too-few-public-methods
 class CallRateDelayThrottle(object):
     """Helper class to provide service call rate throttling.
 

--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -149,7 +149,6 @@ class GlancesSensor(Entity):
         self.rest.update()
 
 
-# pylint: disable=too-few-public-methods
 class GlancesData(object):
     """The class for handling the data retrieval."""
 

--- a/homeassistant/components/sensor/hddtemp.py
+++ b/homeassistant/components/sensor/hddtemp.py
@@ -101,7 +101,6 @@ class HddTempSensor(Entity):
             self._state = STATE_UNKNOWN
 
 
-# pylint: disable=too-few-public-methods
 class HddTempData(object):
     """Get the latest data from HDDTemp and update the states."""
 

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -109,7 +109,7 @@ def get_random_string(length=10):
 class OrderedEnum(enum.Enum):
     """Taken from Python 3.4.0 docs."""
 
-    # pylint: disable=no-init, too-few-public-methods
+    # pylint: disable=no-init
     def __ge__(self, other):
         """Return the greater than element."""
         if self.__class__ is other.__class__:


### PR DESCRIPTION
**Description:**
In #4107 I focused on too-many-* and missed a few too-few-public-methods which was globally disabled too.

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**