### PR TITLE
Upgrade Sphinx to 1.4.9

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
-Sphinx==1.4.8
+Sphinx==1.4.9
 sphinx-autodoc-typehints==1.1.0
 sphinx-autodoc-annotation==1.0.post1


### PR DESCRIPTION
Release 1.4.9
===========

Bugs fixed
----------

* Fix doc/Makefile that can't build man because doc/man exists
* Using the same 'caption' attribute in multiple 'toctree' directives results in warning / error
* Allow the '=' character in the -D option of sphinx-build.py
* ``add_source_parser()`` crashes in debug mode
* ``sphinx.ext.autodoc`` crashes with plain Callable
* Fix query word splitter in JavaScript. It behaves as same as Python's regular expression.
* gettext build broken on substituted images.
* gettext build broken on image node under ``note`` directive.
* imgmath: crashes on showing error messages if image generation failed
* LaTeX writer crashes if admonition is placed before first section title
* Change search order of ``sphinx.ext.inheritance_diagram``