### PR TITLE
[emulated_hue] Set hue-bridgeid in UPNP response

### DIFF
--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -74,6 +74,7 @@ CACHE-CONTROL: max-age=60
 EXT:
 LOCATION: http://{0}:{1}/description.xml
 SERVER: FreeRTOS/6.0.5, UPnP/1.0, IpBridge/0.1
+hue-bridgeid: 1234
 ST: urn:schemas-upnp-org:device:basic:1
 USN: uuid:Socket-1_0-221438K0100073::urn:schemas-upnp-org:device:basic:1
 


### PR DESCRIPTION
**Description:**
Adds `hue-bridgeid` field to UPNP response for emulated_hue. Without this field, my Google Home would never pair with Home Assistant.

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

