### PR TITLE
MAC vendor string for known devices.

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -5,33 +5,32 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/device_tracker/
 """
 import asyncio
-from datetime import timedelta
 import logging
 import os
-from typing import Any, Sequence, Callable
+from datetime import timedelta
+from typing import Any, Callable, Sequence
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
+import homeassistant.util as util
+import homeassistant.util.dt as dt_util
 from homeassistant.bootstrap import (
-    async_prepare_setup_platform, async_log_exception)
-from homeassistant.core import callback
+    async_log_exception, async_prepare_setup_platform)
 from homeassistant.components import group, zone
 from homeassistant.components.discovery import SERVICE_NETGEAR
 from homeassistant.config import load_yaml_config_file
+from homeassistant.const import (
+    ATTR_ENTITY_ID, ATTR_GPS_ACCURACY, ATTR_LATITUDE, ATTR_LONGITUDE,
+    DEVICE_DEFAULT_NAME, STATE_HOME, STATE_NOT_HOME)
+from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_per_platform, discovery
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.typing import GPSType, ConfigType, HomeAssistantType
-import homeassistant.helpers.config_validation as cv
-import homeassistant.util as util
-from homeassistant.util.async import run_coroutine_threadsafe
-import homeassistant.util.dt as dt_util
-from homeassistant.util.yaml import dump
-
 from homeassistant.helpers.event import async_track_utc_time_change
-from homeassistant.const import (
-    ATTR_GPS_ACCURACY, ATTR_LATITUDE, ATTR_LONGITUDE,
-    DEVICE_DEFAULT_NAME, STATE_HOME, STATE_NOT_HOME, ATTR_ENTITY_ID)
+from homeassistant.helpers.typing import ConfigType, GPSType, HomeAssistantType
+from homeassistant.util.async import run_coroutine_threadsafe
+from homeassistant.util.yaml import dump
 
 DOMAIN = 'device_tracker'
 DEPENDENCIES = ['zone']

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -330,7 +330,7 @@ class Device(Entity):
     last_seen = None  # type: dt_util.dt.datetime
     battery = None  # type: str
     attributes = None  # type: dict
-    vendor = None # type: str
+    vendor = None  # type: str
 
     # Track if the last update of this device was HOME.
     last_update_home = False

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -330,6 +330,7 @@ class Device(Entity):
     last_seen = None  # type: dt_util.dt.datetime
     battery = None  # type: str
     attributes = None  # type: dict
+    vendor = None # type: str
 
     # Track if the last update of this device was HOME.
     last_update_home = False
@@ -338,7 +339,7 @@ class Device(Entity):
     def __init__(self, hass: HomeAssistantType, consider_home: timedelta,
                  track: bool, dev_id: str, mac: str, name: str=None,
                  picture: str=None, gravatar: str=None,
-                 hide_if_away: bool=False) -> None:
+                 hide_if_away: bool=False, vendor: str=None) -> None:
         """Initialize a device."""
         self.hass = hass
         self.entity_id = ENTITY_ID_FORMAT.format(dev_id)
@@ -566,10 +567,10 @@ def update_config(path: str, dev_id: str, device: Device):
         device = {device.dev_id: {
             'name': device.name,
             'mac': device.mac,
-            'vendor': device.vendor,
             'picture': device.config_picture,
             'track': device.track,
-            CONF_AWAY_HIDE: device.away_hide
+            CONF_AWAY_HIDE: device.away_hide,
+            'vendor': device.vendor,
         }}
         out.write('\n')
         out.write(dump(device))

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -277,6 +277,9 @@ mficlient==0.3.0
 # homeassistant.components.sensor.miflora
 miflora==0.1.12
 
+# homeassistant.components.device_tracker
+netaddr==0.7.18
+
 # homeassistant.components.discovery
 netdisco==0.7.6
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,10 @@ exclude = .venv,.git,.tox,docs,www_static,venv,bin,lib,deps,build
 
 [pydocstyle]
 match_dir = ^((?!\.|www_static).)*$
+
+[isort]
+multi_line_output = 4
+indent = "    "
+forced_separate = homeassistant
+known_standard_library = typing
+not_skip = __init__.py

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -107,6 +107,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         self.assertEqual(device.config_picture, config.config_picture)
         self.assertEqual(device.away_hide, config.away_hide)
         self.assertEqual(device.consider_home, config.consider_home)
+        self.assertEqual(device.vendor, config.vendor)
 
     # pylint: disable=invalid-name
     @patch('homeassistant.components.device_tracker._LOGGER.warning')
@@ -180,6 +181,18 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         gravatar_url = ("https://www.gravatar.com/avatar/"
                         "55502f40dc8b7c769880b10874abc9d0.jpg?s=80&d=wavatar")
         self.assertEqual(device.config_picture, gravatar_url)
+
+    def test_mac_vendor_lookup(self):
+        """Test if vendor string is lookup in local OUI database."""
+
+        vendor_string = 'Raspberry Pi Foundation'
+        mac = 'B8:27:EB:00:00:00'
+
+        dev_id = 'test'
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), True, dev_id,
+            mac, 'Test name')
+        self.assertEqual(device.vendor, vendor_string)
 
     def test_discovery(self):
         """Test discovery."""

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -2,26 +2,26 @@
 # pylint: disable=protected-access
 import json
 import logging
-import unittest
-from unittest.mock import call, patch
-from datetime import datetime, timedelta
 import os
-
-from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component
-from homeassistant.loader import get_component
-from homeassistant.util.async import run_coroutine_threadsafe
-import homeassistant.util.dt as dt_util
-from homeassistant.const import (
-    ATTR_ENTITY_ID, ATTR_ENTITY_PICTURE, ATTR_FRIENDLY_NAME, ATTR_HIDDEN,
-    STATE_HOME, STATE_NOT_HOME, CONF_PLATFORM)
-import homeassistant.components.device_tracker as device_tracker
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.remote import JSONEncoder
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import call, patch
 
 from tests.common import (
-    get_test_home_assistant, fire_time_changed, fire_service_discovered,
-    patch_yaml_files, assert_setup_component)
+    assert_setup_component, fire_service_discovered, fire_time_changed,
+    get_test_home_assistant, patch_yaml_files)
+
+import homeassistant.components.device_tracker as device_tracker
+import homeassistant.util.dt as dt_util
+from homeassistant.bootstrap import setup_component
+from homeassistant.const import (
+    ATTR_ENTITY_ID, ATTR_ENTITY_PICTURE, ATTR_FRIENDLY_NAME, ATTR_HIDDEN,
+    CONF_PLATFORM, STATE_HOME, STATE_NOT_HOME)
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.loader import get_component
+from homeassistant.remote import JSONEncoder
+from homeassistant.util.async import run_coroutine_threadsafe
 
 TEST_PLATFORM = {device_tracker.DOMAIN: {CONF_PLATFORM: 'test'}}
 

--- a/tests/components/device_tracker/test_tplink.py
+++ b/tests/components/device_tracker/test_tplink.py
@@ -3,12 +3,11 @@
 import os
 import unittest
 
+import requests_mock
 from homeassistant.components import device_tracker
 from homeassistant.components.device_tracker.tplink import Tplink4DeviceScanner
-from homeassistant.const import (CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME,
-                                 CONF_HOST)
-import requests_mock
-
+from homeassistant.const import (CONF_HOST, CONF_PASSWORD, CONF_PLATFORM,
+                                 CONF_USERNAME)
 from tests.common import get_test_home_assistant
 
 


### PR DESCRIPTION
**Description:** Add the MAC vendor string to known device entry to easier identify devices found through device trackers.

This pullrequest adds a feature to device trackers. It will try to find the vendor string for a MAC address in a local IEEE OUI database (using the `netaddr` python library).

This will make it easier to identify found devices in the `known_devices.yaml` file as you can now distinguish between for example a Raspberry Pi, server, Apple phone, Android phone, etc.

An example of how the output now looks:

``` yaml
b827eb000000:
  hide_if_away: false
  mac: B8:27:EB:00:00:00
  name: b827eb000000
  picture:
  track: true
  vendor: Raspberry Pi Foundation
```

This pull request includes some changes related to isort and a fix for a bug that seems to present on the `dev` branch as well https://travis-ci.org/home-assistant/home-assistant/jobs/176031122

I am pitching this PR as an feature proposal. If needed I can pull the isort related changes out into a separate branch. The isort related changes basically make sure the standards set for this project (by: https://github.com/home-assistant/home-assistant/pull/1330 and Pylint) are available for other tools like IDE's or texteditors.

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
