### PR TITLE
Bettar handling of unknown sensor types

### DIFF
--- a/homeassistant/components/sensor/tellduslive.py
+++ b/homeassistant/components/sensor/tellduslive.py
@@ -109,7 +109,7 @@ class TelldusLiveSensor(Entity):
     def name(self):
         """Return the name of the sensor."""
         return "{} {}".format(self._sensor_name or DEVICE_DEFAULT_NAME,
-                              self.quantity_name)
+                              self.quantity_name or "")
 
     @property
     def available(self):
@@ -125,6 +125,8 @@ class TelldusLiveSensor(Entity):
             return self._value_as_humidity
         elif self._sensor_type == SENSOR_TYPE_LUMINANCE:
             return self._value_as_luminance
+        else:
+            return self._sensor_value
 
     @property
     def device_state_attributes(self):
@@ -139,14 +141,17 @@ class TelldusLiveSensor(Entity):
     @property
     def quantity_name(self):
         """Name of quantity."""
-        return SENSOR_TYPES[self._sensor_type][0]
+        return SENSOR_TYPES[self._sensor_type][0] \
+            if self._sensor_type in SENSOR_TYPES else None
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return SENSOR_TYPES[self._sensor_type][1]
+        return SENSOR_TYPES[self._sensor_type][1] \
+            if self._sensor_type in SENSOR_TYPES else None
 
     @property
     def icon(self):
         """Return the icon."""
-        return SENSOR_TYPES[self._sensor_type][2]
+        return SENSOR_TYPES[self._sensor_type][2] \
+            if self._sensor_type in SENSOR_TYPES else None

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -77,7 +77,8 @@ def request_sensors():
     units = NETWORK.request('sensors/list')
     # One unit can contain many sensors.
     if units and 'sensor' in units:
-        return {unit['id']+str(sensor['name']): dict(unit, data=sensor)
+        return {(unit['id'], sensor['name'], sensor['scale']):
+                dict(unit, data=sensor)
                 for unit in units['sensor']
                 for sensor in unit['data']}
     return None


### PR DESCRIPTION
**Description:**
Better handling (don't raise exception) for unknown sensor types.
Fixes https://github.com/home-assistant/home-assistant/issues/4326 (again).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

https://github.com/home-assistant/home-assistant/issues/4326

Might fix https://github.com/home-assistant/home-assistant/issues/4326