### PR TITLE
Bump pyvera to 0.2.21

### DIFF
--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyvera==0.2.20']
+REQUIREMENTS = ['pyvera==0.2.21']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -453,7 +453,7 @@ python-wink==0.10.0
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.2.20
+pyvera==0.2.21
 
 # homeassistant.components.notify.html5
 pywebpush==0.6.1


### PR DESCRIPTION
pyvera 0.2.21 fixes the fact that use of requests.get was not using a
timeout. Some times (after a few days of use) the pyvera poll loop
would hang indefinitely on a requests.get of the event interface. This
would cause the pyvera thread to hang completely. It would also
prevent graceful shutdown, as pyvera does a thread join.

The new version uses a timeout, so that we won't lock up any more.