### PR TITLE
Set executor pool size to 10

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -56,7 +56,7 @@ SERVICE_CALL_LIMIT = 10  # seconds
 ENTITY_ID_PATTERN = re.compile(r"^(\w+)\.(\w+)$")
 
 # Size of a executor pool
-EXECUTOR_POOL_SIZE = 15
+EXECUTOR_POOL_SIZE = 10
 
 # Time for cleanup internal pending tasks
 TIME_INTERVAL_TASKS_CLEANUP = 10


### PR DESCRIPTION
**Description:**
This sets the executor pool size to 10. We set it to 15 because we were experiencing slow downs. However then @pvizeli realized that we never actually used the constant and always passed in 5 (See #4552).

So now setting it to 10 and see how it impacts people.
