### PR TITLE
precision properties for climate components

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -58,6 +58,11 @@ ATTR_OPERATION_LIST = "operation_list"
 ATTR_SWING_MODE = "swing_mode"
 ATTR_SWING_LIST = "swing_list"
 
+# The degree of precision for each platform
+PRECISION_WHOLE = 1
+PRECISION_HALVES = 0.5
+PRECISION_TENTHS = 0.1
+
 CONVERTIBLE_ATTRIBUTE = [
     ATTR_TEMPERATURE,
     ATTR_TARGET_TEMP_LOW,
@@ -372,6 +377,14 @@ class ClimateDevice(Entity):
             return STATE_UNKNOWN
 
     @property
+    def precision(self):
+        """Return the precision of the system."""
+        if self.unit_of_measurement == TEMP_CELSIUS:
+            return PRECISION_TENTHS
+        else:
+            return PRECISION_WHOLE
+
+    @property
     def state_attributes(self):
         """Return the optional state attributes."""
         data = {
@@ -569,8 +582,11 @@ class ClimateDevice(Entity):
         value = convert_temperature(temp, self.temperature_unit,
                                     self.unit_of_measurement)
 
-        if self.unit_of_measurement == TEMP_CELSIUS:
+        # Round in the units appropriate
+        if self.precision == PRECISION_HALVES:
+            return round(value * 2) / 2.0
+        elif self.precision == PRECISION_TENTHS:
             return round(value, 1)
         else:
-            # Users of fahrenheit generally expect integer units.
+            # PRECISION_WHOLE as a fall back
             return round(value)

--- a/homeassistant/components/climate/proliphix.py
+++ b/homeassistant/components/climate/proliphix.py
@@ -7,7 +7,8 @@ https://home-assistant.io/components/climate.proliphix/
 import voluptuous as vol
 
 from homeassistant.components.climate import (
-    STATE_COOL, STATE_HEAT, STATE_IDLE, ClimateDevice, PLATFORM_SCHEMA)
+    PRECISION_TENTHS, STATE_COOL, STATE_HEAT, STATE_IDLE,
+    ClimateDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, TEMP_FAHRENHEIT, ATTR_TEMPERATURE)
 import homeassistant.helpers.config_validation as cv
@@ -59,6 +60,15 @@ class ProliphixThermostat(ClimateDevice):
     def name(self):
         """Return the name of the thermostat."""
         return self._name
+
+    @property
+    def precision(self):
+        """Return the precision of the system.
+
+        Proliphix temperature values are passed back and forth in the
+        API as tenths of degrees F (i.e. 690 for 69 degrees).
+        """
+        return PRECISION_TENTHS
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
This lets components declare their precision for temperatures. If
nothing is declared, we assume 0.1 C and whole integer precision in
F. Currently this supports only WHOLE, HALVES, and TENTHS for
precision, but adding other precision levels is pretty straight
forward.

This also uses proliphix as an example of changing the precision for a
platform.

Closes bug #4350 and #4346 