### PR TITLE
Revert "Catch AttributeError on Wink PubNub update"

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -61,7 +61,7 @@ class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
                 json_data = message
             self.wink.pubnub_update(json.loads(json_data))
             self.update_ha_state()
-        except (AttributeError, KeyError, AttributeError):
+        except (AttributeError, KeyError):
             error = "Pubnub returned invalid json for " + self.name
             logging.getLogger(__name__).error(error)
             self.update_ha_state(True)

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -111,7 +111,7 @@ class WinkDevice(Entity):
         try:
             self.wink.pubnub_update(json.loads(message))
             self.update_ha_state()
-        except (AttributeError, KeyError, AttributeError):
+        except (AttributeError, KeyError):
             error = "Pubnub returned invalid json for " + self.name
             logging.getLogger(__name__).error(error)
             self.update_ha_state(True)


### PR DESCRIPTION
Reverts home-assistant/home-assistant#4253 AttributeError is already caught not sure how I missed that, and not sure why it wasn't actually "catching" the error, but this isn't the fix.