### PR TITLE
switch.tplink: expect daily stats to be empty

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -97,8 +97,12 @@ class SmartPlugSwitch(SwitchDevice):
                     = "%.1f A" % emeter_readings["current"]
 
                 emeter_statics = self.smartplug.get_emeter_daily()
-                self._emeter_params[ATTR_DAILY_CONSUMPTION] \
-                    = "%.2f kW" % emeter_statics[int(time.strftime("%e"))]
+                try:
+                    self._emeter_params[ATTR_DAILY_CONSUMPTION] \
+                        = "%.2f kW" % emeter_statics[int(time.strftime("%e"))]
+                except KeyError:
+                    # device returned no daily history
+                    pass
 
         except OSError:
             _LOGGER.warning('Could not update status for %s', self.name)


### PR DESCRIPTION
**Description:**

Daily stats returned from TP-Link HS110 might be empty, dont' be surprised by it.

**Related issue (if applicable):** fixes #4487


**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

Signed-off-by: Martin Weinelt <hexa@darmstadt.ccc.de>