### PR TITLE
Updated netdisco to 0.7.6

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.helpers.discovery import load_platform, discover
 
-REQUIREMENTS = ['netdisco==0.7.5']
+REQUIREMENTS = ['netdisco==0.7.6']
 
 DOMAIN = 'discovery'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -278,7 +278,7 @@ mficlient==0.3.0
 miflora==0.1.9
 
 # homeassistant.components.discovery
-netdisco==0.7.5
+netdisco==0.7.6
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.2.10


### PR DESCRIPTION
**Description:**
Updates netdisco to 0.7.6 which includes beside other things an updated WebOS discovery

**Related issue (if applicable):** fixes #4128

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

