### PR TITLE
Bugfix World Air Quality Index sensor #4595

### DIFF
--- a/homeassistant/components/sensor/waqi.py
+++ b/homeassistant/components/sensor/waqi.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers import config_validation as cv
 import voluptuous as vol
 
-REQUIREMENTS = ["pwaqi==1.2"]
+REQUIREMENTS = ["pwaqi==1.3"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -346,7 +346,7 @@ pushbullet.py==0.10.0
 pushetta==1.0.15
 
 # homeassistant.components.sensor.waqi
-pwaqi==1.2
+pwaqi==1.3
 
 # homeassistant.components.sensor.cpuspeed
 py-cpuinfo==0.2.3


### PR DESCRIPTION
**Description:**
This PR fixes an issue with WAQI sensor when the external API responds with more than one message in result to the API call. The fix is to use newer version of pwaqi module (1.3) that handles this case properly.

**Related issue (if applicable):** fixes #4595 
