### PR TITLE
Upgrade batinfo to 0.4.2

### DIFF
--- a/homeassistant/components/sensor/linux_battery.py
+++ b/homeassistant/components/sensor/linux_battery.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_NAME
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['batinfo==0.3']
+REQUIREMENTS = ['batinfo==0.4.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -43,7 +43,7 @@ apns2==0.1.1
 astral==1.3
 
 # homeassistant.components.sensor.linux_battery
-batinfo==0.3
+batinfo==0.4.2
 
 # homeassistant.components.sensor.scrape
 beautifulsoup4==4.5.1


### PR DESCRIPTION
## 0.4.2
- Typos and license

Tested with the following configuration:

``` yaml
sensor:
  - platform: linux_battery
    name: Battery Laptop
    battery: 1
```