### PR TITLE
Pass hass object to ServiceRegistry constructor

### DIFF
--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -131,7 +131,7 @@ class HomeAssistant(ha.HomeAssistant):
         self._pending_sheduler = None
 
         self.bus = EventBus(remote_api, self)
-        self.services = ha.ServiceRegistry(self.bus, self.add_job, self.loop)
+        self.services = ha.ServiceRegistry(self)
         self.states = StateMachine(self.bus, self.loop, self.remote_api)
         self.config = ha.Config()
         # This is a dictionary that any component can store any data on.


### PR DESCRIPTION
**Description:**
ServiceRegistry used to get `async_add_job` passed in. However, since that reference might change in the future, it should get the hass object passed in.

Splitting this part out of #4428 while trying to break down what is causing the tests to fail.
