### PR TITLE
Remove fixed throttle for binary_sensor.command_line and sensor.command_line since the scan_interval is configured trough YAML since #1059

### DIFF
--- a/homeassistant/components/binary_sensor/command_line.py
+++ b/homeassistant/components/binary_sensor/command_line.py
@@ -23,8 +23,6 @@ DEFAULT_NAME = 'Binary Command Sensor'
 DEFAULT_PAYLOAD_ON = 'ON'
 DEFAULT_PAYLOAD_OFF = 'OFF'
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COMMAND): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/homeassistant/components/binary_sensor/command_line.py
+++ b/homeassistant/components/binary_sensor/command_line.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.command_line/
 """
 import logging
-from datetime import timedelta
 
 import voluptuous as vol
 

--- a/homeassistant/components/binary_sensor/command_line.py
+++ b/homeassistant/components/binary_sensor/command_line.py
@@ -22,6 +22,8 @@ DEFAULT_NAME = 'Binary Command Sensor'
 DEFAULT_PAYLOAD_ON = 'ON'
 DEFAULT_PAYLOAD_OFF = 'OFF'
 
+SCAN_INTERVAL = 60
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COMMAND): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/sensor.command_line/
 """
 import logging
 import subprocess
-from datetime import timedelta
 
 import voluptuous as vol
 
@@ -15,7 +14,6 @@ from homeassistant.const import (
     CONF_NAME, CONF_VALUE_TEMPLATE, CONF_UNIT_OF_MEASUREMENT, CONF_COMMAND,
     STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -20,6 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Command Sensor'
 
+SCAN_INTERVAL = 60
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COMMAND): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -22,8 +22,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Command Sensor'
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COMMAND): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -96,7 +94,6 @@ class CommandSensorData(object):
         self.command = command
         self.value = None
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data with a shell command."""
         _LOGGER.info('Running command: %s', self.command)


### PR DESCRIPTION
**Description:**
Fixes `scan_interval` for `binary_sensor.command_line` and `sensor.command_line` since the `@Throttle(MIN_TIME_BETWEEN_UPDATES)` limited the configured amount. This caused an additional 60 second delay between checks.

**Related issue (if applicable):** fixes #2499, #2994 and #3652

**Example entry for `configuration.yaml` (if applicable):**
```yaml
binary_sensor:
  platform: command_line
  name: Printer
  command: ping -c 1 192.168.1.10 &> /dev/null && echo success || echo fail
  sensor_class: connectivity
  payload_on: "success"
  payload_off: "fail"
  scan_interval: 30
```


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51