### PR TITLE
Don't fail if component name is None.

### DIFF
--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -77,7 +77,7 @@ def request_sensors():
     units = NETWORK.request('sensors/list')
     # One unit can contain many sensors.
     if units and 'sensor' in units:
-        return {unit['id']+sensor['name']: dict(unit, data=sensor)
+        return {unit['id']+str(sensor['name']): dict(unit, data=sensor)
                 for unit in units['sensor']
                 for sensor in unit['data']}
     return None
@@ -117,7 +117,7 @@ class TelldusLiveData(object):
 
     def _discover(self, found_devices, component_name):
         """Send discovery event if component not yet discovered."""
-        if not len(found_devices):
+        if not found_devices:
             return
 
         _LOGGER.info("discovered %d new %s devices",


### PR DESCRIPTION
**Description:**
Don't fail is sensor name is None - fixes https://github.com/home-assistant/home-assistant/issues/4326
Also, bool([]) == False

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

https://github.com/home-assistant/home-assistant/issues/4326

Might fix https://github.com/home-assistant/home-assistant/issues/4326