### PR TITLE
Upgrade speedtest-cli to 1.0.0

### DIFF
--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -1,5 +1,5 @@
 """
-Support for Speedtest.net based on speedtest-cli.
+Support for Speedtest.net.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.speedtest/
@@ -8,6 +8,7 @@ import logging
 import re
 import sys
 from subprocess import check_output, CalledProcessError
+
 import voluptuous as vol
 
 import homeassistant.util.dt as dt_util
@@ -18,9 +19,9 @@ from homeassistant.const import CONF_MONITORED_CONDITIONS
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_change
 
-REQUIREMENTS = ['speedtest-cli==0.3.4']
-_LOGGER = logging.getLogger(__name__)
+REQUIREMENTS = ['speedtest-cli==1.0.0']
 
+_LOGGER = logging.getLogger(__name__)
 _SPEEDTEST_REGEX = re.compile(r'Ping:\s(\d+\.\d+)\sms[\r\n]+'
                               r'Download:\s(\d+\.\d+)\sMbit/s[\r\n]+'
                               r'Upload:\s(\d+\.\d+)\sMbit/s[\r\n]+')
@@ -30,6 +31,7 @@ CONF_MINUTE = 'minute'
 CONF_HOUR = 'hour'
 CONF_DAY = 'day'
 CONF_SERVER_ID = 'server_id'
+
 SENSOR_TYPES = {
     'ping': ['Ping', 'ms'],
     'download': ['Download', 'Mbit/s'],
@@ -38,7 +40,7 @@ SENSOR_TYPES = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, [vol.In(list(SENSOR_TYPES.keys()))]),
+        vol.All(cv.ensure_list, [vol.In(list(SENSOR_TYPES))]),
     vol.Optional(CONF_SERVER_ID): cv.positive_int,
     vol.Optional(CONF_SECOND, default=[0]):
         vol.All(cv.ensure_list, [vol.All(vol.Coerce(int), vol.Range(0, 59))]),
@@ -52,12 +54,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Speedtest sensor."""
+    """Set up the Speedtest sensor."""
     data = SpeedtestData(hass, config)
     dev = []
     for sensor in config[CONF_MONITORED_CONDITIONS]:
         if sensor not in SENSOR_TYPES:
-            _LOGGER.error('Sensor type: "%s" does not exist', sensor)
+            _LOGGER.error("Sensor type: %s does not exist", sensor)
         else:
             dev.append(SpeedtestSensor(data, sensor))
 
@@ -141,18 +143,18 @@ class SpeedtestData(object):
 
     def update(self, now):
         """Get the latest data from speedtest.net."""
-        import speedtest_cli
+        import speedtest
 
-        _LOGGER.info('Executing speedtest')
+        _LOGGER.info('Executing speedtest...')
         try:
-            args = [sys.executable, speedtest_cli.__file__, '--simple']
+            args = [sys.executable, speedtest.__file__, '--simple']
             if self._server_id:
                 args = args + ['--server', str(self._server_id)]
 
             re_output = _SPEEDTEST_REGEX.split(
-                check_output(args).decode("utf-8"))
+                check_output(args).decode('utf-8'))
         except CalledProcessError as process_error:
-            _LOGGER.error('Error executing speedtest: %s', process_error)
+            _LOGGER.error("Error executing speedtest: %s", process_error)
             return
         self.data = {'ping': round(float(re_output[1]), 2),
                      'download': round(float(re_output[2]), 2),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -510,7 +510,7 @@ snapcast==1.2.2
 somecomfort==0.3.2
 
 # homeassistant.components.sensor.speedtest
-speedtest-cli==0.3.4
+speedtest-cli==1.0.0
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator


### PR DESCRIPTION
1.0.0
----
- Renamed from speedtest_cli to speedtest
- No mutable defaults used as args for methods
- Support gzip encoding if available
- Debug print XML from servers
- and [more](https://github.com/sivel/speedtest-cli/commits/master)...

Tested with the following configuration:

``` yaml
sensor:
  - platform: speedtest
    monitored_conditions:
      - ping
      - download
      - upload
```