### PR TITLE
Warn if fetching properties takes too long

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -217,6 +217,8 @@ class Entity(object):
 
         if state is None:
             state = STATE_UNKNOWN
+        else:
+            state = str(state)
 
         attr = self.state_attributes or {}
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -1,6 +1,7 @@
 """An abstract class for entities."""
 import asyncio
 import logging
+from timeit import default_timer as timer
 
 from typing import Any, Optional, List, Dict
 
@@ -210,7 +211,13 @@ class Entity(object):
                 #     future support?
                 yield from self.hass.loop.run_in_executor(None, self.update)
 
-        state = STATE_UNKNOWN if self.state is None else str(self.state)
+        start = timer()
+
+        state = self.state
+
+        if state is None:
+            state = STATE_UNKNOWN
+
         attr = self.state_attributes or {}
 
         device_attr = self.device_state_attributes
@@ -230,6 +237,13 @@ class Entity(object):
         self._attr_setter('entity_picture', str, ATTR_ENTITY_PICTURE, attr)
         self._attr_setter('hidden', bool, ATTR_HIDDEN, attr)
         self._attr_setter('assumed_state', bool, ATTR_ASSUMED_STATE, attr)
+
+        end = timer()
+
+        if end - start > 0.2:
+            _LOGGER.warning('Updating state for %s took %.3f seconds. '
+                            'Please report to the developers.', self.entity_id,
+                            end - start)
 
         # Overwrite properties that have been set in the config file.
         attr.update(_OVERWRITE.get(self.entity_id, {}))


### PR DESCRIPTION
**Description:**
I have the suspicion that there are some components/platforms out there that are still doing I/O (ie talking to devices) when their properties are fetched. This is bad behavior as data should be fetched inside the update method instead.

This PR will warn if it takes longer than 0.2 seconds to fetch the data.

**Related issue (if applicable):** will help find culprit of #4162
