### PR TITLE
TEMPer component: reset devices on address change

### DIFF
--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -24,27 +24,42 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_OFFSET, default=0): vol.Coerce(float)
 })
 
+TEMPER_SENSORS = []
+
+
+def get_temper_devices():
+    """Scan the Temper devices from temperusb."""
+    from temperusb.temper import TemperHandler
+    return TemperHandler().get_devices()
+
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Temper sensors."""
-    from temperusb.temper import TemperHandler
-
     temp_unit = hass.config.units.temperature_unit
     name = config.get(CONF_NAME)
     scaling = {
         'scale': config.get(CONF_SCALE),
         'offset': config.get(CONF_OFFSET)
     }
-    temper_devices = TemperHandler().get_devices()
-    devices = []
+    temper_devices = get_temper_devices()
 
     for idx, dev in enumerate(temper_devices):
         if idx != 0:
             name = name + '_' + str(idx)
-        devices.append(TemperSensor(dev, temp_unit, name, scaling))
+        TEMPER_SENSORS.append(TemperSensor(dev, temp_unit, name, scaling))
+    add_devices(TEMPER_SENSORS)
 
-    add_devices(devices)
+
+def reset_devices():
+    """
+    Re-scan for underlying Temper sensors and assign them to our devices.
+
+    This assumes the same sensor devices are present in the same order.
+    """
+    temper_devices = get_temper_devices()
+    for sensor, device in zip(TEMPER_SENSORS, temper_devices):
+        sensor.set_temper_device(device)
 
 
 class TemperSensor(Entity):
@@ -52,18 +67,12 @@ class TemperSensor(Entity):
 
     def __init__(self, temper_device, temp_unit, name, scaling):
         """Initialize the sensor."""
-        self.temper_device = temper_device
         self.temp_unit = temp_unit
         self.scale = scaling['scale']
         self.offset = scaling['offset']
         self.current_value = None
         self._name = name
-
-        # set calibration data
-        self.temper_device.set_calibration_data(
-            scale=self.scale,
-            offset=self.offset
-        )
+        self.set_temper_device(temper_device)
 
     @property
     def name(self):
@@ -80,6 +89,16 @@ class TemperSensor(Entity):
         """Return the unit of measurement of this entity, if any."""
         return self.temp_unit
 
+    def set_temper_device(self, temper_device):
+        """Assign the underlying device for this sensor."""
+        self.temper_device = temper_device
+
+        # set calibration data
+        self.temper_device.set_calibration_data(
+            scale=self.scale,
+            offset=self.offset
+        )
+
     def update(self):
         """Retrieve latest state."""
         try:
@@ -88,5 +107,6 @@ class TemperSensor(Entity):
             sensor_value = self.temper_device.get_temperature(format_str)
             self.current_value = round(sensor_value, 1)
         except IOError:
-            _LOGGER.error('Failed to get temperature due to insufficient '
-                          'permissions. Try running with "sudo"')
+            _LOGGER.error('Failed to get temperature. The device address may'
+                          'have changed - attempting to reset device')
+            reset_devices()


### PR DESCRIPTION
**Description:**
TEMPer component: reset devices on address change
    
The USB address of these devices periodically changes, causing
home-assistant to fail to read the temperature data. This PR fixes this
by re-reading the available devices on failure. I've been running this
for several days and for the first time have consistent temperature
data without having to restart home-assistant.


Fixes https://github.com/home-assistant/home-assistant/issues/4389

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51