### PR TITLE
make precision configurable in climate

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -362,6 +362,8 @@ def setup(hass, config):
 class ClimateDevice(Entity):
     """Representation of a climate device."""
 
+    _precision = None
+
     # pylint: disable=no-self-use
     @property
     def state(self):
@@ -560,6 +562,17 @@ class ClimateDevice(Entity):
         """Return the maximum humidity."""
         return 99
 
+    @property
+    def decimal_count(self):
+        """The precision of report temperatures."""
+        if self._precision is not None:
+            return self._precision
+        if self.unit_of_measurement is TEMP_CELSIUS:
+            return 1
+        else:
+            # Users of fahrenheit generally expect integer units.
+            return 0
+
     def _convert_for_display(self, temp):
         """Convert temperature into preferred units for display purposes."""
         if temp is None or not isinstance(temp, Number):
@@ -568,10 +581,4 @@ class ClimateDevice(Entity):
         value = convert_temperature(temp, self.temperature_unit,
                                     self.unit_of_measurement)
 
-        if self.unit_of_measurement is TEMP_CELSIUS:
-            decimal_count = 1
-        else:
-            # Users of fahrenheit generally expect integer units.
-            decimal_count = 0
-
-        return round(value, decimal_count)
+        return round(value, self.decimal_count)

--- a/homeassistant/components/climate/proliphix.py
+++ b/homeassistant/components/climate/proliphix.py
@@ -15,11 +15,13 @@ import homeassistant.helpers.config_validation as cv
 REQUIREMENTS = ['proliphix==0.4.0']
 
 ATTR_FAN = 'fan'
+CONF_PRECISION = 'precision'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_PRECISION): vol.Coerce(int),
 })
 
 
@@ -28,23 +30,25 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     host = config.get(CONF_HOST)
+    precision = config.get(CONF_PRECISION)
 
     import proliphix
 
     pdp = proliphix.PDP(host, username, password)
 
-    add_devices([ProliphixThermostat(pdp)])
+    add_devices([ProliphixThermostat(pdp, precision)])
 
 
 class ProliphixThermostat(ClimateDevice):
     """Representation a Proliphix thermostat."""
 
-    def __init__(self, pdp):
+    def __init__(self, pdp, precision=None):
         """Initialize the thermostat."""
         self._pdp = pdp
         # initial data
         self._pdp.update()
         self._name = self._pdp.name
+        self._precision = precision
 
     @property
     def should_poll(self):


### PR DESCRIPTION
WIP patch to make configuring precision be a more concrete discussion.

This is an attempt to make the climate precision configurable, and
using the proliphix component to demonstrate how a component would
override this.

Up for discussion, as I'd really like to see a way to get back my 0.1
precision on F components.

Addresses issue #4346