### PR TITLE
Change Osram to use Github lightify dep

### DIFF
--- a/homeassistant/components/light/osramlightify.py
+++ b/homeassistant/components/light/osramlightify.py
@@ -94,6 +94,7 @@ class OsramLightifyLight(Light):
         self._light_id = light_id
         self.update_lights = update_lights
         self._brightness = int(self._light.lum() * 2.55)
+        self._state = False
 
     @property
     def name(self):
@@ -166,7 +167,7 @@ class OsramLightifyLight(Light):
         if ATTR_COLOR_TEMP in kwargs:
             color_t = kwargs[ATTR_COLOR_TEMP]
             kelvin = int(((TEMP_MAX - TEMP_MIN) * (color_t - TEMP_MIN_HASS) /
-                (TEMP_MAX_HASS - TEMP_MIN_HASS)) + TEMP_MIN)
+                          (TEMP_MAX_HASS - TEMP_MIN_HASS)) + TEMP_MIN)
             _LOGGER.debug("turn_on requested set_temperature for light:"
                           " %s: %s ", self._light.name, kelvin)
             self._light.set_temperature(kelvin, transition)

--- a/homeassistant/components/light/osramlightify.py
+++ b/homeassistant/components/light/osramlightify.py
@@ -19,7 +19,8 @@ from homeassistant.components.light import (
     SUPPORT_COLOR_TEMP, SUPPORT_RGB_COLOR, SUPPORT_TRANSITION, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['https://github.com/tfriedel/python-lightify/archive/master.zip#lightify==0.0.4']
+REQUIREMENTS = ['https://github.com/tfriedel/python-lightify/archive/'
+                'master.zip#lightify==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -146,31 +147,37 @@ class OsramLightifyLight(Light):
 
         if ATTR_TRANSITION in kwargs:
             transition = kwargs[ATTR_TRANSITION] * 10
-            _LOGGER.debug("turn_on requested transition time for light: %s is: %s ",
+            _LOGGER.debug("turn_on requested transition time for light:"
+                          " %s is: %s ",
                           self._light.name(), transition)
         else:
             transition = 0
-            _LOGGER.debug("turn_on requested transition time for light: %s is: %s ",
+            _LOGGER.debug("turn_on requested transition time for light:"
+                          " %s is: %s ",
                           self._light.name(), transition)
 
         if ATTR_RGB_COLOR in kwargs:
             red, green, blue = kwargs[ATTR_RGB_COLOR]
-            _LOGGER.debug("turn_on requested ATTR_RGB_COLOR for light: %s is: %s %s %s ",
+            _LOGGER.debug("turn_on requested ATTR_RGB_COLOR for light:"
+                          " %s is: %s %s %s ",
                           self._light.name, red, green, blue)
             self._light.set_rgb(red, green, blue, transition)
 
         if ATTR_COLOR_TEMP in kwargs:
             color_t = kwargs[ATTR_COLOR_TEMP]
-            kelvin = int(((TEMP_MAX - TEMP_MIN) * (color_t - TEMP_MIN_HASS) / (TEMP_MAX_HASS - TEMP_MIN_HASS)) + TEMP_MIN)
-            _LOGGER.debug("turn_on requested set_temperature for light: %s: %s ",
-                          self._light.name, kelvin)
+            kelvin = int(((TEMP_MAX - TEMP_MIN) * (color_t - TEMP_MIN_HASS) /
+                (TEMP_MAX_HASS - TEMP_MIN_HASS)) + TEMP_MIN)
+            _LOGGER.debug("turn_on requested set_temperature for light:"
+                          " %s: %s ", self._light.name, kelvin)
             self._light.set_temperature(kelvin, transition)
 
         if ATTR_BRIGHTNESS in kwargs:
             self._brightness = kwargs[ATTR_BRIGHTNESS]
             _LOGGER.debug("turn_on requested brightness for light: %s is: %s ",
                           self._light.name, self._brightness)
-            self._brightness = self._light.set_luminance(int(self._brightness / 2.55), transition)
+            self._brightness = self._light.set_luminance(
+                int(self._brightness / 2.55),
+                transition)
 
         if ATTR_EFFECT in kwargs:
             effect = kwargs.get(ATTR_EFFECT)
@@ -179,7 +186,8 @@ class OsramLightifyLight(Light):
                                     random.randrange(0, 255),
                                     random.randrange(0, 255),
                                     transition)
-                _LOGGER.debug("turn_on requested random effect for light: %s with transition %s ",
+                _LOGGER.debug("turn_on requested random effect for light:"
+                              " %s with transition %s ",
                               self._light.name, transition)
 
         self.update_ha_state()
@@ -190,12 +198,14 @@ class OsramLightifyLight(Light):
                       self._light.name)
         if ATTR_TRANSITION in kwargs:
             transition = kwargs[ATTR_TRANSITION] * 10
-            _LOGGER.debug("turn_off requested transition time for light: %s is: %s ",
+            _LOGGER.debug("turn_off requested transition time for light:"
+                          " %s is: %s ",
                           self._light.name, transition)
             self._light.set_luminance(0, transition)
         else:
             transition = 0
-            _LOGGER.debug("turn_off requested transition time for light: %s is: %s ",
+            _LOGGER.debug("turn_off requested transition time for light:"
+                          " %s is: %s ",
                           self._light.name, transition)
             self._light.set_onoff(0)
             self._state = self._light.on()

--- a/homeassistant/components/light/osramlightify.py
+++ b/homeassistant/components/light/osramlightify.py
@@ -20,7 +20,7 @@ from homeassistant.components.light import (
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['https://github.com/tfriedel/python-lightify/archive/'
-                'master.zip#lightify==0.0.4']
+                'd6eadcf311e6e21746182d1480e97b350dda2b3e.zip#lightify==1.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/light/osramlightify.py
+++ b/homeassistant/components/light/osramlightify.py
@@ -127,7 +127,6 @@ class OsramLightifyLight(Light):
     @property
     def is_on(self):
         """Update Status to True if device is on."""
-        self.update()
         _LOGGER.debug("is_on light state for light: %s is: %s",
                       self._name, self._state)
         return self._state

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -63,9 +63,6 @@ boto3==1.3.1
 coinmarketcap==2.0.1
 
 # homeassistant.scripts.check_config
-colorama<=1
-
-# homeassistant.scripts.check_config
 colorlog>2.1,<3
 
 # homeassistant.components.alarm_control_panel.concord232

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -224,7 +224,7 @@ https://github.com/robbiet480/pygtfs/archive/00546724e4bbcb3053110d844ca44e22462
 https://github.com/sander76/powerviewApi/archive/246e782d60d5c0addcc98d7899a0186f9d5640b0.zip#powerviewApi==0.3.15
 
 # homeassistant.components.light.osramlightify
-https://github.com/tfriedel/python-lightify/archive/master.zip#lightify==0.0.4
+https://github.com/tfriedel/python-lightify/archive/d6eadcf311e6e21746182d1480e97b350dda2b3e.zip#lightify==1.0.4
 
 # homeassistant.components.mysensors
 https://github.com/theolind/pymysensors/archive/0b705119389be58332f17753c53167f551254b6c.zip#pymysensors==0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -259,7 +259,7 @@ libnacl==1.5.0
 liffylights==0.9.4
 
 # homeassistant.components.light.osramlightify
-lightify==1.0.3
+https://github.com/tfriedel/python-lightify/archive/master.zip#lightify==0.0.4
 
 # homeassistant.components.light.limitlessled
 limitlessled==1.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -63,6 +63,9 @@ boto3==1.3.1
 coinmarketcap==2.0.1
 
 # homeassistant.scripts.check_config
+colorama<=1
+
+# homeassistant.scripts.check_config
 colorlog>2.1,<3
 
 # homeassistant.components.alarm_control_panel.concord232
@@ -223,6 +226,9 @@ https://github.com/robbiet480/pygtfs/archive/00546724e4bbcb3053110d844ca44e22462
 # homeassistant.components.scene.hunterdouglas_powerview
 https://github.com/sander76/powerviewApi/archive/246e782d60d5c0addcc98d7899a0186f9d5640b0.zip#powerviewApi==0.3.15
 
+# homeassistant.components.light.osramlightify
+https://github.com/tfriedel/python-lightify/archive/master.zip#lightify==0.0.4
+
 # homeassistant.components.mysensors
 https://github.com/theolind/pymysensors/archive/0b705119389be58332f17753c53167f551254b6c.zip#pymysensors==0.8
 
@@ -257,9 +263,6 @@ libnacl==1.5.0
 
 # homeassistant.components.light.lifx
 liffylights==0.9.4
-
-# homeassistant.components.light.osramlightify
-https://github.com/tfriedel/python-lightify/archive/master.zip#lightify==0.0.4
 
 # homeassistant.components.light.limitlessled
 limitlessled==1.0.2


### PR DESCRIPTION
**Description:**


**Related issue (if applicable):** fixes #3089 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

…tify/commits/master/osramlightify.py ) from Oct 2, 2016 and changed the REQUIRMENTS line to use the fixed lightify component with thread safety fixes