### PR TITLE
Remove chunked encoding

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -101,7 +101,6 @@ class Camera(Entity):
 
         response.content_type = ('multipart/x-mixed-replace; '
                                  'boundary=--jpegboundary')
-        response.enable_chunked_encoding()
         yield from response.prepare(request)
 
         def write(img_bytes):

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -75,7 +75,6 @@ class FFmpegCamera(Camera):
 
         response = web.StreamResponse()
         response.content_type = 'multipart/x-mixed-replace;boundary=ffserver'
-        response.enable_chunked_encoding()
 
         yield from response.prepare(request)
 

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -112,7 +112,6 @@ class MjpegCamera(Camera):
 
         response = web.StreamResponse()
         response.content_type = stream.headers.get(CONTENT_TYPE_HEADER)
-        response.enable_chunked_encoding()
 
         yield from response.prepare(request)
 

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -271,7 +271,6 @@ class SynologyCamera(Camera):
 
         response = web.StreamResponse()
         response.content_type = stream.headers.get(CONTENT_TYPE_HEADER)
-        response.enable_chunked_encoding()
 
         yield from response.prepare(request)
 


### PR DESCRIPTION
**Description:**
We should not force enabling chunked encoding as requests might come in using HTTP 1.0 which does not support chunked encoding.

We should verify if aiohttp.web automatically turns it on if enabled. If not, we should fix it at the server level, not per platform.

**Related issue (if applicable):** fixes #4229
