### PR TITLE
Tweak services return result

### DIFF
--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -11,7 +11,7 @@ from voluptuous.humanize import humanize_error
 from homeassistant.const import (
     MATCH_ALL, EVENT_TIME_CHANGED, EVENT_HOMEASSISTANT_STOP,
     __version__)
-from homeassistant.components import api, frontend
+from homeassistant.components import frontend
 from homeassistant.core import callback
 from homeassistant.remote import JSONEncoder
 from homeassistant.helpers import config_validation as cv
@@ -400,7 +400,7 @@ class ActiveConnection:
         msg = GET_SERVICES_MESSAGE_SCHEMA(msg)
 
         self.send_message(result_message(msg['id'],
-                                         api.async_services_json(self.hass)))
+                                         self.hass.services.async_services()))
 
     def handle_get_config(self, msg):
         """Handle get config command."""

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -6,7 +6,7 @@ from async_timeout import timeout
 import pytest
 
 from homeassistant.core import callback
-from homeassistant.components import websocket_api as wapi, api, frontend
+from homeassistant.components import websocket_api as wapi, frontend
 
 from tests.common import mock_http_component_app
 

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -249,7 +249,7 @@ def test_get_services(hass, websocket_client):
     assert msg['id'] == 5
     assert msg['type'] == wapi.TYPE_RESULT
     assert msg['success']
-    assert msg['result'] == api.async_services_json(hass)
+    assert msg['result'] == hass.services.async_services()
 
 
 @asyncio.coroutine


### PR DESCRIPTION
**Description:**
The returned result for the services message was based on the Rest API spec. Changing it to be the format that we already transform the data to, so no unnecessary data transformation on both server and client.

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

