### PR TITLE
Yarl has been fixed

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,6 @@ pip>=7.0.0
 jinja2>=2.8
 voluptuous==0.9.2
 typing>=3,<4
-yarl==0.7.1
 aiohttp==1.1.6
 async_timeout==1.1.0
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ DOWNLOAD_URL = ('{}/archive/'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 
-# Pinning yarl because yarl 0.8 breaks aiohttp
 REQUIRES = [
     'requests>=2,<3',
     'pyyaml>=3.11,<4',
@@ -22,7 +21,6 @@ REQUIRES = [
     'jinja2>=2.8',
     'voluptuous==0.9.2',
     'typing>=3,<4',
-    'yarl==0.7.1',
     'aiohttp==1.1.6',
     'async_timeout==1.1.0',
 ]


### PR DESCRIPTION
**Description:**
Yarl 0.8.1 reverts the broken change in 0.8. There is no longer a need to pin Yarl to fix our builds.
