### PR TITLE
Add timeout for Netatmo binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/netatmo.py
+++ b/homeassistant/components/binary_sensor/netatmo.py
@@ -30,9 +30,11 @@ SENSOR_TYPES = {
 
 CONF_HOME = 'home'
 CONF_CAMERAS = 'cameras'
+CONF_LIMIT = 'limit'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOME): cv.string,
+    vol.Optional(CONF_LIMIT): cv.positive_int,
     vol.Optional(CONF_CAMERAS, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_MONITORED_CONDITIONS, default=SENSOR_TYPES.keys()):
@@ -45,6 +47,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup access to Netatmo binary sensor."""
     netatmo = get_component('netatmo')
     home = config.get(CONF_HOME, None)
+    limit = config.get(CONF_LIMIT, 15)
 
     import lnetatmo
     try:
@@ -62,18 +65,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                camera_name not in config[CONF_CAMERAS]:
                 continue
         for variable in sensors:
-            add_devices([WelcomeBinarySensor(data, camera_name, home,
+            add_devices([WelcomeBinarySensor(data, camera_name, home, limit,
                                              variable)])
 
 
 class WelcomeBinarySensor(BinarySensorDevice):
     """Represent a single binary sensor in a Netatmo Welcome device."""
 
-    def __init__(self, data, camera_name, home, sensor):
+    def __init__(self, data, camera_name, home, limit, sensor):
         """Setup for access to the Netatmo camera events."""
         self._data = data
         self._camera_name = camera_name
         self._home = home
+        self._limit=limit
         if home:
             self._name = home + ' / ' + camera_name
         else:
@@ -114,14 +118,17 @@ class WelcomeBinarySensor(BinarySensorDevice):
         if self._sensor_name == "Someone known":
             self._state =\
                     self._data.welcomedata.someoneKnownSeen(self._home,
-                                                            self._camera_name)
+                                                            self._camera_name,
+                                                            self._limit*60)
         elif self._sensor_name == "Someone unknown":
             self._state =\
                 self._data.welcomedata.someoneUnknownSeen(self._home,
-                                                          self._camera_name)
+                                                          self._camera_name,
+                                                          self._limit*60)
         elif self._sensor_name == "Motion":
             self._state =\
                 self._data.welcomedata.motionDetected(self._home,
-                                                      self._camera_name)
+                                                      self._camera_name,
+                                                      self._limit*60)
         else:
             return None

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -18,7 +18,7 @@ from homeassistant.util import Throttle
 
 REQUIREMENTS = [
     'https://github.com/jabesq/netatmo-api-python/archive/'
-    'v0.6.0.zip#lnetatmo==0.6.0']
+    'v0.7.0.zip#lnetatmo==0.7.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -187,7 +187,7 @@ https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.
 # https://github.com/deisi/fritzconnection/archive/b5c14515e1c8e2652b06b6316a7f3913df942841.zip#fritzconnection==0.4.6
 
 # homeassistant.components.netatmo
-https://github.com/jabesq/netatmo-api-python/archive/v0.6.0.zip#lnetatmo==0.6.0
+https://github.com/jabesq/netatmo-api-python/archive/v0.7.0.zip#lnetatmo==0.7.0
 
 # homeassistant.components.switch.neato
 https://github.com/jabesq/pybotvac/archive/v0.0.1.zip#pybotvac==0.0.1


### PR DESCRIPTION
**Description:**
This PR introduce a minor change for the Netatmo binary sensor. The sensor will look for all the events between now and a timeout, and no longer limit itself to the last event. This will also disable the binary sensor after this time limit (default to 15 min)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1412

**Example entry for `configuration.yaml` (if applicable):**
```yaml
binary_sensor:
  platform: netatmo
  home: home_name
  limit: 15
  cameras:
    - camera_name1
  monitored_conditions:
    - Someone known
    - Someone unknown 
    - Motion
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.


