### PR TITLE
Catch AttributeError on Wink PubNub update

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -61,7 +61,7 @@ class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
                 json_data = message
             self.wink.pubnub_update(json.loads(json_data))
             self.update_ha_state()
-        except (AttributeError, KeyError):
+        except (AttributeError, KeyError, AttributeError):
             error = "Pubnub returned invalid json for " + self.name
             logging.getLogger(__name__).error(error)
             self.update_ha_state(True)

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -111,7 +111,7 @@ class WinkDevice(Entity):
         try:
             self.wink.pubnub_update(json.loads(message))
             self.update_ha_state()
-        except (AttributeError, KeyError):
+        except (AttributeError, KeyError, AttributeError):
             error = "Pubnub returned invalid json for " + self.name
             logging.getLogger(__name__).error(error)
             self.update_ha_state(True)


### PR DESCRIPTION
**Description:**
Found the following error today during a state change on a Wink switch (Quirky power strip). 

```bash
Nov 06 15:34:36 hass hass[10732]: if outlet.get('outlet_id') == str(self.device_id()):
Nov 06 15:34:36 hass hass[10732]: AttributeError: 'str' object has no attribute 'get'
```

This PR will catch the AttributeError and call the Wink API to fetch the correct state.

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

