### PR TITLE
Add support for rgb light in flux led lights, fixes issue #4303

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -23,6 +23,7 @@ REQUIREMENTS = ['https://github.com/Danielhiversen/flux_led/archive/0.8.zip'
 _LOGGER = logging.getLogger(__name__)
 
 CONF_AUTOMATIC_ADD = 'automatic_add'
+ATTR_MODE = 'mode'
 
 DOMAIN = 'flux_led'
 
@@ -31,6 +32,8 @@ SUPPORT_FLUX_LED = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT |
 
 DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(ATTR_MODE, default='rgbw'):
+        vol.All(cv.string, vol.In(['rgbw', 'rgb'])),
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -48,6 +51,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         device = {}
         device['name'] = device_config[CONF_NAME]
         device['ipaddr'] = ipaddr
+        device[ATTR_MODE] = device_config[ATTR_MODE]
         light = FluxLight(device)
         if light.is_valid:
             lights.append(light)
@@ -65,6 +69,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if ipaddr in light_ips:
             continue
         device['name'] = device['id'] + " " + ipaddr
+        device[ATTR_MODE] = 'rgbw'
         light = FluxLight(device)
         if light.is_valid:
             lights.append(light)
@@ -82,6 +87,7 @@ class FluxLight(Light):
 
         self._name = device['name']
         self._ipaddr = device['ipaddr']
+        self._mode = device[ATTR_MODE]
         self.is_valid = True
         self._bulb = None
         try:
@@ -132,7 +138,11 @@ class FluxLight(Light):
         if rgb:
             self._bulb.setRgb(*tuple(rgb))
         elif brightness:
-            self._bulb.setWarmWhite255(brightness)
+            if self._mode == 'rgbw':
+                self._bulb.setWarmWhite255(brightness)
+            elif self._mode == 'rgb':
+                (red, green, blue) = self._bulb.getRgb()
+                self._bulb.setRgb(red, green, blue, brightness=brightness)
         elif effect == EFFECT_RANDOM:
             self._bulb.setRgb(random.randrange(0, 255),
                               random.randrange(0, 255),


### PR DESCRIPTION
**Description:**
Some flux led lights does not support white mode, and this will allow the user to specify the mode in the config.

**Related issue (if applicable):** fixes #4303

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1424

**Example entry for `configuration.yaml` (if applicable):**
```yaml
    192.168.1.10:
      name: NAME
      mode: "rgb"
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

