### PR TITLE
Migrate callbacks to use schedule_update_ha_state

### DIFF
--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -129,7 +129,7 @@ class ManualAlarm(alarm.AlarmControlPanel):
 
         if self._pending_time:
             track_point_in_time(
-                self._hass, self.update_ha_state,
+                self._hass, self.async_update_ha_state,
                 self._state_ts + self._pending_time)
 
     def alarm_arm_away(self, code=None):
@@ -143,7 +143,7 @@ class ManualAlarm(alarm.AlarmControlPanel):
 
         if self._pending_time:
             track_point_in_time(
-                self._hass, self.update_ha_state,
+                self._hass, self.async_update_ha_state,
                 self._state_ts + self._pending_time)
 
     def alarm_trigger(self, code=None):
@@ -155,11 +155,11 @@ class ManualAlarm(alarm.AlarmControlPanel):
 
         if self._trigger_time:
             track_point_in_time(
-                self._hass, self.update_ha_state,
+                self._hass, self.async_update_ha_state,
                 self._state_ts + self._pending_time)
 
             track_point_in_time(
-                self._hass, self.update_ha_state,
+                self._hass, self.async_update_ha_state,
                 self._state_ts + self._pending_time + self._trigger_time)
 
     def _validate_code(self, code, state):

--- a/homeassistant/components/binary_sensor/ffmpeg.py
+++ b/homeassistant/components/binary_sensor/ffmpeg.py
@@ -138,7 +138,7 @@ class FFmpegBinarySensor(BinarySensorDevice):
     def _callback(self, state):
         """HA-FFmpeg callback for noise detection."""
         self._state = state
-        self.update_ha_state()
+        self.schedule_update_ha_state()
 
     def _start_ffmpeg(self, config):
         """Start a FFmpeg instance."""

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -8,6 +8,7 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.core import callback
 import homeassistant.components.mqtt as mqtt
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, SENSOR_CLASSES)
@@ -66,17 +67,18 @@ class MqttBinarySensor(BinarySensorDevice):
         self._payload_off = payload_off
         self._qos = qos
 
+        @callback
         def message_received(topic, payload, qos):
             """A new MQTT message has been received."""
             if value_template is not None:
-                payload = value_template.render_with_possible_json_value(
+                payload = value_template.async_render_with_possible_json_value(
                     payload)
             if payload == self._payload_on:
                 self._state = True
-                self.update_ha_state()
+                hass.async_add_job(self.async_update_ha_state())
             elif payload == self._payload_off:
                 self._state = False
-                self.update_ha_state()
+                hass.async_add_job(self.async_update_ha_state())
 
         mqtt.subscribe(hass, self._state_topic, message_received, self._qos)
 

--- a/homeassistant/components/binary_sensor/nx584.py
+++ b/homeassistant/components/binary_sensor/nx584.py
@@ -123,7 +123,7 @@ class NX584Watcher(threading.Thread):
         if not zone_sensor:
             return
         zone_sensor._zone['state'] = event['zone_state']
-        zone_sensor.update_ha_state()
+        zone_sensor.schedule_update_ha_state()
 
     def _process_events(self, events):
         for event in events:

--- a/homeassistant/components/binary_sensor/rpi_gpio.py
+++ b/homeassistant/components/binary_sensor/rpi_gpio.py
@@ -72,7 +72,7 @@ class RPiGPIOBinarySensor(BinarySensorDevice):
         def read_gpio(port):
             """Read state from GPIO."""
             self._state = rpi_gpio.read_input(self._port)
-            self.update_ha_state()
+            self.schedule_update_ha_state()
 
         rpi_gpio.edge_detect(self._port, read_gpio, self._bouncetime)
 

--- a/homeassistant/components/binary_sensor/wemo.py
+++ b/homeassistant/components/binary_sensor/wemo.py
@@ -48,7 +48,7 @@ class WemoBinarySensor(BinarySensorDevice):
         if not hasattr(self, 'hass'):
             self.update()
             return
-        self.update_ha_state(True)
+        self.schedule_update_ha_state(True)
 
     @property
     def should_poll(self):

--- a/homeassistant/components/binary_sensor/wemo.py
+++ b/homeassistant/components/binary_sensor/wemo.py
@@ -45,10 +45,10 @@ class WemoBinarySensor(BinarySensorDevice):
         _LOGGER.info(
             'Subscription update for  %s',
             _device)
+        self.update()
         if not hasattr(self, 'hass'):
-            self.update()
             return
-        self.schedule_update_ha_state(True)
+        self.schedule_update_ha_state()
 
     @property
     def should_poll(self):

--- a/homeassistant/components/binary_sensor/zwave.py
+++ b/homeassistant/components/binary_sensor/zwave.py
@@ -96,7 +96,7 @@ class ZWaveBinarySensor(BinarySensorDevice, zwave.ZWaveDeviceEntity, Entity):
         """Called when a value has changed on the network."""
         if self._value.value_id == value.value_id or \
            self._value.node == value.node:
-            self.update_ha_state()
+            self.schedule_update_ha_state()
 
 
 class ZWaveTriggerSensor(ZWaveBinarySensor, Entity):
@@ -112,19 +112,19 @@ class ZWaveTriggerSensor(ZWaveBinarySensor, Entity):
         # If it's active make sure that we set the timeout tracker
         if sensor_value.data:
             track_point_in_time(
-                self._hass, self.update_ha_state,
+                self._hass, self.async_update_ha_state,
                 self.invalidate_after)
 
     def value_changed(self, value):
         """Called when a value has changed on the network."""
         if self._value.value_id == value.value_id:
-            self.update_ha_state()
+            self.schedule_update_ha_state()
             if value.data:
                 # only allow this value to be true for re_arm secs
                 self.invalidate_after = dt_util.utcnow() + datetime.timedelta(
                     seconds=self.re_arm_sec)
                 track_point_in_time(
-                    self._hass, self.update_ha_state,
+                    self._hass, self.async_update_ha_state,
                     self.invalidate_after)
 
     @property

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -158,7 +158,7 @@ class GenericThermostat(ClimateDevice):
 
         self._update_temp(new_state)
         self._control_heating()
-        self.update_ha_state()
+        self.schedule_update_ha_state()
 
     def _update_temp(self, state):
         """Update thermostat with latest state from sensor."""

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -89,7 +89,7 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
         if self._value.value_id == value.value_id or \
            self._value.node == value.node:
             self.update_properties()
-            self.update_ha_state()
+            self.schedule_update_ha_state()
             _LOGGER.debug("Value changed on network %s", value)
 
     def update_properties(self):

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -280,9 +280,9 @@ class CastDevice(MediaPlayerDevice):
     def new_cast_status(self, status):
         """Called when a new cast status is received."""
         self.cast_status = status
-        self.update_ha_state()
+        self.schedule_update_ha_state()
 
     def new_media_status(self, status):
         """Called when a new media status is received."""
         self.media_status = status
-        self.update_ha_state()
+        self.schedule_update_ha_state()

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -8,6 +8,7 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.core import callback
 from homeassistant.components.mqtt import CONF_STATE_TOPIC, CONF_QOS
 from homeassistant.const import (
     CONF_NAME, CONF_VALUE_TEMPLATE, STATE_UNKNOWN, CONF_UNIT_OF_MEASUREMENT)
@@ -55,13 +56,14 @@ class MqttSensor(Entity):
         self._qos = qos
         self._unit_of_measurement = unit_of_measurement
 
+        @callback
         def message_received(topic, payload, qos):
             """A new MQTT message has been received."""
             if value_template is not None:
-                payload = value_template.render_with_possible_json_value(
+                payload = value_template.async_render_with_possible_json_value(
                     payload, self._state)
             self._state = payload
-            self.update_ha_state()
+            hass.async_add_job(self.async_update_ha_state())
 
         mqtt.subscribe(hass, self._state_topic, message_received, self._qos)
 

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -8,6 +8,7 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.core import callback
 from homeassistant.components.mqtt import (
     CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN)
 from homeassistant.components.switch import SwitchDevice
@@ -71,17 +72,18 @@ class MqttSwitch(SwitchDevice):
         self._payload_off = payload_off
         self._optimistic = optimistic
 
+        @callback
         def message_received(topic, payload, qos):
             """A new MQTT message has been received."""
             if value_template is not None:
-                payload = value_template.render_with_possible_json_value(
+                payload = value_template.async_render_with_possible_json_value(
                     payload)
             if payload == self._payload_on:
                 self._state = True
-                self.update_ha_state()
+                hass.async_add_job(self.async_update_ha_state())
             elif payload == self._payload_off:
                 self._state = False
-                self.update_ha_state()
+                hass.async_add_job(self.async_update_ha_state())
 
         if self._state_topic is None:
             # Force into optimistic mode.
@@ -117,7 +119,7 @@ class MqttSwitch(SwitchDevice):
         if self._optimistic:
             # Optimistically assume that switch has changed state.
             self._state = True
-            self.schedule_update_ha_state()
+            self.update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
@@ -126,4 +128,4 @@ class MqttSwitch(SwitchDevice):
         if self._optimistic:
             # Optimistically assume that switch has changed state.
             self._state = False
-            self.schedule_update_ha_state()
+            self.update_ha_state()

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -63,10 +63,10 @@ class WemoSwitch(SwitchDevice):
         _LOGGER.info(
             'Subscription update for  %s',
             _device)
+        self.update()
         if not hasattr(self, 'hass'):
-            self.update()
             return
-        self.update_ha_state(True)
+        self.schedule_update_ha_state()
 
     @property
     def should_poll(self):

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -111,7 +111,7 @@ class TellstickRegistry(object):
         entity = self._id_to_entity_map.get(tellstick_id, None)
         if entity is not None:
             entity.set_tellstick_state(method, data)
-            entity.update_ha_state()
+            entity.schedule_update_ha_state()
 
     def _setup_device_callback(self, hass, tellcore_lib):
         """Register the callback handler."""

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -132,7 +132,8 @@ class VeraDevice(Entity):
         self.update()
 
     def _update_callback(self, _device):
-        self.update_ha_state(True)
+        self.update()
+        self.schedule_update_ha_state()
 
     @property
     def name(self):

--- a/tests/components/binary_sensor/test_nx584.py
+++ b/tests/components/binary_sensor/test_nx584.py
@@ -137,7 +137,7 @@ class TestNX584ZoneSensor(unittest.TestCase):
 class TestNX584Watcher(unittest.TestCase):
     """Test the NX584 watcher."""
 
-    @mock.patch.object(nx584.NX584ZoneSensor, 'update_ha_state')
+    @mock.patch.object(nx584.NX584ZoneSensor, 'schedule_update_ha_state')
     def test_process_zone_event(self, mock_update):
         """Test the processing of zone events."""
         zone1 = {'number': 1, 'name': 'foo', 'state': True}
@@ -151,7 +151,7 @@ class TestNX584Watcher(unittest.TestCase):
         self.assertFalse(zone1['state'])
         self.assertEqual(1, mock_update.call_count)
 
-    @mock.patch.object(nx584.NX584ZoneSensor, 'update_ha_state')
+    @mock.patch.object(nx584.NX584ZoneSensor, 'schedule_update_ha_state')
     def test_process_zone_event_missing_zone(self, mock_update):
         """Test the processing of zone events with missing zones."""
         watcher = nx584.NX584Watcher(None, {})

--- a/tests/components/switch/test_rest.py
+++ b/tests/components/switch/test_rest.py
@@ -12,7 +12,6 @@ from homeassistant.bootstrap import setup_component
 from tests.common import get_test_home_assistant, assert_setup_component
 
 
-@pytest.mark.skip
 class TestRestSwitchSetup(unittest.TestCase):
     """Tests for setting up the REST switch platform."""
 


### PR DESCRIPTION
**Description:**
Migrates a bunch of callbacks to async / use schedule_update_ha_state.
See #4417

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

