### PR TITLE
Pilight receive match fix for bug 4637

### DIFF
--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -22,6 +22,7 @@ CONF_ON_CODE = 'on_code'
 CONF_ON_CODE_RECIEVE = 'on_code_receive'
 CONF_SYSTEMCODE = 'systemcode'
 CONF_UNIT = 'unit'
+CONF_UNITCODE = 'unitcode'
 
 DEPENDENCIES = ['pilight']
 
@@ -30,6 +31,7 @@ COMMAND_SCHEMA = vol.Schema({
     vol.Optional('on'): cv.positive_int,
     vol.Optional('off'): cv.positive_int,
     vol.Optional(CONF_UNIT): cv.positive_int,
+    vol.Optional(CONF_UNITCODE): cv.positive_int,
     vol.Optional(CONF_ID): cv.positive_int,
     vol.Optional(CONF_STATE): cv.string,
     vol.Optional(CONF_SYSTEMCODE): cv.positive_int,

--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -11,7 +11,8 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 import homeassistant.components.pilight as pilight
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_NAME, CONF_ID, CONF_SWITCHES, CONF_STATE)
+from homeassistant.const import (CONF_NAME, CONF_ID, CONF_SWITCHES, CONF_STATE,
+                                 CONF_PROTOCOL)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +25,8 @@ CONF_UNIT = 'unit'
 
 DEPENDENCIES = ['pilight']
 
-COMMAND_SCHEMA = pilight.RF_CODE_SCHEMA.extend({
+COMMAND_SCHEMA = vol.Schema({
+    vol.Optional(CONF_PROTOCOL): cv.string,
     vol.Optional('on'): cv.positive_int,
     vol.Optional('off'): cv.positive_int,
     vol.Optional(CONF_UNIT): cv.positive_int,


### PR DESCRIPTION
**Description:**
This is a bugfix for Bug #4637 

It changes the matching of received codes to fist check that the protocol is within the configured protocols and then match if the rest of the configured values are found in the received data.

**Related issue (if applicable):** fixes #4637 

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
