### PR TITLE
Fix "argument of type 'NoneType' is not iterable" during discovery

### DIFF
--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -18,7 +18,7 @@ from homeassistant.const import (CONF_NAME, CONF_HOST, STATE_OFF, STATE_ON,
                                  STATE_PLAYING, STATE_IDLE)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['rxv==0.3.0']
+REQUIREMENTS = ['rxv==0.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -68,6 +68,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             friendly_name=name,
             unit_desc_url=desc_url).zone_controllers()
         _LOGGER.info("Receivers: %s", receivers)
+        # when we are dynamically discovered config is empty
+        zone_ignore = []
     elif host is None:
         receivers = []
         for recv in rxv.find():

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -464,7 +464,7 @@ radiotherm==1.2
 # rpi-rf==0.9.5
 
 # homeassistant.components.media_player.yamaha
-rxv==0.3.0
+rxv==0.3.1
 
 # homeassistant.components.media_player.samsungtv
 samsungctl==0.5.1


### PR DESCRIPTION
**Related issue (if applicable):** fixes #4226 

When yamaha receivers are dynamically discovered, there config is
empty, which means that we need to set zone_ignore to [] otherwise the
iteration over receivers fails.