### PR TITLE
0.32.1

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -101,7 +101,6 @@ class Camera(Entity):
 
         response.content_type = ('multipart/x-mixed-replace; '
                                  'boundary=--jpegboundary')
-        response.enable_chunked_encoding()
         yield from response.prepare(request)
 
         def write(img_bytes):

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -75,7 +75,6 @@ class FFmpegCamera(Camera):
 
         response = web.StreamResponse()
         response.content_type = 'multipart/x-mixed-replace;boundary=ffserver'
-        response.enable_chunked_encoding()
 
         yield from response.prepare(request)
 

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -112,7 +112,6 @@ class MjpegCamera(Camera):
 
         response = web.StreamResponse()
         response.content_type = stream.headers.get(CONTENT_TYPE_HEADER)
-        response.enable_chunked_encoding()
 
         yield from response.prepare(request)
 

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -271,7 +271,6 @@ class SynologyCamera(Camera):
 
         response = web.StreamResponse()
         response.content_type = stream.headers.get(CONTENT_TYPE_HEADER)
-        response.enable_chunked_encoding()
 
         yield from response.prepare(request)
 

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -69,6 +69,8 @@ class RadioThermostat(ClimateDevice):
         self._current_temperature = None
         self._current_operation = STATE_IDLE
         self._name = None
+        self._fmode = None
+        self._tmode = None
         self.hold_temp = hold_temp
         self.update()
         self._operation_list = [STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_OFF]
@@ -87,8 +89,8 @@ class RadioThermostat(ClimateDevice):
     def device_state_attributes(self):
         """Return the device specific state attributes."""
         return {
-            ATTR_FAN: self.device.fmode['human'],
-            ATTR_MODE: self.device.tmode['human']
+            ATTR_FAN: self._fmode,
+            ATTR_MODE: self._tmode,
         }
 
     @property
@@ -115,10 +117,13 @@ class RadioThermostat(ClimateDevice):
         """Update the data from the thermostat."""
         self._current_temperature = self.device.temp['raw']
         self._name = self.device.name['raw']
-        if self.device.tmode['human'] == 'Cool':
+        self._fmode = self.device.fmode['human']
+        self._tmode = self.device.tmode['human']
+
+        if self._tmode == 'Cool':
             self._target_temperature = self.device.t_cool['raw']
             self._current_operation = STATE_COOL
-        elif self.device.tmode['human'] == 'Heat':
+        elif self._tmode == 'Heat':
             self._target_temperature = self.device.t_heat['raw']
             self._current_operation = STATE_HEAT
         else:

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 32
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 4, 2)

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -92,6 +92,13 @@ class SoCoMock():
         return "RINCON_XXXXXXXXXXXXXXXXX"
 
 
+def fake_add_device(devices, update_befor_add=False):
+    """Fake add device / update."""
+    if update_befor_add:
+        for speaker in devices:
+            speaker.update()
+
+
 class TestSonosMediaPlayer(unittest.TestCase):
     """Test the media_player module."""
 
@@ -117,7 +124,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch('socket.create_connection', side_effect=socket.error())
     def test_ensure_setup_discovery(self, *args):
         """Test a single device using the autodiscovery provided by HASS."""
-        sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
+        sonos.setup_platform(self.hass, {}, fake_add_device, '192.0.2.1')
 
         # Ensure registration took place (#2558)
         self.assertEqual(len(sonos.DEVICES), 1)
@@ -129,7 +136,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
         """Test a single address config'd by the HASS config file."""
         sonos.setup_platform(self.hass,
                              {'hosts': '192.0.2.1'},
-                             mock.MagicMock())
+                             fake_add_device)
 
         # Ensure registration took place (#2558)
         self.assertEqual(len(sonos.DEVICES), 1)
@@ -140,7 +147,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch('socket.create_connection', side_effect=socket.error())
     def test_ensure_setup_sonos_discovery(self, *args):
         """Test a single device using the autodiscovery provided by Sonos."""
-        sonos.setup_platform(self.hass, {}, mock.MagicMock())
+        sonos.setup_platform(self.hass, {}, fake_add_device)
         self.assertEqual(len(sonos.DEVICES), 1)
         self.assertEqual(sonos.DEVICES[0].name, 'Kitchen')
 
@@ -149,7 +156,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch.object(SoCoMock, 'partymode')
     def test_sonos_group_players(self, partymodeMock, *args):
         """Ensuring soco methods called for sonos_group_players service."""
-        sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
+        sonos.setup_platform(self.hass, {}, fake_add_device, '192.0.2.1')
         device = sonos.DEVICES[-1]
         partymodeMock.return_value = True
         device.group_players()
@@ -161,7 +168,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch.object(SoCoMock, 'unjoin')
     def test_sonos_unjoin(self, unjoinMock, *args):
         """Ensuring soco methods called for sonos_unjoin service."""
-        sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
+        sonos.setup_platform(self.hass, {}, fake_add_device, '192.0.2.1')
         device = sonos.DEVICES[-1]
         unjoinMock.return_value = True
         device.unjoin()
@@ -173,7 +180,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch.object(SoCoMock, 'set_sleep_timer')
     def test_sonos_set_sleep_timer(self, set_sleep_timerMock, *args):
         """Ensuring soco methods called for sonos_set_sleep_timer service."""
-        sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
+        sonos.setup_platform(self.hass, {}, fake_add_device, '192.0.2.1')
         device = sonos.DEVICES[-1]
         device.set_sleep_timer(30)
         set_sleep_timerMock.assert_called_once_with(30)
@@ -193,7 +200,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch.object(soco.snapshot.Snapshot, 'snapshot')
     def test_sonos_snapshot(self, snapshotMock, *args):
         """Ensuring soco methods called for sonos_snapshot service."""
-        sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
+        sonos.setup_platform(self.hass, {}, fake_add_device, '192.0.2.1')
         device = sonos.DEVICES[-1]
         snapshotMock.return_value = True
         device.snapshot()
@@ -205,7 +212,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch.object(soco.snapshot.Snapshot, 'restore')
     def test_sonos_restore(self, restoreMock, *args):
         """Ensuring soco methods called for sonos_restor service."""
-        sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
+        sonos.setup_platform(self.hass, {}, fake_add_device, '192.0.2.1')
         device = sonos.DEVICES[-1]
         restoreMock.return_value = True
         device.restore()


### PR DESCRIPTION
We've added a warning to 0.32 to catch platforms accidentally slowing down Home Assistant. Our aim is to fix these quickly when reported, so here is 0.32.1 with all reported platforms fixed.

 - Fix Sonos doing I/O inside the event loop (@pvizeli)
 - Fix Radiotherm doing I/O inside the event loop (@balloob)
 - Fix camera MJPEG streams when using HTTP 1.0 (@balloob)