### PR TITLE
Track tasks only during shutdown and tests

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -268,6 +268,9 @@ class HomeAssistant(object):
     @asyncio.coroutine
     def async_block_till_done(self):
         """Block till all pending work is done."""
+        # To flush out any call_soon_threadsafe
+        yield from asyncio.sleep(0, loop=self.loop)
+
         while self._pending_tasks:
             pending = [task for task in self._pending_tasks
                        if not task.done()]

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -113,7 +113,6 @@ class HomeAssistant(object):
         self.loop.set_default_executor(self.executor)
         self.loop.set_exception_handler(self._async_exception_handler)
         self._pending_tasks = []
-        self._pending_sheduler = None
         self.bus = EventBus(self)
         self.services = ServiceRegistry(self)
         self.states = StateMachine(self.bus, self.loop)
@@ -185,23 +184,9 @@ class HomeAssistant(object):
 
         # pylint: disable=protected-access
         self.loop._thread_ident = threading.get_ident()
-        self._async_tasks_cleanup()
         _async_create_timer(self)
         self.bus.async_fire(EVENT_HOMEASSISTANT_START)
         self.state = CoreState.running
-
-    @callback
-    def _async_tasks_cleanup(self):
-        """Cleanup all pending tasks in a time interval.
-
-        This method must be run in the event loop.
-        """
-        self._pending_tasks = [task for task in self._pending_tasks
-                               if not task.done()]
-
-        # sheduled next cleanup
-        self._pending_sheduler = self.loop.call_later(
-            TIME_INTERVAL_TASKS_CLEANUP, self._async_tasks_cleanup)
 
     def add_job(self, target: Callable[..., None], *args: Any) -> None:
         """Add job to the executor pool.
@@ -212,7 +197,28 @@ class HomeAssistant(object):
         self.loop.call_soon_threadsafe(self.async_add_job, target, *args)
 
     @callback
-    def async_add_job(self, target: Callable[..., None], *args: Any) -> None:
+    def _async_add_job(self, target: Callable[..., None], *args: Any) -> None:
+        """Add a job from within the eventloop.
+
+        This method must be run in the event loop.
+
+        target: target to call.
+        args: parameters for method to call.
+        """
+        if asyncio.iscoroutine(target):
+            self.loop.create_task(target)
+        elif is_callback(target):
+            self.loop.call_soon(target, *args)
+        elif asyncio.iscoroutinefunction(target):
+            self.loop.create_task(target(*args))
+        else:
+            self.loop.run_in_executor(None, target, *args)
+
+    async_add_job = _async_add_job
+
+    @callback
+    def _async_add_job_tracking(self, target: Callable[..., None],
+                                *args: Any) -> None:
         """Add a job from within the eventloop.
 
         This method must be run in the event loop.
@@ -236,6 +242,11 @@ class HomeAssistant(object):
             self._pending_tasks.append(task)
 
     @callback
+    def async_track_tasks(self):
+        """Track tasks so you can wait for all tasks to be done."""
+        self.async_add_job = self._async_add_job_tracking
+
+    @callback
     def async_run_job(self, target: Callable[..., None], *args: Any) -> None:
         """Run a job from within the event loop.
 
@@ -249,16 +260,6 @@ class HomeAssistant(object):
         else:
             self.async_add_job(target, *args)
 
-    def _loop_empty(self) -> bool:
-        """Python 3.4.2 empty loop compatibility function."""
-        # pylint: disable=protected-access
-        if sys.version_info < (3, 4, 3):
-            return len(self.loop._scheduled) == 0 and \
-                   len(self.loop._ready) == 0
-        else:
-            return self.loop._current_handle is None and \
-                   len(self.loop._ready) == 0
-
     def block_till_done(self) -> None:
         """Block till all pending work is done."""
         run_coroutine_threadsafe(
@@ -267,18 +268,14 @@ class HomeAssistant(object):
     @asyncio.coroutine
     def async_block_till_done(self):
         """Block till all pending work is done."""
-        while True:
-            # Wait for the pending tasks are down
+        while self._pending_tasks:
             pending = [task for task in self._pending_tasks
                        if not task.done()]
             self._pending_tasks.clear()
             if len(pending) > 0:
                 yield from asyncio.wait(pending, loop=self.loop)
-
-            # Verify the loop is empty
-            ret = yield from self.loop.run_in_executor(None, self._loop_empty)
-            if ret and not self._pending_tasks:
-                break
+            else:
+                yield from asyncio.sleep(0, loop=self.loop)
 
     def stop(self) -> None:
         """Stop Home Assistant and shuts down all threads."""
@@ -291,9 +288,8 @@ class HomeAssistant(object):
         This method is a coroutine.
         """
         self.state = CoreState.stopping
+        self.async_track_tasks()
         self.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
-        if self._pending_sheduler is not None:
-            self._pending_sheduler.cancel()
         yield from self.async_block_till_done()
         self.executor.shutdown()
         if self._websession is not None:

--- a/tests/common.py
+++ b/tests/common.py
@@ -82,6 +82,7 @@ def async_test_home_assistant(loop):
     loop._thread_ident = threading.get_ident()
 
     hass = ha.HomeAssistant(loop)
+    hass.async_track_tasks()
 
     hass.config.location_name = 'test home'
     hass.config.config_dir = get_test_config_dir()
@@ -103,9 +104,8 @@ def async_test_home_assistant(loop):
     @asyncio.coroutine
     def mock_async_start():
         """Start the mocking."""
-        with patch.object(loop, 'add_signal_handler'),\
-            patch('homeassistant.core._async_create_timer'),\
-                patch.object(hass, '_async_tasks_cleanup', return_value=None):
+        with patch.object(loop, 'add_signal_handler'), \
+                patch('homeassistant.core._async_create_timer'):
             yield from orig_start()
 
     hass.async_start = mock_async_start

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,8 +9,7 @@ import pytz
 
 import homeassistant.core as ha
 from homeassistant.exceptions import InvalidEntityFormatError
-from homeassistant.util.async import (
-    run_callback_threadsafe, run_coroutine_threadsafe)
+from homeassistant.util.async import run_coroutine_threadsafe
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import (METRIC_SYSTEM)
 from homeassistant.const import (
@@ -129,7 +128,7 @@ class TestHomeAssistant(unittest.TestCase):
             """Test Coro."""
             call_count.append('call')
 
-        for i in range(50):
+        for i in range(3):
             self.hass.add_job(test_coro())
 
         run_coroutine_threadsafe(
@@ -137,13 +136,8 @@ class TestHomeAssistant(unittest.TestCase):
             loop=self.hass.loop
         ).result()
 
-        with patch.object(self.hass.loop, 'call_later') as mock_later:
-            run_callback_threadsafe(
-                self.hass.loop, self.hass._async_tasks_cleanup).result()
-            assert mock_later.called
-
-        assert len(self.hass._pending_tasks) == 0
-        assert len(call_count) == 50
+        assert len(self.hass._pending_tasks) == 3
+        assert len(call_count) == 3
 
     def test_async_add_job_pending_tasks_coro(self):
         """Add a coro to pending tasks."""

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -61,6 +61,7 @@ def setUpModule():
                      target=loop.run_forever).start()
 
     slave = remote.HomeAssistant(master_api, loop=loop)
+    slave.async_track_tasks()
     slave.config.config_dir = get_test_config_dir()
     slave.config.skip_pip = True
     bootstrap.setup_component(


### PR DESCRIPTION
**Description:**
Right now we are always tracking all tasks added via `hass.async_add_job`. However, during normal operation we will only need the tasks while we are shutting down. This should give normal operation some performance gain.

This PR will add a second async_add_job method without tracking. By default HASS will run without tracking. When Home Assistant is quitting, it will start tracking the jobs and make sure that all shutdown tasks are properly handled.

Tracking will always be enabled during tests.

Fixes #4375 

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
