### PR TITLE
Add async executor pool for state updates

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -55,8 +55,9 @@ SERVICE_CALL_LIMIT = 10  # seconds
 # Pattern for validating entity IDs (format: <domain>.<entity>)
 ENTITY_ID_PATTERN = re.compile(r"^(\w+)\.(\w+)$")
 
-# Size of a executor pool
-EXECUTOR_POOL_SIZE = 15
+# Size of a executor pools
+EXECUTOR_DEFAULT_POOL_SIZE = 10
+EXECUTOR_ENTITY_POOL_SIZE = 5
 
 # Time for cleanup internal pending tasks
 TIME_INTERVAL_TASKS_CLEANUP = 10
@@ -109,7 +110,10 @@ class HomeAssistant(object):
         else:
             self.loop = loop or asyncio.get_event_loop()
 
-        self.executor = ThreadPoolExecutor(max_workers=EXECUTOR_POOL_SIZE)
+        self.executor = ThreadPoolExecutor(max_workers=\
+                                           EXECUTOR_DEFAULT_POOL_SIZE)
+        self.executor_entity = ThreadPoolExecutor(max_workers=\
+                                                  EXECUTOR_ENTITY_POOL_SIZE)
         self.loop.set_default_executor(self.executor)
         self.loop.set_exception_handler(self._async_exception_handler)
         self._pending_tasks = []
@@ -153,6 +157,7 @@ class HomeAssistant(object):
             self.loop.run_forever()
         finally:
             self.loop.close()
+            self.executor_entity.shutdown(wait=False)
 
     @asyncio.coroutine
     def async_start(self):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -110,10 +110,10 @@ class HomeAssistant(object):
         else:
             self.loop = loop or asyncio.get_event_loop()
 
-        self.executor = ThreadPoolExecutor(max_workers=\
-                                           EXECUTOR_DEFAULT_POOL_SIZE)
-        self.executor_entity = ThreadPoolExecutor(max_workers=\
-                                                  EXECUTOR_ENTITY_POOL_SIZE)
+        self.executor = ThreadPoolExecutor(
+            max_workers=EXECUTOR_DEFAULT_POOL_SIZE)
+        self.executor_entity = ThreadPoolExecutor(
+            max_workers=EXECUTOR_ENTITY_POOL_SIZE)
         self.loop.set_default_executor(self.executor)
         self.loop.set_exception_handler(self._async_exception_handler)
         self._pending_tasks = []

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -210,7 +210,8 @@ class Entity(object):
             else:
                 # PS: Run this in our own thread pool once we have
                 #     future support?
-                yield from self.hass.loop.run_in_executor(None, self.update)
+                yield from self.hass.loop.run_in_executor(
+                    self.hass.executor_entity, self.update)
 
         start = timer()
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -279,11 +279,6 @@ class Entity(object):
 
         That is only needed on executor to not block.
         """
-        # We're already in a thread, do the force refresh here.
-        if force_refresh and not hasattr(self, 'async_update'):
-            self.update()
-            force_refresh = False
-
         self.hass.add_job(self.async_update_ha_state(force_refresh))
 
     def remove(self) -> None:

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -294,12 +294,8 @@ class EntityPlatform(object):
 
     def add_entities(self, new_entities, update_before_add=False):
         """Add entities for a single platform."""
-        if update_before_add:
-            for entity in new_entities:
-                entity.update()
-
         run_coroutine_threadsafe(
-            self.async_add_entities(list(new_entities), False),
+            self.async_add_entities(list(new_entities), update_before_add),
             self.component.hass.loop
         ).result()
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -50,6 +50,7 @@ def get_test_home_assistant():
         loop._thread_ident = threading.get_ident()
         loop.run_forever()
         loop.close()
+        hass.executor_entity.shutdown(wait=False)
         stop_event.set()
 
     threading.Thread(name="LoopThread", target=run_loop, daemon=True).start()
@@ -59,6 +60,7 @@ def get_test_home_assistant():
 
     @patch.object(hass.loop, 'run_forever')
     @patch.object(hass.loop, 'close')
+    @patch.object(hass.executor_entity, 'shutdown')
     def start_hass(*mocks):
         """Helper to start hass."""
         orig_start()

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1,12 +1,12 @@
 """Test the entity helper."""
 # pylint: disable=protected-access
 import asyncio
-from unittest.mock import MagicMock
 
 import pytest
 
 import homeassistant.helpers.entity as entity
 from homeassistant.const import ATTR_HIDDEN
+from homeassistant.util.async import run_coroutine_threadsafe
 
 from tests.common import get_test_home_assistant
 
@@ -82,7 +82,7 @@ class TestHelpersEntity(object):
         def test():
             yield from ent.async_update_ha_state(True)
 
-        self.hass.loop.run_until_complete(test())
+        run_coroutine_threadsafe(test(), self.hass.loop).result()
 
         assert len(sync_update) == 1
         assert len(async_update) == 0
@@ -94,7 +94,7 @@ class TestHelpersEntity(object):
 
         ent.async_update = async_update_func
 
-        self.hass.loop.run_until_complete(test())
+        run_coroutine_threadsafe(test(), self.hass.loop).result()
 
         assert len(sync_update) == 1
         assert len(async_update) == 1

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -1,6 +1,5 @@
 """The tests for the Entity component helper."""
 # pylint: disable=protected-access
-import asyncio
 from collections import OrderedDict
 import logging
 import unittest

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -154,30 +154,6 @@ class TestHelpersEntityComponent(unittest.TestCase):
         assert 1 == len(self.hass.states.entity_ids())
         assert not ent.update.called
 
-    def test_adds_entities_with_update_befor_add_true_deadlock_protect(self):
-        """Test if call update befor add to state machine.
-
-        It need to run update inside executor and never call
-        async_add_entities with True
-        """
-        call = []
-        component = EntityComponent(_LOGGER, DOMAIN, self.hass)
-
-        @asyncio.coroutine
-        def async_add_entities_fake(entities, update_befor_add):
-            """Fake add_entities_call."""
-            call.append(update_befor_add)
-        component._platforms['core'].async_add_entities = \
-            async_add_entities_fake
-
-        ent = EntityTest()
-        ent.update = Mock(spec_set=True)
-        component.add_entities([ent], True)
-
-        assert ent.update.called
-        assert len(call) == 1
-        assert not call[0]
-
     def test_not_adding_duplicate_entities(self):
         """Test for not adding duplicate entities."""
         component = EntityComponent(_LOGGER, DOMAIN, self.hass)


### PR DESCRIPTION
**Description:**

At the moment we use only 5 workers. This PR fix that. We have now also a own executor pool for entity updates, so we don't block Service calls.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

