### PR TITLE
New support Digital Loggers relays

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -317,6 +317,7 @@ omit =
     homeassistant/components/switch/acer_projector.py
     homeassistant/components/switch/anel_pwrctrl.py
     homeassistant/components/switch/arest.py
+    homeassistant/components/switch/digitalloggers.py
     homeassistant/components/switch/dlink.py
     homeassistant/components/switch/edimax.py
     homeassistant/components/switch/hikvisioncam.py

--- a/homeassistant/components/switch/digitalloggers.py
+++ b/homeassistant/components/switch/digitalloggers.py
@@ -1,0 +1,117 @@
+"""
+Support for Digital Loggers DIN III Relays and possibly other items through
+Dwight Hubbard's, python-dlipower.
+
+For more details about python-dlipower, please see
+https://github.com/dwighthubbard/python-dlipower
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_TIMEOUT)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
+
+
+REQUIREMENTS = ['dlipower==0.7.165']
+
+CONF_CYCLETIME = 'cycletime'
+
+DEFAULT_NAME = 'DINRelay'
+DEFAULT_USERNAME = 'admin'
+DEFAULT_PASSWORD = 'admin'
+DEFAULT_TIMEOUT = 20
+DEFAULT_CYCLETIME = 3
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=15)
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+    vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT):
+        vol.All(vol.Coerce(int), vol.Range(min=1, max=600)),
+    vol.Optional(CONF_CYCLETIME, default=DEFAULT_CYCLETIME):
+        vol.All(vol.Coerce(int), vol.Range(min=1, max=600)),
+
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Find and return DIN III Relay switch."""
+    import dlipower
+
+    host = config.get(CONF_HOST)
+    controllername = config.get(CONF_NAME)
+    user = config.get(CONF_USERNAME)
+    pswd = config.get(CONF_PASSWORD)
+    tout = config.get(CONF_TIMEOUT)
+    cycl = config.get(CONF_CYCLETIME)
+
+    power_switch = dlipower.PowerSwitch(
+        hostname=host, userid=user, password=pswd, timeout=tout,
+        cycletime=cycl)
+
+    if not power_switch.verify():
+        _LOGGER.error('Could not connect to DIN III Relay')
+        return False
+
+    for switch in power_switch:
+
+        # TODO(dethpickle)  Throttle the update for all relays of one
+        # physical device using util.Throttle.
+
+        add_devices(
+            [DINRelay(controllername, host, switch.outlet_number,
+                      power_switch)]
+        )
+
+
+class DINRelay(SwitchDevice):
+
+    """Representation of a DIN III Relay switch."""
+
+    def __init__(self, name, host, outletnumber, switchref):
+        """Initialize the DIN III Relay switch."""
+        self._host = host
+        self.controllername = name
+        self.outletnumber = outletnumber
+        self.switchref = switchref
+        self.update()
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._outletname
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._is_on
+
+    def turn_on(self, **kwargs):
+        """Instruct the light to turn on.        """
+        self.switchref.on(outlet=self.outletnumber)
+
+    def turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
+        self.switchref.off(outlet=self.outletnumber)
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Fetch new state data for this light.
+
+        This is the only method that should fetch new data for Home Assistant.
+        """
+        self.switchref.status(outlet=self.outletnumber)
+        self._is_on = (self.switchref.status(outlet=self.outletnumber) == 'ON')
+        self._outletname = "{}_{}".format(self.controllername,
+                                          self.switchref.get_outlet_name(
+                                            outlet=self.outletnumber))

--- a/homeassistant/components/switch/digitalloggers.py
+++ b/homeassistant/components/switch/digitalloggers.py
@@ -84,9 +84,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class DINRelay(SwitchDevice):
-    """Representation of a individual DIN III Relay switch.
-    Eight per device.
-    """
+    """Representation of a individual DIN III relay port."""
 
     def __init__(self, name, outletnumber, parent_device):
         """Initialize the DIN III Relay switch."""

--- a/homeassistant/components/switch/digitalloggers.py
+++ b/homeassistant/components/switch/digitalloggers.py
@@ -4,6 +4,10 @@ Dwight Hubbard's, python-dlipower.
 
 For more details about python-dlipower, please see
 https://github.com/dwighthubbard/python-dlipower
+
+Custom ports are NOT supported due to a limitation of the dlipower
+library, not the digital loggers switch
+
 """
 import logging
 from datetime import timedelta
@@ -25,9 +29,11 @@ DEFAULT_NAME = 'DINRelay'
 DEFAULT_USERNAME = 'admin'
 DEFAULT_PASSWORD = 'admin'
 DEFAULT_TIMEOUT = 20
-DEFAULT_CYCLETIME = 3
+DEFAULT_CYCLETIME = 2
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
+# TODO: Add DEFAULT_PORT contribute non-80 support to dlipower
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,14 +69,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if not power_switch.verify():
         _LOGGER.error('Could not connect to DIN III Relay')
         return False
-
-    # for switch in power_switch:
-    #     add_devices(
-    #         [DINRelay(controllername, switch.outlet_number, power_switch)]
-    #     )
-
-# Idiot, pay attention to
-# https://dev-docs.home-assistant.io/en/master/api/entity.html
 
     devices = []
     parent_device = DINRelayDevice(power_switch)
@@ -127,10 +125,11 @@ class DINRelay(SwitchDevice):
         self._outletname = "{}_{}".format(
             self.controllername,
             self._parent_device.statuslocal[self.outletnumber - 1][1]
-            )
+        )
 
 
 class DINRelayDevice(object):
+
     """Device representation for per device throttling."""
 
     def __init__(self, device):

--- a/homeassistant/components/switch/digitalloggers.py
+++ b/homeassistant/components/switch/digitalloggers.py
@@ -146,4 +146,3 @@ class DINRelayDevice(object):
     def update(self):
         """Fetch new state data for this device."""
         self.statuslocal = self._device.statuslist()
-

--- a/homeassistant/components/switch/digitalloggers.py
+++ b/homeassistant/components/switch/digitalloggers.py
@@ -33,8 +33,6 @@ DEFAULT_PASSWORD = 'admin'
 DEFAULT_TIMEOUT = 20
 DEFAULT_CYCLETIME = 2
 
-# TODO: Add DEFAULT_PORT contribute non-80 support to dlipower
-
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 
 _LOGGER = logging.getLogger(__name__)
@@ -134,6 +132,7 @@ class DINRelayDevice(object):
     def __init__(self, device):
         """Initialize the DINRelay device."""
         self._device = device
+        self.update()
 
     def turn_on(self, **kwargs):
         """Instruct the relay to turn on."""
@@ -147,14 +146,4 @@ class DINRelayDevice(object):
     def update(self):
         """Fetch new state data for this device."""
         self.statuslocal = self._device.statuslist()
-        """
-        statuslist looks like:
-            [[1, u'FR Lawn South', u'OFF'],
-             [2, u'FR Lawn North', u'OFF'],
-             [3, u'Plants Drip', u'ON'],
-             [4, u'BK Lawn North old', u'OFF'],
-             [5, u'BK Lawn North new', u'OFF'],
-             [6, u'BK Lawn South', u'ON'],
-             [7, u'BK Slope Low', u'OFF'],
-             [8, u'BK Slope High', u'OFF']]
-        """
+

--- a/homeassistant/components/switch/digitalloggers.py
+++ b/homeassistant/components/switch/digitalloggers.py
@@ -1,6 +1,8 @@
 """
-Support for Digital Loggers DIN III Relays and possibly other items through
-Dwight Hubbard's, python-dlipower.
+Support for Digital Loggers DIN III Relays.
+
+Support for Digital Loggers DIN III Relays and possibly other items
+through Dwight Hubbard's, python-dlipower.
 
 For more details about python-dlipower, please see
 https://github.com/dwighthubbard/python-dlipower
@@ -82,9 +84,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class DINRelay(SwitchDevice):
-
     """Representation of a individual DIN III Relay switch.
-    Eight per device."""
+    Eight per device.
+    """
 
     def __init__(self, name, outletnumber, parent_device):
         """Initialize the DIN III Relay switch."""
@@ -129,7 +131,6 @@ class DINRelay(SwitchDevice):
 
 
 class DINRelayDevice(object):
-
     """Device representation for per device throttling."""
 
     def __init__(self, device):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -84,6 +84,9 @@ directpy==0.1
 # homeassistant.components.updater
 distro==1.0.1
 
+# homeassistant.components.switch.digitalloggers
+dlipower==0.7.165
+
 # homeassistant.components.notify.xmpp
 dnspython3==1.15.0
 


### PR DESCRIPTION
**Description:** Adding platform support for Digital Loggers relays.
These switches: http://www.digital-loggers.com/dinfaqs.html
Using this library: https://github.com/dwighthubbard/python-dlipower

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1528

**Example entry for `configuration.yaml` (if applicable):**
```yaml
# Example configuration.yaml entry
switch:
  - platform: digitalloggers
    host: 192.168.1.43
    password: SuperSecret123!!
    name: FantasticRelayDevice
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.   (not sure what I'd have to do here - I don't have any tests)

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51