### PR TITLE
Clean up tests

### DIFF
--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import call, patch
 from datetime import datetime, timedelta
 import os
 
+from homeassistant.core import callback
 from homeassistant.bootstrap import setup_component
 from homeassistant.loader import get_component
 import homeassistant.util.dt as dt_util
@@ -312,6 +313,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
                                         TEST_PLATFORM))
         test_events = []
 
+        @callback
         def listener(event):
             """Helper method that will verify our event got called."""
             test_events.append(event)

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -6,6 +6,7 @@ import socket
 
 import voluptuous as vol
 
+from homeassistant.core import callback
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.mqtt as mqtt
 from homeassistant.const import (
@@ -29,6 +30,7 @@ class TestMQTT(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
+    @callback
     def record_calls(self, *args):
         """Helper for recording calls."""
         self.calls.append(args)
@@ -236,6 +238,7 @@ class TestMQTTCallbacks(unittest.TestCase):
         """Test if receiving triggers an event."""
         calls = []
 
+        @callback
         def record(event):
             """Helper to record calls."""
             calls.append(event)
@@ -321,6 +324,7 @@ class TestMQTTCallbacks(unittest.TestCase):
         """Test receiving a non utf8 encoded message."""
         calls = []
 
+        @callback
         def record(event):
             """Helper to record calls."""
             calls.append(event)

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -1,6 +1,7 @@
 """The tests for the notify demo platform."""
 import unittest
 
+from homeassistant.core import callback
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.notify as notify
 from homeassistant.components.notify import demo
@@ -23,6 +24,7 @@ class TestNotifyDemo(unittest.TestCase):
         self.events = []
         self.calls = []
 
+        @callback
         def record_event(event):
             """Record event to send notification."""
             self.events.append(event)
@@ -33,6 +35,7 @@ class TestNotifyDemo(unittest.TestCase):
         """"Stop down everything that was started."""
         self.hass.stop()
 
+    @callback
     def record_calls(self, *args):
         """Helper for recording calls."""
         self.calls.append(args)

--- a/tests/components/notify/test_group.py
+++ b/tests/components/notify/test_group.py
@@ -1,6 +1,7 @@
 """The tests for the notify.group platform."""
 import unittest
 
+from homeassistant.core import callback
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.notify as notify
 from homeassistant.components.notify import group
@@ -34,6 +35,7 @@ class TestNotifyGroup(unittest.TestCase):
 
         assert self.service is not None
 
+        @callback
         def record_event(event):
             """Record event to send notification."""
             self.events.append(event)

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime, timedelta
 import unittest
 
+from homeassistant.core import callback
 from homeassistant.const import MATCH_ALL
 from homeassistant.components import recorder
 from homeassistant.bootstrap import setup_component
@@ -110,6 +111,7 @@ class TestRecorder(unittest.TestCase):
 
         events = []
 
+        @callback
         def event_listener(event):
             """Record events from eventbus."""
             if event.event_type == event_type:

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -357,7 +357,7 @@ class TestComponentsGroup(unittest.TestCase):
 
     def test_changing_group_visibility(self):
         """Test that a group can be hidden and shown."""
-        setup_component(self.hass, 'group', {
+        assert setup_component(self.hass, 'group', {
             'group': {
                 'test_group': 'hello.world,sensor.happy'
             }
@@ -367,12 +367,12 @@ class TestComponentsGroup(unittest.TestCase):
 
         # Hide the group
         group.set_visibility(self.hass, group_entity_id, False)
-        group_state = self.hass.states.get(group_entity_id)
         self.hass.block_till_done()
+        group_state = self.hass.states.get(group_entity_id)
         self.assertTrue(group_state.attributes.get(ATTR_HIDDEN))
 
         # Show it again
         group.set_visibility(self.hass, group_entity_id, True)
-        group_state = self.hass.states.get(group_entity_id)
         self.hass.block_till_done()
+        group_state = self.hass.states.get(group_entity_id)
         self.assertIsNone(group_state.attributes.get(ATTR_HIDDEN))

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -39,6 +39,7 @@ class TestComponentLogbook(unittest.TestCase):
         """Test if service call create log book entry."""
         calls = []
 
+        @ha.callback
         def event_listener(event):
             calls.append(event)
 
@@ -69,6 +70,7 @@ class TestComponentLogbook(unittest.TestCase):
         """Test if service call create log book entry without message."""
         calls = []
 
+        @ha.callback
         def event_listener(event):
             calls.append(event)
 

--- a/tests/components/test_mqtt_eventstream.py
+++ b/tests/components/test_mqtt_eventstream.py
@@ -6,7 +6,7 @@ from unittest.mock import ANY, patch
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.mqtt_eventstream as eventstream
 from homeassistant.const import EVENT_STATE_CHANGED
-from homeassistant.core import State
+from homeassistant.core import State, callback
 from homeassistant.remote import JSONEncoder
 import homeassistant.util.dt as dt_util
 
@@ -130,7 +130,12 @@ class TestMqttEventStream(unittest.TestCase):
         self.hass.block_till_done()
 
         calls = []
-        self.hass.bus.listen_once('test_event', lambda _: calls.append(1))
+
+        @callback
+        def listener(_):
+            calls.append(1)
+
+        self.hass.bus.listen_once('test_event', listener)
         self.hass.block_till_done()
 
         payload = json.dumps(

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -4,6 +4,7 @@ import unittest
 
 import pytest
 
+from homeassistant.core import callback
 from homeassistant.bootstrap import setup_component
 from homeassistant.components import rfxtrx as rfxtrx
 from tests.common import get_test_home_assistant
@@ -89,6 +90,7 @@ class TestRFXTRX(unittest.TestCase):
 
         calls = []
 
+        @callback
         def record_event(event):
             """Add recorded event to set."""
             calls.append(event)
@@ -133,6 +135,7 @@ class TestRFXTRX(unittest.TestCase):
 
         calls = []
 
+        @callback
         def record_event(event):
             """Add recorded event to set."""
             calls.append(event)

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access
 import unittest
 
+from homeassistant.core import callback
 from homeassistant.bootstrap import setup_component
 from homeassistant.components import script
 
@@ -54,6 +55,7 @@ class TestScriptComponent(unittest.TestCase):
         event = 'test_event'
         events = []
 
+        @callback
         def record_event(event):
             """Add recorded event to set."""
             events.append(event)
@@ -93,6 +95,7 @@ class TestScriptComponent(unittest.TestCase):
         event = 'test_event'
         events = []
 
+        @callback
         def record_event(event):
             """Add recorded event to set."""
             events.append(event)

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest import mock
 import unittest
 
+from homeassistant.core import callback
 # Otherwise can't test just this file (import order issue)
 import homeassistant.components  # noqa
 import homeassistant.util.dt as dt_util
@@ -33,6 +34,7 @@ class TestScriptHelper(unittest.TestCase):
         event = 'test_event'
         calls = []
 
+        @callback
         def record_event(event):
             """Add recorded event to set."""
             calls.append(event)
@@ -58,6 +60,7 @@ class TestScriptHelper(unittest.TestCase):
         """Test the calling of a service."""
         calls = []
 
+        @callback
         def record_call(service):
             """Add recorded event to set."""
             calls.append(service)
@@ -80,6 +83,7 @@ class TestScriptHelper(unittest.TestCase):
         """Test the calling of a service."""
         calls = []
 
+        @callback
         def record_call(service):
             """Add recorded event to set."""
             calls.append(service)
@@ -114,6 +118,7 @@ class TestScriptHelper(unittest.TestCase):
         event = 'test_event'
         events = []
 
+        @callback
         def record_event(event):
             """Add recorded event to set."""
             events.append(event)
@@ -146,6 +151,7 @@ class TestScriptHelper(unittest.TestCase):
         event = 'test_evnt'
         events = []
 
+        @callback
         def record_event(event):
             """Add recorded event to set."""
             events.append(event)
@@ -178,6 +184,7 @@ class TestScriptHelper(unittest.TestCase):
         event = 'test_event'
         events = []
 
+        @callback
         def record_event(event):
             """Add recorded event to set."""
             events.append(event)
@@ -211,6 +218,7 @@ class TestScriptHelper(unittest.TestCase):
         """Test if we can pass variables to script."""
         calls = []
 
+        @callback
         def record_call(service):
             """Add recorded event to set."""
             calls.append(service)
@@ -257,6 +265,7 @@ class TestScriptHelper(unittest.TestCase):
         event = 'test_event'
         events = []
 
+        @callback
         def record_event(event):
             """Add recorded event to set."""
             events.append(event)
@@ -290,6 +299,7 @@ class TestScriptHelper(unittest.TestCase):
         event = 'test_event'
         events = []
 
+        @callback
         def record_event(event):
             """Add recorded event to set."""
             events.append(event)
@@ -318,6 +328,7 @@ class TestScriptHelper(unittest.TestCase):
         event = 'test_event'
         events = []
 
+        @callback
         def record_event(event):
             """Add recorded event to set."""
             events.append(event)


### PR DESCRIPTION
Migrates a bunch of tests to use callbacks to avoid having to use threads. Speeds up tests and should improve reliability.