### PR TITLE
Add support for off script to WOL switch

### DIFF
--- a/homeassistant/components/switch/wake_on_lan.py
+++ b/homeassistant/components/switch/wake_on_lan.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.script import Script
 from homeassistant.const import (CONF_HOST, CONF_NAME)
 
 REQUIREMENTS = ['wakeonlan==0.2.2']
@@ -19,6 +20,7 @@ REQUIREMENTS = ['wakeonlan==0.2.2']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_MAC_ADDRESS = 'mac_address'
+CONF_OFF_ACTION = 'turn_off'
 
 DEFAULT_NAME = 'Wake on LAN'
 DEFAULT_PING_TIMEOUT = 1
@@ -27,6 +29,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_MAC_ADDRESS): cv.string,
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_OFF_ACTION): cv.SCRIPT_SCHEMA,
 })
 
 
@@ -35,20 +38,22 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
     mac_address = config.get(CONF_MAC_ADDRESS)
+    off_action = config.get(CONF_OFF_ACTION)
 
-    add_devices([WOLSwitch(hass, name, host, mac_address)])
+    add_devices([WOLSwitch(hass, name, host, mac_address, off_action)])
 
 
 class WOLSwitch(SwitchDevice):
     """Representation of a wake on lan switch."""
 
-    def __init__(self, hass, name, host, mac_address):
+    def __init__(self, hass, name, host, mac_address, off_action):
         """Initialize the WOL switch."""
         from wakeonlan import wol
         self._hass = hass
         self._name = name
         self._host = host
         self._mac_address = mac_address
+        self._off_script = Script(hass, off_action) if off_action else None
         self._state = False
         self._wol = wol
         self.update()
@@ -74,8 +79,10 @@ class WOLSwitch(SwitchDevice):
         self.update_ha_state()
 
     def turn_off(self):
-        """Do nothing."""
-        pass
+        """Turn the device off if an off action is present."""
+        if self._off_script is not None:
+            self._off_script.run()
+            self.update_ha_state()
 
     def update(self):
         """Check if device is on and update the state."""


### PR DESCRIPTION
**Description:**
The only way to achieve a switch that can turn a remote device on and off for now is to use a mix of command, template and wake_on_lan switches. By adding a turn_off option to the wake_on_lan, I'm hoping to make this process less tedious.

The command is a script so any service can be called. My own usage calls a _shell_command_. A payload could also be published on a MQTT broker and the target machine would shut itself down.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
To Do

**Example entry for `configuration.yaml` (if applicable):**
```yaml
switch: 
  - platform: wake_on_lan
    name: network_media
    mac_address: "01:23:45:67:89:AB"
    host: "192.168.5.6"
    turn_off:
      service: shell_command.device_off
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

