### PR TITLE
Use entity_id for backend, friendly name for frontend

### DIFF
--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -15,6 +15,9 @@ from homeassistant.const import (
     CONF_COMMAND_ON, CONF_COMMAND_STATE)
 import homeassistant.helpers.config_validation as cv
 
+DOMAIN = "switch"
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
 _LOGGER = logging.getLogger(__name__)
 
 SWITCH_SCHEMA = vol.Schema({
@@ -45,11 +48,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         switches.append(
             CommandSwitch(
                 hass,
+                device_name,
                 device_config.get(CONF_FRIENDLY_NAME, device_name),
                 device_config.get(CONF_COMMAND_ON),
                 device_config.get(CONF_COMMAND_OFF),
                 device_config.get(CONF_COMMAND_STATE),
-                value_template,
+                value_template
             )
         )
 
@@ -63,11 +67,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class CommandSwitch(SwitchDevice):
     """Representation a switch that can be toggled using shell commands."""
 
-    def __init__(self, hass, name, command_on, command_off,
-                 command_state, value_template):
+    def __init__(self, hass, device_name, friendly_name, command_on,
+                 command_off, command_state, value_template):
         """Initialize the switch."""
         self._hass = hass
-        self._name = name
+        self.entity_id = ENTITY_ID_FORMAT.format(device_name)
+        self._name = friendly_name
         self._state = False
         self._command_on = command_on
         self._command_off = command_off

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -9,14 +9,12 @@ import subprocess
 
 import voluptuous as vol
 
-from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA,
+                                             ENTITY_ID_FORMAT)
 from homeassistant.const import (
     CONF_FRIENDLY_NAME, CONF_SWITCHES, CONF_VALUE_TEMPLATE, CONF_COMMAND_OFF,
     CONF_COMMAND_ON, CONF_COMMAND_STATE)
 import homeassistant.helpers.config_validation as cv
-
-DOMAIN = "switch"
-ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +37,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     devices = config.get(CONF_SWITCHES, {})
     switches = []
 
-    for device_name, device_config in devices.items():
+    for object_id, device_config in devices.items():
         value_template = device_config.get(CONF_VALUE_TEMPLATE)
 
         if value_template is not None:
@@ -48,8 +46,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         switches.append(
             CommandSwitch(
                 hass,
-                device_name,
-                device_config.get(CONF_FRIENDLY_NAME, device_name),
+                object_id,
+                device_config.get(CONF_FRIENDLY_NAME, object_id),
                 device_config.get(CONF_COMMAND_ON),
                 device_config.get(CONF_COMMAND_OFF),
                 device_config.get(CONF_COMMAND_STATE),

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -65,11 +65,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class CommandSwitch(SwitchDevice):
     """Representation a switch that can be toggled using shell commands."""
 
-    def __init__(self, hass, device_name, friendly_name, command_on,
+    def __init__(self, hass, object_id, friendly_name, command_on,
                  command_off, command_state, value_template):
         """Initialize the switch."""
         self._hass = hass
-        self.entity_id = ENTITY_ID_FORMAT.format(device_name)
+        self.entity_id = ENTITY_ID_FORMAT.format(object_id)
         self._name = friendly_name
         self._state = False
         self._command_on = command_on

--- a/tests/components/switch/test_command_line.py
+++ b/tests/components/switch/test_command_line.py
@@ -162,16 +162,23 @@ class TestCommandSwitch(unittest.TestCase):
         """Test with state value."""
         self.hass = get_test_home_assistant()
 
-        # Set state command to false
-        statecmd = False
+        # args: hass, device_name, friendly_name, command_on, command_off,
+        #       command_state, value_template
+        init_args = [
+                self.hass,
+                "test_device_name",
+                "Test friendly name!",
+                "echo 'on command'",
+                "echo 'off command'",
+                False,
+                None
+        ]
 
-        no_state_device = command_line.CommandSwitch(self.hass, "Test", "echo",
-                                                     "echo", statecmd, None)
+        no_state_device = command_line.CommandSwitch(*init_args)
         self.assertTrue(no_state_device.assumed_state)
 
         # Set state command
-        statecmd = 'cat {}'
+        init_args[-2] = 'cat {}'
 
-        state_device = command_line.CommandSwitch(self.hass, "Test", "echo",
-                                                  "echo", statecmd, None)
+        state_device = command_line.CommandSwitch(*init_args)
         self.assertFalse(state_device.assumed_state)

--- a/tests/components/switch/test_command_line.py
+++ b/tests/components/switch/test_command_line.py
@@ -182,3 +182,21 @@ class TestCommandSwitch(unittest.TestCase):
 
         state_device = command_line.CommandSwitch(*init_args)
         self.assertFalse(state_device.assumed_state)
+
+    def test_entity_id_set_correctly(self):
+        """Test that entity_id is set correctly from object_id"""
+        self.hass = get_test_home_assistant()
+
+        init_args = [
+                self.hass,
+                "test_device_name",
+                "Test friendly name!",
+                "echo 'on command'",
+                "echo 'off command'",
+                False,
+                None
+        ]
+
+        test_switch = command_line.CommandSwitch(*init_args)
+        self.assertEqual(test_switch.entity_id, 'switch.test_device_name')
+        self.assertEqual(test_switch.name, 'Test friendly name!')


### PR DESCRIPTION
**Description:**

Use entity_id for backend, friendly name for frontend

Closes https://github.com/home-assistant/home-assistant/issues/3434

Command line switches had the option to set a `friendly_name` reportedly
for use in the front end. However, if set, it was also being used as the
`entity_id`.

This did not seem like obvious behavior to me. This PR changes the
behavior so the entity_id is the object_id, which must already be
unique, and is an obvious place to have a very predictable slug (even if
long or unsightly), and the friendly name (if set) is used for the
display.

Example:

```yaml
switch:
  platform: command_line
  switches:
    rf_kitchen_light_one:
      command_on: switch_command on kitchen
      command_off: switch_command off kitchen
      command_state: query_command kitchen
      value_template: '{{ value == "online" }}'
      friendly_name: "Beautiful bright kitchen light!"
```

If you were using in an automation or from dev tools, would use:
`switch.rf_kitchen_light_one`, but your front end would still show `Beautiful
bright kitchen light!`

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

https://github.com/home-assistant/home-assistant/issues/3434

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) <- this change better reflects current documentation

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass** <- in process, will update tomorrow
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51