### PR TITLE
Fixing 'Unknown' status for Nest Protect devices

### DIFF
--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -195,14 +195,14 @@ class NestProtectSensor(NestSensor):
         if self.variable == 'battery_level':
             self._state = getattr(self.device, self.variable)
         else:
+            self._state = 'Unknown'
+            
             if state == 0:
                 self._state = 'Ok'
             if state == 1 or state == 2:
                 self._state = 'Warning'
             if state == 3:
                 self._state = 'Emergency'
-
-        self._state = 'Unknown'
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -196,7 +196,6 @@ class NestProtectSensor(NestSensor):
             self._state = getattr(self.device, self.variable)
         else:
             self._state = 'Unknown'
-            
             if state == 0:
                 self._state = 'Ok'
             if state == 1 or state == 2:


### PR DESCRIPTION
**Description:**  After the refactor next protect sensors broke because of the switch from return statements to the use of self._state.  This fixes that.


**Related issue (if applicable):** fixes #4293


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

