### PR TITLE
Expose isort preferences for tools.

### DIFF
--- a/homeassistant/util/async.py
+++ b/homeassistant/util/async.py
@@ -6,6 +6,7 @@ from asyncio import coroutines
 from asyncio.futures import Future
 
 try:
+    # pylint: disable=ungrouped-imports
     from asyncio import ensure_future
 except ImportError:
     # Python 3.4.3 and earlier has this as async

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,6 @@ match_dir = ^((?!\.|www_static).)*$
 [isort]
 multi_line_output = 4
 indent = "    "
-forced_separate = homeassistant,voluptuous,aiohttp
 known_standard_library = typing
 not_skip = __init__.py
+force_sort_within_sections = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,15 @@ exclude = .venv,.git,.tox,docs,www_static,venv,bin,lib,deps,build
 match_dir = ^((?!\.|www_static).)*$
 
 [isort]
+# https://github.com/timothycrosley/isort
+# https://github.com/timothycrosley/isort/wiki/isort-Settings
+# splits long import on multiple lines indented by 4 spaces
 multi_line_output = 4
 indent = "    "
-known_standard_library = typing
+# by default isort don't check module indexes
 not_skip = __init__.py
+# will group `import x` and `from x import` of the same module.
 force_sort_within_sections = true
+# typing is stdlib on py35 but 3rd party on py34, let it hang in between
+known_inbetweens = typing
+sections = FUTURE,STDLIB,INBETWEENS,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,10 @@ exclude = .venv,.git,.tox,docs,www_static,venv,bin,lib,deps,build
 
 [pydocstyle]
 match_dir = ^((?!\.|www_static).)*$
+
+[isort]
+multi_line_output = 4
+indent = "    "
+forced_separate = homeassistant,voluptuous,aiohttp
+known_standard_library = typing
+not_skip = __init__.py


### PR DESCRIPTION
**Description:** If you're like me you automate everything, including your coding. So I run `isort` and `autopep8` whenever I save a file to get rid of those pesky linting errors. 

The changes basically make sure the standards set for this project (by: #1330 and Pylint) are available for other tools like IDE's or texteditors.

I created an additional branch (which I don't suggest merging as it will upset a lot of people) where isort with these settings is applied to the entire codebase in order to proof linting works. https://github.com/aequitas/home-assistant/pull/1

The `forced_separate` is to satisfy pylint who otherwise throws errors like
```
************* Module homeassistant.components.google
C: 17, 0: Imports from package voluptuous are not grouped (ungrouped-imports)
```

A consideration might be to disable that check in pylint.

Please let me know if you think this is worth accepting in the codebase. I can also spend some time on getting `autopep8` work.
