### PR TITLE
Fix so shell script adheres to posix standards.

### DIFF
--- a/script/lint
+++ b/script/lint
@@ -3,8 +3,8 @@
 # NOTE: all testing is now driven through tox. The tox command below
 # performs roughly what this test did in the past.
 
-if [ "$1" == "--changed" ]; then
-  export files=`git diff upstream/dev --name-only | grep -v requirements_all.txt`
+if [ "$1" = "--changed" ]; then
+  export files="`git diff upstream/dev --name-only | grep -v requirements_all.txt`"
   echo "================================================="
   echo "FILES CHANGED (git diff upstream/dev --name-only)"
   echo "================================================="


### PR DESCRIPTION
**Description:**
Ubuntu and Debian uses dash as /bin/sh. Dash is more picky than bash that scripts uses proper POSIX syntax. The script/lint did not use proper posix shell syntax, and failed to run properly under Ubuntu.

Since the script itself is not covered by tests, I have run no automated tests. I have however verified manually using ad-hoc testing that it works.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

