### PR TITLE
Upgrade sendgrid to 3.6.3

### DIFF
--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -13,7 +13,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import (CONF_API_KEY, CONF_SENDER, CONF_RECIPIENT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['sendgrid==3.6.2']
+REQUIREMENTS = ['sendgrid==3.6.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -483,7 +483,7 @@ schiene==0.18
 scsgate==0.1.0
 
 # homeassistant.components.notify.sendgrid
-sendgrid==3.6.2
+sendgrid==3.6.3
 
 # homeassistant.components.notify.slack
 slacker==0.9.29


### PR DESCRIPTION
## 3.6.3
- Update deprecated Heroku command

Tested with the following configuration:

``` yaml
notify:
  - name: sendgrid
    platform: sendgrid
    api_key: !secret sendgrid_api
    sender: you@example.com
    recipient: me@example.com
```

Message sent with "Call Service":

``` json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!",
  "title": "Test message"
}
```
