### PR TITLE
Feedreader sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -162,6 +162,7 @@ omit =
     homeassistant/components/emoncms_history.py
     homeassistant/components/fan/mqtt.py
     homeassistant/components/feedreader.py
+    homeassistant/components/*/feedreader.py
     homeassistant/components/foursquare.py
     homeassistant/components/hdmi_cec.py
     homeassistant/components/ifttt.py

--- a/homeassistant/components/sensor/feedreader.py
+++ b/homeassistant/components/sensor/feedreader.py
@@ -1,0 +1,72 @@
+"""
+Support for feedreader sensors.
+
+For more details about this platform, please refer to the documentation at
+at https://home-assistant.io/components/sensor.feedreader/
+"""
+import logging
+
+from homeassistant.helpers.entity import Entity
+
+DEPENDENCIES = ['feedreader']
+
+DOMAIN = 'feedreader'
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up feedreader sensors."""
+    for url in discovery_info:
+        adding = "Adding feedreader sensor for " + url
+        logging.getLogger(__name__).info(adding)
+        add_devices([FeedreaderSensor(hass, url)])
+
+
+class FeedreaderSensor(Entity):
+    """Representation of a feedreader sensor."""
+
+    def __init__(self, hass, url):
+        """Initialize the sensor."""
+        self.hass = hass
+        self._url = url
+        self._state = None
+        self.update()
+
+    @property
+    def state(self):
+        """Return the state."""
+        return self._state
+
+    @property
+    def unique_id(self):
+        """Return the ID of the sensor."""
+        return '{}.{}'.format(self.__class__, self.name)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._url.split("/")[2].replace(".", "_")
+
+    def update(self):
+        """Update state of the device."""
+        self._state = self.hass.data[DOMAIN][self._url]['title']
+
+    @property
+    def should_poll(self):
+        """Poll the feed."""
+        return True
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        feed = self.hass.data[DOMAIN][self._url]
+        published = feed.get('published')
+        updated = feed.get('updated')
+        link = feed.get('link')
+        feed_id = feed.get('id')
+        content = feed.get('content')
+        attributes = {"published": published,
+                      "updated": updated,
+                      "link": link,
+                      "id": feed_id,
+                      "content": content}
+        return attributes


### PR DESCRIPTION
**Description:**
This will create a sensor of the last entry of each feed the user has defined under feedreader. The sensor will have a state equal to the title of the last entry and has state attributes of updated, published, id, content, and link.

Using the new hass.data to store the "feed" to access in the sensor corresponding sensor.

Currently the feedreader only polls every hour, so these sensors will only update every hour. Is there any reason the feedreader couldn't poll every 60 seconds like other sensors?

@rpitera I think you might find this useful for the IFTTT status page.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
No changes to the current feedreader config all currently configured feeds will automatically get a sensor.
```yaml
feedreader:
  urls:
    - https://github.com/blog.atom
    - http://status.winkapp.com/history.atom
    - http://status.ifttt.com/history.atom
    - https://home-assistant.io/atom.xml
```

**Example of status.winkapp.com sensor.**
![image](https://cloud.githubusercontent.com/assets/6432770/20350410/cc9c30a0-abdc-11e6-9f86-c5f103bcb2c8.png)


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
`script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

