### PR TITLE
Move Honeywell I/O out of event loop

### DIFF
--- a/homeassistant/components/climate/honeywell.py
+++ b/homeassistant/components/climate/honeywell.py
@@ -223,7 +223,6 @@ class HoneywellUSThermostat(ClimateDevice):
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        self._device.refresh()
         return self._device.current_temperature
 
     @property
@@ -274,3 +273,7 @@ class HoneywellUSThermostat(ClimateDevice):
         """Set the system mode (Cool, Heat, etc)."""
         if hasattr(self._device, ATTR_SYSTEM_MODE):
             self._device.system_mode = operation_mode
+
+    def update(self):
+        """Update the state."""
+        self._device.refresh()


### PR DESCRIPTION
**Description:**
This moves the update of data for Honeywell entities out of the event loop and into an update method.

**Related issue (if applicable):** #4210 
