### PR TITLE
Fix possible sigterm / unittest / Fix all lazy test

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -266,7 +266,7 @@ class HomeAssistant(object):
 
             # Verify the loop is empty
             ret = yield from self.loop.run_in_executor(None, self._loop_empty)
-            if ret:
+            if ret and not self._pending_tasks:
                 break
 
     def stop(self) -> None:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -221,7 +221,7 @@ class HomeAssistant(object):
 
             # cleanup
             if len(self._pending_tasks) > 50:
-                self._pending_task = \
+                self._pending_tasks = \
                     [sheduled for sheduled in self._pending_tasks
                      if not sheduled.done()]
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -259,10 +259,10 @@ class HomeAssistant(object):
         """Block till all pending work is done."""
         while True:
             # Wait for the pending tasks are down
-            if len(self._pending_tasks) > 0:
-                pending = [task for task in self._pending_tasks
-                           if not task.done()]
-                self._pending_tasks.clear()
+            pending = [task for task in self._pending_tasks
+                       if not task.done()]
+            self._pending_tasks.clear()
+            if len(pending) > 0:
                 yield from asyncio.wait(pending, loop=self.loop)
 
             # Verify the loop is empty

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -14,7 +14,6 @@ import re
 import signal
 import sys
 import threading
-import weakref
 
 from types import MappingProxyType
 from typing import Optional, Any, Callable, List  # NOQA
@@ -110,7 +109,7 @@ class HomeAssistant(object):
         self.executor = ThreadPoolExecutor(max_workers=5)
         self.loop.set_default_executor(self.executor)
         self.loop.set_exception_handler(self._async_exception_handler)
-        self._pending_tasks = weakref.WeakSet()
+        self._pending_tasks = []
         self.bus = EventBus(self)
         self.services = ServiceRegistry(self.bus, self.async_add_job,
                                         self.loop)
@@ -218,7 +217,13 @@ class HomeAssistant(object):
 
         # if a task is sheduled
         if task is not None:
-            self._pending_tasks.add(task)
+            self._pending_tasks.append(task)
+
+            # cleanup
+            if len(self._pending_tasks) > 50:
+                self._pending_task = \
+                    [sheduled for sheduled in self._pending_tasks
+                     if not sheduled.done()]
 
     @callback
     def async_run_job(self, target: Callable[..., None], *args: Any) -> None:
@@ -254,8 +259,10 @@ class HomeAssistant(object):
         """Block till all pending work is done."""
         while True:
             # Wait for the pending tasks are down
-            pending = list(self._pending_tasks)
-            if len(pending) > 0:
+            if len(self._pending_tasks) > 0:
+                pending = [task for task in self._pending_tasks
+                           if not task.done()]
+                self._pending_tasks.clear()
                 yield from asyncio.wait(pending, loop=self.loop)
 
             # Verify the loop is empty

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -219,11 +219,10 @@ class HomeAssistant(object):
         if task is not None:
             self._pending_tasks.append(task)
 
-            # cleanup
-            if len(self._pending_tasks) > 50:
-                self._pending_tasks = \
-                    [sheduled for sheduled in self._pending_tasks
-                     if not sheduled.done()]
+        # cleanup
+        if len(self._pending_tasks) > 50:
+            self._pending_tasks = [sheduled for sheduled in self._pending_tasks
+                                   if not sheduled.done()]
 
     @callback
     def async_run_job(self, target: Callable[..., None], *args: Any) -> None:

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -16,7 +16,6 @@ import logging
 import time
 import threading
 import urllib.parse
-import weakref
 
 from typing import Optional
 
@@ -128,7 +127,7 @@ class HomeAssistant(ha.HomeAssistant):
         self.executor = ThreadPoolExecutor(max_workers=5)
         self.loop.set_default_executor(self.executor)
         self.loop.set_exception_handler(self._async_exception_handler)
-        self._pending_tasks = weakref.WeakSet()
+        self._pending_tasks = []
 
         self.bus = EventBus(remote_api, self)
         self.services = ha.ServiceRegistry(self.bus, self.add_job, self.loop)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -120,42 +120,40 @@ class TestHomeAssistant(unittest.TestCase):
 
     def test_async_add_job_pending_taks_add(self):
         """Add a coro to pending tasks."""
-        have_call = False
+        call_count = []
 
         @asyncio.coroutine
         def test_coro():
             """Test Coro."""
-            global have_call
-            have_call = True
+            call_count.append('call')
 
         self.hass.add_job(test_coro())
 
         assert len(self.hass._pending_tasks) == 1
         self.hass.block_till_done()
-        assert have_call
+        assert len(call_count) == 1
 
     def test_async_add_job_pending_taks_cleanup(self):
         """Add a coro to pending tasks."""
-        call_count = 0
+        call_count = []
 
         @asyncio.coroutine
         def test_coro():
             """Test Coro."""
-            global call_count
-            call_count += 1
+            call_count.append('call')
 
         for i in range(50):
             self.hass.add_job(test_coro())
 
         assert len(self.hass._pending_tasks) == 50
         self.hass.block_till_done()
-        assert call_count == 50
+        assert len(call_count) == 50
 
         self.hass.add_job(test_coro())
 
         assert len(self.hass._pending_tasks) == 1
         self.hass.block_till_done()
-        assert call_count == 51
+        assert len(call_count) == 51
 
 
 class TestEvent(unittest.TestCase):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -118,6 +118,43 @@ class TestHomeAssistant(unittest.TestCase):
 
     #     self.assertEqual(1, len(calls))
 
+    def test_async_add_job_pending_taks_add(self):
+        """Add a coro to pending tasks."""
+        have_call = False
+
+        @asyncio.coroutine
+        def test_coro():
+            """Test Coro."""
+            have_call = True
+
+        self.hass.add_job(test_coro())
+
+        assert len(self.hass._pending_tasks) == 1
+        self.hass.block_till_done()
+        assert have_call
+
+    def test_async_add_job_pending_taks_cleanup(self):
+        """Add a coro to pending tasks."""
+        call_count = 0
+
+        @asyncio.coroutine
+        def test_coro():
+            """Test Coro."""
+            call_count += 1
+
+        for i in range(50):
+            self.hass.add_job(test_coro())
+
+        assert len(self.hass._pending_tasks) == 50
+        self.hass.block_till_done()
+        assert call_count == 50
+
+        self.hass.add_job(test_coro())
+
+        assert len(self.hass._pending_tasks) == 1
+        self.hass.block_till_done()
+        assert call_count == 51
+
 
 class TestEvent(unittest.TestCase):
     """A Test Event class."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -125,6 +125,7 @@ class TestHomeAssistant(unittest.TestCase):
         @asyncio.coroutine
         def test_coro():
             """Test Coro."""
+            global have_call
             have_call = True
 
         self.hass.add_job(test_coro())
@@ -140,6 +141,7 @@ class TestHomeAssistant(unittest.TestCase):
         @asyncio.coroutine
         def test_coro():
             """Test Coro."""
+            global call_count
             call_count += 1
 
         for i in range(50):


### PR DESCRIPTION
**Description:**

As we start with threadpool replacement have we use WeakSet. We had now that could make a sigterm but we had to test it and found out, that can make a sigterm. So I replace that with a list and add a clear routine. I had also unittest for that stuff.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
