### PR TITLE
Tweak block_till_done

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -252,8 +252,9 @@ class HomeAssistant(object):
         """Block till all pending work is done."""
         while True:
             # Wait for the pending tasks are down
-            if len(self._pending_tasks) > 0:
-                yield from asyncio.wait(self._pending_tasks, loop=self.loop)
+            pending = list(self._pending_tasks)
+            if len(pending) > 0:
+                yield from asyncio.wait(pending, loop=self.loop)
 
             # Verify the loop is empty
             ret = yield from self.loop.run_in_executor(None, self._loop_empty)


### PR DESCRIPTION
Every time you refer to a weakmap it will remove all entries that no longer exist. In our block_till_done method we referred to it twice and it could happen that the map became empty between the time that we checked the length and it got passed into `asyncio.wait`, causing `asyncio.wait` to raise an error.
