### PR TITLE
Fix rest switch default template

### DIFF
--- a/homeassistant/components/switch/rest.py
+++ b/homeassistant/components/switch/rest.py
@@ -12,11 +12,12 @@ import voluptuous as vol
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_NAME, CONF_RESOURCE, CONF_TIMEOUT)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.template import Template
 
 CONF_BODY_OFF = 'body_off'
 CONF_BODY_ON = 'body_on'
-DEFAULT_BODY_OFF = 'OFF'
-DEFAULT_BODY_ON = 'ON'
+DEFAULT_BODY_OFF = Template('OFF')
+DEFAULT_BODY_ON = Template('ON')
 DEFAULT_NAME = 'REST Switch'
 DEFAULT_TIMEOUT = 10
 CONF_IS_ON_TEMPLATE = 'is_on_template'


### PR DESCRIPTION
**Description:**

Template now a object and not a string.

**Related issue (if applicable):** fixes #4330

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

