### PR TITLE
Add Bose Soundtouch component

### DIFF
--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -204,3 +204,35 @@ sonos_clear_sleep_timer:
     entity_id:
       description: Name(s) of entites that will have the timer cleared.
       example: 'media_player.living_room_sonos'
+
+soundtouch_play_everywhere:
+  description: Play on all Bose Soundtouch devices
+
+  fields:
+    entity_id:
+      description: Name of entites that will coordinate the grouping. Platform dependent. It is a shortcut for creating a multi-room zone with all devices
+      example: 'media_player.soundtouch_home'
+
+soundtouch_create_zone:
+  description: Create a multi-room zone
+
+  fields:
+    entity_id:
+      description: Name of entites that will coordinate the multi-room zone. Platform dependent.
+      example: 'media_player.soundtouch_home'
+
+soundtouch_add_zone_slave:
+  description: Add a slave to a multi-room zone
+
+  fields:
+    entity_id:
+      description: Name of entites that will be added to the multi-room zone. Platform dependent.
+      example: 'media_player.soundtouch_home'
+
+soundtouch_remove_zone_slave:
+  description: Remove a slave from the multi-room zone
+
+  fields:
+    entity_id:
+      description: Name of entites that will be remove from the multi-room zone. Platform dependent.
+      example: 'media_player.soundtouch_home'

--- a/homeassistant/components/media_player/soundtouch.py
+++ b/homeassistant/components/media_player/soundtouch.py
@@ -1,0 +1,593 @@
+"""Support for interface with a Bose Soundtouch."""
+import logging
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
+
+from os import path
+import requests
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.media_player import (
+    SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP,
+    SUPPORT_VOLUME_SET, SUPPORT_TURN_ON, MediaPlayerDevice, PLATFORM_SCHEMA)
+from homeassistant.config import load_yaml_config_file
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, STATE_OFF, STATE_UNKNOWN, CONF_PORT, STATE_PAUSED,
+    STATE_PLAYING, STATE_UNAVAILABLE)
+
+REQUIREMENTS = []
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'media_player'
+SERVICE_PLAY_EVERYWHERE = 'soundtouch_play_everywhere'
+SERVICE_CREATE_ZONE = 'soundtouch_create_zone'
+SERVICE_ADD_ZONE_SLAVE = 'soundtouch_add_zone_slave'
+SERVICE_REMOVE_ZONE_SLAVE = 'soundtouch_remove_zone_slave'
+
+SOUNDTOUCH_PLAY_EVERYWHERE = vol.Schema({
+    'master': cv.entity_id,
+})
+
+SOUNDTOUCH_CREATE_ZONE_SCHEMA = vol.Schema({
+    'master': cv.entity_id,
+    'slaves': cv.entity_ids
+})
+
+SOUNDTOUCH_ADD_ZONE_SCHEMA = vol.Schema({
+    'master': cv.entity_id,
+    'slaves': cv.entity_ids
+})
+
+SOUNDTOUCH_REMOVE_ZONE_SCHEMA = vol.Schema({
+    'master': cv.entity_id,
+    'slaves': cv.entity_ids
+})
+
+DEFAULT_NAME = 'Bose Soundtouch'
+DEFAULT_PORT = 8090
+
+DEVICES = []
+
+SUPPORT_SOUNDTOUCH = SUPPORT_PAUSE | SUPPORT_VOLUME_STEP | \
+                     SUPPORT_VOLUME_MUTE | SUPPORT_PREVIOUS_TRACK | \
+                     SUPPORT_NEXT_TRACK | SUPPORT_TURN_OFF | \
+                     SUPPORT_VOLUME_SET | SUPPORT_TURN_ON
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Bose Soundtouch platform."""
+    name = config.get(CONF_NAME)
+
+    remote_config = {
+        'name': 'HomeAssistant',
+        'description': config.get(CONF_NAME),
+        'id': 'ha.component.soundtouch',
+        'port': config.get(CONF_PORT),
+        'host': config.get(CONF_HOST)
+    }
+
+    soundtouch_device = SoundTouchDevice(name, remote_config)
+    DEVICES.append(soundtouch_device)
+    add_devices([soundtouch_device])
+
+    descriptions = load_yaml_config_file(
+        path.join(path.dirname(__file__), 'services.yaml'))
+
+    hass.services.register(DOMAIN, SERVICE_PLAY_EVERYWHERE,
+                           play_everywhere_service,
+                           descriptions.get(SERVICE_PLAY_EVERYWHERE),
+                           schema=SOUNDTOUCH_PLAY_EVERYWHERE)
+    hass.services.register(DOMAIN, SERVICE_CREATE_ZONE,
+                           create_zone_service,
+                           descriptions.get(SERVICE_CREATE_ZONE),
+                           schema=SOUNDTOUCH_CREATE_ZONE_SCHEMA)
+    hass.services.register(DOMAIN, SERVICE_REMOVE_ZONE_SLAVE,
+                           remove_zone_slave,
+                           descriptions.get(SERVICE_REMOVE_ZONE_SLAVE),
+                           schema=SOUNDTOUCH_REMOVE_ZONE_SCHEMA)
+    hass.services.register(DOMAIN, SERVICE_ADD_ZONE_SLAVE,
+                           add_zone_slave,
+                           descriptions.get(SERVICE_ADD_ZONE_SLAVE),
+                           schema=SOUNDTOUCH_ADD_ZONE_SCHEMA)
+
+
+def play_everywhere_service(service):
+    """
+    Create a zone (multi-room)  and play on all devices.
+
+    :param service: Home Assistant service with 'master' data set
+
+    :Example:
+
+    - service: media_player.soundtouch_play_everywhere
+      data:
+        master: media_player.soundtouch_living_room
+
+    """
+    master_device_id = service.data.get('master')
+    slaves = [d for d in DEVICES if d.entity_id != master_device_id]
+    masters = [device for device in DEVICES
+               if device.entity_id == master_device_id]
+    try:
+        request_body = _create_zone(masters, slaves)
+        _LOGGER.info("Playing everywhere with master device %s",
+                     masters[0].entity_id)
+        requests.post("http://" + masters[0].config["host"] + ":" + str(
+            masters[0].config["port"]) + "/setZone",
+                      request_body)
+    except SoundtouchException as soundtouch_exception:
+        _LOGGER.error(str(soundtouch_exception))
+
+
+def create_zone_service(service):
+    """
+    Create a zone (multi-room) on a master and play on specified slaves.
+
+    At least one master and one slave must be specified
+
+    :param service: Home Assistant service with 'master' and 'slaves' data set
+
+    :Example:
+
+    - service: media_player.soundtouch_create_zone
+      data:
+        master: media_player.soundtouch_living_room
+        slaves:
+          - media_player.soundtouch_room
+          - media_player.soundtouch_kitchen
+
+    """
+    master_device_id = service.data.get('master')
+    slaves_ids = service.data.get('slaves')
+    slaves = [device for device in DEVICES if device.entity_id in slaves_ids]
+    masters = [device for device in DEVICES
+               if device.entity_id == master_device_id]
+    try:
+        request_body = _create_zone(masters, slaves)
+        _LOGGER.info("Creating multi-room zone with master device %s",
+                     masters[0].entity_id)
+        requests.post("http://" + masters[0].config["host"] + ":" + str(
+            masters[0].config["port"]) + "/setZone",
+                      request_body)
+    except SoundtouchException as soundtouch_exception:
+        _LOGGER.error(str(soundtouch_exception))
+
+
+def add_zone_slave(service):
+    """
+    Add slave(s) to and existing zone (multi-room).
+
+    Zone must already exist and slaves array can not be empty.
+
+    :param service: Home Assistant service with 'master' and 'slaves' data set
+
+    :Example:
+
+    - service: media_player.soundtouch_add_zone_slave
+      data:
+        master: media_player.soundtouch_living_room
+        slaves:
+          - media_player.soundtouch_room
+
+    """
+    master_device_id = service.data.get('master')
+    slaves_ids = service.data.get('slaves')
+    slaves = [device for device in DEVICES if device.entity_id in slaves_ids]
+    masters = [device for device in DEVICES
+               if device.entity_id == master_device_id]
+    try:
+        request_body = _get_zone_request_body(masters, slaves)
+        _LOGGER.info("Adding slaves to multi-room zone with master device %s",
+                     masters[0].entity_id)
+        requests.post(
+            "http://" + masters[0].config["host"] + ":" + str(
+                masters[0].config["port"]) + "/addZoneSlave",
+            request_body)
+    except SoundtouchException as soundtouch_exception:
+        _LOGGER.error(str(soundtouch_exception))
+
+
+def remove_zone_slave(service):
+    """
+    Remove slave(s) from and existing zone (multi-room).
+
+    Zone must already exist and slaves array can not be empty.
+    Note: If removing last slave, the zone will be deleted and you'll have to
+    create a new one. You will not be able to add a new slave anymore
+
+    :param service: Home Assistant service with 'master' and 'slaves' data set
+
+    :Example:
+
+    - service: media_player.soundtouch_remove_zone_slave
+      data:
+        master: media_player.soundtouch_living_room
+        slaves:
+          - media_player.soundtouch_room
+
+    """
+    master_device_id = service.data.get('master')
+    slaves_ids = service.data.get('slaves')
+    slaves = [device for device in DEVICES if device.entity_id in slaves_ids]
+    masters = [device for device in DEVICES
+               if device.entity_id == master_device_id]
+    try:
+        request_body = _get_zone_request_body(masters, slaves)
+        _LOGGER.info("Removing slaves from multi-room zone with master " +
+                     "device %s", masters[0].entity_id)
+        requests.post(
+            "http://" + masters[0].config["host"] + ":" + str(
+                masters[0].config["port"]) + "/removeZoneSlave",
+            request_body)
+    except SoundtouchException as spundtouch_exception:
+        _LOGGER.error(str(spundtouch_exception))
+
+
+def _get_zone_request_body(masters, slaves):
+    if len(masters) < 1:
+        raise MasterNotFoundException()
+    if len(slaves) <= 0:
+        raise NoSlavesException()
+    master_device_info = _get_device_info(masters[0])
+    request_body = '<zone master="%s">' % (master_device_info["device_id"])
+    for slave in slaves:
+        slave_info = _get_device_info(slave)
+        request_body += '<member ipaddress="%s">%s</member>' % (
+            slave_info["device_ip"], slave_info["device_id"])
+    request_body += '</zone>'
+    return request_body
+
+
+def _create_zone(masters, slaves):
+    if len(masters) < 1:
+        raise MasterNotFoundException()
+    if len(slaves) <= 0:
+        raise NoSlavesException()
+    master_device_info = _get_device_info(masters[0])
+    request_body = '<zone master="%s" senderIPAddress="%s">' % (
+        master_device_info["device_id"], master_device_info["device_ip"])
+    for slave in slaves:
+        slave_info = _get_device_info(slave)
+        request_body += '<member ipaddress="%s">%s</member>' % (
+            slave_info["device_ip"], slave_info["device_id"])
+    request_body += '</zone>'
+    return request_body
+
+
+def _get_device_info(device):
+    response = requests.get(
+        "http://" + device.config["host"] + ":" + str(device.config["port"]) +
+        "/info")
+    dom = minidom.parseString(response.text)
+    device_id = dom.getElementsByTagName("info")[0].attributes[
+        "deviceID"].value
+    device_name = dom.getElementsByTagName("name")[0].firstChild.nodeValue
+    device_type = dom.getElementsByTagName("type")[0].firstChild.nodeValue
+    device_ip = dom.getElementsByTagName("ipAddress")[0].firstChild.nodeValue
+    return {
+        "device_id": device_id,
+        "device_name": device_name,
+        "device_type": device_type,
+        "device_ip": device_ip,
+        "device_port": device.config["port"]
+    }
+
+
+class SoundTouchDevice(MediaPlayerDevice):
+    """Representation of a SoundTouch Bose devicce."""
+
+    def __init__(self, name, config):
+        """Create Soundtouch Entity."""
+        self._name = name
+        self._muted = False
+        self._playing = True
+        self._state = STATE_UNKNOWN
+        self._remote = None
+        self._config = config
+        self._media_title = None
+        self._media_artist = None
+        self._media_album_name = None
+        self._media_image_url = None
+        self._media_duration = None
+        self._media_track = None
+
+    def _reset_properties(self):
+        self._media_title = None
+        self._media_artist = None
+        self._media_album_name = None
+        self._media_image_url = None
+        self._media_duration = None
+        self._media_track = None
+
+    @property
+    def config(self):
+        """Return specific soundtouch configuration."""
+        return self._config
+
+    def _set_image_url(self, source, doc):
+        art_status = None
+        if source in ["SPOTIFY", "INTERNET_RADIO", "STORED_MUSIC"]:
+            art_status = doc.getElementsByTagName("art")[0].attributes[
+                "artImageStatus"].value
+        if art_status == "IMAGE_PRESENT":
+            self._media_image_url = \
+                doc.getElementsByTagName("art")[0].firstChild.nodeValue
+        else:
+            self._media_image_url = None
+
+    def _set_media_album(self, source, doc):
+        if source in ['SPOTIFY', 'STORED_MUSIC']:
+            self._media_album_name =\
+                doc.getElementsByTagName("album")[0].firstChild.nodeValue
+        else:
+            self._media_album_name = None
+
+    def _set_media_artist(self, source, doc):
+        if source in ['SPOTIFY', 'STORED_MUSIC']:
+            self._media_artist =\
+                doc.getElementsByTagName("artist")[0].firstChild.nodeValue
+        else:
+            self._media_artist = None
+
+    def _set_media_track(self, source, doc):
+        if source in ['SPOTIFY', 'STORED_MUSIC']:
+            self._media_track = \
+                doc.getElementsByTagName("track")[0].firstChild.nodeValue
+        else:
+            self._media_track = None
+
+    def _set_media_title(self, source, doc):
+        if source in ['SPOTIFY', 'STORED_MUSIC']:
+            self._media_title = self.media_artist + " - " + self.media_track
+        elif source == 'INTERNET_RADIO':
+            self._media_title = doc.getElementsByTagName("stationName")[
+                0].firstChild.nodeValue
+
+    def _set_media_duration(self, source, doc):
+        if source in ['SPOTIFY', 'STORED_MUSIC']:
+            self._media_duration = \
+                int(doc.getElementsByTagName("time")[0].attributes[
+                    "total"].value)
+        else:
+            self._media_duration = None
+
+    def update(self):
+        """Retrieve the latest data."""
+        doc = self._get_status()
+        source = doc.getElementsByTagName("ContentItem")[0].attributes[
+            "source"].value
+        if source == 'STANDBY':
+            self._state = STATE_OFF
+            self._reset_properties()
+        elif source == 'INVALID_SOURCE':
+            self._state = STATE_UNAVAILABLE
+            self._reset_properties()
+        else:
+            status = doc.getElementsByTagName("playStatus")[
+                0].firstChild.nodeValue
+            if status == "PLAY_STATE":
+                self._state = STATE_PLAYING
+            elif status == "PAUSE_STATE":
+                self._state = STATE_PAUSED
+            else:
+                self._state = STATE_UNKNOWN
+
+            if self._state in [STATE_PLAYING, STATE_PAUSED]:
+                self._set_image_url(source, doc)
+                self._set_media_album(source, doc)
+                self._set_media_artist(source, doc)
+                self._set_media_track(source, doc)
+                self._set_media_title(source, doc)
+                self._set_media_duration(source, doc)
+
+    def _get_status(self):
+        response = requests.get(
+            'http://' + self._config['host'] + ":" + str(self._config['port'])
+            + '/now_playing')
+        doc = minidom.parseString(response.text)
+        return doc
+
+    def _send_key(self, key):
+        action = '/key'
+        press = '<key state="press" sender="Gabbo">%s</key>' % key
+        release = '<key state="release" sender="Gabbo">%s</key>' % key
+        requests.post('http://' + self._config['host'] + ":" +
+                      str(self._config['port']) + action, press)
+        requests.post('http://' + self._config['host'] + ":" +
+                      str(self._config['port']) + action, release)
+
+    def _get_volume(self):
+        action = '/volume'
+        response = requests.get(
+            'http://' + self._config['host'] + ":" + str(self._config['port'])
+            + action)
+        doc = minidom.parseString(response.text)
+        return int(doc.getElementsByTagName("actualvolume")[
+            0].firstChild.nodeValue)
+
+    def _set_volume(self, volume):
+        action = '/volume'
+        volume = '<volume>%s</volume>' % volume
+        requests.post('http://' + self._config['host'] + ":" +
+                      str(self._config['port']) + action, volume)
+
+    @property
+    def volume_level(self):
+        """Volume level of the media player (0..1)."""
+        return self._get_volume() / 100
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def is_volume_muted(self):
+        """Boolean if volume is currently muted."""
+        return self.volume_level == 0.0
+
+    @property
+    def supported_media_commands(self):
+        """Flag of media commands that are supported."""
+        return SUPPORT_SOUNDTOUCH
+
+    def turn_off(self):
+        """Turn off media player."""
+        state = self.state
+        if state in [STATE_PLAYING, STATE_PAUSED]:
+            _LOGGER.info("Turning off device " + self.entity_id)
+            self._send_key('POWER')
+        else:
+            _LOGGER.warning(
+                "Unable to turn off Soundtouch device " +
+                self.entity_id + " because it is already in standby")
+
+    def turn_on(self):
+        """Turn the media player on."""
+        state = self.state
+        if state in [STATE_OFF]:
+            _LOGGER.info("Turning on device " + self.entity_id)
+            self._send_key('POWER')
+        else:
+            _LOGGER.warning(
+                "Unable to turn on Soundtouch device " +
+                self.entity_id + " because it is already playing")
+
+    def volume_up(self):
+        """Volume up the media player."""
+        current_volume = self._get_volume()
+        self._set_volume(current_volume + 5)
+
+    def volume_down(self):
+        """Volume down media player."""
+        current_volume = self._get_volume()
+        self._set_volume(current_volume - 5)
+
+    def set_volume_level(self, volume):
+        """Set volume level, range 0..1."""
+        self._set_volume(int(volume * 100))
+
+    def mute_volume(self, mute):
+        """Send mute command."""
+        self._send_key('MUTE')
+
+    def media_play_pause(self):
+        """Simulate play pause media player."""
+        state = self.state
+        if state == STATE_PLAYING:
+            self.media_pause()
+        elif state == STATE_PAUSED:
+            self.media_play()
+
+    def media_play(self):
+        """Send play command."""
+        self._playing = True
+        self._send_key('PLAY')
+
+    def media_pause(self):
+        """Send media pause command to media player."""
+        self._playing = False
+        self._send_key('PAUSE')
+
+    def media_next_track(self):
+        """Send next track command."""
+        self._send_key('NEXT_TRACK')
+
+    def media_previous_track(self):
+        """Send the previous track command."""
+        self._send_key('PREV_TRACK')
+
+    @property
+    def media_image_url(self):
+        """Image url of current playing media."""
+        return self._media_image_url
+
+    @property
+    def media_title(self):
+        """Title of current playing media."""
+        return self._media_title
+
+    @property
+    def media_duration(self):
+        """Duration of current playing media in seconds."""
+        return self._media_duration
+
+    @property
+    def media_artist(self):
+        """Artist of current playing media."""
+        return self._media_artist
+
+    @property
+    def media_track(self):
+        """Artist of current playing media."""
+        return self._media_track
+
+    @property
+    def media_album_name(self):
+        """Album name of current playing media."""
+        return self._media_album_name
+
+    def play_media(self, media_type, media_id, **kwargs):
+        """Play a piece of media."""
+        _LOGGER.info("Starting media with media_id:" + str(media_id))
+        xpath = "./preset[@id='%s']" % str(media_id)
+        key = '/presets'
+        response = requests.get(
+            'http://' + self._config['host'] + ":" + str(self._config[
+                'port']) + key)
+        tree = ET.ElementTree(ET.fromstring(response.text))
+        preset = tree.find(xpath)
+        if preset is not None:
+            content = ET.tostring(preset[0]).decode('utf-8')
+            requests.post(
+                'http://' + self._config['host'] + ":" +
+                str(self._config['port']) + '/select',
+                content)
+        else:
+            _LOGGER.warning("Unable to find preset with id " + str(media_id))
+
+
+class SoundtouchException(Exception):
+    """Parent Soundtouch Exception."""
+
+    def __init__(self):
+        """Soundtouch Exception."""
+        super(SoundtouchException, self).__init__()
+
+
+class MasterNotFoundException(SoundtouchException):
+    """Exception while managing multi-room action without valid master."""
+
+    def __init__(self):
+        """MasterNotFoundException."""
+        super(MasterNotFoundException, self).__init__()
+
+    def __str__(self):
+        """Return str(self)."""
+        return "Unable to find Master"
+
+
+class NoSlavesException(SoundtouchException):
+    """Exception while managing multi-room actions without valid slaves."""
+
+    def __init__(self):
+        """NoSlavesException."""
+        super(NoSlavesException, self).__init__()
+
+    def __str__(self):
+        """Return str(self)."""
+        return "No slaves available"

--- a/tests/components/media_player/test_soundtouch.py
+++ b/tests/components/media_player/test_soundtouch.py
@@ -1,0 +1,790 @@
+"""Test the Soundtouch component."""
+import logging
+import unittest
+from unittest import mock
+
+from homeassistant.components.media_player import soundtouch
+from homeassistant.components.media_player.soundtouch import SoundTouchDevice
+from homeassistant.const import (
+    STATE_OFF, STATE_UNKNOWN, STATE_PAUSED, STATE_PLAYING,
+    STATE_UNAVAILABLE)
+from tests.common import get_test_home_assistant
+
+
+class MockService:
+    """Mock Soundtouch service."""
+
+    def __init__(self, master, slaves):
+        """Create a new service."""
+        self.data = {
+            "master": master,
+            "slaves": slaves
+        }
+
+
+class MockResponse:
+    """Mock Soundtouch XML response."""
+
+    def __init__(self, text):
+        """Create new XML response."""
+        self.text = text
+
+
+def _mocked_volume_level(*args, **kwargs):
+    if args[0] == 'http://192.168.0.1:8090/volume':
+        return MockResponse("""<?xml version="1.0" encoding="UTF-8" ?>
+<volume deviceID="MAC-1">
+    <targetvolume>12</targetvolume>
+    <actualvolume>12</actualvolume>
+    <muteenabled>false</muteenabled>
+</volume>
+        """)
+
+
+def _mock_send_volume_up(*args, **kwargs):
+    if args[0] != 'http://192.168.0.1:8090/volume' \
+            or args[1] != '<volume>17</volume>':
+        raise Exception('Bad volume level')
+
+
+def _mock_send_volume_down(*args, **kwargs):
+    if args[0] != 'http://192.168.0.1:8090/volume' \
+            or args[1] != '<volume>7</volume>':
+        raise Exception('Bad volume level')
+
+
+def _mock_send_mute(*args, **kwargs):
+    if args[0] != 'http://192.168.0.1:8090/key' or args[1] not in [
+            '<key state="press" sender="Gabbo">MUTE</key>',
+            '<key state="release" sender="Gabbo">MUTE</key>']:
+        raise Exception("unkown call")
+
+
+def _mocked_volume_muted(*args, **kwargs):
+    if args[0] == 'http://192.168.0.1:8090/volume':
+        return MockResponse("""<?xml version="1.0" encoding="UTF-8" ?>
+<volume deviceID="MAC-1">
+    <targetvolume>0</targetvolume>
+    <actualvolume>0</actualvolume>
+    <muteenabled>false</muteenabled>
+</volume>
+        """)
+
+
+def _mocked_state_off(*args, **kwargs):
+    if args[0] == 'http://192.168.0.1:8090/now_playing':
+        return MockResponse("""<?xml version="1.0" encoding="UTF-8" ?>
+<nowPlaying deviceID="MAC-2" source="STANDBY">
+    <ContentItem source="STANDBY" isPresetable="true"/>
+</nowPlaying>""")
+
+
+def _mocked_state_unavailable(*args, **kwargs):
+    if args[0] == 'http://192.168.0.1:8090/now_playing':
+        return MockResponse("""<?xml version="1.0" encoding="UTF-8" ?>
+<nowPlaying deviceID="MAC-2" source="INVALID_SOURCE">
+    <ContentItem source="INVALID_SOURCE" isPresetable="true"/>
+</nowPlaying>""")
+
+
+def _mocked_state_playing(*args, **kwargs):
+    if args[0] == 'http://192.168.0.1:8090/now_playing':
+        return MockResponse("""<?xml version="1.0" encoding="UTF-8" ?>
+<nowPlaying deviceID="MAC-1" source="SPOTIFY" sourceAccount="xxx">
+    <ContentItem source="SPOTIFY" type="uri" location="xxx"
+        sourceAccount="xxx" isPresetable="true">
+        <itemName>Afternoon Accoustic</itemName>
+    </ContentItem>
+    <track>Cherry Wine - Live</track>
+    <artist>Hozier</artist>
+    <album>Take Me to Church EP</album>
+    <art artImageStatus="IMAGE_PRESENT">
+        http://i.scdn.co/image/0f12b4c66fbd0XXX
+    </art>
+    <time total="239">196</time>
+    <skipEnabled/>
+    <favoriteEnabled/>
+    <playStatus>PLAY_STATE</playStatus>
+    <shuffleSetting>SHUFFLE_ON</shuffleSetting>
+    <repeatSetting>REPEAT_OFF</repeatSetting>
+    <skipPreviousEnabled/>
+    <streamType>TRACK_ONDEMAND</streamType>
+    <trackID>spotify:track:xxxx</trackID>
+</nowPlaying>""")
+
+
+def _mocked_state_playing_stored_music(*args, **kwargs):
+    # pylint: disable=invalid-name
+    if args[0] == 'http://192.168.0.1:8090/now_playing':
+        return MockResponse("""<?xml version="1.0" encoding="UTF-8" ?>
+<nowPlaying deviceID="MAC-1" source="STORED_MUSIC" sourceAccount="XXX">
+    <ContentItem source="STORED_MUSIC" location="27$2521" sourceAccount="XXX"
+        isPresetable="true">
+        <itemName>System of a Down</itemName>
+    </ContentItem>
+    <track>Chop Suey!</track>
+    <artist>System of a Down</artist>
+    <album>Toxicity</album>
+    <offset>5</offset>
+    <art artImageStatus="SHOW_DEFAULT_IMAGE"/>
+    <time total="210">7</time>
+    <skipEnabled/>
+    <playStatus>PLAY_STATE</playStatus>
+    <shuffleSetting>SHUFFLE_OFF</shuffleSetting>
+    <repeatSetting>REPEAT_OFF</repeatSetting>
+    <skipPreviousEnabled/>
+</nowPlaying>""")
+
+
+def _mocked_state_playing_radio(*args, **kwargs):
+    if args[0] == 'http://192.168.0.1:8090/now_playing':
+        return MockResponse("""<?xml version="1.0" encoding="UTF-8" ?>
+<nowPlaying deviceID="MAC-1" source="INTERNET_RADIO">
+    <ContentItem source="INTERNET_RADIO" location="1307" sourceAccount=""
+        isPresetable="true">
+        <itemName>franceinfo</itemName>
+    </ContentItem>
+    <track></track>
+    <artist></artist>
+    <album></album>
+    <stationName>franceinfo</stationName>
+    <art artImageStatus="IMAGE_PRESENT">
+        http://item.radio456.com/007452/logo/logo-1307.jpg
+    </art>
+    <playStatus>PLAY_STATE</playStatus>
+    <description>MP3 64 kbps Paris France, La radio franceinfo vous propose
+        à tout moment une information complète, des reportages, et des
+        émissions d’actualité.
+    </description>
+    <stationLocation>Paris France</stationLocation>
+</nowPlaying>""")
+
+
+def _mocked_state_playing_unknown(*args, **kwargs):
+    if args[0] == 'http://192.168.0.1:8090/now_playing':
+        return MockResponse("""<?xml version="1.0" encoding="UTF-8" ?>
+<nowPlaying deviceID="MAC-1" source="OTHER">
+    <ContentItem source="OTHER" location="1307" sourceAccount=""
+        isPresetable="true">
+        <itemName>Other</itemName>
+    </ContentItem>
+    <track></track>
+    <artist></artist>
+    <album></album>
+    <stationName>franceinfo</stationName>
+    <art artImageStatus="IMAGE_PRESENT">
+        http://item.radio456.com/007452/logo/logo-1307.jpg
+    </art>
+    <playStatus>PLAY_STATE</playStatus>
+    <description>Other</description>
+    <stationLocation>Other</stationLocation>
+</nowPlaying>""")
+
+
+def _mocked_state_pause(*args, **kwargs):
+    if args[0] == 'http://192.168.0.1:8090/now_playing':
+        return MockResponse("""<?xml version="1.0" encoding="UTF-8" ?>
+<nowPlaying deviceID="MAC-1" source="SPOTIFY" sourceAccount="xxx">
+    <ContentItem source="SPOTIFY" type="uri" location="xxx"
+        sourceAccount="xxx" isPresetable="true">
+        <itemName>Afternoon Accoustic</itemName>
+    </ContentItem>
+    <track>Cherry Wine - Live</track>
+    <artist>Hozier</artist>
+    <album>Take Me to Church EP</album>
+    <art artImageStatus="IMAGE_PRESENT">
+        http://i.scdn.co/image/0f12b4c66fbd023e6c74ce011c7d0f0ca1322c46
+    </art>
+    <time total="239">196</time>
+    <skipEnabled/>
+    <favoriteEnabled/>
+    <playStatus>PAUSE_STATE</playStatus>
+    <shuffleSetting>SHUFFLE_ON</shuffleSetting>
+    <repeatSetting>REPEAT_OFF</repeatSetting>
+    <skipPreviousEnabled/>
+    <streamType>TRACK_ONDEMAND</streamType>
+    <trackID>spotify:track:xxxx</trackID>
+</nowPlaying>""")
+
+
+def _mocked_state_unknown(*args, **kwargs):
+    if args[0] == 'http://192.168.0.1:8090/now_playing':
+        return MockResponse("""<?xml version="1.0" encoding="UTF-8" ?>
+<nowPlaying deviceID="MAC-1" source="SPOTIFY" sourceAccount="xxx">
+    <ContentItem source="SPOTIFY" type="uri" location="xxx"
+        sourceAccount="xxx" isPresetable="true">
+        <itemName>Afternoon Accoustic</itemName>
+    </ContentItem>
+    <track>Cherry Wine - Live</track>
+    <artist>Hozier</artist>
+    <album>Take Me to Church EP</album>
+    <art artImageStatus="IMAGE_PRESENT">
+        http://i.scdn.co/image/0f12b4c66fbd023e6c74ce011c7d0f0ca1322c46
+    </art>
+    <time total="239">196</time>
+    <skipEnabled/>
+    <favoriteEnabled/>
+    <playStatus>OTHER</playStatus>
+    <shuffleSetting>SHUFFLE_ON</shuffleSetting>
+    <repeatSetting>REPEAT_OFF</repeatSetting>
+    <skipPreviousEnabled/>
+    <streamType>TRACK_ONDEMAND</streamType>
+    <trackID>spotify:track:xxxx</trackID>
+</nowPlaying>""")
+
+
+def _mock_send_key_power(*args, **kwargs):
+    if args[0] != 'http://192.168.0.1:8090/key' or args[1] not in [
+            '<key state="press" sender="Gabbo">POWER</key>',
+            '<key state="release" sender="Gabbo">POWER</key>']:
+        raise Exception("unkown call")
+
+
+def _mock_send_play(*args, **kwargs):
+    if args[0] != 'http://192.168.0.1:8090/key' or args[1] not in [
+            '<key state="press" sender="Gabbo">PLAY</key>',
+            '<key state="release" sender="Gabbo">PLAY</key>']:
+        raise Exception("unkown call")
+
+
+def _mock_send_pause(*args, **kwargs):
+    if args[0] != 'http://192.168.0.1:8090/key' or args[1] not in [
+            '<key state="press" sender="Gabbo">PAUSE</key>',
+            '<key state="release" sender="Gabbo">PAUSE</key>']:
+        raise Exception("unkown call")
+
+
+def _mock_send_next_track(*args, **kwargs):
+    if args[0] != 'http://192.168.0.1:8090/key' or args[1] not in [
+            '<key state="press" sender="Gabbo">NEXT_TRACK</key>',
+            '<key state="release" sender="Gabbo">NEXT_TRACK</key>']:
+        raise Exception("unkown call")
+
+
+def _mock_send_previous_track(*args, **kwargs):
+    if args[0] != 'http://192.168.0.1:8090/key' or args[1] not in [
+            '<key state="press" sender="Gabbo">PREV_TRACK</key>',
+            '<key state="release" sender="Gabbo">PREV_TRACK</key>']:
+        raise Exception("unkown call")
+
+
+def _mock_get_presets(*args, **kwargs):
+    if args[0] == 'http://192.168.0.1:8090/presets':
+        return MockResponse("""<?xml version="1.0" encoding="UTF-8" ?>
+<presets>
+    <preset id="1" createdOn="1476019956" updatedOn="1476019956">
+        <ContentItem source="SPOTIFY" type="uri" location="YYYY"
+            sourceAccount="YYYY" isPresetable="true">
+            <itemName>Zedd</itemName>
+        </ContentItem>
+    </preset>
+</presets>
+        """)
+
+
+def _mock_get_state_info(*args, **kwargs):
+    if args[0] == 'http://192.168.88.1:8090/info':
+        return MockResponse("""<?xml version="1.0" encoding="UTF-8" ?>
+<info deviceID="00112233445566">
+    <name>Home</name>
+    <type>SoundTouch 20</type>
+    <margeAccountUUID>XXXX</margeAccountUUID>
+    <components>
+        <component>
+            <componentCategory>SCM</componentCategory>
+            <softwareVersion>
+                13.0.9.29919.1889959 epdbuild.trunk.cepeswbldXXX
+            </softwareVersion>
+            <serialNumber>XXXXX</serialNumber>
+        </component>
+        <component>
+            <componentCategory>PackagedProduct</componentCategory>
+            <serialNumber>XXXXX</serialNumber>
+        </component>
+    </components>
+    <margeURL>https://streaming.bose.com</margeURL>
+    <networkInfo type="SCM">
+        <macAddress>00112233445566</macAddress>
+        <ipAddress>192.168.88.1</ipAddress>
+    </networkInfo>
+    <networkInfo type="SMSC">
+        <macAddress>00112233445566</macAddress>
+        <ipAddress>192.168.88.1</ipAddress>
+    </networkInfo>
+    <moduleType>sm2</moduleType>
+    <variant>spotty</variant>
+    <variantMode>normal</variantMode>
+    <countryCode>GB</countryCode>
+    <regionCode>GB</regionCode>
+</info>""")
+    if args[0] == "http://192.168.0.1:8090/info":
+        return MockResponse("""<?xml version="1.0" encoding="UTF-8" ?>
+<info deviceID="778899AABBCC">
+    <name>Room</name>
+    <type>SoundTouch 10</type>
+    <margeAccountUUID>XXXX</margeAccountUUID>
+    <components>
+        <component>
+            <componentCategory>SCM</componentCategory>
+            <softwareVersion>
+                13.0.9.29919.1889959 epdbuild.trunk.cepeswbldXXX
+            </softwareVersion>
+            <serialNumber>XXXXX</serialNumber>
+        </component>
+        <component>
+            <componentCategory>PackagedProduct</componentCategory>
+            <serialNumber>XXXX</serialNumber>
+        </component>
+    </components>
+    <margeURL>https://streaming.bose.com</margeURL>
+    <networkInfo type="SCM">
+        <macAddress>778899AABBCC</macAddress>
+        <ipAddress>192.168.0.1</ipAddress>
+    </networkInfo>
+    <networkInfo type="SMSC">
+        <macAddress>778899AABBCC</macAddress>
+        <ipAddress>192.168.0.1</ipAddress>
+    </networkInfo>
+    <moduleType>sm2</moduleType>
+    <variant>rhino</variant>
+    <variantMode>normal</variantMode>
+    <countryCode>GB</countryCode>
+    <regionCode>GB</regionCode>
+</info>""")
+
+
+def _mock_create_zone(*args, **kwargs):
+    if (args[0] != "http://192.168.88.1:8090/setZone" or
+            args[1] != '<zone master="00112233445566" '
+                       'senderIPAddress="192.168.88.1">'
+                       '<member ipaddress="192.168.0.1">'
+                       '778899AABBCC</member></zone>'):
+        raise Exception("Bad argument")
+
+
+def _mock_add_zone_slave(*args, **kwargs):
+    if (args[0] != "http://192.168.88.1:8090/addZoneSlave" or
+            args[1] != '<zone master="00112233445566">'
+                       '<member ipaddress="192.168.0.1">'
+                       '778899AABBCC</member></zone>'):
+        raise Exception("Bad argument")
+
+
+def _mock_remove_zone_slave(*args, **kwargs):
+    if (args[0] != 'http://192.168.88.1:8090/removeZoneSlave' or
+            args[1] != '<zone master="00112233445566">'
+                       '<member ipaddress="192.168.0.1">'
+                       '778899AABBCC</member></zone>'):
+        raise Exception("Bad argument")
+
+
+def _mock_select(*args, **kwargs):
+    if args[0] != 'http://192.168.0.1:8090/select' \
+            or 'location="YYYY"' not in args[1]:
+        raise Exception('Wrong content')
+
+
+class TestSoundtouchMediaPlayer(unittest.TestCase):
+    """Bose Soundtouch test class."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        logging.disable(logging.CRITICAL)
+        self.hass = get_test_home_assistant()
+        soundtouch.setup_platform(self.hass,
+                                  {
+                                      'host': '192.168.0.1',
+                                      'port': 8090,
+                                      'name': 'soundtouch'
+                                  },
+                                  mock.MagicMock())
+        soundtouch.DEVICES[0].entity_id = 'entity_1'
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        logging.disable(logging.NOTSET)
+        soundtouch.DEVICES = []
+        self.hass.stop()
+
+    def test_ensure_setup_config(self):
+        """Test setup OK."""
+        self.assertEqual(len(soundtouch.DEVICES), 1)
+        self.assertEqual(soundtouch.DEVICES[0].name, 'soundtouch')
+        self.assertEqual(soundtouch.DEVICES[0].config['port'], 8090)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_off)
+    def test_update(self, mock_state_off):
+        """Test update device state."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(mock_state_off.call_count, 1)
+        self.assertEqual(soundtouch.DEVICES[0].state, STATE_OFF)
+
+    @mock.patch('requests.get', side_effect=_mocked_volume_level)
+    def test_get_volume_level(self, mock_get):
+        """Test volume level."""
+        self.assertEqual(soundtouch.DEVICES[0].volume_level, 0.12)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_off)
+    def test_get_state_off(self, mock_get):
+        """Test state device is off."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].state, STATE_OFF)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_unavailable)
+    def test_get_state_unavailable(self, mock_get):
+        """Test state device is unavailable."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].state, STATE_UNAVAILABLE)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing)
+    def test_get_state_playing(self, mock_get):
+        """Test state device is playing."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].state, STATE_PLAYING)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_pause)
+    def test_get_state_pause(self, mock_get):
+        """Test state device is paused."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].state, STATE_PAUSED)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_unknown)
+    def test_get_state_unkown(self, mock_get):
+        """Test state device is unknown."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].state, STATE_UNKNOWN)
+        self.assertEqual(mock_get.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_volume_muted)
+    def test_is_muted(self, mock_get):
+        """Test device volume is muted."""
+        self.assertEqual(soundtouch.DEVICES[0].is_volume_muted, True)
+
+    def test_media_commands(self):
+        """Test supported media commands."""
+        self.assertEqual(soundtouch.DEVICES[0].supported_media_commands, 1469)
+
+    @mock.patch('requests.post', side_effect=_mock_send_key_power)
+    @mock.patch('requests.get', side_effect=_mocked_state_playing)
+    def test_should_turn_off(self, mocked_get, mock_send_key):
+        """Test device is turned off."""
+        soundtouch.DEVICES[0].update()
+        soundtouch.DEVICES[0].entity_id = 'entity_id'
+        soundtouch.DEVICES[0].turn_off()
+        self.assertEqual(mock_send_key.call_count, 2)
+        self.assertEqual(mocked_get.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_off)
+    def test_should_not_turn_off_if_not_playing(self, mocked_get):
+        # pylint: disable=invalid-name
+        """Test don't send turn off command if device is not playing."""
+        soundtouch.DEVICES[0].update()
+        soundtouch.DEVICES[0].entity_id = 'entity_id'
+        soundtouch.DEVICES[0].turn_off()
+        self.assertEqual(mocked_get.call_count, 1)
+
+    @mock.patch('requests.post', side_effect=_mock_send_key_power)
+    @mock.patch('requests.get', side_effect=_mocked_state_off)
+    def test_should_turn_on(self, mocked_get, mock_send_key):
+        """Test device is turned on."""
+        soundtouch.DEVICES[0].update()
+        soundtouch.DEVICES[0].entity_id = 'entity_id'
+        soundtouch.DEVICES[0].turn_on()
+        self.assertEqual(mock_send_key.call_count, 2)
+        self.assertEqual(mocked_get.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing)
+    def test_should_not_turn_on_if_playing(self, mocked_get):
+        # pylint: disable=invalid-name
+        """Test don't send turn on command if device is already playing."""
+        soundtouch.DEVICES[0].update()
+        soundtouch.DEVICES[0].entity_id = 'entity_id'
+        soundtouch.DEVICES[0].turn_on()
+        self.assertEqual(mocked_get.call_count, 1)
+
+    @mock.patch('requests.post', side_effect=_mock_send_volume_up)
+    @mock.patch('requests.get', side_effect=_mocked_volume_level)
+    def test_volume_up(self, get_volume, send_volume):
+        """Test volume up."""
+        soundtouch.DEVICES[0].volume_up()
+        self.assertEqual(get_volume.call_count, 1)
+        self.assertEqual(send_volume.call_count, 1)
+
+    @mock.patch('requests.post', side_effect=_mock_send_volume_down)
+    @mock.patch('requests.get', side_effect=_mocked_volume_level)
+    def test_volume_down(self, get_volume, send_volume):
+        """Test volume down."""
+        soundtouch.DEVICES[0].volume_down()
+        self.assertEqual(get_volume.call_count, 1)
+        self.assertEqual(send_volume.call_count, 1)
+
+    @mock.patch('requests.post', side_effect=_mock_send_volume_up)
+    def test_set_volume_level(self, send_volume):
+        """Test set volume level."""
+        soundtouch.DEVICES[0].set_volume_level(0.17)
+        self.assertEqual(send_volume.call_count, 1)
+
+    @mock.patch('requests.post', side_effect=_mock_send_mute)
+    def test_mute(self, send_mute):
+        """Test mute volume."""
+        soundtouch.DEVICES[0].mute_volume(None)
+        self.assertEqual(send_mute.call_count, 2)
+
+    @mock.patch('requests.post', side_effect=_mock_send_play)
+    def test_play(self, send_play):
+        """Test play command."""
+        soundtouch.DEVICES[0].media_play()
+        self.assertEqual(send_play.call_count, 2)
+
+    @mock.patch('requests.post', side_effect=_mock_send_pause)
+    def test_pause(self, send_pause):
+        """Test pause command."""
+        soundtouch.DEVICES[0].media_pause()
+        self.assertEqual(send_pause.call_count, 2)
+
+    @mock.patch('requests.post', side_effect=_mock_send_play)
+    @mock.patch('requests.get', side_effect=_mocked_state_pause)
+    def test_play_pause_play(self, get_status, send_play):
+        """Test play/pause if device is in pause."""
+        soundtouch.DEVICES[0].update()
+        soundtouch.DEVICES[0].media_play_pause()
+        self.assertEqual(get_status.call_count, 1)
+        self.assertEqual(send_play.call_count, 2)
+
+    @mock.patch('requests.post', side_effect=_mock_send_pause)
+    @mock.patch('requests.get', side_effect=_mocked_state_playing)
+    def test_play_pause_pause(self, get_status, send_pause):
+        """Test play/pause if device is playing."""
+        soundtouch.DEVICES[0].update()
+        soundtouch.DEVICES[0].media_play_pause()
+        self.assertEqual(get_status.call_count, 1)
+        self.assertEqual(send_pause.call_count, 2)
+
+    @mock.patch('requests.post', side_effect=_mock_send_next_track)
+    def test_next_track(self, mock_next_track):
+        """Test next track."""
+        soundtouch.DEVICES[0].media_next_track()
+        self.assertEqual(mock_next_track.call_count, 2)
+
+    @mock.patch('requests.post', side_effect=_mock_send_previous_track)
+    def test_previous_track(self, previous_track):
+        """Test previous track."""
+        soundtouch.DEVICES[0].media_previous_track()
+        self.assertEqual(previous_track.call_count, 2)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing)
+    def test_get_image_url(self, get_status):
+        """Test get Image URL if present."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].media_image_url.strip(),
+                         "http://i.scdn.co/image/0f12b4c66fbd0XXX")
+        self.assertEqual(get_status.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing_stored_music)
+    def test_get_image_url_if_no_image(self, state_playing_stored_music):
+        """Test returning None as image URL if no image is available."""
+        soundtouch.DEVICES[0].update()
+        self.assertIsNone(soundtouch.DEVICES[0].media_image_url)
+        self.assertEqual(state_playing_stored_music.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing)
+    def test_get_media_title(self, state_playing):
+        """Test media title for streaming/stored music."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].media_title,
+                         "Hozier - Cherry Wine - Live")
+        self.assertEqual(state_playing.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing_radio)
+    def test_get_media_title_radio(self, state_playing_radio):
+        """Test media title for radio."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].media_title, "franceinfo")
+        self.assertEqual(state_playing_radio.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing)
+    def test_get_media_track(self, state_playing):
+        """Test media track for streaming/stored music..."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].media_track,
+                         "Cherry Wine - Live")
+        self.assertEqual(state_playing.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing_radio)
+    def test_get_media_track_radio(self, state_playing_radio):
+        """Test media track for radio."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].media_track, None)
+        self.assertEqual(state_playing_radio.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing_unknown)
+    def test_get_media_title_unknown(self, state_playing_unknown):
+        """Test media title is None if unable to get media title."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].media_title, None)
+        self.assertEqual(state_playing_unknown.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing)
+    def test_get_media_artist(self, state_playing):
+        """Test artist for streaming/stored music."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].media_artist, "Hozier")
+        self.assertEqual(state_playing.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing_radio)
+    def test_get_media_artist_radio(self, state_playing_radio):
+        """Test get artist is None for radio."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].media_artist, None)
+        self.assertEqual(state_playing_radio.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing)
+    def test_get_media_album(self, state_playing):
+        """Test media album for streaming/stored music."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].media_album_name,
+                         "Take Me to Church EP")
+        self.assertEqual(state_playing.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing_radio)
+    def test_get_media_album_radio(self, state_playing_radio):
+        """Test media album is None for radio."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].media_album_name, None)
+        self.assertEqual(state_playing_radio.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing)
+    def test_get_media_duration(self, state_playing):
+        """Test media duration for streaming/stored music."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].media_duration, 239)
+        self.assertEqual(state_playing.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mocked_state_playing_radio)
+    def test_get_media_duration_radio(self, state_playing_radio):
+        """Test media duration for streaming/stored music."""
+        soundtouch.DEVICES[0].update()
+        self.assertEqual(soundtouch.DEVICES[0].media_duration, None)
+        self.assertEqual(state_playing_radio.call_count, 1)
+
+    @mock.patch('requests.post', side_effect=_mock_select)
+    @mock.patch('requests.get', side_effect=_mock_get_presets)
+    def test_play_media(self, presets, select):
+        """Test play preset 1."""
+        soundtouch.DEVICES[0].play_media('PLAYLIST', 1)
+        self.assertEqual(presets.call_count, 1)
+        self.assertEqual(select.call_count, 1)
+
+    @mock.patch('requests.get', side_effect=_mock_get_presets)
+    def test_play_media_unknown(self, mock_presets):
+        """Test play unkown preset (valid is 1)."""
+        soundtouch.DEVICES[0].play_media('PLAYLIST', 8)
+        self.assertEqual(mock_presets.call_count, 1)
+
+    @mock.patch('requests.post', side_effect=_mock_create_zone)
+    @mock.patch('requests.get', side_effect=_mock_get_state_info)
+    def test_play_everywhere(self, get_state_info, create_zone):
+        """Test play everywhere with master device 'master_id'."""
+        device1 = SoundTouchDevice("device1", {
+            "host": "192.168.88.1",
+            "port": 8090
+        })
+        device1.entity_id = "master_id"
+        soundtouch.DEVICES.append(device1)
+        service = MockService("master_id", [])
+        soundtouch.play_everywhere_service(service)
+        self.assertEqual(get_state_info.call_count, 2)
+        self.assertEqual(create_zone.call_count, 1)
+
+    def test_play_everywhere_without_master(self):
+        # pylint: disable=invalid-name, no-self-use
+        """Test play everywhere without master do nothing."""
+        service = MockService("master_id", [])
+        soundtouch.play_everywhere_service(service)
+
+    def test_play_everywhere_without_slaves(self):
+        # pylint: disable=invalid-name, no-self-use
+        """Test play everywhere without slaves do nothing."""
+        service = MockService("entity_1", [])
+        soundtouch.play_everywhere_service(service)
+
+    @mock.patch('requests.post', side_effect=_mock_create_zone)
+    @mock.patch('requests.get', side_effect=_mock_get_state_info)
+    def test_create_zone(self, get_state_info, create_zone):
+        """Test creating a zone with 1 master and 1 slave."""
+        device1 = SoundTouchDevice("device1", {
+            "host": "192.168.88.1",
+            "port": 8090
+        })
+        device1.entity_id = "master_id"
+        soundtouch.DEVICES.append(device1)
+        service = MockService("master_id", ["entity_1"])
+        soundtouch.create_zone_service(service)
+        self.assertEqual(get_state_info.call_count, 2)
+        self.assertEqual(create_zone.call_count, 1)
+
+    def test_create_zone_without_master(self):
+        # pylint: disable= no-self-use
+        """Test creating a zone without master do nothing."""
+        service = MockService("master_id", [])
+        soundtouch.create_zone_service(service)
+
+    def test_create_zone_without_slaves(self):
+        # pylint: disable=no-self-use
+        """Test creating a zone without slave(s) do nothing."""
+        service = MockService("entity_1", [])
+        soundtouch.create_zone_service(service)
+
+    @mock.patch('requests.post', side_effect=_mock_add_zone_slave)
+    @mock.patch('requests.get', side_effect=_mock_get_state_info)
+    def test_add_zone_slave(self, get_state_info, add_zone_slave):
+        """Test adding a slave to an existing zone."""
+        device1 = SoundTouchDevice("device1", {
+            "host": "192.168.88.1",
+            "port": 8090
+        })
+        device1.entity_id = "master_id"
+        soundtouch.DEVICES.append(device1)
+        service = MockService("master_id", ["entity_1"])
+        soundtouch.add_zone_slave(service)
+        self.assertEqual(get_state_info.call_count, 2)
+        self.assertEqual(add_zone_slave.call_count, 1)
+
+    def test_add_zone_slave_without_master(self):
+        # pylint: disable=invalid-name, no-self-use
+        """Test adding a slave to a zone without a master do nothing."""
+        service = MockService("master_id", [])
+        soundtouch.add_zone_slave(service)
+
+    def test_add_zone_slave_without_slaves(self):
+        # pylint: disable=invalid-name, no-self-use
+        """Test adding a slave without slave do nothing."""
+        service = MockService("entity_1", [])
+        soundtouch.add_zone_slave(service)
+
+    @mock.patch('requests.post', side_effect=_mock_remove_zone_slave)
+    @mock.patch('requests.get', side_effect=_mock_get_state_info)
+    def test_remove_zone_slave(self, get_state_info, remove_zone_slave):
+        """Test removing a slave from a zone."""
+        device1 = SoundTouchDevice("device1", {
+            "host": "192.168.88.1",
+            "port": 8090
+        })
+        device1.entity_id = "master_id"
+        soundtouch.DEVICES.append(device1)
+        service = MockService("master_id", ["entity_1"])
+        soundtouch.remove_zone_slave(service)
+        self.assertEqual(get_state_info.call_count, 2)
+        self.assertEqual(remove_zone_slave.call_count, 1)
+
+    def test_remove_zone_slave_without_master(self):
+        # pylint: disable=invalid-name, no-self-use
+        """Test removing a slave zone without master do nothing."""
+        service = MockService("master_id", [])
+        soundtouch.remove_zone_slave(service)
+
+    def test_remove_zone_slave_without_slaves(self):
+        # pylint: disable=invalid-name, no-self-use
+        """Test removing a slave zone without slave to remove do nothing."""
+        service = MockService("entity_1", [])
+        soundtouch.remove_zone_slave(service)


### PR DESCRIPTION
**Description:**

Add support to Bose Soundtouch multi-rooms speakers (https://www.bose.com/en_us/products/speakers/wireless_speakers/soundtouch-10-wireless-system.html).

This PR add support for the following media supports:
* DLNA
* Radio
* Spotify

I'm unable to test others (Google Music, Deezer, Apple Music, ...) because I don't have any accounts but I should be able to create trial accounts in order to implement theses providers in the future.

Multi-room is fully supported.

I'm not a *native* Python developer and I didn't know all quality software tools used by Home Assistant (Tox, Pylint, ...) so I tried to do my best but any feedback are welcome.
I have errors with Tox but I guess nothing related to this PR.

**Related issue (if applicable):** No

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1409

I'll start working on the documentation after submitting this PR

**Example entry for `configuration.yaml` (if applicable):**

## Defined devices

```yaml
media_player:
  - platform: soundtouch
    host: 192.168.1.1
    port: 8090
    name: Soundtouch Living Room
  - platform: soundtouch
    host: 192.168.1.2
    port: 8090
    name: Soundtouch Kitchen
...
```

## Play media
Soundtouch devices support 6 presets who can be used in order to change the selection

```yaml
- service: media_player.play_media
  data:
    entity_id: media_player.soundtouch_living_room
    media_content_id: <1-6>
    media_content_type: PLAYLIST
```

## Multi-room

In order to use multi-room ('Zone' in soundtouch vocabulary):

### Create a zone and play on all other slaves

```yaml
automation:
  - alias: Play everywhere
    trigger:
       ...
    action:
      - service: media_player.soundtouch_play_everywhere
        data:
          master: media_player.soundtouch_living_room
```

### Creating a zone with one master and two slaves

```yaml
- service: media_player.soundtouch_create_zone
  data:
    master: media_player.soundtouch_living_room
    slaves:
      - media_player.soundtouch_room
      - media_player.soundtouch_kitchen
```

### Adding a slave to an existing zone

```yaml
- service: media_player.soundtouch_add_zone_slave
  data:
    master: media_player.soundtouch_living_room
    slaves:
      - media_player.soundtouch_room      
```

### Removing a slave from a zone (removing all slaves delete the zone)

```yaml
- service: media_player.soundtouch_remove_zone_slave
  data:
    master: media_player.soundtouch_living_room
    slaves:
      - media_player.soundtouch_room      
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) => Not yet

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`. => Unit tests added so I didn't update this file

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
