### PR TITLE
Allow configuring min/max temp for proliphix climate component

### DIFF
--- a/homeassistant/components/climate/proliphix.py
+++ b/homeassistant/components/climate/proliphix.py
@@ -15,11 +15,15 @@ import homeassistant.helpers.config_validation as cv
 REQUIREMENTS = ['proliphix==0.4.0']
 
 ATTR_FAN = 'fan'
+CONF_MIN_TEMP = 'min_temp'
+CONF_MAX_TEMP = 'max_temp'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_MAX_TEMP): vol.Coerce(float),
+    vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
 })
 
 
@@ -28,23 +32,27 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     host = config.get(CONF_HOST)
+    max_temp = config.get(CONF_MAX_TEMP)
+    min_temp = config.get(CONF_MIN_TEMP)
 
     import proliphix
 
     pdp = proliphix.PDP(host, username, password)
 
-    add_devices([ProliphixThermostat(pdp)])
+    add_devices([ProliphixThermostat(pdp, min_temp, max_temp)])
 
 
 class ProliphixThermostat(ClimateDevice):
     """Representation a Proliphix thermostat."""
 
-    def __init__(self, pdp):
+    def __init__(self, pdp, min_temp=None, max_temp=None):
         """Initialize the thermostat."""
         self._pdp = pdp
         # initial data
         self._pdp.update()
         self._name = self._pdp.name
+        self._min_temp = min_temp
+        self._max_temp = max_temp
 
     @property
     def should_poll(self):
@@ -92,6 +100,26 @@ class ProliphixThermostat(ClimateDevice):
             return STATE_HEAT
         elif state == 6:
             return STATE_COOL
+
+    @property
+    def min_temp(self):
+        """Return the minimum temperature."""
+        # pylint: disable=no-member
+        if self._min_temp:
+            return self._min_temp
+        else:
+            # get default temp from super class
+            return ClimateDevice.min_temp.fget(self)
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature."""
+        # pylint: disable=no-member
+        if self._max_temp:
+            return self._max_temp
+        else:
+            # Get default temp from super class
+            return ClimateDevice.max_temp.fget(self)
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""


### PR DESCRIPTION
The default 7 - 35 C range is really wide, and especially on mobile
makes setting the slider to make changes means you are using about 5%
of the real estate.

This allows for setting min_temp and max_temp in config much like is
done with generic thermostat to provide a custom range here.