### PR TITLE
Support monitoring removable network interfaces (sensor.systemmonitor)

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_RESOURCES, STATE_OFF, STATE_ON, CONF_TYPE)
+    CONF_RESOURCES, STATE_OFF, STATE_ON, STATE_UNKNOWN, CONF_TYPE)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
@@ -48,6 +48,18 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
             vol.Optional('arg'): cv.string,
         })])
 })
+
+IO_COUNTER = {
+    'network_out': 0,
+    'network_in': 1,
+    'packets_out': 2,
+    'packets_in': 3,
+}
+
+IF_ADDRS = {
+    'ipv4_address': 0,
+    'ipv6_address': 1,
+}
 
 
 # pylint: disable=unused-argument
@@ -126,20 +138,25 @@ class SystemMonitorSensor(Entity):
                 self._state = STATE_ON
             else:
                 self._state = STATE_OFF
-        elif self.type == 'network_out':
-            self._state = round(psutil.net_io_counters(pernic=True)
-                                [self.argument][0] / 1024**2, 1)
-        elif self.type == 'network_in':
-            self._state = round(psutil.net_io_counters(pernic=True)
-                                [self.argument][1] / 1024**2, 1)
-        elif self.type == 'packets_out':
-            self._state = psutil.net_io_counters(pernic=True)[self.argument][2]
-        elif self.type == 'packets_in':
-            self._state = psutil.net_io_counters(pernic=True)[self.argument][3]
-        elif self.type == 'ipv4_address':
-            self._state = psutil.net_if_addrs()[self.argument][0][1]
-        elif self.type == 'ipv6_address':
-            self._state = psutil.net_if_addrs()[self.argument][1][1]
+        elif self.type == 'network_out' or self.type == 'network_in':
+            counters = psutil.net_io_counters(pernic=True)
+            if self.argument in counters:
+                counter = counters[self.argument][IO_COUNTER[self.type]]
+                self._state = round(counter / 1024**2, 1)
+            else:
+                self._state = STATE_UNKNOWN
+        elif self.type == 'packets_out' or self.type == 'packets_in':
+            counters = psutil.net_io_counters(pernic=True)
+            if self.argument in counters:
+                self._state = counters[self.argument][IO_COUNTER[self.type]]
+            else:
+                self._state = STATE_UNKNOWN
+        elif self.type == 'ipv4_address' or self.type == 'ipv6_address':
+            addresses = psutil.net_if_addrs()
+            if self.argument in addresses:
+                self._state = addresses[self.argument][IF_ADDRS[self.type]][1]
+            else:
+                self._state = STATE_UNKNOWN
         elif self.type == 'last_boot':
             self._state = dt_util.as_local(
                 dt_util.utc_from_timestamp(psutil.boot_time())


### PR DESCRIPTION
**Description:**
Support monitoring network, packets and IP addresses of removable network interfaces (ones that aren't necessarily always present). Without this change a `KeyError` is thrown at startup for the first monitored interface which doesn't exist at startup and that also breaks every monitor after it in the loop. The use case is for monitoring removable (e.g. USB) ethernet/ppp devices which aren't always attached.

I tried to reduce the duplication of the `self.argument in …` checks by combining related branches and using a dictionary to name the magic number array offsets from psutil.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A. This is a straightforward change.

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  platform: systemmonitor
  resources:
    - type: network_in
      arg: ppp0
    - type: network_out
      arg: ppp0
    - type: ipv4_address
      arg: ppp0
    - type: packets_in
      arg: ppp0
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] ~Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

