### PR TITLE
Add Broadlink switch support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -311,6 +311,7 @@ omit =
     homeassistant/components/switch/acer_projector.py
     homeassistant/components/switch/anel_pwrctrl.py
     homeassistant/components/switch/arest.py
+    homeassistant/components/switch/broadlink.py
     homeassistant/components/switch/dlink.py
     homeassistant/components/switch/edimax.py
     homeassistant/components/switch/hikvisioncam.py

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -1,0 +1,267 @@
+"""
+Support for Broadlink RM devices.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.broadlink/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (
+    CONF_FRIENDLY_NAME, CONF_SWITCHES, CONF_COMMAND_OFF,
+    CONF_COMMAND_ON, CONF_OPTIMISTIC, CONF_HOST, CONF_MAC)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+SWITCH_SCHEMA = vol.Schema({
+    vol.Optional(CONF_COMMAND_OFF, default='true'): cv.string,
+    vol.Optional(CONF_COMMAND_ON, default='true'): cv.string,
+    vol.Optional(CONF_FRIENDLY_NAME): cv.string,
+    vol.Optional(CONF_OPTIMISTIC, default=True): cv.boolean,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SWITCHES): vol.Schema({cv.slug: SWITCH_SCHEMA}),
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_MAC): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup Broadlink switches."""
+    import binascii
+    devices = config.get(CONF_SWITCHES, {})
+    switches = []
+    ip_addr = (config.get(CONF_HOST), 80)
+    mac_addr = binascii.unhexlify(
+        config.get(CONF_MAC).encode().replace(b':', b''))
+
+    try:
+        broadlink = Broadlink.Device(ip_addr, mac_addr)
+        auth = broadlink.auth()
+        if auth:
+            _LOGGER.info('Broadlink connection successfully established.')
+
+    except ValueError as error:
+        _LOGGER.error(error)
+
+    for object_id, device_config in devices.items():
+
+        switches.append(
+            BroadlinkSwitch(
+                hass,
+                object_id,
+                device_config.get(CONF_FRIENDLY_NAME, object_id),
+                device_config.get(CONF_COMMAND_ON),
+                device_config.get(CONF_COMMAND_OFF),
+                device_config.get(CONF_OPTIMISTIC),
+                broadlink
+            )
+        )
+
+    if not switches:
+        _LOGGER.error("No switches added.")
+        return False
+
+    add_devices(switches)
+
+
+class BroadlinkSwitch(SwitchDevice):
+    """Representation of an Broadlink switch."""
+
+    def __init__(self, hass, object_id, friendly_name, command_on,
+                 command_off, optimistic, broadlink):
+        """Initialize the switch."""
+        self._hass = hass
+        self._name = friendly_name
+        self._state = False
+        self._command_on = command_on
+        self._command_off = command_off
+        self._optimistic = optimistic
+        self._broadlink = broadlink
+
+    @staticmethod
+    def _switch(command):
+        """Execute the actual commands."""
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    @property
+    def assumed_state(self):
+        """Return if the state is based on assumptions."""
+        return self._optimistic
+
+    def update(self):
+        """Update device state."""
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        import base64
+        self._state = True
+        _LOGGER.info("Running command: %s", self._command_on)
+        auth = self._broadlink.auth()
+        if auth:
+            self._broadlink.send_data(base64.b64decode(self._command_on))
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        import base64
+        self._state = False
+        _LOGGER.info("Running command: %s", self._command_off)
+        auth = self._broadlink.auth()
+        if auth:
+            self._broadlink.send_data(base64.b64decode(self._command_off))
+
+
+class Broadlink():
+    """Broadlink connector class."""
+
+    class Device:
+        """Broadlink Device."""
+
+        def __init__(self, host, mac):
+            """Initialize the object."""
+            import socket
+            import random
+            import threading
+            self.host = host
+            self.mac = mac
+            self.count = random.randrange(0xffff)
+
+            self.key = b'\x09\x76\x28\x34\x3f\xe9\x9e'\
+                       b'\x23\x76\x5c\x15\x13\xac\xcf\x8b\x02'
+            self.ivr = b'\x56\x2e\x17\x99\x6d\x09\x3d\x28\xdd'\
+                       b'\xb3\xba\x69\x5a\x2e\x6f\x58'
+
+            self.ip_arr = bytearray([0, 0, 0, 0])
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            self.sock.bind(('', 0))
+            self.lock = threading.Lock()
+
+        def auth(self):
+            """Obtain the authentication key."""
+            from Crypto.Cipher import AES
+            payload = bytearray(0x50)
+            payload[0x04] = 0x31
+            payload[0x05] = 0x31
+            payload[0x06] = 0x31
+            payload[0x07] = 0x31
+            payload[0x08] = 0x31
+            payload[0x09] = 0x31
+            payload[0x0a] = 0x31
+            payload[0x0b] = 0x31
+            payload[0x0c] = 0x31
+            payload[0x0d] = 0x31
+            payload[0x0e] = 0x31
+            payload[0x0f] = 0x31
+            payload[0x10] = 0x31
+            payload[0x11] = 0x31
+            payload[0x12] = 0x31
+            payload[0x1e] = 0x01
+            payload[0x2d] = 0x01
+            payload[0x30] = ord('T')
+            payload[0x31] = ord('e')
+            payload[0x32] = ord('s')
+            payload[0x33] = ord('t')
+            payload[0x34] = ord(' ')
+            payload[0x35] = ord(' ')
+            payload[0x36] = ord('1')
+
+            response = self.send_packet(0x65, payload)
+
+            enc_payload = response[0x38:]
+
+            aes = AES.new(bytes(self.key), AES.MODE_CBC, bytes(self.ivr))
+            payload = aes.decrypt(bytes(enc_payload))
+
+            if payload:
+                self.ip_arr = payload[0x00:0x04]
+                self.key = payload[0x04:0x14]
+                return True
+            else:
+                _LOGGER.error('Connection to broadlink device has failed.')
+                return False
+
+        def send_packet(self, command, payload, timeout=5.0):
+            """Send packet to Broadlink device."""
+            import socket
+            from Crypto.Cipher import AES
+            try:
+                packet = bytearray(0x38)
+                packet[0x00] = 0x5a
+                packet[0x01] = 0xa5
+                packet[0x02] = 0xaa
+                packet[0x03] = 0x55
+                packet[0x04] = 0x5a
+                packet[0x05] = 0xa5
+                packet[0x06] = 0xaa
+                packet[0x07] = 0x55
+                packet[0x24] = 0x2a
+                packet[0x25] = 0x27
+                packet[0x26] = command
+                packet[0x28] = self.count & 0xff
+                packet[0x29] = self.count >> 8
+                packet[0x2a] = self.mac[0]
+                packet[0x2b] = self.mac[1]
+                packet[0x2c] = self.mac[2]
+                packet[0x2d] = self.mac[3]
+                packet[0x2e] = self.mac[4]
+                packet[0x2f] = self.mac[5]
+                packet[0x30] = self.ip_arr[0]
+                packet[0x31] = self.ip_arr[1]
+                packet[0x32] = self.ip_arr[2]
+                packet[0x33] = self.ip_arr[3]
+            except (IndexError, TypeError, NameError):
+                _LOGGER.error('Invalid IP or MAC address.')
+                return bytearray(0x30)
+
+            checksum = 0xbeaf
+            for i, _ in enumerate(payload):
+                checksum += payload[i]
+                checksum = checksum & 0xffff
+
+            aes = AES.new(bytes(self.key), AES.MODE_CBC, bytes(self.ivr))
+            payload = aes.encrypt(bytes(payload))
+
+            packet[0x34] = checksum & 0xff
+            packet[0x35] = checksum >> 8
+
+            for i, _ in enumerate(payload):
+                packet.append(payload[i])
+
+            checksum = 0xbeaf
+            for i, _ in enumerate(packet):
+                checksum += packet[i]
+                checksum = checksum & 0xffff
+            packet[0x20] = checksum & 0xff
+            packet[0x21] = checksum >> 8
+
+            with self.lock:
+                self.sock.sendto(packet, self.host)
+                try:
+                    self.sock.settimeout(timeout)
+                    response = self.sock.recvfrom(1024)
+                except socket.timeout:
+                    _LOGGER.error("Socket timeout...")
+                    return bytearray(0x30)
+
+            return response[0]
+
+        def send_data(self, data):
+            """Send an IR or RF packet."""
+            packet = bytearray([0x02, 0x00, 0x00, 0x00])
+            packet += data
+            self.send_packet(0x6a, packet)

--- a/homeassistant/scripts/broadlink.py
+++ b/homeassistant/scripts/broadlink.py
@@ -1,0 +1,238 @@
+"""Script to enter Broadlink RM devices in learning mode."""
+
+import argparse
+
+
+class Broadlink():
+    """Broadlink connector class."""
+
+    class Device:
+        """Broadlink Device."""
+
+        def __init__(self, host, mac):
+            """Initialize the object."""
+            import socket
+            import random
+            import threading
+            self.host = host
+            self.mac = mac
+            self.count = random.randrange(0xffff)
+
+            self.key = b'\x09\x76\x28\x34\x3f\xe9\x9e'\
+                       b'\x23\x76\x5c\x15\x13\xac\xcf\x8b\x02'
+            self.ivr = b'\x56\x2e\x17\x99\x6d\x09\x3d\x28\xdd'\
+                       b'\xb3\xba\x69\x5a\x2e\x6f\x58'
+
+            self.ip_arr = bytearray([0, 0, 0, 0])
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            self.sock.bind(('', 0))
+            self.lock = threading.Lock()
+
+        def auth(self):
+            """Obtain the authentication key."""
+            from Crypto.Cipher import AES
+            payload = bytearray(0x50)
+            payload[0x04] = 0x31
+            payload[0x05] = 0x31
+            payload[0x06] = 0x31
+            payload[0x07] = 0x31
+            payload[0x08] = 0x31
+            payload[0x09] = 0x31
+            payload[0x0a] = 0x31
+            payload[0x0b] = 0x31
+            payload[0x0c] = 0x31
+            payload[0x0d] = 0x31
+            payload[0x0e] = 0x31
+            payload[0x0f] = 0x31
+            payload[0x10] = 0x31
+            payload[0x11] = 0x31
+            payload[0x12] = 0x31
+            payload[0x1e] = 0x01
+            payload[0x2d] = 0x01
+            payload[0x30] = ord('T')
+            payload[0x31] = ord('e')
+            payload[0x32] = ord('s')
+            payload[0x33] = ord('t')
+            payload[0x34] = ord(' ')
+            payload[0x35] = ord(' ')
+            payload[0x36] = ord('1')
+
+            response = self.send_packet(0x65, payload)
+
+            enc_payload = response[0x38:]
+
+            aes = AES.new(bytes(self.key), AES.MODE_CBC, bytes(self.ivr))
+            payload = aes.decrypt(bytes(enc_payload))
+
+            if payload:
+                self.ip_arr = payload[0x00:0x04]
+                self.key = payload[0x04:0x14]
+                return True
+            else:
+                print('Connection to broadlink device has failed.')
+                return False
+
+        def send_packet(self, command, payload, timeout=5.0):
+            """Send packet to Broadlink device."""
+            import socket
+            from Crypto.Cipher import AES
+            try:
+                packet = bytearray(0x38)
+                packet[0x00] = 0x5a
+                packet[0x01] = 0xa5
+                packet[0x02] = 0xaa
+                packet[0x03] = 0x55
+                packet[0x04] = 0x5a
+                packet[0x05] = 0xa5
+                packet[0x06] = 0xaa
+                packet[0x07] = 0x55
+                packet[0x24] = 0x2a
+                packet[0x25] = 0x27
+                packet[0x26] = command
+                packet[0x28] = self.count & 0xff
+                packet[0x29] = self.count >> 8
+                packet[0x2a] = self.mac[0]
+                packet[0x2b] = self.mac[1]
+                packet[0x2c] = self.mac[2]
+                packet[0x2d] = self.mac[3]
+                packet[0x2e] = self.mac[4]
+                packet[0x2f] = self.mac[5]
+                packet[0x30] = self.ip_arr[0]
+                packet[0x31] = self.ip_arr[1]
+                packet[0x32] = self.ip_arr[2]
+                packet[0x33] = self.ip_arr[3]
+            except (IndexError, TypeError, NameError):
+                print('Invalid IP or MAC address.')
+                return bytearray(0x30)
+
+            checksum = 0xbeaf
+            for i, _ in enumerate(payload):
+                checksum += payload[i]
+                checksum = checksum & 0xffff
+
+            aes = AES.new(bytes(self.key), AES.MODE_CBC, bytes(self.ivr))
+            payload = aes.encrypt(bytes(payload))
+
+            packet[0x34] = checksum & 0xff
+            packet[0x35] = checksum >> 8
+
+            for i, _ in enumerate(payload):
+                packet.append(payload[i])
+
+            checksum = 0xbeaf
+            for i, _ in enumerate(packet):
+                checksum += packet[i]
+                checksum = checksum & 0xffff
+            packet[0x20] = checksum & 0xff
+            packet[0x21] = checksum >> 8
+
+            with self.lock:
+                self.sock.sendto(packet, self.host)
+                try:
+                    self.sock.settimeout(timeout)
+                    response = self.sock.recvfrom(1024)
+                except socket.timeout:
+                    print("Socket timeout...")
+                    return bytearray(0x30)
+
+            return response[0]
+
+        def send_data(self, data):
+            """Send an IR or RF packet."""
+            packet = bytearray([0x02, 0x00, 0x00, 0x00])
+            packet += data
+            self.send_packet(0x6a, packet)
+
+        def enter_learning(self):
+            """Enter learning mode."""
+            packet = bytearray(16)
+            packet[0] = 3
+            self.send_packet(0x6a, packet)
+
+        def check_data(self):
+            """Obtain the IR or RF packet."""
+            from Crypto.Cipher import AES
+            packet = bytearray(16)
+            packet[0] = 4
+            response = self.send_packet(0x6a, packet)
+            err = response[0x22] | (response[0x23] << 8)
+            if err == 0:
+                aes = AES.new(bytes(self.key), AES.MODE_CBC, bytes(self.ivr))
+                payload = aes.decrypt(bytes(response[0x38:]))
+                return payload[0x04:]
+
+
+def yesno(question, default="yes"):
+    """Ask a yes/no question and return their answer."""
+    import sys
+
+    valid = {"yes": True, "y": True, "ye": True,
+             "no": False, "n": False}
+    if default is None:
+        prompt = " [y/n] "
+    elif default == "yes":
+        prompt = " [Y/n] "
+    elif default == "no":
+        prompt = " [y/N] "
+    else:
+        raise ValueError("invalid default answer: '%s'" % default)
+
+    while True:
+        sys.stdout.write(question + prompt)
+        choice = input().lower()
+        if default is not None and choice == '':
+            return valid[default]
+        elif choice in valid:
+            return valid[choice]
+        else:
+            sys.stdout.write("Please respond with 'yes' or 'no' "
+                             "(or 'y' or 'n').\n")
+
+
+def run(args):
+    """Handle ensure config commandline script."""
+    import base64
+    import binascii
+
+    parser = argparse.ArgumentParser(
+        description="Put Broadlink RM device in learning mode")
+    parser.add_argument(
+        '--script',
+        choices=['broadlink'])
+    parser.add_argument(
+        '-i', '--ip',
+        default=None,
+        help="Device IP address")
+    parser.add_argument(
+        '-m', '--mac',
+        default=None,
+        help="Device MAC address")
+
+    args = parser.parse_args()
+
+    if args.ip is None and args.mac is None:
+        parser.print_help()
+        return 1
+
+    ip_addr = (args.ip, 80)
+    mac_addr = binascii.unhexlify(args.mac.encode().replace(b':', b''))
+    device = Broadlink.Device(host=ip_addr, mac=mac_addr)
+
+    device.auth()
+
+    print("Broadlink: Learning mode... \nPlease press the matching button")
+    device.enter_learning()
+
+    while True:
+        packet = device.check_data()
+        if packet:
+            print("\n\n Your packet is: \n\n {} \n\n"
+                  .format(base64.b64encode(packet).decode('utf8')))
+            if yesno("Do you want to learn next key (y/n): "):
+                device.enter_learning()
+                continue
+            else:
+                break
+    return 0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -40,10 +40,10 @@ apcaccess==0.0.4
 apns2==0.1.1
 
 # homeassistant.components.sun
-astral==1.3.2
+astral==1.2
 
 # homeassistant.components.sensor.linux_battery
-batinfo==0.4.2
+batinfo==0.3
 
 # homeassistant.components.sensor.scrape
 beautifulsoup4==4.5.1
@@ -76,7 +76,7 @@ concord232==0.14
 directpy==0.1
 
 # homeassistant.components.updater
-distro==1.0.1
+distro==1.0.0
 
 # homeassistant.components.notify.xmpp
 dnspython3==1.15.0
@@ -113,19 +113,16 @@ fitbit==0.2.3
 fixerio==0.1.1
 
 # homeassistant.components.notify.free_mobile
-freesms==0.1.1
+freesms==0.1.0
 
 # homeassistant.components.conversation
-fuzzywuzzy==0.14.0
+fuzzywuzzy==0.12.0
 
 # homeassistant.components.device_tracker.bluetooth_le_tracker
 # gattlib==0.20150805
 
 # homeassistant.components.notify.gntp
 gntp==1.0.3
-
-# homeassistant.components.google
-google-api-python-client==1.5.5
 
 # homeassistant.components.sensor.google_travel_time
 googlemaps==2.4.4
@@ -155,13 +152,13 @@ hikvision==0.4
 # http://github.com/adafruit/Adafruit_Python_DHT/archive/310c59b0293354d07d94375f1365f7b9b9110c7d.zip#Adafruit_DHT==1.3.0
 
 # homeassistant.components.light.flux_led
-https://github.com/Danielhiversen/flux_led/archive/0.9.zip#flux_led==0.9
+https://github.com/Danielhiversen/flux_led/archive/0.8.zip#flux_led==0.8
 
 # homeassistant.components.switch.tplink
 https://github.com/GadgetReactor/pyHS100/archive/1f771b7d8090a91c6a58931532e42730b021cbde.zip#pyHS100==0.2.0
 
 # homeassistant.components.switch.dlink
-https://github.com/LinuxChristian/pyW215/archive/v0.3.6.zip#pyW215==0.3.6
+https://github.com/LinuxChristian/pyW215/archive/v0.3.5.zip#pyW215==0.3.5
 
 # homeassistant.components.media_player.webostv
 # homeassistant.components.notify.webostv
@@ -175,7 +172,7 @@ https://github.com/TheRealLink/pythinkingcleaner/archive/v0.0.2.zip#pythinkingcl
 https://github.com/Xorso/pyalarmdotcom/archive/0.1.1.zip#pyalarmdotcom==0.1.1
 
 # homeassistant.components.media_player.braviatv
-https://github.com/aparraga/braviarc/archive/0.3.6.zip#braviarc==0.3.6
+https://github.com/aparraga/braviarc/archive/0.3.5.zip#braviarc==0.3.5
 
 # homeassistant.components.media_player.roku
 https://github.com/bah2830/python-roku/archive/3.1.2.zip#roku==3.1.2
@@ -190,9 +187,9 @@ https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.
 # https://github.com/deisi/fritzconnection/archive/b5c14515e1c8e2652b06b6316a7f3913df942841.zip#fritzconnection==0.4.6
 
 # homeassistant.components.netatmo
-https://github.com/jabesq/netatmo-api-python/archive/v0.7.0.zip#lnetatmo==0.7.0
+https://github.com/jabesq/netatmo-api-python/archive/v0.6.0.zip#lnetatmo==0.6.0
 
-# homeassistant.components.neato
+# homeassistant.components.switch.neato
 https://github.com/jabesq/pybotvac/archive/v0.0.1.zip#pybotvac==0.0.1
 
 # homeassistant.components.sensor.sabnzbd
@@ -231,6 +228,9 @@ https://github.com/theolind/pymysensors/archive/0b705119389be58332f17753c53167f5
 
 # homeassistant.components.alarm_control_panel.simplisafe
 https://github.com/w1ll1am23/simplisafe-python/archive/586fede0e85fd69e56e516aaa8e97eb644ca8866.zip#simplisafe-python==0.0.1
+
+# homeassistant.components.notify.html5
+https://github.com/web-push-libs/pywebpush/archive/e743dc92558fc62178d255c0018920d74fa778ed.zip#pywebpush==0.5.0
 
 # homeassistant.components.media_player.lg_netcast
 https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
@@ -275,16 +275,13 @@ messagebird==1.2.0
 mficlient==0.3.0
 
 # homeassistant.components.sensor.miflora
-miflora==0.1.12
+miflora==0.1.9
 
 # homeassistant.components.discovery
-netdisco==0.7.6
+netdisco==0.7.5
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.2.10
-
-# homeassistant.components.google
-oauth2client==3.0.0
 
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1
@@ -297,12 +294,11 @@ panasonic_viera==0.2
 
 # homeassistant.components.device_tracker.aruba
 # homeassistant.components.device_tracker.asuswrt
-# homeassistant.components.device_tracker.cisco_ios
 # homeassistant.components.media_player.pandora
 pexpect==4.0.1
 
 # homeassistant.components.light.hue
-phue==0.9
+phue==0.8
 
 # homeassistant.components.pilight
 pilight==0.1.1
@@ -316,10 +312,10 @@ plexapi==2.0.2
 pmsensor==0.3
 
 # homeassistant.components.climate.proliphix
-proliphix==0.4.1
+proliphix==0.4.0
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.0.0
+psutil==4.4.2
 
 # homeassistant.components.wink
 pubnub==3.8.2
@@ -366,7 +362,7 @@ pydispatcher==2.0.5
 pyemby==0.1
 
 # homeassistant.components.envisalink
-pyenvisalink==1.9
+pyenvisalink==1.7
 
 # homeassistant.components.ifttt
 pyfttt==0.3
@@ -411,13 +407,13 @@ pyserial==3.1.1
 pysnmp==4.3.2
 
 # homeassistant.components.digital_ocean
-python-digitalocean==1.10.1
+python-digitalocean==1.10.0
 
 # homeassistant.components.sensor.darksky
 python-forecastio==1.3.5
 
 # homeassistant.components.sensor.hp_ilo
-python-hpilo==3.9
+python-hpilo==3.8
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3
@@ -447,16 +443,13 @@ python-telegram-bot==5.2.0
 python-twitch==1.3.0
 
 # homeassistant.components.wink
-python-wink==0.10.0
+python-wink==0.9.0
 
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.2.21
-
-# homeassistant.components.notify.html5
-pywebpush==0.6.1
+pyvera==0.2.20
 
 # homeassistant.components.wemo
 pywemo==0.4.7
@@ -471,22 +464,22 @@ radiotherm==1.2
 # rpi-rf==0.9.5
 
 # homeassistant.components.media_player.yamaha
-rxv==0.4.0
+rxv==0.3.1
 
 # homeassistant.components.media_player.samsungtv
 samsungctl==0.5.1
 
 # homeassistant.components.sensor.deutsche_bahn
-schiene==0.18
+schiene==0.17
 
 # homeassistant.components.scsgate
 scsgate==0.1.0
 
 # homeassistant.components.notify.sendgrid
-sendgrid==3.6.3
+sendgrid==3.6.0
 
 # homeassistant.components.notify.slack
-slacker==0.9.30
+slacker==0.9.29
 
 # homeassistant.components.notify.xmpp
 sleekxmpp==1.3.1
@@ -505,7 +498,7 @@ speedtest-cli==0.3.4
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator
-sqlalchemy==1.1.4
+sqlalchemy==1.1.2
 
 # homeassistant.components.statsd
 statsd==3.2.1
@@ -572,7 +565,7 @@ xboxapi==0.1.1
 xmltodict==0.10.2
 
 # homeassistant.components.sensor.yahoo_finance
-yahoo-finance==1.4.0
+yahoo-finance==1.3.2
 
 # homeassistant.components.sensor.yweather
 yahooweather==0.8


### PR DESCRIPTION
**Description:**
This `Broadlink RM` switch platform allow to you control Broadlink RM2 Pro and RM mini IR+RF devices

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1485

**Example entry for `configuration.yaml` (if applicable):**
```yaml
switch:
  platform: broadlink
  host: IP_ADDRESS
  mac: 'MAC_ADDRESS'
  switches:
    reciever:
      command_on: 'switch_packet on'
      command_off: 'switch_packet off'
```
Configuration variables:
- **host** (*Required*): The hostname/IP address to connect to.
- **mac** (*Required*):  Device mac address.
- **switches** (*Required*): The array that contains all switches.
  - **identifier** (*Required*): Name of the command switch as slug. Multiple entries are possible.
    - **command_on** (*Required*): Base64 encoded packet from RM device to take for on.
    - **command_off** (*Required*): Base64 encoded packet from RM device to take for off.
    - **optimistic** (*Optional*): Default true: Flag that defines if switch works in optimistic mode. 
    - **friendly_name** (*Optional*): The name used to display the switch in the frontend.


How to obtain IR/RF packet while in learning mode?
Run: hass --script broadlink --ip `YOUR_DEVICE_IP` --mac `YOUR_DEVICE_MAC`

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

