### PR TITLE
Stop Octoprint from logging errors during startup

### DIFF
--- a/homeassistant/components/octoprint.py
+++ b/homeassistant/components/octoprint.py
@@ -44,11 +44,8 @@ def setup(hass, config):
         _LOGGER.error("Error setting up OctoPrint API: %r", conn_err)
         return False
 
-    for component, discovery_service in (
-            ('sensor', DISCOVER_SENSORS),
-            ('binary_sensor', DISCOVER_BINARY_SENSORS)):
-        discovery.discover(hass, discovery_service, component=component,
-                           hass_config=config)
+    discovery.load_platform(hass, 'sensor', DOMAIN, {}, config)
+    discovery.load_platform(hass, 'binary_sensor', DOMAIN, {}, config)
 
     return True
 

--- a/homeassistant/components/octoprint.py
+++ b/homeassistant/components/octoprint.py
@@ -11,13 +11,10 @@ import requests
 import voluptuous as vol
 
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONTENT_TYPE_JSON
-from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-DISCOVER_BINARY_SENSORS = 'octoprint.binary_sensor'
-DISCOVER_SENSORS = 'octoprint.sensors'
 DOMAIN = 'octoprint'
 
 OCTOPRINT = None
@@ -43,9 +40,6 @@ def setup(hass, config):
     except requests.exceptions.RequestException as conn_err:
         _LOGGER.error("Error setting up OctoPrint API: %r", conn_err)
         return False
-
-    discovery.load_platform(hass, 'sensor', DOMAIN, {}, config)
-    discovery.load_platform(hass, 'binary_sensor', DOMAIN, {}, config)
 
     return True
 


### PR DESCRIPTION
**Description:**
Switched to discovery.load_platform however the following Traceback is now occurring. Even though this Traceback is thrown all of the sensors still get setup. @balloob 

```bash
Traceback (most recent call last):
  File "/home/pi/.virtualenvs/hass_dev/lib/python3.4/site-packages/homeassistant-0.32.0.dev0-py3.4.egg/homeassistant/helpers/entity_component.py", line 148, in _async_setup_platform
    entity_platform.add_entities, discovery_info
  File "/usr/lib/python3.4/asyncio/futures.py", line 388, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.4/asyncio/tasks.py", line 286, in _wakeup
    value = future.result()
  File "/usr/lib/python3.4/asyncio/futures.py", line 277, in result
    raise self._exception
  File "/usr/lib/python3.4/concurrent/futures/thread.py", line 54, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/pi/.virtualenvs/hass_dev/lib/python3.4/site-packages/homeassistant-0.32.0.dev0-py3.4.egg/homeassistant/components/sensor/octoprint.py", line 49, in setup_platform
    for octo_type in monitored_conditions:
TypeError: 'NoneType' object is not iterable
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

