### PR TITLE
Add link to issue in warning slow entity update

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -244,7 +244,8 @@ class Entity(object):
 
         if end - start > 0.2:
             _LOGGER.warning('Updating state for %s took %.3f seconds. '
-                            'Please report to the developers.', self.entity_id,
+                            'Please report platform to the developers at '
+                            'https://goo.gl/Nvioub', self.entity_id,
                             end - start)
 
         # Overwrite properties that have been set in the config file.


### PR DESCRIPTION
This adds a url to the warning that is printed when the update of an entity is too slow.

Url points at https://github.com/home-assistant/home-assistant/issues/4210