### PR TITLE
New config parameter for min_max sensor to specify number of digits for rounding mean value

### DIFF
--- a/homeassistant/components/sensor/min_max.py
+++ b/homeassistant/components/sensor/min_max.py
@@ -62,7 +62,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     round_digits = config.get(CONF_ROUND_DIGITS)
 
     yield from async_add_devices(
-        [MinMaxSensor(hass, entity_ids, name, sensor_type, round_digits)], True)
+        [MinMaxSensor(hass, entity_ids, name, sensor_type, round_digits)],
+        True)
     return True
 
 
@@ -152,6 +153,7 @@ class MinMaxSensor(Entity):
         if len(sensor_values) == self.count_sensors:
             self.min_value = min(sensor_values)
             self.max_value = max(sensor_values)
-            self.mean = round(sum(sensor_values) / self.count_sensors, self._round_digits)
+            self.mean = round(sum(sensor_values) / self.count_sensors,
+                              self._round_digits)
         else:
             self.min_value = self.max_value = self.mean = STATE_UNKNOWN

--- a/homeassistant/components/sensor/min_max.py
+++ b/homeassistant/components/sensor/min_max.py
@@ -32,6 +32,7 @@ ATTR_TO_PROPERTY = [
 ]
 
 CONF_ENTITY_IDS = 'entity_ids'
+CONF_ROUND_DIGITS = 'round_digits'
 
 DEFAULT_NAME = 'Min/Max/Avg Sensor'
 
@@ -48,6 +49,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.string, vol.In(SENSOR_TYPES.values())),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Required(CONF_ENTITY_IDS): cv.entity_ids,
+    vol.Optional(CONF_ROUND_DIGITS, default=2): vol.Coerce(int),
 })
 
 
@@ -57,20 +59,22 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     entity_ids = config.get(CONF_ENTITY_IDS)
     name = config.get(CONF_NAME)
     sensor_type = config.get(CONF_TYPE)
+    round_digits = config.get(CONF_ROUND_DIGITS)
 
     yield from async_add_devices(
-        [MinMaxSensor(hass, entity_ids, name, sensor_type)], True)
+        [MinMaxSensor(hass, entity_ids, name, sensor_type, round_digits)], True)
     return True
 
 
 class MinMaxSensor(Entity):
     """Representation of a min/max sensor."""
 
-    def __init__(self, hass, entity_ids, name, sensor_type):
+    def __init__(self, hass, entity_ids, name, sensor_type, round_digits):
         """Initialize the min/max sensor."""
         self._hass = hass
         self._entity_ids = entity_ids
         self._sensor_type = sensor_type
+        self._round_digits = round_digits
         self._name = '{} {}'.format(
             name, next(v for k, v in SENSOR_TYPES.items()
                        if self._sensor_type == v))
@@ -148,6 +152,6 @@ class MinMaxSensor(Entity):
         if len(sensor_values) == self.count_sensors:
             self.min_value = min(sensor_values)
             self.max_value = max(sensor_values)
-            self.mean = round(sum(sensor_values) / self.count_sensors, 2)
+            self.mean = round(sum(sensor_values) / self.count_sensors, self._round_digits)
         else:
             self.min_value = self.max_value = self.mean = STATE_UNKNOWN


### PR DESCRIPTION
**Description:**
Added new configuration parameter to **min_max** sensor (`round_digits`) to let users specify the number of digits for rounding the mean value. Default remains 2.
Typical use-case for the `mean` type sensor is probably calculating the average value of temperature or humidity sensors around the house. A 1-digit precision is normally more than sufficient.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1404

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: min_max
    type: mean
    round_digits: 1
    entity_ids:
      - sensor.kitchen_temperature
      - sensor.living_room_temperature
      - sensor.office_temperature
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
