### PR TITLE
[emulated_hue] Make trusted_networks iterable

### DIFF
--- a/homeassistant/components/emulated_hue.py
+++ b/homeassistant/components/emulated_hue.py
@@ -77,7 +77,7 @@ def setup(hass, yaml_config):
         ssl_key=None,
         cors_origins=None,
         use_x_forwarded_for=False,
-        trusted_networks=None,
+        trusted_networks=[],
         login_threshold=0,
         is_ban_enabled=False
     )


### PR DESCRIPTION
Following [the recent HTTP component re-org](https://github.com/home-assistant/home-assistant/pull/4575), the `trusted_networks` argument passed to `HomeAssistantWSGI` must be "iterable" due to its' use in `http/auth.py`:

https://github.com/home-assistant/home-assistant/blob/8fc7b896a568489265e9bdf4d9c878bdcd09c6f3/homeassistant/components/http/auth.py#L59-L61

This PR sets the value of `trusted_networks` HTTP server that the emulated_hue starts to `[]` instead of `None`, which restores service on my dev install.

/cc @balloob 