### PR TITLE
Pin versions on linters for tests

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,10 @@
-flake8>=3.0.4
-pylint>=1.5.6
+# linters such as flake8 and pylint should be pinned, as new releases
+# make new things fail. Manually update these pins when pulling in a
+# new version
+flake8==3.0.4
+pylint==1.6.4
+mypy-lang==0.4.5
+pydocstyle==1.1.1
 coveralls>=1.1
 pytest>=2.9.2
 pytest-aiohttp>=0.1.3
@@ -7,7 +12,5 @@ pytest-asyncio>=0.5.0
 pytest-cov>=2.3.1
 pytest-timeout>=1.0.0
 pytest-catchlog>=1.2.2
-pydocstyle>=1.0.0
 requests_mock>=1.0
-mypy-lang>=0.4
 mock-open>=1.3.1


### PR DESCRIPTION
The linters really need to specify an exact version, because when
either flake8 or pylint release a new version, a whole lot of new
issues are caught, causing failures on the code unrelated to the
patches being pushed.

Pinning is a best practice for linters. This allows patches which move
forward the linter version to happen with any code fixes required for
it to pass.