### PR TITLE
Fixes #3511 - handle multiple return values

### DIFF
--- a/homeassistant/components/media_player/denon.py
+++ b/homeassistant/components/media_player/denon.py
@@ -62,7 +62,14 @@ class DenonDevice(MediaPlayerDevice):
     def telnet_request(cls, telnet, command):
         """Execute `command` and return the response."""
         telnet.write(command.encode('ASCII') + b'\r')
-        return telnet.read_until(b'\r', timeout=0.2).decode('ASCII').strip()
+        lines = []
+        while True:
+            line = telnet.read_until(b'\r', timeout=0.2)
+            if not line:
+                break
+            lines.append(line.decode('ASCII').strip())
+
+        return lines[0]
 
     def telnet_command(self, command):
         """Establish a telnet connection and sends `command`."""
@@ -79,9 +86,6 @@ class DenonDevice(MediaPlayerDevice):
             return False
 
         self._pwstate = self.telnet_request(telnet, 'PW?')
-        # PW? sends also SISTATUS, which is not interesting
-        telnet.read_until(b"\r", timeout=0.2)
-
         volume_str = self.telnet_request(telnet, 'MV?')[len('MV'):]
         self._volume = int(volume_str) / 60
         self._muted = (self.telnet_request(telnet, 'MU?') == 'MUON')


### PR DESCRIPTION
**Description:**
The Denon "control protocol" can return multiple lines in response to a single command. Given AVR devices are more complex, they seem to utilize this more often causing breakage. This change reads the entire response into `lines`, then just returns the first value for compatibility. The full response will be needed to implement additional AVR functionality in the future.  

**Related issue (if applicable):** fixes #3511
