### PR TITLE
Remove broken disable verify ssl synology

### DIFF
--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -57,6 +57,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup a Synology IP Camera."""
+    if not config.get(CONF_VERIFY_SSL):
+        _LOGGER.warning('SSL verification currently cannot be disabled. '
+                        'See https://goo.gl/1h1119')
+
     # Determine API to use for authentication
     syno_api_url = SYNO_API_URL.format(
         config.get(CONF_URL), WEBAPI_PATH, QUERY_CGI)
@@ -72,7 +76,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             query_req = yield from hass.websession.get(
                 syno_api_url,
                 params=query_payload,
-                verify_ssl=config.get(CONF_VERIFY_SSL)
             )
     except asyncio.TimeoutError:
         _LOGGER.error("Timeout on %s", syno_api_url)
@@ -113,7 +116,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             camera_req = yield from hass.websession.get(
                 syno_camera_url,
                 params=camera_payload,
-                verify_ssl=config.get(CONF_VERIFY_SSL),
                 cookies={'id': session_id}
             )
     except asyncio.TimeoutError:
@@ -165,7 +167,6 @@ def get_session_id(hass, username, password, login_url, valid_cert):
             auth_req = yield from hass.websession.get(
                 login_url,
                 params=auth_payload,
-                verify_ssl=valid_cert
             )
     except asyncio.TimeoutError:
         _LOGGER.error("Timeout on %s", login_url)
@@ -233,7 +234,6 @@ class SynologyCamera(Camera):
                 response = yield from self.hass.websession.get(
                     image_url,
                     params=image_payload,
-                    verify_ssl=self._valid_cert,
                     cookies={'id': self._session_id}
                 )
         except asyncio.TimeoutError:
@@ -263,7 +263,6 @@ class SynologyCamera(Camera):
                 stream = yield from self.hass.websession.get(
                     streaming_url,
                     payload=streaming_payload,
-                    verify_ssl=self._valid_cert,
                     cookies={'id': self._session_id}
                 )
         except asyncio.TimeoutError:


### PR DESCRIPTION
**Description:**
Disabling SSL verification for Synology camera's has been broken in 0.32 as reported in https://github.com/home-assistant/home-assistant/issues/4257. I don't have time for a proper fix right now so will just ensure now that it at least works with SSL verification enabled.

**Related issue (if applicable):** #4257