### PR TITLE
zoneminder: Support excluding archived events

### DIFF
--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -6,17 +6,32 @@ https://home-assistant.io/components/sensor.zoneminder/
 """
 import logging
 
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers.entity import Entity
 import homeassistant.components.zoneminder as zoneminder
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['zoneminder']
 
+CONF_INCLUDE_ARCHIVED = "include_archived"
+
+DEFAULT_INCLUDE_ARCHIVED = False
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_INCLUDE_ARCHIVED, default=DEFAULT_INCLUDE_ARCHIVED):
+        cv.boolean,
+})
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the ZoneMinder sensor platform."""
+    include_archived = config.get(CONF_INCLUDE_ARCHIVED)
+
     sensors = []
 
     monitors = zoneminder.get_state('api/monitors.json')
@@ -25,7 +40,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             ZMSensorMonitors(int(i['Monitor']['Id']), i['Monitor']['Name'])
         )
         sensors.append(
-            ZMSensorEvents(int(i['Monitor']['Id']), i['Monitor']['Name'])
+            ZMSensorEvents(int(i['Monitor']['Id']), i['Monitor']['Name'],
+                           include_archived)
         )
 
     add_devices(sensors)
@@ -64,10 +80,11 @@ class ZMSensorMonitors(Entity):
 class ZMSensorEvents(Entity):
     """Get the number of events for each monitor."""
 
-    def __init__(self, monitor_id, monitor_name):
+    def __init__(self, monitor_id, monitor_name, include_archived):
         """Initiate event sensor."""
         self._monitor_id = monitor_id
         self._monitor_name = monitor_name
+        self._include_archived = include_archived
         self._state = None
 
     @property
@@ -87,8 +104,13 @@ class ZMSensorEvents(Entity):
 
     def update(self):
         """Update the sensor."""
+        archived_filter = '/Archived:0'
+        if self._include_archived:
+            archived_filter = ''
+
         event = zoneminder.get_state(
-            'api/events/index/MonitorId:%i.json' % self._monitor_id
+            'api/events/index/MonitorId:%i%s.json' % (self._monitor_id,
+                                                      archived_filter)
         )
 
         self._state = event['pagination']['count']


### PR DESCRIPTION
**Description:**
ZoneMinder supports archiving camera events and sensor.zoneminder currently includes archived events in the event count for each camera. For my workflow, I only want to see the count of "untriaged" events (ones I haven't reviewed and either deleted or archived) so having the event count exclude archived events is useful at least for me.  I suspect other people (who archive) would also prefer to exclude the archived events by default so I'm making it the default. There is a somewhat related quote in [ZM docs](https://zoneminder.readthedocs.io/en/stable/userguide/filterevents.html?highlight=archive): "In general you’ll probably do most filtering on un-archived events."

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1455

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: zoneminder
    include_archived: False
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] ~~New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~~
  - [x] ~~New dependencies are only imported inside functions that use them ([example][ex-import]).~~
  - [x] ~~New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~~
  - [x] ~~New files were added to `.coveragerc`.~~

If the code does not interact with devices:
  - [x] ~~Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**~~
  - [x] ~~Tests have been added to verify that the new code works.~~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51