### PR TITLE
Disable insteon hub

### DIFF
--- a/homeassistant/components/insteon_hub.py
+++ b/homeassistant/components/insteon_hub.py
@@ -33,6 +33,10 @@ def setup(hass, config):
 
     This will automatically import associated lights.
     """
+    _LOGGER.warning('Component disabled at request from Insteon. '
+                    'For more information: https://goo.gl/zLJaic')
+    return False
+    # pylint: disable=unreachable
     import insteon
 
     username = config[DOMAIN][CONF_USERNAME]

--- a/homeassistant/components/light/insteon_hub.py
+++ b/homeassistant/components/light/insteon_hub.py
@@ -8,6 +8,8 @@ from homeassistant.components.insteon_hub import INSTEON
 from homeassistant.components.light import (ATTR_BRIGHTNESS,
                                             SUPPORT_BRIGHTNESS, Light)
 
+DEPENDENCIES = ['insteon_hub']
+
 SUPPORT_INSTEON_HUB = SUPPORT_BRIGHTNESS
 
 


### PR DESCRIPTION
This disables the Insteon Hub component. It can be re-enabled again once https://github.com/home-assistant/home-assistant/issues/3811 has been resolved.

😞 