### PR TITLE
Entity and climate: do not convert temperature unnecessary

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -562,16 +562,15 @@ class ClimateDevice(Entity):
 
     def _convert_for_display(self, temp):
         """Convert temperature into preferred units for display purposes."""
-        if temp is None or not isinstance(temp, Number):
+        if (temp is None or not isinstance(temp, Number) or
+                self.temperature_unit == self.unit_of_measurement):
             return temp
 
         value = convert_temperature(temp, self.temperature_unit,
                                     self.unit_of_measurement)
 
         if self.unit_of_measurement is TEMP_CELSIUS:
-            decimal_count = 1
+            return round(value, 1)
         else:
             # Users of fahrenheit generally expect integer units.
-            decimal_count = 0
-
-        return round(value, decimal_count)
+            return int(value)

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -569,7 +569,7 @@ class ClimateDevice(Entity):
         value = convert_temperature(temp, self.temperature_unit,
                                     self.unit_of_measurement)
 
-        if self.unit_of_measurement is TEMP_CELSIUS:
+        if self.unit_of_measurement == TEMP_CELSIUS:
             return round(value, 1)
         else:
             # Users of fahrenheit generally expect integer units.

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -573,4 +573,4 @@ class ClimateDevice(Entity):
             return round(value, 1)
         else:
             # Users of fahrenheit generally expect integer units.
-            return int(value)
+            return round(value)

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -262,7 +262,9 @@ class Entity(object):
             units = self.hass.config.units
             if (unit_of_measure in (TEMP_CELSIUS, TEMP_FAHRENHEIT) and
                     unit_of_measure != units.temperature_unit):
-                state = str(units.temperature(float(state), unit_of_measure))
+                prec = len(state) - state.index('.') - 1 if '.' in state else 0
+                temp = units.temperature(float(state), unit_of_measure)
+                state = str(round(temp) if prec == 0 else round(temp, prec))
                 attr[ATTR_UNIT_OF_MEASUREMENT] = units.temperature_unit
         except ValueError:
             # Could not convert state to float

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -259,8 +259,9 @@ class Entity(object):
         # Convert temperature if we detect one
         try:
             unit_of_measure = attr.get(ATTR_UNIT_OF_MEASUREMENT)
-            if unit_of_measure in (TEMP_CELSIUS, TEMP_FAHRENHEIT):
-                units = self.hass.config.units
+            units = self.hass.config.units
+            if (unit_of_measure in (TEMP_CELSIUS, TEMP_FAHRENHEIT) and
+                    unit_of_measure != units.temperature_unit):
                 state = str(units.temperature(float(state), unit_of_measure))
                 attr[ATTR_UNIT_OF_MEASUREMENT] = units.temperature_unit
         except ValueError:

--- a/homeassistant/util/temperature.py
+++ b/homeassistant/util/temperature.py
@@ -31,4 +31,4 @@ def convert(temperature: float, from_unit: str, to_unit: str) -> float:
     elif from_unit == TEMP_CELSIUS:
         return celsius_to_fahrenheit(temperature)
     else:
-        return round(fahrenheit_to_celsius(temperature), 1)
+        return fahrenheit_to_celsius(temperature)

--- a/tests/components/test_google.py
+++ b/tests/components/test_google.py
@@ -2,6 +2,8 @@
 import logging
 import unittest
 
+import pytest
+
 import homeassistant.components.google as google
 from homeassistant.bootstrap import setup_component
 from tests.common import get_test_home_assistant
@@ -9,6 +11,8 @@ from tests.common import get_test_home_assistant
 _LOGGER = logging.getLogger(__name__)
 
 
+# Because they connect to the internet
+@pytest.mark.skip
 class TestGoogle(unittest.TestCase):
     """Test the Google component."""
 

--- a/tests/components/test_google.py
+++ b/tests/components/test_google.py
@@ -2,8 +2,6 @@
 import logging
 import unittest
 
-import pytest
-
 import homeassistant.components.google as google
 from homeassistant.bootstrap import setup_component
 from tests.common import get_test_home_assistant
@@ -11,8 +9,6 @@ from tests.common import get_test_home_assistant
 _LOGGER = logging.getLogger(__name__)
 
 
-# Because they connect to the internet
-@pytest.mark.skip
 class TestGoogle(unittest.TestCase):
     """Test the Google component."""
 

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -80,7 +80,8 @@ class TestUnitSystem(unittest.TestCase):
             METRIC_SYSTEM.temperature(25, METRIC_SYSTEM.temperature_unit))
         self.assertEqual(
             26.7,
-            METRIC_SYSTEM.temperature(80, IMPERIAL_SYSTEM.temperature_unit))
+            round(METRIC_SYSTEM.temperature(
+                80, IMPERIAL_SYSTEM.temperature_unit), 1))
 
     def test_temperature_to_imperial(self):
         """Test temperature conversion to imperial system."""


### PR DESCRIPTION
**Description:**
While doing research for #4350 I figured that we can do a better job at converting temperatures. 

This patch will: 
 - Do not convert when passed in unit is already expected unit
 - When rounding to 0 precision, use `round(value)` instead of `round(value, 0)`, so we get an integer.
 - No longer default round conversion from F->C
 - Maintain precision in entity when converting between F & C

Fixes #3081 #4205 

CC @sdague 