### PR TITLE
Skip broken Sonarr tests

### DIFF
--- a/tests/components/sensor/test_sonarr.py
+++ b/tests/components/sensor/test_sonarr.py
@@ -2,6 +2,9 @@
 import unittest
 import time
 from datetime import datetime
+
+import pytest
+
 from homeassistant.components.sensor import sonarr
 
 from tests.common import get_test_home_assistant
@@ -751,6 +754,7 @@ class TestSonarrSetup(unittest.TestCase):
                 device.device_state_attributes["Bob's Burgers"]
             )
 
+    @pytest.mark.skip
     @unittest.mock.patch('requests.get', side_effect=mocked_requests_get)
     def test_upcoming_today(self, req_mock):
         """
@@ -781,6 +785,7 @@ class TestSonarrSetup(unittest.TestCase):
                 device.device_state_attributes["Bob's Burgers"]
             )
 
+    @pytest.mark.skip
     @unittest.mock.patch('requests.get', side_effect=mocked_requests_get)
     def test_ssl(self, req_mock):
         """Tests SSL being enabled"""


### PR DESCRIPTION
**Description:**
Two tests are either broken or flaky, disabling them.

Introduced in #4496 