### PR TITLE
Bugfix discovery use wrong time async

### DIFF
--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -127,8 +127,9 @@ def load_platform(hass, component, platform, discovered=None,
 
     Use `listen_platform` to register a callback for these events.
     """
-    hass.add_job(async_load_platform(hass, component, platform, discovered,
-                 hass_config))
+    hass.add_job(
+        async_load_platform(hass, component, platform, discovered,
+                            hass_config))
 
 
 @asyncio.coroutine

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -48,7 +48,7 @@ def async_listen(hass, service, callback):
 
 def discover(hass, service, discovered=None, component=None, hass_config=None):
     """Fire discovery event. Can ensure a component is loaded."""
-    hass.async_add_job(
+    hass.add_job(
         async_discover(hass, service, discovered, component, hass_config))
 
 
@@ -127,9 +127,8 @@ def load_platform(hass, component, platform, discovered=None,
 
     Use `listen_platform` to register a callback for these events.
     """
-    hass.async_add_job(
-        async_load_platform(hass, component, platform, discovered,
-                            hass_config))
+    hass.add_job(async_load_platform(hass, component, platform, discovered,
+                 hass_config))
 
 
 @asyncio.coroutine


### PR DESCRIPTION
**Description:**

At this point, we need to use `add_job` instead `async_add_job`.

**Related issue (if applicable):** fixes #4512

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

