### PR TITLE
Light effects

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID)
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 from homeassistant.util.async import run_callback_threadsafe
@@ -31,13 +31,6 @@ GROUP_NAME_ALL_LIGHTS = 'all lights'
 ENTITY_ID_ALL_LIGHTS = group.ENTITY_ID_FORMAT.format('all_lights')
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
-
-# Configuration for possible effects
-CONF_EFFECT_LIST = "effect_list"
-
-PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_EFFECT_LIST): list
-})
 
 # Bitfield of features supported by the light entity
 ATTR_SUPPORTED_FEATURES = 'supported_features'

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -92,10 +92,10 @@ VALID_BRIGHTNESS = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255))
 
 LIGHT_TURN_ON_SCHEMA = vol.Schema({
     ATTR_ENTITY_ID: cv.entity_ids,
-    ATTR_PROFILE: str,
+    ATTR_PROFILE: cv.string,
     ATTR_TRANSITION: VALID_TRANSITION,
     ATTR_BRIGHTNESS: VALID_BRIGHTNESS,
-    ATTR_COLOR_NAME: str,
+    ATTR_COLOR_NAME: cv.string,
     ATTR_RGB_COLOR: vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
                             vol.Coerce(tuple)),
     ATTR_XY_COLOR: vol.All(vol.ExactSequence((cv.small_float, cv.small_float)),
@@ -104,7 +104,7 @@ LIGHT_TURN_ON_SCHEMA = vol.Schema({
                                             max=color_util.HASS_COLOR_MAX)),
     ATTR_WHITE_VALUE: vol.All(int, vol.Range(min=0, max=255)),
     ATTR_FLASH: vol.In([FLASH_SHORT, FLASH_LONG]),
-    ATTR_EFFECT: str,
+    ATTR_EFFECT: cv.string,
 })
 
 LIGHT_TURN_OFF_SCHEMA = vol.Schema({

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID)
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 from homeassistant.util.async import run_callback_threadsafe
@@ -31,6 +31,13 @@ GROUP_NAME_ALL_LIGHTS = 'all lights'
 ENTITY_ID_ALL_LIGHTS = group.ENTITY_ID_FORMAT.format('all_lights')
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
+
+# Configuration for possible effects
+CONF_EFFECT_LIST = "effect_list"
+
+PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_EFFECT_LIST): list
+})
 
 # Bitfield of features supported by the light entity
 ATTR_SUPPORTED_FEATURES = 'supported_features'
@@ -64,6 +71,9 @@ ATTR_FLASH = "flash"
 FLASH_SHORT = "short"
 FLASH_LONG = "long"
 
+# List of possible effects
+ATTR_EFFECT_LIST = "effect_list"
+
 # Apply an effect to the light, can be EFFECT_COLORLOOP.
 ATTR_EFFECT = "effect"
 EFFECT_COLORLOOP = "colorloop"
@@ -78,6 +88,8 @@ PROP_TO_ATTR = {
     'rgb_color': ATTR_RGB_COLOR,
     'xy_color': ATTR_XY_COLOR,
     'white_value': ATTR_WHITE_VALUE,
+    'effect_list': ATTR_EFFECT_LIST,
+    'effect': ATTR_EFFECT,
     'supported_features': ATTR_SUPPORTED_FEATURES,
 }
 
@@ -99,7 +111,7 @@ LIGHT_TURN_ON_SCHEMA = vol.Schema({
                                             max=color_util.HASS_COLOR_MAX)),
     ATTR_WHITE_VALUE: vol.All(int, vol.Range(min=0, max=255)),
     ATTR_FLASH: vol.In([FLASH_SHORT, FLASH_LONG]),
-    ATTR_EFFECT: vol.In([EFFECT_COLORLOOP, EFFECT_RANDOM, EFFECT_WHITE]),
+    ATTR_EFFECT: str,
 })
 
 LIGHT_TURN_OFF_SCHEMA = vol.Schema({
@@ -312,6 +324,16 @@ class Light(ToggleEntity):
     @property
     def white_value(self):
         """Return the white value of this light between 0..255."""
+        return None
+
+    @property
+    def effect_list(self):
+        """Return the list of supported effects."""
+        return None
+
+    @property
+    def effect(self):
+        """Return the current effect."""
         return None
 
     @property

--- a/homeassistant/components/light/demo.py
+++ b/homeassistant/components/light/demo.py
@@ -7,25 +7,29 @@ https://home-assistant.io/components/demo/
 import random
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_RGB_COLOR, ATTR_WHITE_VALUE,
-    ATTR_XY_COLOR, SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_RGB_COLOR,
-    SUPPORT_WHITE_VALUE, Light)
+    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT,
+    ATTR_RGB_COLOR, ATTR_WHITE_VALUE, ATTR_XY_COLOR, SUPPORT_BRIGHTNESS,
+    SUPPORT_COLOR_TEMP, SUPPORT_EFFECT, SUPPORT_RGB_COLOR, SUPPORT_WHITE_VALUE,
+    Light)
 
 LIGHT_COLORS = [
     [237, 224, 33],
     [255, 63, 111],
 ]
 
+LIGHT_EFFECT_LIST = ['rainbow', 'none']
+
 LIGHT_TEMPS = [240, 380]
 
-SUPPORT_DEMO = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_RGB_COLOR |
-                SUPPORT_WHITE_VALUE)
+SUPPORT_DEMO = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_EFFECT |
+                SUPPORT_RGB_COLOR | SUPPORT_WHITE_VALUE)
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Setup the demo light platform."""
     add_devices_callback([
-        DemoLight("Bed Light", False),
+        DemoLight("Bed Light", False, effect_list=LIGHT_EFFECT_LIST,
+                  effect=LIGHT_EFFECT_LIST[0]),
         DemoLight("Ceiling Lights", True, LIGHT_COLORS[0], LIGHT_TEMPS[1]),
         DemoLight("Kitchen Lights", True, LIGHT_COLORS[1], LIGHT_TEMPS[0])
     ])
@@ -36,7 +40,7 @@ class DemoLight(Light):
 
     def __init__(
             self, name, state, rgb=None, ct=None, brightness=180,
-            xy_color=(.5, .5), white=200):
+            xy_color=(.5, .5), white=200, effect_list=None, effect=None):
         """Initialize the light."""
         self._name = name
         self._state = state
@@ -45,6 +49,8 @@ class DemoLight(Light):
         self._brightness = brightness
         self._xy_color = xy_color
         self._white = white
+        self._effect_list = effect_list
+        self._effect = effect
 
     @property
     def should_poll(self):
@@ -82,6 +88,16 @@ class DemoLight(Light):
         return self._white
 
     @property
+    def effect_list(self):
+        """Return the list of supported effects."""
+        return self._effect_list
+
+    @property
+    def effect(self):
+        """Return the current effect."""
+        return self._effect
+
+    @property
     def is_on(self):
         """Return true if light is on."""
         return self._state
@@ -109,6 +125,9 @@ class DemoLight(Light):
 
         if ATTR_WHITE_VALUE in kwargs:
             self._white = kwargs[ATTR_WHITE_VALUE]
+
+        if ATTR_EFFECT in kwargs:
+            self._effect = kwargs[ATTR_EFFECT]
 
         self.update_ha_state()
 

--- a/homeassistant/components/light/mqtt_template.py
+++ b/homeassistant/components/light/mqtt_template.py
@@ -42,7 +42,7 @@ SUPPORT_MQTT_TEMPLATE = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT | SUPPORT_FLASH |
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_EFFECT_LIST): list,
+    vol.Optional(CONF_EFFECT_LIST): vol.All(cv.ensure_list, [cv.sring]),
     vol.Required(CONF_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Required(CONF_COMMAND_ON_TEMPLATE): cv.template,

--- a/homeassistant/components/light/mqtt_template.py
+++ b/homeassistant/components/light/mqtt_template.py
@@ -42,7 +42,7 @@ SUPPORT_MQTT_TEMPLATE = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT | SUPPORT_FLASH |
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_EFFECT_LIST): vol.All(cv.ensure_list, [cv.sring]),
+    vol.Optional(CONF_EFFECT_LIST): vol.All(cv.ensure_list, [cv.string]),
     vol.Required(CONF_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Required(CONF_COMMAND_ON_TEMPLATE): cv.template,

--- a/homeassistant/components/light/mqtt_template.py
+++ b/homeassistant/components/light/mqtt_template.py
@@ -10,9 +10,9 @@ import voluptuous as vol
 
 import homeassistant.components.mqtt as mqtt
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATTR_TRANSITION, PLATFORM_SCHEMA,
-    ATTR_FLASH, SUPPORT_BRIGHTNESS, SUPPORT_FLASH,
-    SUPPORT_RGB_COLOR, SUPPORT_TRANSITION, Light)
+    ATTR_BRIGHTNESS, ATTR_EFFECT, ATTR_FLASH, ATTR_RGB_COLOR, ATTR_TRANSITION,
+    CONF_EFFECT_LIST, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT,
+    SUPPORT_FLASH, SUPPORT_RGB_COLOR, SUPPORT_TRANSITION, Light)
 from homeassistant.const import CONF_NAME, CONF_OPTIMISTIC, STATE_ON, STATE_OFF
 from homeassistant.components.mqtt import (
     CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN)
@@ -34,8 +34,9 @@ CONF_BRIGHTNESS_TEMPLATE = 'brightness_template'
 CONF_RED_TEMPLATE = 'red_template'
 CONF_GREEN_TEMPLATE = 'green_template'
 CONF_BLUE_TEMPLATE = 'blue_template'
+CONF_EFFECT_TEMPLATE = 'effect_template'
 
-SUPPORT_MQTT_TEMPLATE = (SUPPORT_BRIGHTNESS | SUPPORT_FLASH |
+SUPPORT_MQTT_TEMPLATE = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT | SUPPORT_FLASH |
                          SUPPORT_RGB_COLOR | SUPPORT_TRANSITION)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -49,6 +50,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_RED_TEMPLATE): cv.template,
     vol.Optional(CONF_GREEN_TEMPLATE): cv.template,
     vol.Optional(CONF_BLUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_EFFECT_TEMPLATE): cv.template,
     vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
     vol.Optional(CONF_QOS, default=mqtt.DEFAULT_QOS):
         vol.All(vol.Coerce(int), vol.In([0, 1, 2])),
@@ -61,6 +63,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([MqttTemplate(
         hass,
         config.get(CONF_NAME),
+        config.get(CONF_EFFECT_LIST),
         {
             key: config.get(key) for key in (
                 CONF_STATE_TOPIC,
@@ -75,7 +78,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 CONF_BRIGHTNESS_TEMPLATE,
                 CONF_RED_TEMPLATE,
                 CONF_GREEN_TEMPLATE,
-                CONF_BLUE_TEMPLATE
+                CONF_BLUE_TEMPLATE,
+                CONF_EFFECT_TEMPLATE
             )
         },
         config.get(CONF_OPTIMISTIC),
@@ -87,10 +91,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class MqttTemplate(Light):
     """Representation of a MQTT Template light."""
 
-    def __init__(self, hass, name, topics, templates, optimistic, qos, retain):
+    def __init__(self, hass, name, effect_list, topics, templates, optimistic,
+                 qos, retain):
         """Initialize MQTT Template light."""
         self._hass = hass
         self._name = name
+        self._effect_list = effect_list
         self._topics = topics
         self._templates = templates
         for tpl in self._templates.values():
@@ -114,6 +120,7 @@ class MqttTemplate(Light):
             self._rgb = [0, 0, 0]
         else:
             self._rgb = None
+        self._effect = None
 
         def state_received(topic, payload, qos):
             """A new MQTT message has been received."""
@@ -151,6 +158,14 @@ class MqttTemplate(Light):
                         render_with_possible_json_value(payload))
                 except ValueError:
                     _LOGGER.warning('Invalid color value received')
+
+            # read effect
+            if self._templates[CONF_EFFECT_TEMPLATE] is not None:
+                try:
+                    self._effect = self._templates[CONF_EFFECT_TEMPLATE].\
+                        render_with_possible_json_value(payload)
+                except ValueError:
+                    _LOGGER.warning('Invalid effect value received')
 
             self.update_ha_state()
 
@@ -191,6 +206,16 @@ class MqttTemplate(Light):
         """Return True if unable to access real state of the entity."""
         return self._optimistic
 
+    @property
+    def effect_list(self):
+        """Return the list of supported effects."""
+        return self._effect_list
+
+    @property
+    def effect(self):
+        """Return the current effect."""
+        return self._effect
+
     def turn_on(self, **kwargs):
         """Turn the entity on."""
         # state
@@ -213,6 +238,10 @@ class MqttTemplate(Light):
 
             if self._optimistic:
                 self._rgb = kwargs[ATTR_RGB_COLOR]
+
+        # effect
+        if ATTR_EFFECT in kwargs:
+            values['effect'] = kwargs.get(ATTR_EFFECT)
 
         # flash
         if ATTR_FLASH in kwargs:

--- a/homeassistant/components/light/mqtt_template.py
+++ b/homeassistant/components/light/mqtt_template.py
@@ -163,17 +163,14 @@ class MqttTemplate(Light):
 
             # read effect
             if self._templates[CONF_EFFECT_TEMPLATE] is not None:
-                try:
-                    effect = self._templates[CONF_EFFECT_TEMPLATE].\
-                        render_with_possible_json_value(payload)
-                except ValueError:
-                    _LOGGER.warning('Invalid effect value received')
+                effect = self._templates[CONF_EFFECT_TEMPLATE].\
+                    render_with_possible_json_value(payload)
+
+                # validate effect value
+                if effect in self._effect_list:
+                    self._effect = effect
                 else:
-                    # validate effect value
-                    if effect in self._effect_list:
-                        self._effect = effect
-                    else:
-                        _LOGGER.warning('Unsupported effect value received')
+                    _LOGGER.warning('Unsupported effect value received')
 
             self.update_ha_state()
 

--- a/homeassistant/components/light/mqtt_template.py
+++ b/homeassistant/components/light/mqtt_template.py
@@ -164,10 +164,16 @@ class MqttTemplate(Light):
             # read effect
             if self._templates[CONF_EFFECT_TEMPLATE] is not None:
                 try:
-                    self._effect = self._templates[CONF_EFFECT_TEMPLATE].\
+                    effect = self._templates[CONF_EFFECT_TEMPLATE].\
                         render_with_possible_json_value(payload)
                 except ValueError:
                     _LOGGER.warning('Invalid effect value received')
+                else:
+                    # validate effect value
+                    if effect in self._effect_list:
+                        self._effect = effect
+                    else:
+                        _LOGGER.warning('Unsupported effect value received')
 
             self.update_ha_state()
 

--- a/homeassistant/components/light/mqtt_template.py
+++ b/homeassistant/components/light/mqtt_template.py
@@ -11,8 +11,8 @@ import voluptuous as vol
 import homeassistant.components.mqtt as mqtt
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_EFFECT, ATTR_FLASH, ATTR_RGB_COLOR, ATTR_TRANSITION,
-    CONF_EFFECT_LIST, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT,
-    SUPPORT_FLASH, SUPPORT_RGB_COLOR, SUPPORT_TRANSITION, Light)
+    PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT, SUPPORT_FLASH,
+    SUPPORT_RGB_COLOR, SUPPORT_TRANSITION, Light)
 from homeassistant.const import CONF_NAME, CONF_OPTIMISTIC, STATE_ON, STATE_OFF
 from homeassistant.components.mqtt import (
     CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN)
@@ -27,6 +27,7 @@ DEPENDENCIES = ['mqtt']
 DEFAULT_NAME = 'MQTT Template Light'
 DEFAULT_OPTIMISTIC = False
 
+CONF_EFFECT_LIST = "effect_list"
 CONF_COMMAND_ON_TEMPLATE = 'command_on_template'
 CONF_COMMAND_OFF_TEMPLATE = 'command_off_template'
 CONF_STATE_TEMPLATE = 'state_template'
@@ -41,6 +42,7 @@ SUPPORT_MQTT_TEMPLATE = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT | SUPPORT_FLASH |
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_EFFECT_LIST): list,
     vol.Required(CONF_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Required(CONF_COMMAND_ON_TEMPLATE): cv.template,

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -37,6 +37,7 @@ class TestDemoClimate(unittest.TestCase):
         self.assertEqual(25, state.attributes.get(light.ATTR_BRIGHTNESS))
         self.assertEqual(
             (82, 91, 0), state.attributes.get(light.ATTR_RGB_COLOR))
+        self.assertEqual('rainbow', state.attributes.get(light.ATTR_EFFECT))
         light.turn_on(
             self.hass, ENTITY_LIGHT, rgb_color=(251, 252, 253),
             white_value=254)
@@ -45,10 +46,11 @@ class TestDemoClimate(unittest.TestCase):
         self.assertEqual(254, state.attributes.get(light.ATTR_WHITE_VALUE))
         self.assertEqual(
             (251, 252, 253), state.attributes.get(light.ATTR_RGB_COLOR))
-        light.turn_on(self.hass, ENTITY_LIGHT, color_temp=400)
+        light.turn_on(self.hass, ENTITY_LIGHT, color_temp=400, effect='none')
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_LIGHT)
         self.assertEqual(400, state.attributes.get(light.ATTR_COLOR_TEMP))
+        self.assertEqual('none', state.attributes.get(light.ATTR_EFFECT))
 
     def test_turn_off(self):
         """Test light turn off method."""


### PR DESCRIPTION
**Description:** Add support for more light effects.

**Motivation:** When a light displays an effect (e.g. colorloop) it is a special state and that should be displayed in the UI. Switching between effects should also be possible. While having predefined effect names is handy, it is also too restrictive so I kept the existing effect names but lifted the validation. I also added the ability to provide an `effect_list` that lists all possible effects on a *per-light basis*.

**Related issue (if applicable):** fixes #4489

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1489

**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer):** home-assistant/home-assistant-polymer#156

**Example entry for `configuration.yaml` (if applicable):**
```yaml
light:
  - platform: mqtt_template
    name: bedroom_abigaelle_colordesk
    effect_list:
      - solid
      - rainbow
      - juggle
      - confetti
      - applause
    state_topic: 'milkyway/bedroom/abigaelle/colordesk/status'
    command_topic: 'milkyway/bedroom/abigaelle/colordesk/set'
    command_on_template: >
      {"state":"ON"
      {%- if brightness is defined -%}
      ,"brightness":{{ brightness }}
      {%- endif -%}
      {%- if red is defined and green is defined and blue is defined -%}
      ,"color":[{{ red }},{{ green }},{{ blue }}]
      {%- endif -%}
      {%- if effect is defined -%}
      ,"effect":"{{ effect }}"
      {%- endif -%}
      }
    command_off_template: '{"state":"OFF"}'
    state_template: '{{ value_json.state | lower }}'
    brightness_template: '{{ value_json.brightness }}'
    red_template: '{{ value_json.color[0] }}'
    green_template: '{{ value_json.color[1] }}'
    blue_template: '{{ value_json.color[2] }}'
    effect_template: '{{ value_json.effect }}'
```

**UI rendering:**
![Light effect more infos](https://i.imgur.com/bKJXONv.png)

**Actual result:**
![Light effect rainbow](https://i.imgur.com/DjppWwk.jpg)

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
