### PR TITLE
Add exception handling to Sonarr

### DIFF
--- a/homeassistant/components/sensor/sonarr.py
+++ b/homeassistant/components/sensor/sonarr.py
@@ -15,7 +15,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (CONF_API_KEY, CONF_HOST, CONF_PORT)
 from homeassistant.const import CONF_MONITORED_CONDITIONS
 from homeassistant.const import CONF_SSL
-from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 
@@ -87,6 +86,7 @@ class SonarrSensor(Entity):
         self.ssl = 's' if conf.get(CONF_SSL) else ''
 
         # Object data
+        self.data = []
         self._tz = timezone(str(hass.config.time_zone))
         self.type = sensor_type
         self._name = SENSOR_TYPES[self.type][0]
@@ -112,7 +112,7 @@ class SonarrSensor(Entity):
         except OSError:
             _LOGGER.error('Host %s is not available', self.host)
             self._available = False
-            self._state = STATE_UNAVAILABLE
+            self._state = None
             return
 
         if res.status_code == 200:
@@ -181,8 +181,6 @@ class SonarrSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
         attributes = {}
-        if not self.available:
-            return attributes
         if self.type == 'upcoming':
             for show in self.data:
                 attributes[show['series']['title']] = 'S{:02d}E{:02d}'.format(

--- a/tests/components/sensor/test_sonarr.py
+++ b/tests/components/sensor/test_sonarr.py
@@ -6,7 +6,6 @@ from datetime import datetime
 import pytest
 
 from homeassistant.components.sensor import sonarr
-from homeassistant.const import STATE_UNAVAILABLE
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/sensor/test_sonarr.py
+++ b/tests/components/sensor/test_sonarr.py
@@ -839,4 +839,4 @@ class TestSonarrSetup(unittest.TestCase):
         sonarr.setup_platform(self.hass, config, self.add_devices, None)
         for device in self.DEVICES:
             device.update()
-            self.assertEqual(STATE_UNAVAILABLE, device.state)
+            self.assertEqual(None, device.state)


### PR DESCRIPTION
**Description:**
When the target Sonarr service is not available during setup, set the sensors to unavailable. 

Since Sonarr is a self-hosted solution, it makes sense that the user would know about the availability of the service, and that it would return. When the service becomes available again, the sensors will pick up the data.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51