### PR TITLE
Add option to hide the group card switch

### DIFF
--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -29,11 +29,13 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 CONF_ENTITIES = 'entities'
 CONF_VIEW = 'view'
+CONF_HIDE_SWITCH = 'hide_switch'
 
 ATTR_AUTO = 'auto'
 ATTR_ORDER = 'order'
 ATTR_VIEW = 'view'
 ATTR_VISIBLE = 'visible'
+ATTR_HIDE_SWITCH = 'hide_switch'
 
 SERVICE_SET_VISIBILITY = 'set_visibility'
 SET_VISIBILITY_SERVICE_SCHEMA = vol.Schema({
@@ -61,6 +63,7 @@ CONFIG_SCHEMA = vol.Schema({
         CONF_VIEW: cv.boolean,
         CONF_NAME: cv.string,
         CONF_ICON: cv.icon,
+        CONF_HIDE_SWITCH: cv.boolean,
     }, cv.match_all))
 }, extra=vol.ALLOW_EXTRA)
 
@@ -206,11 +209,13 @@ def _async_process_config(hass, config, component):
         entity_ids = conf.get(CONF_ENTITIES) or []
         icon = conf.get(CONF_ICON)
         view = conf.get(CONF_VIEW)
+        hide_switch = conf.get(CONF_HIDE_SWITCH)
 
         # Don't create tasks and await them all. The order is important as
         # groups get a number based on creation order.
         group = yield from Group.async_create_group(
-            hass, name, entity_ids, icon=icon, view=view, object_id=object_id)
+            hass, name, entity_ids, icon=icon, view=view,
+            hide_switch=hide_switch, object_id=object_id)
         groups.append(group)
 
     if groups:
@@ -221,7 +226,7 @@ class Group(Entity):
     """Track a group of entity ids."""
 
     def __init__(self, hass, name, order=None, user_defined=True, icon=None,
-                 view=False):
+                 view=False, hide_switch=False):
         """Initialize a group.
 
         This Object has factory function for creation.
@@ -239,20 +244,22 @@ class Group(Entity):
         self._assumed_state = False
         self._async_unsub_state_changed = None
         self._visible = True
+        self._hide_switch = hide_switch
 
     @staticmethod
     def create_group(hass, name, entity_ids=None, user_defined=True,
-                     icon=None, view=False, object_id=None):
+                     icon=None, view=False, hide_switch=False, object_id=None):
         """Initialize a group."""
         return run_coroutine_threadsafe(
             Group.async_create_group(hass, name, entity_ids, user_defined,
-                                     icon, view, object_id),
+                                     icon, view, hide_switch, object_id),
             hass.loop).result()
 
     @staticmethod
     @asyncio.coroutine
     def async_create_group(hass, name, entity_ids=None, user_defined=True,
-                           icon=None, view=False, object_id=None):
+                           icon=None, view=False, hide_switch=False,
+                           object_id=None):
         """Initialize a group.
 
         This method must be run in the event loop.
@@ -260,7 +267,8 @@ class Group(Entity):
         group = Group(
             hass, name,
             order=len(hass.states.async_entity_ids(DOMAIN)),
-            user_defined=user_defined, icon=icon, view=view)
+            user_defined=user_defined, icon=icon, view=view,
+            hide_switch=hide_switch)
 
         group.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, object_id or name, hass=hass)
@@ -319,6 +327,8 @@ class Group(Entity):
             data[ATTR_AUTO] = True
         if self._view:
             data[ATTR_VIEW] = True
+        if self._hide_switch:
+            data[ATTR_HIDE_SWITCH] = True
         return data
 
     @property

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -29,13 +29,13 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 CONF_ENTITIES = 'entities'
 CONF_VIEW = 'view'
-CONF_HIDE_SWITCH = 'hide_switch'
+CONF_CONTROL = 'control'
 
 ATTR_AUTO = 'auto'
 ATTR_ORDER = 'order'
 ATTR_VIEW = 'view'
 ATTR_VISIBLE = 'visible'
-ATTR_HIDE_SWITCH = 'hide_switch'
+ATTR_CONTROL = 'control'
 
 SERVICE_SET_VISIBILITY = 'set_visibility'
 SET_VISIBILITY_SERVICE_SCHEMA = vol.Schema({
@@ -63,7 +63,7 @@ CONFIG_SCHEMA = vol.Schema({
         CONF_VIEW: cv.boolean,
         CONF_NAME: cv.string,
         CONF_ICON: cv.icon,
-        CONF_HIDE_SWITCH: cv.boolean,
+        CONF_CONTROL: cv.string,
     }, cv.match_all))
 }, extra=vol.ALLOW_EXTRA)
 
@@ -209,13 +209,13 @@ def _async_process_config(hass, config, component):
         entity_ids = conf.get(CONF_ENTITIES) or []
         icon = conf.get(CONF_ICON)
         view = conf.get(CONF_VIEW)
-        hide_switch = conf.get(CONF_HIDE_SWITCH)
+        control = conf.get(CONF_CONTROL)
 
         # Don't create tasks and await them all. The order is important as
         # groups get a number based on creation order.
         group = yield from Group.async_create_group(
             hass, name, entity_ids, icon=icon, view=view,
-            hide_switch=hide_switch, object_id=object_id)
+            control=control, object_id=object_id)
         groups.append(group)
 
     if groups:
@@ -226,7 +226,7 @@ class Group(Entity):
     """Track a group of entity ids."""
 
     def __init__(self, hass, name, order=None, user_defined=True, icon=None,
-                 view=False, hide_switch=False):
+                 view=False, control=None):
         """Initialize a group.
 
         This Object has factory function for creation.
@@ -244,21 +244,21 @@ class Group(Entity):
         self._assumed_state = False
         self._async_unsub_state_changed = None
         self._visible = True
-        self._hide_switch = hide_switch
+        self._control = control
 
     @staticmethod
     def create_group(hass, name, entity_ids=None, user_defined=True,
-                     icon=None, view=False, hide_switch=False, object_id=None):
+                     icon=None, view=False, control=None, object_id=None):
         """Initialize a group."""
         return run_coroutine_threadsafe(
             Group.async_create_group(hass, name, entity_ids, user_defined,
-                                     icon, view, hide_switch, object_id),
+                                     icon, view, control, object_id),
             hass.loop).result()
 
     @staticmethod
     @asyncio.coroutine
     def async_create_group(hass, name, entity_ids=None, user_defined=True,
-                           icon=None, view=False, hide_switch=False,
+                           icon=None, view=False, control=None,
                            object_id=None):
         """Initialize a group.
 
@@ -268,7 +268,7 @@ class Group(Entity):
             hass, name,
             order=len(hass.states.async_entity_ids(DOMAIN)),
             user_defined=user_defined, icon=icon, view=view,
-            hide_switch=hide_switch)
+            control=control)
 
         group.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, object_id or name, hass=hass)
@@ -327,8 +327,8 @@ class Group(Entity):
             data[ATTR_AUTO] = True
         if self._view:
             data[ATTR_VIEW] = True
-        if self._hide_switch:
-            data[ATTR_HIDE_SWITCH] = True
+        if self._control:
+            data[ATTR_CONTROL] = self._control
         return data
 
     @property

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -146,7 +146,8 @@ def get_entity_ids(hass, entity_id, domain_filter=None):
     """
     group = hass.states.get(entity_id)
 
-    if not group or ATTR_ENTITY_ID not in group.attributes:
+    if not group or ATTR_ENTITY_ID not in group.attributes or \
+       group.attributes.get(ATTR_HIDE_SWITCH):
         return []
 
     entity_ids = group.attributes[ATTR_ENTITY_ID]

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -146,8 +146,7 @@ def get_entity_ids(hass, entity_id, domain_filter=None):
     """
     group = hass.states.get(entity_id)
 
-    if not group or ATTR_ENTITY_ID not in group.attributes or \
-       group.attributes.get(ATTR_HIDE_SWITCH):
+    if not group or ATTR_ENTITY_ID not in group.attributes:
         return []
 
     entity_ids = group.attributes[ATTR_ENTITY_ID]

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -228,6 +228,7 @@ class TestComponentsGroup(unittest.TestCase):
                         'entities': 'light.Bowl, ' + test_group.entity_id,
                         'icon': 'mdi:work',
                         'view': True,
+                        'hide_switch': True,
                     }
         group_conf['test_group'] = 'hello.world,sensor.happy'
         group_conf['empty_group'] = {'name': 'Empty Group', 'entities': None}
@@ -243,6 +244,7 @@ class TestComponentsGroup(unittest.TestCase):
         self.assertEqual('mdi:work',
                          group_state.attributes.get(ATTR_ICON))
         self.assertTrue(group_state.attributes.get(group.ATTR_VIEW))
+        self.assertTrue(group_state.attributes.get(group.ATTR_HIDE_SWITCH))
         self.assertTrue(group_state.attributes.get(ATTR_HIDDEN))
         self.assertEqual(1, group_state.attributes.get(group.ATTR_ORDER))
 
@@ -254,6 +256,7 @@ class TestComponentsGroup(unittest.TestCase):
         self.assertIsNone(group_state.attributes.get(group.ATTR_AUTO))
         self.assertIsNone(group_state.attributes.get(ATTR_ICON))
         self.assertIsNone(group_state.attributes.get(group.ATTR_VIEW))
+        self.assertIsNone(group_state.attributes.get(group.ATTR_HIDE_SWITCH))
         self.assertIsNone(group_state.attributes.get(ATTR_HIDDEN))
         self.assertEqual(2, group_state.attributes.get(group.ATTR_ORDER))
 

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -228,7 +228,7 @@ class TestComponentsGroup(unittest.TestCase):
                         'entities': 'light.Bowl, ' + test_group.entity_id,
                         'icon': 'mdi:work',
                         'view': True,
-                        'hide_switch': True,
+                        'control': 'hidden',
                     }
         group_conf['test_group'] = 'hello.world,sensor.happy'
         group_conf['empty_group'] = {'name': 'Empty Group', 'entities': None}
@@ -244,7 +244,8 @@ class TestComponentsGroup(unittest.TestCase):
         self.assertEqual('mdi:work',
                          group_state.attributes.get(ATTR_ICON))
         self.assertTrue(group_state.attributes.get(group.ATTR_VIEW))
-        self.assertTrue(group_state.attributes.get(group.ATTR_HIDE_SWITCH))
+        self.assertEqual('hidden',
+                         group_state.attributes.get(group.ATTR_CONTROL))
         self.assertTrue(group_state.attributes.get(ATTR_HIDDEN))
         self.assertEqual(1, group_state.attributes.get(group.ATTR_ORDER))
 
@@ -256,7 +257,7 @@ class TestComponentsGroup(unittest.TestCase):
         self.assertIsNone(group_state.attributes.get(group.ATTR_AUTO))
         self.assertIsNone(group_state.attributes.get(ATTR_ICON))
         self.assertIsNone(group_state.attributes.get(group.ATTR_VIEW))
-        self.assertIsNone(group_state.attributes.get(group.ATTR_HIDE_SWITCH))
+        self.assertIsNone(group_state.attributes.get(group.ATTR_CONTROL))
         self.assertIsNone(group_state.attributes.get(ATTR_HIDDEN))
         self.assertEqual(2, group_state.attributes.get(group.ATTR_ORDER))
 


### PR DESCRIPTION
**Description:**
Adds an option to hide the group card switch as described in the following feature request:
https://community.home-assistant.io/t/add-option-to-hide-the-group-card-master-switch/2824

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io/pull/1516

**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) (if applicable):** home-assistant/home-assistant-polymer/pull/159

**Example entry for `configuration.yaml` (if applicable):**
```yaml
hombot:
  name: "Hom-Bot"
  control: hidden
  entities:
    - sensor.hombot_status
    - sensor.hombot_battery
    - script.hombot_clean
    - script.hombot_pause
    - script.hombot_home
    - sensor.hombot_last_clean
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
