### PR TITLE
Fix device tracker sending invalid event data

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -31,7 +31,7 @@ from homeassistant.util.yaml import dump
 from homeassistant.helpers.event import track_utc_time_change
 from homeassistant.const import (
     ATTR_GPS_ACCURACY, ATTR_LATITUDE, ATTR_LONGITUDE,
-    DEVICE_DEFAULT_NAME, STATE_HOME, STATE_NOT_HOME)
+    DEVICE_DEFAULT_NAME, STATE_HOME, STATE_NOT_HOME, ATTR_ENTITY_ID)
 
 DOMAIN = 'device_tracker'
 DEPENDENCIES = ['zone']
@@ -242,7 +242,10 @@ class DeviceTracker(object):
             if device.track:
                 device.update_ha_state()
 
-            self.hass.bus.fire(EVENT_NEW_DEVICE, device)
+            self.hass.bus.fire(EVENT_NEW_DEVICE, {
+                ATTR_ENTITY_ID: device.entity_id,
+                ATTR_HOST_NAME: device.host_name,
+            })
 
             # During init, we ignore the group
             if self.group is not None:

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the device tracker component."""
 # pylint: disable=protected-access
+import json
 import logging
 import unittest
 from unittest.mock import call, patch
@@ -15,6 +16,7 @@ from homeassistant.const import (
     STATE_HOME, STATE_NOT_HOME, CONF_PLATFORM)
 import homeassistant.components.device_tracker as device_tracker
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.remote import JSONEncoder
 
 from tests.common import (
     get_test_home_assistant, fire_time_changed, fire_service_discovered,
@@ -324,7 +326,16 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         device_tracker.see(self.hass, 'mac_1', host_name='hello')
 
         self.hass.block_till_done()
-        self.assertEqual(1, len(test_events))
+
+        assert len(test_events) == 1
+
+        # Assert we can serialize the event
+        json.dumps(test_events[0].as_dict(), cls=JSONEncoder)
+
+        assert test_events[0].data == {
+            'entity_id': 'device_tracker.hello',
+            'host_name': 'hello',
+        }
 
     # pylint: disable=invalid-name
     def test_not_write_duplicate_yaml_keys(self):


### PR DESCRIPTION
**Description:**
Our device tracker was sending an event on startup. This event incorrectly was sending the internal device class over the event bus instead of data from it. This fixes it.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
device_tracker:

recorder:
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

