### PR TITLE
Upgrade yahoo-finance to 1.4.0

### DIFF
--- a/homeassistant/components/sensor/yahoo_finance.py
+++ b/homeassistant/components/sensor/yahoo_finance.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['yahoo-finance==1.3.2']
+REQUIREMENTS = ['yahoo-finance==1.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -572,7 +572,7 @@ xboxapi==0.1.1
 xmltodict==0.10.2
 
 # homeassistant.components.sensor.yahoo_finance
-yahoo-finance==1.3.2
+yahoo-finance==1.4.0
 
 # homeassistant.components.sensor.yweather
 yahooweather==0.8


### PR DESCRIPTION
## 1.4.0
- Add 21 additional queries
- Remove get_info() method
- Add support for Python 3.5
- Add to README information about datatables.org and YQLQueryError issues.

Tested with the following configuration:

``` yaml
sensor:
  - platform: yahoo_finance
    symbols:
      - RHT
      - GOOGL
      - FAAFD
```
