### PR TITLE
LiteJet: Unit tests and new trigger options held_more_than and held_less_than.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -40,9 +40,6 @@ omit =
     homeassistant/components/isy994.py
     homeassistant/components/*/isy994.py
 
-    homeassistant/components/litejet.py
-    homeassistant/components/*/litejet.py
-
     homeassistant/components/modbus.py
     homeassistant/components/*/modbus.py
 

--- a/homeassistant/components/automation/litejet.py
+++ b/homeassistant/components/automation/litejet.py
@@ -11,22 +11,34 @@ import voluptuous as vol
 from homeassistant.core import callback
 from homeassistant.const import CONF_PLATFORM
 import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
+from homeassistant.helpers.event import track_point_in_utc_time
 
 DEPENDENCIES = ['litejet']
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_NUMBER = 'number'
+CONF_HELD_MORE_THAN = 'held_more_than'
+CONF_HELD_LESS_THAN = 'held_less_than'
 
 TRIGGER_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'litejet',
-    vol.Required(CONF_NUMBER): cv.positive_int
+    vol.Required(CONF_NUMBER): cv.positive_int,
+    vol.Optional(CONF_HELD_MORE_THAN):
+        vol.All(cv.time_period, cv.positive_timedelta),
+    vol.Optional(CONF_HELD_LESS_THAN):
+        vol.All(cv.time_period, cv.positive_timedelta)
 })
 
 
 def async_trigger(hass, config, action):
     """Listen for events based on configuration."""
     number = config.get(CONF_NUMBER)
+    held_more_than = config.get(CONF_HELD_MORE_THAN)
+    held_less_than = config.get(CONF_HELD_LESS_THAN)
+    pressed_time = None
+    cancel_pressed_more_than = None
 
     @callback
     def call_action():
@@ -34,8 +46,53 @@ def async_trigger(hass, config, action):
         hass.async_run_job(action, {
             'trigger': {
                 CONF_PLATFORM: 'litejet',
-                CONF_NUMBER: number
+                CONF_NUMBER: number,
+                CONF_HELD_MORE_THAN: held_more_than,
+                CONF_HELD_LESS_THAN: held_less_than
             },
         })
 
-    hass.data['litejet_system'].on_switch_released(number, call_action)
+    # held_more_than and held_less_than: trigger on released (if in time range)
+    # held_more_than: trigger after pressed with calculation
+    # held_less_than: trigger on released with calculation
+    # neither: trigger on pressed
+
+    @callback
+    def pressed_more_than_satisfied(now):
+        """Handle the LiteJet's switch's button pressed >= held_more_than."""
+        call_action()
+
+    def pressed():
+        """Handle the press of the LiteJet switch's button."""
+        nonlocal cancel_pressed_more_than, pressed_time
+        nonlocal held_less_than, held_more_than
+        pressed_time = dt_util.utcnow()
+        if held_more_than is None and held_less_than is None:
+            call_action()
+        if held_more_than is not None and held_less_than is None:
+            cancel_pressed_more_than = track_point_in_utc_time(
+                hass,
+                pressed_more_than_satisfied,
+                dt_util.utcnow() + held_more_than)
+
+    def released():
+        """Handle the release of the LiteJet switch's button."""
+        nonlocal cancel_pressed_more_than, pressed_time
+        nonlocal held_less_than, held_more_than
+        # pylint: disable=not-callable
+        if cancel_pressed_more_than is not None:
+            cancel_pressed_more_than()
+            cancel_pressed_more_than = None
+        held_time = dt_util.utcnow() - pressed_time
+        if held_less_than is not None and held_time < held_less_than:
+            if held_more_than is None or held_time > held_more_than:
+                call_action()
+
+    hass.data['litejet_system'].on_switch_pressed(number, pressed)
+    hass.data['litejet_system'].on_switch_released(number, released)
+
+    def async_remove():
+        """Remove all subscriptions used for this trigger."""
+        return
+
+    return async_remove

--- a/tests/components/automation/test_litejet.py
+++ b/tests/components/automation/test_litejet.py
@@ -1,0 +1,251 @@
+"""The tests for the litejet component."""
+import logging
+import unittest
+from unittest import mock
+from datetime import timedelta
+
+from homeassistant import bootstrap
+import homeassistant.util.dt as dt_util
+from homeassistant.components import litejet
+from tests.common import (fire_time_changed, get_test_home_assistant)
+import homeassistant.components.automation as automation
+
+_LOGGER = logging.getLogger(__name__)
+
+ENTITY_SWITCH = 'switch.mock_switch_1'
+ENTITY_SWITCH_NUMBER = 1
+ENTITY_OTHER_SWITCH = 'switch.mock_switch_2'
+ENTITY_OTHER_SWITCH_NUMBER = 2
+
+
+class TestLiteJetTrigger(unittest.TestCase):
+    """Test the litejet component."""
+
+    @mock.patch('pylitejet.LiteJet')
+    def setup_method(self, method, mock_pylitejet):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.start()
+
+        self.switch_pressed_callbacks = {}
+        self.switch_released_callbacks = {}
+        self.calls = []
+
+        def get_switch_name(number):
+            return "Mock Switch #"+str(number)
+
+        def on_switch_pressed(number, callback):
+            self.switch_pressed_callbacks[number] = callback
+
+        def on_switch_released(number, callback):
+            self.switch_released_callbacks[number] = callback
+
+        def record_call(service):
+            self.calls.append(service)
+
+        self.mock_lj = mock_pylitejet.return_value
+        self.mock_lj.loads.return_value = range(0)
+        self.mock_lj.button_switches.return_value = range(1, 3)
+        self.mock_lj.all_switches.return_value = range(1, 6)
+        self.mock_lj.scenes.return_value = range(0)
+        self.mock_lj.get_switch_name.side_effect = get_switch_name
+        self.mock_lj.on_switch_pressed.side_effect = on_switch_pressed
+        self.mock_lj.on_switch_released.side_effect = on_switch_released
+
+        config = {
+            'litejet': {
+                'port': '/tmp/this_will_be_mocked'
+            }
+        }
+        assert bootstrap.setup_component(self.hass, litejet.DOMAIN, config)
+
+        self.hass.services.register('test', 'automation', record_call)
+
+        self.hass.block_till_done()
+
+        self.start_time = dt_util.utcnow()
+        self.last_delta = timedelta(0)
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def simulate_press(self, number):
+        _LOGGER.info('*** simulate press of %d', number)
+        callback = self.switch_pressed_callbacks.get(number)
+        with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
+                        return_value=self.start_time + self.last_delta):
+            if callback is not None:
+                callback()
+            self.hass.block_till_done()
+
+    def simulate_release(self, number):
+        _LOGGER.info('*** simulate release of %d', number)
+        callback = self.switch_released_callbacks.get(number)
+        with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
+                        return_value=self.start_time + self.last_delta):
+            if callback is not None:
+                callback()
+            self.hass.block_till_done()
+
+    def simulate_time(self, delta):
+        _LOGGER.info(
+            '*** simulate time change by %s: %s',
+            delta,
+            self.start_time + delta)
+        self.last_delta = delta
+        with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
+                        return_value=self.start_time + delta):
+            _LOGGER.info('now=%s', dt_util.utcnow())
+            fire_time_changed(self.hass, self.start_time + delta)
+            self.hass.block_till_done()
+            _LOGGER.info('done with now=%s', dt_util.utcnow())
+
+    def setup_automation(self, trigger):
+        assert bootstrap.setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: [
+                {
+                    'alias': 'My Test',
+                    'trigger': trigger,
+                    'action': {
+                        'service': 'test.automation'
+                    }
+                }
+            ]
+        })
+        self.hass.block_till_done()
+
+    def test_simple(self):
+        """Test the simplest form of a LiteJet trigger."""
+        self.setup_automation({
+            'platform': 'litejet',
+            'number': ENTITY_OTHER_SWITCH_NUMBER
+        })
+
+        self.simulate_press(ENTITY_OTHER_SWITCH_NUMBER)
+        self.simulate_release(ENTITY_OTHER_SWITCH_NUMBER)
+
+        assert len(self.calls) == 1
+
+    def test_held_more_than_short(self):
+        """Test a too short hold."""
+        self.setup_automation({
+            'platform': 'litejet',
+            'number': ENTITY_OTHER_SWITCH_NUMBER,
+            'held_more_than': {
+                'milliseconds': '200'
+            }
+        })
+
+        self.simulate_press(ENTITY_OTHER_SWITCH_NUMBER)
+        self.simulate_time(timedelta(seconds=0.1))
+        self.simulate_release(ENTITY_OTHER_SWITCH_NUMBER)
+        assert len(self.calls) == 0
+
+    def test_held_more_than_long(self):
+        """Test a hold that is long enough."""
+        self.setup_automation({
+            'platform': 'litejet',
+            'number': ENTITY_OTHER_SWITCH_NUMBER,
+            'held_more_than': {
+                'milliseconds': '200'
+            }
+        })
+
+        self.simulate_press(ENTITY_OTHER_SWITCH_NUMBER)
+        assert len(self.calls) == 0
+        self.simulate_time(timedelta(seconds=0.3))
+        assert len(self.calls) == 1
+        self.simulate_release(ENTITY_OTHER_SWITCH_NUMBER)
+        assert len(self.calls) == 1
+
+    def test_held_less_than_short(self):
+        """Test a hold that is short enough."""
+        self.setup_automation({
+            'platform': 'litejet',
+            'number': ENTITY_OTHER_SWITCH_NUMBER,
+            'held_less_than': {
+                'milliseconds': '200'
+            }
+        })
+
+        self.simulate_press(ENTITY_OTHER_SWITCH_NUMBER)
+        self.simulate_time(timedelta(seconds=0.1))
+        assert len(self.calls) == 0
+        self.simulate_release(ENTITY_OTHER_SWITCH_NUMBER)
+        assert len(self.calls) == 1
+
+    def test_held_less_than_long(self):
+        """Test a hold that is too long."""
+        self.setup_automation({
+            'platform': 'litejet',
+            'number': ENTITY_OTHER_SWITCH_NUMBER,
+            'held_less_than': {
+                'milliseconds': '200'
+            }
+        })
+
+        self.simulate_press(ENTITY_OTHER_SWITCH_NUMBER)
+        assert len(self.calls) == 0
+        self.simulate_time(timedelta(seconds=0.3))
+        assert len(self.calls) == 0
+        self.simulate_release(ENTITY_OTHER_SWITCH_NUMBER)
+        assert len(self.calls) == 0
+
+    def test_held_in_range_short(self):
+        """Test an in-range trigger with a too short hold."""
+        self.setup_automation({
+            'platform': 'litejet',
+            'number': ENTITY_OTHER_SWITCH_NUMBER,
+            'held_more_than': {
+                'milliseconds': '100'
+            },
+            'held_less_than': {
+                'milliseconds': '300'
+            }
+        })
+
+        self.simulate_press(ENTITY_OTHER_SWITCH_NUMBER)
+        self.simulate_time(timedelta(seconds=0.05))
+        self.simulate_release(ENTITY_OTHER_SWITCH_NUMBER)
+        assert len(self.calls) == 0
+
+    def test_held_in_range_just_right(self):
+        """Test an in-range trigger with a just right hold."""
+        self.setup_automation({
+            'platform': 'litejet',
+            'number': ENTITY_OTHER_SWITCH_NUMBER,
+            'held_more_than': {
+                'milliseconds': '100'
+            },
+            'held_less_than': {
+                'milliseconds': '300'
+            }
+        })
+
+        self.simulate_press(ENTITY_OTHER_SWITCH_NUMBER)
+        assert len(self.calls) == 0
+        self.simulate_time(timedelta(seconds=0.2))
+        assert len(self.calls) == 0
+        self.simulate_release(ENTITY_OTHER_SWITCH_NUMBER)
+        assert len(self.calls) == 1
+
+    def test_held_in_range_long(self):
+        """Test an in-range trigger with a too long hold."""
+        self.setup_automation({
+            'platform': 'litejet',
+            'number': ENTITY_OTHER_SWITCH_NUMBER,
+            'held_more_than': {
+                'milliseconds': '100'
+            },
+            'held_less_than': {
+                'milliseconds': '300'
+            }
+        })
+
+        self.simulate_press(ENTITY_OTHER_SWITCH_NUMBER)
+        assert len(self.calls) == 0
+        self.simulate_time(timedelta(seconds=0.4))
+        assert len(self.calls) == 0
+        self.simulate_release(ENTITY_OTHER_SWITCH_NUMBER)
+        assert len(self.calls) == 0

--- a/tests/components/light/test_litejet.py
+++ b/tests/components/light/test_litejet.py
@@ -2,7 +2,6 @@
 import logging
 import unittest
 from unittest import mock
-import time
 
 from homeassistant import bootstrap
 from homeassistant.components import litejet
@@ -57,11 +56,6 @@ class TestLiteJetLight(unittest.TestCase):
                 }
             })
         self.hass.block_till_done()
-
-        while self.light() is None or self.other_light() is None:
-            _LOGGER.warning('*** need to wait for expected states to appear')
-            time.sleep(0.01)
-        _LOGGER.info('*** all states ready for test')
 
         self.mock_lj.get_load_level.reset_mock()
 

--- a/tests/components/light/test_litejet.py
+++ b/tests/components/light/test_litejet.py
@@ -1,0 +1,174 @@
+"""The tests for the litejet component."""
+import logging
+import unittest
+from unittest import mock
+import time
+
+from homeassistant import bootstrap
+from homeassistant.components import litejet
+from tests.common import get_test_home_assistant
+import homeassistant.components.light as light
+
+_LOGGER = logging.getLogger(__name__)
+
+ENTITY_LIGHT = 'light.mock_load_1'
+ENTITY_LIGHT_NUMBER = 1
+ENTITY_OTHER_LIGHT = 'light.mock_load_2'
+ENTITY_OTHER_LIGHT_NUMBER = 2
+
+
+class TestLiteJetLight(unittest.TestCase):
+    """Test the litejet component."""
+
+    @mock.patch('pylitejet.LiteJet')
+    def setup_method(self, method, mock_pylitejet):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.start()
+
+        self.load_activated_callbacks = {}
+        self.load_deactivated_callbacks = {}
+
+        def get_load_name(number):
+            return "Mock Load #"+str(number)
+
+        def on_load_activated(number, callback):
+            self.load_activated_callbacks[number] = callback
+
+        def on_load_deactivated(number, callback):
+            self.load_deactivated_callbacks[number] = callback
+
+        self.mock_lj = mock_pylitejet.return_value
+        self.mock_lj.loads.return_value = range(1, 3)
+        self.mock_lj.button_switches.return_value = range(0)
+        self.mock_lj.all_switches.return_value = range(0)
+        self.mock_lj.scenes.return_value = range(0)
+        self.mock_lj.get_load_level.return_value = 0
+        self.mock_lj.get_load_name.side_effect = get_load_name
+        self.mock_lj.on_load_activated.side_effect = on_load_activated
+        self.mock_lj.on_load_deactivated.side_effect = on_load_deactivated
+
+        assert bootstrap.setup_component(
+            self.hass,
+            litejet.DOMAIN,
+            {
+                'litejet': {
+                    'port': '/tmp/this_will_be_mocked'
+                }
+            })
+        self.hass.block_till_done()
+
+        while self.light() is None or self.other_light() is None:
+            _LOGGER.warning('*** need to wait for expected states to appear')
+            time.sleep(0.01)
+        _LOGGER.info('*** all states ready for test')
+
+        self.mock_lj.get_load_level.reset_mock()
+
+    def light(self):
+        return self.hass.states.get(ENTITY_LIGHT)
+
+    def other_light(self):
+        return self.hass.states.get(ENTITY_OTHER_LIGHT)
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_on_brightness(self):
+        """Test turning the light on with brightness."""
+
+        assert self.light().state == 'off'
+        assert self.other_light().state == 'off'
+
+        assert not light.is_on(self.hass, ENTITY_LIGHT)
+
+        light.turn_on(self.hass, ENTITY_LIGHT, brightness=102)
+        self.hass.block_till_done()
+        self.mock_lj.activate_load_at.assert_called_with(
+            ENTITY_LIGHT_NUMBER, 39, 0)
+
+    def test_on_off(self):
+        """Test turning the light on and off."""
+
+        assert self.light().state == 'off'
+        assert self.other_light().state == 'off'
+
+        assert not light.is_on(self.hass, ENTITY_LIGHT)
+
+        light.turn_on(self.hass, ENTITY_LIGHT)
+        self.hass.block_till_done()
+        self.mock_lj.activate_load.assert_called_with(ENTITY_LIGHT_NUMBER)
+
+        light.turn_off(self.hass, ENTITY_LIGHT)
+        self.hass.block_till_done()
+        self.mock_lj.deactivate_load.assert_called_with(ENTITY_LIGHT_NUMBER)
+
+    def test_activated_event(self):
+        """Test handling an event from LiteJet."""
+
+        self.mock_lj.get_load_level.return_value = 99
+
+        # Light 1
+
+        _LOGGER.info(self.load_activated_callbacks[ENTITY_LIGHT_NUMBER])
+        self.load_activated_callbacks[ENTITY_LIGHT_NUMBER]()
+        self.hass.block_till_done()
+
+        self.mock_lj.get_load_level.assert_called_once_with(
+            ENTITY_LIGHT_NUMBER)
+
+        assert light.is_on(self.hass, ENTITY_LIGHT)
+        assert not light.is_on(self.hass, ENTITY_OTHER_LIGHT)
+        assert self.light().state == 'on'
+        assert self.other_light().state == 'off'
+        assert self.light().attributes.get(light.ATTR_BRIGHTNESS) == 255
+
+        # Light 2
+
+        self.mock_lj.get_load_level.return_value = 40
+
+        self.mock_lj.get_load_level.reset_mock()
+
+        self.load_activated_callbacks[ENTITY_OTHER_LIGHT_NUMBER]()
+        self.hass.block_till_done()
+
+        self.mock_lj.get_load_level.assert_called_once_with(
+            ENTITY_OTHER_LIGHT_NUMBER)
+
+        assert light.is_on(self.hass, ENTITY_OTHER_LIGHT)
+        assert light.is_on(self.hass, ENTITY_LIGHT)
+        assert self.light().state == 'on'
+        assert self.other_light().state == 'on'
+        assert int(self.other_light().attributes[light.ATTR_BRIGHTNESS]) == 103
+
+    def test_deactivated_event(self):
+        """Test handling an event from LiteJet."""
+
+        # Initial state is on.
+
+        self.mock_lj.get_load_level.return_value = 99
+
+        self.load_activated_callbacks[ENTITY_OTHER_LIGHT_NUMBER]()
+        self.hass.block_till_done()
+
+        assert light.is_on(self.hass, ENTITY_OTHER_LIGHT)
+
+        # Event indicates it is off now.
+
+        self.mock_lj.get_load_level.reset_mock()
+        self.mock_lj.get_load_level.return_value = 0
+
+        self.load_deactivated_callbacks[ENTITY_OTHER_LIGHT_NUMBER]()
+        self.hass.block_till_done()
+
+        # (Requesting the level is not strictly needed with a deactivated
+        # event but the implementation happens to do it. This could be
+        # changed to a assert_not_called in the future.)
+        self.mock_lj.get_load_level.assert_called_with(
+            ENTITY_OTHER_LIGHT_NUMBER)
+
+        assert not light.is_on(self.hass, ENTITY_OTHER_LIGHT)
+        assert not light.is_on(self.hass, ENTITY_LIGHT)
+        assert self.light().state == 'off'
+        assert self.other_light().state == 'off'

--- a/tests/components/scene/test_litejet.py
+++ b/tests/components/scene/test_litejet.py
@@ -1,0 +1,70 @@
+"""The tests for the litejet component."""
+import logging
+import unittest
+from unittest import mock
+import time
+
+from homeassistant import bootstrap
+from homeassistant.components import litejet
+from tests.common import get_test_home_assistant
+import homeassistant.components.scene as scene
+
+_LOGGER = logging.getLogger(__name__)
+
+ENTITY_SCENE = 'scene.mock_scene_1'
+ENTITY_SCENE_NUMBER = 1
+ENTITY_OTHER_SCENE = 'scene.mock_scene_2'
+ENTITY_OTHER_SCENE_NUMBER = 2
+
+
+class TestLiteJetScene(unittest.TestCase):
+    """Test the litejet component."""
+
+    @mock.patch('pylitejet.LiteJet')
+    def setup_method(self, method, mock_pylitejet):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.start()
+
+        def get_scene_name(number):
+            return "Mock Scene #"+str(number)
+
+        self.mock_lj = mock_pylitejet.return_value
+        self.mock_lj.loads.return_value = range(0)
+        self.mock_lj.button_switches.return_value = range(0)
+        self.mock_lj.all_switches.return_value = range(0)
+        self.mock_lj.scenes.return_value = range(1, 3)
+        self.mock_lj.get_scene_name.side_effect = get_scene_name
+
+        assert bootstrap.setup_component(
+            self.hass,
+            litejet.DOMAIN,
+            {
+                'litejet': {
+                    'port': '/tmp/this_will_be_mocked'
+                }
+            })
+        self.hass.block_till_done()
+
+        while self.scene() is None or self.other_scene() is None:
+            _LOGGER.warning('*** need to wait for expected states')
+            time.sleep(0.01)
+        _LOGGER.info('*** all states ready for test')
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def scene(self):
+        return self.hass.states.get(ENTITY_SCENE)
+
+    def other_scene(self):
+        return self.hass.states.get(ENTITY_OTHER_SCENE)
+
+    def test_activate(self):
+        """Test activating the scene."""
+
+        scene.activate(self.hass, ENTITY_SCENE)
+        self.hass.block_till_done()
+        self.mock_lj.activate_scene.assert_called_once_with(
+            ENTITY_SCENE_NUMBER)

--- a/tests/components/scene/test_litejet.py
+++ b/tests/components/scene/test_litejet.py
@@ -2,7 +2,6 @@
 import logging
 import unittest
 from unittest import mock
-import time
 
 from homeassistant import bootstrap
 from homeassistant.components import litejet
@@ -45,11 +44,6 @@ class TestLiteJetScene(unittest.TestCase):
                 }
             })
         self.hass.block_till_done()
-
-        while self.scene() is None or self.other_scene() is None:
-            _LOGGER.warning('*** need to wait for expected states')
-            time.sleep(0.01)
-        _LOGGER.info('*** all states ready for test')
 
     def teardown_method(self, method):
         """Stop everything that was started."""

--- a/tests/components/switch/test_litejet.py
+++ b/tests/components/switch/test_litejet.py
@@ -53,14 +53,15 @@ class TestLiteJetSwitch(unittest.TestCase):
             }
         }
         expect_states = True
-        if method == 'test_include_switches_False':
+        if method == self.test_include_switches_False:
             config['litejet']['include_switches'] = False
             expect_states = False
-        elif method == 'test_include_switches_unspecified':
+        elif method == self.test_include_switches_unspecified:
             expect_states = False
         else:
             config['litejet']['include_switches'] = True
 
+        _LOGGER.warning("method=%s config=%s", method, config)
         assert bootstrap.setup_component(self.hass, litejet.DOMAIN, config)
         self.hass.block_till_done()
 

--- a/tests/components/switch/test_litejet.py
+++ b/tests/components/switch/test_litejet.py
@@ -65,8 +65,7 @@ class TestLiteJetSwitch(unittest.TestCase):
         self.hass.block_till_done()
 
         if expect_states:
-            while self.hass.states.get(ENTITY_SWITCH) is None or \
-                  self.hass.states.get(ENTITY_OTHER_SWITCH) is None:
+            while self.switch() is None or self.other_switch() is None:
                 _LOGGER.warning('*** need to wait for expected states')
                 time.sleep(0.01)
             _LOGGER.info('*** all states ready for test')
@@ -74,6 +73,12 @@ class TestLiteJetSwitch(unittest.TestCase):
     def teardown_method(self, method):
         """Stop everything that was started."""
         self.hass.stop()
+
+    def switch(self):
+        return self.hass.states.get(ENTITY_SWITCH)
+
+    def other_switch(self):
+        return self.hass.states.get(ENTITY_OTHER_SWITCH)
 
     def test_include_switches_unspecified(self):
         """Test that switches are ignored by default."""
@@ -90,8 +95,8 @@ class TestLiteJetSwitch(unittest.TestCase):
     def test_on_off(self):
         """Test turning the switch on and off."""
 
-        assert self.hass.states.get(ENTITY_SWITCH).state == 'off'
-        assert self.hass.states.get(ENTITY_OTHER_SWITCH).state == 'off'
+        assert self.switch().state == 'off'
+        assert self.other_switch().state == 'off'
 
         assert not switch.is_on(self.hass, ENTITY_SWITCH)
 
@@ -114,8 +119,8 @@ class TestLiteJetSwitch(unittest.TestCase):
 
         assert switch.is_on(self.hass, ENTITY_SWITCH)
         assert not switch.is_on(self.hass, ENTITY_OTHER_SWITCH)
-        assert self.hass.states.get(ENTITY_SWITCH).state == 'on'
-        assert self.hass.states.get(ENTITY_OTHER_SWITCH).state == 'off'
+        assert self.switch().state == 'on'
+        assert self.other_switch().state == 'off'
 
         # Switch 2
 
@@ -124,8 +129,8 @@ class TestLiteJetSwitch(unittest.TestCase):
 
         assert switch.is_on(self.hass, ENTITY_OTHER_SWITCH)
         assert switch.is_on(self.hass, ENTITY_SWITCH)
-        assert self.hass.states.get(ENTITY_OTHER_SWITCH).state == 'on'
-        assert self.hass.states.get(ENTITY_SWITCH).state == 'on'
+        assert self.other_switch().state == 'on'
+        assert self.switch().state == 'on'
 
     def test_released_event(self):
         """Test handling an event from LiteJet."""
@@ -144,5 +149,5 @@ class TestLiteJetSwitch(unittest.TestCase):
 
         assert not switch.is_on(self.hass, ENTITY_OTHER_SWITCH)
         assert not switch.is_on(self.hass, ENTITY_SWITCH)
-        assert self.hass.states.get(ENTITY_OTHER_SWITCH).state == 'off'
-        assert self.hass.states.get(ENTITY_SWITCH).state == 'off'
+        assert self.other_switch().state == 'off'
+        assert self.switch().state == 'off'

--- a/tests/components/switch/test_litejet.py
+++ b/tests/components/switch/test_litejet.py
@@ -2,7 +2,6 @@
 import logging
 import unittest
 from unittest import mock
-import time
 
 from homeassistant import bootstrap
 from homeassistant.components import litejet
@@ -52,24 +51,13 @@ class TestLiteJetSwitch(unittest.TestCase):
                 'port': '/tmp/this_will_be_mocked',
             }
         }
-        expect_states = True
         if method == self.test_include_switches_False:
             config['litejet']['include_switches'] = False
-            expect_states = False
-        elif method == self.test_include_switches_unspecified:
-            expect_states = False
-        else:
+        elif method != self.test_include_switches_unspecified:
             config['litejet']['include_switches'] = True
 
-        _LOGGER.warning("method=%s config=%s", method, config)
         assert bootstrap.setup_component(self.hass, litejet.DOMAIN, config)
         self.hass.block_till_done()
-
-        if expect_states:
-            while self.switch() is None or self.other_switch() is None:
-                _LOGGER.warning('*** need to wait for expected states')
-                time.sleep(0.01)
-            _LOGGER.info('*** all states ready for test')
 
     def teardown_method(self, method):
         """Stop everything that was started."""

--- a/tests/components/switch/test_litejet.py
+++ b/tests/components/switch/test_litejet.py
@@ -1,0 +1,148 @@
+"""The tests for the litejet component."""
+import logging
+import unittest
+from unittest import mock
+import time
+
+from homeassistant import bootstrap
+from homeassistant.components import litejet
+from tests.common import get_test_home_assistant
+import homeassistant.components.switch as switch
+
+_LOGGER = logging.getLogger(__name__)
+
+ENTITY_SWITCH = 'switch.mock_switch_1'
+ENTITY_SWITCH_NUMBER = 1
+ENTITY_OTHER_SWITCH = 'switch.mock_switch_2'
+ENTITY_OTHER_SWITCH_NUMBER = 2
+
+
+class TestLiteJetSwitch(unittest.TestCase):
+    """Test the litejet component."""
+
+    @mock.patch('pylitejet.LiteJet')
+    def setup_method(self, method, mock_pylitejet):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.start()
+
+        self.switch_pressed_callbacks = {}
+        self.switch_released_callbacks = {}
+
+        def get_switch_name(number):
+            return "Mock Switch #"+str(number)
+
+        def on_switch_pressed(number, callback):
+            self.switch_pressed_callbacks[number] = callback
+
+        def on_switch_released(number, callback):
+            self.switch_released_callbacks[number] = callback
+
+        self.mock_lj = mock_pylitejet.return_value
+        self.mock_lj.loads.return_value = range(0)
+        self.mock_lj.button_switches.return_value = range(1, 3)
+        self.mock_lj.all_switches.return_value = range(1, 6)
+        self.mock_lj.scenes.return_value = range(0)
+        self.mock_lj.get_switch_name.side_effect = get_switch_name
+        self.mock_lj.on_switch_pressed.side_effect = on_switch_pressed
+        self.mock_lj.on_switch_released.side_effect = on_switch_released
+
+        config = {
+            'litejet': {
+                'port': '/tmp/this_will_be_mocked',
+            }
+        }
+        expect_states = True
+        if method == 'test_include_switches_False':
+            config['litejet']['include_switches'] = False
+            expect_states = False
+        elif method == 'test_include_switches_unspecified':
+            expect_states = False
+        else:
+            config['litejet']['include_switches'] = True
+
+        assert bootstrap.setup_component(self.hass, litejet.DOMAIN, config)
+        self.hass.block_till_done()
+
+        if expect_states:
+            while self.hass.states.get(ENTITY_SWITCH) is None or \
+                  self.hass.states.get(ENTITY_OTHER_SWITCH) is None:
+                _LOGGER.warning('*** need to wait for expected states')
+                time.sleep(0.01)
+            _LOGGER.info('*** all states ready for test')
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_include_switches_unspecified(self):
+        """Test that switches are ignored by default."""
+
+        self.mock_lj.button_switches.assert_not_called()
+        self.mock_lj.all_switches.assert_not_called()
+
+    def test_include_switches_False(self):
+        """Test that switches can be explicitly ignored."""
+
+        self.mock_lj.button_switches.assert_not_called()
+        self.mock_lj.all_switches.assert_not_called()
+
+    def test_on_off(self):
+        """Test turning the switch on and off."""
+
+        assert self.hass.states.get(ENTITY_SWITCH).state == 'off'
+        assert self.hass.states.get(ENTITY_OTHER_SWITCH).state == 'off'
+
+        assert not switch.is_on(self.hass, ENTITY_SWITCH)
+
+        switch.turn_on(self.hass, ENTITY_SWITCH)
+        self.hass.block_till_done()
+        self.mock_lj.press_switch.assert_called_with(ENTITY_SWITCH_NUMBER)
+
+        switch.turn_off(self.hass, ENTITY_SWITCH)
+        self.hass.block_till_done()
+        self.mock_lj.release_switch.assert_called_with(ENTITY_SWITCH_NUMBER)
+
+    def test_pressed_event(self):
+        """Test handling an event from LiteJet."""
+
+        # Switch 1
+
+        _LOGGER.info(self.switch_pressed_callbacks[ENTITY_SWITCH_NUMBER])
+        self.switch_pressed_callbacks[ENTITY_SWITCH_NUMBER]()
+        self.hass.block_till_done()
+
+        assert switch.is_on(self.hass, ENTITY_SWITCH)
+        assert not switch.is_on(self.hass, ENTITY_OTHER_SWITCH)
+        assert self.hass.states.get(ENTITY_SWITCH).state == 'on'
+        assert self.hass.states.get(ENTITY_OTHER_SWITCH).state == 'off'
+
+        # Switch 2
+
+        self.switch_pressed_callbacks[ENTITY_OTHER_SWITCH_NUMBER]()
+        self.hass.block_till_done()
+
+        assert switch.is_on(self.hass, ENTITY_OTHER_SWITCH)
+        assert switch.is_on(self.hass, ENTITY_SWITCH)
+        assert self.hass.states.get(ENTITY_OTHER_SWITCH).state == 'on'
+        assert self.hass.states.get(ENTITY_SWITCH).state == 'on'
+
+    def test_released_event(self):
+        """Test handling an event from LiteJet."""
+
+        # Initial state is on.
+
+        self.switch_pressed_callbacks[ENTITY_OTHER_SWITCH_NUMBER]()
+        self.hass.block_till_done()
+
+        assert switch.is_on(self.hass, ENTITY_OTHER_SWITCH)
+
+        # Event indicates it is off now.
+
+        self.switch_released_callbacks[ENTITY_OTHER_SWITCH_NUMBER]()
+        self.hass.block_till_done()
+
+        assert not switch.is_on(self.hass, ENTITY_OTHER_SWITCH)
+        assert not switch.is_on(self.hass, ENTITY_SWITCH)
+        assert self.hass.states.get(ENTITY_OTHER_SWITCH).state == 'off'
+        assert self.hass.states.get(ENTITY_SWITCH).state == 'off'

--- a/tests/components/test_litejet.py
+++ b/tests/components/test_litejet.py
@@ -1,0 +1,42 @@
+"""The tests for the litejet component."""
+import logging
+import unittest
+
+from homeassistant.components import litejet
+from tests.common import get_test_home_assistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TestLiteJet(unittest.TestCase):
+    """Test the litejet component."""
+
+    def setup_method(self, method):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.start()
+        self.hass.block_till_done()
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_is_ignored_unspecified(self):
+        self.hass.data['litejet_config'] = {}
+        assert not litejet.is_ignored(self.hass, 'Test')
+
+    def test_is_ignored_empty(self):
+        self.hass.data['litejet_config'] = {
+            litejet.CONF_EXCLUDE_NAMES: []
+        }
+        assert not litejet.is_ignored(self.hass, 'Test')
+
+    def test_is_ignored_normal(self):
+        self.hass.data['litejet_config'] = {
+            litejet.CONF_EXCLUDE_NAMES: ['Test', 'Other One']
+        }
+        assert litejet.is_ignored(self.hass, 'Test')
+        assert not litejet.is_ignored(self.hass, 'Other one')
+        assert not litejet.is_ignored(self.hass, 'Other 0ne')
+        assert litejet.is_ignored(self.hass, 'Other One There')
+        assert litejet.is_ignored(self.hass, 'Other One')


### PR DESCRIPTION
**Description:**
LiteJet: Unit tests and new trigger options held_more_than and held_less_than.

* Unit tests for the LiteJet component and associated platforms. Coverage is almost 100% -- just misses one line.
* The automation LiteJet trigger returns an empty "removal" function to ensure the automation base is happy with it. The pylitejet library doesn't actually support a real removal.
* The automation LiteJet trigger can detect hold time and act appropriately to support things like short tap or long hold.

**Related issue (if applicable):** none

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1463

**Example entry for `configuration.yaml` (if applicable):**
```yaml
automation:
- trigger:
    platform: litejet
    number: 55
    held_more_than:
      milliseconds: 1000
    held_less_than:
      milliseconds: 2000
  ...
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

