### PR TITLE
Add support for Prometheus

### DIFF
--- a/homeassistant/components/prometheus.py
+++ b/homeassistant/components/prometheus.py
@@ -1,0 +1,201 @@
+"""
+Support for Prometheus metrics export
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/prometheus/
+"""
+import asyncio
+import logging
+
+from aiohttp import web
+
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.const import (ATTR_HIDDEN, EVENT_STATE_CHANGED,
+                                 TEMP_CELSIUS, TEMP_FAHRENHEIT)
+from homeassistant import core as ha
+from homeassistant.helpers import state as state_helper
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_PROMETHEUS_HIDDEN = 'prometheus_hidden'
+
+REQUIREMENTS = ['prometheus_client==0.0.18']
+
+DOMAIN = 'prometheus'
+DEPENDENCIES = ['http']
+
+
+def setup(hass, config):
+    import prometheus_client
+
+    hass.http.register_view(PrometheusView(hass, prometheus_client))
+
+    metrics = Metrics(prometheus_client)
+
+    hass.bus.listen(EVENT_STATE_CHANGED, metrics.handle_event)
+
+    return True
+
+
+class Metrics:
+    def __init__(self, prometheus_client):
+        self.prometheus_client = prometheus_client
+        self._metrics = {}
+
+    def handle_event(self, event):
+        """Listen for new messages on the bus, and add them to Prometheus"""
+        state = event.data.get('new_state')
+        if state is None:
+            return
+
+        _LOGGER.info("Handling state update for %s", state.entity_id)
+
+        if (state.attributes.get(ATTR_HIDDEN) or
+                state.attributes.get(ATTR_PROMETHEUS_HIDDEN)):
+            return
+
+        domain, _ = ha.split_entity_id(state.entity_id)
+        handler = '_handle_' + domain
+
+        if hasattr(self, handler):
+            getattr(self, handler)(state)
+
+    def _metric(self, metric, factory, documentation, labels=None):
+        if labels is None:
+            labels = ['entity', 'friendly_name']
+
+        try:
+            return self._metrics[metric]
+        except KeyError:
+            self._metrics[metric] = factory(metric, documentation, labels)
+            return self._metrics[metric]
+
+    def _labels(self, state):
+        return {
+            'entity': state.entity_id,
+            'friendly_name': state.attributes.get('friendly_name'),
+        }
+
+    def _battery(self, state):
+        if 'battery_level' in state.attributes:
+            m = self._metric(
+                'battery_level_percent',
+                self.prometheus_client.Gauge,
+                'Battery level as a percentage of its capacity',
+            )
+            try:
+                value = float(state.attributes['battery_level'])
+                m.labels(**self._labels(state)).set(value)
+            except ValueError:
+                pass
+
+    def _handle_binary_sensor(self, state):
+        m = self._metric(
+            'binary_sensor_state',
+            self.prometheus_client.Gauge,
+            'State of the binary sensor (0/1)',
+        )
+
+        value = state_helper.state_as_number(state)
+        m.labels(**self._labels(state)).set(value)
+
+    def _handle_device_tracker(self, state):
+        m = self._metric(
+            'device_tracker_state',
+            self.prometheus_client.Gauge,
+            'State of the device tracker (0/1)',
+        )
+
+        value = state_helper.state_as_number(state)
+        m.labels(**self._labels(state)).set(value)
+
+    def _handle_light(self, state):
+        m = self._metric(
+            'light_state',
+            self.prometheus_client.Gauge,
+            'Load level of a light (0..1)',
+        )
+
+        try:
+            if 'brightness' in state.attributes:
+                value = state.attributes['brightness'] / 255.0
+            else:
+                value = state_helper.state_as_number(state)
+            value = value * 100
+            m.labels(**self._labels(state)).set(value)
+        except ValueError:
+            pass
+
+    def _handle_sensor(self, state):
+
+        _sensor_types = {
+            TEMP_CELSIUS: (
+                'temperature_c', self.prometheus_client.Gauge,
+                'Temperature in degrees Celsius',
+            ),
+            TEMP_FAHRENHEIT: (
+                'temperature_c', self.prometheus_client.Gauge,
+                'Temperature in degrees Celsius',
+            ),
+            '%': (
+                'relative_humidity', self.prometheus_client.Gauge,
+                'Relative humidity (0..100)',
+            ),
+            'lux': (
+                'light_lux', self.prometheus_client.Gauge,
+                'Light level in lux',
+            ),
+            'kWh': (
+                'electricity_used_kwh', self.prometheus_client.Gauge,
+                'Electricity used by this device in KWh',
+            ),
+            'V': (
+                'voltage', self.prometheus_client.Gauge,
+                'Currently reported voltage in Volts',
+            ),
+            'W': (
+                'electricity_usage_w', self.prometheus_client.Gauge,
+                'Currently reported electricity draw in Watts',
+            ),
+        }
+
+        unit = state.attributes.get('unit_of_measurement')
+        m = _sensor_types.get(unit)
+
+        if m is not None:
+            m = self._metric(*m)
+            try:
+                value = state_helper.state_as_number(state)
+                m.labels(**self._labels(state)).set(value)
+            except ValueError:
+                pass
+
+        self._battery(state)
+
+    def _handle_switch(self, state):
+        m = self._metric(
+            'switch_state',
+            self.prometheus_client.Gauge,
+            'State of the switch (0/1)',
+        )
+
+        value = state_helper.state_as_number(state)
+        m.labels(**self._labels(state)).set(value)
+
+
+class PrometheusView(HomeAssistantView):
+    url = '/api/prometheus'
+    name = 'api:prometheus'
+
+    def __init__(self, hass, prometheus_client):
+        super().__init__(hass)
+        self.prometheus_client = prometheus_client
+
+    @asyncio.coroutine
+    def get(self, request):
+        """Handle request for Prometheus metrics"""
+        _LOGGER.debug('Received Prometheus metrics request')
+
+        return web.Response(
+            body=self.prometheus_client.generate_latest(),
+            content_type="text/plain")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -342,6 +342,9 @@ pmsensor==0.3
 # homeassistant.components.climate.proliphix
 proliphix==0.4.1
 
+# homeassistant.components.prometheus
+prometheus_client==0.0.18
+
 # homeassistant.components.sensor.systemmonitor
 psutil==5.0.0
 

--- a/tests/components/test_prometheus.py
+++ b/tests/components/test_prometheus.py
@@ -1,0 +1,59 @@
+"""The tests for the Prometheus exporter."""
+import unittest
+
+import requests
+
+from homeassistant import bootstrap, const
+import homeassistant.core as ha
+import homeassistant.components.prometheus as prometheus
+import homeassistant.components.http as http
+
+from tests.common import get_test_instance_port, get_test_home_assistant
+
+API_PASSWORD = "test1234"
+SERVER_PORT = get_test_instance_port()
+PROMETHEUS_URL = "http://127.0.0.1:{}/api/prometheus".format(SERVER_PORT)
+HA_HEADERS = {
+    const.HTTP_HEADER_HA_AUTH: API_PASSWORD,
+}
+
+hass = None
+
+
+# pylint: disable=invalid-name
+def setUpModule():
+    """Initialize a Home Assistant server."""
+    global hass
+
+    hass = get_test_home_assistant()
+
+    assert bootstrap.setup_component(
+        hass, http.DOMAIN,
+        {http.DOMAIN: {http.CONF_API_PASSWORD: API_PASSWORD,
+                       http.CONF_SERVER_PORT: SERVER_PORT}})
+
+    assert bootstrap.setup_component(hass, 'api')
+
+    assert bootstrap.setup_component(hass, 'prometheus')
+
+    hass.start()
+
+
+# pylint: disable=invalid-name
+def tearDownModule():
+    """Stop everything that was started."""
+    hass.stop()
+
+
+class TestPrometheus(unittest.TestCase):
+    """Test the Prometheus component."""
+
+    def test_view(self):
+        """Test prometheus metrics view."""
+        req = requests.get(PROMETHEUS_URL, headers=HA_HEADERS)
+        self.assertEqual(req.headers['content-type'], 'text/plain')
+        for line in req.text.split("\n"):
+            if line:
+                self.assertTrue(
+                    line.startswith('# ') or line.startswith('process_'),
+                )


### PR DESCRIPTION
**Description:**


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1454

**Example entry for `configuration.yaml` (if applicable):**
```yaml
prometheus:
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

Prometheus (https://prometheus.io/) is an open source metric and alerting
system. This adds support for exporting some metrics to Prometheus, using
its Python client library.