### PR TITLE
Upgrade fuzzywuzzy to 0.14.0

### DIFF
--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['fuzzywuzzy==0.12.0']
+REQUIREMENTS = ['fuzzywuzzy==0.14.0']
 
 ATTR_TEXT = 'text'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -113,7 +113,7 @@ fixerio==0.1.1
 freesms==0.1.0
 
 # homeassistant.components.conversation
-fuzzywuzzy==0.12.0
+fuzzywuzzy==0.14.0
 
 # homeassistant.components.device_tracker.bluetooth_le_tracker
 # gattlib==0.20150805


### PR DESCRIPTION
0.14.0 (2016-11-04)
-------------------

- Possible PEP-8 fix + make pep-8 warnings appear in test
- Test for stderr log instead of warning
- Convert warning.warn to logging.warning.
- Additional details for empty string warning from process.
- String formatting fix for python 2.6
- Enclose warnings.simplefilter() inside a with statement.

Tested with the following configuration:

``` yaml
conversation:
```