### PR TITLE
Upgrade psutil to 5.0.0

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==4.4.2']
+REQUIREMENTS = ['psutil==5.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -315,7 +315,7 @@ pmsensor==0.3
 proliphix==0.4.0
 
 # homeassistant.components.sensor.systemmonitor
-psutil==4.4.2
+psutil==5.0.0
 
 # homeassistant.components.wink
 pubnub==3.8.2


### PR DESCRIPTION
5.0.0
=====

**Enhncements**

- new Process.oneshot() context manager making Process methods around +2x faster in general and from +2x to +6x faster on Windows.
- better error message in case of version conflict on import.

**Bug fixes**

- [NetBSD] net_connections() and Process.connections() may fail without raising an exception.
- [Windows] memory leak in cpu_stats() and WindowsService.description().

Tested with the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
```
