### PR TITLE
Hotfix deadlock on platform setup

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -294,8 +294,12 @@ class EntityPlatform(object):
 
     def add_entities(self, new_entities, update_before_add=False):
         """Add entities for a single platform."""
+        if update_before_add:
+            for entity in new_entities:
+                entity.update()
+
         run_coroutine_threadsafe(
-            self.async_add_entities(list(new_entities), update_before_add),
+            self.async_add_entities(list(new_entities), False),
             self.component.hass.loop
         ).result()
 

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -153,6 +153,30 @@ class TestHelpersEntityComponent(unittest.TestCase):
         assert 1 == len(self.hass.states.entity_ids())
         assert not ent.update.called
 
+    def test_adds_entities_with_update_befor_add_true_deadlock_protect(self):
+        """Test if call update befor add to state machine.
+
+        It need to run update inside executor and never call
+        async_add_entities with True
+        """
+        call = []
+        component = EntityComponent(_LOGGER, DOMAIN, self.hass)
+
+        @asyncio.coroutine
+        def async_add_entities_fake(entities, update_befor_add):
+            """Fake add_entities_call."""
+            call.append(update_befor_add)
+        component._platforms['core'].async_add_entities = \
+            async_add_entities_fake
+
+        ent = EntityTest()
+        ent.update = Mock(spec_set=True)
+        component.add_entities([ent], True)
+
+        assert ent.update.called
+        assert len(call) == 1
+        assert not call[0]
+
     def test_not_adding_duplicate_entities(self):
         """Test for not adding duplicate entities."""
         component = EntityComponent(_LOGGER, DOMAIN, self.hass)

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -1,5 +1,6 @@
 """The tests for the Entity component helper."""
 # pylint: disable=protected-access
+import asyncio
 from collections import OrderedDict
 import logging
 import unittest


### PR DESCRIPTION
**Description:**

Fix a possible Deadlock, if you use `update_before_add` in a executor. Since it possible that we setup more than 15 platform at once and if they will run in a executor and call `add_devices` it block all this executors. So if we call later update inside loop with a new executor, we had a deadlock.

It is not allow to call a function from executor to inside loop they will make a new executor. That is deadlock dangeres.

I also add  unittest they will protect this for future changes.

Fixes #4361

**EDIT**
It is analog to https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/helpers/entity.py#L176-L188 but It transform to this component.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

