### PR TITLE
Add flic smart button component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -122,6 +122,7 @@ omit =
     homeassistant/components/alarm_control_panel/simplisafe.py
     homeassistant/components/binary_sensor/arest.py
     homeassistant/components/binary_sensor/concord232.py
+    homeassistant/components/binary_sensor/flic.py
     homeassistant/components/binary_sensor/rest.py
     homeassistant/components/browser.py
     homeassistant/components/camera/amcrest.py

--- a/homeassistant/components/binary_sensor/flic.py
+++ b/homeassistant/components/binary_sensor/flic.py
@@ -19,8 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 CONF_AUTO_SCAN = "auto_scan"
-CONF_THRESHOLD_DOUBLE_CLICK = "threshold_double_click"
-CONF_THRESHOLD_LONG_CLICK = "threshold_long_click"
+CONF_THRESHOLD_DOUBLE_CLICK = "double_click_threshold"
+CONF_THRESHOLD_LONG_CLICK = "long_click_threshold"
 
 EVENT_FLIC_SINGLE_CLICK = "flic_single_click"
 EVENT_FLIC_LONG_CLICK = "flic_long_click"

--- a/homeassistant/components/binary_sensor/flic.py
+++ b/homeassistant/components/binary_sensor/flic.py
@@ -182,7 +182,7 @@ class FlicButton(BinarySensorDevice):
         return attr
 
     def _button_up_down(self, channel, click_type, was_queued, time_diff):
-        """Called when the button is pressed or released."""
+        """Fire click event depending on click type."""
         import pyflic
 
         if not was_queued:
@@ -228,3 +228,13 @@ class FlicButton(BinarySensorDevice):
             "name": self.name,
             "address": self.address
         })
+
+    def _connection_status_changed(self, channel,
+                                   connection_status, disconnect_reason):
+        """Remove device, if button disconnects."""
+        import pyflic
+
+        if connection_status == pyflic.ConnectionStatus.Disconnected:
+            _LOGGER.info("Button (%s) disconnected. Reason: %s",
+                         self.address, disconnect_reason)
+            self.remove()

--- a/homeassistant/components/binary_sensor/flic.py
+++ b/homeassistant/components/binary_sensor/flic.py
@@ -61,7 +61,8 @@ def async_setup_platform(hass, config, async_add_entities,
                                         main_client, address))
 
     main_client.on_new_verified_button = new_button_callback
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, main_client.close)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,
+                               lambda event: main_client.close())
     hass.loop.run_in_executor(None, main_client.handle_events)
 
     # Initialize scan flic client responsible for scanning for new buttons
@@ -69,6 +70,8 @@ def async_setup_platform(hass, config, async_add_entities,
     if auto_scan:
         scan_client = pyflic.FlicClient(host, port)
         start_scanning(hass, config, async_add_entities, scan_client)
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,
+                                   lambda event: scan_client.close())
         hass.loop.run_in_executor(None, scan_client.handle_events)
 
     # Get addresses of already verified buttons

--- a/homeassistant/components/binary_sensor/flic.py
+++ b/homeassistant/components/binary_sensor/flic.py
@@ -222,4 +222,7 @@ class FlicButton(BinarySensorDevice):
 
     def _fire_event(self, event):
         """Fire the passed event with device-dependent data."""
-        self._hass.bus.fire(event, self.address)
+        self._hass.bus.fire(event, {
+            "name": self.name,
+            "address": self.address
+        })

--- a/homeassistant/components/binary_sensor/flic.py
+++ b/homeassistant/components/binary_sensor/flic.py
@@ -19,9 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 CONF_AUTO_SCAN = "auto_scan"
-CONF_THRESHOLDS = "thresholds"
-CONF_THRESHOLD_DOUBLE_CLICK = "double_click"
-CONF_THRESHOLD_LONG_CLICK = "long_click"
+CONF_THRESHOLD_DOUBLE_CLICK = "threshold_double_click"
+CONF_THRESHOLD_LONG_CLICK = "threshold_long_click"
 
 EVENT_FLIC_SINGLE_CLICK = "flic_single_click"
 EVENT_FLIC_LONG_CLICK = "flic_long_click"
@@ -30,14 +29,13 @@ EVENT_FLIC_DOUBLE_CLICK = "flic_double_click"
 
 # Validation of the user's configuration
 THRESHOLDS_SCHEMA = vol.Schema({
-    vol.Optional(CONF_THRESHOLD_LONG_CLICK, default=500): float,
-    vol.Optional(CONF_THRESHOLD_DOUBLE_CLICK, default=300): float
 })
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default='localhost'): cv.string,
     vol.Optional(CONF_PORT, default=5551): cv.port,
     vol.Optional(CONF_AUTO_SCAN, default=True): cv.boolean,
-    vol.Optional(CONF_THRESHOLDS): THRESHOLDS_SCHEMA
+    vol.Optional(CONF_THRESHOLD_LONG_CLICK, default=0.5): float,
+    vol.Optional(CONF_THRESHOLD_DOUBLE_CLICK, default=0.3): float
 })
 
 
@@ -110,9 +108,8 @@ def start_scanning(hass, config, async_add_entities, client):
 @asyncio.coroutine
 def setup_button(hass, config, async_add_entities, client, address):
     """Setup single button device."""
-    threshold_config = config.get(CONF_THRESHOLDS)
-    double_click_threshold = threshold_config[CONF_THRESHOLD_DOUBLE_CLICK]
-    long_click_threshold = threshold_config[CONF_THRESHOLD_LONG_CLICK]
+    double_click_threshold = config.get(CONF_THRESHOLD_DOUBLE_CLICK)
+    long_click_threshold = config.get(CONF_THRESHOLD_LONG_CLICK)
 
     button = FlicButton(hass, client, address,
                         double_click_threshold, long_click_threshold)

--- a/homeassistant/components/binary_sensor/flic.py
+++ b/homeassistant/components/binary_sensor/flic.py
@@ -5,7 +5,8 @@ import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import (
+    CONF_HOST, CONF_PORT, CONF_DISCOVERY, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, PLATFORM_SCHEMA)
 from homeassistant.util.async import run_callback_threadsafe
@@ -16,8 +17,6 @@ REQUIREMENTS = ['https://github.com/soldag/pyflic/archive/0.4.zip#pyflic==0.4']
 _LOGGER = logging.getLogger(__name__)
 
 
-CONF_AUTO_SCAN = "auto_scan"
-
 EVENT_NAME = "flic_click"
 EVENT_DATA_NAME = "button_name"
 EVENT_DATA_ADDRESS = "button_address"
@@ -27,7 +26,7 @@ EVENT_DATA_TYPE = "click_type"
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default='localhost'): cv.string,
     vol.Optional(CONF_PORT, default=5551): cv.port,
-    vol.Optional(CONF_AUTO_SCAN, default=True): cv.boolean
+    vol.Optional(CONF_DISCOVERY, default=True): cv.boolean
 })
 
 
@@ -41,7 +40,7 @@ def async_setup_platform(hass, config, async_add_entities,
     # connecting to buttons and retrieving events
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
-    auto_scan = config.get(CONF_AUTO_SCAN)
+    discovery = config.get(CONF_DISCOVERY)
 
     try:
         client = pyflic.FlicClient(host, port)
@@ -55,7 +54,7 @@ def async_setup_platform(hass, config, async_add_entities,
                                         client, address))
 
     client.on_new_verified_button = new_button_callback
-    if auto_scan:
+    if discovery:
         start_scanning(hass, config, async_add_entities, client)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,

--- a/homeassistant/components/binary_sensor/flic.py
+++ b/homeassistant/components/binary_sensor/flic.py
@@ -1,0 +1,207 @@
+"""
+Contains functionality to use a flic button as a binary sensor.
+"""
+import asyncio
+import logging
+from datetime import datetime
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
+from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
+from homeassistant.util.async import fire_coroutine_threadsafe, run_callback_threadsafe
+
+
+REQUIREMENTS = ['https://github.com/soldag/pyflic/archive/0.4.zip#pyflic==0.4']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+CONF_AUTO_SCAN = "auto_scan"
+CONF_THRESHOLDS = "thresholds"
+CONF_THRESHOLD_DOUBLE_CLICK = "double_click"
+CONF_THRESHOLD_LONG_CLICK = "long_click"
+
+EVENT_FLIC_SINGLE_CLICK = "flic_single_click"
+EVENT_FLIC_LONG_CLICK = "flic_long_click"
+EVENT_FLIC_DOUBLE_CLICK = "flic_double_click"
+
+
+# Validation of the user's configuration
+THRESHOLDS_SCHEMA = vol.Schema({
+    vol.Optional(CONF_THRESHOLD_LONG_CLICK, default=500): float,
+    vol.Optional(CONF_THRESHOLD_DOUBLE_CLICK, default=300): float
+})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST, default='localhost'): cv.string,
+    vol.Optional(CONF_PORT, default=5551): cv.port,
+    vol.Optional(CONF_AUTO_SCAN, default=True): cv.boolean,
+    vol.Optional(CONF_THRESHOLDS): THRESHOLDS_SCHEMA
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Setup the flic platform."""
+    import pyflic
+
+    # Get event loop
+    loop = asyncio.get_event_loop()
+
+    # Initialize main flic client responsible for connecting to buttons and retrieve events
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    try:
+        main_client = pyflic.FlicClient(host, port)
+    except ConnectionRefusedError:
+        _LOGGER.error("Failed to connect to flic server.")
+        return
+
+    def new_button_callback(address):
+        asyncio.ensure_future(setup_button(hass, config, async_add_entities, main_client, address), loop=loop)
+
+    main_client.on_new_verified_button = new_button_callback
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, lambda: main_client.close())
+    loop.run_in_executor(None, main_client.handle_events)
+
+    # Initialize scan flic client responsible for scanning for new buttons
+    auto_scan = config.get(CONF_AUTO_SCAN)
+    if auto_scan:
+        scan_client = pyflic.FlicClient(host, port)
+        start_scanning(hass, config, async_add_entities, scan_client)
+        loop.run_in_executor(None, scan_client.handle_events)
+
+    # Get addresses of already verified buttons
+    addresses = yield from get_verified_addresses(main_client)
+    if addresses:
+        for address in addresses:
+            yield from setup_button(hass, config, async_add_entities, main_client, address)
+
+
+def start_scanning(hass, config, async_add_entities, client):
+    """Start a new flic client for scanning for new buttons and connecting to them."""
+    import pyflic
+
+    _LOGGER.info("Start scan wizard")
+    scan_wizard = pyflic.ScanWizard()
+
+    def scan_callback(scan_wizard, result, address, name):
+        if result == pyflic.ScanWizardResult.WizardSuccess:
+            _LOGGER.info("Found new button " + name + " (" + address + ")")
+
+            # Restart scan wizard
+            start_scanning(hass, config, async_add_entities, client)
+        else:
+            _LOGGER.info("Failed to connect to button (" + address + "). Reason: " + result)
+
+    scan_wizard.on_completed = scan_callback
+    client.add_scan_wizard(scan_wizard)
+
+
+@asyncio.coroutine
+def setup_button(hass, config, async_add_entities, client, address):
+    """Setup single button device"""
+    double_click_threshold = config.get(CONF_THRESHOLDS)[CONF_THRESHOLD_DOUBLE_CLICK]
+    long_click_threshold = config.get(CONF_THRESHOLDS)[CONF_THRESHOLD_LONG_CLICK]
+
+    button = FlicButton(hass, client, address, double_click_threshold, long_click_threshold)
+    _LOGGER.info("Connected to button (" + address + ")")
+
+    yield from async_add_entities([button])
+
+
+def get_verified_addresses(client):
+    """Retrieve addresses of verified buttons"""
+    future = asyncio.Future()
+    loop = asyncio.get_event_loop()
+
+    def callback(items):
+        addresses = items["bd_addr_of_verified_buttons"]
+        run_callback_threadsafe(loop, future.set_result, addresses)
+    client.get_info(callback)
+
+    return future
+
+
+class FlicButton(BinarySensorDevice):
+    """Representation of a flic button."""
+
+    def __init__(self, hass, client, address, double_click_threshold, long_click_threshold):
+        """Initialize the flic button."""
+        import pyflic
+
+        self._hass = hass
+        self._address = address
+        self._double_click_threshold = double_click_threshold
+        self._long_click_threshold = long_click_threshold
+        self._is_down = False
+        self._last_click = self._last_down = self._last_up = datetime.min
+
+        # Initialize connection channel
+        self._channel = pyflic.ButtonConnectionChannel(self._address)
+        self._channel.on_button_up_or_down = self._button_up_down
+        client.add_connection_channel(self._channel)
+
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self.address.replace(":", "")
+
+    @property
+    def address(self):
+        """Return the bluetooth address of the device."""
+        return self._address
+
+    @property
+    def is_on(self):
+        """Return true if sensor is on."""
+        return self._is_down
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def state_attributes(self):
+        """Return device specific state attributes."""
+        attr = super(FlicButton, self).state_attributes
+        attr["address"] = self.address
+
+        return attr
+
+    def _button_up_down(self, channel, click_type, was_queued, time_diff):
+        """Called when the button is pressed or released"""
+        import pyflic
+
+        if not was_queued:
+            # Set state
+            self._is_down = click_type == pyflic.ClickType.ButtonDown
+            self.update_ha_state()
+
+            # Fire events
+            now = datetime.now()
+            if self._is_down:
+                self._last_down = now
+            else:
+                self._last_up = now
+                diff = now - self._last_down
+                if diff.total_seconds() >= self._long_click_threshold:
+                    self._hass.bus.fire(EVENT_FLIC_LONG_CLICK, self.address)
+                else:
+                    diff = now - self._last_click
+                    if diff.total_seconds() <= self._double_click_threshold:
+                        self._last_click = datetime.min
+                        self._hass.bus.fire(EVENT_FLIC_DOUBLE_CLICK, self.address)
+                    else:
+                        self._last_click = now
+
+                        @asyncio.coroutine
+                        def defer_trigger():
+                            yield from asyncio.sleep(self._double_click_threshold)
+                            if self._last_click == now:
+                                self._last_click = datetime.now()
+                                self._hass.bus.fire(EVENT_FLIC_SINGLE_CLICK, self.address)
+                        fire_coroutine_threadsafe(defer_trigger(), self._hass.loop)

--- a/homeassistant/components/binary_sensor/flic.py
+++ b/homeassistant/components/binary_sensor/flic.py
@@ -87,14 +87,13 @@ def start_scanning(hass, config, async_add_entities, client):
     """Start a new flic client for scanning & connceting to new buttons."""
     import pyflic
 
-    _LOGGER.info("Start scan wizard")
     scan_wizard = pyflic.ScanWizard()
 
     def scan_completed_callback(scan_wizard, result, address, name):
         """Restart scan wizard to constantly check for new buttons."""
         if result == pyflic.ScanWizardResult.WizardSuccess:
             _LOGGER.info("Found new button (%s)", address)
-        else:
+        elif result != pyflic.ScanWizardResult.WizardFailedTimeout:
             _LOGGER.info("Failed to connect to button (%s). Reason: %s",
                          address, result)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -238,6 +238,9 @@ https://github.com/robbiet480/pygtfs/archive/00546724e4bbcb3053110d844ca44e22462
 # homeassistant.components.scene.hunterdouglas_powerview
 https://github.com/sander76/powerviewApi/archive/246e782d60d5c0addcc98d7899a0186f9d5640b0.zip#powerviewApi==0.3.15
 
+# homeassistant.components.binary_sensor.flic
+https://github.com/soldag/pyflic/archive/0.4.zip#pyflic==0.4
+
 # homeassistant.components.light.osramlightify
 https://github.com/tfriedel/python-lightify/archive/d6eadcf311e6e21746182d1480e97b350dda2b3e.zip#lightify==1.0.4
 


### PR DESCRIPTION
**Description:**
This component let users use flic buttons to trigger automations.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1527

**Example entry for `configuration.yaml` (if applicable):**
```yaml
binary_sensor:
  - platform: flic
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
