### PR TITLE
Only check heater status if present

### DIFF
--- a/homeassistant/components/device_tracker/volvooncall.py
+++ b/homeassistant/components/device_tracker/volvooncall.py
@@ -55,25 +55,30 @@ def setup_scanner(hass, config, see):
             """True if any door/window is opened."""
             return any([door[key] for key in door if "Open" in key])
 
+        attributes = dict(
+            unlocked=not vehicle["carLocked"],
+            tank_volume=vehicle["fuelTankVolume"],
+            average_fuel_consumption=round(
+                vehicle["averageFuelConsumption"] / 10, 1),  # l/100km
+            washer_fluid_low=vehicle["washerFluidLevel"] != "Normal",
+            brake_fluid_low=vehicle["brakeFluid"] != "Normal",
+            service_warning=vehicle["serviceWarningStatus"] != "Normal",
+            bulb_failures=len(vehicle["bulbFailures"]) > 0,
+            doors_open=any_opened(vehicle["doors"]),
+            windows_open=any_opened(vehicle["windows"]),
+            fuel=vehicle["fuelAmount"],
+            odometer=round(vehicle["odometer"] / 1000),  # km
+            range=vehicle["distanceToEmpty"])
+
+        if "heater" in vehicle and \
+           "status" in vehicle["heater"]:
+            attributes.update(heater_on=vehicle["heater"]["status"] != "off")
+
         see(dev_id=dev_id,
             host_name=host_name,
             gps=(position["latitude"],
                  position["longitude"]),
-            attributes=dict(
-                unlocked=not vehicle["carLocked"],
-                tank_volume=vehicle["fuelTankVolume"],
-                average_fuel_consumption=round(
-                    vehicle["averageFuelConsumption"] / 10, 1),  # l/100km
-                washer_fluid_low=vehicle["washerFluidLevel"] != "Normal",
-                brake_fluid_low=vehicle["brakeFluid"] != "Normal",
-                service_warning=vehicle["serviceWarningStatus"] != "Normal",
-                bulb_failures=len(vehicle["bulbFailures"]) > 0,
-                doors_open=any_opened(vehicle["doors"]),
-                windows_open=any_opened(vehicle["windows"]),
-                heater_on=vehicle["heater"]["status"] != "off",
-                fuel=vehicle["fuelAmount"],
-                odometer=round(vehicle["odometer"] / 1000),  # km
-                range=vehicle["distanceToEmpty"]))
+            attributes=attributes)
 
     def update(now):
         """Update status from the online service."""


### PR DESCRIPTION
**Description:**
Only check heater status if attribute is present (volvo on call)

Fixes issue reported in https://github.com/home-assistant/home-assistant/pull/4170#issuecomment-261648630

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

