### PR TITLE
Bugfix device_tracker init tracker scan

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -530,7 +530,7 @@ def async_setup_scanner_platform(hass: HomeAssistantType, config: ConfigType,
             else:
                 host_name = scanner.get_device_name(mac)
                 seen.add(mac)
-            hass.async_add_job(async_see_device(mac=mac, host_name=host_name))
+            hass.add_job(async_see_device(mac=mac, host_name=host_name))
 
     async_track_utc_time_change(
         hass, device_tracker_scan, second=range(0, 60, interval))


### PR DESCRIPTION
**Description:**

The function was first a coro. After I change that to function that will run in a executor, I forget to change that.

**Related issue (if applicable):** fixes #4511

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

