### PR TITLE
Requirements use zip instead of git

### DIFF
--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -18,8 +18,8 @@ _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = [
-    'git+https://github.com/technicalpickles/python-nest.git'
-    '@0be5c8a6307ee81540f21aac4fcd22cc5d98c988'  # nest-cam branch
+    'http://github.com/technicalpickles/python-nest'
+    '/archive/0be5c8a6307ee81540f21aac4fcd22cc5d98c988.zip'  # nest-cam branch
     '#python-nest==3.0.0']
 
 DOMAIN = 'nest'

--- a/homeassistant/components/nuimo_controller.py
+++ b/homeassistant/components/nuimo_controller.py
@@ -13,7 +13,8 @@ from homeassistant.const import (CONF_MAC, CONF_NAME, EVENT_HOMEASSISTANT_STOP)
 
 REQUIREMENTS = [
     '--only-binary=all '  # avoid compilation of gattlib
-    'git+https://github.com/getSenic/nuimo-linux-python'
+    'http://github.com/getSenic/nuimo-linux-python'
+    '/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip'
     '#nuimo==1.0.0']
 
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -11,7 +11,7 @@ aiohttp==1.1.6
 async_timeout==1.1.0
 
 # homeassistant.components.nuimo_controller
---only-binary=all git+https://github.com/getSenic/nuimo-linux-python#nuimo==1.0.0
+--only-binary=all http://github.com/getSenic/nuimo-linux-python/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip#nuimo==1.0.0
 
 # homeassistant.components.isy994
 PyISY==1.0.7
@@ -131,9 +131,6 @@ fuzzywuzzy==0.14.0
 # homeassistant.components.device_tracker.bluetooth_le_tracker
 # gattlib==0.20150805
 
-# homeassistant.components.nest
-git+https://github.com/technicalpickles/python-nest.git@0be5c8a6307ee81540f21aac4fcd22cc5d98c988#python-nest==3.0.0
-
 # homeassistant.components.notify.gntp
 gntp==1.0.3
 
@@ -166,6 +163,9 @@ hikvision==0.4
 
 # homeassistant.components.sensor.dht
 # http://github.com/adafruit/Adafruit_Python_DHT/archive/310c59b0293354d07d94375f1365f7b9b9110c7d.zip#Adafruit_DHT==1.3.0
+
+# homeassistant.components.nest
+http://github.com/technicalpickles/python-nest/archive/0be5c8a6307ee81540f21aac4fcd22cc5d98c988.zip#python-nest==3.0.0
 
 # homeassistant.components.light.flux_led
 https://github.com/Danielhiversen/flux_led/archive/0.9.zip#flux_led==0.9


### PR DESCRIPTION
**Description:**
This ensures requirements are pointing at zip files if they are getting the release from github. That way we won't require git to be installed.
