### PR TITLE
Fix platform discovery when platform discovered during discovery of a

### DIFF
--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -151,11 +151,10 @@ def async_load_platform(hass, component, platform, discovered=None,
     This method is a coroutine.
     """
     did_lock = False
-    if component not in hass.config.components:
-        setup_lock = hass.data.get('setup_lock')
-        if setup_lock and setup_lock.locked():
-            did_lock = True
-            yield from setup_lock.acquire()
+    setup_lock = hass.data.get('setup_lock')
+    if setup_lock and setup_lock.locked():
+        did_lock = True
+        yield from setup_lock.acquire()
 
     setup_success = True
 


### PR DESCRIPTION
**Description:**
Fix an issue where when a component got discovered, that then in it's setup discovered platforms we would get into a situation that would fail setup.

**Related issue (if applicable):** fixes #4435

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

component