### PR TITLE
Make UI more responsive to power off for Samsung Smart TV

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -128,6 +128,8 @@ class SamsungTVDevice(MediaPlayerDevice):
     def turn_off(self):
         """Turn off media player."""
         self.send_key('KEY_POWEROFF')
+        # Force closing of remote session to provide instant UI feedback
+        self.get_remote().close()
 
     def volume_up(self):
         """Volume up the media player."""


### PR DESCRIPTION
**Description:**

When turning off a Samsung Smart TV from HA, the TV turns off immediately, but the web UI lags several seconds in updating this fact, which makes it confusing.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
