### PR TITLE
Added persistent_notification in case of error during Unifi device_tracker setup

### DIFF
--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -9,6 +9,7 @@ import urllib
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
+import homeassistant.loader as loader
 from homeassistant.components.device_tracker import DOMAIN, PLATFORM_SCHEMA
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 
@@ -18,6 +19,9 @@ REQUIREMENTS = ['urllib3', 'unifi==1.2.5']
 _LOGGER = logging.getLogger(__name__)
 CONF_PORT = 'port'
 CONF_SITE_ID = 'site_id'
+
+NOTIFICATION_ID = 'unifi_notification'
+NOTIFICATION_TITLE = 'Unifi Device Tracker Setup'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default='localhost'): cv.string,
@@ -38,10 +42,18 @@ def get_scanner(hass, config):
     site_id = config[DOMAIN].get(CONF_SITE_ID)
     port = config[DOMAIN].get(CONF_PORT)
 
+    persistent_notification = loader.get_component('persistent_notification')
     try:
         ctrl = Controller(host, username, password, port, 'v4', site_id)
     except urllib.error.HTTPError as ex:
-        _LOGGER.error('Failed to connect to unifi: %s', ex)
+        _LOGGER.error('Failed to connect to Unifi: %s', ex)
+        persistent_notification.create(
+            hass, 'Failed to connect to Unifi. '
+            'Error: {}<br />'
+            'You will need to restart hass after fixing.'
+            ''.format(ex),
+            title=NOTIFICATION_TITLE,
+            notification_id=NOTIFICATION_ID)
         return False
 
     return UnifiScanner(ctrl)

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -6,6 +6,7 @@ import urllib
 from unifi import controller
 import voluptuous as vol
 
+from tests.common import get_test_home_assistant
 from homeassistant.components.device_tracker import DOMAIN, unifi as unifi
 from homeassistant.const import (CONF_HOST, CONF_USERNAME, CONF_PASSWORD,
                                  CONF_PLATFORM)
@@ -13,6 +14,14 @@ from homeassistant.const import (CONF_HOST, CONF_USERNAME, CONF_PASSWORD,
 
 class TestUnifiScanner(unittest.TestCase):
     """Test the Unifiy platform."""
+
+    def setUp(self):
+        """Initialize values for this testcase class."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
 
     @mock.patch('homeassistant.components.device_tracker.unifi.UnifiScanner')
     @mock.patch.object(controller, 'Controller')
@@ -25,7 +34,7 @@ class TestUnifiScanner(unittest.TestCase):
                 CONF_PASSWORD: 'password',
             })
         }
-        result = unifi.get_scanner(None, config)
+        result = unifi.get_scanner(self.hass, config)
         self.assertEqual(mock_scanner.return_value, result)
         self.assertEqual(mock_ctrl.call_count, 1)
         self.assertEqual(
@@ -52,7 +61,7 @@ class TestUnifiScanner(unittest.TestCase):
                 'site_id': 'abcdef01',
             })
         }
-        result = unifi.get_scanner(None, config)
+        result = unifi.get_scanner(self.hass, config)
         self.assertEqual(mock_scanner.return_value, result)
         self.assertEqual(mock_ctrl.call_count, 1)
         self.assertEqual(
@@ -96,7 +105,7 @@ class TestUnifiScanner(unittest.TestCase):
         }
         mock_ctrl.side_effect = urllib.error.HTTPError(
             '/', 500, 'foo', {}, None)
-        result = unifi.get_scanner(None, config)
+        result = unifi.get_scanner(self.hass, config)
         self.assertFalse(result)
 
     def test_scanner_update(self):  # pylint: disable=no-self-use


### PR DESCRIPTION
**Description:**

 Added persistent notification if Unifi device_tracker errors out during setup. 

![screenshot from 2016-12-03 01-14-29](https://cloud.githubusercontent.com/assets/809840/20857325/e3dbacf2-b8f5-11e6-8b9d-5ffeae1ce347.png)

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

