### PR TITLE
Removed raise statement to don't pollute the user log.

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -222,7 +222,6 @@ class WUndergroundData(object):
         except ValueError as err:
             _LOGGER.error("Check WUnderground API %s", err.args)
             self.data = None
-            raise
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES_ALERTS)
     def update_alerts(self):
@@ -237,4 +236,3 @@ class WUndergroundData(object):
         except ValueError as err:
             _LOGGER.error("Check WUnderground API %s", err.args)
             self.alerts = None
-            raise

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -137,7 +137,7 @@ class TestWundergroundSetup(unittest.TestCase):
             ]
         }
 
-        self.assertFalse(
+        self.assertTrue(
             wunderground.setup_platform(self.hass, invalid_config,
                                         self.add_devices, None))
 


### PR DESCRIPTION
**Description:**

 Removed raise statement to don't pollute the user log. Only the error message should be displayed.

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  