### PR TITLE
Refactory aiohttp clientsession handling in HA

### DIFF
--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION)
 from homeassistant.exceptions import TemplateError
 from homeassistant.components.camera import (PLATFORM_SCHEMA, Camera)
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util.async import run_coroutine_threadsafe
 
@@ -108,8 +109,9 @@ class GenericCamera(Camera):
         # async
         else:
             try:
+                websession = async_get_clientsession(self.hass)
                 with async_timeout.timeout(10, loop=self.hass.loop):
-                    response = yield from self.hass.websession.get(
+                    response = yield from websession.get(
                         url, auth=self._auth)
                     self._last_image = yield from response.read()
                     yield from response.release()

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_AUTHENTICATION,
     HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION)
 from homeassistant.components.camera import (PLATFORM_SCHEMA, Camera)
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -101,9 +102,10 @@ class MjpegCamera(Camera):
             return
 
         # connect to stream
+        websession = async_get_clientsession(self.hass)
         try:
             with async_timeout.timeout(10, loop=self.hass.loop):
-                stream = yield from self.hass.websession.get(
+                stream = yield from websession.get(
                     self._mjpeg_url,
                     auth=self._auth
                 )

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 from homeassistant.components.http import HomeAssistantView, KEY_AUTHENTICATED
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.async import run_coroutine_threadsafe
 from homeassistant.const import (
@@ -705,8 +706,9 @@ def _async_fetch_image(hass, url):
 
     content, content_type = (None, None)
     try:
+        websession = async_get_clientsession(hass)
         with async_timeout.timeout(10, loop=hass.loop):
-            response = yield from hass.websession.get(url)
+            response = yield from websession.get(url)
             if response.status == 200:
                 content = yield from response.read()
                 content_type = response.headers.get(CONTENT_TYPE_HEADER)

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -18,6 +18,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_LATITUDE, CONF_LONGITUDE, CONF_ELEVATION, CONF_MONITORED_CONDITIONS,
     ATTR_ATTRIBUTION)
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
     async_track_point_in_utc_time, async_track_utc_time_change)
@@ -155,8 +156,9 @@ class YrData(object):
 
         if self._nextrun is None or dt_util.utcnow() >= self._nextrun:
             try:
+                websession = async_get_clientsession(self.hass)
                 with async_timeout.timeout(10, loop=self.hass.loop):
-                    resp = yield from self.hass.websession.get(self._url)
+                    resp = yield from websession.get(self._url)
                 if resp.status != 200:
                     try_again('{} returned {}'.format(self._url, resp.status))
                     return

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -18,7 +18,6 @@ import threading
 from types import MappingProxyType
 from typing import Optional, Any, Callable, List  # NOQA
 
-import aiohttp
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
@@ -121,20 +120,11 @@ class HomeAssistant(object):
         self.data = {}
         self.state = CoreState.not_running
         self.exit_code = None
-        self._websession = None
 
     @property
     def is_running(self) -> bool:
         """Return if Home Assistant is running."""
         return self.state in (CoreState.starting, CoreState.running)
-
-    @property
-    def websession(self):
-        """Return an aiohttp session to make web requests."""
-        if self._websession is None:
-            self._websession = aiohttp.ClientSession(loop=self.loop)
-
-        return self._websession
 
     def start(self) -> None:
         """Start home assistant."""
@@ -295,8 +285,6 @@ class HomeAssistant(object):
         self.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         yield from self.async_block_till_done()
         self.executor.shutdown()
-        if self._websession is not None:
-            yield from self._websession.close()
         self.state = CoreState.not_running
         self.loop.stop()
 

--- a/homeassistant/helpers/httpclient.py
+++ b/homeassistant/helpers/httpclient.py
@@ -1,0 +1,110 @@
+"""Helper for aiohttp webclient stuff."""
+import asyncio
+
+import aiohttp
+
+from homeassistant.core import callback
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+
+
+DATA_CONNECTOR = 'aiohttp_connector'
+DATA_CONNECTOR_NOTVERIFY = 'aiohttp_connector_notverify'
+DATA_CLIENTSESSION = 'aiohttp_clientsession'
+DATA_CLIENTSESSION_NOTVERIFY = 'aiohttp_clientsession_notverify'
+
+
+def get_clientsession(hass, verify_ssl=True):
+    """Return default aiohttp ClientSession.
+
+    This method must be run in the event loop.
+    """
+    if verify_ssl:
+        key = DATA_CLIENTSESSION
+    else:
+        key = DATA_CLIENTSESSION_NOTVERIFY
+
+    if key not in hass.data:
+        connector = _async_get_connector(hass, verify_ssl)
+        clientsession = aiohttp.ClientSession(
+            loop=hass.loop,
+            connector=connector
+        )
+        _async_register_clientsession_shutdown(hass, clientsession)
+        hass.data[key] = clientsession
+
+    return hass.data[key]
+
+
+def create_clientsession(hass, verify_ssl=True, auto_cleanup=True, **kwargs):
+    """Create a new ClientSession with kwargs, i.e. for cookies.
+
+    Is auto_cleanup False, you need call detach() after this session will be
+    unused. True it do it self on homeassistant_stop.
+
+    This method must be run in the event loop.
+    """
+    connector = _async_get_connector(hass, verify_ssl)
+
+    clientsession = aiohttp.ClientSession(
+        loop=hass.loop,
+        connector=connector,
+        **kwargs
+    )
+
+    if auto_cleanup:
+        _async_register_clientsession_shutdown(hass, clientsession)
+
+    return clientsession
+
+
+def _async_register_clientsession_shutdown(hass, clientsession):
+    """Register ClientSession close on homeassistant shutdown.
+
+    This method must be run in the event loop.
+    """
+    @callback
+    def _async_close_websession():
+        """Close websession."""
+        clientsession.detach()
+
+    hass.bus.async_listen_once(
+        EVENT_HOMEASSISTANT_STOP, _async_close_websession)
+
+
+def _async_get_connector(hass, verify_ssl=True):
+    """Return the connector pool for aiohttp.
+
+    This method must be run in the event loop.
+    """
+    if verify_ssl:
+        if DATA_CONNECTOR not in hass.data:
+            connector = aiohttp.TCPConnector()
+            hass.data[DATA_CONNECTOR] = connector
+
+            _async_register_connector_shutdown(hass, connector)
+        else:
+            connector = hass.data[DATA_CONNECTOR]
+    else:
+        if DATA_CONNECTOR_NOTVERIFY not in hass.data:
+            connector = aiohttp.TCPConnector(verify_ssl=False)
+            hass.data[DATA_CONNECTOR_NOTVERIFY] = connector
+
+            _async_register_connector_shutdown(hass, connector)
+        else:
+            connector = hass.data[DATA_CONNECTOR_NOTVERIFY]
+
+    return connector
+
+
+def _async_register_connector_shutdown(hass, connector):
+    """Register connector pool close on homeassistant shutdown.
+
+    This method must be run in the event loop.
+    """
+    @asyncio.coroutine
+    def _async_close_connector(event):
+        """Close websession on shutdown."""
+        yield from connector.close()
+
+    hass.bus.async_listen_once(
+        EVENT_HOMEASSISTANT_STOP, _async_close_connector)

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -138,7 +138,6 @@ class HomeAssistant(ha.HomeAssistant):
         self.data = {}
         self.state = ha.CoreState.not_running
         self.exit_code = None
-        self._websession = None
         self.config.api = local_api
 
     def start(self):

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -7,6 +7,7 @@ from homeassistant.bootstrap import setup_component
 from homeassistant.const import HTTP_HEADER_HA_AUTH
 import homeassistant.components.media_player as mp
 import homeassistant.components.http as http
+from homeassistant.helpers.aiohttp_client import DATA_CLIENTSESSION
 
 import requests
 
@@ -289,7 +290,7 @@ class TestMediaPlayerWeb(unittest.TestCase):
             def close(self):
                 pass
 
-        self.hass._websession = MockWebsession()
+        self.hass.data[DATA_CLIENTSESSION] = MockWebsession()
 
         assert self.hass.states.is_state(entity_id, 'playing')
         state = self.hass.states.get(entity_id)

--- a/tests/helpers/test_aiohttp_client.py
+++ b/tests/helpers/test_aiohttp_client.py
@@ -1,0 +1,81 @@
+"""Test the aiohttp client helper."""
+import unittest
+
+import aiohttp
+
+import homeassistant.helpers.aiohttp_client as client
+from homeassistant.util.async import run_callback_threadsafe
+
+from tests.common import get_test_home_assistant
+
+
+class TestHelpersAiohttpClient(unittest.TestCase):
+    """Test homeassistant.helpers.aiohttp_client module."""
+
+    def setup_method(self, method):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_get_clientsession_with_ssl(self):
+        """Test init clientsession with ssl."""
+        run_callback_threadsafe(self.hass.loop, client.async_get_clientsession,
+                                self.hass).result()
+
+        assert isinstance(
+            self.hass.data[client.DATA_CLIENTSESSION], aiohttp.ClientSession)
+        assert isinstance(
+            self.hass.data[client.DATA_CONNECTOR], aiohttp.TCPConnector)
+
+    def test_get_clientsession_without_ssl(self):
+        """Test init clientsession without ssl."""
+        run_callback_threadsafe(self.hass.loop, client.async_get_clientsession,
+                                self.hass, False).result()
+
+        assert isinstance(
+            self.hass.data[client.DATA_CLIENTSESSION_NOTVERIFY],
+            aiohttp.ClientSession)
+        assert isinstance(
+            self.hass.data[client.DATA_CONNECTOR_NOTVERIFY],
+            aiohttp.TCPConnector)
+
+    def test_create_clientsession_with_ssl_and_cookies(self):
+        """Test create clientsession with ssl."""
+        def _async_helper():
+            return client.async_create_clientsession(
+                self.hass,
+                cookies={'bla': True}
+            )
+
+        session = run_callback_threadsafe(
+            self.hass.loop,
+            _async_helper,
+        ).result()
+
+        assert isinstance(
+            session, aiohttp.ClientSession)
+        assert isinstance(
+            self.hass.data[client.DATA_CONNECTOR], aiohttp.TCPConnector)
+
+    def test_create_clientsession_without_ssl_and_cookies(self):
+        """Test create clientsession without ssl."""
+        def _async_helper():
+            return client.async_create_clientsession(
+                self.hass,
+                False,
+                cookies={'bla': True}
+            )
+
+        session = run_callback_threadsafe(
+            self.hass.loop,
+            _async_helper,
+        ).result()
+
+        assert isinstance(
+            session, aiohttp.ClientSession)
+        assert isinstance(
+            self.hass.data[client.DATA_CONNECTOR_NOTVERIFY],
+            aiohttp.TCPConnector)


### PR DESCRIPTION
**Description:**

Refactory aiohttp clientsession handling. Now we use hass.data for websession and support easy use cookies or not validate ssl stuff.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

