### PR TITLE
Fix wrong name handling in rfxtrx sensor

### DIFF
--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -124,7 +124,7 @@ class RfxtrxSensor(Entity):
     @property
     def name(self):
         """Get the name of the sensor."""
-        return self._name
+        return "{} {}".format(self._name, self.data_type)
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
**Description:**

I think that is the real fix for bad name handling with rfxtrx sensors. Look at #4530 for discusion.

**Related issue (if applicable):** fixes #4530 #4478 #4284

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

