### PR TITLE
Allow tolerance to be customisable

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -21,10 +21,10 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['switch', 'sensor']
 
-TOL_TEMP = 0.3
+DEFAULT_TOLERANCE = 0.3
+DEFAULT_NAME = 'Generic Thermostat'
 
 CONF_NAME = 'name'
-DEFAULT_NAME = 'Generic Thermostat'
 CONF_HEATER = 'heater'
 CONF_SENSOR = 'target_sensor'
 CONF_MIN_TEMP = 'min_temp'
@@ -32,6 +32,7 @@ CONF_MAX_TEMP = 'max_temp'
 CONF_TARGET_TEMP = 'target_temp'
 CONF_AC_MODE = 'ac_mode'
 CONF_MIN_DUR = 'min_cycle_duration'
+CONF_TOLERANCE = 'tolerance'
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -42,6 +43,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MIN_DUR): vol.All(cv.time_period, cv.positive_timedelta),
     vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_TOLERANCE, default=DEFAULT_TOLERANCE): vol.Coerce(float),
     vol.Optional(CONF_TARGET_TEMP): vol.Coerce(float),
 })
 
@@ -56,23 +58,26 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     target_temp = config.get(CONF_TARGET_TEMP)
     ac_mode = config.get(CONF_AC_MODE)
     min_cycle_duration = config.get(CONF_MIN_DUR)
+    tolerance = config.get(CONF_TOLERANCE)
 
     add_devices([GenericThermostat(
         hass, name, heater_entity_id, sensor_entity_id, min_temp, max_temp,
-        target_temp, ac_mode, min_cycle_duration)])
+        target_temp, ac_mode, min_cycle_duration, tolerance)])
 
 
 class GenericThermostat(ClimateDevice):
     """Representation of a GenericThermostat device."""
 
     def __init__(self, hass, name, heater_entity_id, sensor_entity_id,
-                 min_temp, max_temp, target_temp, ac_mode, min_cycle_duration):
+                 min_temp, max_temp, target_temp, ac_mode, min_cycle_duration,
+                 tolerance):
         """Initialize the thermostat."""
         self.hass = hass
         self._name = name
         self.heater_entity_id = heater_entity_id
         self.ac_mode = ac_mode
         self.min_cycle_duration = min_cycle_duration
+        self._tolerance = tolerance
 
         self._active = False
         self._cur_temp = None
@@ -193,7 +198,7 @@ class GenericThermostat(ClimateDevice):
                 return
 
         if self.ac_mode:
-            too_hot = self._cur_temp - self._target_temp > TOL_TEMP
+            too_hot = self._cur_temp - self._target_temp > self._tolerance
             is_cooling = self._is_device_active
             if too_hot and not is_cooling:
                 _LOGGER.info('Turning on AC %s', self.heater_entity_id)
@@ -202,7 +207,7 @@ class GenericThermostat(ClimateDevice):
                 _LOGGER.info('Turning off AC %s', self.heater_entity_id)
                 switch.turn_off(self.hass, self.heater_entity_id)
         else:
-            too_cold = self._target_temp - self._cur_temp > TOL_TEMP
+            too_cold = self._target_temp - self._cur_temp > self._tolerance
             is_heating = self._is_device_active
 
             if too_cold and not is_heating:


### PR DESCRIPTION
**Description:**

Tolerance should be customisable to allow for inaccurate sensors.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#soon

**Example entry for `configuration.yaml` (if applicable):**
```yaml
climate:
  platform: generic_thermostat
  heater: switch.heater
  sensor: sensor.temp
  tolerance: 5
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.