### PR TITLE
Upgrade freesms to 0.1.1

### DIFF
--- a/homeassistant/components/notify/free_mobile.py
+++ b/homeassistant/components/notify/free_mobile.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN, CONF_USERNAME
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ['freesms==0.1.0']
+REQUIREMENTS = ['freesms==0.1.1']
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -113,7 +113,7 @@ fitbit==0.2.3
 fixerio==0.1.1
 
 # homeassistant.components.notify.free_mobile
-freesms==0.1.0
+freesms==0.1.1
 
 # homeassistant.components.conversation
 fuzzywuzzy==0.14.0


### PR DESCRIPTION
0.1.1
------
- Fix an encoding error when installing with Python 3.x and a non utf-8 locale