### PR TITLE
Rflink 433Mhz gateway platform and components

### DIFF
--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -84,9 +84,16 @@ class DimmableRflinkLight(RflinkLight):
         """Turn the device on."""
         if ATTR_BRIGHTNESS in kwargs:
             # rflink only support 16 brightness levels
-            self._brightness = int(kwargs[ATTR_BRIGHTNESS]/16)*16
+            self._brightness = int(kwargs[ATTR_BRIGHTNESS]/17)*17
 
+        # if receiver supports dimming this will turn on the light
+        # at the requested dim level
         self._send_command("dim", self._brightness)
+
+        # if the receiving device does not support dimlevel this
+        # will ensure it is turned on when full brightness is set
+        if self._brightness == 255:
+            self._send_command("turn_on")
 
     @property
     def brightness(self):

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -18,8 +18,6 @@ DEPENDENCIES = ['rflink']
 
 _LOGGER = logging.getLogger(__name__)
 
-KNOWN_DEVICE_IDS = []
-
 VALID_CONFIG_KEYS = [
     'aliasses',
     'name',
@@ -62,7 +60,7 @@ def devices_from_config(domain_config, hass=None):
 
         # now we know
         device_ids = [device_id] + config.get('aliasses', [])
-        KNOWN_DEVICE_IDS.extend(device_ids)
+        rflink.KNOWN_DEVICE_IDS.extend(device_ids)
     return devices
 
 
@@ -87,8 +85,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         entity_class = entity_class_for_type(entity_type)
 
         device_id = rflink.serialize_id(packet)
-        if device_id not in KNOWN_DEVICE_IDS:
-            KNOWN_DEVICE_IDS.append(device_id)
+        if device_id not in rflink.KNOWN_DEVICE_IDS:
+            rflink.KNOWN_DEVICE_IDS.append(device_id)
             device = entity_class(device_id, hass)
             yield from async_add_devices([device])
             # make sure the packet is processed by the new entity

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -24,23 +24,17 @@ KNOWN_DEVICES = []
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup the Rflink platform."""
-
     @asyncio.coroutine
     def add_new_device(event):
         """Check if device is known, otherwise add to list of known devices."""
         packet = event.data[rflink.ATTR_PACKET]
-        print(packet)
         device_id = rflink.serialize_id(packet)
-        print(device_id)
         if device_id not in KNOWN_DEVICES:
-            print('adding')
             KNOWN_DEVICES.append(device_id)
             device = RflinkLight(device_id, device_id, hass)
             yield from async_add_devices([device])
-            device._match_packet(packet)
-        print(KNOWN_DEVICES)
+            device.match_packet(packet)
 
-    print(DOMAIN, rflink.RFLINK_EVENT[DOMAIN])
     hass.bus.async_listen(rflink.RFLINK_EVENT[DOMAIN], add_new_device)
 
 

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -41,8 +41,7 @@ PLATFORM_SCHEMA = vol.Schema({
             vol.Optional(CONF_ALIASSES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
-            vol.Optional(CONF_SIGNAL_REPETITIONS,
-                         default=DEFAULT_SIGNAL_REPETITIONS): vol.Coerce(int),
+            vol.Optional(CONF_SIGNAL_REPETITIONS): vol.Coerce(int),
         },
     }),
 })

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -194,7 +194,7 @@ class DimmableRflinkLight(SwitchableRflinkDevice, Light):
         return SUPPORT_BRIGHTNESS
 
 
-class HybridRflinkLight(DimmableRflinkLight):
+class HybridRflinkLight(SwitchableRflinkDevice, Light):
     """Rflink light device that sends out both dim and on/off commands.
 
     Used for protocols which support lights that are not exclusively on/off
@@ -209,6 +209,8 @@ class HybridRflinkLight(DimmableRflinkLight):
     Which results in a nice house disco :)
 
     """
+
+    _brightness = 255
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
@@ -225,3 +227,13 @@ class HybridRflinkLight(DimmableRflinkLight):
         # will ensure it is turned on when full brightness is set
         if self._brightness == 255:
             yield from self._async_handle_command("turn_on")
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return self._brightness
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_BRIGHTNESS

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -136,7 +136,8 @@ class DimmableRflinkLight(RflinkLight):
 
     _brightness = 255
 
-    def turn_on(self, **kwargs):
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
         """Turn the device on."""
         if ATTR_BRIGHTNESS in kwargs:
             # rflink only support 16 brightness levels
@@ -144,12 +145,12 @@ class DimmableRflinkLight(RflinkLight):
 
         # if receiver supports dimming this will turn on the light
         # at the requested dim level
-        self._send_command('dim', self._brightness)
+        yield from self._async_send_command('dim', self._brightness)
 
         # if the receiving device does not support dimlevel this
         # will ensure it is turned on when full brightness is set
         if self._brightness == 255:
-            self._send_command("turn_on")
+            yield from self._async_send_command("turn_on")
 
     @property
     def brightness(self):

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -22,6 +22,7 @@ DEPENDENCIES = ['rflink']
 _LOGGER = logging.getLogger(__name__)
 
 TYPE_DIMMABLE = 'dimmable'
+TYPE_SWITCHABLE = 'switchable'
 
 
 PLATFORM_SCHEMA = vol.Schema({
@@ -36,7 +37,7 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Optional(CONF_DEVICES, default={}): vol.Schema({
         cv.string: {
             vol.Optional(CONF_NAME): cv.string,
-            vol.Optional(CONF_TYPE): vol.Any(TYPE_DIMMABLE),
+            vol.Optional(CONF_TYPE): vol.Any(TYPE_DIMMABLE, TYPE_SWITCHABLE),
             vol.Optional(CONF_ALIASSES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
@@ -68,6 +69,7 @@ def entity_class_for_type(entity_type):
     """
     entity_device_mapping = {
         TYPE_DIMMABLE: DimmableRflinkLight,
+        TYPE_SWITCHABLE: RflinkLight,
     }
 
     return entity_device_mapping.get(entity_type, RflinkLight)

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -1,0 +1,58 @@
+"""
+Support for Rflink lights.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.rflink/
+"""
+import asyncio
+import logging
+
+import homeassistant.components.rflink as rflink
+from homeassistant.components.light import Light
+
+from . import DOMAIN
+
+DEPENDENCIES = ['rflink']
+
+_LOGGER = logging.getLogger(__name__)
+
+# PLATFORM_SCHEMA = rfxtrx.DEFAULT_SCHEMA
+
+KNOWN_DEVICES = []
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Setup the Rflink platform."""
+
+    @asyncio.coroutine
+    def add_new_device(event):
+        """Check if device is known, otherwise add to list of known devices."""
+        packet = event.data[rflink.ATTR_PACKET]
+        print(packet)
+        device_id = rflink.serialize_id(packet)
+        print(device_id)
+        if device_id not in KNOWN_DEVICES:
+            print('adding')
+            KNOWN_DEVICES.append(device_id)
+            device = RflinkLight(device_id, device_id, hass)
+            yield from async_add_devices([device])
+            device._match_packet(packet)
+        print(KNOWN_DEVICES)
+
+    print(DOMAIN, rflink.RFLINK_EVENT[DOMAIN])
+    hass.bus.async_listen(rflink.RFLINK_EVENT[DOMAIN], add_new_device)
+
+
+class RflinkLight(rflink.RflinkDevice, Light):
+    """Representation of a Rflink light."""
+
+    domain = DOMAIN
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        self._send_command("turn_on")
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        self._send_command("turn_off")

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -11,9 +11,9 @@ from homeassistant.components import group
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
 from homeassistant.components.rflink import (
-    CONF_ALIASSES, CONF_DEVICES, CONF_IGNORE_DEVICES, CONF_NEW_DEVICES_GROUP,
-    DATA_DEVICE_REGISTER, DATA_ENTITY_LOOKUP, DOMAIN, EVENT_KEY_COMMAND,
-    EVENT_KEY_ID, SwitchableRflinkDevice, cv, vol)
+    CONF_ALIASSES, CONF_DEVICES, CONF_FIRE_EVENT, CONF_IGNORE_DEVICES,
+    CONF_NEW_DEVICES_GROUP, DATA_DEVICE_REGISTER, DATA_ENTITY_LOOKUP, DOMAIN,
+    EVENT_KEY_COMMAND, EVENT_KEY_ID, SwitchableRflinkDevice, cv, vol)
 from homeassistant.const import CONF_NAME, CONF_PLATFORM, CONF_TYPE
 
 DEPENDENCIES = ['rflink']
@@ -33,6 +33,7 @@ PLATFORM_SCHEMA = vol.Schema({
             vol.Optional(CONF_TYPE): vol.Any(TYPE_DIMMABLE),
             vol.Optional(CONF_ALIASSES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
         },
     }),
 })

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -159,11 +159,6 @@ class DimmableRflinkLight(SwitchableRflinkDevice, Light):
         # at the requested dim level
         yield from self._async_handle_command('dim', self._brightness)
 
-        # if the receiving device does not support dimlevel this
-        # will ensure it is turned on when full brightness is set
-        if self._brightness == 255:
-            yield from self._async_handle_command("turn_on")
-
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -59,7 +59,7 @@ def devices_from_config(domain_config, hass=None):
 
         # now we know
         device_ids = [device_id] + config.get('aliasses', [])
-        rflink.KNOWN_DEVICE_IDS.extend(device_ids)
+        hass.data[rflink.DATA_KNOWN_DEVICES].extend(device_ids)
     return devices
 
 
@@ -85,10 +85,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         entity_type = entity_type_for_device_id(event['id'])
         entity_class = entity_class_for_type(entity_type)
 
-        if device_id in rflink.KNOWN_DEVICE_IDS:
+        if device_id in hass.data[rflink.DATA_KNOWN_DEVICES]:
             return
 
-        rflink.KNOWN_DEVICE_IDS.append(device_id)
+        hass.data[rflink.DATA_KNOWN_DEVICES].append(device_id)
         device = entity_class(device_id, hass)
         yield from async_add_devices([device])
         # make sure the event is processed by the new entity

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -80,20 +80,24 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     def add_new_device(ha_event):
         """Check if device is known, otherwise add to list of known devices."""
         event = ha_event.data[rflink.ATTR_EVENT]
+        device_id = event['id']
+
         entity_type = entity_type_for_device_id(event['id'])
         entity_class = entity_class_for_type(entity_type)
 
-        if event['id'] not in rflink.KNOWN_DEVICE_IDS:
-            rflink.KNOWN_DEVICE_IDS.append(event['id'])
-            device = entity_class(event['id'], hass)
-            yield from async_add_devices([device])
-            # make sure the event is processed by the new entity
-            device.match_event(event)
+        if device_id in rflink.KNOWN_DEVICE_IDS:
+            return
 
-            # maybe add to new devices group
-            if new_devices_group:
-                yield from new_devices_group.async_update_tracked_entity_ids(
-                    list(new_devices_group.tracking) + [device.entity_id])
+        rflink.KNOWN_DEVICE_IDS.append(device_id)
+        device = entity_class(device_id, hass)
+        yield from async_add_devices([device])
+        # make sure the event is processed by the new entity
+        device.match_event(event)
+
+        # maybe add to new devices group
+        if new_devices_group:
+            yield from new_devices_group.async_update_tracked_entity_ids(
+                list(new_devices_group.tracking) + [device.entity_id])
 
     hass.bus.async_listen(rflink.RFLINK_EVENT[DOMAIN], add_new_device)
 

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -16,8 +16,6 @@ from homeassistant.components.rflink import (
     EVENT_KEY_COMMAND, EVENT_KEY_ID, SwitchableRflinkDevice, cv, vol)
 from homeassistant.const import CONF_NAME, CONF_PLATFORM, CONF_TYPE
 
-from . import DOMAIN as PLATFORM
-
 DEPENDENCIES = ['rflink']
 
 _LOGGER = logging.getLogger(__name__)
@@ -129,11 +127,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class RflinkLight(SwitchableRflinkDevice, Light):
     """Representation of a Rflink light."""
 
-    # used for matching bus events
-    platform = PLATFORM
+    pass
 
 
-class DimmableRflinkLight(RflinkLight):
+class DimmableRflinkLight(SwitchableRflinkDevice, Light):
     """Rflink light device that support dimming."""
 
     _brightness = 255

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -146,12 +146,12 @@ class DimmableRflinkLight(SwitchableRflinkDevice, Light):
 
         # if receiver supports dimming this will turn on the light
         # at the requested dim level
-        yield from self._async_send_command('dim', self._brightness)
+        yield from self._async_handle_command('dim', self._brightness)
 
         # if the receiving device does not support dimlevel this
         # will ensure it is turned on when full brightness is set
         if self._brightness == 255:
-            yield from self._async_send_command("turn_on")
+            yield from self._async_handle_command("turn_on")
 
     @property
     def brightness(self):

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -120,7 +120,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         entity_type = entity_type_for_device_id(event[EVENT_KEY_ID])
         entity_class = entity_class_for_type(entity_type)
 
-        device = entity_class(device_id, hass)
+        device_config = config[CONF_DEVICE_DEFAULTS]
+        device = entity_class(device_id, hass, **device_config)
         yield from async_add_devices([device])
 
         # register entity to listen to incoming rflink events

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -8,7 +8,8 @@ import asyncio
 import logging
 
 import homeassistant.components.rflink as rflink
-from homeassistant.components.light import Light
+from homeassistant.components.light import (ATTR_BRIGHTNESS,
+                                            SUPPORT_BRIGHTNESS, Light)
 
 from . import DOMAIN
 
@@ -17,6 +18,10 @@ DEPENDENCIES = ['rflink']
 _LOGGER = logging.getLogger(__name__)
 
 KNOWN_DEVICE_IDS = []
+
+SUPPORTS = {
+    'newkaku': SUPPORT_BRIGHTNESS,
+}
 
 
 @asyncio.coroutine
@@ -42,6 +47,7 @@ class RflinkLight(rflink.RflinkDevice, Light):
 
     # used for matching bus events
     domain = DOMAIN
+    _brightness = 255
 
     def _handle_packet(self, packet):
         """Domain specific packet handler."""
@@ -53,8 +59,27 @@ class RflinkLight(rflink.RflinkDevice, Light):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        self._send_command("turn_on")
+        if ATTR_BRIGHTNESS in kwargs:
+            # rflink only support 16 brightness levels
+            self._brightness = int(kwargs[ATTR_BRIGHTNESS]/16)*16
+
+        supports = self.supported_features
+        if supports and supports & SUPPORT_BRIGHTNESS:
+            self._send_command("dim", self._brightness)
+        else:
+            self._send_command("turn_on")
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
         self._send_command("turn_off")
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return self._brightness
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        protocol = self._device_id.split('_')[0]
+        return SUPPORTS.get(protocol, 0)

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -47,7 +47,7 @@ def devices_from_config(domain_config, hass=None):
     """Parse config and add rflink switch devices."""
 
     devices = []
-    for device_id, config in domain_config['devices'].items():
+    for device_id, config in domain_config.get('devices', {}).items():
         # extract only valid keys from device configuration
         kwargs = {k: v for k, v in config.items() if k in VALID_CONFIG_KEYS}
         # determine which kind of entity to create

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -41,7 +41,11 @@ PLATFORM_SCHEMA = vol.Schema({
 
 
 def entity_type_for_device_id(device_id):
-    """Return entity class for procotol of a given device_id."""
+    """Return entity class for procotol of a given device_id.
+
+    Async friendly.
+
+    """
     entity_type_mapping = {
         'newkaku': TYPE_DIMMABLE,
     }
@@ -50,7 +54,11 @@ def entity_type_for_device_id(device_id):
 
 
 def entity_class_for_type(entity_type):
-    """Translate entity type to entity class."""
+    """Translate entity type to entity class.
+
+    Async friendly.
+
+    """
     entity_device_mapping = {
         TYPE_DIMMABLE: DimmableRflinkLight,
     }
@@ -96,11 +104,11 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         event = ha_event.data[ATTR_EVENT]
         device_id = event[EVENT_KEY_ID]
 
-        entity_type = entity_type_for_device_id(event[EVENT_KEY_ID])
-        entity_class = entity_class_for_type(entity_type)
-
         if device_id in hass.data[DATA_KNOWN_DEVICES]:
             return
+
+        entity_type = entity_type_for_device_id(event[EVENT_KEY_ID])
+        entity_class = entity_class_for_type(entity_type)
 
         hass.data[DATA_KNOWN_DEVICES].append(device_id)
         device = entity_class(device_id, hass)

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -1,8 +1,8 @@
-"""
-Support for Rflink lights.
+"""Support for Rflink lights.
 
-For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/light.rflink/
+For more details about this platform, please refer to the documentation
+at https://home-assistant.io/components/light.rflink/
+
 """
 import asyncio
 import logging
@@ -80,7 +80,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     @asyncio.coroutine
     def add_new_device(event):
         """Check if device is known, otherwise add to list of known devices."""
-        packet = event.data[rflink.ATTR_PACKET]
+        packet = event.data[rflink.ATTR_EVENT]
         entity_type = entity_type_for_device_id(packet['protocol'])
         entity_class = entity_class_for_type(entity_type)
 
@@ -115,7 +115,7 @@ class DimmableRflinkLight(RflinkLight):
         """Turn the device on."""
         if ATTR_BRIGHTNESS in kwargs:
             # rflink only support 16 brightness levels
-            self._brightness = int(kwargs[ATTR_BRIGHTNESS]/17)*17
+            self._brightness = int(kwargs[ATTR_BRIGHTNESS] / 17) * 17
 
         # if receiver supports dimming this will turn on the light
         # at the requested dim level

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -86,8 +86,7 @@ def devices_from_config(domain_config, hass=None):
             entity_type = entity_type_for_device_id(device_id)
         entity_class = entity_class_for_type(entity_type)
 
-        device_config = domain_config[CONF_DEVICE_DEFAULTS]
-        device_config.update(**config)
+        device_config = dict(domain_config[CONF_DEVICE_DEFAULTS], **config)
         device = entity_class(device_id, hass, **device_config)
         devices.append(device)
 

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -45,6 +45,8 @@ ATTR_COMMAND = 'command'
 
 _LOGGER = logging.getLogger(__name__)
 
+KNOWN_DEVICE_IDS = []
+
 
 def serialize_id(packet):
     """Serialize packet identifiers into device id."""

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -131,12 +131,12 @@ def async_setup(hass, config):
                 # put switch/light command onto bus for user to subscribe to
                 if event_type == EVENT_KEY_COMMAND:
                     hass.bus.fire(EVENT_BUTTON_PRESSED, {
-                        ATTR_ENTITY_ID: entity.name,
+                        ATTR_ENTITY_ID: entity.entity_id,
                         ATTR_STATE: event[EVENT_KEY_COMMAND],
                     })
                     _LOGGER.debug(
                         'fired bus event for %s: %s',
-                        entity.name,
+                        entity.entity_id,
                         event[EVENT_KEY_COMMAND])
         else:
             _LOGGER.debug('device_id not known, adding new device')

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -85,19 +85,20 @@ def async_setup(hass, config):
         Rflink packets arrive as dictionaries of varying content depending
         on their type. Identify the packets and distribute accordingly.
         """
-        device_id = serialize_id(packet)
-
-        # don't process if set to ignore
-        for ignore in ignore_device_ids:
-            if (ignore == device_id or
-               ('*' in ignore and device_id.startswith(ignore))):
-                return
+        packet_type = identify_packet_type(packet)
 
         # fire bus event for packet type
-        packet_type = identify_packet_type(packet)
         if not packet_type:
             _LOGGER.info(packet)
         elif packet_type in RFLINK_EVENT:
+            device_id = serialize_id(packet)
+
+            # don't fire if device is set to ignore
+            for ignore in ignore_device_ids:
+                if (ignore == device_id or
+                   ('*' in ignore and device_id.startswith(ignore))):
+                    return
+
             hass.bus.fire(RFLINK_EVENT[packet_type], {ATTR_PACKET: packet})
         else:
             _LOGGER.debug('unhandled packet of type: %s', packet_type)

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -153,7 +153,6 @@ def async_setup(hass, config):
     @callback
     def reconnect(exc=None):
         """Schedule reconnect after connection has been unexpectedly lost."""
-
         # reset protocol binding before starting reconnect
         RflinkCommand.set_rflink_protocol(None)
 

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -179,9 +179,11 @@ class RflinkDevice(Entity):
 
         """
         device_id = event['id']
-        if device_id and (
-            device_id == self._device_id or
-                device_id in self._aliasses):
+        if not device_id:
+            return
+        match = device_id == self._device_id
+        match_alias = device_id in self._aliasses
+        if match or match_alias:
             self.handle_event(event)
 
     def handle_event(self, event):

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -106,7 +106,8 @@ def async_setup(hass, config):
     def send_command_ack(event):
         """Send command to rflink gateway via asyncio transport/protocol.
 
-        Waits for Rflink to confirm the packet has been sent.
+        Puts command on outgoing buffer then waits for Rflink to confirm
+        the command has been send out in the ether.
 
         """
         yield from protocol.send_command_ack(
@@ -117,7 +118,10 @@ def async_setup(hass, config):
     def send_command(event):
         """Send command to rflink gateway via asyncio transport/protocol.
 
-        Does not wait for Rflink to confirm the packet has been sent.
+        Puts command on outgoing buffer and returns straight away.
+        Rflink protocol/transport handles asynchronous writing of buffer
+        to serial/tcp device. Does not wait for command send
+        confirmation.
 
         """
         protocol.send_command(

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -1,5 +1,4 @@
-"""
-Support for Rflink components.
+"""Support for Rflink components.
 
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/rflink/
@@ -36,16 +35,18 @@ def serialize_id(packet):
 
 
 def deserialize_id(device_id):
-    """Splits device id into dict of packet identifiers."""
+    """Split device id into dict of packet identifiers."""
     return device_id.split('_')
 
 
-def identify_device_type(packet):
+def identify_packet_type(packet):
     """Look at packet to determine type of device."""
     if 'switch' in packet:
         return 'light'
     elif 'temperature' in packet:
         return 'sensor'
+    elif 'version' in packet:
+        return 'informative'
     else:
         return 'unknown'
 
@@ -53,49 +54,54 @@ def identify_device_type(packet):
 @asyncio.coroutine
 def async_setup(hass, config):
     """Setup the Rflink component."""
-
     from rflink.protocol import create_rflink_connection
 
     def packet_callback(packet):
-        """Handle incoming rflink packets."""
-        if 'version' in packet:
-            _LOGGER.info('Rflink gateway info: %s', packet)
+        """Handle incoming rflink packets.
+
+        Rflink packets arrive as dictionaries of varying content depending
+        on their type. Identify the packets and distribute accordingly.
+        """
+        packet_type = identify_packet_type(packet)
+        if not packet_type:
+            _LOGGER.info(packet)
+        elif packet_type in RFLINK_EVENT:
+            hass.bus.fire(RFLINK_EVENT[packet_type], {ATTR_PACKET: packet})
         else:
-            device_type = identify_device_type(packet)
-            if device_type in RFLINK_EVENT:
-                hass.bus.fire(RFLINK_EVENT[device_type], {ATTR_PACKET: packet})
+            _LOGGER.debug('unhandled packet of type: %s', packet_type)
 
     # when connecting to tcp host instead of serial port (optional)
     host = config[DOMAIN].get('host', None)
     # tcp port when host configured, otherwise serial port
     port = config[DOMAIN]['port']
 
+    # initiate serial/tcp connection to Rflink gateway
     connection = create_rflink_connection(
         port=port,
         host=host,
         packet_callback=packet_callback,
         loop=hass.loop,
     )
-
     transport, protocol = yield from connection
+    # handle shutdown of rflink asyncio transport
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,
                                lambda x: transport.close())
 
+    # provide channel for sending commands to rflink gateway
     def send_command(event):
-        print('sending command')
+        """Send command to rflink gateway via asyncio transport/protocol."""
         command = event.data[ATTR_COMMAND]
-        print(command)
         protocol.send_command(*command)
-
     hass.bus.async_listen(RFLINK_EVENT['send_command'], send_command)
 
+    # whoo
     return True
 
 
 class RflinkDevice(Entity):
     """Represents a Rflink device.
 
-    Contains the common logic for Rflink lights and switches.
+    Contains the common logic for Rflink entities.
     """
 
     domain = None
@@ -103,20 +109,20 @@ class RflinkDevice(Entity):
     def __init__(self, name, device_id, hass):
         """Initialize the device."""
         self._name = name
-        # self._rflink = rflink
         self._state = None
         self._device_id = device_id
         self.hass = hass
 
         if self.domain:
             hass.bus.async_listen(RFLINK_EVENT[self.domain], lambda event:
-                                  self._match_packet(event.data[ATTR_PACKET]))
+                                  self.match_packet(event.data[ATTR_PACKET]))
 
-    def _match_packet(self, packet):
+    def match_packet(self, packet):
         """Match and handle incoming packets.
 
         Match incoming packet to this device id
-        and adjust state accordingly."""
+        and adjust state accordingly.
+        """
         if serialize_id(packet) == self._device_id:
             self._handle_packet(packet)
 
@@ -137,13 +143,11 @@ class RflinkDevice(Entity):
 
     @property
     def name(self):
-        """Return the name of the device if any."""
-        return self._name
-
-    @property
-    def should_fire_event(self):
-        """Return is the device must fire event."""
-        return self._should_fire_event
+        """Return a name for the device."""
+        if self._name:
+            return self._name
+        else:
+            return self._device_id
 
     @property
     def is_on(self):
@@ -152,19 +156,11 @@ class RflinkDevice(Entity):
 
     @property
     def assumed_state(self):
-        """Return true if unable to access real state of entity."""
-        return True
-
-    def turn_off(self, **kwargs):
-        """Turn the device off."""
-        self._send_command("turn_off")
-
-    def update_state(self, state):
-        """Update det state of the device."""
-        self._state = state
-        self.update_ha_state()
+        """Assume device state until first device packet sets state."""
+        return self._state is None
 
     def _send_command(self, command):
+        """Send a command for this device."""
         if command == "turn_on":
             self._event(self._device_id.split('_') + ['on'])
             self._state = True
@@ -176,7 +172,7 @@ class RflinkDevice(Entity):
         self.update_ha_state()
 
     def _event(self, command):
-        print('event command', command)
+        """Fire command event."""
         self.hass.bus.fire(
             RFLINK_EVENT['send_command'],
             {ATTR_COMMAND: command}

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -65,8 +65,9 @@ def async_setup(hass, config):
             if device_type in RFLINK_EVENT:
                 hass.bus.fire(RFLINK_EVENT[device_type], {ATTR_PACKET: packet})
 
-    # port = '/dev/ttyACM0'
-    host = config[DOMAIN]['host']
+    # when connecting to tcp host instead of serial port (optional)
+    host = config[DOMAIN].get('host', None)
+    # tcp port when host configured, otherwise serial port
     port = config[DOMAIN]['port']
 
     connection = create_rflink_connection(

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -150,7 +150,7 @@ class RflinkDevice(Entity):
     # default state
     _state = STATE_UNKNOWN
 
-    def __init__(self, device_id, hass, name=None, aliasses=None, icon=None):
+    def __init__(self, device_id, hass, name=None, aliasses=None):
         """Initialize the device."""
         self.hass = hass
 
@@ -166,9 +166,6 @@ class RflinkDevice(Entity):
             self._aliasses = aliasses
         else:
             self._aliasses = []
-
-        # optional attributes
-        self._icon = icon
 
         # listen to component domain specific messages
         hass.bus.async_listen(RFLINK_EVENT[self.domain], lambda event:
@@ -221,11 +218,6 @@ class RflinkDevice(Entity):
     def assumed_state(self):
         """Assume device state until first device event sets state."""
         return self._state is STATE_UNKNOWN
-
-    @property
-    def icon(self):
-        """Return the icon to use for device if any."""
-        return self._icon
 
     def _send_command(self, command, *args):
         """Send a command for this device to Rflink gateway."""

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -182,15 +182,25 @@ class RflinkDevice(Entity):
         """Assume device state until first device packet sets state."""
         return self._state is None
 
-    def _send_command(self, command):
+    def _send_command(self, command, *args):
         """Send a command for this device."""
         if command == "turn_on":
-            self._event(self._device_id.split('_') + ['on'])
+            cmd = 'on'
             self._state = True
 
         elif command == 'turn_off':
-            self._event(self._device_id.split('_') + ['off'])
+            cmd = 'off'
             self._state = False
+
+        elif command == 'dim':
+            # convert brightness to rflink dim level
+            cmd = str(int(args[0]/17))
+            self._state = True
+
+        # send protocol, device id, switch nr and command to rflink
+        self._event(self._device_id.split('_') + [cmd])
+
+        # todo, wait for rflink ok response
 
         self.update_ha_state()
 

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -43,10 +43,9 @@ RFLINK_EVENT = {
 
 ATTR_EVENT = 'event'
 ATTR_COMMAND = 'command'
+DATA_KNOWN_DEVICES = 'rflink_known_device_ids'
 
 _LOGGER = logging.getLogger(__name__)
-
-KNOWN_DEVICE_IDS = []
 
 
 def identify_event_type(event):
@@ -64,8 +63,8 @@ def async_setup(hass, config):
     """Setup the Rflink component."""
     from rflink.protocol import create_rflink_connection
 
-    # make sure no known devices are left (mostly during tests)
-    del KNOWN_DEVICE_IDS[:]
+    # initialize list of known devices
+    hass.data[DATA_KNOWN_DEVICES] = []
 
     def event_callback(event):
         """Handle incoming rflink events.

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -165,7 +165,6 @@ def async_setup(hass, config):
     @asyncio.coroutine
     def connect():
         """Setup connection and hook it into HA for reconnect/shutdown."""
-
         _LOGGER.info('initiating Rflink connection')
 
         # rflink create_rflink_connection decides based on the value of host
@@ -347,7 +346,6 @@ class RflinkCommand(RflinkDevice):
         switch) changes the state.
 
         """
-
         # cancel any outstanding tasks from the previous state change
         if self._repetition_task:
             self._repetition_task.cancel()

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -133,6 +133,10 @@ def async_setup(hass, config):
                         ATTR_ENTITY_ID: entity.name,
                         ATTR_STATE: event[EVENT_KEY_COMMAND],
                     })
+                    _LOGGER.debug(
+                        'fired bus event for %s: %s',
+                        entity.name,
+                        event[EVENT_KEY_COMMAND])
         else:
             _LOGGER.debug('device_id not known, adding new device')
 

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -81,7 +81,7 @@ def async_setup(hass, config):
     """Setup the Rflink component."""
     from rflink.protocol import create_rflink_connection
 
-    ignore_device_ids = config.get('ignore_device', [])
+    ignore_device_ids = config.get('ignore_devices', [])
 
     def packet_callback(packet):
         """Handle incoming rflink packets.

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -48,6 +48,10 @@ _LOGGER = logging.getLogger(__name__)
 
 def serialize_id(packet):
     """Serialize packet identifiers into device id."""
+    # invalid packet
+    if not (packet.get('protocol') and packet.get('id')):
+        return None
+
     return '_'.join(filter(None, [
         slugify(packet['protocol']),
         packet['id'],
@@ -92,6 +96,8 @@ def async_setup(hass, config):
             _LOGGER.info(packet)
         elif packet_type in RFLINK_EVENT:
             device_id = serialize_id(packet)
+            if not device_id:
+                return
 
             # don't fire if device is set to ignore
             for ignore in ignore_device_ids:
@@ -169,7 +175,9 @@ class RflinkDevice(Entity):
         or any of its aliasses (including wildcards).
         """
         device_id = serialize_id(packet)
-        if device_id == self._device_id or device_id in self._aliasses:
+        if device_id and (
+            device_id == self._device_id or
+                device_id in self._aliasses):
             self.handle_packet(packet)
 
     def handle_packet(self, packet):

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -127,17 +127,6 @@ def async_setup(hass, config):
             for entity in entities:
                 _LOGGER.debug('passing event to %s', entities)
                 entity.handle_event(event)
-
-                # put switch/light command onto bus for user to subscribe to
-                if event_type == EVENT_KEY_COMMAND:
-                    hass.bus.fire(EVENT_BUTTON_PRESSED, {
-                        ATTR_ENTITY_ID: entity.entity_id,
-                        ATTR_STATE: event[EVENT_KEY_COMMAND],
-                    })
-                    _LOGGER.debug(
-                        'fired bus event for %s: %s',
-                        entity.entity_id,
-                        event[EVENT_KEY_COMMAND])
         else:
             _LOGGER.debug('device_id not known, adding new device')
 
@@ -212,6 +201,17 @@ class RflinkDevice(Entity):
 
         # propagate changes through ha
         self.hass.async_add_job(self.async_update_ha_state())
+
+        # put command onto bus for user to subscribe to
+        if identify_event_type(event) == EVENT_KEY_COMMAND:
+            self.hass.bus.fire(EVENT_BUTTON_PRESSED, {
+                ATTR_ENTITY_ID: self.entity_id,
+                ATTR_STATE: event[EVENT_KEY_COMMAND],
+            })
+            _LOGGER.debug(
+                'fired bus event for %s: %s',
+                self.entity_id,
+                event[EVENT_KEY_COMMAND])
 
     def _handle_event(self, event):
         """Platform specific event handler."""

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -29,7 +29,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP, STATE_UNKNOWN
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
-REQUIREMENTS = ['rflink==0.0.5']
+REQUIREMENTS = ['rflink==0.0.6']
 
 DOMAIN = 'rflink'
 

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -111,7 +111,7 @@ def async_setup(hass, config):
 
         """
         event_type = identify_event_type(event)
-        _LOGGER.debug('event type %s', event_type)
+        _LOGGER.debug('event of type %s: %s', event_type, event)
 
         # don't propagate non entity events (eg: version string, ack response)
         if event_type not in hass.data[DATA_ENTITY_LOOKUP]:

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -36,7 +36,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import voluptuous as vol
 
-REQUIREMENTS = ['rflink==0.0.23']
+REQUIREMENTS = ['rflink==0.0.24']
 
 DOMAIN = 'rflink'
 

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -30,7 +30,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_STOP, STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['rflink==0.0.16']
+REQUIREMENTS = ['rflink==0.0.17']
 
 DOMAIN = 'rflink'
 

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -222,6 +222,11 @@ class RflinkDevice(Entity):
         """Assume device state until first device event sets state."""
         return self._state is STATE_UNKNOWN
 
+    @property
+    def icon(self):
+        """Return the icon to use for device if any."""
+        return self._icon
+
     def _send_command(self, command, *args):
         """Send a command for this device to Rflink gateway."""
         if command == "turn_on":

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -42,6 +42,7 @@ DOMAIN = 'rflink'
 
 CONF_ALIASSES = 'aliasses'
 CONF_DEVICES = 'devices'
+CONF_DEVICE_DEFAULTS = 'device_defaults'
 CONF_FIRE_EVENT = 'fire_event'
 CONF_IGNORE_DEVICES = 'ignore_devices'
 CONF_NEW_DEVICES_GROUP = 'new_devices_group'
@@ -57,10 +58,6 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_WAIT_FOR_ACK, default=True): cv.boolean,
         vol.Optional(CONF_IGNORE_DEVICES, default=[]):
             vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
-        vol.Optional(CONF_SIGNAL_REPETITIONS,
-                     default=DEFAULT_SIGNAL_REPETITIONS): vol.Coerce(int),
-
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -315,6 +312,10 @@ class RflinkCommand(RflinkDevice):
             return self.hass.loop.run_in_executor(
                 None, ft.partial(
                     self._protocol.send_command, self._device_id, cmd))
+
+        # give away control to allow repetitions of simultanious switched
+        # entities to alternate
+        yield from asyncio.sleep(0)
 
 
 class SwitchableRflinkDevice(RflinkCommand):

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -31,6 +31,7 @@ import logging
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP,
     STATE_UNKNOWN)
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import voluptuous as vol
@@ -100,7 +101,7 @@ def async_setup(hass, config):
     # allow platform to specify function to register new unknown devices
     hass.data[DATA_DEVICE_REGISTER] = {}
 
-    @asyncio.coroutine
+    @callback
     def event_callback(event):
         """Handle incoming rflink events.
 
@@ -142,7 +143,8 @@ def async_setup(hass, config):
 
             # if device is not yet known, register with platform (if loaded)
             if event_type in hass.data[DATA_DEVICE_REGISTER]:
-                yield from hass.data[DATA_DEVICE_REGISTER][event_type](event)
+                hass.async_run_job(
+                    hass.data[DATA_DEVICE_REGISTER][event_type], event)
 
     # when connecting to tcp host instead of serial port (optional)
     host = config[DOMAIN][CONF_HOST]

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -73,7 +73,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def identify_event_type(event):
-    """Look at event to determine type of device."""
+    """Look at event to determine type of device.
+
+    Async friendly.
+
+    """
     if 'command' in event:
         return 'light'
     elif 'sensor' in event:

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -36,7 +36,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import voluptuous as vol
 
-REQUIREMENTS = ['rflink==0.0.18']
+REQUIREMENTS = ['rflink==0.0.19']
 
 DOMAIN = 'rflink'
 

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -30,7 +30,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_STOP, STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['rflink==0.0.17']
+REQUIREMENTS = ['rflink==0.0.18']
 
 DOMAIN = 'rflink'
 

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -58,7 +58,6 @@ CONFIG_SCHEMA = vol.Schema({
 ATTR_EVENT = 'event'
 ATTR_STATE = 'state'
 
-DATA_KNOWN_DEVICES = 'rflink_known_device_ids'
 DATA_ENTITY_LOOKUP = 'rflink_entity_lookup'
 DATA_DEVICE_REGISTER = 'rflink_device_register'
 
@@ -90,9 +89,6 @@ def identify_event_type(event):
 def async_setup(hass, config):
     """Setup the Rflink component."""
     from rflink.protocol import create_rflink_connection
-
-    # initialize list of known devices
-    hass.data[DATA_KNOWN_DEVICES] = []
 
     # allow entities to register themselves by device_id to be looked up when
     # new rflink events arrive to be handled
@@ -138,9 +134,6 @@ def async_setup(hass, config):
                         ATTR_STATE: event[EVENT_KEY_COMMAND],
                     })
         else:
-            if event_id in hass.data[DATA_KNOWN_DEVICES]:
-                return
-
             _LOGGER.debug('device_id not known, adding new device')
 
             # if device is not yet known, register with platform (if loaded)

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -41,11 +41,13 @@ CONF_IGNORE_DEVICES = 'ignore_devices'
 CONF_DEVICES = 'devices'
 CONF_NEW_DEVICES_GROUP = 'new_devices_group'
 CONF_ALIASSES = 'aliasses'
+CONF_WAIT_FOR_ACK = 'wait_for_ack'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_PORT): vol.Any(cv.port, cv.string),
         vol.Optional(CONF_HOST, default=None): cv.string,
+        vol.Optional(CONF_WAIT_FOR_ACK, default=True): cv.boolean,
         vol.Optional(CONF_IGNORE_DEVICES, default=[]):
             vol.All(cv.ensure_list, [cv.string]),
     }),
@@ -155,7 +157,7 @@ def async_setup(hass, config):
             event.data[ATTR_COMMAND],
         )
 
-    if config.get('wait_for_ack', True):
+    if config[DOMAIN][CONF_WAIT_FOR_ACK]:
         hass.bus.async_listen(RFLINK_EVENT['send_command'], send_command_ack)
     else:
         hass.bus.async_listen(RFLINK_EVENT['send_command'], send_command)

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -10,7 +10,7 @@ import logging
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['rflink==0.0.4']
+REQUIREMENTS = ['rflink==0.0.5']
 
 DOMAIN = 'rflink'
 

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -203,7 +203,7 @@ class RflinkDevice(Entity):
     @property
     def assumed_state(self):
         """Assume device state until first device packet sets state."""
-        return self._state is None
+        return self._state is STATE_UNKNOWN
 
     def _send_command(self, command, *args):
         """Send a command for this device to Rflink gateway."""

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -153,13 +153,13 @@ def async_setup(hass, config):
     @callback
     def reconnect(exc=None):
         """Schedule reconnect after connection has been unexpectedly lost."""
-        _LOGGER.warning('disconnected from Rflink, reconnecting')
 
         # reset protocol binding before starting reconnect
         RflinkCommand.set_rflink_protocol(None)
 
         # if HA is not stopping, initiate new connection
         if hass.state != CoreState.stopping:
+            _LOGGER.warning('disconnected from Rflink, reconnecting')
             hass.async_add_job(connect)
 
     @asyncio.coroutine

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -1,0 +1,182 @@
+"""
+Support for Rflink components.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/rflink/
+"""
+import asyncio
+import logging
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['rflink==0.0.4']
+
+DOMAIN = 'rflink'
+
+RFLINK_EVENT = {
+    'light': 'rflink_switch_packet_received',
+    'sensor': 'rflink_sensor_packet_received',
+    'send_command': 'rflink_send_command',
+}
+
+ATTR_PACKET = 'packet'
+ATTR_COMMAND = 'command'
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def serialize_id(packet):
+    """Serialize packet identifiers into device id."""
+    return '_'.join(filter(None, [
+        packet['protocol'],
+        packet['id'],
+        packet.get('switch', None),
+    ]))
+
+
+def deserialize_id(device_id):
+    """Splits device id into dict of packet identifiers."""
+    return device_id.split('_')
+
+
+def identify_device_type(packet):
+    """Look at packet to determine type of device."""
+    if 'switch' in packet:
+        return 'light'
+    elif 'temperature' in packet:
+        return 'sensor'
+    else:
+        return 'unknown'
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Setup the Rflink component."""
+
+    from rflink.protocol import create_rflink_connection
+
+    def packet_callback(packet):
+        """Handle incoming rflink packets."""
+        if 'version' in packet:
+            _LOGGER.info('Rflink gateway info: %s', packet)
+        else:
+            device_type = identify_device_type(packet)
+            if device_type in RFLINK_EVENT:
+                hass.bus.fire(RFLINK_EVENT[device_type], {ATTR_PACKET: packet})
+
+    # port = '/dev/ttyACM0'
+    host = config[DOMAIN]['host']
+    port = config[DOMAIN]['port']
+
+    connection = create_rflink_connection(
+        port=port,
+        host=host,
+        packet_callback=packet_callback,
+        loop=hass.loop,
+    )
+
+    transport, protocol = yield from connection
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,
+                               lambda x: transport.close())
+
+    def send_command(event):
+        print('sending command')
+        command = event.data[ATTR_COMMAND]
+        print(command)
+        protocol.send_command(*command)
+
+    hass.bus.async_listen(RFLINK_EVENT['send_command'], send_command)
+
+    return True
+
+
+class RflinkDevice(Entity):
+    """Represents a Rflink device.
+
+    Contains the common logic for Rflink lights and switches.
+    """
+
+    domain = None
+
+    def __init__(self, name, device_id, hass):
+        """Initialize the device."""
+        self._name = name
+        # self._rflink = rflink
+        self._state = None
+        self._device_id = device_id
+        self.hass = hass
+
+        if self.domain:
+            hass.bus.async_listen(RFLINK_EVENT[self.domain], lambda event:
+                                  self._match_packet(event.data[ATTR_PACKET]))
+
+    def _match_packet(self, packet):
+        """Match and handle incoming packets.
+
+        Match incoming packet to this device id
+        and adjust state accordingly."""
+        if serialize_id(packet) == self._device_id:
+            self._handle_packet(packet)
+
+    def _handle_packet(self, packet):
+        """Handle incoming packet for device type."""
+        command = packet['command']
+        if command == 'on':
+            self._state = True
+        elif command == 'off':
+            self._state = False
+
+        self.hass.async_add_job(self.async_update_ha_state())
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._name
+
+    @property
+    def should_fire_event(self):
+        """Return is the device must fire event."""
+        return self._should_fire_event
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    @property
+    def assumed_state(self):
+        """Return true if unable to access real state of entity."""
+        return True
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        self._send_command("turn_off")
+
+    def update_state(self, state):
+        """Update det state of the device."""
+        self._state = state
+        self.update_ha_state()
+
+    def _send_command(self, command):
+        if command == "turn_on":
+            self._event(self._device_id.split('_') + ['on'])
+            self._state = True
+
+        elif command == 'turn_off':
+            self._event(self._device_id.split('_') + ['off'])
+            self._state = False
+
+        self.update_ha_state()
+
+    def _event(self, command):
+        print('event command', command)
+        self.hass.bus.fire(
+            RFLINK_EVENT['send_command'],
+            {ATTR_COMMAND: command}
+        )

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -69,19 +69,22 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         """Check if device is known, otherwise create device entity."""
         event = event.data[rflink.ATTR_EVENT]
         device_id = event['id']
-        if device_id not in rflink.KNOWN_DEVICE_IDS:
-            rflink.KNOWN_DEVICE_IDS.append(device_id)
-            rflinksensor = partial(RflinkSensor, device_id, hass)
-            device = rflinksensor(event['sensor'], event['unit'])
-            # add device entity
-            yield from async_add_devices([device])
-            # make sure the event is processed by the new entity
-            device.match_event(event)
 
-            # maybe add to new devices group
-            if new_devices_group:
-                yield from new_devices_group.async_update_tracked_entity_ids(
-                    list(new_devices_group.tracking) + [device.entity_id])
+        if device_id in rflink.KNOWN_DEVICE_IDS:
+            return
+
+        rflink.KNOWN_DEVICE_IDS.append(device_id)
+        rflinksensor = partial(RflinkSensor, device_id, hass)
+        device = rflinksensor(event['sensor'], event['unit'])
+        # add device entity
+        yield from async_add_devices([device])
+        # make sure the event is processed by the new entity
+        device.match_event(event)
+
+        # maybe add to new devices group
+        if new_devices_group:
+            yield from new_devices_group.async_update_tracked_entity_ids(
+                list(new_devices_group.tracking) + [device.entity_id])
 
     hass.bus.async_listen(rflink.RFLINK_EVENT[DOMAIN], add_new_device)
 

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -45,7 +45,11 @@ PLATFORM_SCHEMA = vol.Schema({
 
 
 def lookup_unit_for_sensor_type(sensor_type):
-    """Get unit for sensor type."""
+    """Get unit for sensor type.
+
+    Async friendly.
+
+    """
     from rflink.parser import UNITS, PACKET_FIELDS
     field_abbrev = {v: k for k, v in PACKET_FIELDS.items()}
 

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -16,8 +16,6 @@ from homeassistant.components.rflink import (
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT, CONF_NAME, CONF_PLATFORM)
 
-from . import DOMAIN as PLATFORM
-
 DEPENDENCIES = ['rflink']
 
 _LOGGER = logging.getLogger(__name__)
@@ -113,9 +111,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
 class RflinkSensor(RflinkDevice):
     """Representation of a Rflink sensor."""
-
-    # used for matching bus events
-    platform = PLATFORM
 
     def __init__(self, device_id, hass, sensor_type,
                  unit_of_measurement, **kwargs):

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -1,4 +1,4 @@
-"""Support for Rflink lights.
+"""Support for Rflink sensors.
 
 For more details about this platform, please refer to the documentation
 at https://home-assistant.io/components/light.rflink/
@@ -99,6 +99,12 @@ class RflinkSensor(rflink.RflinkDevice):
         """Handle sensor specific args and super init."""
         self._sensor_type = sensor_type
         self._unit = unit
+
+        # if user does not override icon in config and a icon is available
+        # for the specific sensor type, set icon
+        if not kwargs.get('icon') and sensor_type in SENSOR_ICONS:
+            kwargs['icon'] = SENSOR_ICONS[self._sensor_type]
+
         super().__init__(device_id, hass, **kwargs)
 
     def _handle_event(self, event):
@@ -114,11 +120,3 @@ class RflinkSensor(rflink.RflinkDevice):
     def state(self):
         """Return value."""
         return self._state
-
-    @property
-    def icon(self):
-        """Return possible sensor specific icon or user override."""
-        if self._icon:
-            return self._icon
-        elif self._sensor_type in SENSOR_ICONS:
-            return SENSOR_ICONS[self._sensor_type]

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -14,7 +14,8 @@ from homeassistant.components.rflink import (
     DATA_ENTITY_LOOKUP, DOMAIN, EVENT_KEY_ID, EVENT_KEY_SENSOR, EVENT_KEY_UNIT,
     RflinkDevice, cv, vol)
 from homeassistant.const import (
-    ATTR_UNIT_OF_MEASUREMENT, CONF_NAME, CONF_PLATFORM)
+    ATTR_UNIT_OF_MEASUREMENT, CONF_NAME, CONF_PLATFORM,
+    CONF_UNIT_OF_MEASUREMENT)
 
 DEPENDENCIES = ['rflink']
 
@@ -35,6 +36,7 @@ PLATFORM_SCHEMA = vol.Schema({
         cv.string: {
             vol.Optional(CONF_NAME): cv.string,
             vol.Required(CONF_SENSOR_TYPE): cv.string,
+            vol.Optional(CONF_UNIT_OF_MEASUREMENT, default=None): cv.string,
             vol.Optional(CONF_ALIASSES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
         },
@@ -58,8 +60,9 @@ def devices_from_config(domain_config, hass=None):
     """Parse config and add rflink sensor devices."""
     devices = []
     for device_id, config in domain_config[CONF_DEVICES].items():
-        config[ATTR_UNIT_OF_MEASUREMENT] = lookup_unit_for_sensor_type(
-            config[CONF_SENSOR_TYPE])
+        if not config[ATTR_UNIT_OF_MEASUREMENT]:
+            config[ATTR_UNIT_OF_MEASUREMENT] = lookup_unit_for_sensor_type(
+                config[CONF_SENSOR_TYPE])
         device = RflinkSensor(device_id, hass, **config)
         devices.append(device)
 

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -120,7 +120,6 @@ class RflinkSensor(rflink.RflinkDevice):
     @property
     def icon(self):
         """Return possible sensor specific icon or user override."""
-        print(self._icon, self._value_key)
         if self._icon:
             return self._icon
         elif self._value_key in SENSOR_ICONS:

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -33,17 +33,16 @@ VALID_CONFIG_KEYS = [
     'name',
     'icon',
     'value_key',
-    'unit',
 ]
 
 
 def devices_from_config(domain_config, hass=None):
     """Parse config and add rflink sensor devices."""
-
     devices = []
     for device_id, config in domain_config.get('devices', {}).items():
         # extract only valid keys from device configuration
         kwargs = {k: v for k, v in config.items() if k in VALID_CONFIG_KEYS}
+        kwargs['unit'] = SENSOR_KEYS_AND_UNITS[kwargs['value_key']]
         devices.append(RflinkSensor(device_id, hass, **kwargs))
         rflink.KNOWN_DEVICE_IDS.append(device_id)
     return devices

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -27,7 +27,7 @@ SENSOR_KEYS_AND_UNITS = {
 
 SENSOR_ICONS = {
     'humidity': 'mdi:water-percent',
-    'battery': 'battery',
+    'battery': 'mdi:battery',
 }
 
 

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -26,7 +26,6 @@ SENSOR_ICONS = {
 VALID_CONFIG_KEYS = [
     'aliasses',
     'name',
-    'icon',
     'sensor_type',
 ]
 
@@ -99,12 +98,6 @@ class RflinkSensor(rflink.RflinkDevice):
         """Handle sensor specific args and super init."""
         self._sensor_type = sensor_type
         self._unit = unit
-
-        # if user does not override icon in config and a icon is available
-        # for the specific sensor type, set icon
-        if not kwargs.get('icon') and sensor_type in SENSOR_ICONS:
-            kwargs['icon'] = SENSOR_ICONS[self._sensor_type]
-
         super().__init__(device_id, hass, **kwargs)
 
     def _handle_event(self, event):
@@ -120,3 +113,9 @@ class RflinkSensor(rflink.RflinkDevice):
     def state(self):
         """Return value."""
         return self._state
+
+    @property
+    def icon(self):
+        """Return possible sensor specific icon."""
+        if self._sensor_type in SENSOR_ICONS:
+            return SENSOR_ICONS[self._sensor_type]

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -9,9 +9,14 @@ from functools import partial
 import logging
 
 from homeassistant.components import group
-import homeassistant.components.rflink as rflink
+from homeassistant.components.rflink import (
+    ATTR_EVENT, CONF_ALIASSES, CONF_DEVICES, CONF_NEW_DEVICES_GROUP,
+    DATA_KNOWN_DEVICES, DOMAIN, EVENT_KEY_ID, EVENT_KEY_SENSOR, EVENT_KEY_UNIT,
+    RFLINK_EVENT, RflinkDevice, cv, vol)
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT, CONF_NAME, CONF_PLATFORM)
 
-from . import DOMAIN
+from . import DOMAIN as PLATFORM
 
 DEPENDENCIES = ['rflink']
 
@@ -23,11 +28,20 @@ SENSOR_ICONS = {
     'temperature': 'mdi:thermometer',
 }
 
-VALID_CONFIG_KEYS = [
-    'aliasses',
-    'name',
-    'sensor_type',
-]
+CONF_SENSOR_TYPE = 'sensor_type'
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_PLATFORM): DOMAIN,
+    vol.Optional(CONF_NEW_DEVICES_GROUP, default=None): cv.string,
+    vol.Optional(CONF_DEVICES, default={}): vol.Schema({
+        cv.string: {
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Required(CONF_SENSOR_TYPE): cv.string,
+            vol.Optional(CONF_ALIASSES, default=[]):
+                vol.All(cv.ensure_list, [cv.string]),
+        },
+    }),
+})
 
 
 def lookup_unit_for_sensor_type(sensor_type):
@@ -41,12 +55,11 @@ def lookup_unit_for_sensor_type(sensor_type):
 def devices_from_config(domain_config, hass=None):
     """Parse config and add rflink sensor devices."""
     devices = []
-    for device_id, config in domain_config.get('devices', {}).items():
-        # extract only valid keys from device configuration
-        kwargs = {k: v for k, v in config.items() if k in VALID_CONFIG_KEYS}
-        kwargs['unit'] = lookup_unit_for_sensor_type(kwargs['sensor_type'])
-        devices.append(RflinkSensor(device_id, hass, **kwargs))
-        hass.data[rflink.DATA_KNOWN_DEVICES].append(device_id)
+    for device_id, config in domain_config[CONF_DEVICES].items():
+        config[ATTR_UNIT_OF_MEASUREMENT] = lookup_unit_for_sensor_type(
+            config[CONF_SENSOR_TYPE])
+        devices.append(RflinkSensor(device_id, hass, **config))
+        hass.data[DATA_KNOWN_DEVICES].append(device_id)
     return devices
 
 
@@ -57,24 +70,24 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     yield from async_add_devices(devices_from_config(config, hass))
 
     # add new (unconfigured) devices to user desired group
-    if config.get('new_devices_group'):
+    if config[CONF_NEW_DEVICES_GROUP]:
         new_devices_group = yield from group.Group.async_create_group(
-            hass, config.get('new_devices_group'), [], True)
+            hass, config[CONF_NEW_DEVICES_GROUP], [], True)
     else:
         new_devices_group = None
 
     @asyncio.coroutine
     def add_new_device(event):
         """Check if device is known, otherwise create device entity."""
-        event = event.data[rflink.ATTR_EVENT]
-        device_id = event['id']
+        event = event.data[ATTR_EVENT]
+        device_id = event[EVENT_KEY_ID]
 
-        if device_id in hass.data[rflink.DATA_KNOWN_DEVICES]:
+        if device_id in hass.data[DATA_KNOWN_DEVICES]:
             return
 
-        hass.data[rflink.DATA_KNOWN_DEVICES].append(device_id)
+        hass.data[DATA_KNOWN_DEVICES].append(device_id)
         rflinksensor = partial(RflinkSensor, device_id, hass)
-        device = rflinksensor(event['sensor'], event['unit'])
+        device = rflinksensor(event[EVENT_KEY_SENSOR], event[EVENT_KEY_UNIT])
         # add device entity
         yield from async_add_devices([device])
         # make sure the event is processed by the new entity
@@ -85,19 +98,20 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             yield from new_devices_group.async_update_tracked_entity_ids(
                 list(new_devices_group.tracking) + [device.entity_id])
 
-    hass.bus.async_listen(rflink.RFLINK_EVENT[DOMAIN], add_new_device)
+    hass.bus.async_listen(RFLINK_EVENT[PLATFORM], add_new_device)
 
 
-class RflinkSensor(rflink.RflinkDevice):
+class RflinkSensor(RflinkDevice):
     """Representation of a Rflink sensor."""
 
     # used for matching bus events
-    domain = DOMAIN
+    platform = PLATFORM
 
-    def __init__(self, device_id, hass, sensor_type, unit, **kwargs):
+    def __init__(self, device_id, hass, sensor_type,
+                 unit_of_measurement, **kwargs):
         """Handle sensor specific args and super init."""
         self._sensor_type = sensor_type
-        self._unit = unit
+        self._unit_of_measurement = unit_of_measurement
         super().__init__(device_id, hass, **kwargs)
 
     def _handle_event(self, event):
@@ -107,7 +121,7 @@ class RflinkSensor(rflink.RflinkDevice):
     @property
     def unit_of_measurement(self):
         """Return measurement unit."""
-        return self._unit
+        return self._unit_of_measurement
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -22,6 +22,12 @@ KNOWN_DEVICE_IDS = []
 SENSOR_KEYS_AND_UNITS = {
     'temperature': '°C',
     'humidity': '%',
+    'battery': None,
+}
+
+SENSOR_ICONS = {
+    'humidity': 'mdi:water-percent',
+    'battery': 'battery',
 }
 
 
@@ -90,3 +96,12 @@ class RflinkSensor(rflink.RflinkDevice):
     def state(self):
         """Return value."""
         return self._state
+
+    @property
+    def icon(self):
+        """Return possible sensor specific icon or user override."""
+        print(self._icon, self._value_key)
+        if self._icon:
+            return self._icon
+        elif self._value_key in SENSOR_ICONS:
+            return SENSOR_ICONS[self._value_key]

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -47,7 +47,7 @@ def devices_from_config(domain_config, hass=None):
         kwargs = {k: v for k, v in config.items() if k in VALID_CONFIG_KEYS}
         kwargs['unit'] = lookup_unit_for_sensor_type(kwargs['sensor_type'])
         devices.append(RflinkSensor(device_id, hass, **kwargs))
-        rflink.KNOWN_DEVICE_IDS.append(device_id)
+        hass.data[rflink.DATA_KNOWN_DEVICES].append(device_id)
     return devices
 
 
@@ -70,10 +70,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         event = event.data[rflink.ATTR_EVENT]
         device_id = event['id']
 
-        if device_id in rflink.KNOWN_DEVICE_IDS:
+        if device_id in hass.data[rflink.DATA_KNOWN_DEVICES]:
             return
 
-        rflink.KNOWN_DEVICE_IDS.append(device_id)
+        hass.data[rflink.DATA_KNOWN_DEVICES].append(device_id)
         rflinksensor = partial(RflinkSensor, device_id, hass)
         device = rflinksensor(event['sensor'], event['unit'])
         # add device entity

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -43,7 +43,7 @@ def devices_from_config(domain_config, hass=None):
     """Parse config and add rflink sensor devices."""
 
     devices = []
-    for device_id, config in domain_config['devices'].items():
+    for device_id, config in domain_config.get('devices', {}).items():
         # extract only valid keys from device configuration
         kwargs = {k: v for k, v in config.items() if k in VALID_CONFIG_KEYS}
         devices.append(RflinkSensor(device_id, hass, **kwargs))

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -17,8 +17,6 @@ DEPENDENCIES = ['rflink']
 
 _LOGGER = logging.getLogger(__name__)
 
-KNOWN_DEVICE_IDS = []
-
 SENSOR_KEYS_AND_UNITS = {
     'temperature': '°C',
     'humidity': '%',
@@ -47,6 +45,7 @@ def devices_from_config(domain_config, hass=None):
         # extract only valid keys from device configuration
         kwargs = {k: v for k, v in config.items() if k in VALID_CONFIG_KEYS}
         devices.append(RflinkSensor(device_id, hass, **kwargs))
+        rflink.KNOWN_DEVICE_IDS.append(device_id)
     return devices
 
 
@@ -68,8 +67,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         """Check if device is known, otherwise create device entity."""
         packet = event.data[rflink.ATTR_PACKET]
         device_id = rflink.serialize_id(packet)
-        if device_id not in KNOWN_DEVICE_IDS:
-            KNOWN_DEVICE_IDS.append(device_id)
+        if device_id not in rflink.KNOWN_DEVICE_IDS:
+            rflink.KNOWN_DEVICE_IDS.append(device_id)
             rflinksensor = partial(RflinkSensor, device_id, hass)
             devices = []
             # create entity for each value in this packet

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -1,0 +1,77 @@
+"""
+Support for Rflink lights.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.rflink/
+"""
+import asyncio
+import logging
+from functools import partial
+
+import homeassistant.components.rflink as rflink
+
+from . import DOMAIN
+
+DEPENDENCIES = ['rflink']
+
+_LOGGER = logging.getLogger(__name__)
+
+KNOWN_DEVICE_IDS = []
+
+SENSOR_KEYS_AND_UNITS = {
+    'temperature': '°C',
+    'humidity': '%',
+}
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Setup the Rflink platform."""
+    @asyncio.coroutine
+    def add_new_device(event):
+        """Check if device is known, otherwise add to list of known devices."""
+        packet = event.data[rflink.ATTR_PACKET]
+        device_id = rflink.serialize_id(packet)
+        if device_id not in KNOWN_DEVICE_IDS:
+            KNOWN_DEVICE_IDS.append(device_id)
+            rflinksensor = partial(RflinkSensor, device_id, device_id, hass)
+            devices = []
+            for sensor_key, unit in SENSOR_KEYS_AND_UNITS.items():
+                if sensor_key in packet:
+                    devices.append(rflinksensor(sensor_key, unit))
+            yield from async_add_devices(devices)
+            # make sure the packet is processed by the new entities
+            for device in devices:
+                device.match_packet(packet)
+
+    hass.bus.async_listen(rflink.RFLINK_EVENT[DOMAIN], add_new_device)
+
+
+class RflinkSensor(rflink.RflinkDevice):
+    """Representation of a Rflink sensor."""
+
+    # used for matching bus events
+    domain = DOMAIN
+    # packets can contain multiple values
+    # which value is this entity bound to
+    value_key = None
+
+    def __init__(self, name, device_id, hass, value_key, unit):
+        """Handle sensor specific args and super init."""
+        self.value_key = value_key
+        self._unit = unit
+        super().__init__(name, device_id, hass)
+
+    def _handle_packet(self, packet):
+        """Domain specific packet handler."""
+        self._state = packet[self.value_key]
+
+    @property
+    def state(self):
+        """Return value."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return measurement unit."""
+        return self._unit

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -5,8 +5,8 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.rflink/
 """
 import asyncio
-import logging
 from functools import partial
+import logging
 
 import homeassistant.components.rflink as rflink
 
@@ -29,13 +29,14 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup the Rflink platform."""
     @asyncio.coroutine
     def add_new_device(event):
-        """Check if device is known, otherwise add to list of known devices."""
+        """Check if device is known, otherwise create device entity."""
         packet = event.data[rflink.ATTR_PACKET]
         device_id = rflink.serialize_id(packet)
         if device_id not in KNOWN_DEVICE_IDS:
             KNOWN_DEVICE_IDS.append(device_id)
-            rflinksensor = partial(RflinkSensor, device_id, device_id, hass)
+            rflinksensor = partial(RflinkSensor, device_id, hass)
             devices = []
+            # create entity for each value in this packet
             for sensor_key, unit in SENSOR_KEYS_AND_UNITS.items():
                 if sensor_key in packet:
                     devices.append(rflinksensor(sensor_key, unit))
@@ -53,25 +54,25 @@ class RflinkSensor(rflink.RflinkDevice):
     # used for matching bus events
     domain = DOMAIN
     # packets can contain multiple values
-    # which value is this entity bound to
+    # which value this entity is bound to
     value_key = None
 
-    def __init__(self, name, device_id, hass, value_key, unit):
+    def __init__(self, device_id, hass, value_key, unit, **kwargs):
         """Handle sensor specific args and super init."""
-        self.value_key = value_key
+        self._value_key = value_key
         self._unit = unit
-        super().__init__(name, device_id, hass)
+        super().__init__(device_id, hass, **kwargs)
 
     def _handle_packet(self, packet):
         """Domain specific packet handler."""
-        self._state = packet[self.value_key]
-
-    @property
-    def state(self):
-        """Return value."""
-        return self._state
+        self._state = packet[self._value_key]
 
     @property
     def unit_of_measurement(self):
         """Return measurement unit."""
         return self._unit
+
+    @property
+    def state(self):
+        """Return value."""
+        return self._state

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -10,9 +10,9 @@ import logging
 
 from homeassistant.components import group
 from homeassistant.components.rflink import (
-    ATTR_EVENT, CONF_ALIASSES, CONF_DEVICES, CONF_NEW_DEVICES_GROUP,
-    DATA_DEVICE_REGISTER, DATA_ENTITY_LOOKUP, DATA_KNOWN_DEVICES, DOMAIN,
-    EVENT_KEY_ID, EVENT_KEY_SENSOR, EVENT_KEY_UNIT, RflinkDevice, cv, vol)
+    CONF_ALIASSES, CONF_DEVICES, CONF_NEW_DEVICES_GROUP, DATA_DEVICE_REGISTER,
+    DATA_ENTITY_LOOKUP, DATA_KNOWN_DEVICES, DOMAIN, EVENT_KEY_ID,
+    EVENT_KEY_SENSOR, EVENT_KEY_UNIT, RflinkDevice, cv, vol)
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT, CONF_NAME, CONF_PLATFORM)
 
@@ -101,7 +101,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             EVENT_KEY_SENSOR][device_id].append(device)
 
         # make sure the event is processed by the new entity
-        device.match_event(event)
+        device.handle_event(event)
 
         # maybe add to new devices group
         if new_devices_group:

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -30,10 +30,32 @@ SENSOR_ICONS = {
     'battery': 'mdi:battery',
 }
 
+VALID_CONFIG_KEYS = [
+    'aliasses',
+    'name',
+    'icon',
+    'value_key',
+    'unit',
+]
+
+
+def devices_from_config(domain_config, hass=None):
+    """Parse config and add rflink sensor devices."""
+
+    devices = []
+    for device_id, config in domain_config['devices'].items():
+        # extract only valid keys from device configuration
+        kwargs = {k: v for k, v in config.items() if k in VALID_CONFIG_KEYS}
+        devices.append(RflinkSensor(device_id, hass, **kwargs))
+    return devices
+
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup the Rflink platform."""
+    # add devices from config
+    yield from async_add_devices(devices_from_config(config, hass))
+
     # add new (unconfigured) devices to user desired group
     if config.get('new_devices_group'):
         new_devices_group = yield from group.Group.async_create_group(

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -11,8 +11,8 @@ import logging
 from homeassistant.components import group
 from homeassistant.components.rflink import (
     CONF_ALIASSES, CONF_DEVICES, CONF_NEW_DEVICES_GROUP, DATA_DEVICE_REGISTER,
-    DATA_ENTITY_LOOKUP, DATA_KNOWN_DEVICES, DOMAIN, EVENT_KEY_ID,
-    EVENT_KEY_SENSOR, EVENT_KEY_UNIT, RflinkDevice, cv, vol)
+    DATA_ENTITY_LOOKUP, DOMAIN, EVENT_KEY_ID, EVENT_KEY_SENSOR, EVENT_KEY_UNIT,
+    RflinkDevice, cv, vol)
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT, CONF_NAME, CONF_PLATFORM)
 
@@ -62,7 +62,7 @@ def devices_from_config(domain_config, hass=None):
             config[CONF_SENSOR_TYPE])
         device = RflinkSensor(device_id, hass, **config)
         devices.append(device)
-        hass.data[DATA_KNOWN_DEVICES].append(device_id)
+
         # register entity to listen to incoming rflink events
         hass.data[DATA_ENTITY_LOOKUP][
             EVENT_KEY_SENSOR][device_id].append(device)
@@ -86,8 +86,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     def add_new_device(event):
         """Check if device is known, otherwise create device entity."""
         device_id = event[EVENT_KEY_ID]
-
-        hass.data[DATA_KNOWN_DEVICES].append(device_id)
 
         rflinksensor = partial(RflinkSensor, device_id, hass)
         device = rflinksensor(event[EVENT_KEY_SENSOR], event[EVENT_KEY_UNIT])

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -45,8 +45,3 @@ class RflinkSwitch(rflink.SwitchableRflinkDevice, SwitchDevice):
 
     # used for matching bus events
     domain = DOMAIN
-
-    @property
-    def icon(self):
-        """Return the icon to use for device if any."""
-        return self._icon

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -13,8 +13,6 @@ from homeassistant.components.rflink import (
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
 
-from . import DOMAIN as PLATFORM
-
 DEPENDENCIES = ['rflink']
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,5 +53,4 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class RflinkSwitch(SwitchableRflinkDevice, SwitchDevice):
     """Representation of a Rflink switch."""
 
-    # used for matching bus events
-    platform = PLATFORM
+    pass

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -1,8 +1,8 @@
-"""
-Support for Rflink switches.
+"""Support for Rflink switches.
 
-For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/switch.rflink/
+For more details about this platform, please refer to the documentation
+at https://home-assistant.io/components/switch.rflink/
+
 """
 import asyncio
 import logging
@@ -25,7 +25,6 @@ VALID_CONFIG_KEYS = [
 
 def devices_from_config(domain_config, hass=None):
     """Parse config and add rflink switch devices."""
-
     devices = []
     for device_id, config in domain_config.get('devices', {}).items():
         # extract only valid keys from device configuration

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -8,8 +8,8 @@ import asyncio
 import logging
 
 from homeassistant.components.rflink import (
-    CONF_ALIASSES, CONF_DEVICES, DATA_KNOWN_DEVICES, DOMAIN,
-    SwitchableRflinkDevice, cv, vol)
+    CONF_ALIASSES, CONF_DEVICES, DATA_ENTITY_LOOKUP, DATA_KNOWN_DEVICES,
+    DOMAIN, EVENT_KEY_COMMAND, SwitchableRflinkDevice, cv, vol)
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
 
@@ -36,8 +36,13 @@ def devices_from_config(domain_config, hass=None):
     """Parse config and add rflink switch devices."""
     devices = []
     for device_id, config in domain_config[CONF_DEVICES].items():
-        devices.append(RflinkSwitch(device_id, hass, **config))
+        device = RflinkSwitch(device_id, hass, **config)
+        devices.append(device)
         hass.data[DATA_KNOWN_DEVICES].append(device_id)
+        # register entity (and aliasses) to listen to incoming rflink events
+        for _id in config[CONF_ALIASSES] + [device_id]:
+            hass.data[DATA_ENTITY_LOOKUP][
+                EVENT_KEY_COMMAND][_id].append(device)
     return devices
 
 

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -19,7 +19,6 @@ _LOGGER = logging.getLogger(__name__)
 VALID_CONFIG_KEYS = [
     'aliasses',
     'name',
-    'icon',
 ]
 
 

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -27,7 +27,7 @@ def devices_from_config(domain_config, hass=None):
     """Parse config and add rflink switch devices."""
 
     devices = []
-    for device_id, config in domain_config['devices'].items():
+    for device_id, config in domain_config.get('devices', {}).items():
         # extract only valid keys from device configuration
         kwargs = {k: v for k, v in config.items() if k in VALID_CONFIG_KEYS}
         devices.append(RflinkSwitch(device_id, hass, **kwargs))

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -43,8 +43,7 @@ def devices_from_config(domain_config, hass=None):
     """Parse config and add rflink switch devices."""
     devices = []
     for device_id, config in domain_config[CONF_DEVICES].items():
-        device_config = domain_config[CONF_DEVICE_DEFAULTS]
-        device_config.update(**config)
+        device_config = dict(domain_config[CONF_DEVICE_DEFAULTS], **config)
         device = RflinkSwitch(device_id, hass, **device_config)
         devices.append(device)
 

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -8,8 +8,8 @@ import asyncio
 import logging
 
 from homeassistant.components.rflink import (
-    CONF_ALIASSES, CONF_DEVICES, DATA_ENTITY_LOOKUP, DATA_KNOWN_DEVICES,
-    DOMAIN, EVENT_KEY_COMMAND, SwitchableRflinkDevice, cv, vol)
+    CONF_ALIASSES, CONF_DEVICES, DATA_ENTITY_LOOKUP, DOMAIN, EVENT_KEY_COMMAND,
+    SwitchableRflinkDevice, cv, vol)
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
 
@@ -36,7 +36,7 @@ def devices_from_config(domain_config, hass=None):
     for device_id, config in domain_config[CONF_DEVICES].items():
         device = RflinkSwitch(device_id, hass, **config)
         devices.append(device)
-        hass.data[DATA_KNOWN_DEVICES].append(device_id)
+
         # register entity (and aliasses) to listen to incoming rflink events
         for _id in config[CONF_ALIASSES] + [device_id]:
             hass.data[DATA_ENTITY_LOOKUP][

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -30,7 +30,7 @@ def devices_from_config(domain_config, hass=None):
         # extract only valid keys from device configuration
         kwargs = {k: v for k, v in config.items() if k in VALID_CONFIG_KEYS}
         devices.append(RflinkSwitch(device_id, hass, **kwargs))
-        rflink.KNOWN_DEVICE_IDS.append(device_id)
+        hass.data[rflink.DATA_KNOWN_DEVICES].append(device_id)
     return devices
 
 

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -31,6 +31,7 @@ def devices_from_config(domain_config, hass=None):
         # extract only valid keys from device configuration
         kwargs = {k: v for k, v in config.items() if k in VALID_CONFIG_KEYS}
         devices.append(RflinkSwitch(device_id, hass, **kwargs))
+        rflink.KNOWN_DEVICE_IDS.append(device_id)
     return devices
 
 

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -32,8 +32,7 @@ PLATFORM_SCHEMA = vol.Schema({
             vol.Optional(CONF_ALIASSES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
-            vol.Optional(CONF_SIGNAL_REPETITIONS,
-                         default=DEFAULT_SIGNAL_REPETITIONS): vol.Coerce(int),
+            vol.Optional(CONF_SIGNAL_REPETITIONS): vol.Coerce(int),
         },
     }),
 })

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -8,8 +8,8 @@ import asyncio
 import logging
 
 from homeassistant.components.rflink import (
-    CONF_ALIASSES, CONF_DEVICES, DATA_ENTITY_LOOKUP, DOMAIN, EVENT_KEY_COMMAND,
-    SwitchableRflinkDevice, cv, vol)
+    CONF_ALIASSES, CONF_DEVICES, CONF_FIRE_EVENT, DATA_ENTITY_LOOKUP, DOMAIN,
+    EVENT_KEY_COMMAND, SwitchableRflinkDevice, cv, vol)
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
 
@@ -25,6 +25,7 @@ PLATFORM_SCHEMA = vol.Schema({
             vol.Optional(CONF_NAME): cv.string,
             vol.Optional(CONF_ALIASSES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
         },
     }),
 })

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -1,0 +1,52 @@
+"""
+Support for Rflink switches.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.rflink/
+"""
+import asyncio
+import logging
+
+import homeassistant.components.rflink as rflink
+from homeassistant.components.switch import SwitchDevice
+
+from . import DOMAIN
+
+DEPENDENCIES = ['rflink']
+
+_LOGGER = logging.getLogger(__name__)
+
+VALID_CONFIG_KEYS = [
+    'aliasses',
+    'name',
+    'icon',
+]
+
+
+def devices_from_config(domain_config, hass=None):
+    """Parse config and add rflink switch devices."""
+
+    devices = []
+    for device_id, config in domain_config['devices'].items():
+        # extract only valid keys from device configuration
+        kwargs = {k: v for k, v in config.items() if k in VALID_CONFIG_KEYS}
+        devices.append(RflinkSwitch(device_id, hass, **kwargs))
+    return devices
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Setup the Rflink platform."""
+    yield from async_add_devices(devices_from_config(config, hass))
+
+
+class RflinkSwitch(rflink.SwitchableRflinkDevice, SwitchDevice):
+    """Representation of a Rflink switch."""
+
+    # used for matching bus events
+    domain = DOMAIN
+
+    @property
+    def icon(self):
+        """Return the icon to use for device if any."""
+        return self._icon

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -564,7 +564,7 @@ pyzabbix==0.7.4
 radiotherm==1.2
 
 # homeassistant.components.rflink
-rflink==0.0.20
+rflink==0.0.23
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -564,7 +564,7 @@ pyzabbix==0.7.4
 radiotherm==1.2
 
 # homeassistant.components.rflink
-rflink==0.0.17
+rflink==0.0.18
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -563,6 +563,9 @@ pyzabbix==0.7.4
 # homeassistant.components.climate.radiotherm
 radiotherm==1.2
 
+# homeassistant.components.rflink
+rflink==0.0.4
+
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.6
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -564,7 +564,7 @@ pyzabbix==0.7.4
 radiotherm==1.2
 
 # homeassistant.components.rflink
-rflink==0.0.14
+rflink==0.0.16
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -564,7 +564,7 @@ pyzabbix==0.7.4
 radiotherm==1.2
 
 # homeassistant.components.rflink
-rflink==0.0.16
+rflink==0.0.17
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -564,7 +564,7 @@ pyzabbix==0.7.4
 radiotherm==1.2
 
 # homeassistant.components.rflink
-rflink==0.0.18
+rflink==0.0.20
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -564,7 +564,7 @@ pyzabbix==0.7.4
 radiotherm==1.2
 
 # homeassistant.components.rflink
-rflink==0.0.23
+rflink==0.0.24
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -564,7 +564,7 @@ pyzabbix==0.7.4
 radiotherm==1.2
 
 # homeassistant.components.rflink
-rflink==0.0.4
+rflink==0.0.14
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.6

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -280,7 +280,7 @@ def test_signal_repetitions(hass, monkeypatch):
 
 @asyncio.coroutine
 def test_signal_repetitions_alternation(hass, monkeypatch):
-    """Simultaniously switching entities must alternate repetitions."""
+    """Simultaneously switching entities must alternate repetitions."""
     config = {
         'rflink': {
             'port': '/dev/ttyABC0',

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -244,6 +244,7 @@ def test_signal_repetitions(hass, monkeypatch):
         hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
                                  {ATTR_ENTITY_ID: 'light.test'}))
 
+    # wait for commands and repetitions to finish
     yield from hass.async_block_till_done()
 
     assert protocol.send_command_ack.call_count == 2
@@ -253,6 +254,7 @@ def test_signal_repetitions(hass, monkeypatch):
         hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
                                  {ATTR_ENTITY_ID: 'light.test1'}))
 
+    # wait for commands and repetitions to finish
     yield from hass.async_block_till_done()
 
     assert protocol.send_command_ack.call_count == 5
@@ -263,10 +265,14 @@ def test_signal_repetitions(hass, monkeypatch):
         'command': 'off',
     })
 
+    # make sure entity is created before setting state
+    yield from hass.async_block_till_done()
+
     hass.async_add_job(
         hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
                                  {ATTR_ENTITY_ID: 'light.protocol_0_2'}))
 
+    # wait for commands and repetitions to finish
     yield from hass.async_block_till_done()
 
     assert protocol.send_command_ack.call_count == 8

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -33,6 +33,10 @@ CONFIG = {
                 'name': 'dim_test',
                 'type': 'dimmable',
             },
+            'switchable_0_0': {
+                'name': 'switch_test',
+                'type': 'switchable',
+            }
         },
     },
 }

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -154,7 +154,7 @@ def test_new_light_group(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, create, _ = yield from mock_rflink(
+    event_callback, _, _ = yield from mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     # test event for new unconfigured sensor
@@ -188,7 +188,7 @@ def test_firing_bus_event(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, create, _ = yield from mock_rflink(
+    event_callback, _, _ = yield from mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     calls = []

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -46,7 +46,7 @@ CONFIG = {
 def test_default_setup(hass, monkeypatch):
     """Test all basic functionality of the rflink switch component."""
     # setup mocking rflink module
-    event_callback, create, protocol = yield from mock_rflink(
+    event_callback, create, protocol, _ = yield from mock_rflink(
         hass, CONFIG, DOMAIN, monkeypatch)
 
     # make sure arguments are passed
@@ -156,7 +156,7 @@ def test_new_light_group(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = yield from mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     # test event for new unconfigured sensor
@@ -191,7 +191,7 @@ def test_firing_bus_event(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = yield from mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     calls = []
@@ -236,7 +236,7 @@ def test_signal_repetitions(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, protocol = yield from mock_rflink(
+    event_callback, _, protocol, _ = yield from mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     # test if signal repetition is performed according to configuration
@@ -295,7 +295,7 @@ def test_signal_repetitions_alternation(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    _, _, protocol = yield from mock_rflink(
+    _, _, protocol, _ = yield from mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     hass.async_add_job(
@@ -332,7 +332,7 @@ def test_signal_repetitions_cancelling(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    _, _, protocol = yield from mock_rflink(
+    _, _, protocol, _ = yield from mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     hass.async_add_job(

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -57,7 +57,7 @@ def test_default_setup(hass, monkeypatch):
     # incoming events for its name and aliasses
 
     # mock incoming command event for this device
-    yield from event_callback({
+    event_callback({
         'id': 'protocol_0_0',
         'command': 'on',
     })
@@ -69,7 +69,7 @@ def test_default_setup(hass, monkeypatch):
     assert 'assumed_state' not in light_after_first_command.attributes
 
     # mock incoming command event for this device
-    yield from event_callback({
+    event_callback({
         'id': 'protocol_0_0',
         'command': 'off',
     })
@@ -79,7 +79,7 @@ def test_default_setup(hass, monkeypatch):
 
     # test following aliasses
     # mock incoming command event for this device alias
-    yield from event_callback({
+    event_callback({
         'id': 'test_alias_0_0',
         'command': 'on',
     })
@@ -88,7 +88,7 @@ def test_default_setup(hass, monkeypatch):
     assert hass.states.get('light.test').state == 'on'
 
     # test event for new unconfigured sensor
-    yield from event_callback({
+    event_callback({
         'id': 'protocol2_0_1',
         'command': 'on',
     })
@@ -114,7 +114,7 @@ def test_default_setup(hass, monkeypatch):
 
     # protocols supporting dimming should send dim commands
     # create dimmable entity
-    yield from event_callback({
+    event_callback({
         'id': 'newkaku_0_1',
         'command': 'off',
     })
@@ -158,7 +158,7 @@ def test_new_light_group(hass, monkeypatch):
         hass, config, DOMAIN, monkeypatch)
 
     # test event for new unconfigured sensor
-    yield from event_callback({
+    event_callback({
         'id': 'protocol_0_0',
         'command': 'off',
     })
@@ -199,7 +199,7 @@ def test_firing_bus_event(hass, monkeypatch):
     hass.bus.async_listen_once(EVENT_BUTTON_PRESSED, listener)
 
     # test event for new unconfigured sensor
-    yield from event_callback({
+    event_callback({
         'id': 'protocol_0_0',
         'command': 'off',
     })

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -205,4 +205,4 @@ def test_firing_bus_event(hass, monkeypatch):
     })
     yield from hass.async_block_till_done()
 
-    assert calls[0].data == {'state': 'off', 'entity_id': 'test'}
+    assert calls[0].data == {'state': 'off', 'entity_id': 'light.test'}

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -130,8 +130,6 @@ def test_default_setup(hass, monkeypatch):
 
     # dimmable should send highest dim level when turning on
     assert protocol.send_command_ack.call_args_list[2][0][1] == '15'
-    # and send on command for fallback
-    assert protocol.send_command_ack.call_args_list[3][0][1] == 'on'
 
     hass.async_add_job(
         hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
@@ -141,7 +139,7 @@ def test_default_setup(hass, monkeypatch):
                                  }))
     yield from hass.async_block_till_done()
 
-    assert protocol.send_command_ack.call_args_list[4][0][1] == '7'
+    assert protocol.send_command_ack.call_args_list[3][0][1] == '7'
 
 
 @asyncio.coroutine

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -280,7 +280,7 @@ def test_signal_repetitions(hass, monkeypatch):
 
 @asyncio.coroutine
 def test_signal_repetitions_alternation(hass, monkeypatch):
-    """Entities switched simultaniously should alternate repetitions."""
+    """Simultaniously switching entities must alternate repetitions."""
     config = {
         'rflink': {
             'port': '/dev/ttyABC0',

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -182,6 +182,7 @@ def test_firing_bus_event(hass, monkeypatch):
                 'protocol_0_0': {
                     'name': 'test',
                     'aliasses': ['test_alias_0_0'],
+                    'fire_event': True,
                 },
             },
         },

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -1,0 +1,167 @@
+"""Test for RFlink light components.
+
+Test setup of rflink lights component/platform. State tracking and
+control of Rflink switch devices.
+
+"""
+
+import asyncio
+
+from homeassistant.components.light import ATTR_BRIGHTNESS
+from homeassistant.const import (
+    ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON)
+
+from ..test_rflink import mock_rflink
+
+DOMAIN = 'light'
+
+CONFIG = {
+    'rflink': {
+        'port': '/dev/ttyABC0',
+        'ignore_devices': ['ignore_wildcard_*', 'ignore_light'],
+    },
+    DOMAIN: {
+        'platform': 'rflink',
+        'devices': {
+            'protocol_0_0': {
+                'name': 'test',
+                'aliasses': ['test_alias_0_0'],
+            },
+            'dimmable_0_0': {
+                'name': 'dim_test',
+                'type': 'dimmable',
+            },
+        },
+    },
+}
+
+
+@asyncio.coroutine
+def test_default_setup(hass, monkeypatch):
+    """Test all basic functionality of the rflink switch component."""
+    # setup mocking rflink module
+    event_callback, create, protocol = yield from mock_rflink(
+        hass, CONFIG, DOMAIN, monkeypatch)
+
+    # make sure arguments are passed
+    assert create.call_args_list[0][1]['ignore']
+
+    # test default state of light loaded from config
+    light_initial = hass.states.get('light.test')
+    assert light_initial.state == 'off'
+    assert light_initial.attributes['assumed_state']
+
+    # light should follow state of the hardware device by interpreting
+    # incoming events for its name and aliasses
+
+    # mock incoming command event for this device
+    event_callback({
+        'id': 'protocol_0_0',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    light_after_first_command = hass.states.get('light.test')
+    assert light_after_first_command.state == 'on'
+    # also after receiving first command state not longer has to be assumed
+    assert 'assumed_state' not in light_after_first_command.attributes
+
+    # mock incoming command event for this device
+    event_callback({
+        'id': 'protocol_0_0',
+        'command': 'off',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get('light.test').state == 'off'
+
+    # test following aliasses
+    # mock incoming command event for this device alias
+    event_callback({
+        'id': 'test_alias_0_0',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get('light.test').state == 'on'
+
+    # test event for new unconfigured sensor
+    event_callback({
+        'id': 'protocol2_0_1',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get('light.protocol2_0_1').state == 'on'
+
+    # test changing state from HA propagates to Rflink
+    hass.async_add_job(
+        hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
+                                 {ATTR_ENTITY_ID: 'light.test'}))
+    yield from hass.async_block_till_done()
+    assert hass.states.get('light.test').state == 'off'
+    assert protocol.send_command_ack.call_args_list[0][0][0] == 'protocol_0_0'
+    assert protocol.send_command_ack.call_args_list[0][0][1] == 'off'
+
+    hass.async_add_job(
+        hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
+                                 {ATTR_ENTITY_ID: 'light.test'}))
+    yield from hass.async_block_till_done()
+    assert hass.states.get('light.test').state == 'on'
+    assert protocol.send_command_ack.call_args_list[1][0][1] == 'on'
+
+    # protocols supporting dimming should send dim commands
+    # create dimmable entity
+    event_callback({
+        'id': 'newkaku_0_1',
+        'command': 'off',
+    })
+    yield from hass.async_block_till_done()
+    hass.async_add_job(
+        hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
+                                 {ATTR_ENTITY_ID: 'light.newkaku_0_1'}))
+    yield from hass.async_block_till_done()
+
+    # dimmable should send highest dim level when turning on
+    assert protocol.send_command_ack.call_args_list[2][0][1] == '15'
+    # and send on command for fallback
+    assert protocol.send_command_ack.call_args_list[3][0][1] == 'on'
+
+    hass.async_add_job(
+        hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
+                                 {
+                                     ATTR_ENTITY_ID: 'light.newkaku_0_1',
+                                     ATTR_BRIGHTNESS: 128,
+                                 }))
+    yield from hass.async_block_till_done()
+
+    assert protocol.send_command_ack.call_args_list[4][0][1] == '7'
+
+
+@asyncio.coroutine
+def test_new_light_group(hass, monkeypatch):
+    """New devices should be added to configured group."""
+    config = {
+        'rflink': {
+            'port': '/dev/ttyABC0',
+        },
+        DOMAIN: {
+            'platform': 'rflink',
+            'new_devices_group': 'new_rflink_lights',
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, create, _ = yield from mock_rflink(
+        hass, config, DOMAIN, monkeypatch)
+
+    # test event for new unconfigured sensor
+    event_callback({
+        'id': 'protocol_0_0',
+        'command': 'off',
+    })
+    yield from hass.async_block_till_done()
+
+    # make sure new device is added to correct group
+    group = hass.states.get('group.new_rflink_lights')
+    assert group.attributes.get('entity_id') == ('light.protocol_0_0',)

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -55,7 +55,7 @@ def test_default_setup(hass, monkeypatch):
     # incoming events for its name and aliasses
 
     # mock incoming command event for this device
-    event_callback({
+    yield from event_callback({
         'id': 'protocol_0_0',
         'command': 'on',
     })
@@ -67,7 +67,7 @@ def test_default_setup(hass, monkeypatch):
     assert 'assumed_state' not in light_after_first_command.attributes
 
     # mock incoming command event for this device
-    event_callback({
+    yield from event_callback({
         'id': 'protocol_0_0',
         'command': 'off',
     })
@@ -77,7 +77,7 @@ def test_default_setup(hass, monkeypatch):
 
     # test following aliasses
     # mock incoming command event for this device alias
-    event_callback({
+    yield from event_callback({
         'id': 'test_alias_0_0',
         'command': 'on',
     })
@@ -86,7 +86,7 @@ def test_default_setup(hass, monkeypatch):
     assert hass.states.get('light.test').state == 'on'
 
     # test event for new unconfigured sensor
-    event_callback({
+    yield from event_callback({
         'id': 'protocol2_0_1',
         'command': 'on',
     })
@@ -112,7 +112,7 @@ def test_default_setup(hass, monkeypatch):
 
     # protocols supporting dimming should send dim commands
     # create dimmable entity
-    event_callback({
+    yield from event_callback({
         'id': 'newkaku_0_1',
         'command': 'off',
     })
@@ -156,7 +156,7 @@ def test_new_light_group(hass, monkeypatch):
         hass, config, DOMAIN, monkeypatch)
 
     # test event for new unconfigured sensor
-    event_callback({
+    yield from event_callback({
         'id': 'protocol_0_0',
         'command': 'off',
     })

--- a/tests/components/sensor/test_rflink.py
+++ b/tests/components/sensor/test_rflink.py
@@ -1,0 +1,129 @@
+"""Test for DSMR components.
+
+Tests setup of the DSMR component and ensure incoming telegrams cause
+Entity to be updated with new values.
+
+"""
+
+import asyncio
+from unittest.mock import Mock
+
+from homeassistant.bootstrap import async_setup_component
+from tests.common import assert_setup_component
+
+
+@asyncio.coroutine
+def mock_rflink(hass, config, monkeypatch):
+    """Create mock Rflink asyncio protocol, test component setup."""
+    transport, protocol = (Mock(), Mock())
+
+    @asyncio.coroutine
+    def create_rflink_connection(*args, **kwargs):
+        return transport, protocol
+    mock_create = Mock(wraps=create_rflink_connection)
+    monkeypatch.setattr(
+        'rflink.protocol.create_rflink_connection',
+        mock_create)
+
+    # verify instanstiation of component with given config
+    with assert_setup_component(1, 'sensor'):
+        yield from async_setup_component(hass, 'sensor', config)
+
+    # hook into mock config for injecting events
+    event_callback = mock_create.call_args_list[0][1]['event_callback']
+    assert event_callback
+
+    return event_callback, mock_create
+
+
+@asyncio.coroutine
+def test_default_setup(hass, monkeypatch):
+    """Test all basic functionality of the rflink sensor component."""
+
+    config = {
+        'rflink': {
+            'port': '/dev/ttyABC0',
+            'ignore_devices': ['ignore_wildcard_*', 'ignore_sensor'],
+        },
+        'sensor': {
+            'platform': 'rflink',
+            'devices': {
+                'test': {
+                    'name': 'test',
+                    'sensor_type': 'temperature',
+                    'icon': 'mdi:thermometer-lines',
+                },
+            },
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, create = yield from mock_rflink(hass, config, monkeypatch)
+
+    # make sure arguments are passed
+    assert create.call_args_list[0][1]['ignore']
+
+    # test default state of sensor loaded from config
+    config_sensor = hass.states.get('sensor.test')
+    assert config_sensor
+    assert config_sensor.state == 'unknown'
+    assert config_sensor.attributes['unit_of_measurement'] == '°C'
+    assert config_sensor.attributes['icon'] == 'mdi:thermometer-lines'
+
+    # test event for config sensor
+    event_callback({
+        'id': 'test',
+        'sensor': 'temperature',
+        'value': 1,
+        'unit': '°C',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get('sensor.test').state == '1'
+
+    # test event for new unconfigured sensor
+    event_callback({
+        'id': 'test2',
+        'sensor': 'temperature',
+        'value': 0,
+        'unit': '°C',
+    })
+    yield from hass.async_block_till_done()
+
+    # test  state of new sensor
+    new_sensor = hass.states.get('sensor.test2')
+    assert new_sensor
+    assert new_sensor.state == '0'
+    assert new_sensor.attributes['unit_of_measurement'] == '°C'
+    assert new_sensor.attributes['icon'] == 'mdi:thermometer'
+
+
+@asyncio.coroutine
+def test_new_sensors_group(hass, monkeypatch):
+    """New devices should be added to configured group."""
+
+    config = {
+        'rflink': {
+            'port': '/dev/ttyABC0',
+        },
+        'sensor': {
+            'platform': 'rflink',
+            'new_devices_group': 'new_rflink_sensors',
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, _ = yield from mock_rflink(hass, config, monkeypatch)
+
+    # test event for new unconfigured sensor
+    event_callback({
+        'id': 'test',
+        'sensor': 'temperature',
+        'value': 0,
+        'unit': '°C',
+    })
+    yield from hass.async_block_till_done()
+
+    # make sure new device is added to correct group
+    group = hass.states.get('group.new_rflink_sensors')
+    assert group.attributes.get('entity_id') == ('sensor.test',)

--- a/tests/components/sensor/test_rflink.py
+++ b/tests/components/sensor/test_rflink.py
@@ -45,7 +45,7 @@ def test_default_setup(hass, monkeypatch):
     assert config_sensor.attributes['unit_of_measurement'] == '°C'
 
     # test event for config sensor
-    event_callback({
+    yield from event_callback({
         'id': 'test',
         'sensor': 'temperature',
         'value': 1,
@@ -56,7 +56,7 @@ def test_default_setup(hass, monkeypatch):
     assert hass.states.get('sensor.test').state == '1'
 
     # test event for new unconfigured sensor
-    event_callback({
+    yield from event_callback({
         'id': 'test2',
         'sensor': 'temperature',
         'value': 0,
@@ -90,7 +90,7 @@ def test_new_sensors_group(hass, monkeypatch):
         hass, config, DOMAIN, monkeypatch)
 
     # test event for new unconfigured sensor
-    event_callback({
+    yield from event_callback({
         'id': 'test',
         'sensor': 'temperature',
         'value': 0,

--- a/tests/components/sensor/test_rflink.py
+++ b/tests/components/sensor/test_rflink.py
@@ -1,7 +1,7 @@
-"""Test for DSMR components.
+"""Test for RFlink sensor components.
 
-Tests setup of the DSMR component and ensure incoming telegrams cause
-Entity to be updated with new values.
+Test setup of rflink sensor component/platform. Verify manual and
+automatic sensor creation.
 
 """
 

--- a/tests/components/sensor/test_rflink.py
+++ b/tests/components/sensor/test_rflink.py
@@ -45,7 +45,7 @@ def test_default_setup(hass, monkeypatch):
     assert config_sensor.attributes['unit_of_measurement'] == '°C'
 
     # test event for config sensor
-    yield from event_callback({
+    event_callback({
         'id': 'test',
         'sensor': 'temperature',
         'value': 1,
@@ -56,7 +56,7 @@ def test_default_setup(hass, monkeypatch):
     assert hass.states.get('sensor.test').state == '1'
 
     # test event for new unconfigured sensor
-    yield from event_callback({
+    event_callback({
         'id': 'test2',
         'sensor': 'temperature',
         'value': 0,
@@ -90,7 +90,7 @@ def test_new_sensors_group(hass, monkeypatch):
         hass, config, DOMAIN, monkeypatch)
 
     # test event for new unconfigured sensor
-    yield from event_callback({
+    event_callback({
         'id': 'test',
         'sensor': 'temperature',
         'value': 0,

--- a/tests/components/sensor/test_rflink.py
+++ b/tests/components/sensor/test_rflink.py
@@ -22,7 +22,6 @@ CONFIG = {
             'test': {
                 'name': 'test',
                 'sensor_type': 'temperature',
-                'icon': 'mdi:thermometer-lines',
             },
         },
     },
@@ -44,7 +43,6 @@ def test_default_setup(hass, monkeypatch):
     assert config_sensor
     assert config_sensor.state == 'unknown'
     assert config_sensor.attributes['unit_of_measurement'] == '°C'
-    assert config_sensor.attributes['icon'] == 'mdi:thermometer-lines'
 
     # test event for config sensor
     event_callback({

--- a/tests/components/sensor/test_rflink.py
+++ b/tests/components/sensor/test_rflink.py
@@ -32,7 +32,7 @@ CONFIG = {
 def test_default_setup(hass, monkeypatch):
     """Test all basic functionality of the rflink sensor component."""
     # setup mocking rflink module
-    event_callback, create, _ = yield from mock_rflink(
+    event_callback, create, _, _ = yield from mock_rflink(
         hass, CONFIG, DOMAIN, monkeypatch)
 
     # make sure arguments are passed
@@ -86,7 +86,7 @@ def test_new_sensors_group(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = yield from mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     # test event for new unconfigured sensor

--- a/tests/components/switch/test_rflink.py
+++ b/tests/components/switch/test_rflink.py
@@ -1,0 +1,131 @@
+"""Test for RFlink switch components.
+
+Test setup of rflink switch component/platform. State tracking and
+control of Rflink switch devices.
+
+"""
+
+import asyncio
+from unittest.mock import Mock
+
+from homeassistant.bootstrap import async_setup_component
+from homeassistant.const import (
+    ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON)
+from tests.common import assert_setup_component
+
+DOMAIN = 'switch'
+
+CONFIG = {
+    'rflink': {
+        'port': '/dev/ttyABC0',
+        'ignore_devices': ['ignore_wildcard_*', 'ignore_sensor'],
+    },
+    'switch': {
+        'platform': 'rflink',
+        'devices': {
+            'protocol_0_0': {
+                    'name': 'test',
+                    'aliasses': ['test_alias_0_0'],
+            },
+        },
+    },
+}
+
+
+@asyncio.coroutine
+def mock_rflink(hass, config, domain, monkeypatch):
+    """Create mock Rflink asyncio protocol, test component setup."""
+    transport, protocol = (Mock(), Mock())
+
+    @asyncio.coroutine
+    def send_command_ack(*command):
+        return True
+    protocol.send_command_ack = Mock(wraps=send_command_ack)
+
+    @asyncio.coroutine
+    def create_rflink_connection(*args, **kwargs):
+        return transport, protocol
+    mock_create = Mock(wraps=create_rflink_connection)
+    monkeypatch.setattr(
+        'rflink.protocol.create_rflink_connection',
+        mock_create)
+
+    # verify instanstiation of component with given config
+    with assert_setup_component(1, domain):
+        yield from async_setup_component(hass, domain, config)
+
+    # hook into mock config for injecting events
+    event_callback = mock_create.call_args_list[0][1]['event_callback']
+    assert event_callback
+
+    return event_callback, mock_create, protocol
+
+
+@asyncio.coroutine
+def test_default_setup(hass, monkeypatch):
+    """Test all basic functionality of the rflink switch component."""
+
+    # setup mocking rflink module
+    event_callback, create, protocol = yield from mock_rflink(
+        hass, CONFIG, 'switch', monkeypatch)
+
+    # make sure arguments are passed
+    assert create.call_args_list[0][1]['ignore']
+
+    # test default state of switch loaded from config
+    switch_initial = hass.states.get('switch.test')
+    assert switch_initial.state == 'off'
+    assert switch_initial.attributes['assumed_state']
+
+    # switch should follow state of the hardware device by interpreting
+    # incoming events for its name and aliasses
+
+    # mock incoming command event for this device
+    event_callback({
+        'id': 'protocol_0_0',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    switch_after_first_command = hass.states.get('switch.test')
+    assert switch_after_first_command.state == 'on'
+    # also after receiving first command state not longer has to be assumed
+    assert 'assumed_state' not in switch_after_first_command.attributes
+
+    # mock incoming command event for this device
+    event_callback({
+        'id': 'protocol_0_0',
+        'command': 'off',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get('switch.test').state == 'off'
+
+    # test following aliasses
+    # mock incoming command event for this device alias
+    event_callback({
+        'id': 'test_alias_0_0',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get('switch.test').state == 'on'
+
+    # The switch component does not support adding new devices for incoming
+    # events because every new unkown device is added as a light by default.
+
+    # test changing state from HA propagates to Rflink
+    hass.async_add_job(
+        hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
+                                 {ATTR_ENTITY_ID: 'switch.test'}))
+    yield from hass.async_block_till_done()
+    assert hass.states.get('switch.test').state == 'off'
+    assert protocol.send_command_ack.call_args_list[0][0][0] == 'protocol_0_0'
+    assert protocol.send_command_ack.call_args_list[0][0][1] == 'off'
+
+    hass.async_add_job(
+        hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
+                                 {ATTR_ENTITY_ID: 'switch.test'}))
+    yield from hass.async_block_till_done()
+    assert hass.states.get('switch.test').state == 'on'
+    assert protocol.send_command_ack.call_args_list[1][0][1] == 'on'

--- a/tests/components/switch/test_rflink.py
+++ b/tests/components/switch/test_rflink.py
@@ -50,7 +50,7 @@ def test_default_setup(hass, monkeypatch):
     # incoming events for its name and aliasses
 
     # mock incoming command event for this device
-    yield from event_callback({
+    event_callback({
         'id': 'protocol_0_0',
         'command': 'on',
     })
@@ -62,7 +62,7 @@ def test_default_setup(hass, monkeypatch):
     assert 'assumed_state' not in switch_after_first_command.attributes
 
     # mock incoming command event for this device
-    yield from event_callback({
+    event_callback({
         'id': 'protocol_0_0',
         'command': 'off',
     })
@@ -72,7 +72,7 @@ def test_default_setup(hass, monkeypatch):
 
     # test following aliasses
     # mock incoming command event for this device alias
-    yield from event_callback({
+    event_callback({
         'id': 'test_alias_0_0',
         'command': 'on',
     })

--- a/tests/components/switch/test_rflink.py
+++ b/tests/components/switch/test_rflink.py
@@ -35,7 +35,7 @@ CONFIG = {
 def test_default_setup(hass, monkeypatch):
     """Test all basic functionality of the rflink switch component."""
     # setup mocking rflink module
-    event_callback, create, protocol = yield from mock_rflink(
+    event_callback, create, protocol, _ = yield from mock_rflink(
         hass, CONFIG, DOMAIN, monkeypatch)
 
     # make sure arguments are passed

--- a/tests/components/switch/test_rflink.py
+++ b/tests/components/switch/test_rflink.py
@@ -50,7 +50,7 @@ def test_default_setup(hass, monkeypatch):
     # incoming events for its name and aliasses
 
     # mock incoming command event for this device
-    event_callback({
+    yield from event_callback({
         'id': 'protocol_0_0',
         'command': 'on',
     })
@@ -62,7 +62,7 @@ def test_default_setup(hass, monkeypatch):
     assert 'assumed_state' not in switch_after_first_command.attributes
 
     # mock incoming command event for this device
-    event_callback({
+    yield from event_callback({
         'id': 'protocol_0_0',
         'command': 'off',
     })
@@ -72,7 +72,7 @@ def test_default_setup(hass, monkeypatch):
 
     # test following aliasses
     # mock incoming command event for this device alias
-    event_callback({
+    yield from event_callback({
         'id': 'test_alias_0_0',
         'command': 'on',
     })

--- a/tests/components/test_rflink.py
+++ b/tests/components/test_rflink.py
@@ -59,7 +59,7 @@ def test_version_banner(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, create, protocol = yield from mock_rflink(
+    event_callback, _, _ = yield from mock_rflink(
         hass, config, domain, monkeypatch)
 
     yield from event_callback({
@@ -91,7 +91,7 @@ def test_send_no_wait(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, create, protocol = yield from mock_rflink(
+    _, _, protocol = yield from mock_rflink(
         hass, config, domain, monkeypatch)
 
     hass.async_add_job(

--- a/tests/components/test_rflink.py
+++ b/tests/components/test_rflink.py
@@ -62,7 +62,7 @@ def test_version_banner(hass, monkeypatch):
     event_callback, _, _ = yield from mock_rflink(
         hass, config, domain, monkeypatch)
 
-    yield from event_callback({
+    event_callback({
         'hardware': 'Nodo RadioFrequencyLink',
         'firmware': 'RFLink Gateway',
         'version': '1.1',

--- a/tests/components/test_rflink.py
+++ b/tests/components/test_rflink.py
@@ -1,0 +1,100 @@
+"""Common functions for Rflink component tests and generic platform tests."""
+
+import asyncio
+from unittest.mock import Mock
+
+from homeassistant.bootstrap import async_setup_component
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF
+from tests.common import assert_setup_component
+
+
+@asyncio.coroutine
+def mock_rflink(hass, config, domain, monkeypatch):
+    """Create mock Rflink asyncio protocol, test component setup."""
+    transport, protocol = (Mock(), Mock())
+
+    @asyncio.coroutine
+    def send_command_ack(*command):
+        return True
+    protocol.send_command_ack = Mock(wraps=send_command_ack)
+
+    @asyncio.coroutine
+    def send_command(*command):
+        return True
+    protocol.send_command = Mock(wraps=send_command)
+
+    @asyncio.coroutine
+    def create_rflink_connection(*args, **kwargs):
+        """Return mocked transport and protocol."""
+        return transport, protocol
+    mock_create = Mock(wraps=create_rflink_connection)
+    monkeypatch.setattr(
+        'rflink.protocol.create_rflink_connection',
+        mock_create)
+
+    # verify instanstiation of component with given config
+    with assert_setup_component(1, domain):
+        yield from async_setup_component(hass, domain, config)
+
+    # hook into mock config for injecting events
+    event_callback = mock_create.call_args_list[0][1]['event_callback']
+    assert event_callback
+
+    return event_callback, mock_create, protocol
+
+
+@asyncio.coroutine
+def test_version_banner(hass, monkeypatch):
+    """Test sending unknown commands doesn't cause issues."""
+    # use sensor domain during testing main platform
+    domain = 'sensor'
+    config = {
+        'rflink': {'port': '/dev/ttyABC0', },
+        domain: {
+            'platform': 'rflink',
+            'devices': {
+                'test': {'name': 'test', 'sensor_type': 'temperature', },
+            },
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, create, protocol = yield from mock_rflink(
+        hass, config, domain, monkeypatch)
+
+    event_callback({
+        'hardware': 'Nodo RadioFrequencyLink',
+        'firmware': 'RFLink Gateway',
+        'version': '1.1',
+        'revision': '45',
+    })
+
+
+@asyncio.coroutine
+def test_send_no_wait(hass, monkeypatch):
+    """Test command sending without ack."""
+    domain = 'switch'
+    config = {
+        'rflink': {'port': '/dev/ttyABC0', },
+        'wait_for_ack': False,
+        domain: {
+            'platform': 'rflink',
+            'devices': {
+                'protocol_0_0': {
+                        'name': 'test',
+                        'aliasses': ['test_alias_0_0'],
+                },
+            },
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, create, protocol = yield from mock_rflink(
+        hass, config, domain, monkeypatch)
+
+    hass.async_add_job(
+        hass.services.async_call(domain, SERVICE_TURN_OFF,
+                                 {ATTR_ENTITY_ID: 'switch.test'}))
+    yield from hass.async_block_till_done()
+    assert protocol.send_command.call_args_list[0][0][0] == 'protocol_0_0'
+    assert protocol.send_command.call_args_list[0][0][1] == 'off'

--- a/tests/components/test_rflink.py
+++ b/tests/components/test_rflink.py
@@ -62,7 +62,7 @@ def test_version_banner(hass, monkeypatch):
     event_callback, create, protocol = yield from mock_rflink(
         hass, config, domain, monkeypatch)
 
-    event_callback({
+    yield from event_callback({
         'hardware': 'Nodo RadioFrequencyLink',
         'firmware': 'RFLink Gateway',
         'version': '1.1',

--- a/tests/components/test_rflink.py
+++ b/tests/components/test_rflink.py
@@ -75,8 +75,10 @@ def test_send_no_wait(hass, monkeypatch):
     """Test command sending without ack."""
     domain = 'switch'
     config = {
-        'rflink': {'port': '/dev/ttyABC0', },
-        'wait_for_ack': False,
+        'rflink': {
+            'port': '/dev/ttyABC0',
+            'wait_for_ack': False,
+        },
         domain: {
             'platform': 'rflink',
             'devices': {

--- a/tests/components/test_rflink.py
+++ b/tests/components/test_rflink.py
@@ -10,7 +10,7 @@ from tests.common import assert_setup_component
 
 
 @asyncio.coroutine
-def mock_rflink(hass, config, domain, monkeypatch):
+def mock_rflink(hass, config, domain, monkeypatch, failures=None):
     """Create mock Rflink asyncio protocol, test component setup."""
     transport, protocol = (Mock(), Mock())
 
@@ -27,7 +27,18 @@ def mock_rflink(hass, config, domain, monkeypatch):
     @asyncio.coroutine
     def create_rflink_connection(*args, **kwargs):
         """Return mocked transport and protocol."""
-        return transport, protocol
+        # failures can be a list of booleans indicating in which sequence
+        # creating a connection should success or fail
+        if failures:
+            fail = failures.pop()
+        else:
+            fail = False
+
+        if fail:
+            raise ConnectionRefusedError
+        else:
+            return transport, protocol
+
     mock_create = Mock(wraps=create_rflink_connection)
     monkeypatch.setattr(
         'rflink.protocol.create_rflink_connection',
@@ -41,10 +52,8 @@ def mock_rflink(hass, config, domain, monkeypatch):
     event_callback = mock_create.call_args_list[0][1]['event_callback']
     assert event_callback
 
-    print(mock_create.call_args_list)
     disconnect_callback = mock_create.call_args_list[
         0][1]['disconnect_callback']
-    print(disconnect_callback)
 
     return event_callback, mock_create, protocol, disconnect_callback
 
@@ -109,7 +118,7 @@ def test_send_no_wait(hass, monkeypatch):
 
 
 @asyncio.coroutine
-def test_reconnecting(hass, monkeypatch):
+def test_reconnecting_after_disconnect(hass, monkeypatch):
     """An unexpected disconnect should cause a reconnect."""
     domain = 'sensor'
     config = {
@@ -123,9 +132,47 @@ def test_reconnecting(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    _, _, _, disconnect_callback = yield from mock_rflink(
+    _, mock_create, _, disconnect_callback = yield from mock_rflink(
         hass, config, domain, monkeypatch)
 
-    assert disconnect_callback
+    assert disconnect_callback, 'disconnect callback not passed to rflink'
 
+    # rflink initiated disconnect
     disconnect_callback(None)
+
+    yield from hass.async_block_till_done()
+
+    # we expect 2 call, the initial and reconnect
+    assert mock_create.call_count == 2
+
+
+@asyncio.coroutine
+def test_reconnecting_after_failure(hass, monkeypatch):
+    """A failure to reconnect should be retried."""
+    domain = 'sensor'
+    config = {
+        'rflink': {
+            'port': '/dev/ttyABC0',
+            CONF_RECONNECT_INTERVAL: 0,
+        },
+        domain: {
+            'platform': 'rflink',
+        },
+    }
+
+    # success first time but fail second
+    failures = [False, True, False]
+
+    # setup mocking rflink module
+    _, mock_create, _, disconnect_callback = yield from mock_rflink(
+        hass, config, domain, monkeypatch, failures=failures)
+
+    # rflink initiated disconnect
+    disconnect_callback(None)
+
+    # wait for reconnects to have happened
+    yield from hass.async_block_till_done()
+    yield from hass.async_block_till_done()
+
+    # we expect 3 calls, the initial and 2 reconnects
+    assert mock_create.call_count == 3


### PR DESCRIPTION
**Description:** The change is intended to add support for the Rflink gateway devices (http://www.nemcon.nl/blog2/ & https://www.nodo-shop.nl/nl/21-rflink-gateway) which allow receiving and sending of 433Mhz packets much like rfxtrx. It builds on the rflink python package (https://pypi.python.org/pypi/rflink) which was initiated for this cause.

At the moment this is a very rough (but working) sketch with a lot of debugging. Expect much of the code to be changed, move around or migrate towards the rflink package to be available for a broader audience.

**Feel free to leave feedback or feature requests.**

I try to model this close to the rfxtrx platform but since this platform is developed asyncio first not a lot can be shared (yet).

**Please help by testing this out with your own Rflink device and providing feedback.**

What works at the moment:
- [x] Receiving and sending of on/off switch events to control lights.
- [x] Automatically adding discovered devices (but not stored yet)
- [x] Temparature & humidity sensors

Todos:
- [x] add tests
- [x] fix linting
- [x] cleanup
- [ ] doorbell support
- [ ] covers support? 
- [x] persistent devices from configuration.yaml
- [ ] assumed state configuration? (per device?)
- [x] temperature unit per device configuration
- [x] (debug) logging through log framework
- [x] shared known devices (light can be configured as switch)
- [x] component.rflink spawns devices? or event to create platform device?
- [ ] use service pattern instead of direct bus events? 
- [ ] rflink unsupported devices debug enable
- [ ] leave last box unchecked
- [x] config validation
- [ ] loading previous state from recorder

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1715

**Example entry for `configuration.yaml` (if applicable):**
```yaml
rflink:
  port: /dev/serial/by-id/usb-Arduino__www.arduino.cc__0042_55632313338351B08080-if00
  # send simultaneous commands as quickly as possible (may cause commands to fail)
  # wait_for_ack: false
  # ignore_device:
  #   - digitech_*
 
light:
  - platform: rflink
    # adds new devices to this group if not configured below
    new_devices_group: New Rflink Lights
    devices:
      newkaku_00000001_a:
        name: bedroom
      newkaku_00000001_b:
        name: kitchen
        aliasses:
          - kaku_000000_3

sensor:
  - platform: rflink
    # adds new devices to this group if not configured below
    new_devices_group: New Rflink Sensors
    devices:
      digitech_002f:
        # a single rflink packet can contain multiple values (eg: temperature and humidity)
        # setting value_key allows to specify which key should be used from the packet
        value_key: temperature

switch:
  - platform: rflink
    devices:
      newkaku_00000001_1:
        name: ventilator
        icon: mdi:fan

```

If you want to test this on for example your laptop/desktop without having to modify your existing HASS server but you don't want to have your Rflink hooked to the serial port of your laptop/desktop, this module support connecting through TCP as well. On the host connected to the Rflink install `socat` and run:

```bash
socat -ddd /dev/ttyACM0,b57600 TCP-LISTEN:1234,reuseaddr
```

This will expose the serial line on a tcp connection.

Then configure the component like this:
```yaml
rflink:
  host: hostname
  port: 1234

light:
  - platform: rflink
```


