### PR TITLE
Protect hm thread for hangs on events

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -544,19 +544,19 @@ def _hm_event_handler(hass, proxy, device, caller, attribute, value):
 
     # keypress event
     if attribute in HM_PRESS_EVENTS:
-        hass.bus.fire(EVENT_KEYPRESS, {
+        hass.add_job(hass.bus.async_fire(EVENT_KEYPRESS, {
             ATTR_NAME: hmdevice.NAME,
             ATTR_PARAM: attribute,
             ATTR_CHANNEL: channel
-        })
+        }))
         return
 
     # impulse event
     if attribute in HM_IMPULSE_EVENTS:
-        hass.bus.fire(EVENT_KEYPRESS, {
+        hass.add_job(hass.bus.async_fire(EVENT_KEYPRESS, {
             ATTR_NAME: hmdevice.NAME,
             ATTR_CHANNEL: channel
-        })
+        }))
         return
 
     _LOGGER.warning("Event is unknown and not forwarded to HA")


### PR DESCRIPTION
**Description:**

To many homematic events will hang the thread on waiting of event loop. So this change will process events most faster and protect for micro hangs with 0.34.0

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

