### PR TITLE
Prevent Pandora component from crashing or hanging during shutdown.

### DIFF
--- a/homeassistant/components/media_player/pandora.py
+++ b/homeassistant/components/media_player/pandora.py
@@ -22,6 +22,7 @@ from homeassistant.components.media_player import (
 from homeassistant.const import (STATE_OFF, STATE_PAUSED, STATE_PLAYING,
                                  STATE_IDLE)
 from homeassistant import util
+from homeassistant import exceptions
 
 REQUIREMENTS = ['pexpect==4.0.1']
 _LOGGER = logging.getLogger(__name__)
@@ -138,7 +139,11 @@ class PandoraMediaPlayer(MediaPlayerDevice):
             _LOGGER.info('Killed Pianobar subprocess')
         self._pianobar = None
         self._player_state = STATE_OFF
-        self.update_ha_state()
+        try:
+            self.update_ha_state()
+        except exceptions.HomeAssistantError:
+            # System shutdown occurring.
+            pass
 
     def media_play(self):
         """Send play command."""
@@ -349,6 +354,8 @@ class PandoraMediaPlayer(MediaPlayerDevice):
             while not self._pianobar.expect('.+', timeout=0.1):
                 pass
         except pexpect.exceptions.TIMEOUT:
+            pass
+        except pexpect.exceptions.EOF:
             pass
 
 

--- a/homeassistant/components/media_player/pandora.py
+++ b/homeassistant/components/media_player/pandora.py
@@ -121,7 +121,7 @@ class PandoraMediaPlayer(MediaPlayerDevice):
         self.update_playing_status()
 
         self._player_state = STATE_IDLE
-        self.update_ha_state()
+        self.schedule_update_ha_state()
 
     def turn_off(self):
         """Turn the media player off."""
@@ -139,28 +139,24 @@ class PandoraMediaPlayer(MediaPlayerDevice):
             _LOGGER.info('Killed Pianobar subprocess')
         self._pianobar = None
         self._player_state = STATE_OFF
-        try:
-            self.update_ha_state()
-        except exceptions.HomeAssistantError:
-            # System shutdown occurring.
-            pass
+        self.schedule_update_ha_state()
 
     def media_play(self):
         """Send play command."""
         self._send_pianobar_command(SERVICE_MEDIA_PLAY_PAUSE)
         self._player_state = STATE_PLAYING
-        self.update_ha_state()
+        self.schedule_update_ha_state()
 
     def media_pause(self):
         """Send pause command."""
         self._send_pianobar_command(SERVICE_MEDIA_PLAY_PAUSE)
         self._player_state = STATE_PAUSED
-        self.update_ha_state()
+        self.schedule_update_ha_state()
 
     def media_next_track(self):
         """Go to next track."""
         self._send_pianobar_command(SERVICE_MEDIA_NEXT_TRACK)
-        self.update_ha_state()
+        self.schedule_update_ha_state()
 
     @property
     def supported_media_commands(self):

--- a/homeassistant/components/media_player/pandora.py
+++ b/homeassistant/components/media_player/pandora.py
@@ -22,7 +22,6 @@ from homeassistant.components.media_player import (
 from homeassistant.const import (STATE_OFF, STATE_PAUSED, STATE_PLAYING,
                                  STATE_IDLE)
 from homeassistant import util
-from homeassistant import exceptions
 
 REQUIREMENTS = ['pexpect==4.0.1']
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
**Description:**
I noticed a hang if Pandora is playing when HA is shut down in 0.30. In 0.32 it just crashes with an exception about HA shutting down. This small PR fixes both these issues and lets it close cleanly. 

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.



[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

