### PR TITLE
Increase update delay

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -242,7 +242,7 @@ class Entity(object):
 
         end = timer()
 
-        if end - start > 0.2:
+        if end - start > 0.4:
             _LOGGER.warning('Updating state for %s took %.3f seconds. '
                             'Please report platform to the developers at '
                             'https://goo.gl/Nvioub', self.entity_id,


### PR DESCRIPTION
**Description:**
After more updates are coming in for #4210 it looks like we're a bit too strict with the delay as we're getting reports of sensors that are correct (time_date, template). Not sure what would make Python run that slow, it could be a bunch of extra threads and we'll have to look further into that too.

CC @lwis 

**Related issue (if applicable):** #4210
