### PR TITLE
(InfluxDB) Configuration for a default measurement value for events without a unit.

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -21,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_DB_NAME = 'database'
 CONF_TAGS = 'tags'
+CONF_DEFAULT_MEASUREMENT = 'default_measurement'
 
 DEFAULT_DATABASE = 'home_assistant'
 DEFAULT_HOST = 'localhost'
@@ -40,6 +41,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_DB_NAME, default=DEFAULT_DATABASE): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+        vol.Optional(CONF_DEFAULT_MEASUREMENT): cv.string,
         vol.Optional(CONF_TAGS, default={}):
             vol.Schema({cv.string: cv.string}),
         vol.Optional(CONF_WHITELIST, default=[]):
@@ -65,6 +67,7 @@ def setup(hass, config):
     blacklist = conf.get(CONF_BLACKLIST)
     whitelist = conf.get(CONF_WHITELIST)
     tags = conf.get(CONF_TAGS)
+    default_measurement = conf.get(CONF_DEFAULT_MEASUREMENT)
 
     try:
         influx = InfluxDBClient(
@@ -96,7 +99,10 @@ def setup(hass, config):
 
         measurement = state.attributes.get('unit_of_measurement')
         if measurement in (None, ''):
-            measurement = state.entity_id
+            if default_measurement:
+                measurement = default_measurement
+            else:
+                measurement = state.entity_id
 
         json_body = [
             {


### PR DESCRIPTION
**Description:**

We already retain the domain/object_id in the message, and as described in the issue it doesn't make sense to store the measurement type as the entity_id, personally for me 'state' is a better fit, but to avoid breaking change I've made this an optional config.

**Related issue (if applicable):** fixes #4590

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
influxdb:
  host: 'host',
  username: 'user',
  password: 'pass',
  default_measurement: 'state'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works