### PR TITLE
Fix CORS when static resources registered

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -277,9 +277,15 @@ class HomeAssistantWSGI(object):
     @asyncio.coroutine
     def start(self):
         """Start the wsgi server."""
+        cors_added = set()
         if self.cors is not None:
             for route in list(self.app.router.routes()):
+                if hasattr(route, 'resource'):
+                    route = route.resource
+                if route in cors_added:
+                    continue
                 self.cors.add(route)
+                cors_added.add(route)
 
         if self.ssl_certificate:
             context = ssl.SSLContext(SSL_VERSION)

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -44,6 +44,10 @@ def setUpModule():
 
     bootstrap.setup_component(hass, 'api')
 
+    # Registering static path as it caused CORS to blow up
+    hass.http.register_static_path(
+        '/custom_components', hass.config.path('custom_components'))
+
     hass.start()
 
 
@@ -53,11 +57,12 @@ def tearDownModule():
     hass.stop()
 
 
-class TestHttp:
+class TestCors:
     """Test HTTP component."""
 
     def test_cors_allowed_with_password_in_url(self):
         """Test cross origin resource sharing with password in url."""
+
         req = requests.get(_url(const.URL_API),
                            params={'api_password': API_PASSWORD},
                            headers={const.HTTP_HEADER_ORIGIN: HTTP_BASE_URL})


### PR DESCRIPTION
**Description:**
CORS blew up when static resources were defined.

**Related issue (if applicable):** fixes #4705

**Example entry for `configuration.yaml` (if applicable):**
```yaml
http:
  cors_allowed_origins:
    - https://home-assistant.io

```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

