### PR TITLE
device tracker

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -332,7 +332,6 @@ class Device(Entity):
     gps = None  # type: GPSType
     gps_accuracy = 0
     last_seen = None  # type: dt_util.dt.datetime
-    battery = None  # type: str
     attributes = None  # type: dict
     vendor = None  # type: str
 
@@ -396,9 +395,6 @@ class Device(Entity):
             attr[ATTR_LONGITUDE] = self.gps[1]
             attr[ATTR_GPS_ACCURACY] = self.gps_accuracy
 
-        if self.battery:
-            attr[ATTR_BATTERY] = self.battery
-
         if self.attributes:
             for key, value in self.attributes.items():
                 attr[key] = value
@@ -419,8 +415,13 @@ class Device(Entity):
         self.host_name = host_name
         self.location_name = location_name
         self.gps_accuracy = gps_accuracy or 0
-        self.battery = battery
-        self.attributes = attributes
+        if (battery or attributes) and self.attributes is None:
+            self.attributes = {}
+        if battery:
+            self.attributes[ATTR_BATTERY] = battery
+        if attributes:
+            for key, value in attributes.items():
+                self.attributes[key] = value
         self.gps = None
 
         if gps is not None:


### PR DESCRIPTION
**Description:**
You can have two different platforms to track the same device. One platform getting the gps position from a phone and one platform scanning the local network for the phone.
The platform tracking the phone by the gps position might also have access to more info as the battery status. The platform scanning the local network will currently overwrite all extra attributes. This pr will only update attributes if a new value is available. 

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

