### PR TITLE
Fixed incorrect event-order in logbook

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -139,9 +139,10 @@ class LogbookView(HomeAssistantView):
         def get_results():
             """Query DB for results."""
             events = recorder.get_model('Events')
-            query = recorder.query('Events').filter(
-                (events.time_fired > start_day) &
-                (events.time_fired < end_day))
+            query = recorder.query('Events').order_by(
+                events.time_fired).filter(
+                    (events.time_fired > start_day) &
+                    (events.time_fired < end_day))
             events = recorder.execute(query)
             return _exclude_events(events, self.config)
 


### PR DESCRIPTION
**Description:**
With 0.33.3 I've noticed, that the ordering of events on the logbooksite was scrambled. Same with 0.33.4. This PR fixes the issue by adding `order_by(events.time_fired)` when getting the events.
Maybe it's just my MySQL that's returning the data that way. But I guess in any case it's ok to ensure a correct ordering.