### PR TITLE
Make sure all nest platforms require discovery info

### DIFF
--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -60,6 +60,9 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup Nest binary sensors."""
+    if discovery_info is None:
+        return
+
     nest = hass.data[DATA_NEST]
     conf = config.get(CONF_MONITORED_CONDITIONS, _VALID_BINARY_SENSOR_TYPES)
 

--- a/homeassistant/components/camera/nest.py
+++ b/homeassistant/components/camera/nest.py
@@ -26,6 +26,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a Nest Cam."""
     if discovery_info is None:
         return
+
     camera_devices = hass.data[nest.DATA_NEST].camera_devices()
     cameras = [NestCamera(structure, device)
                for structure, device in camera_devices]

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -31,9 +31,10 @@ STATE_HEAT_COOL = 'heat-cool'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Nest thermostat."""
-    _LOGGER.debug("Setting up nest thermostat")
     if discovery_info is None:
         return
+
+    _LOGGER.debug("Setting up nest thermostat")
 
     temp_unit = hass.config.units.temperature_unit
 

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -68,6 +68,9 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Nest Sensor."""
+    if discovery_info is None:
+        return
+
     nest = hass.data[DATA_NEST]
     conf = config.get(CONF_MONITORED_CONDITIONS, _VALID_SENSOR_TYPES)
 


### PR DESCRIPTION
**Description:**

The recent work on Nest changed started using discovery for the other component, and introduced the use of a configurator. https://github.com/home-assistant/home-assistant/issues/4730 demonstrates errors if the sensor platform for nest is configured in `configruation.yaml` but the configurator hasn't been used yet.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/4730

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

