### PR TITLE
Add timeout to requests (notify.nma)

### DIFF
--- a/homeassistant/components/notify/nma.py
+++ b/homeassistant/components/notify/nma.py
@@ -26,8 +26,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def get_service(hass, config):
     """Get the NMA notification service."""
-    response = requests.get(_RESOURCE + 'verify',
-                            params={"apikey": config[CONF_API_KEY]})
+    parameters = {
+        'apikey': config[CONF_API_KEY],
+    }
+    response = requests.get(
+        '{}{}'.format(_RESOURCE, 'verify'), params=parameters, timeout=5)
     tree = ET.fromstring(response.content)
 
     if tree[0].tag == 'error':
@@ -47,14 +50,15 @@ class NmaNotificationService(BaseNotificationService):
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
         data = {
-            "apikey": self._api_key,
-            "application": 'home-assistant',
-            "event": kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT),
-            "description": message,
-            "priority": 0,
+            'apikey': self._api_key,
+            'application': 'home-assistant',
+            'event': kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT),
+            'description': message,
+            'priority': 0,
         }
 
-        response = requests.get(_RESOURCE + 'notify', params=data)
+        response = requests.get(
+            '{}{}'.format(_RESOURCE, 'notify'), params=data, timeout=5)
         tree = ET.fromstring(response.content)
 
         if tree[0].tag == 'error':


### PR DESCRIPTION
**Description:**
Add timeout to requests.

**Example entry for `configuration.yaml` (if applicable):**
```yaml
notify:
  - name: NOTIFIER_NAME
    platform: nma
    api_key: ABCDEFGHJKLMNOPQRSTUVXYZ
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

