### PR TITLE
Delay device discovery during WeMo component initialization.

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -76,6 +76,14 @@ def setup(hass, config):
 
     discovery.listen(hass, SERVICE_WEMO, discovery_dispatch)
 
+    hass.add_job(wemo_startup_scan, hass, config)
+    return True
+
+
+def wemo_startup_scan(hass, config):
+    """Run device discovery once the component has been initialized."""
+    import pywemo
+
     _LOGGER.info("Scanning for WeMo devices.")
     devices = [(device.host, device) for device in pywemo.discover_devices()]
 
@@ -97,4 +105,3 @@ def setup(hass, config):
         discovery_info = (device.name, device.model_name, url, device.mac,
                           device.serialnumber)
         discovery.discover(hass, SERVICE_WEMO, discovery_info)
-    return True


### PR DESCRIPTION
**Description:**

When network discovery finds multiple WeMo platforms (in my case switch and light) then both platforms depend on the WeMo component. Because we are running a one-shot discovery during component initialization which takes some time the second initialization failed.

This patch delays running the pywemo specific discovery to occur after the component initialization has completed.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

Schedule device discovery to run after the WeMo component has finished
initializing. This avoids a situation where initialization fails because
discovery triggered initialization of two WeMo platforms that both
try to setup the WeMo component.