### PR TITLE
Bump netdisco

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.helpers.discovery import load_platform, discover
 
-REQUIREMENTS = ['netdisco==0.7.6']
+REQUIREMENTS = ['netdisco==0.7.7']
 
 DOMAIN = 'discovery'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -278,7 +278,7 @@ mficlient==0.3.0
 miflora==0.1.13
 
 # homeassistant.components.discovery
-netdisco==0.7.6
+netdisco==0.7.7
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.2.10


### PR DESCRIPTION
**Description:**
This bumps Netdisco to the new version which disables the Samsung AC discovery. This broke discovery on Synology devices. Thanks to @jaharkes for [reporting](https://github.com/home-assistant/netdisco/issues/64#issuecomment-262400398) (and my bad for having it get lost before the last release).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
