### PR TITLE
Updated email message headers to have 'Date', 'Message-Id' fields (#4693)

### DIFF
--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -9,6 +9,7 @@ import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.image import MIMEImage
+import email.utils
 
 import voluptuous as vol
 
@@ -18,6 +19,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import (
     CONF_USERNAME, CONF_PASSWORD, CONF_PORT, CONF_SENDER, CONF_RECIPIENT)
 import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -134,6 +136,8 @@ class MailNotificationService(BaseNotificationService):
         msg['To'] = self.recipient
         msg['From'] = self._sender
         msg['X-Mailer'] = 'HomeAssistant'
+        msg['Date'] = email.utils.format_datetime(dt_util.now())
+        msg['Message-Id'] = email.utils.make_msgid()
 
         return self._send_email(msg)
 

--- a/tests/components/notify/test_smtp.py
+++ b/tests/components/notify/test_smtp.py
@@ -34,16 +34,18 @@ class TestNotifySmtp(unittest.TestCase):
     def test_text_email(self):
         """Test build of default text email behavior."""
         msg = self.mailer.send_message('Test msg')
-        expected = ('Content-Type: text/plain; charset="us-ascii"\n'
+        expected = ('^Content-Type: text/plain; charset="us-ascii"\n'
                     'MIME-Version: 1.0\n'
                     'Content-Transfer-Encoding: 7bit\n'
                     'Subject: Home Assistant\n'
                     'To: testrecip@test.com\n'
                     'From: test@test.com\n'
                     'X-Mailer: HomeAssistant\n'
+                    'Date: [^\n]+\n'
+                    'Message-Id: <[^@]+@[^>]+>\n'
                     '\n'
-                    'Test msg')
-        self.assertEqual(msg, expected)
+                    'Test msg$')
+        self.assertRegex(msg, expected)
 
     def test_mixed_email(self):
         """Test build of mixed text email behavior."""


### PR DESCRIPTION
**Description:** Added 'Date' and 'Message-Id' fields to smtp messages.


**Related issue (if applicable):** fixes #4693 

**Checklist:**
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**