### PR TITLE
Refactor tellstick code

### DIFF
--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -6,14 +6,14 @@ https://home-assistant.io/components/light.tellstick/
 """
 import voluptuous as vol
 
-from homeassistant.components import tellstick
 from homeassistant.components.light import (ATTR_BRIGHTNESS,
                                             SUPPORT_BRIGHTNESS, Light)
 from homeassistant.components.tellstick import (DEFAULT_SIGNAL_REPETITIONS,
                                                 ATTR_DISCOVER_DEVICES,
-                                                ATTR_DISCOVER_CONFIG)
+                                                ATTR_DISCOVER_CONFIG,
+                                                DOMAIN, TellstickDevice)
 
-PLATFORM_SCHEMA = vol.Schema({vol.Required("platform"): tellstick.DOMAIN})
+PLATFORM_SCHEMA = vol.Schema({vol.Required("platform"): DOMAIN})
 
 SUPPORT_TELLSTICK = SUPPORT_BRIGHTNESS
 
@@ -22,32 +22,25 @@ SUPPORT_TELLSTICK = SUPPORT_BRIGHTNESS
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup Tellstick lights."""
     if (discovery_info is None or
-            discovery_info[ATTR_DISCOVER_DEVICES] is None or
-            tellstick.TELLCORE_REGISTRY is None):
+            discovery_info[ATTR_DISCOVER_DEVICES] is None):
         return
 
+    # Allow platform level override, fallback to module config
     signal_repetitions = discovery_info.get(ATTR_DISCOVER_CONFIG,
                                             DEFAULT_SIGNAL_REPETITIONS)
 
-    add_devices(TellstickLight(
-        tellstick.TELLCORE_REGISTRY.get_tellcore_device(tellcore_light_id), signal_repetitions)
-                for tellcore_light_id in discovery_info[ATTR_DISCOVER_DEVICES])
+    add_devices(TellstickLight(tellcore_id, signal_repetitions)
+                for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES])
 
 
-class TellstickLight(tellstick.TellstickDevice, Light):
+class TellstickLight(TellstickDevice, Light):
     """Representation of a Tellstick light."""
 
-    def __init__(self, tellcore_device, signal_repetitions):
+    def __init__(self, tellcore_id, signal_repetitions):
         """Initialize the light."""
-        self._brightness = 255
-        tellstick.TellstickDevice.__init__(self,
-                                           tellcore_device,
-                                           signal_repetitions)
+        super().__init__(tellcore_id, signal_repetitions)
 
-    @property
-    def is_on(self):
-        """Return true if switch is on."""
-        return self._state
+        self._brightness = 255
 
     @property
     def brightness(self):
@@ -59,37 +52,29 @@ class TellstickLight(tellstick.TellstickDevice, Light):
         """Flag supported features."""
         return SUPPORT_TELLSTICK
 
-    def set_tellstick_state(self, last_command_sent, last_data_sent):
-        """Update the internal representation of the switch."""
-        from tellcore.constants import TELLSTICK_TURNON, TELLSTICK_DIM
-        if last_command_sent == TELLSTICK_DIM:
-            if last_data_sent is not None:
-                self._brightness = int(last_data_sent)
-            self._state = (self._brightness > 0)
-        else:
-            self._state = (last_command_sent == TELLSTICK_TURNON)
+    def _parse_ha_data(self, kwargs):
+        return kwargs.get(ATTR_BRIGHTNESS)
 
-    def _send_tellstick_command(self, command, data):
-        """Handle the turn_on / turn_off commands."""
-        from tellcore.constants import (TELLSTICK_TURNOFF, TELLSTICK_DIM)
-        if command == TELLSTICK_TURNOFF:
-            self._tellcore_device.turn_off()
-        elif command == TELLSTICK_DIM:
+    def _parse_tellcore_data(self, tellcore_data)
+        if tellcore_data is not None:
+            brightness = int(tellcore_data)
+            return brightness
+        else:
+            return None
+
+    def _update_model(self, new_state, data):
+        if new_state:
+          brightness = data
+          if brightness is not None:
+              self._brightness = brightness
+
+          self._state = (self._brightness > 0)
+        else:
+          self._state = False
+
+    def _send_tellstick_command(self):
+        if self._state:
             self._tellcore_device.dim(self._brightness)
         else:
-            raise NotImplementedError(
-                "Command not implemented: {}".format(command))
+            self._tellcore_device.turn_off()
 
-    def turn_on(self, **kwargs):
-        """Turn the switch on."""
-        from tellcore.constants import TELLSTICK_DIM
-        brightness = kwargs.get(ATTR_BRIGHTNESS)
-        if brightness is not None:
-            self._brightness = brightness
-
-        self.call_tellstick(TELLSTICK_DIM, self._brightness)
-
-    def turn_off(self, **kwargs):
-        """Turn the switch off."""
-        from tellcore.constants import TELLSTICK_TURNOFF
-        self.call_tellstick(TELLSTICK_TURNOFF)

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -53,11 +53,11 @@ class TellstickLight(TellstickDevice, Light):
         return SUPPORT_TELLSTICK
 
     def _parse_ha_data(self, kwargs):
-        """Turn the value from HA into something useful"""
+        """Turn the value from HA into something useful."""
         return kwargs.get(ATTR_BRIGHTNESS)
 
     def _parse_tellcore_data(self, tellcore_data):
-        """Turn the value recieved from tellcore into something useful"""
+        """Turn the value recieved from tellcore into something useful."""
         if tellcore_data is not None:
             brightness = int(tellcore_data)
             return brightness
@@ -65,20 +65,19 @@ class TellstickLight(TellstickDevice, Light):
             return None
 
     def _update_model(self, new_state, data):
-        """Update the device entity state to match the arguments"""
+        """Update the device entity state to match the arguments."""
         if new_state:
-          brightness = data
-          if brightness is not None:
-              self._brightness = brightness
+            brightness = data
+            if brightness is not None:
+                self._brightness = brightness
 
-          self._state = (self._brightness > 0)
+            self._state = (self._brightness > 0)
         else:
-          self._state = False
+            self._state = False
 
     def _send_tellstick_command(self):
-        """Let tellcore update the physical device to match the current state"""
+        """Let tellcore update the device to match the current state."""
         if self._state:
             self._tellcore_device.dim(self._brightness)
         else:
             self._tellcore_device.turn_off()
-

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -53,9 +53,11 @@ class TellstickLight(TellstickDevice, Light):
         return SUPPORT_TELLSTICK
 
     def _parse_ha_data(self, kwargs):
+        """Turn the value from HA into something useful"""
         return kwargs.get(ATTR_BRIGHTNESS)
 
-    def _parse_tellcore_data(self, tellcore_data)
+    def _parse_tellcore_data(self, tellcore_data):
+        """Turn the value recieved from tellcore into something useful"""
         if tellcore_data is not None:
             brightness = int(tellcore_data)
             return brightness
@@ -63,6 +65,7 @@ class TellstickLight(TellstickDevice, Light):
             return None
 
     def _update_model(self, new_state, data):
+        """Update the device entity state to match the arguments"""
         if new_state:
           brightness = data
           if brightness is not None:
@@ -73,6 +76,7 @@ class TellstickLight(TellstickDevice, Light):
           self._state = False
 
     def _send_tellstick_command(self):
+        """Let tellcore update the physical device to match the current state"""
         if self._state:
             self._tellcore_device.dim(self._brightness)
         else:

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -30,18 +30,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                             DEFAULT_SIGNAL_REPETITIONS)
 
     add_devices(TellstickLight(
-        tellstick.TELLCORE_REGISTRY.get_device(switch_id), signal_repetitions)
-                for switch_id in discovery_info[ATTR_DISCOVER_DEVICES])
+        tellstick.TELLCORE_REGISTRY.get_tellcore_device(tellcore_light_id), signal_repetitions)
+                for tellcore_light_id in discovery_info[ATTR_DISCOVER_DEVICES])
 
 
 class TellstickLight(tellstick.TellstickDevice, Light):
     """Representation of a Tellstick light."""
 
-    def __init__(self, tellstick_device, signal_repetitions):
+    def __init__(self, tellcore_device, signal_repetitions):
         """Initialize the light."""
         self._brightness = 255
         tellstick.TellstickDevice.__init__(self,
-                                           tellstick_device,
+                                           tellcore_device,
                                            signal_repetitions)
 
     @property
@@ -65,17 +65,17 @@ class TellstickLight(tellstick.TellstickDevice, Light):
         if last_command_sent == TELLSTICK_DIM:
             if last_data_sent is not None:
                 self._brightness = int(last_data_sent)
-            self._state = self._brightness > 0
+            self._state = (self._brightness > 0)
         else:
-            self._state = last_command_sent == TELLSTICK_TURNON
+            self._state = (last_command_sent == TELLSTICK_TURNON)
 
     def _send_tellstick_command(self, command, data):
         """Handle the turn_on / turn_off commands."""
         from tellcore.constants import (TELLSTICK_TURNOFF, TELLSTICK_DIM)
         if command == TELLSTICK_TURNOFF:
-            self.tellstick_device.turn_off()
+            self._tellcore_device.turn_off()
         elif command == TELLSTICK_DIM:
-            self.tellstick_device.dim(self._brightness)
+            self._tellcore_device.dim(self._brightness)
         else:
             raise NotImplementedError(
                 "Command not implemented: {}".format(command))

--- a/homeassistant/components/sensor/tellstick.py
+++ b/homeassistant/components/sensor/tellstick.py
@@ -84,10 +84,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             sensor_name = str(tellcore_sensor.id)
 
         for datatype in sensor_value_descriptions:
-            if datatype & datatype_mask and tellcore_sensor.has_value(datatype):
-                sensor_info = sensor_value_descriptions[datatype]
-                sensors.append(TellstickSensor(
-                    sensor_name, tellcore_sensor, datatype, sensor_info))
+            if datatype & datatype_mask:
+                if tellcore_sensor.has_value(datatype):
+                    sensor_info = sensor_value_descriptions[datatype]
+                    sensors.append(TellstickSensor(
+                        sensor_name, tellcore_sensor, datatype, sensor_info))
 
     add_devices(sensors)
 

--- a/homeassistant/components/sensor/tellstick.py
+++ b/homeassistant/components/sensor/tellstick.py
@@ -16,6 +16,8 @@ import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['tellcore-py==1.1.2']
 
+_LOGGER = logging.getLogger(__name__)
+
 DatatypeDescription = namedtuple('DatatypeDescription', ['name', 'unit'])
 
 CONF_DATATYPE_MASK = 'datatype_mask'
@@ -65,15 +67,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     }
 
     try:
-        core = telldus.TelldusCore()
+        tellcore_lib = telldus.TelldusCore()
     except OSError:
-        logging.getLogger(__name__).exception('Could not initialize Tellstick')
+        _LOGGER.exception('Could not initialize Tellstick')
         return
 
     sensors = []
     datatype_mask = config.get(CONF_DATATYPE_MASK)
 
-    for tellcore_sensor in core.sensors():
+    for tellcore_sensor in tellcore_lib.sensors():
         try:
             sensor_name = config[tellcore_sensor.id]
         except KeyError:

--- a/homeassistant/components/sensor/tellstick.py
+++ b/homeassistant/components/sensor/tellstick.py
@@ -73,19 +73,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     sensors = []
     datatype_mask = config.get(CONF_DATATYPE_MASK)
 
-    for ts_sensor in core.sensors():
+    for tellcore_sensor in core.sensors():
         try:
-            sensor_name = config[ts_sensor.id]
+            sensor_name = config[tellcore_sensor.id]
         except KeyError:
             if config.get(CONF_ONLY_NAMED):
                 continue
-            sensor_name = str(ts_sensor.id)
+            sensor_name = str(tellcore_sensor.id)
 
         for datatype in sensor_value_descriptions:
-            if datatype & datatype_mask and ts_sensor.has_value(datatype):
+            if datatype & datatype_mask and tellcore_sensor.has_value(datatype):
                 sensor_info = sensor_value_descriptions[datatype]
                 sensors.append(TellstickSensor(
-                    sensor_name, ts_sensor, datatype, sensor_info))
+                    sensor_name, tellcore_sensor, datatype, sensor_info))
 
     add_devices(sensors)
 
@@ -93,10 +93,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class TellstickSensor(Entity):
     """Representation of a Tellstick sensor."""
 
-    def __init__(self, name, sensor, datatype, sensor_info):
+    def __init__(self, name, tellcore_sensor, datatype, sensor_info):
         """Initialize the sensor."""
-        self.datatype = datatype
-        self.sensor = sensor
+        self._datatype = datatype
+        self._tellcore_sensor = tellcore_sensor
         self._unit_of_measurement = sensor_info.unit or None
         self._value = None
 
@@ -119,4 +119,4 @@ class TellstickSensor(Entity):
 
     def update(self):
         """Update tellstick sensor."""
-        self._value = self.sensor.value(self.datatype).value
+        self._value = self._tellcore_sensor.value(self._datatype).value

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -27,8 +27,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         ATTR_DISCOVER_CONFIG, tellstick.DEFAULT_SIGNAL_REPETITIONS)
 
     add_devices(TellstickSwitchDevice(
-        tellstick.TELLCORE_REGISTRY.get_device(switch_id), signal_repetitions)
-                for switch_id in discovery_info[ATTR_DISCOVER_DEVICES])
+        tellstick.TELLCORE_REGISTRY.get_tellcore_device(tellcore_switch_id), signal_repetitions)
+                for tellcore_switch_id in discovery_info[ATTR_DISCOVER_DEVICES])
 
 
 class TellstickSwitchDevice(tellstick.TellstickDevice, ToggleEntity):
@@ -42,15 +42,15 @@ class TellstickSwitchDevice(tellstick.TellstickDevice, ToggleEntity):
     def set_tellstick_state(self, last_command_sent, last_data_sent):
         """Update the internal representation of the switch."""
         from tellcore.constants import TELLSTICK_TURNON
-        self._state = last_command_sent == TELLSTICK_TURNON
+        self._state = (last_command_sent == TELLSTICK_TURNON)
 
     def _send_tellstick_command(self, command, data):
         """Handle the turn_on / turn_off commands."""
         from tellcore.constants import TELLSTICK_TURNON, TELLSTICK_TURNOFF
         if command == TELLSTICK_TURNON:
-            self.tellstick_device.turn_on()
+            self._tellcore_device.turn_on()
         elif command == TELLSTICK_TURNOFF:
-            self.tellstick_device.turn_off()
+            self._tellcore_device.turn_off()
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -34,19 +34,19 @@ class TellstickSwitch(TellstickDevice, ToggleEntity):
     """Representation of a Tellstick switch."""
 
     def _parse_ha_data(self, kwargs):
-        """Turn the value from HA into something useful"""
+        """Turn the value from HA into something useful."""
         return None
 
     def _parse_tellcore_data(self, tellcore_data):
-        """Turn the value recieved from tellcore into something useful"""
+        """Turn the value recieved from tellcore into something useful."""
         return None
 
     def _update_model(self, new_state, data):
-        """Update the device entity state to match the arguments"""
+        """Update the device entity state to match the arguments."""
         self._state = new_state
 
     def _send_tellstick_command(self):
-        """Let tellcore update the physical device to match the current state"""
+        """Let tellcore update the device to match the current state."""
         if self._state:
             self._tellcore_device.turn_on()
         else:

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -34,15 +34,19 @@ class TellstickSwitch(TellstickDevice, ToggleEntity):
     """Representation of a Tellstick switch."""
 
     def _parse_ha_data(self, kwargs):
+        """Turn the value from HA into something useful"""
         return None
 
-    def _parse_tellcore_data(self, tellcore_data)
+    def _parse_tellcore_data(self, tellcore_data):
+        """Turn the value recieved from tellcore into something useful"""
         return None
 
     def _update_model(self, new_state, data):
+        """Update the device entity state to match the arguments"""
         self._state = new_state
 
     def _send_tellstick_command(self):
+        """Let tellcore update the physical device to match the current state"""
         if self._state:
             self._tellcore_device.turn_on()
         else:

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -6,61 +6,47 @@ https://home-assistant.io/components/switch.tellstick/
 """
 import voluptuous as vol
 
-from homeassistant.components import tellstick
-from homeassistant.components.tellstick import (ATTR_DISCOVER_DEVICES,
-                                                ATTR_DISCOVER_CONFIG)
+from homeassistant.components.tellstick import (DEFAULT_SIGNAL_REPETITIONS,
+                                                ATTR_DISCOVER_DEVICES,
+                                                ATTR_DISCOVER_CONFIG,
+                                                DOMAIN, TellstickDevice)
 from homeassistant.helpers.entity import ToggleEntity
 
-PLATFORM_SCHEMA = vol.Schema({vol.Required("platform"): tellstick.DOMAIN})
+PLATFORM_SCHEMA = vol.Schema({vol.Required("platform"): DOMAIN})
 
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup Tellstick switches."""
     if (discovery_info is None or
-            discovery_info[ATTR_DISCOVER_DEVICES] is None or
-            tellstick.TELLCORE_REGISTRY is None):
+            discovery_info[ATTR_DISCOVER_DEVICES] is None):
         return
 
     # Allow platform level override, fallback to module config
-    signal_repetitions = discovery_info.get(
-        ATTR_DISCOVER_CONFIG, tellstick.DEFAULT_SIGNAL_REPETITIONS)
+    signal_repetitions = discovery_info.get(ATTR_DISCOVER_CONFIG,
+                                            DEFAULT_SIGNAL_REPETITIONS)
 
-    add_devices(TellstickSwitchDevice(
-        tellstick.TELLCORE_REGISTRY.get_tellcore_device(tellcore_switch_id), signal_repetitions)
-                for tellcore_switch_id in discovery_info[ATTR_DISCOVER_DEVICES])
+    add_devices(TellstickSwitch(tellcore_id, signal_repetitions)
+                for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES])
 
 
-class TellstickSwitchDevice(tellstick.TellstickDevice, ToggleEntity):
+class TellstickSwitch(TellstickDevice, ToggleEntity):
     """Representation of a Tellstick switch."""
 
-    @property
-    def is_on(self):
-        """Return true if switch is on."""
-        return self._state
+    def _parse_ha_data(self, kwargs):
+        return None
 
-    def set_tellstick_state(self, last_command_sent, last_data_sent):
-        """Update the internal representation of the switch."""
-        from tellcore.constants import TELLSTICK_TURNON
-        self._state = (last_command_sent == TELLSTICK_TURNON)
+    def _parse_tellcore_data(self, tellcore_data)
+        return None
 
-    def _send_tellstick_command(self, command, data):
-        """Handle the turn_on / turn_off commands."""
-        from tellcore.constants import TELLSTICK_TURNON, TELLSTICK_TURNOFF
-        if command == TELLSTICK_TURNON:
+    def _update_model(self, new_state, data):
+        self._state = new_state
+
+    def _send_tellstick_command(self):
+        if self._state:
             self._tellcore_device.turn_on()
-        elif command == TELLSTICK_TURNOFF:
+        else:
             self._tellcore_device.turn_off()
-
-    def turn_on(self, **kwargs):
-        """Turn the switch on."""
-        from tellcore.constants import TELLSTICK_TURNON
-        self.call_tellstick(TELLSTICK_TURNON)
-
-    def turn_off(self, **kwargs):
-        """Turn the switch off."""
-        from tellcore.constants import TELLSTICK_TURNOFF
-        self.call_tellstick(TELLSTICK_TURNOFF)
 
     @property
     def force_update(self) -> bool:


### PR DESCRIPTION
**Description:**
This started as an attempt to solve issue #4403. However, the tellstick code was very convoluted and hard to follow. For instance, "telldus device" was used to mean either an object derived from the HA Entity, or an object from the tellcore python library, with no clear separation. Also, the separation of concern between the common base class TelldusDevice and the swich/light subclasses was vague, with the actual workflow going up and down the hierarchy for no apparent reason.

So I decided to clean up the code as a first step, to be able to solve #4403 properly.

This is supposed to be a pure refactoring, with no changes in how the code actually behaves. I have tested that it works on my tellstick setup, but as far as I can tell, tox does not really exercise the tellstick code. :-(

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
