### PR TITLE
Fix setting temperature in Celsius on radiotherm CT50

### DIFF
--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -135,9 +135,9 @@ class RadioThermostat(ClimateDevice):
         if temperature is None:
             return
         if self._current_operation == STATE_COOL:
-            self.device.t_cool = temperature
+            self.device.t_cool = round(temperature * 2.0) / 2.0
         elif self._current_operation == STATE_HEAT:
-            self.device.t_heat = temperature
+            self.device.t_heat = round(temperature * 2.0) / 2.0
         if self.hold_temp:
             self.device.hold = 1
         else:
@@ -159,6 +159,6 @@ class RadioThermostat(ClimateDevice):
         elif operation_mode == STATE_AUTO:
             self.device.tmode = 3
         elif operation_mode == STATE_COOL:
-            self.device.t_cool = self._target_temperature
+            self.device.t_cool = round(self._target_temperature * 2.0) / 2.0
         elif operation_mode == STATE_HEAT:
-            self.device.t_heat = self._target_temperature
+            self.device.t_heat = round(self._target_temperature * 2.0) / 2.0


### PR DESCRIPTION
**Description:**
There seem to be a bug in Radiotherm CT50 thermostat, when setting temperature that is not an integer or ending ".5", it does not do anything (and still return success). CT50 API always expects temperature in Fahrenheit. If home assistant is set to use metric units (and Celsius degrees), it converts temperature before sending to the thermostat. But resulting temperature in Fahrenheit might not be an integer or ending ".5". As a result, only certain Celsius temperatures can be set, such as 20C (=68F) or 25C (=77F), but not 22C (=71.6F) for example. The proposed fix rounds temperature to the nearest 0.5 before sending to CT50, so it works for any Celsius temperature.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

