### PR TITLE
device_tracker.see should not call async methods

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -242,7 +242,7 @@ class DeviceTracker(object):
             if device.track:
                 device.update_ha_state()
 
-            self.hass.bus.async_fire(EVENT_NEW_DEVICE, device)
+            self.hass.bus.fire(EVENT_NEW_DEVICE, device)
 
             # During init, we ignore the group
             if self.group is not None:


### PR DESCRIPTION
**Description:**
The device_tracker `see` method that is passed into platforms is not async friendly. However it was making 1 call to a method that was async. This PR fixes it.

Reported by @bbangert on Gitter. http://paste.ofcode.org/329QM5hKqd3RGCZcMq2EEBu