### PR TITLE
Better handling of accented characters in slugify (#4399)

### DIFF
--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -13,7 +13,10 @@ from types import MappingProxyType
 
 from typing import Any, Optional, TypeVar, Callable, Sequence, KeysView, Union
 
+from unicodedata import normalize
+
 from .dt import as_local, utcnow
+
 
 T = TypeVar('T')
 U = TypeVar('U')
@@ -35,7 +38,7 @@ def sanitize_path(path: str) -> str:
 
 def slugify(text: str) -> str:
     """Slugify a given text."""
-    text = text.lower().replace(" ", "_")
+    text = normalize('NFKD', text).lower().replace(" ", "_")
 
     return RE_SLUGIFY.sub("", text)
 

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -10,13 +10,11 @@ import random
 import string
 from functools import wraps
 from types import MappingProxyType
+from unicodedata import normalize
 
 from typing import Any, Optional, TypeVar, Callable, Sequence, KeysView, Union
 
-from unicodedata import normalize
-
 from .dt import as_local, utcnow
-
 
 T = TypeVar('T')
 U = TypeVar('U')

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -30,6 +30,7 @@ class TestUtil(unittest.TestCase):
         self.assertEqual("test", util.slugify("T-!@#$!#@$!$est"))
         self.assertEqual("test_more", util.slugify("Test More"))
         self.assertEqual("test_more", util.slugify("Test_(More)"))
+        self.assertEqual("test_more", util.slugify("Tèst_Mörê"))
 
     def test_repr_helper(self):
         """Test repr_helper."""


### PR DESCRIPTION
**Description:**
Accented characters are removed in generated entity id names, instead of stripped of their accents. This patch fixes this behavior.

**Related issue (if applicable):** fixes #4399.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
