### PR TITLE
WIP: Convert switch/sensor/binary/cover/notify for all command line platform

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -4,6 +4,7 @@ Component to interface with binary sensors.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor/
 """
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -39,12 +40,13 @@ SENSOR_CLASSES = [
 SENSOR_CLASSES_SCHEMA = vol.All(vol.Lower, vol.In(SENSOR_CLASSES))
 
 
-def setup(hass, config):
+@asyncio.coroutine
+def async_setup(hass, config):
     """Track states and offer events for binary sensors."""
     component = EntityComponent(
         logging.getLogger(__name__), DOMAIN, hass, SCAN_INTERVAL)
 
-    component.setup(config)
+    yield from component.async_setup(config)
 
     return True
 

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -94,8 +94,8 @@ def async_setup(hass, config):
                 yield from switch.async_update_ha_state(True)
 
     descriptions = yield from hass.loop.run_in_executor(
-        None, load_yaml_config_file(os.path.join(
-            os.path.dirname(__file__), 'services.yaml')))
+        None, load_yaml_config_file, os.path.join(
+            os.path.dirname(__file__), 'services.yaml'))
 
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_OFF, async_handle_switch_service,

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -4,6 +4,7 @@ Component to interface with various switches that can be controlled remotely.
 For more details about this component, please refer to the documentation
 at https://home-assistant.io/components/switch/
 """
+import asyncio
 from datetime import timedelta
 import logging
 import os
@@ -69,38 +70,40 @@ def toggle(hass, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_TOGGLE, data)
 
 
-def setup(hass, config):
+@asyncio.coroutine
+def async_setup(hass, config):
     """Track states and offer events for switches."""
     component = EntityComponent(
         _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_SWITCHES)
-    component.setup(config)
+    yield from component.async_setup(config)
 
-    def handle_switch_service(service):
+    @asyncio.coroutine
+    def asnyc_handle_switch_service(service):
         """Handle calls to the switch services."""
-        target_switches = component.extract_from_service(service)
+        target_switches = component.async_extract_from_service(service)
 
         for switch in target_switches:
             if service.service == SERVICE_TURN_ON:
-                switch.turn_on()
+                yield from switch.async_turn_on()
             elif service.service == SERVICE_TOGGLE:
-                switch.toggle()
+                yield from switch.async_toggle()
             else:
-                switch.turn_off()
+                yield from switch.async_turn_off()
 
             if switch.should_poll:
-                switch.update_ha_state(True)
+                switch.async_update_ha_state(True)
 
-    descriptions = load_yaml_config_file(
-        os.path.join(os.path.dirname(__file__), 'services.yaml'))
-    hass.services.register(DOMAIN, SERVICE_TURN_OFF, handle_switch_service,
-                           descriptions.get(SERVICE_TURN_OFF),
-                           schema=SWITCH_SERVICE_SCHEMA)
-    hass.services.register(DOMAIN, SERVICE_TURN_ON, handle_switch_service,
-                           descriptions.get(SERVICE_TURN_ON),
-                           schema=SWITCH_SERVICE_SCHEMA)
-    hass.services.register(DOMAIN, SERVICE_TOGGLE, handle_switch_service,
-                           descriptions.get(SERVICE_TOGGLE),
-                           schema=SWITCH_SERVICE_SCHEMA)
+    descriptions = hass.loop.run_in_executor(None, load_yaml_config_file(
+        os.path.join(os.path.dirname(__file__), 'services.yaml')))
+    hass.services.async_register(
+        DOMAIN, SERVICE_TURN_OFF, async_handle_switch_service,
+        descriptions.get(SERVICE_TURN_OFF), schema=SWITCH_SERVICE_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_TURN_ON, async_handle_switch_service,
+        descriptions.get(SERVICE_TURN_ON), schema=SWITCH_SERVICE_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_TOGGLE, async_handle_switch_service,
+        descriptions.get(SERVICE_TOGGLE), schema=SWITCH_SERVICE_SCHEMA)
 
     return True
 

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -91,10 +91,12 @@ def async_setup(hass, config):
                 yield from switch.async_turn_off()
 
             if switch.should_poll:
-                switch.async_update_ha_state(True)
+                yield from switch.async_update_ha_state(True)
 
-    descriptions = hass.loop.run_in_executor(None, load_yaml_config_file(
-        os.path.join(os.path.dirname(__file__), 'services.yaml')))
+    descriptions = yield from hass.loop.run_in_executor(
+        None, load_yaml_config_file(os.path.join(
+            os.path.dirname(__file__), 'services.yaml')))
+
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_OFF, async_handle_switch_service,
         descriptions.get(SERVICE_TURN_OFF), schema=SWITCH_SERVICE_SCHEMA)

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -78,7 +78,7 @@ def async_setup(hass, config):
     yield from component.async_setup(config)
 
     @asyncio.coroutine
-    def asnyc_handle_switch_service(service):
+    def async_handle_switch_service(service):
         """Handle calls to the switch services."""
         target_switches = component.async_extract_from_service(service)
 

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -161,15 +161,15 @@ class CommandSwitch(SwitchDevice):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the device on."""
-        ret = yield from CommandSwitch._switch(self._command_on)
-        if (ret and not self._command_state):
+        ret = yield from CommandSwitch._async_switch(self._command_on)
+        if ret and not self._command_state:
             self._state = True
-            self.update_ha_state()
+            yield from self.async_update_ha_state()
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the device off."""
-        ret = yield from CommandSwitch._switch(self._command_off)
-        if (ret and not self._command_state):
+        ret = yield from CommandSwitch._async_switch(self._command_off)
+        if ret and not self._command_state:
             self._state = False
-            self.update_ha_state()
+            yield from self.async_update_ha_state()

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -151,7 +151,7 @@ class CommandSwitch(SwitchDevice):
         if not self._command_state:
             return
 
-        payload = str(yield from self._async_query_state())
+        payload = yield from self._async_query_state()
         if not self._value_template:
             self._state = (payload.lower() == "true")
 

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -68,7 +68,7 @@ class CommandSwitch(SwitchDevice):
     def __init__(self, hass, name, command_on, command_off,
                  command_state, value_template):
         """Initialize the switch."""
-        self._hass = hass
+        self.hass = hass
         self._name = name
         self._state = False
         self._command_on = command_on
@@ -82,7 +82,10 @@ class CommandSwitch(SwitchDevice):
         _LOGGER.info('Running command: %s', command)
 
         proc = yield from asyncio.create_subprocess_shell(
-            command, loop=self.hass.loop)
+            command, stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL, loop=self.hass.loop
+        )
         success = (yield from proc.wait()) == 0
 
         if not success:
@@ -96,7 +99,8 @@ class CommandSwitch(SwitchDevice):
         _LOGGER.info('Running state command: %s', command)
 
         proc = yield from asyncio.create_subprocess_shell(
-            command, loop=self.hass.loop, stdout=asyncio.subprocess.PIPE)
+            command, loop=self.hass.loop, stdout=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.DEVNULL, sterr=asyncio.subprocess.DEVNULL)
         return_value, _ = yield from proc.communicate()
         return return_value.strip().decode('utf-8')
 
@@ -105,7 +109,10 @@ class CommandSwitch(SwitchDevice):
         """Execute state command for return code."""
         _LOGGER.info('Running state command: %s', command)
         proc = yield from asyncio.create_subprocess_shell(
-            command, loop=self.hass.loop)
+            command, stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL, loop=self.hass.loop
+        )
         return (yield from proc.wait()) == 0
 
     @property

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -4,13 +4,13 @@ Support for custom shell commands to turn a switch on/off.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.command_line/
 """
-import asyncio
 import logging
 import subprocess
 
 import voluptuous as vol
 
-from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA,
+                                             ENTITY_ID_FORMAT)
 from homeassistant.const import (
     CONF_FRIENDLY_NAME, CONF_SWITCHES, CONF_VALUE_TEMPLATE, CONF_COMMAND_OFF,
     CONF_COMMAND_ON, CONF_COMMAND_STATE)
@@ -32,13 +32,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 # pylint: disable=unused-argument
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return switches controlled by shell commands."""
     devices = config.get(CONF_SWITCHES, {})
     switches = []
 
-    for device_name, device_config in devices.items():
+    for object_id, device_config in devices.items():
         value_template = device_config.get(CONF_VALUE_TEMPLATE)
 
         if value_template is not None:
@@ -47,11 +46,12 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         switches.append(
             CommandSwitch(
                 hass,
-                device_config.get(CONF_FRIENDLY_NAME, device_name),
+                object_id,
+                device_config.get(CONF_FRIENDLY_NAME, object_id),
                 device_config.get(CONF_COMMAND_ON),
                 device_config.get(CONF_COMMAND_OFF),
                 device_config.get(CONF_COMMAND_STATE),
-                value_template,
+                value_template
             )
         )
 
@@ -59,61 +59,52 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         _LOGGER.error("No switches added")
         return False
 
-    yield from async_add_devices(switches)
+    add_devices(switches)
 
 
 class CommandSwitch(SwitchDevice):
     """Representation a switch that can be toggled using shell commands."""
 
-    def __init__(self, hass, name, command_on, command_off,
-                 command_state, value_template):
+    def __init__(self, hass, object_id, friendly_name, command_on,
+                 command_off, command_state, value_template):
         """Initialize the switch."""
-        self.hass = hass
-        self._name = name
+        self._hass = hass
+        self.entity_id = ENTITY_ID_FORMAT.format(object_id)
+        self._name = friendly_name
         self._state = False
         self._command_on = command_on
         self._command_off = command_off
         self._command_state = command_state
         self._value_template = value_template
 
-    @asyncio.coroutine
-    def _async_switch(self, command):
+    @staticmethod
+    def _switch(command):
         """Execute the actual commands."""
         _LOGGER.info('Running command: %s', command)
 
-        proc = yield from asyncio.create_subprocess_shell(
-            command, stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL, loop=self.hass.loop
-        )
-        success = (yield from proc.wait()) == 0
+        success = (subprocess.call(command, shell=True) == 0)
 
         if not success:
             _LOGGER.error('Command failed: %s', command)
 
         return success
 
-    @asyncio.coroutine
-    def _async_query_state_value(self, command):
+    @staticmethod
+    def _query_state_value(command):
         """Execute state command for return value."""
         _LOGGER.info('Running state command: %s', command)
 
-        proc = yield from asyncio.create_subprocess_shell(
-            command, loop=self.hass.loop, stdout=asyncio.subprocess.PIPE,
-            stdin=asyncio.subprocess.DEVNULL, sterr=asyncio.subprocess.DEVNULL)
-        return_value, _ = yield from proc.communicate()
-        return return_value.strip().decode('utf-8')
+        try:
+            return_value = subprocess.check_output(command, shell=True)
+            return return_value.strip().decode('utf-8')
+        except subprocess.CalledProcessError:
+            _LOGGER.error('Command failed: %s', command)
 
-    @asyncio.coroutine
-    def _async_query_state_code(self, command):
+    @staticmethod
+    def _query_state_code(command):
         """Execute state command for return code."""
         _LOGGER.info('Running state command: %s', command)
-        proc = yield from asyncio.create_subprocess_shell(
-            command, stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL, loop=self.hass.loop
-        )
-        return (yield from proc.wait()) == 0
+        return subprocess.call(command, shell=True) == 0
 
     @property
     def should_poll(self):
@@ -135,47 +126,34 @@ class CommandSwitch(SwitchDevice):
         """Return true if we do optimistic updates."""
         return self._command_state is False
 
-    @asyncio.coroutine
-    def _async_query_state(self):
+    def _query_state(self):
         """Query for state."""
         if not self._command_state:
             _LOGGER.error('No state command specified')
             return
-
         if self._value_template:
-            ret = yield from self._async_query_state_value(
-                self._command_state)
-            return ret
+            return CommandSwitch._query_state_value(self._command_state)
+        return CommandSwitch._query_state_code(self._command_state)
 
-        ret = yield from self._async_query_state_code(
-            self._command_state)
-        return ret
-
-    @asyncio.coroutine
-    def async_update(self):
+    def update(self):
         """Update device state."""
-        if not self._command_state:
-            return
-
-        payload = yield from self._async_query_state()
-        if not self._value_template:
+        if self._command_state:
+            payload = str(self._query_state())
+            if self._value_template:
+                payload = self._value_template.render_with_possible_json_value(
+                    payload)
             self._state = (payload.lower() == "true")
 
-        payload = self._value_template.async_render_with_possible_json_value(
-            payload)
-
-    @asyncio.coroutine
-    def async_turn_on(self, **kwargs):
+    def turn_on(self, **kwargs):
         """Turn the device on."""
-        ret = yield from self._async_switch(self._command_on)
-        if ret and not self._command_state:
+        if (CommandSwitch._switch(self._command_on) and
+                not self._command_state):
             self._state = True
-            yield from self.async_update_ha_state()
+            self.update_ha_state()
 
-    @asyncio.coroutine
-    def async_turn_off(self, **kwargs):
+    def turn_off(self, **kwargs):
         """Turn the device off."""
-        ret = yield from self._async_switch(self._command_off)
-        if ret and not self._command_state:
+        if (CommandSwitch._switch(self._command_off) and
+                not self._command_state):
             self._state = False
-            yield from self.async_update_ha_state()
+            self.update_ha_state()

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -330,7 +330,8 @@ class ToggleEntity(Entity):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the entity on."""
-        self.hass.run_in_executor(None, ft.partial(self.turn_on, **kwargs))
+        yield from self.hass.run_in_executor(
+            None, ft.partial(self.turn_on, **kwargs))
 
     def turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
@@ -339,7 +340,8 @@ class ToggleEntity(Entity):
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the entity off."""
-        self.hass.run_in_executor(None, ft.partial(self.turn_off, **kwargs))
+        yield from self.hass.run_in_executor(
+            None, ft.partial(self.turn_off, **kwargs))
 
     def toggle(self) -> None:
         """Toggle the entity."""

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -1,6 +1,7 @@
 """An abstract class for entities."""
 import asyncio
 import logging
+import functools as ft
 from timeit import default_timer as timer
 
 from typing import Any, Optional, List, Dict
@@ -324,23 +325,21 @@ class ToggleEntity(Entity):
 
     def turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
-        run_coroutine_threadsafe(self.async_turn_on(**kwargs),
-                                 self.hass.loop).result()
+        raise NotImplementedError()
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the entity on."""
-        raise NotImplementedError()
+        self.hass.run_in_executor(None, ft.partial(self.turn_on, **kwargs))
 
     def turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
-        run_coroutine_threadsafe(self.async_turn_off(**kwargs),
-                                 self.hass.loop).result()
+        raise NotImplementedError()
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the entity off."""
-        raise NotImplementedError()
+        self.hass.run_in_executor(None, ft.partial(self.turn_off, **kwargs))
 
     def toggle(self) -> None:
         """Toggle the entity."""

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -330,7 +330,7 @@ class ToggleEntity(Entity):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the entity on."""
-        yield from self.hass.run_in_executor(
+        yield from self.hass.loop.run_in_executor(
             None, ft.partial(self.turn_on, **kwargs))
 
     def turn_off(self, **kwargs) -> None:
@@ -340,7 +340,7 @@ class ToggleEntity(Entity):
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the entity off."""
-        yield from self.hass.run_in_executor(
+        yield from self.hass.loop.run_in_executor(
             None, ft.partial(self.turn_off, **kwargs))
 
     def toggle(self) -> None:

--- a/tests/components/switch/test_command_line.py
+++ b/tests/components/switch/test_command_line.py
@@ -165,13 +165,13 @@ class TestCommandSwitch(unittest.TestCase):
         # Set state command to false
         statecmd = False
 
-        no_state_device = command_line.CommandSwitch(self.hass, "Test", "echo",
-                                                     "echo", statecmd, None)
+        no_state_device = command_line.CommandSwitch(
+            self.hass, None, "Test", "echo", "echo", statecmd, None)
         self.assertTrue(no_state_device.assumed_state)
 
         # Set state command
         statecmd = 'cat {}'
 
-        state_device = command_line.CommandSwitch(self.hass, "Test", "echo",
-                                                  "echo", statecmd, None)
+        state_device = command_line.CommandSwitch(
+            self.hass, None, "Test", "echo", "echo", statecmd, None)
         self.assertFalse(state_device.assumed_state)


### PR DESCRIPTION
**Description:**

Convert  switch/sensor/binary/cover/notify device object and component to async. So I can convert command line (subprocess) stuff to asyncio version.


If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

