### PR TITLE
Make the wind details more robust (weather.openweathermap)

### DIFF
--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -98,7 +98,7 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def temperature(self):
         """Return the temperature."""
-        return self.data.get_temperature('celsius')['temp']
+        return self.data.get_temperature('celsius').get('temp')
 
     @property
     def temperature_unit(self):
@@ -108,7 +108,7 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def pressure(self):
         """Return the pressure."""
-        return self.data.get_pressure()['press']
+        return self.data.get_pressure().get('press')
 
     @property
     def humidity(self):
@@ -118,14 +118,12 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def wind_speed(self):
         """Return the wind speed."""
-        wind_speed = self.data.get_wind().get('speed')
-        return wind_speed if wind_speed is not None else STATE_UNKNOWN
+        return self.data.get_wind().get('speed')
 
     @property
     def wind_bearing(self):
         """Return the wind bearing."""
-        wind_bearing = self.data.get_wind().get('deg')
-        return wind_bearing if wind_bearing is not None else STATE_UNKNOWN
+        return self.data.get_wind().get('deg')
 
     @property
     def attribution(self):

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -118,12 +118,14 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def wind_speed(self):
         """Return the wind speed."""
-        return self.data.get_wind()['speed']
+        wind_speed = self.data.get_wind().get('speed')
+        return wind_speed if wind_speed is not None else STATE_UNKNOWN
 
     @property
     def wind_bearing(self):
         """Return the wind bearing."""
-        return self.data.get_wind()['deg']
+        wind_bearing = self.data.get_wind().get('deg')
+        return wind_bearing if wind_bearing is not None else STATE_UNKNOWN
 
     @property
     def attribution(self):


### PR DESCRIPTION
**Description:**
OpenWeatherMap is not providing details for the wind speed and wind bearing if there is no wind.

Thanks @Bart274 reporting this.

**Example entry for `configuration.yaml` (if applicable):**
```yaml
weather:
  - platform: openweathermap
    api_key: !secret owm_api
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

