### PR TITLE
Faster async entity update on component.

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -377,7 +377,8 @@ class EntityPlatform(object):
 
                 update_coro = entity.async_update_ha_state(True)
                 if hasattr(entity, 'async_update'):
-                    tasks.append(update_coro)
+                    tasks.append(
+                        self.component.hass.loop.create_task(update_coro))
                 else:
                     to_update.append(update_coro)
 


### PR DESCRIPTION
**Description:**

I impove the update flow. The old stuff have first update all None async stuff and shedule the async stuff at once and wait. Now it shedule all async stuff and run the None async updates and wait until async stuff is done. So we can use the time between sequence updates to task the async updates.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

