### PR TITLE
Add logging to platform/component setup

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -142,7 +142,7 @@ def _async_setup_component(hass: core.HomeAssistant,
         async_comp = hasattr(component, 'async_setup')
 
         try:
-            _LOGGER.info("Setup component %s", domain)
+            _LOGGER.info("Setting up %s", domain)
             if async_comp:
                 result = yield from component.async_setup(hass, config)
             else:

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 from types import ModuleType
 from typing import Any, Optional, Dict
 
-import async_timeout
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
@@ -143,12 +142,11 @@ def _async_setup_component(hass: core.HomeAssistant,
         async_comp = hasattr(component, 'async_setup')
 
         try:
-            with async_timeout.timeout(30, loop=hass.loop):
-                if async_comp:
-                    result = yield from component.async_setup(hass, config)
-                else:
-                    result = yield from hass.loop.run_in_executor(
-                        None, component.setup, hass, config)
+            if async_comp:
+                result = yield from component.async_setup(hass, config)
+            else:
+                result = yield from hass.loop.run_in_executor(
+                    None, component.setup, hass, config)
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception('Error during setup of component %s', domain)
             _async_persistent_notification(hass, domain, True)

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -142,6 +142,7 @@ def _async_setup_component(hass: core.HomeAssistant,
         async_comp = hasattr(component, 'async_setup')
 
         try:
+            _LOGGER.info("Setup component %s", domain)
             if async_comp:
                 result = yield from component.async_setup(hass, config)
             else:

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -138,6 +138,7 @@ class EntityComponent(object):
         entity_platform = self._platforms[key]
 
         try:
+            self.logger.info("Setup platform %s", platform_type)
             if getattr(platform, 'async_setup_platform', None):
                 yield from platform.async_setup_platform(
                     self.hass, platform_config,

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -138,7 +138,7 @@ class EntityComponent(object):
         entity_platform = self._platforms[key]
 
         try:
-            self.logger.info("Setup platform %s", platform_type)
+            self.logger.info("Setting up %s.%s", self.domain, platform_type)
             if getattr(platform, 'async_setup_platform', None):
                 yield from platform.async_setup_platform(
                     self.hass, platform_config,

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -1,8 +1,6 @@
 """Helpers for components that manage entities."""
 import asyncio
 
-import async_timeout
-
 from homeassistant import config as conf_util
 from homeassistant.bootstrap import (
     async_prepare_setup_platform, async_prepare_setup_component)
@@ -140,18 +138,16 @@ class EntityComponent(object):
         entity_platform = self._platforms[key]
 
         try:
-            with async_timeout.timeout(30, loop=self.hass.loop):
-                if getattr(platform, 'async_setup_platform', None):
-                    yield from platform.async_setup_platform(
-                        self.hass, platform_config,
-                        entity_platform.async_add_entities, discovery_info
-                    )
-                else:
-                    yield from self.hass.loop.run_in_executor(
-                        None, platform.setup_platform, self.hass,
-                        platform_config, entity_platform.add_entities,
-                        discovery_info
-                    )
+            if getattr(platform, 'async_setup_platform', None):
+                yield from platform.async_setup_platform(
+                    self.hass, platform_config,
+                    entity_platform.async_add_entities, discovery_info
+                )
+            else:
+                yield from self.hass.loop.run_in_executor(
+                    None, platform.setup_platform, self.hass, platform_config,
+                    entity_platform.add_entities, discovery_info
+                )
 
             self.hass.config.components.append(
                 '{}.{}'.format(self.domain, platform_type))


### PR DESCRIPTION
**Description:**

I see (on a wrong VM with bad network route) that a lot of component will block the hole setup/bootstrap while the setup block forever. Not all component or platform api have a timeout. So it sugest that homeassistant is blocking but a component setup block all stuff and we yield from. This timeout will protect the bootstrap from blocking with a bad component.

**EDIT**
With this info, we can see now on which component/platform hass hangs while the component/platform block hole bootstrap.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

