### PR TITLE
ZWave Cover: Switch based cover did not get initialized

### DIFF
--- a/homeassistant/components/cover/zwave.py
+++ b/homeassistant/components/cover/zwave.py
@@ -36,15 +36,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             and value.index == 0):
         value.set_change_verified(False)
         add_devices([ZwaveRollershutter(value)])
-    elif value.node.specific == zwave.const.GENERIC_TYPE_ENTRY_CONTROL:
-        if (value.command_class == zwave.const.COMMAND_CLASS_SWITCH_BINARY or
-                value.command_class ==
-                zwave.const.COMMAND_CLASS_BARRIER_OPERATOR):
-            if (value.type != zwave.const.TYPE_BOOL and
-                    value.genre != zwave.const.GENRE_USER):
-                return
-            value.set_change_verified(False)
-            add_devices([ZwaveGarageDoor(value)])
+    elif (value.command_class == zwave.const.COMMAND_CLASS_SWITCH_BINARY or
+          value.command_class == zwave.const.COMMAND_CLASS_BARRIER_OPERATOR):
+        if (value.type != zwave.const.TYPE_BOOL and
+                value.genre != zwave.const.GENRE_USER):
+            return
+        value.set_change_verified(False)
+        add_devices([ZwaveGarageDoor(value)])
     else:
         return
 


### PR DESCRIPTION
**Description:**
Wrong tests for checking correct values. This only affected switch based garagedoor controllers.
This should make them reappear in hass again.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
#4443 
