### PR TITLE
Add more unittest for async_add_job

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -164,7 +164,7 @@ class TestHomeAssistant(unittest.TestCase):
             call_count.append('call')
 
         for i in range(40):
-            self.hass.add_job(test_executor())
+            self.hass.add_job(test_executor)
 
         assert len(self.hass._pending_tasks) == 40
         self.hass.block_till_done()
@@ -180,7 +180,7 @@ class TestHomeAssistant(unittest.TestCase):
             call_count.append('call')
 
         for i in range(40):
-            self.hass.add_job(test_callback())
+            self.hass.add_job(test_callback)
 
         assert len(self.hass._pending_tasks) == 0
         assert len(call_count) == 40

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -183,6 +183,7 @@ class TestHomeAssistant(unittest.TestCase):
             self.hass.add_job(test_callback)
 
         assert len(self.hass._pending_tasks) == 0
+        self.hass.block_till_done()
         assert len(call_count) == 40
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -118,7 +118,7 @@ class TestHomeAssistant(unittest.TestCase):
 
     #     self.assertEqual(1, len(calls))
 
-    def test_async_add_job_pending_taks_add(self):
+    def test_async_add_job_pending_tasks_add(self):
         """Add a coro to pending tasks."""
         call_count = []
 
@@ -133,8 +133,8 @@ class TestHomeAssistant(unittest.TestCase):
         self.hass.block_till_done()
         assert len(call_count) == 1
 
-    def test_async_add_job_pending_taks_cleanup(self):
-        """Add a coro to pending tasks."""
+    def test_async_add_job_pending_tasks_cleanup(self):
+        """Add a coro to pending tasks and test cleanup."""
         call_count = []
 
         @asyncio.coroutine
@@ -154,6 +154,36 @@ class TestHomeAssistant(unittest.TestCase):
         assert len(self.hass._pending_tasks) == 1
         self.hass.block_till_done()
         assert len(call_count) == 51
+
+    def test_async_add_job_pending_tasks_executor(self):
+        """Run a executor in pending tasks."""
+        call_count = []
+
+        def test_executor():
+            """Test executor."""
+            call_count.append('call')
+
+        for i in range(40):
+            self.hass.add_job(test_executor())
+
+        assert len(self.hass._pending_tasks) == 40
+        self.hass.block_till_done()
+        assert len(call_count) == 40
+
+    def test_async_add_job_pending_tasks_callback(self):
+        """Run a callback in pending tasks."""
+        call_count = []
+
+        @ha.callback
+        def test_callback():
+            """Test callback."""
+            call_count.append('call')
+
+        for i in range(40):
+            self.hass.add_job(test_callback())
+
+        assert len(self.hass._pending_tasks) == 0
+        assert len(call_count) == 40
 
 
 class TestEvent(unittest.TestCase):


### PR DESCRIPTION
**Description:**

I add more unittest for async_add_job to test all shedulable stuff. I know that @callback don't add a task but I think that should not be lazy since `call_soon` will execute it soon as possible and we block short with `block_till_done`. I fix also some spell from my first unittests.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
