### PR TITLE
Yr.no: New aiohttp client needs params to form websession URL

### DIFF
--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -70,7 +70,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         _LOGGER.error("Latitude or longitude not set in Home Assistant config")
         return False
 
-    coordinates = dict(lat=latitude, lon=longitude, msl=elevation)
+    coordinates = {'lat': str(latitude),
+                   'lon': str(longitude),
+                   'msl': str(elevation)}
 
     dev = []
     for sensor_type in config[CONF_MONITORED_CONDITIONS]:
@@ -135,8 +137,8 @@ class YrData(object):
 
     def __init__(self, hass, coordinates, devices):
         """Initialize the data object."""
-        self._url = 'http://api.yr.no/weatherapi/locationforecast/1.9/?' \
-            'lat={lat};lon={lon};msl={msl}'.format(**coordinates)
+        self._url = 'http://api.yr.no/weatherapi/locationforecast/1.9/'
+        self._urlparams = coordinates
         self._nextrun = None
         self.devices = devices
         self.data = {}
@@ -158,9 +160,10 @@ class YrData(object):
             try:
                 websession = async_get_clientsession(self.hass)
                 with async_timeout.timeout(10, loop=self.hass.loop):
-                    resp = yield from websession.get(self._url)
+                    resp = yield from websession.get(self._url,
+                                                     params=self._urlparams)
                 if resp.status != 200:
-                    try_again('{} returned {}'.format(self._url, resp.status))
+                    try_again('{} returned {}'.format(resp.url, resp.status))
                     return
                 text = yield from resp.text()
                 self.hass.async_add_job(resp.release())

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -5,6 +5,7 @@ import functools
 import json as _json
 from unittest import mock
 from urllib.parse import urlparse, parse_qs
+import yarl
 
 
 class AiohttpClientMocker:
@@ -20,7 +21,8 @@ class AiohttpClientMocker:
                 status=200,
                 text=None,
                 content=None,
-                json=None):
+                json=None,
+                params=None):
         """Mock a request."""
         if json:
             text = _json.dumps(json)
@@ -28,6 +30,8 @@ class AiohttpClientMocker:
             content = text.encode('utf-8')
         if content is None:
             content = b''
+        if params:
+            url = str(yarl.URL(url).with_query(params))
 
         self._mocks.append(AiohttpClientMockResponse(
             method, url, status, content))
@@ -58,11 +62,11 @@ class AiohttpClientMocker:
         return len(self.mock_calls)
 
     @asyncio.coroutine
-    def match_request(self, method, url, *, auth=None): \
+    def match_request(self, method, url, *, auth=None, params=None): \
             # pylint: disable=unused-variable
         """Match a request against pre-registered requests."""
         for response in self._mocks:
-            if response.match_request(method, url):
+            if response.match_request(method, url, params):
                 self.mock_calls.append((method, url))
                 return response
 
@@ -82,10 +86,13 @@ class AiohttpClientMockResponse:
         self.status = status
         self.response = response
 
-    def match_request(self, method, url):
+    def match_request(self, method, url, params=None):
         """Test if response answers request."""
         if method.lower() != self.method.lower():
             return False
+
+        if params:
+            url = str(yarl.URL(url).with_query(params))
 
         # regular expression matching
         if self._url_parts is None:


### PR DESCRIPTION
**Description:**
aiohttp client 1.1.5 seems to have broken manual parameters....

**Related issue (if applicable):** fixes #4629 


**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: yr
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

