### PR TITLE
Weather platform Forecast

### DIFF
--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -30,8 +30,6 @@ ATTR_WEATHER_WIND_BEARING = 'wind_bearing'
 ATTR_WEATHER_WIND_SPEED = 'wind_speed'
 ATTR_FORECAST = 'forecast'
 
-CONF_FORECAST = 'forecast'
-
 
 def setup(hass, config):
     """Setup the weather component."""

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -92,7 +92,7 @@ class WeatherEntity(Entity):
     def state_attributes(self):
         """Return the state attributes."""
         data = {
-            ATTR_WEATHER_TEMPERATURE: self._temp_for_display,
+            ATTR_WEATHER_TEMPERATURE: self._temp_for_display(self.temperature),
             ATTR_WEATHER_HUMIDITY: self.humidity,
         }
 
@@ -118,6 +118,10 @@ class WeatherEntity(Entity):
 
         forecast = self.forecast
         if forecast is not None:
+            for forecast_entry in forecast:
+                forecast_entry['temp'] = self._temp_for_display(
+                    forecast_entry['temp'])
+
             data[ATTR_FORECAST] = forecast
 
         return data
@@ -132,10 +136,8 @@ class WeatherEntity(Entity):
         """Return the current condition."""
         raise NotImplementedError()
 
-    @property
-    def _temp_for_display(self):
+    def _temp_for_display(self, temp):
         """Convert temperature into preferred units for display purposes."""
-        temp = self.temperature
         unit = self.temperature_unit
         hass_unit = self.hass.config.units.temperature_unit
 

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -29,6 +29,8 @@ ATTR_WEATHER_TEMPERATURE = 'temperature'
 ATTR_WEATHER_WIND_BEARING = 'wind_bearing'
 ATTR_WEATHER_WIND_SPEED = 'wind_speed'
 ATTR_FORECAST = 'forecast'
+ATTR_FORECAST_TEMP = 'temperature'
+ATTR_FORECAST_TIME = 'datetime'
 
 
 def setup(hass, config):
@@ -119,8 +121,8 @@ class WeatherEntity(Entity):
         forecast = self.forecast
         if forecast is not None:
             for forecast_entry in forecast:
-                forecast_entry['temp'] = self._temp_for_display(
-                    forecast_entry['temp'])
+                forecast_entry[ATTR_FORECAST_TEMP] = self._temp_for_display(
+                    forecast_entry[ATTR_FORECAST_TEMP])
 
             data[ATTR_FORECAST] = forecast
 

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -118,11 +118,13 @@ class WeatherEntity(Entity):
         if attribution is not None:
             data[ATTR_WEATHER_ATTRIBUTION] = attribution
 
-        forecast = self.forecast
-        if forecast is not None:
-            for forecast_entry in forecast:
+        if self.forecast is not None:
+            forecast = []
+            for forecast_entry in self.forecast:
+                forecast_entry = dict(forecast_entry)
                 forecast_entry[ATTR_FORECAST_TEMP] = self._temp_for_display(
                     forecast_entry[ATTR_FORECAST_TEMP])
+                forecast.append(forecast_entry)
 
             data[ATTR_FORECAST] = forecast
 

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -28,7 +28,9 @@ ATTR_WEATHER_PRESSURE = 'pressure'
 ATTR_WEATHER_TEMPERATURE = 'temperature'
 ATTR_WEATHER_WIND_BEARING = 'wind_bearing'
 ATTR_WEATHER_WIND_SPEED = 'wind_speed'
+ATTR_FORECAST = 'forecast'
 
+CONF_FORECAST = 'forecast'
 
 def setup(hass, config):
     """Setup the weather component."""
@@ -83,6 +85,10 @@ class WeatherEntity(Entity):
         return None
 
     @property
+    def forecast(self):
+        return None
+
+    @property
     def state_attributes(self):
         """Return the state attributes."""
         data = {
@@ -109,6 +115,10 @@ class WeatherEntity(Entity):
         attribution = self.attribution
         if attribution is not None:
             data[ATTR_WEATHER_ATTRIBUTION] = attribution
+
+        forecast = self.forecast
+        if forecast is not None:
+            data[ATTR_FORECAST] = forecast
 
         return data
 

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -32,6 +32,7 @@ ATTR_FORECAST = 'forecast'
 
 CONF_FORECAST = 'forecast'
 
+
 def setup(hass, config):
     """Setup the weather component."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
@@ -86,6 +87,7 @@ class WeatherEntity(Entity):
 
     @property
     def forecast(self):
+        """Return the forecast."""
         return None
 
     @property

--- a/homeassistant/components/weather/demo.py
+++ b/homeassistant/components/weather/demo.py
@@ -105,11 +105,11 @@ class DemoWeather(WeatherEntity):
 
         forecast_data = []
         for entry in self._forecast:
-            dict = {
+            data_dict = {
                 'datetime': reftime.isoformat(),
                 'temp': entry
             }
             reftime = reftime + timedelta(hours=4)
-            forecast_data.append(dict)
+            forecast_data.append(data_dict)
 
         return forecast_data

--- a/homeassistant/components/weather/demo.py
+++ b/homeassistant/components/weather/demo.py
@@ -6,7 +6,8 @@ https://home-assistant.io/components/demo/
 """
 from datetime import datetime, timedelta
 
-from homeassistant.components.weather import WeatherEntity
+from homeassistant.components.weather import (
+    WeatherEntity, ATTR_FORECAST_TEMP, ATTR_FORECAST_TIME)
 from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
 CONDITION_CLASSES = {
@@ -106,8 +107,8 @@ class DemoWeather(WeatherEntity):
         forecast_data = []
         for entry in self._forecast:
             data_dict = {
-                'datetime': reftime.isoformat(),
-                'temp': entry
+                ATTR_FORECAST_TIME: reftime.isoformat(),
+                ATTR_FORECAST_TEMP: entry
             }
             reftime = reftime + timedelta(hours=4)
             forecast_data.append(data_dict)

--- a/homeassistant/components/weather/demo.py
+++ b/homeassistant/components/weather/demo.py
@@ -4,6 +4,8 @@ Demo platform that offers fake meteorological data.
 For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/demo/
 """
+from datetime import datetime, timedelta
+
 from homeassistant.components.weather import WeatherEntity
 from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
@@ -28,8 +30,10 @@ CONDITION_CLASSES = {
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Demo weather."""
     add_devices([
-        DemoWeather('South', 'Sunshine', 21, 92, 1099, 0.5, TEMP_CELSIUS),
-        DemoWeather('North', 'Shower rain', -12, 54, 987, 4.8, TEMP_FAHRENHEIT)
+        DemoWeather('South', 'Sunshine', 21, 92, 1099, 0.5, TEMP_CELSIUS,
+                    [22, 19, 15, 12, 14, 18, 21]),
+        DemoWeather('North', 'Shower rain', -12, 54, 987, 4.8, TEMP_FAHRENHEIT,
+                    [-10, -13, -18, -23, -19, -14, -9])
     ])
 
 
@@ -37,7 +41,7 @@ class DemoWeather(WeatherEntity):
     """Representation of a weather condition."""
 
     def __init__(self, name, condition, temperature, humidity, pressure,
-                 wind_speed, temperature_unit):
+                 wind_speed, temperature_unit, forecast):
         """Initialize the Demo weather."""
         self._name = name
         self._condition = condition
@@ -46,6 +50,7 @@ class DemoWeather(WeatherEntity):
         self._humidity = humidity
         self._pressure = pressure
         self._wind_speed = wind_speed
+        self._forecast = forecast
 
     @property
     def name(self):
@@ -92,3 +97,19 @@ class DemoWeather(WeatherEntity):
     def attribution(self):
         """Return the attribution."""
         return 'Powered by Home Assistant'
+
+    @property
+    def forecast(self):
+        """Return the forecast."""
+        reftime = datetime.now().replace(hour=16, minute=00)
+
+        forecast_data = []
+        for entry in self._forecast:
+            dict = {
+                'datetime': reftime.isoformat(),
+                'temp': entry
+            }
+            reftime = reftime + timedelta(hours=4)
+            forecast_data.append(dict)
+
+        return forecast_data

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -9,7 +9,8 @@ from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.components.weather import WeatherEntity, PLATFORM_SCHEMA
+from homeassistant.components.weather import (
+    WeatherEntity, PLATFORM_SCHEMA, ATTR_FORECAST_TEMP, ATTR_FORECAST_TIME)
 from homeassistant.const import (CONF_API_KEY, CONF_NAME, CONF_LATITUDE,
                                  CONF_LONGITUDE, STATE_UNKNOWN, TEMP_CELSIUS)
 import homeassistant.helpers.config_validation as cv
@@ -134,9 +135,11 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast array."""
-        return [{'datetime': entry.get_reference_time('iso'),
-                 'temp': entry.get_temperature('celsius').get('temp', None)}
-                for entry in self.forecast_data.get_weathers()]
+        return [{
+                ATTR_FORECAST_TIME: entry.get_reference_time('iso'),
+                ATTR_FORECAST_TEMP: entry.get_temperature('celsius')
+                .get('temp', None)
+                } for entry in self.forecast_data.get_weathers()]
 
     def update(self):
         """Get the latest data from OWM and updates the states."""

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -136,10 +136,9 @@ class OpenWeatherMapWeather(WeatherEntity):
     def forecast(self):
         """Return the forecast array."""
         return [{
-                ATTR_FORECAST_TIME: entry.get_reference_time('iso'),
-                ATTR_FORECAST_TEMP: entry.get_temperature('celsius')
-                .get('temp', None)
-                } for entry in self.forecast_data.get_weathers()]
+            ATTR_FORECAST_TIME: entry.get_reference_time('iso'),
+            ATTR_FORECAST_TEMP: entry.get_temperature('celsius').get('temp')}
+                for entry in self.forecast_data.get_weathers()]
 
     def update(self):
         """Get the latest data from OWM and updates the states."""

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -10,8 +10,8 @@ from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant.components.weather import WeatherEntity, PLATFORM_SCHEMA
-from homeassistant.const import (
-    CONF_API_KEY, CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE, STATE_UNKNOWN)
+from homeassistant.const import (CONF_API_KEY, CONF_NAME, CONF_LATITUDE,
+                                 CONF_LONGITUDE, STATE_UNKNOWN, TEMP_CELSIUS)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
@@ -104,7 +104,7 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        return self._temperature_unit
+        return TEMP_CELSIUS
 
     @property
     def pressure(self):
@@ -134,11 +134,8 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast array."""
-        temp_unit = ('celsius' if self.hass.config.units.is_metric else
-                     'fahrenheit')
-
         return [{'datetime': entry.get_reference_time('iso'),
-                 'temp': entry.get_temperature(temp_unit).get('temp', None)}
+                 'temp': entry.get_temperature('celsius').get('temp', None)}
                 for entry in self.forecast_data.get_weathers()]
 
     def update(self):

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -138,7 +138,7 @@ class OpenWeatherMapWeather(WeatherEntity):
                      'fahrenheit')
 
         def create_dict(entry):
-            """Creates dict for forecast entry"""
+            """Create a dict containing forecast data for a specified time."""
             return {
                 'datetime': entry.get_reference_time('iso'),
                 'temp': entry.get_temperature(temp_unit).get('temp', None),

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.components.weather import (WeatherEntity, PLATFORM_SCHEMA)
+from homeassistant.components.weather import WeatherEntity, PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_API_KEY, CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
@@ -134,18 +134,18 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast array."""
-        forecast_array = []
-        temp_unit = 'celsius' if self.hass.config.units.is_metric else 'fahrenheit'
+        temp_unit = ('celsius' if self.hass.config.units.is_metric else
+                     'fahrenheit')
 
-        for forecast_entry in self.forecast_data.get_weathers():
-            data_dict = {
-                'datetime': forecast_entry.get_reference_time('iso'),
-                'temp': forecast_entry.get_temperature(temp_unit)
-                        .get('temp', None),
+        def create_dict(entry):
+            """Creates dict for forecast entry"""
+            return {
+                'datetime': entry.get_reference_time('iso'),
+                'temp': entry.get_temperature(temp_unit).get('temp', None),
             }
-            forecast_array.append(data_dict)
 
-        return forecast_array
+        return [create_dict(entry) for entry in
+                self.forecast_data.get_weathers()]
 
     def update(self):
         """Get the latest data from OWM and updates the states."""

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -137,15 +137,9 @@ class OpenWeatherMapWeather(WeatherEntity):
         temp_unit = ('celsius' if self.hass.config.units.is_metric else
                      'fahrenheit')
 
-        def create_dict(entry):
-            """Create a dict containing forecast data for a specified time."""
-            return {
-                'datetime': entry.get_reference_time('iso'),
-                'temp': entry.get_temperature(temp_unit).get('temp', None),
-            }
-
-        return [create_dict(entry) for entry in
-                self.forecast_data.get_weathers()]
+        return [{'datetime': entry.get_reference_time('iso'),
+                 'temp': entry.get_temperature(temp_unit).get('temp', None)}
+                for entry in self.forecast_data.get_weathers()]
 
     def update(self):
         """Get the latest data from OWM and updates the states."""

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -144,7 +144,11 @@ class OpenWeatherMapWeather(WeatherEntity):
         forecast_array = []
 
         for forecast_entry in self.forecast_data.get_weathers():
-            forecast_array.append(forecast_entry.to_JSON())
+            data_dict = {
+                'datetime': forecast_entry.get_reference_time('iso'),
+                'temp': forecast_entry.get_temperature('celsius').get('temp', None),
+            }
+            forecast_array.append(data_dict)
 
         return forecast_array
 
@@ -181,11 +185,11 @@ class WeatherData(object):
     @Throttle(MIN_TIME_BETWEEN_FORECAST_UPDATES)
     def update_forecast(self):
         """Get the lastest forecast from OpenWeatherMap."""
-        fc = self.owm.three_hours_forecast_at_coords(
+        fcd = self.owm.three_hours_forecast_at_coords(
             self.latitude, self.longitude)
 
-        if fc is None:
+        if fcd is None:
             _LOGGER.warning("Failed to fetch forecast data from OWM")
             return
 
-        self.forecast_data = fc.get_forecast()
+        self.forecast_data = fcd.get_forecast()

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -9,7 +9,8 @@ from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.components.weather import WeatherEntity, PLATFORM_SCHEMA, CONF_FORECAST
+from homeassistant.components.weather import (
+    WeatherEntity, PLATFORM_SCHEMA, CONF_FORECAST)
 from homeassistant.const import (
     CONF_API_KEY, CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
@@ -136,8 +137,8 @@ class OpenWeatherMapWeather(WeatherEntity):
 
     @property
     def forecast(self):
-        """Return the forecast object"""
-        if self._forecast == False:
+        """Return the forecast array."""
+        if self._forecast is False:
             return None
 
         forecast_array = []
@@ -180,7 +181,8 @@ class WeatherData(object):
     @Throttle(MIN_TIME_BETWEEN_FORECAST_UPDATES)
     def update_forecast(self):
         """Get the lastest forecast from OpenWeatherMap."""
-        fc = self.owm.three_hours_forecast_at_coords(self.latitude, self.longitude)
+        fc = self.owm.three_hours_forecast_at_coords(
+            self.latitude, self.longitude)
 
         if fc is None:
             _LOGGER.warning("Failed to fetch forecast data from OWM")

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -146,7 +146,8 @@ class OpenWeatherMapWeather(WeatherEntity):
         for forecast_entry in self.forecast_data.get_weathers():
             data_dict = {
                 'datetime': forecast_entry.get_reference_time('iso'),
-                'temp': forecast_entry.get_temperature('celsius').get('temp', None),
+                'temp': forecast_entry.get_temperature('celsius')
+                    .get('temp', None),
             }
             forecast_array.append(data_dict)
 

--- a/tests/components/weather/test_weather.py
+++ b/tests/components/weather/test_weather.py
@@ -5,7 +5,7 @@ from homeassistant.components import weather
 from homeassistant.components.weather import (
     ATTR_WEATHER_ATTRIBUTION, ATTR_WEATHER_HUMIDITY, ATTR_WEATHER_OZONE,
     ATTR_WEATHER_PRESSURE, ATTR_WEATHER_TEMPERATURE, ATTR_WEATHER_WIND_BEARING,
-    ATTR_WEATHER_WIND_SPEED)
+    ATTR_WEATHER_WIND_SPEED, ATTR_FORECAST, ATTR_FORECAST_TEMP)
 from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.bootstrap import setup_component
 
@@ -45,6 +45,9 @@ class TestWeather(unittest.TestCase):
         assert data.get(ATTR_WEATHER_OZONE) is None
         assert data.get(ATTR_WEATHER_ATTRIBUTION) == \
             'Powered by Home Assistant'
+        assert data.get(ATTR_FORECAST)[0].get(ATTR_FORECAST_TEMP) == 22
+        assert data.get(ATTR_FORECAST)[6].get(ATTR_FORECAST_TEMP) == 21
+        assert len(data.get(ATTR_FORECAST)) == 7
 
     def test_temperature_convert(self):
         """Test temperature conversion."""


### PR DESCRIPTION
**Description:**
This change adds the `forecast` option to the `weather` platform.
The OpenWeatherMap (weather platform, not sensor) has been updated to include the forecast data (every 30 minutes).
The forecast is contained as an attribute, holding an array with the JSON objects

The end goal would be to update the frontend as well, to show a card for the weather platform, showing current conditions, as well as a graph (or multiple) for the forecast data.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1536

**Example entry for `configuration.yaml` (if applicable):**
```yaml
weather:
  - platform: openweathermap
    api_key: xxxxx
    forecast: True
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
         **Was unable to run tests for py3.4 locally**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.