### PR TITLE
Adding support for WOL to Panasonic Viera component

### DIFF
--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -24,7 +24,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Panasonic Viera TV'
 DEFAULT_PORT = 55000
-DEFAULT_MAC = ""
 
 SUPPORT_VIERATV = SUPPORT_PAUSE | SUPPORT_VOLUME_STEP | \
     SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
@@ -35,7 +34,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_MAC, default=DEFAULT_MAC): cv.string,
+    vol.Optional(CONF_MAC): cv.string,
 })
 
 

--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -136,6 +136,7 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
         return SUPPORT_VIERATV
 
     def turn_on(self):
+        """Turn ON the media player."""
         if self._mac:
             self._wol.send_magic_packet(self._mac)
             self.update()

--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.panasonic_viera/
 """
 import logging
-import platform
 
 import voluptuous as vol
 
@@ -14,7 +13,8 @@ from homeassistant.components.media_player import (
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP, MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN, CONF_PORT, CONF_MAC)
+    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN, CONF_PORT,
+    CONF_MAC)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['panasonic_viera==0.2',
@@ -29,7 +29,7 @@ DEFAULT_MAC = ""
 SUPPORT_VIERATV = SUPPORT_PAUSE | SUPPORT_VOLUME_STEP | \
     SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
     SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK | \
-    SUPPORT_TURN_OFF | SUPPORT_TURN_ON 
+    SUPPORT_TURN_OFF | SUPPORT_TURN_ON
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -46,7 +46,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     name = config.get(CONF_NAME)
     port = config.get(CONF_PORT)
-    mac  = config.get(CONF_MAC)
+    mac = config.get(CONF_MAC)
 
     if discovery_info:
         _LOGGER.debug('%s', discovery_info)
@@ -136,7 +136,7 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
         return SUPPORT_VIERATV
 
     def turn_on(self):
-        if self._mac :
+        if self._mac:
             self._wol.send_magic_packet(self._mac)
             self.update()
 

--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -5,33 +5,37 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.panasonic_viera/
 """
 import logging
+import platform
 
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
+    SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP, MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN, CONF_PORT)
+    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN, CONF_PORT, CONF_MAC)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['panasonic_viera==0.2']
+REQUIREMENTS = ['panasonic_viera==0.2',
+                'wakeonlan==0.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Panasonic Viera TV'
 DEFAULT_PORT = 55000
+DEFAULT_MAC = ""
 
 SUPPORT_VIERATV = SUPPORT_PAUSE | SUPPORT_VOLUME_STEP | \
     SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
     SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK | \
-    SUPPORT_TURN_OFF
+    SUPPORT_TURN_OFF | SUPPORT_TURN_ON 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_MAC, default=DEFAULT_MAC): cv.string,
 })
 
 
@@ -42,6 +46,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     name = config.get(CONF_NAME)
     port = config.get(CONF_PORT)
+    mac  = config.get(CONF_MAC)
 
     if discovery_info:
         _LOGGER.debug('%s', discovery_info)
@@ -51,7 +56,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
         host = vals[0]
         remote = RemoteControl(host, port)
-        add_devices([PanasonicVieraTVDevice(name, remote)])
+        add_devices([PanasonicVieraTVDevice(name, remote, mac)])
         return True
 
     host = config.get(CONF_HOST)
@@ -64,22 +69,27 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                       host, port, error)
         return False
 
-    add_devices([PanasonicVieraTVDevice(name, remote)])
+    add_devices([PanasonicVieraTVDevice(name, remote, mac)])
     return True
 
 
 class PanasonicVieraTVDevice(MediaPlayerDevice):
     """Representation of a Panasonic Viera TV."""
 
-    def __init__(self, name, remote):
+    def __init__(self, name, remote, mac_address):
         """Initialize the Panasonic device."""
         # Save a reference to the imported class
+
+        from wakeonlan import wol
+
         self._name = name
         self._muted = False
         self._playing = True
         self._state = STATE_UNKNOWN
         self._remote = remote
         self._volume = 0
+        self._wol = wol
+        self._mac = mac_address
 
     def update(self):
         """Retrieve the latest data."""
@@ -124,6 +134,11 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
     def supported_media_commands(self):
         """Flag of media commands that are supported."""
         return SUPPORT_VIERATV
+
+    def turn_on(self):
+        if self._mac :
+            self._wol.send_magic_packet(self._mac)
+            self.update()
 
     def turn_off(self):
         """Turn off media player."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -66,6 +66,9 @@ boto3==1.3.1
 coinmarketcap==2.0.1
 
 # homeassistant.scripts.check_config
+colorama<=1
+
+# homeassistant.scripts.check_config
 colorlog>2.1,<3
 
 # homeassistant.components.alarm_control_panel.concord232
@@ -548,6 +551,7 @@ vsure==0.11.1
 # homeassistant.components.sensor.vasttrafik
 vtjp==0.1.11
 
+# homeassistant.components.media_player.panasonic_viera
 # homeassistant.components.switch.wake_on_lan
 wakeonlan==0.2.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -66,9 +66,6 @@ boto3==1.3.1
 coinmarketcap==2.0.1
 
 # homeassistant.scripts.check_config
-colorama<=1
-
-# homeassistant.scripts.check_config
 colorlog>2.1,<3
 
 # homeassistant.components.alarm_control_panel.concord232


### PR DESCRIPTION
**Description:**
Adding support for WOL on Panasonic Viera

Based on information of my local Panasonic Support office I've manage to turn on Panasonic Viera AS750E via WOL magic packet. Following configuration must be made on the TV:

`Menu -> Network -> TV Remote APP Settings -> Networked Standby -> On`

Also based on the information provided from Panasonic Support this must work on many models released 2014/2015 and at most of the models released 2016

**Example entry for `configuration.yaml` (if applicable):**
```yaml
media_player:
  - platform: panasonic_viera
    host: 192.168.1.169
    mac: "20.C6.EB.E9.0F.72"
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) - in progress

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`. - no new files