### PR TITLE
change add_job to use call_soon_threadsafe

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -210,8 +210,7 @@ class HomeAssistant(object):
         target: target to call.
         args: parameters for method to call.
         """
-        run_callback_threadsafe(
-            self.loop, self.async_add_job, target, *args).result()
+        self.loop.call_soon_threadsafe(self.async_add_job, target, *args)
 
     @callback
     def async_add_job(self, target: Callable[..., None], *args: Any) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -156,19 +156,19 @@ class TestHomeAssistant(unittest.TestCase):
 
         @asyncio.coroutine
         def wait_finish_callback():
-            """Wait until all stuff is sheduled."""
-            while len(call_count) < 50:
+            """Wait until all stuff is scheduled."""
+            while len(call_count) < 2:
                 yield from asyncio.sleep(0)
 
-        for i in range(50):
+        for i in range(2):
             self.hass.add_job(test_coro())
 
         run_coroutine_threadsafe(
             wait_finish_callback(), self.hass.loop).result()
 
-        assert len(self.hass._pending_tasks) == 50
+        assert len(self.hass._pending_tasks) == 2
         self.hass.block_till_done()
-        assert len(call_count) == 50
+        assert len(call_count) == 2
 
     def test_async_add_job_pending_tasks_executor(self):
         """Run a executor in pending tasks."""
@@ -180,19 +180,19 @@ class TestHomeAssistant(unittest.TestCase):
 
         @asyncio.coroutine
         def wait_finish_callback():
-            """Wait until all stuff is sheduled."""
-            while len(call_count) < 40:
+            """Wait until all stuff is scheduled."""
+            while len(call_count) < 2:
                 yield from asyncio.sleep(0)
 
-        for i in range(40):
+        for i in range(2):
             self.hass.add_job(test_executor)
 
         run_coroutine_threadsafe(
             wait_finish_callback(), self.hass.loop).result()
 
-        assert len(self.hass._pending_tasks) == 40
+        assert len(self.hass._pending_tasks) == 2
         self.hass.block_till_done()
-        assert len(call_count) == 40
+        assert len(call_count) == 2
 
     def test_async_add_job_pending_tasks_callback(self):
         """Run a callback in pending tasks."""
@@ -203,12 +203,22 @@ class TestHomeAssistant(unittest.TestCase):
             """Test callback."""
             call_count.append('call')
 
-        for i in range(40):
+        @asyncio.coroutine
+        def wait_finish_callback():
+            """Wait until all stuff is scheduled."""
+            while len(call_count) < 2:
+                yield from asyncio.sleep(0)
+
+        for i in range(2):
             self.hass.add_job(test_callback)
+
+        run_coroutine_threadsafe(
+            wait_finish_callback(), self.hass.loop).result()
+
         self.hass.block_till_done()
 
         assert len(self.hass._pending_tasks) == 0
-        assert len(call_count) == 40
+        assert len(call_count) == 2
 
 
 class TestEvent(unittest.TestCase):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -154,8 +154,17 @@ class TestHomeAssistant(unittest.TestCase):
             """Test Coro."""
             call_count.append('call')
 
+        @asyncio.coroutine
+        def wait_finish_callback():
+            """Wait until all stuff is sheduled."""
+            while len(call_count) < 50:
+                yield from asyncio.sleep(0)
+
         for i in range(50):
             self.hass.add_job(test_coro())
+
+        run_coroutine_threadsafe(
+            wait_finish_callback(), self.hass.loop).result()
 
         assert len(self.hass._pending_tasks) == 50
         self.hass.block_till_done()
@@ -169,8 +178,17 @@ class TestHomeAssistant(unittest.TestCase):
             """Test executor."""
             call_count.append('call')
 
+        @asyncio.coroutine
+        def wait_finish_callback():
+            """Wait until all stuff is sheduled."""
+            while len(call_count) < 40:
+                yield from asyncio.sleep(0)
+
         for i in range(40):
             self.hass.add_job(test_executor)
+
+        run_coroutine_threadsafe(
+            wait_finish_callback(), self.hass.loop).result()
 
         assert len(self.hass._pending_tasks) == 40
         self.hass.block_till_done()
@@ -187,9 +205,9 @@ class TestHomeAssistant(unittest.TestCase):
 
         for i in range(40):
             self.hass.add_job(test_callback)
+        self.hass.block_till_done()
 
         assert len(self.hass._pending_tasks) == 0
-        self.hass.block_till_done()
         assert len(call_count) == 40
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -160,8 +160,8 @@ class TestHomeAssistant(unittest.TestCase):
         @asyncio.coroutine
         def wait_finish_callback():
             """Wait until all stuff is scheduled."""
-            yield from asyncio.sleep(0)
-            yield from asyncio.sleep(0)
+            yield from asyncio.sleep(0, loop=self.hass.loop)
+            yield from asyncio.sleep(0, loop=self.hass.loop)
 
         run_coroutine_threadsafe(
             wait_finish_callback(), self.hass.loop).result()
@@ -181,8 +181,8 @@ class TestHomeAssistant(unittest.TestCase):
         @asyncio.coroutine
         def wait_finish_callback():
             """Wait until all stuff is scheduled."""
-            yield from asyncio.sleep(0)
-            yield from asyncio.sleep(0)
+            yield from asyncio.sleep(0, loop=self.hass.loop)
+            yield from asyncio.sleep(0, loop=self.hass.loop)
 
         for i in range(2):
             self.hass.add_job(test_executor)
@@ -206,8 +206,8 @@ class TestHomeAssistant(unittest.TestCase):
         @asyncio.coroutine
         def wait_finish_callback():
             """Wait until all stuff is scheduled."""
-            yield from asyncio.sleep(0)
-            yield from asyncio.sleep(0)
+            yield from asyncio.sleep(0, loop=self.hass.loop)
+            yield from asyncio.sleep(0, loop=self.hass.loop)
 
         for i in range(2):
             self.hass.add_job(test_callback)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -154,14 +154,14 @@ class TestHomeAssistant(unittest.TestCase):
             """Test Coro."""
             call_count.append('call')
 
+        for i in range(2):
+            self.hass.add_job(test_coro())
+
         @asyncio.coroutine
         def wait_finish_callback():
             """Wait until all stuff is scheduled."""
-            while len(call_count) < 2:
-                yield from asyncio.sleep(0)
-
-        for i in range(2):
-            self.hass.add_job(test_coro())
+            yield from asyncio.sleep(0)
+            yield from asyncio.sleep(0)
 
         run_coroutine_threadsafe(
             wait_finish_callback(), self.hass.loop).result()
@@ -181,8 +181,8 @@ class TestHomeAssistant(unittest.TestCase):
         @asyncio.coroutine
         def wait_finish_callback():
             """Wait until all stuff is scheduled."""
-            while len(call_count) < 2:
-                yield from asyncio.sleep(0)
+            yield from asyncio.sleep(0)
+            yield from asyncio.sleep(0)
 
         for i in range(2):
             self.hass.add_job(test_executor)
@@ -206,8 +206,8 @@ class TestHomeAssistant(unittest.TestCase):
         @asyncio.coroutine
         def wait_finish_callback():
             """Wait until all stuff is scheduled."""
-            while len(call_count) < 2:
-                yield from asyncio.sleep(0)
+            yield from asyncio.sleep(0)
+            yield from asyncio.sleep(0)
 
         for i in range(2):
             self.hass.add_job(test_callback)


### PR DESCRIPTION
**Description:**

For faster schedule a job and not to long blocking a executor (also with schedule_update_ha_state).

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

