### PR TITLE
Fix Zwave light naming & configurable refresh

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -201,7 +201,7 @@ class ZwaveColorLight(ZwaveDimmer):
         self._rgb = None
         self._ct = None
 
-        super().__init__(value)
+        super().__init__(value, refresh, delay)
 
         # Create a listener so the color values can be linked to this entity
         dispatcher.connect(

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -204,7 +204,7 @@ def object_id(value):
 
     # Add the instance id if there is more than one instance for the value
     if value.instance > 1:
-        return '{}_{}'.format(object_id, value.instance)
+        return '{}_{}'.format(_object_id, value.instance)
     return _object_id
 
 


### PR DESCRIPTION
**Description:**


**Related issue (if applicable):** fixes #4500 
fixes #4499 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant/pull/4476 and https://github.com/home-assistant/home-assistant/pull/4437

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

