### PR TITLE
Fix Nest interpreting Celsius temperature as Fahrenheit

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -229,7 +229,7 @@ class NestThermostat(ClimateDevice):
         self._eco_temperature = self.device.eco_temperature
         self._locked_temperature = self.device.locked_temperature
         self._is_locked = self.device.is_locked
-        if self.device.temperature == 'C':
+        if self.device.temperature_scale == 'C':
             self._temperature_scale = TEMP_CELSIUS
         else:
             self._temperature_scale = TEMP_FAHRENHEIT


### PR DESCRIPTION
**Description:**
This should fix the temperature shown on Nest thermostats when using Celsius. It looks like it was checking the `temperature` property instead of the correct `temperature_scale` property.

Can someone with a Nest verify this for me.

https://community.home-assistant.io/t/0-34-0-nest-climate-shows-incorrect-temperature/7124

CC @technicalpickles 