### PR TITLE
Increase logging level of errors inside HASS

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -306,21 +306,14 @@ class HomeAssistant(object):
     @callback
     def _async_exception_handler(self, loop, context):
         """Handle all exception inside the core loop."""
-        message = context.get('message')
-        if message:
-            _LOGGER.warning(
-                "Error inside async loop: %s",
-                message
-            )
-
-        # for debug modus
+        kwargs = {}
         exception = context.get('exception')
-        if exception is not None:
-            exc_info = (type(exception), exception, exception.__traceback__)
-            _LOGGER.debug(
-                "Exception inside async loop: ",
-                exc_info=exc_info
-            )
+        if exception:
+            kwargs['exc_info'] = (type(exception), exception,
+                                  exception.__traceback__)
+
+        _LOGGER.error('Error doing job: %s', context['message'],
+                      **kwargs)
 
     @callback
     def _async_stop_handler(self, *args):


### PR DESCRIPTION
**Description:**
This increases the logging level of errors that happen while running HASS. Now all errors will get logged with verbosity level "error" including the traceback.

New logging will look like this (note coro is logged twice because it is scheduled twice. Once as a coro function, once as a coro)

<img width="948" alt="screen shot 2016-11-16 at 22 10 51" src="https://cloud.githubusercontent.com/assets/1444314/20378300/fe235154-ac49-11e6-9c80-869518c1aec2.png">

**Related issue (if applicable):** fixes #4402 #4418 
