### PR TITLE
Revert "Update reference to correct tplink switch"

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -15,7 +15,7 @@ from homeassistant.const import (CONF_HOST, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['https://github.com/GadgetReactor/pyHS100/archive/'
-                'fadb76c5a0e04f4995f16055845ffedc6d658316.zip#pyHS100==0.2.1']
+                '1f771b7d8090a91c6a58931532e42730b021cbde.zip#pyHS100==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -173,7 +173,7 @@ http://github.com/technicalpickles/python-nest/archive/2512973b4b390d3965da43529
 https://github.com/Danielhiversen/flux_led/archive/0.9.zip#flux_led==0.9
 
 # homeassistant.components.switch.tplink
-https://github.com/GadgetReactor/pyHS100/archive/fadb76c5a0e04f4995f16055845ffedc6d658316.zip#pyHS100==0.2.1
+https://github.com/GadgetReactor/pyHS100/archive/1f771b7d8090a91c6a58931532e42730b021cbde.zip#pyHS100==0.2.0
 
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.3.7.zip#pyW215==0.3.7


### PR DESCRIPTION
Reverts home-assistant/home-assistant#4670

Rollback to the previous working version. The upgrade introduced new code that requires an update to the bindings, which I'll gladly work on during this development cycle.