### PR TITLE
Fixed unit_of_measurement functionality for knx sensor

### DIFF
--- a/homeassistant/components/sensor/knx.py
+++ b/homeassistant/components/sensor/knx.py
@@ -87,17 +87,10 @@ def update_and_define_min_max(config, minimum_default,
 class KNXSensorBaseClass():
     """Sensor Base Class for all KNX Sensors."""
 
-    _unit_of_measurement = None
-
     @property
     def cache(self):
         """We don't want to cache any Sensor Value."""
         return False
-
-    @property
-    def unit_of_measurement(self):
-        """Return the defined Unit of Measurement for the KNX Sensor."""
-        return self._unit_of_measurement
 
 
 class KNXSensorFloatClass(KNXGroupAddress, KNXSensorBaseClass):
@@ -121,6 +114,11 @@ class KNXSensorFloatClass(KNXGroupAddress, KNXSensorBaseClass):
     def state(self):
         """Return the Value of the KNX Sensor."""
         return self._value
+
+    @property
+    def unit_of_measurement(self):
+        """Return the defined Unit of Measurement for the KNX Sensor."""
+        return self._unit_of_measurement
 
     def update(self):
         """Update KNX sensor."""


### PR DESCRIPTION
**Description:**
Moved unit_of_measurement property to make it functional again

**Related issue (if applicable):** fixes  #4567


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

