### PR TITLE
Default dimmable brightness to 255 from 100

### DIFF
--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -64,7 +64,7 @@ class ISYLightDevice(isy.ISYDevice, Light):
         if not self._node.fastoff():
             _LOGGER.debug('Unable to turn on light.')
 
-    def turn_on(self, brightness=100, **kwargs) -> None:
+    def turn_on(self, brightness=255, **kwargs) -> None:
         """Send the turn on command to the ISY994 light device."""
         if not self._node.on(val=brightness):
             _LOGGER.debug('Unable to turn on light.')

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -61,10 +61,10 @@ class ISYLightDevice(isy.ISYDevice, Light):
 
     def turn_off(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 light device."""
-        if not self._node.fastoff():
+        if not self._node.off():
             _LOGGER.debug('Unable to turn on light.')
 
-    def turn_on(self, brightness=255, **kwargs) -> None:
+    def turn_on(self, brightness=None, **kwargs) -> None:
         """Send the turn on command to the ISY994 light device."""
         if not self._node.on(val=brightness):
             _LOGGER.debug('Unable to turn on light.')


### PR DESCRIPTION
**Changes default ISY dimmable light brightness to 255**

Note, the branch name was misspelled and should have been "isy-brightness-fix". Thank you, auto-correct.

**Related issue:** fixes #4619

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

Full brightness for ISY dimmers is 255. The current 100 value turns dimmer switches on to just under half brightness.  Probably just an oversight from the Sept implementation.