### PR TITLE
#4421 - Forced icons to be displayed via SSL to avoid Mixed Content warnings

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -172,7 +172,7 @@ class WUndergroundSensor(Entity):
     def entity_picture(self):
         """Return the entity picture."""
         if self._condition == 'weather':
-            return self.rest.data['icon_url']
+            return self.rest.data['icon_url'].replace('http://','https://')
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/sensor.wunderground/
 from datetime import timedelta
 import logging
 
+import re
 import requests
 import voluptuous as vol
 
@@ -172,7 +173,8 @@ class WUndergroundSensor(Entity):
     def entity_picture(self):
         """Return the entity picture."""
         if self._condition == 'weather':
-            return self.rest.data['icon_url'].replace('http://', 'https://')
+            url = self.rest.data['icon_url']
+            return re.sub(r'^http://', 'https://', url, flags=re.IGNORECASE)
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -172,7 +172,7 @@ class WUndergroundSensor(Entity):
     def entity_picture(self):
         """Return the entity picture."""
         if self._condition == 'weather':
-            return self.rest.data['icon_url'].replace('http://','https://')
+            return self.rest.data['icon_url'].replace('http://', 'https://')
 
     @property
     def unit_of_measurement(self):

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -25,7 +25,7 @@ VALID_CONFIG = {
 
 FEELS_LIKE = '40'
 WEATHER = 'Clear'
-ICON_URL = 'https://icons.wxug.com/i/c/k/clear.gif'
+HTTPS_ICON_URL = 'https://icons.wxug.com/i/c/k/clear.gif'
 ALERT_MESSAGE = 'This is a test alert message'
 
 
@@ -61,7 +61,7 @@ def mocked_requests_get(*args, **kwargs):
                 },
                 "feelslike_c": FEELS_LIKE,
                 "weather": WEATHER,
-                "icon_url": ICON_URL,
+                "icon_url": 'http://icons.wxug.com/i/c/k/clear.gif',
                 "display_location": {
                     "city": "Holly Springs",
                     "country": "US",
@@ -150,7 +150,7 @@ class TestWundergroundSetup(unittest.TestCase):
             device.update()
             self.assertTrue(str(device.name).startswith('PWS_'))
             if device.name == 'PWS_weather':
-                self.assertEqual(ICON_URL, device.entity_picture)
+                self.assertEqual(HTTPS_ICON_URL, device.entity_picture)
                 self.assertEqual(WEATHER, device.state)
                 self.assertIsNone(device.unit_of_measurement)
             elif device.name == 'PWS_alerts':

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -25,7 +25,7 @@ VALID_CONFIG = {
 
 FEELS_LIKE = '40'
 WEATHER = 'Clear'
-ICON_URL = 'http://icons.wxug.com/i/c/k/clear.gif'
+ICON_URL = 'https://icons.wxug.com/i/c/k/clear.gif'
 ALERT_MESSAGE = 'This is a test alert message'
 
 


### PR DESCRIPTION
**Description:**
WUnderground icons are referenced via HTTP causing Mixed Content warnings when using HA with TLS. This patch force all icons hosted by WU via HTTPS instead of HTTP.

The domain 'wxug.com' is also managed and maintained by WU and supports  HTTPS requests. 

**Related issue (if applicable):** fixes #4421 

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests updated
