### PR TITLE
Fix docstring (sensor.pvoutput)

### DIFF
--- a/homeassistant/components/sensor/pvoutput.py
+++ b/homeassistant/components/sensor/pvoutput.py
@@ -95,7 +95,7 @@ class PvoutputSensor(Entity):
 
     @property
     def device_state_attributes(self):
-        """Return the state attributes of the Pi-Hole."""
+        """Return the state attributes of the monitored installation."""
         if self.pvcoutput is not None:
             return {
                 ATTR_ENERGY_GENERATION: self.pvcoutput.energy_generation,


### PR DESCRIPTION
**Description:**
Was still referring to Pi-Hole.

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
