### PR TITLE
Improve async generic camera's error handling

### DIFF
--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -118,7 +118,7 @@ class GenericCamera(Camera):
             except asyncio.TimeoutError:
                 _LOGGER.error('Timeout getting camera image')
                 return self._last_image
-            except aiohttp.errors.ClientOSError as error:
+            except aiohttp.errors.ClientError as error:
                 _LOGGER.error('Error getting camera image: %s', error)
                 return self._last_image
 

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -118,6 +118,9 @@ class GenericCamera(Camera):
             except asyncio.TimeoutError:
                 _LOGGER.error('Timeout getting camera image')
                 return self._last_image
+            except aiohttp.errors.ClientOSError as error:
+                _LOGGER.error('Error getting camera image: %s', error)
+                return self._last_image
 
         self._last_url = url
         return self._last_image

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -91,7 +91,7 @@ class GenericCamera(Camera):
         if url == self._last_url and self._limit_refetch:
             return self._last_image
 
-        # aiohttp don't support DigestAuth jet
+        # aiohttp don't support DigestAuth yet
         if self._authentication == HTTP_DIGEST_AUTHENTICATION:
             def fetch():
                 """Read image from a URL."""
@@ -109,17 +109,16 @@ class GenericCamera(Camera):
         else:
             try:
                 with async_timeout.timeout(10, loop=self.hass.loop):
-                    respone = yield from self.hass.websession.get(
-                        url,
-                        auth=self._auth
-                    )
-                    self._last_image = yield from respone.read()
-                    yield from respone.release()
+                    response = yield from self.hass.websession.get(
+                        url, auth=self._auth)
+                    self._last_image = yield from response.read()
+                    yield from response.release()
             except asyncio.TimeoutError:
                 _LOGGER.error('Timeout getting camera image')
                 return self._last_image
-            except aiohttp.errors.ClientError as error:
-                _LOGGER.error('Error getting camera image: %s', error)
+            except (aiohttp.errors.ClientError,
+                    aiohttp.errors.ClientDisconnectedError) as err:
+                _LOGGER.error('Error getting new camera image: %s', err)
                 return self._last_image
 
         self._last_url = url

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -10,7 +10,7 @@ import logging
 from xml.parsers.expat import ExpatError
 
 import async_timeout
-from aiohttp.web import HTTPException
+import aiohttp
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -155,11 +155,8 @@ class YrData(object):
                 return
             text = yield from resp.text()
             self.hass.async_add_job(resp.release())
-        except asyncio.TimeoutError as err:
-            try_again(err)
-            return
-        except HTTPException as err:
-            resp.close()
+        except (asyncio.TimeoutError, aiohttp.errors.ClientError,
+                aiohttp.errors.ClientDisconnectedError) as err:
             try_again(err)
             return
 


### PR DESCRIPTION
**Description:**
Handle connection errors for generic camera in the async version similar to the non-async version (see line 103)

Logs currently fills with the following error:

```bash
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/aiohttp/server.py", line 261, in start
    yield from self.handle_request(message, payload)
  File "/usr/local/lib/python3.5/site-packages/aiohttp/web.py", line 88, in handle_request
    resp = yield from handler(request)
  File "/usr/src/app/homeassistant/components/http.py", line 495, in handle
    result = yield from result
  File "/usr/src/app/homeassistant/components/camera/__init__.py", line 187, in get
    response = yield from self.handle(request, camera)
  File "/usr/src/app/homeassistant/components/camera/__init__.py", line 205, in handle
    image = yield from camera.async_camera_image()
  File "/usr/src/app/homeassistant/components/camera/generic.py", line 114, in async_camera_image
    auth=self._auth
  File "/usr/local/lib/python3.5/site-packages/aiohttp/client.py", line 555, in __iter__
    resp = yield from self._coro
  File "/usr/local/lib/python3.5/site-packages/aiohttp/client.py", line 198, in _request
    conn = yield from self._connector.connect(req)
  File "/usr/local/lib/python3.5/site-packages/aiohttp/connector.py", line 314, in connect
    .format(key, exc.strerror)) from exc
aiohttp.errors.ClientOSError: [Errno 113] Cannot connect to host 192.168.88.90:80 ssl:False [Can not connect to 192.168.88.90:80 [No route to host]]
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
camera:
  - platform: generic
    still_image_url: http://192.168.88.90/cgi-bin/guest/Video.cgi?media=JPEG
    name: Gate
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
