### PR TITLE
Added str_to_json as global method for templates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -387,6 +387,14 @@ def timestamp_utc(value):
         return value
 
 
+def str_to_json(value):
+    """Convert a given json string to python dict."""
+    try:
+        return json.loads(value)
+    except (ValueError, KeyError, TypeError):
+        return value
+
+
 def strptime(string, fmt):
     """Parse a time string to datetime."""
     try:
@@ -431,3 +439,4 @@ ENV.globals['utcnow'] = dt_util.utcnow
 ENV.globals['as_timestamp'] = dt_util.as_timestamp
 ENV.globals['relative_time'] = dt_util.get_age
 ENV.globals['strptime'] = strptime
+ENV.globals['str_to_json'] = str_to_json

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -439,4 +439,4 @@ ENV.globals['utcnow'] = dt_util.utcnow
 ENV.globals['as_timestamp'] = dt_util.as_timestamp
 ENV.globals['relative_time'] = dt_util.get_age
 ENV.globals['strptime'] = strptime
-ENV.globals['str_to_json'] = str_to_json
+ENV.globals['json_to_dict'] = json.loads

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -123,6 +123,24 @@ class TestHelpersTemplate(unittest.TestCase):
                 template.Template('{{ %s | multiply(10) | round }}' % inp,
                                   self.hass).render())
 
+    def test_str_to_json(self):
+        """Test the parse timestamp method."""
+        invalid_json = 'some none valid json string'
+        temp = '{{ str_to_json(\'%s\') }}' % invalid_json
+        self.assertEqual(
+            'some none valid json string',
+            template.Template(temp, self.hass).render()
+        )
+
+        valid_json = '{"property1": "value1",' \
+            '"property2": ["value2_1", "value2_2"]}'
+        temp = '{%% set json_data = str_to_json(\'%s\') %%}' \
+            '{{ json_data.property2[0] }}' % valid_json
+        self.assertEqual(
+            'value2_1',
+            template.Template(temp, self.hass).render()
+        )
+
     def test_strptime(self):
         """Test the parse timestamp method."""
         tests = [

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -123,24 +123,6 @@ class TestHelpersTemplate(unittest.TestCase):
                 template.Template('{{ %s | multiply(10) | round }}' % inp,
                                   self.hass).render())
 
-    def test_str_to_json(self):
-        """Test the parse timestamp method."""
-        invalid_json = 'some none valid json string'
-        temp = '{{ str_to_json(\'%s\') }}' % invalid_json
-        self.assertEqual(
-            'some none valid json string',
-            template.Template(temp, self.hass).render()
-        )
-
-        valid_json = '{"property1": "value1",' \
-            '"property2": ["value2_1", "value2_2"]}'
-        temp = '{%% set json_data = str_to_json(\'%s\') %%}' \
-            '{{ json_data.property2[0] }}' % valid_json
-        self.assertEqual(
-            'value2_1',
-            template.Template(temp, self.hass).render()
-        )
-
     def test_strptime(self):
         """Test the parse timestamp method."""
         tests = [


### PR DESCRIPTION
**Description:**
Added ability for templates to convert a json string to a python dict.

```
{% set json_str = '{"property1": "value1"}' %}
{% set json_data = str_to_json(json_str) %}
{{ json_data.property1 }}
```


