### PR TITLE
MQTT Automation: parse payload as JSON

### DIFF
--- a/homeassistant/components/automation/mqtt.py
+++ b/homeassistant/components/automation/mqtt.py
@@ -4,6 +4,8 @@ Offer MQTT listening automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#mqtt-trigger
 """
+import json
+
 import voluptuous as vol
 
 from homeassistant.core import callback
@@ -31,13 +33,20 @@ def async_trigger(hass, config, action):
     def mqtt_automation_listener(msg_topic, msg_payload, qos):
         """Listen for MQTT messages."""
         if payload is None or payload == msg_payload:
+            data = {
+                'platform': 'mqtt',
+                'topic': msg_topic,
+                'payload': msg_payload,
+                'qos': qos,
+            }
+
+            try:
+                data['payload_json'] = json.loads(msg_payload)
+            except ValueError:
+                pass
+
             hass.async_run_job(action, {
-                'trigger': {
-                    'platform': 'mqtt',
-                    'topic': msg_topic,
-                    'payload': msg_payload,
-                    'qos': qos,
-                }
+                'trigger': data
             })
 
     return mqtt.async_subscribe(hass, topic, mqtt_automation_listener)

--- a/tests/components/automation/test_mqtt.py
+++ b/tests/components/automation/test_mqtt.py
@@ -42,16 +42,17 @@ class TestAutomationMQTT(unittest.TestCase):
                     'service': 'test.automation',
                     'data_template': {
                         'some': '{{ trigger.platform }} - {{ trigger.topic }}'
-                                ' - {{ trigger.payload }}'
+                                ' - {{ trigger.payload }} - '
+                                '{{ trigger.payload_json.hello }}'
                     },
                 }
             }
         })
 
-        fire_mqtt_message(self.hass, 'test-topic', 'test_payload')
+        fire_mqtt_message(self.hass, 'test-topic', '{ "hello": "world" }')
         self.hass.block_till_done()
         self.assertEqual(1, len(self.calls))
-        self.assertEqual('mqtt - test-topic - test_payload',
+        self.assertEqual('mqtt - test-topic - { "hello": "world" } - world',
                          self.calls[0].data['some'])
 
         automation.turn_off(self.hass)


### PR DESCRIPTION
**Description:**
The automation trigger value will now have an optional payload_json value available if the payload can be parsed as JSON. Example template that can now be used:

Message received on MQTT topic:

```
{ "temperature": "100" }
```

Can now be rendered with the following template:

```
{{ trigger.payload_json.temperature }}
```

**Related issue (if applicable):** #4683

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

