### PR TITLE
Change pending task sheduler to time based cleanup

### DIFF
--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -128,6 +128,7 @@ class HomeAssistant(ha.HomeAssistant):
         self.loop.set_default_executor(self.executor)
         self.loop.set_exception_handler(self._async_exception_handler)
         self._pending_tasks = []
+        self._pending_sheduler = None
 
         self.bus = EventBus(remote_api, self)
         self.services = ha.ServiceRegistry(self.bus, self.add_job, self.loop)

--- a/tests/common.py
+++ b/tests/common.py
@@ -102,7 +102,8 @@ def async_test_home_assistant(loop):
     @asyncio.coroutine
     def mock_async_start():
         with patch.object(loop, 'add_signal_handler'), \
-             patch('homeassistant.core._async_create_timer'):
+             patch('homeassistant.core._async_create_timer'), \
+             patch.object(hass, '_async_tasks_cleanup', return_value=None):
             yield from orig_start()
 
     hass.async_start = mock_async_start


### PR DESCRIPTION
**Description:**

Use a time based sheduler to clear internal running task/future list.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

