### PR TITLE
Add websocket API

### DIFF
--- a/homeassistant/components/frontend/www_static/websocket_test.html
+++ b/homeassistant/components/frontend/www_static/websocket_test.html
@@ -20,7 +20,7 @@
     <div class='controls'>
       <textarea id="messageinput">
         {
-          "id": 1, "type": "listen_event", "event_type": "state_changed"
+          "id": 1, "type": "subscribe_events", "event_type": "state_changed"
         }
       </textarea>
       <pre>
@@ -35,6 +35,22 @@ Examples:
 
 {
   "id": 4, "type": "unsubscribe_events", "subscription": 2
+}
+
+{
+  "id": 5, "type": "get_states"
+}
+
+{
+  "id": 6, "type": "get_config"
+}
+
+{
+  "id": 7, "type": "get_services"
+}
+
+{
+  "id": 8, "type": "get_panels"
 }
       </pre>
     </div>

--- a/homeassistant/components/frontend/www_static/websocket_test.html
+++ b/homeassistant/components/frontend/www_static/websocket_test.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>WebSocket debug</title>
+    <style>
+      .controls {
+        display: flex;
+        flex-direction: row;
+      }
+
+      .controls textarea {
+        height: 160px;
+        min-width: 400px;
+        margin-right: 24px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class='controls'>
+      <textarea id="messageinput">
+        {
+          "type": "listen_event", "event_type": "state_changed"
+        }
+      </textarea>
+      <pre>
+Examples:
+{
+  "type": "listen_event", "event_type": "state_changed"
+}
+
+{
+  "type": "call_service", "domain": "light", "service": "turn_off"
+}
+      </pre>
+    </div>
+    <div>
+      <button type="button" onclick="openSocket();" >Open</button>
+      <button type="button" onclick="send();" >Send</button>
+      <button type="button" onclick="closeSocket();" >Close</button>
+    </div>
+    <!-- Server responses get written here -->
+    <pre id="messages"></pre>
+
+    <!-- Script to utilise the WebSocket -->
+    <script type="text/javascript">
+      var webSocket;
+      var messages = document.getElementById("messages");
+
+      function openSocket(){
+        var isOpen = false;
+        // Ensures only one connection is open at a time
+        if(webSocket !== undefined && webSocket.readyState !== WebSocket.CLOSED){
+          writeResponse("WebSocket is already opened.");
+          return;
+        }
+        // Create a new instance of the websocket
+        webSocket = new WebSocket("ws://localhost:8123/api/websocket");
+
+        /**
+         * Binds functions to the listeners for the websocket.
+         */
+        webSocket.onopen = function(event){
+          if (!isOpen) {
+            isOpen = true;
+            writeResponse('Connection opened');
+          }
+          // For reasons I can't determine, onopen gets called twice
+          // and the first time event.data is undefined.
+          // Leave a comment if you know the answer.
+          if(event.data === undefined)
+            return;
+
+          writeResponse(event.data);
+        };
+
+        webSocket.onmessage = function(event){
+          writeResponse(event.data);
+        };
+
+        webSocket.onclose = function(event){
+          writeResponse("Connection closed");
+        };
+      }
+
+      /**
+       * Sends the value of the text input to the server
+       */
+      function send(){
+        var text = document.getElementById("messageinput").value;
+        webSocket.send(text);
+      }
+
+      function closeSocket(){
+        webSocket.close();
+      }
+
+      function writeResponse(text){
+        messages.innerHTML += "\n" + text;
+      }
+
+      openSocket();
+    </script>
+  </body>
+</html>

--- a/homeassistant/components/frontend/www_static/websocket_test.html
+++ b/homeassistant/components/frontend/www_static/websocket_test.html
@@ -20,17 +20,17 @@
     <div class='controls'>
       <textarea id="messageinput">
         {
-          "type": "listen_event", "event_type": "state_changed"
+          "id": 1, "type": "listen_event", "event_type": "state_changed"
         }
       </textarea>
       <pre>
 Examples:
 {
-  "type": "listen_event", "event_type": "state_changed"
+  "id": 2, "type": "listen_event", "event_type": "state_changed"
 }
 
 {
-  "type": "call_service", "domain": "light", "service": "turn_off"
+  "id": 3, "type": "call_service", "domain": "light", "service": "turn_off"
 }
       </pre>
     </div>

--- a/homeassistant/components/frontend/www_static/websocket_test.html
+++ b/homeassistant/components/frontend/www_static/websocket_test.html
@@ -26,11 +26,15 @@
       <pre>
 Examples:
 {
-  "id": 2, "type": "listen_event", "event_type": "state_changed"
+  "id": 2, "type": "subscribe_events", "event_type": "state_changed"
 }
 
 {
   "id": 3, "type": "call_service", "domain": "light", "service": "turn_off"
+}
+
+{
+  "id": 4, "type": "unsubscribe_events", "subscription": 2
 }
       </pre>
     </div>

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -181,6 +181,7 @@ class ActiveConnection:
     """Handle an active websocket client connection."""
 
     def __init__(self, hass, request):
+        """Initialize an active connection."""
         self.hass = hass
         self.request = request
         self.wsock = None

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -9,7 +9,8 @@ import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
 from homeassistant.const import (
-    MATCH_ALL, EVENT_TIME_CHANGED, EVENT_HOMEASSISTANT_STOP)
+    MATCH_ALL, EVENT_TIME_CHANGED, EVENT_HOMEASSISTANT_STOP,
+    __version__)
 from homeassistant.components import api, frontend
 from homeassistant.core import callback
 from homeassistant.remote import JSONEncoder
@@ -105,14 +106,16 @@ BASE_COMMAND_MESSAGE_SCHEMA = vol.Schema({
 def auth_ok_message():
     """Return an auth_ok message."""
     return {
-        'type': TYPE_AUTH_OK
+        'type': TYPE_AUTH_OK,
+        'ha_version': __version__,
     }
 
 
 def auth_required_message():
     """Return an auth_required message."""
     return {
-        'type': TYPE_AUTH_REQUIRED
+        'type': TYPE_AUTH_REQUIRED,
+        'ha_version': __version__,
     }
 
 
@@ -120,7 +123,7 @@ def auth_invalid_message(message):
     """Return an auth_invalid message."""
     return {
         'type': TYPE_AUTH_INVALID,
-        'message': message
+        'message': message,
     }
 
 

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -1,0 +1,244 @@
+"""Websocket based API for Home Assistant."""
+import asyncio
+from functools import partial
+import json
+import logging
+
+import aiohttp
+from aiohttp import web
+import voluptuous as vol
+from voluptuous.humanize import humanize_error
+
+from homeassistant.const import (
+    MATCH_ALL, EVENT_TIME_CHANGED, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.core import callback
+from homeassistant.remote import JSONEncoder
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.http.auth import validate_password
+from homeassistant.components.http.const import KEY_AUTHENTICATED
+
+DOMAIN = 'websocket_api'
+
+URL = "/api/websocket"
+DEPENDENCIES = 'http',
+
+ERR_INVALID_JSON = 1
+ERR_INVALID_AUTH = 2
+ERR_INVALID_FORMAT = 3
+ERR_INVALID_MSG_TYPE = 4
+ERR_AUTH_REQUIRED = 5
+
+TYPE_ERROR = 'error'
+TYPE_AUTH = 'auth'
+TYPE_AUTH_OK = 'auth_ok'
+TYPE_AUTH_REQUIRED = 'auth_required'
+TYPE_EVENT = 'event'
+TYPE_LISTEN_EVENT = 'listen_event'
+TYPE_CALL_SERVICE = 'call_service'
+
+_LOGGER = logging.getLogger(__name__)
+
+JSON_DUMP = partial(json.dumps, cls=JSONEncoder)
+
+AUTH_MESSAGE_SCHEMA = vol.Schema({
+    vol.Required('type'): TYPE_AUTH,
+    vol.Required('api_password'): str,
+})
+
+LISTEN_EVENT_MESSAGE_SCHEMA = vol.Schema({
+    vol.Required('type'): TYPE_LISTEN_EVENT,
+    vol.Optional('event_type', default=MATCH_ALL): str,
+})
+
+CALL_SERVICE_MESSAGE_SCHEMA = vol.Schema({
+    vol.Required('type'): TYPE_CALL_SERVICE,
+    vol.Required('domain'): str,
+    vol.Required('service'): str,
+    vol.Optional('service_data', default=None): dict
+})
+
+SERVER_MESSAGE_SCHEMA = vol.Any(LISTEN_EVENT_MESSAGE_SCHEMA,
+                                CALL_SERVICE_MESSAGE_SCHEMA)
+
+
+def auth_ok_message():
+    """Return an auth_ok message."""
+    return {
+        'type': TYPE_AUTH_OK
+    }
+
+
+def auth_required_message():
+    """Return an auth_ok message."""
+    return {
+        'type': TYPE_AUTH_REQUIRED
+    }
+
+
+def event_message(event):
+    """Return an event message."""
+    return {
+        'type': TYPE_EVENT,
+        'event': event.as_dict(),
+    }
+
+
+def error_message(code, message):
+    """Return an error message."""
+    return {
+        'type': TYPE_ERROR,
+        'error': {
+            'code': code,
+            'message': message,
+        },
+    }
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Initialize the websocket API."""
+    hass.http.register_view(WebsocketAPIView)
+    return True
+
+
+class WebsocketAPIView(HomeAssistantView):
+    """View to serve a websockets endpoint."""
+
+    name = "websocketapi"
+    url = URL
+    requires_auth = False
+
+    @asyncio.coroutine
+    def get(self, request):
+        """Handle an incoming websocket connection."""
+        # pylint: disable=no-self-use
+        hass = request.app['hass']
+        wsock = web.WebSocketResponse()
+        yield from wsock.prepare(request)
+
+        def debug(message1, message2=''):
+            """Print a debug message."""
+            _LOGGER.debug('WS %s: %s %s', id(wsock), message1, message2)
+
+        def error(message1, message2=''):
+            """Print an error message."""
+            _LOGGER.error('WS %s: %s %s', id(wsock), message1, message2)
+
+        disconnect_tasks = []
+
+        debug('Connected')
+
+        # Set up to cancel this connection when Home Assistant shuts down
+        socket_task = asyncio.Task.current_task(loop=hass.loop)
+
+        @callback
+        def cancel_connection(event):
+            """Cancel this connection."""
+            socket_task.cancel()
+
+        hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, cancel_connection)
+
+        def send_message(message):
+            """Helper method to send messages."""
+            debug('Sending', message)
+            wsock.send_json(message, dumps=JSON_DUMP)
+
+        @callback
+        def forward_event(event):
+            """Event listener that forwards events to websocket."""
+            if event.event_type == EVENT_TIME_CHANGED:
+                return
+
+            send_message(event_message(event))
+
+        msg = None
+        authenticated = False
+
+        try:
+            # Validate authentication
+            if request[KEY_AUTHENTICATED]:
+                send_message(auth_ok_message())
+                authenticated = True
+
+            else:
+                send_message(auth_required_message())
+                msg = yield from wsock.receive_json()
+                msg = AUTH_MESSAGE_SCHEMA(msg)
+
+                if not validate_password(request, msg['api_password']):
+                    debug('Invalid password')
+                    send_message(error_message(ERR_INVALID_AUTH,
+                                               'Invalid password'))
+                    return wsock
+
+                authenticated = True
+                send_message(auth_ok_message())
+
+            msg = yield from wsock.receive_json()
+
+            while msg:
+                debug('Received', msg)
+                msg = SERVER_MESSAGE_SCHEMA(msg)
+
+                if msg['type'] == TYPE_LISTEN_EVENT:
+                    disconnect_tasks.append(
+                        hass.bus.async_listen(msg['event_type'],
+                                              forward_event))
+
+                elif msg['type'] == TYPE_CALL_SERVICE:
+                    hass.async_add_job(hass.services.async_call, msg['domain'],
+                                       msg['service'], msg['service_data'])
+
+                msg = yield from wsock.receive_json()
+
+        except vol.Invalid as err:
+            # When we require authentication, the first message has to be
+            # of type='auth'. If it wasn't, give a more helpful error message.
+            if (not authenticated and isinstance(msg, dict) and
+                    msg.get('type') != TYPE_AUTH):
+                error_code = ERR_AUTH_REQUIRED
+                error_msg = 'Authentication required'
+            else:
+                error_code = ERR_INVALID_FORMAT
+                error_msg = 'Message incorrectly formatted: '
+                if msg:
+                    error_msg += humanize_error(msg, err)
+                else:
+                    error_msg += str(err)
+
+            error(error_msg)
+            send_message(error_message(error_code, error_msg))
+
+        except TypeError as err:
+            # We did not get a string message
+            msg = yield from wsock.receive()
+
+            if msg.type == aiohttp.WSMsgType.CLOSED:
+                debug('Connection closed by client')
+            else:
+                error('Received unexpected message from client', msg)
+
+        except ValueError as err:
+            # String message contained invalid JSON
+            msg = 'Received invalid JSON'
+            value = getattr(err, 'doc', None)  # Py3.5+ only
+            if value:
+                msg += ': {}'.format(value)
+
+            error(msg)
+            send_message(error_message(ERR_INVALID_FORMAT, msg))
+
+        except asyncio.CancelledError:
+            debug('Connection cancelled by server')
+
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception('Unexpected error inside websocket API.')
+
+        finally:
+            for task in disconnect_tasks:
+                task()
+
+            yield from wsock.close()
+            debug('Closed connection')
+
+        return wsock

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -4,7 +4,6 @@ from functools import partial
 import json
 import logging
 
-import aiohttp
 from aiohttp import web
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
@@ -13,6 +12,7 @@ from homeassistant.const import (
     MATCH_ALL, EVENT_TIME_CHANGED, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.core import callback
 from homeassistant.remote import JSONEncoder
+from homeassistant.helpers import config_validation as cv
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.auth import validate_password
 from homeassistant.components.http.const import KEY_AUTHENTICATED
@@ -22,19 +22,17 @@ DOMAIN = 'websocket_api'
 URL = "/api/websocket"
 DEPENDENCIES = 'http',
 
-ERR_INVALID_JSON = 1
-ERR_INVALID_AUTH = 2
-ERR_INVALID_FORMAT = 3
-ERR_INVALID_MSG_TYPE = 4
-ERR_AUTH_REQUIRED = 5
+ERR_ID_REUSE = 1
+ERR_INVALID_FORMAT = 2
 
-TYPE_ERROR = 'error'
 TYPE_AUTH = 'auth'
 TYPE_AUTH_OK = 'auth_ok'
 TYPE_AUTH_REQUIRED = 'auth_required'
+TYPE_AUTH_INVALID = 'auth_invalid'
 TYPE_EVENT = 'event'
 TYPE_LISTEN_EVENT = 'listen_event'
 TYPE_CALL_SERVICE = 'call_service'
+TYPE_RESULT = 'result'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,19 +44,23 @@ AUTH_MESSAGE_SCHEMA = vol.Schema({
 })
 
 LISTEN_EVENT_MESSAGE_SCHEMA = vol.Schema({
+    vol.Required('id'): cv.positive_int,
     vol.Required('type'): TYPE_LISTEN_EVENT,
     vol.Optional('event_type', default=MATCH_ALL): str,
 })
 
 CALL_SERVICE_MESSAGE_SCHEMA = vol.Schema({
+    vol.Required('id'): cv.positive_int,
     vol.Required('type'): TYPE_CALL_SERVICE,
     vol.Required('domain'): str,
     vol.Required('service'): str,
     vol.Optional('service_data', default=None): dict
 })
 
-SERVER_MESSAGE_SCHEMA = vol.Any(LISTEN_EVENT_MESSAGE_SCHEMA,
-                                CALL_SERVICE_MESSAGE_SCHEMA)
+SERVER_MESSAGE_SCHEMA = vol.Schema({
+    vol.Required('id'): cv.positive_int,
+    vol.Required('type'): vol.Any(TYPE_CALL_SERVICE, TYPE_LISTEN_EVENT)
+}, extra=vol.ALLOW_EXTRA)
 
 
 def auth_ok_message():
@@ -69,28 +71,49 @@ def auth_ok_message():
 
 
 def auth_required_message():
-    """Return an auth_ok message."""
+    """Return an auth_required message."""
     return {
         'type': TYPE_AUTH_REQUIRED
     }
 
 
-def event_message(event):
+def auth_invalid_message(message):
+    """Return an auth_invalid message."""
+    return {
+        'type': TYPE_AUTH_INVALID,
+        'message': message
+    }
+
+
+def event_message(iden, event):
     """Return an event message."""
     return {
+        'id': iden,
         'type': TYPE_EVENT,
         'event': event.as_dict(),
     }
 
 
-def error_message(code, message):
-    """Return an error message."""
+def error_message(iden, code, message):
+    """Return an error result message."""
     return {
-        'type': TYPE_ERROR,
+        'id': iden,
+        'type': TYPE_RESULT,
+        'success': False,
         'error': {
             'code': code,
             'message': message,
         },
+    }
+
+
+def result_message(iden, result=None):
+    """Return a success result message."""
+    return {
+        'id': iden,
+        'type': TYPE_RESULT,
+        'success': True,
+        'result': result,
     }
 
 
@@ -120,13 +143,9 @@ class WebsocketAPIView(HomeAssistantView):
             """Print a debug message."""
             _LOGGER.debug('WS %s: %s %s', id(wsock), message1, message2)
 
-        def error(message1, message2=''):
+        def log_error(message1, message2=''):
             """Print an error message."""
             _LOGGER.error('WS %s: %s %s', id(wsock), message1, message2)
-
-        disconnect_tasks = []
-
-        debug('Connected')
 
         # Set up to cancel this connection when Home Assistant shuts down
         socket_task = asyncio.Task.current_task(loop=hass.loop)
@@ -143,21 +162,14 @@ class WebsocketAPIView(HomeAssistantView):
             debug('Sending', message)
             wsock.send_json(message, dumps=JSON_DUMP)
 
-        @callback
-        def forward_event(event):
-            """Event listener that forwards events to websocket."""
-            if event.event_type == EVENT_TIME_CHANGED:
-                return
-
-            send_message(event_message(event))
+        debug('Connected')
 
         msg = None
         authenticated = False
+        event_listeners = {}
 
         try:
-            # Validate authentication
             if request[KEY_AUTHENTICATED]:
-                send_message(auth_ok_message())
                 authenticated = True
 
             else:
@@ -165,68 +177,84 @@ class WebsocketAPIView(HomeAssistantView):
                 msg = yield from wsock.receive_json()
                 msg = AUTH_MESSAGE_SCHEMA(msg)
 
-                if not validate_password(request, msg['api_password']):
+                if validate_password(request, msg['api_password']):
+                    authenticated = True
+
+                else:
                     debug('Invalid password')
-                    send_message(error_message(ERR_INVALID_AUTH,
-                                               'Invalid password'))
+                    send_message(auth_invalid_message('Invalid password'))
                     return wsock
 
-                authenticated = True
-                send_message(auth_ok_message())
+            if not authenticated:
+                return wsock
+
+            send_message(auth_ok_message())
 
             msg = yield from wsock.receive_json()
+
+            last_id = 0
 
             while msg:
                 debug('Received', msg)
                 msg = SERVER_MESSAGE_SCHEMA(msg)
+                cur_id = msg['id']
 
-                if msg['type'] == TYPE_LISTEN_EVENT:
-                    disconnect_tasks.append(
-                        hass.bus.async_listen(msg['event_type'],
-                                              forward_event))
+                if cur_id < last_id:
+                    send_message(error_message(
+                        cur_id, ERR_ID_REUSE,
+                        'Identifier values have to increase.'))
+
+                elif msg['type'] == TYPE_LISTEN_EVENT:
+                    msg = LISTEN_EVENT_MESSAGE_SCHEMA(msg)
+
+                    event_listeners[msg['id']] = hass.bus.async_listen(
+                        msg['event_type'],
+                        partial(_forward_event, msg['id'], send_message))
+
+                    send_message(result_message(msg['id']))
 
                 elif msg['type'] == TYPE_CALL_SERVICE:
-                    hass.async_add_job(hass.services.async_call, msg['domain'],
-                                       msg['service'], msg['service_data'])
+                    msg = CALL_SERVICE_MESSAGE_SCHEMA(msg)
 
+                    hass.async_add_job(_call_service_helper(hass, msg,
+                                                            send_message))
+
+                last_id = cur_id
                 msg = yield from wsock.receive_json()
 
         except vol.Invalid as err:
-            # When we require authentication, the first message has to be
-            # of type='auth'. If it wasn't, give a more helpful error message.
-            if (not authenticated and isinstance(msg, dict) and
-                    msg.get('type') != TYPE_AUTH):
-                error_code = ERR_AUTH_REQUIRED
-                error_msg = 'Authentication required'
+            error_msg = 'Message incorrectly formatted: '
+            if msg:
+                error_msg += humanize_error(msg, err)
             else:
-                error_code = ERR_INVALID_FORMAT
-                error_msg = 'Message incorrectly formatted: '
-                if msg:
-                    error_msg += humanize_error(msg, err)
-                else:
-                    error_msg += str(err)
+                error_msg += str(err)
 
-            error(error_msg)
-            send_message(error_message(error_code, error_msg))
+            log_error(error_msg)
+
+            if not authenticated:
+                send_message(auth_invalid_message(error_msg))
+
+            else:
+                if isinstance(msg, dict):
+                    iden = msg.get('id')
+                else:
+                    iden = None
+
+                send_message(error_message(iden, ERR_INVALID_FORMAT,
+                                           error_msg))
 
         except TypeError as err:
-            # We did not get a string message
-            msg = yield from wsock.receive()
-
-            if msg.type == aiohttp.WSMsgType.CLOSED:
+            if wsock.closed:
                 debug('Connection closed by client')
             else:
-                error('Received unexpected message from client', msg)
+                log_error('Unexpected TypeError', msg)
 
         except ValueError as err:
-            # String message contained invalid JSON
             msg = 'Received invalid JSON'
             value = getattr(err, 'doc', None)  # Py3.5+ only
             if value:
                 msg += ': {}'.format(value)
-
-            error(msg)
-            send_message(error_message(ERR_INVALID_FORMAT, msg))
+            log_error(msg)
 
         except asyncio.CancelledError:
             debug('Connection cancelled by server')
@@ -235,10 +263,35 @@ class WebsocketAPIView(HomeAssistantView):
             _LOGGER.exception('Unexpected error inside websocket API.')
 
         finally:
-            for task in disconnect_tasks:
-                task()
+            for unsub in event_listeners.values():
+                unsub()
 
             yield from wsock.close()
             debug('Closed connection')
 
         return wsock
+
+
+@asyncio.coroutine
+def _call_service_helper(hass, msg, send_message):
+    """Helper to call a service and fire complete message."""
+    yield from hass.services.async_call(msg['domain'], msg['service'],
+                                        msg['service_data'])
+    try:
+        send_message(result_message(msg['id']))
+    except RuntimeError:
+        # Socket has been closed.
+        pass
+
+
+@callback
+def _forward_event(iden, send_message, event):
+    """Helper to forward events to websocket."""
+    if event.event_type == EVENT_TIME_CHANGED:
+        return
+
+    try:
+        send_message(event_message(iden, event))
+    except RuntimeError:
+        # Socket has been closed.
+        pass

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,5 +12,6 @@ pytest-asyncio>=0.5.0
 pytest-cov>=2.3.1
 pytest-timeout>=1.2.0
 pytest-catchlog>=1.2.2
+pytest-sugar>=0.7.1
 requests_mock>=1.0
 mock-open>=1.3.1

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -1,0 +1,204 @@
+import asyncio
+from unittest.mock import patch
+
+from aiohttp import WSMsgType
+from async_timeout import timeout
+import pytest
+
+from homeassistant.core import callback
+from homeassistant.components import websocket_api as wapi
+
+from tests.common import mock_http_component_app
+
+API_PASSWORD = 'test1234'
+
+
+@pytest.fixture
+def websocket_client(loop, hass, test_client):
+    """Websocket client fixture connected to websocket server."""
+    websocket_app = mock_http_component_app(hass)
+    wapi.WebsocketAPIView().register(websocket_app.router)
+
+    client = loop.run_until_complete(test_client(websocket_app))
+    ws = loop.run_until_complete(client.ws_connect(wapi.URL))
+
+    auth_ok = loop.run_until_complete(ws.receive_json())
+    assert auth_ok['type'] == wapi.TYPE_AUTH_OK
+
+    yield ws
+
+    if not ws.closed:
+        loop.run_until_complete(ws.close())
+
+
+@pytest.fixture
+def no_auth_websocket_client(hass, loop, test_client):
+    """Websocket connection that requires authentication."""
+    websocket_app = mock_http_component_app(hass, API_PASSWORD)
+    wapi.WebsocketAPIView().register(websocket_app.router)
+
+    client = loop.run_until_complete(test_client(websocket_app))
+    ws = loop.run_until_complete(client.ws_connect(wapi.URL))
+
+    auth_ok = loop.run_until_complete(ws.receive_json())
+    assert auth_ok['type'] == wapi.TYPE_AUTH_REQUIRED
+
+    yield ws
+
+    if not ws.closed:
+        loop.run_until_complete(ws.close())
+
+
+@asyncio.coroutine
+def test_auth_via_msg(no_auth_websocket_client):
+    """Test authenticating."""
+    no_auth_websocket_client.send_json({
+        'type': wapi.TYPE_AUTH,
+        'api_password': API_PASSWORD
+    })
+
+    msg = yield from no_auth_websocket_client.receive_json()
+
+    assert msg['type'] == wapi.TYPE_AUTH_OK
+
+
+@asyncio.coroutine
+def test_auth_via_msg_incorrect_pass(no_auth_websocket_client):
+    """Test authenticating."""
+    no_auth_websocket_client.send_json({
+        'type': wapi.TYPE_AUTH,
+        'api_password': API_PASSWORD + 'wrong'
+    })
+
+    msg = yield from no_auth_websocket_client.receive_json()
+
+    assert msg['type'] == wapi.TYPE_ERROR
+    error = msg['error']
+    assert error['code'] == wapi.ERR_INVALID_AUTH
+    assert error['message'].startswith('Invalid password')
+
+
+@asyncio.coroutine
+def test_pre_auth_only_auth_allowed(no_auth_websocket_client):
+    """Verify that before authentication, only auth messages are allowed."""
+    no_auth_websocket_client.send_json({
+        'type': wapi.TYPE_CALL_SERVICE,
+        'domain': 'domain_test',
+        'service': 'test_service',
+        'service_data': {
+            'hello': 'world'
+        }
+    })
+
+    msg = yield from no_auth_websocket_client.receive_json()
+
+    assert msg['type'] == wapi.TYPE_ERROR
+    error = msg['error']
+    assert error['code'] == wapi.ERR_AUTH_REQUIRED
+    assert error['message'].startswith('Authentication required')
+
+
+@asyncio.coroutine
+def test_invalid_message_format(websocket_client):
+    """Test sending invalid JSON."""
+    websocket_client.send_json({'type': 5})
+
+    msg = yield from websocket_client.receive_json()
+
+    assert msg['type'] == wapi.TYPE_ERROR
+    error = msg['error']
+    assert error['code'] == wapi.ERR_INVALID_FORMAT
+    assert error['message'].startswith('Message incorrectly formatted')
+
+
+@asyncio.coroutine
+def test_invalid_json(websocket_client):
+    """Test sending invalid JSON."""
+    websocket_client.send_str('this is not JSON')
+
+    msg = yield from websocket_client.receive_json()
+
+    assert msg['type'] == wapi.TYPE_ERROR
+    error = msg['error']
+    assert error['code'] == wapi.ERR_INVALID_FORMAT
+    assert error['message'].startswith('Received invalid JSON')
+
+
+@asyncio.coroutine
+def test_quiting_hass(hass, websocket_client):
+    """Test sending invalid JSON."""
+    with patch.object(hass.loop, 'stop'):
+        yield from hass.async_stop()
+
+    msg = yield from websocket_client.receive()
+
+    assert msg.type == WSMsgType.CLOSE
+
+
+@asyncio.coroutine
+def test_call_service(hass, websocket_client):
+    """Test call service command."""
+    calls = []
+
+    @callback
+    def service_call(call):
+        calls.append(call)
+
+    hass.services.async_register('domain_test', 'test_service', service_call)
+
+    websocket_client.send_json({
+        'type': wapi.TYPE_CALL_SERVICE,
+        'domain': 'domain_test',
+        'service': 'test_service',
+        'service_data': {
+            'hello': 'world'
+        }
+    })
+
+    yield from websocket_client.close()
+
+    assert len(calls) == 1
+    call = calls[0]
+
+    assert call.domain == 'domain_test'
+    assert call.service == 'test_service'
+    assert call.data == {'hello': 'world'}
+
+
+@asyncio.coroutine
+def test_call_listen_event_match_event_type(hass, websocket_client):
+    """Test call service command."""
+    init_count = sum(hass.bus.async_listeners().values())
+
+    websocket_client.send_json({
+        'type': wapi.TYPE_LISTEN_EVENT,
+        'event_type': 'test_event'
+    })
+
+    for _ in range(4):
+        yield from asyncio.sleep(0, loop=hass.loop)
+        list_count = sum(hass.bus.async_listeners().values())
+        if list_count == init_count + 1:
+            break
+
+    # Verify we have a new listener
+    assert list_count == init_count + 1
+
+    hass.bus.async_fire('ignore_event')
+    hass.bus.async_fire('test_event', {'hello': 'world'})
+    hass.bus.async_fire('ignore_event')
+
+    with timeout(3, loop=hass.loop):
+        msg = yield from websocket_client.receive_json()
+
+    assert msg['type'] == wapi.TYPE_EVENT
+    event = msg['event']
+
+    assert event['event_type'] == 'test_event'
+    assert event['data'] == {'hello': 'world'}
+    assert event['origin'] == 'LOCAL'
+
+    yield from websocket_client.close()
+
+    # Check our listener got unsubscribed
+    assert sum(hass.bus.async_listeners().values()) == init_count

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv =
     LANG=en_US.UTF-8
     PYTHONPATH = {toxinidir}:{toxinidir}/homeassistant
 commands =
-     py.test -v --timeout=30 --duration=10 --cov --cov-report= {posargs}
+     py.test --timeout=30 --duration=10 --cov --cov-report= {posargs}
 deps =
      -r{toxinidir}/requirements_all.txt
      -r{toxinidir}/requirements_test.txt


### PR DESCRIPTION
This is the start of a new websocket API. Goal of this API is to power the next generation of Home Assistant clients.

To test websocket API locally, navigate to the included websocket tester at http://localhost:8123/static/websocket_test.html

(this is also the draft for the docs)

# Server states

 1. Client connects
 2. Authentication phase starts
    a. If no further authentication necessary for the user: go to 3
    b. Server sends `auth_required` message
    c. Client sends `auth` message
    d. If `auth` message correct: go to 3.
    e. Server sends `auth_invalid`. Go to 6.
 3. Send `auth_ok` message
 4. Authentication phase ends.
 5. Command phase starts.
    a. Client can send commands.
    b. Server can send results of previous commands.
 6. Client or server disconnects session.

During the command phase, the client attaches a unique identifier to each message. The server will add this identifier to each message so that the client can link each message to it's origin.

# Message format

Each API message is a JSON serialized object containing a `type` key. After the authentication phase messages also must contain an `id`, an integer that contains the number of interactions.

Example of an auth message:

```json5
{
  "type": "auth",
  "api_password": "supersecret"
}
```

```json5
{
   "id" 5,
   "type":"event",
   "event":{
      "data":{},
      "event_type":"test_event",
      "time_fired":"2016-11-26T01:37:24.265429+00:00",
      "origin":"LOCAL"
   }
}
```

# Authentication phase

When a client connects to the server, the server will test if the client is authenticated. Authentication will not be necessary if no api_password is set or if the user fulfills one of the other criteria for authentication (trusted network, password in url/header).

If no authentication is needed, the authentication phase will complete and the server will send an `auth_ok` message.

```json5
{
  "type": "auth_ok"
}
```

If authentication is necessary, the server sends out `auth_required`.

```json5
{
  "type": "auth_required"
}
```

This means that the next message from the client should be an auth message:

```json5
{
  "type": "auth",
  "api_password": "supersecret"
}
```

If the client supplies valid authentication, the authentication phase will complete by the server sending the `auth_ok` message:

```json5
{
  "type": "auth_ok"
}
```

If the data is incorrect, the server will reply with `auth_invalid` message and disconnect the session.

```json5
{
  "type": "auth_invalid",
  "message": "Invalid password"
}
```

# Command phase

During this phase the client can give commands to the server. The server will respond to each command with a `result` message indicating when the command is done and if it was successful.

```json5
{
  "id": 6.
  "type": "result",
  "success": true,
  // Can contain extra result info
  "result": null
}
```

## Subscribe to events

The command `subscribe_events` will subscribe your client to the event bus. You can either listen to all events or to a specific event type. If you want to listen to multiple event types, you will have to send multiple `subscribe_events` commands.

```json5
{
  "id": 18,
  "type": "subscribe_events",
  // Optional
  "event_type": "state_changed"
}
```

The server will respond with a result message to indicate that the subscription is active.

```json5
{
  "id": 18,
  "type": "result",
  "success": true,
  "result": null
}
```

For each event that matches, the server will send a message of type `event`. The `id` in the message will point at the original `id` of the `listen_event` command.

```json5
{
   "id": 18,
   "type":"event",
   "event":{
      "data":{
         "entity_id":"light.bed_light",
         "new_state":{
            "entity_id":"light.bed_light",
            "last_changed":"2016-11-26T01:37:24.265390+00:00",
            "state":"on",
            "attributes":{
               "rgb_color":[
                  254,
                  208,
                  0
               ],
               "color_temp":380,
               "supported_features":147,
               "xy_color":[
                  0.5,
                  0.5
               ],
               "brightness":180,
               "white_value":200,
               "friendly_name":"Bed Light"
            },
            "last_updated":"2016-11-26T01:37:24.265390+00:00"
         },
         "old_state":{
            "entity_id":"light.bed_light",
            "last_changed":"2016-11-26T01:37:10.466994+00:00",
            "state":"off",
            "attributes":{
               "supported_features":147,
               "friendly_name":"Bed Light"
            },
            "last_updated":"2016-11-26T01:37:10.466994+00:00"
         }
      },
      "event_type":"state_changed",
      "time_fired":"2016-11-26T01:37:24.265429+00:00",
      "origin":"LOCAL"
   }
}
```

## Unsubscribing from events

You can unsubscribe from previously created subscription events. Pass the id of the original subscription command as value to the subscription field.

```json5
{
  "id": 19,
  "type": "unsubscribe_events",
  "subscription": 18
}
```

The server will respond with a result message to indicate that unsubscribing was successful.

```json5
{
  "id": 19,
  "type": "result",
  "success": true,
  "result": null
}
```


## Calling a service

This will call a service in Home Assistant. Right now there is no return value. The client can listen to `state_changed` events if it is interested in changed entities as a result of a service call.

```json5
{
  "id": 24,
  "type": "call_service",
  "domain": "light",
  "service": "turn_on",
  // Optional
  "service_data": {
    "entity_id": "light.kitchen"
  }
}
```

The server will indicate with a message indicating that the service is done executing.

```json5
{
  "id": 24,
  "type": "result",
  "success": true,
  "result": null
}
```

## Fetching states

This will get a dump of all the current states in Home Assistant.

```json5
{
  "id": 19,
  "type": "get_states"
}
```

The server will respond with a result message containing the states.

```json5
{
  "id": 19,
  "type": "result",
  "success": true,
  "result": [ … ]
}
```

## Fetching config

This will get a dump of the current config in Home Assistant.

```json5
{
  "id": 19,
  "type": "get_config"
}
```

The server will respond with a result message containing the config.

```json5
{
  "id": 19,
  "type": "result",
  "success": true,
  "result": { … }
}
```

## Fetching services

This will get a dump of the current services in Home Assistant.

```json5
{
  "id": 19,
  "type": "get_config"
}
```

The server will respond with a result message containing the services.

```json5
{
  "id": 19,
  "type": "result",
  "success": true,
  "result": { … }
}
```

## Fetching panels

This will get a dump of the current registered panels in Home Assistant.

```json5
{
  "id": 19,
  "type": "get_panels"
}
```

The server will respond with a result message containing the current registered panels.

```json5
{
  "id": 19,
  "type": "result",
  "success": true,
  "result": [ … ]
}
```

# Error handling

If an error occurs, the `success` key in the `result` message will be set to `false`. It will contain an `error` key containing an object with two keys: `code` and `message`.

| Code | Description |
| ----- | ------------ |
| 1 | A non-increasing identifier has been supplied.
| 2 | Received message is not in expected format (voluptuous validation error).
| 3 | Requested item cannot be found

```json5
{
   "id": 12,
   "type":"result",
   "success": false,
   "error": {
      "code": 2,
      "message": "Message incorrectly formatted: expected str for dictionary value @ data['event_type']. Got 100"
   }
}
```
