### PR TITLE
Daily consumption information for HS110

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -6,9 +6,9 @@ https://home-assistant.io/components/switch.tplink/
 """
 import logging
 
-import voluptuous as vol
-
 import time
+
+import voluptuous as vol
 
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_HOST, CONF_NAME)
@@ -82,23 +82,23 @@ class SmartPlugSwitch(SwitchDevice):
         """Update the TP-Link switch's state."""
 
         try:
-          self._state = self.smartplug.state
+            self._state = self.smartplug.state
 
-          if self._emeter_present:
-              emeter_readings = self.smartplug.get_emeter_realtime()
+            if self._emeter_present:
+                emeter_readings = self.smartplug.get_emeter_realtime()
 
-              self._emeter_params[ATTR_CURRENT_CONSUMPTION] \
-                  = "%.1f W" % emeter_readings["power"]
-              self._emeter_params[ATTR_TOTAL_CONSUMPTION] \
-                  = "%.2f kW" % emeter_readings["total"]
-              self._emeter_params[ATTR_VOLTAGE] \
-                  = "%.2f V" % emeter_readings["voltage"]
-              self._emeter_params[ATTR_CURRENT] \
-                  = "%.1f A" % emeter_readings["current"]
+                self._emeter_params[ATTR_CURRENT_CONSUMPTION] \
+                    = "%.1f W" % emeter_readings["power"]
+                self._emeter_params[ATTR_TOTAL_CONSUMPTION] \
+                    = "%.2f kW" % emeter_readings["total"]
+                self._emeter_params[ATTR_VOLTAGE] \
+                    = "%.2f V" % emeter_readings["voltage"]
+                self._emeter_params[ATTR_CURRENT] \
+                    = "%.1f A" % emeter_readings["current"]
 
-              emeter_statics = self.smartplug.get_emeter_daily()
-              self._emeter_params[ATTR_DAILY_CONSUMPTION] \
-                  = "%.2f kW" % emeter_statics[int(time.strftime("%e"))]
+                emeter_statics = self.smartplug.get_emeter_daily()
+                self._emeter_params[ATTR_DAILY_CONSUMPTION] \
+                    = "%.2f kW" % emeter_statics[int(time.strftime("%e"))]
 
-        except (RequestException, ValueError, KeyError):
-          _LOGGER.warning('Could not update status for %s', self.name)
+        except OSError:
+            _LOGGER.warning('Could not update status for %s', self.name)

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -42,6 +42,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     add_devices([SmartPlugSwitch(SmartPlug(host), name)], True)
 
+
 class SmartPlugSwitch(SwitchDevice):
     """Representation of a TPLink Smart Plug switch."""
 

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -81,7 +81,6 @@ class SmartPlugSwitch(SwitchDevice):
 
     def update(self):
         """Update the TP-Link switch's state."""
-
         try:
             self._state = self.smartplug.state
 

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -8,6 +8,8 @@ import logging
 
 import voluptuous as vol
 
+import time
+
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_HOST, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
@@ -21,6 +23,7 @@ DEFAULT_NAME = 'TPLink Switch HS100'
 
 ATTR_CURRENT_CONSUMPTION = 'Current consumption'
 ATTR_TOTAL_CONSUMPTION = 'Total consumption'
+ATTR_DAILY_CONSUMPTION = 'Daily consumption'
 ATTR_VOLTAGE = 'Voltage'
 ATTR_CURRENT = 'Current'
 
@@ -38,7 +41,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
 
     add_devices([SmartPlugSwitch(SmartPlug(host), name)], True)
-
 
 class SmartPlugSwitch(SwitchDevice):
     """Representation of a TPLink Smart Plug switch."""
@@ -78,16 +80,25 @@ class SmartPlugSwitch(SwitchDevice):
 
     def update(self):
         """Update the TP-Link switch's state."""
-        self._state = self.smartplug.state
 
-        if self._emeter_present:
-            emeter_readings = self.smartplug.get_emeter_realtime()
+        try:
+          self._state = self.smartplug.state
 
-            self._emeter_params[ATTR_CURRENT_CONSUMPTION] \
-                = "%.1f W" % emeter_readings["power"]
-            self._emeter_params[ATTR_TOTAL_CONSUMPTION] \
-                = "%.2f kW" % emeter_readings["total"]
-            self._emeter_params[ATTR_VOLTAGE] \
-                = "%.2f V" % emeter_readings["voltage"]
-            self._emeter_params[ATTR_CURRENT] \
-                = "%.1f A" % emeter_readings["current"]
+          if self._emeter_present:
+              emeter_readings = self.smartplug.get_emeter_realtime()
+
+              self._emeter_params[ATTR_CURRENT_CONSUMPTION] \
+                  = "%.1f W" % emeter_readings["power"]
+              self._emeter_params[ATTR_TOTAL_CONSUMPTION] \
+                  = "%.2f kW" % emeter_readings["total"]
+              self._emeter_params[ATTR_VOLTAGE] \
+                  = "%.2f V" % emeter_readings["voltage"]
+              self._emeter_params[ATTR_CURRENT] \
+                  = "%.1f A" % emeter_readings["current"]
+
+              emeter_statics = self.smartplug.get_emeter_daily()
+              self._emeter_params[ATTR_DAILY_CONSUMPTION] \
+                  = "%.2f kW" % emeter_statics[int(time.strftime("%e"))]
+
+        except (RequestException, ValueError, KeyError):
+          _LOGGER.warning('Could not update status for %s', self.name)


### PR DESCRIPTION
**Description:**
A minor extension of the switch tplink for get de total energy consumed in the current day.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
