### PR TITLE
support for last will and birth message for mqtt

### DIFF
--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -227,6 +227,8 @@ class TestMQTTCallbacks(unittest.TestCase):
             assert setup_component(self.hass, mqtt.DOMAIN, {
                 mqtt.DOMAIN: {
                     mqtt.CONF_BROKER: 'mock-broker',
+                    mqtt.CONF_BIRTH_MESSAGE: {mqtt.ATTR_TOPIC: 'birth',
+                                              mqtt.ATTR_PAYLOAD: 'birth'}
                 }
             })
 
@@ -290,6 +292,12 @@ class TestMQTTCallbacks(unittest.TestCase):
             2: 'topic/test',
             3: 'home/sensor',
         }, mqtt.MQTT_CLIENT.progress)
+
+    def test_mqtt_birth_message_on_connect(self):
+        """Test birth message on connect."""
+        mqtt.MQTT_CLIENT._mqtt_on_connect(None, None, 0, 0)
+        mqtt.MQTT_CLIENT._mqttc.publish.assert_called_with('birth', 'birth', 0,
+                                                           False)
 
     def test_mqtt_disconnect_tries_no_reconnect_on_stop(self):
         """Test the disconnect tries."""


### PR DESCRIPTION
**Description:**
This PR is based on work done by @renekliment (PR #1316). 

It adds support for last will and birth message for the mqtt platform.

**Example entry for `configuration.yaml` (if applicable):**
```yaml
broker: localhost
port: 1883
client_id: home-assistant
keepalive: 60
username: hass
password: password
birth_message:
  topic: 'hass/status'
  payload: 'online'
  qos: 1
  retain: true
will_message:
  topic: 'hass/status'
  payload: 'offline'
  qos: 1
  retain: true
```