### PR TITLE
notify.html5: decode bytes values in registration data

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -141,11 +141,23 @@ def _load_config(filename):
         return None
 
 
+class JSONBytesDecoder(json.JSONEncoder):
+    """JSONEncoder to decode bytes objects to unicode."""
+
+    # pylint: disable=method-hidden
+    def default(self, obj):
+        """Decode object if it's a bytes object, else defer to baseclass."""
+        if isinstance(obj, bytes):
+            return obj.decode()
+        return json.JSONEncoder.default(self, obj)
+
+
 def _save_config(filename, config):
     """Save configuration."""
     try:
         with open(filename, 'w') as fdesc:
-            fdesc.write(json.dumps(config))
+            fdesc.write(json.dumps(
+                config, cls=JSONBytesDecoder, indent=4, sort_keys=True))
     except (IOError, TypeError) as error:
         _LOGGER.error('Saving config file failed: %s', error)
         return False


### PR DESCRIPTION
**Description:**

Occassionally the values of `keys` and `p256h` are bytes objects instead of
strings. As JSON by default does not serialize bytes objects let's decode
bytes objects to unicode strings.

Resolves the registration issue mentioned in #4012.

Signed-off-by: Martin Weinelt <hexa@darmstadt.ccc.de>


**Related issue (if applicable):** partially fixes #4012

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

