### PR TITLE
Add entities in sequence.

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -313,10 +313,11 @@ class EntityPlatform(object):
         if not new_entities:
             return
 
-        tasks = [self._async_process_entity(entity, update_before_add)
-                 for entity in new_entities]
+        # Do it in sequence so if two entities have the same name entity id
+        # generation is deterministic.
+        for entity in new_entities:
+            yield from self._async_process_entity(entity, update_before_add)
 
-        yield from asyncio.wait(tasks, loop=self.component.hass.loop)
         yield from self.component.async_update_group()
 
         if self._async_unsub_polling is not None or \

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -292,7 +292,7 @@ class TestHelpersEntityComponent(unittest.TestCase):
         assert platform2_setup.called
 
     @patch('homeassistant.helpers.entity_component.EntityComponent'
-           '._async_setup_platform')
+           '._async_setup_platform', return_value=mock_coro()())
     @patch('homeassistant.bootstrap.async_setup_component',
            return_value=mock_coro(True)())
     def test_setup_does_discovery(self, mock_setup_component, mock_setup):

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -394,7 +394,8 @@ class TestHelpersEntityComponent(unittest.TestCase):
             """Create entity helper."""
             entity = EntityTest()
             entity.entity_id = generate_entity_id(component.entity_id_format,
-                                                  'Number', hass=self.hass)
+                                                  'Number {}'.format(number),
+                                                  hass=self.hass)
             return entity
 
         component.add_entities(create_entity(i) for i in range(2))


### PR DESCRIPTION
**Description:**
Adding multiple entities with the same name could end up with a not-deterministic result in which entity got `_2` appended to the entity id.

**Related issue (if applicable):** fixes #4248 #4478
