### PR TITLE
0.33.4

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 33
-PATCH_VERSION = '3'
+PATCH_VERSION = '4'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 4, 2)

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -109,7 +109,7 @@ class HomeAssistant(object):
         else:
             self.loop = loop or asyncio.get_event_loop()
 
-        self.executor = ThreadPoolExecutor(max_workers=5)
+        self.executor = ThreadPoolExecutor(max_workers=EXECUTOR_POOL_SIZE)
         self.loop.set_default_executor(self.executor)
         self.loop.set_exception_handler(self._async_exception_handler)
         self._pending_tasks = []

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -56,7 +56,7 @@ SERVICE_CALL_LIMIT = 10  # seconds
 ENTITY_ID_PATTERN = re.compile(r"^(\w+)\.(\w+)$")
 
 # Size of a executor pool
-EXECUTOR_POOL_SIZE = 15
+EXECUTOR_POOL_SIZE = 10
 
 # Time for cleanup internal pending tasks
 TIME_INTERVAL_TASKS_CLEANUP = 10


### PR DESCRIPTION
 - Set executor pool size to 10 (as intended) (@pvizeli)

This should fix occasional performance problems that some people have reported.