### PR TITLE
create light.hue_activate_scene service

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -22,6 +22,7 @@ from homeassistant.components.light import (
     FLASH_LONG, FLASH_SHORT, SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP,
     SUPPORT_EFFECT, SUPPORT_FLASH, SUPPORT_RGB_COLOR, SUPPORT_TRANSITION,
     SUPPORT_XY_COLOR, Light, PLATFORM_SCHEMA)
+from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (CONF_FILENAME, CONF_HOST, DEVICE_DEFAULT_NAME)
 from homeassistant.loader import get_component
 import homeassistant.helpers.config_validation as cv
@@ -37,6 +38,8 @@ _LOGGER = logging.getLogger(__name__)
 CONF_ALLOW_UNREACHABLE = 'allow_unreachable'
 
 DEFAULT_ALLOW_UNREACHABLE = False
+DOMAIN = "light"
+SERVICE_HUE_SCENE = "hue_activate_scene"
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
@@ -51,6 +54,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_ALLOW_UNREACHABLE): cv.boolean,
     vol.Optional(CONF_FILENAME): cv.string,
+})
+
+ATTR_GROUP_NAME = "group_name"
+ATTR_SCENE_NAME = "scene_name"
+SCENE_SCHEMA = vol.Schema({
+    vol.Required(ATTR_GROUP_NAME): cv.string,
+    vol.Required(ATTR_SCENE_NAME): cv.string,
 })
 
 
@@ -166,6 +176,20 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable):
             add_devices(new_lights)
 
     _CONFIGURED_BRIDGES[socket.gethostbyname(host)] = True
+
+    # create a service for calling run_scene directly on the bridge,
+    # used to simplify automation rules.
+    def hue_activate_scene(call):
+        """Service to call directly directly into bridge to set scenes."""
+        group_name = call.data[ATTR_GROUP_NAME]
+        scene_name = call.data[ATTR_SCENE_NAME]
+        bridge.run_scene(group_name, scene_name)
+
+    descriptions = load_yaml_config_file(
+        os.path.join(os.path.dirname(__file__), 'services.yaml'))
+    hass.services.register(DOMAIN, SERVICE_HUE_SCENE, hue_activate_scene,
+                           descriptions.get(SERVICE_HUE_SCENE))
+
     update_lights()
 
 

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -188,7 +188,8 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable):
     descriptions = load_yaml_config_file(
         os.path.join(os.path.dirname(__file__), 'services.yaml'))
     hass.services.register(DOMAIN, SERVICE_HUE_SCENE, hue_activate_scene,
-                           descriptions.get(SERVICE_HUE_SCENE))
+                           descriptions.get(SERVICE_HUE_SCENE),
+                           schema=SCENE_SCHEMA)
 
     update_lights()
 

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -81,3 +81,15 @@ toggle:
     transition:
       description: Duration in seconds it takes to get to next state
       example: 60
+
+hue_activate_scene:
+  description: Activate a hue scene stored in the hue hub
+
+  fields:
+    group_name:
+      description: Name of hue group/room from the hue app
+      example: "Living Room"
+
+    scene_name:
+      description: Name of hue scene from the hue app
+      example: "Energize"


### PR DESCRIPTION
**Description:** create light.hue_activate_scene service for use by automation

**Related issue (if applicable):** fixes #3994 

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

This creates a light.hue_activate_scene service that takes group_name
and scene_name, and calls phue's bridge.run_scene with those
parameters. This allows calling hue bridge stored scene names by name
during automation.

This only currently works reliably in 1 hue hub configurations (which
is most of them). Phue will be further enhanced to display warnings
when it can't figure out what to do with the parameters passed in to HA.