### PR TITLE
Do not serve HTTP requests while stopping

### DIFF
--- a/homeassistant/components/http.py
+++ b/homeassistant/components/http.py
@@ -461,6 +461,9 @@ def request_handler_factory(view, handler):
     @asyncio.coroutine
     def handle(request):
         """Handle incoming request."""
+        if not view.hass.is_running:
+            return web.Response(status=503)
+
         remote_addr = view.hass.http.get_real_ip(request)
 
         # Auth code verbose on purpose


### PR DESCRIPTION
**Description:**
Prevent web requests from being handled when we're closing HASS.

Handling web requests was preventing Home Assistant from closing if a browser window was open. We correctly close all requests when we fire a HOMEASSISTANT_STOP event, however the Polymer UI will try to reconnect to the event stream when the stream gets cancelled (which happened on stop), preventing HASS from being done as it wouldn't try to cancel more ongoing connections.

Now it will return a `503 Service Unavailable` when trying to connect to HASS while it is stopping
