### PR TITLE
Add sensor to show how many clients are connected.

### DIFF
--- a/homeassistant/components/sensor/api_streams.py
+++ b/homeassistant/components/sensor/api_streams.py
@@ -1,3 +1,4 @@
+"""Entity to track connections to stream API."""
 import asyncio
 import logging
 
@@ -38,6 +39,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
 
 class APICount(Entity):
+    """Entity to represent how many people are connected to stream API."""
 
     def __init__(self):
         """Initialize the API count."""

--- a/homeassistant/components/sensor/api_streams.py
+++ b/homeassistant/components/sensor/api_streams.py
@@ -1,0 +1,59 @@
+import asyncio
+import logging
+
+from homeassistant.helpers.entity import Entity
+
+
+class StreamHandler(logging.Handler):
+    """Check log messages for stream connect/disconnect."""
+
+    def __init__(self, entity):
+        """Initialize handler."""
+        super().__init__()
+        self.entity = entity
+        self.count = 0
+
+    def handle(self, record):
+        """Handle a log message."""
+        if not record.msg.startswith('STREAM'):
+            return
+
+        if record.msg.endswith('ATTACHED'):
+            self.entity.count += 1
+        elif record.msg.endswith('RESPONSE CLOSED'):
+            self.entity.count -= 1
+
+        self.entity.schedule_update_ha_state()
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the logger for filters."""
+    entity = APICount()
+
+    logging.getLogger('homeassistant.components.api').addHandler(
+        StreamHandler(entity))
+
+    yield from async_add_devices([entity])
+
+
+class APICount(Entity):
+
+    def __init__(self):
+        """Initialize the API count."""
+        self.count = 0
+
+    @property
+    def name(self):
+        """Return name of entity."""
+        return "Connected clients"
+
+    @property
+    def state(self):
+        """Return current API count."""
+        return self.count
+
+    @property
+    def unit_of_measurement(self):
+        """Unit of measurement."""
+        return "clients"

--- a/tests/components/sensor/test_api_streams.py
+++ b/tests/components/sensor/test_api_streams.py
@@ -1,0 +1,39 @@
+import asyncio
+import logging
+
+from homeassistant.bootstrap import async_setup_component
+from tests.common import assert_setup_component
+
+
+@asyncio.coroutine
+def test_api_streams(hass):
+    """Test API streams."""
+    log = logging.getLogger('homeassistant.components.api')
+
+    with assert_setup_component(1):
+        yield from async_setup_component(hass, 'sensor', {
+            'sensor': {
+                'platform': 'api_streams',
+            }
+        })
+
+    state = hass.states.get('sensor.current_viewers')
+    assert state.state == '0'
+
+    log.debug('STREAM 1 ATTACHED')
+    yield from hass.async_block_till_done()
+
+    state = hass.states.get('sensor.current_viewers')
+    assert state.state == '1'
+
+    log.debug('STREAM 1 ATTACHED')
+    yield from hass.async_block_till_done()
+
+    state = hass.states.get('sensor.current_viewers')
+    assert state.state == '2'
+
+    log.debug('STREAM 1 RESPONSE CLOSED')
+    yield from hass.async_block_till_done()
+
+    state = hass.states.get('sensor.current_viewers')
+    assert state.state == '1'

--- a/tests/components/sensor/test_api_streams.py
+++ b/tests/components/sensor/test_api_streams.py
@@ -17,23 +17,23 @@ def test_api_streams(hass):
             }
         })
 
-    state = hass.states.get('sensor.current_viewers')
+    state = hass.states.get('sensor.connected_clients')
     assert state.state == '0'
 
     log.debug('STREAM 1 ATTACHED')
     yield from hass.async_block_till_done()
 
-    state = hass.states.get('sensor.current_viewers')
+    state = hass.states.get('sensor.connected_clients')
     assert state.state == '1'
 
     log.debug('STREAM 1 ATTACHED')
     yield from hass.async_block_till_done()
 
-    state = hass.states.get('sensor.current_viewers')
+    state = hass.states.get('sensor.connected_clients')
     assert state.state == '2'
 
     log.debug('STREAM 1 RESPONSE CLOSED')
     yield from hass.async_block_till_done()
 
-    state = hass.states.get('sensor.current_viewers')
+    state = hass.states.get('sensor.connected_clients')
     assert state.state == '1'


### PR DESCRIPTION
**Description:**
This adds a sensor to show how many clients are connected to the stream API. As this API is used in the UI, it will show how many people currently have the UI open.

<img width="80" alt="screen shot 2016-11-16 at 22 46 27" src="https://cloud.githubusercontent.com/assets/1444314/20379004/914b9258-ac4e-11e6-8e4b-fc96c1f4a302.png">

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1462

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  platform: api_streams
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

