### PR TITLE
ZWave: Fix missing battery_level, node_id and location

### DIFF
--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -22,7 +22,8 @@ DEFAULT_NAME = 'ZWave Climate'
 REMOTEC = 0x5254
 REMOTEC_ZXT_120 = 0x8377
 REMOTEC_ZXT_120_THERMOSTAT = (REMOTEC, REMOTEC_ZXT_120)
-
+ATTR_OPERATING_STATE = 'operating_state'
+ATTR_FAN_STATE = 'fan_state'
 
 WORKAROUND_ZXT_120 = 'zxt_120'
 
@@ -269,9 +270,10 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
     @property
     def device_state_attributes(self):
         """Return the device specific state attributes."""
-        data = {}
+        data = zwave.ZWaveDeviceEntity(self._value,
+                                       DOMAIN).device_state_attributes
         if self._operating_state:
-            data["operating_state"] = self._operating_state,
+            data[ATTR_OPERATING_STATE] = self._operating_state,
         if self._fan_state:
-            data["fan_state"] = self._fan_state
+            data[ATTR_FAN_STATE] = self._fan_state
         return data

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -270,8 +270,7 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
     @property
     def device_state_attributes(self):
         """Return the device specific state attributes."""
-        data = zwave.ZWaveDeviceEntity(self._value,
-                                       DOMAIN).device_state_attributes
+        data = super().device_state_attributes
         if self._operating_state:
             data[ATTR_OPERATING_STATE] = self._operating_state,
         if self._fan_state:


### PR DESCRIPTION
**Description:**
When adding operating_state attribute, I forgot to inherit the zwave main attributes.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
#4408 At least zwave
