### PR TITLE
Change pilight systemcode validation to integer

### DIFF
--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -30,7 +30,7 @@ COMMAND_SCHEMA = pilight.RF_CODE_SCHEMA.extend({
     vol.Optional(CONF_UNIT): cv.string,
     vol.Optional(CONF_ID): cv.positive_int,
     vol.Optional(CONF_STATE): cv.string,
-    vol.Optional(CONF_SYSTEMCODE): cv.string,
+    vol.Optional(CONF_SYSTEMCODE): cv.positive_int,
 })
 
 SWITCHES_SCHEMA = vol.Schema({

--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -27,7 +27,7 @@ DEPENDENCIES = ['pilight']
 COMMAND_SCHEMA = pilight.RF_CODE_SCHEMA.extend({
     vol.Optional('on'): cv.positive_int,
     vol.Optional('off'): cv.positive_int,
-    vol.Optional(CONF_UNIT): cv.string,
+    vol.Optional(CONF_UNIT): cv.positive_int,
     vol.Optional(CONF_ID): cv.positive_int,
     vol.Optional(CONF_STATE): cv.string,
     vol.Optional(CONF_SYSTEMCODE): cv.positive_int,


### PR DESCRIPTION
**Description:**
This changes the config validation for systemcode in pilight-switch to be an integer instead of a string. Strings cause an error in the pilight daemon. The systemcode is used as integer everywhere in the pilight code:
https://github.com/pilight/pilight/search?utf8=%E2%9C%93&q=systemcode

**Related issue (if applicable):** fixes #4282 


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

According to the pilight code the systemcode should be an integer and
not a string (it is an int in the pilight code). Passing this as a
string caused errors from pilight:
"ERROR: elro_800_switch: insufficient number of arguments"

This fixes #4282