### PR TITLE
Migrate remote to async

### DIFF
--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -4,7 +4,9 @@ Component to interface with universal remote control devices.
 For more details about this component, please refer to the documentation
 at https://home-assistant.io/components/remote/
 """
+import asyncio
 from datetime import timedelta
+import functools as ft
 import logging
 import os
 
@@ -86,44 +88,57 @@ def sync(hass, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_SYNC, data)
 
 
-def setup(hass, config):
+@asyncio.coroutine
+def async_setup(hass, config):
     """Track states and offer events for remotes."""
     component = EntityComponent(
         _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_REMOTES)
-    component.setup(config)
+    yield from component.async_setup(config)
 
-    def handle_remote_service(service):
+    def async_handle_remote_service(service):
         """Handle calls to the remote services."""
-        target_remotes = component.extract_from_service(service)
+        target_remotes = component.async_extract_from_service(service)
 
         activity_id = service.data.get(ATTR_ACTIVITY)
         device = service.data.get(ATTR_DEVICE)
         command = service.data.get(ATTR_COMMAND)
 
+        update_tasks = []
         for remote in target_remotes:
             if service.service == SERVICE_TURN_ON:
-                remote.turn_on(activity=activity_id)
+                yield from remote.async_turn_on(activity=activity_id)
             elif service.service == SERVICE_SEND_COMMAND:
-                remote.send_command(device=device, command=command)
+                yield from remote.async_send_command(
+                    device=device, command=command)
             elif service.service == SERVICE_SYNC:
-                remote.sync()
+                yield from remote.async_sync()
             else:
-                remote.turn_off()
+                yield from remote.async_turn_off()
 
             if remote.should_poll:
-                remote.update_ha_state(True)
+                update_coro = remote.async_update_ha_state(True)
+                if hasattr(remote, 'async_update'):
+                    update_tasks.append(hass.loop.create_task(update_coro))
+                else:
+                    yield from update_coro
 
-    descriptions = load_yaml_config_file(
-        os.path.join(os.path.dirname(__file__), 'services.yaml'))
-    hass.services.register(DOMAIN, SERVICE_TURN_OFF, handle_remote_service,
-                           descriptions.get(SERVICE_TURN_OFF),
-                           schema=REMOTE_SERVICE_SCHEMA)
-    hass.services.register(DOMAIN, SERVICE_TURN_ON, handle_remote_service,
-                           descriptions.get(SERVICE_TURN_ON),
-                           schema=REMOTE_SERVICE_TURN_ON_SCHEMA)
-    hass.services.register(DOMAIN, SERVICE_SEND_COMMAND, handle_remote_service,
-                           descriptions.get(SERVICE_SEND_COMMAND),
-                           schema=REMOTE_SERVICE_SEND_COMMAND_SCHEMA)
+        if update_tasks:
+            yield from asyncio.wait(update_tasks, loop=hass.loop)
+
+    descriptions = yield from hass.loop.run_in_executor(
+        None, load_yaml_config_file, os.path.join(
+            os.path.dirname(__file__), 'services.yaml'))
+    hass.services.async_register(
+        DOMAIN, SERVICE_TURN_OFF, async_handle_remote_service,
+        descriptions.get(SERVICE_TURN_OFF), schema=REMOTE_SERVICE_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_TURN_ON, async_handle_remote_service,
+        descriptions.get(SERVICE_TURN_ON),
+        schema=REMOTE_SERVICE_TURN_ON_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_SEND_COMMAND, async_handle_remote_service,
+        descriptions.get(SERVICE_SEND_COMMAND),
+        schema=REMOTE_SERVICE_SEND_COMMAND_SCHEMA)
 
     return True
 
@@ -131,14 +146,19 @@ def setup(hass, config):
 class RemoteDevice(ToggleEntity):
     """Representation of a remote."""
 
-    def turn_on(self, **kwargs):
-        """Turn a device on with the remote."""
+    def sync(self):
+        """Sync remote device."""
         raise NotImplementedError()
 
-    def turn_off(self, **kwargs):
-        """Turn a device off with the remote."""
-        raise NotImplementedError()
+    def async_sync(self):
+        """Sync remote device."""
+        yield from self.hass.loop.run_in_executor(None, self.sync)
 
     def send_command(self, **kwargs):
         """Send a command to a device."""
         raise NotImplementedError()
+
+    def async_send_command(self, **kwargs):
+        """Send a command to a device."""
+        yield from self.hass.loop.run_in_executor(
+            None, ft.partial(self.send_command, **kwargs))

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -95,6 +95,7 @@ def async_setup(hass, config):
         _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_REMOTES)
     yield from component.async_setup(config)
 
+    @asyncio.coroutine
     def async_handle_remote_service(service):
         """Handle calls to the remote services."""
         target_remotes = component.async_extract_from_service(service)

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -82,12 +82,6 @@ def send_command(hass, device, command, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_SEND_COMMAND, data)
 
 
-def sync(hass, entity_id=None):
-    """Sync remote device."""
-    data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.services.call(DOMAIN, SERVICE_SYNC, data)
-
-
 @asyncio.coroutine
 def async_setup(hass, config):
     """Track states and offer events for remotes."""
@@ -111,8 +105,6 @@ def async_setup(hass, config):
             elif service.service == SERVICE_SEND_COMMAND:
                 yield from remote.async_send_command(
                     device=device, command=command)
-            elif service.service == SERVICE_SYNC:
-                yield from remote.async_sync()
             else:
                 yield from remote.async_turn_off()
 
@@ -131,7 +123,8 @@ def async_setup(hass, config):
             os.path.dirname(__file__), 'services.yaml'))
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_OFF, async_handle_remote_service,
-        descriptions.get(SERVICE_TURN_OFF), schema=REMOTE_SERVICE_SCHEMA)
+        descriptions.get(SERVICE_TURN_OFF),
+        schema=REMOTE_SERVICE_SCHEMA)
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_ON, async_handle_remote_service,
         descriptions.get(SERVICE_TURN_ON),
@@ -146,14 +139,6 @@ def async_setup(hass, config):
 
 class RemoteDevice(ToggleEntity):
     """Representation of a remote."""
-
-    def sync(self):
-        """Sync remote device."""
-        raise NotImplementedError()
-
-    def async_sync(self):
-        """Sync remote device."""
-        yield from self.hass.loop.run_in_executor(None, self.sync)
 
     def send_command(self, **kwargs):
         """Send a command to a device."""

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -14,17 +14,14 @@ import homeassistant.components.remote as remote
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     CONF_NAME, CONF_HOST, CONF_PORT, ATTR_ENTITY_ID)
-from homeassistant.components.remote import PLATFORM_SCHEMA, DOMAIN
+from homeassistant.components.remote import (
+    PLATFORM_SCHEMA, DOMAIN, ATTR_DEVICE, ATTR_COMMAND, ATTR_ACTIVITY)
 from homeassistant.util import slugify
 from homeassistant.config import load_yaml_config_file
 
 REQUIREMENTS = ['pyharmony==1.0.12']
 
 _LOGGER = logging.getLogger(__name__)
-
-ATTR_DEVICE = 'device'
-ATTR_COMMAND = 'command'
-ATTR_ACTIVITY = 'activity'
 
 DEFAULT_PORT = 5222
 DEVICES = []

--- a/tests/components/remote/test_demo.py
+++ b/tests/components/remote/test_demo.py
@@ -9,7 +9,6 @@ from homeassistant.const import (
     SERVICE_TURN_ON, SERVICE_TURN_OFF)
 from tests.common import get_test_home_assistant, mock_service
 
-SERVICE_SYNC = 'sync'
 SERVICE_SEND_COMMAND = 'send_command'
 
 
@@ -81,22 +80,6 @@ class TestDemoRemote(unittest.TestCase):
 
         self.assertEqual(remote.DOMAIN, call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual('entity_id_val', call.data[ATTR_ENTITY_ID])
-
-        # Test sync
-        sync_calls = mock_service(
-            self.hass, remote.DOMAIN, SERVICE_SYNC)
-
-        remote.sync(
-            self.hass, entity_id='entity_id_val')
-
-        self.hass.block_till_done()
-
-        self.assertEqual(1, len(sync_calls))
-        call = sync_calls[-1]
-
-        self.assertEqual(remote.DOMAIN, call.domain)
-        self.assertEqual(SERVICE_SYNC, call.service)
         self.assertEqual('entity_id_val', call.data[ATTR_ENTITY_ID])
 
         # Test send_command

--- a/tests/components/remote/test_init.py
+++ b/tests/components/remote/test_init.py
@@ -11,7 +11,6 @@ import homeassistant.components.remote as remote
 
 from tests.common import mock_service, get_test_home_assistant
 TEST_PLATFORM = {remote.DOMAIN: {CONF_PLATFORM: 'test'}}
-SERVICE_SYNC = 'sync'
 SERVICE_SEND_COMMAND = 'send_command'
 
 


### PR DESCRIPTION
**Description:**

Migrate remote to async and remote entity.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

