### PR TITLE
Add support for Hue LightGroups

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -179,6 +179,7 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable):
                 new_lights.append(lights[light_id])
             else:
                 lights[light_id].info = info
+                lights[light_id].update_ha_state()
 
         for lightgroup_id, info in api_groups.items():
             if lightgroup_id not in lightgroups:
@@ -188,6 +189,7 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable):
                 new_lightgroups.append(lightgroups[lightgroup_id])
             else:
                 lightgroups[lightgroup_id].info = info
+                lightgroups[lightgroup_id].update_ha_state()
 
         if new_lights:
             add_devices(new_lights)

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -304,7 +304,8 @@ class HueLight(Light):
             if self.allow_unreachable:
                 return self.info['state']['on']
             else:
-                return self.info['state']['reachable'] and self.info['state']['on']
+                return self.info['state']['reachable'] and \
+                       self.info['state']['on']
 
     @property
     def supported_features(self):

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -163,7 +163,6 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable):
             return
 
         new_lights = []
-        new_lightgroups = []
 
         api_name = api.get('config').get('name')
         if api_name in ('RaspBee-GW', 'deCONZ-GW'):
@@ -179,23 +178,20 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable):
                 new_lights.append(lights[light_id])
             else:
                 lights[light_id].info = info
-                lights[light_id].update_ha_state()
+                lights[light_id].schedule_update_ha_state()
 
         for lightgroup_id, info in api_groups.items():
             if lightgroup_id not in lightgroups:
                 lightgroups[lightgroup_id] = HueLight(
                     int(lightgroup_id), info, bridge, update_lights,
                     bridge_type, allow_unreachable, True)
-                new_lightgroups.append(lightgroups[lightgroup_id])
+                new_lights.append(lightgroups[lightgroup_id])
             else:
                 lightgroups[lightgroup_id].info = info
-                lightgroups[lightgroup_id].update_ha_state()
+                lightgroups[lightgroup_id].schedule_update_ha_state()
 
         if new_lights:
             add_devices(new_lights)
-
-        if new_lightgroups:
-            add_devices(new_lightgroups)
 
     _CONFIGURED_BRIDGES[socket.gethostbyname(host)] = True
 

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -303,7 +303,7 @@ class HueLight(Light):
                 return self.info['state']['on']
             else:
                 return self.info['state']['reachable'] and \
-                       self.info['state']['on']
+                    self.info['state']['on']
 
     @property
     def supported_features(self):

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -181,15 +181,13 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable):
                 lights[light_id].info = info
 
         for lightgroup_id, info in api_groups.items():
-            if info['type'] == 'LightGroup':
-                if lightgroup_id not in lightgroups:
-                    lightgroups[lightgroup_id] = \
-                        HueLightGroup(int(lightgroup_id), info,
-                                      bridge, update_lights,
-                                      bridge_type)
-                    new_lights.append(lightgroups[lightgroup_id])
-                else:
-                    lightgroups[lightgroup_id].info = info
+            if lightgroup_id not in lightgroups:
+                lightgroups[lightgroup_id] = HueLightGroup(
+                    int(lightgroup_id), info, bridge, update_lights,
+                    bridge_type)
+                new_lights.append(lightgroups[lightgroup_id])
+            else:
+                lightgroups[lightgroup_id].info = info
 
         if new_lights:
             add_devices(new_lights)
@@ -390,6 +388,21 @@ class HueLightGroup(Light):
     def name(self):
         """Return the name of the Hue light group."""
         return self.info.get('name', DEVICE_DEFAULT_NAME)
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return self.info['action'].get('bri')
+
+    @property
+    def xy_color(self):
+        """Return the XY color value."""
+        return self.info['action'].get('xy')
+
+    @property
+    def color_temp(self):
+        """Return the CT color value."""
+        return self.info['action'].get('ct')
 
     @property
     def is_on(self):


### PR DESCRIPTION
**Description:**
This PR adds basic support for Hue LightGroups.

Currently, storing lights in a group in hass causes hass to send multiple API calls when turning on or turning off, therefore, the lights don't turn on/off simultaneous. When sending the request to a group, the lights will turn on/off simultaneous.

The new Hue app doesn't provide a UI to create groups, but the old one does. Also, some light fixtures (like Philips Hue beyond) have multiple light sources that are combined in a group automatically.

There are still a few things worth mentioning:
* The API to get a group returns a `any_on` and `all_on`. I've used the `any_on`, since that mimics the current behaviour of a group in hass.
* The Group API provides a state of a (random) single light in the group (in the `action` dict). By using this, you can control a group in the interface UI as if it would be one light.

Also, there is still a issue that I don't know how to solve:
* Turning on/off a group doesn't update the state of the individual lights of that group in the UI, however, the `update_lights()` is executed and `lights` and `lightgroups` arrays are modified. I don't know how I can tell hass to update the state of the entities.

**Related issue (if applicable):** https://community.home-assistant.io/t/philips-hue-light-group/508/5

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

