### PR TITLE
Fix broken EnOcean support

### DIFF
--- a/homeassistant/components/binary_sensor/enocean.py
+++ b/homeassistant/components/binary_sensor/enocean.py
@@ -20,7 +20,7 @@ DEPENDENCIES = ['enocean']
 DEFAULT_NAME = 'EnOcean binary sensor'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ID): cv.string,
+    vol.Required(CONF_ID): cv.ensure_list,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_SENSOR_CLASS, default=None): SENSOR_CLASSES_SCHEMA,
 })

--- a/homeassistant/components/binary_sensor/enocean.py
+++ b/homeassistant/components/binary_sensor/enocean.py
@@ -20,7 +20,7 @@ DEPENDENCIES = ['enocean']
 DEFAULT_NAME = 'EnOcean binary sensor'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ID): cv.ensure_list,
+    vol.Required(CONF_ID): vol.All(cv.ensure_list, [vol.Coerce(int)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_SENSOR_CLASS, default=None): SENSOR_CLASSES_SCHEMA,
 })

--- a/homeassistant/components/light/enocean.py
+++ b/homeassistant/components/light/enocean.py
@@ -26,7 +26,8 @@ DEPENDENCIES = ['enocean']
 SUPPORT_ENOCEAN = SUPPORT_BRIGHTNESS
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_ID, default=[]): vol.All(cv.ensure_list, [vol.Coerce(int)]),
+    vol.Optional(CONF_ID, default=[]): vol.All(cv.ensure_list,
+                                               [vol.Coerce(int)]),
     vol.Required(CONF_SENDER_ID): vol.All(cv.ensure_list, [vol.Coerce(int)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })

--- a/homeassistant/components/light/enocean.py
+++ b/homeassistant/components/light/enocean.py
@@ -26,7 +26,7 @@ DEPENDENCIES = ['enocean']
 SUPPORT_ENOCEAN = SUPPORT_BRIGHTNESS
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ID): cv.ensure_list,
+    vol.Optional(CONF_ID, default=[]): cv.ensure_list,
     vol.Required(CONF_SENDER_ID): cv.ensure_list,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })

--- a/homeassistant/components/light/enocean.py
+++ b/homeassistant/components/light/enocean.py
@@ -26,8 +26,8 @@ DEPENDENCIES = ['enocean']
 SUPPORT_ENOCEAN = SUPPORT_BRIGHTNESS
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ID): cv.string,
-    vol.Required(CONF_SENDER_ID): cv.string,
+    vol.Required(CONF_ID): cv.ensure_list,
+    vol.Required(CONF_SENDER_ID): cv.ensure_list,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 

--- a/homeassistant/components/light/enocean.py
+++ b/homeassistant/components/light/enocean.py
@@ -26,8 +26,8 @@ DEPENDENCIES = ['enocean']
 SUPPORT_ENOCEAN = SUPPORT_BRIGHTNESS
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_ID, default=[]): cv.ensure_list,
-    vol.Required(CONF_SENDER_ID): cv.ensure_list,
+    vol.Optional(CONF_ID, default=[]): vol.All(cv.ensure_list, [vol.Coerce(int)]),
+    vol.Required(CONF_SENDER_ID): vol.All(cv.ensure_list, [vol.Coerce(int)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 

--- a/homeassistant/components/sensor/enocean.py
+++ b/homeassistant/components/sensor/enocean.py
@@ -20,7 +20,7 @@ DEFAULT_NAME = 'EnOcean sensor'
 DEPENDENCIES = ['enocean']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ID): cv.string,
+    vol.Required(CONF_ID): cv.ensure_list,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 

--- a/homeassistant/components/sensor/enocean.py
+++ b/homeassistant/components/sensor/enocean.py
@@ -20,7 +20,7 @@ DEFAULT_NAME = 'EnOcean sensor'
 DEPENDENCIES = ['enocean']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ID): cv.ensure_list,
+    vol.Required(CONF_ID): vol.All(cv.ensure_list, [vol.Coerce(int)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 

--- a/homeassistant/components/switch/enocean.py
+++ b/homeassistant/components/switch/enocean.py
@@ -20,7 +20,7 @@ DEFAULT_NAME = 'EnOcean Switch'
 DEPENDENCIES = ['enocean']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ID): cv.string,
+    vol.Required(CONF_ID): cv.ensure_list,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 

--- a/homeassistant/components/switch/enocean.py
+++ b/homeassistant/components/switch/enocean.py
@@ -20,7 +20,7 @@ DEFAULT_NAME = 'EnOcean Switch'
 DEPENDENCIES = ['enocean']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ID): cv.ensure_list,
+    vol.Required(CONF_ID): vol.All(cv.ensure_list, [vol.Coerce(int)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 


### PR DESCRIPTION
**Description:**
EnOcean support was broken in 9219d65c3e03cf6f6c3af37a9d1f06c8b6db5160 because the IDs are read in as strings, but they should be lists. This is related to https://github.com/home-assistant/home-assistant/pull/3183.

Also, CONF_ID is not required configuration for enocean lights. Not allowing this, breaks backwards compatibility.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

