### PR TITLE
Fix websocket async

### DIFF
--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -204,7 +204,6 @@ class ActiveConnection:
         self.hass = hass
         self.request = request
         self.wsock = None
-        self.socket_task = None
         self.event_listeners = {}
 
     def debug(self, message1, message2=''):
@@ -220,22 +219,6 @@ class ActiveConnection:
         self.debug('Sending', message)
         self.wsock.send_json(message, dumps=JSON_DUMP)
 
-    @callback
-    def _cancel_connection(self, event):
-        """Cancel this connection."""
-        self.socket_task.cancel()
-
-    @asyncio.coroutine
-    def _call_service_helper(self, msg):
-        """Helper to call a service and fire complete message."""
-        yield from self.hass.services.async_call(msg['domain'], msg['service'],
-                                                 msg['service_data'], True)
-        try:
-            self.send_message(result_message(msg['id']))
-        except RuntimeError:
-            # Socket has been closed.
-            pass
-
     @asyncio.coroutine
     def handle(self):
         """Handle the websocket connection."""
@@ -243,9 +226,15 @@ class ActiveConnection:
         yield from wsock.prepare(self.request)
 
         # Set up to cancel this connection when Home Assistant shuts down
-        self.socket_task = asyncio.Task.current_task(loop=self.hass.loop)
-        self.hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP,
-                                   self._cancel_connection)
+        socket_task = asyncio.Task.current_task(loop=self.hass.loop)
+
+        @callback
+        def cancel_connection(event):
+            """Cancel this connection."""
+            socket_task.cancel()
+
+        unsub_stop = self.hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP,
+                                                cancel_connection)
 
         self.debug('Connected')
 
@@ -339,6 +328,8 @@ class ActiveConnection:
             _LOGGER.exception(error)
 
         finally:
+            unsub_stop()
+
             for unsub in self.event_listeners.values():
                 unsub()
 
@@ -386,7 +377,18 @@ class ActiveConnection:
         """Handle call service command."""
         msg = CALL_SERVICE_MESSAGE_SCHEMA(msg)
 
-        self.hass.async_add_job(self._call_service_helper(msg))
+        @asyncio.coroutine
+        def call_service_helper(msg):
+            """Helper to call a service and fire complete message."""
+            yield from self.hass.services.async_call(
+                msg['domain'], msg['service'], msg['service_data'], True)
+            try:
+                self.send_message(result_message(msg['id']))
+            except RuntimeError:
+                # Socket has been closed.
+                pass
+
+        self.hass.async_add_job(call_service_helper(msg))
 
     def handle_get_states(self, msg):
         """Handle get states command."""


### PR DESCRIPTION
**Description:**
Fix the websocket sometimes from writing to the websocket from outside of the event loop.

Problem here was that the `callback` annotation didn't survive the use of `partial`.

**Related issue (if applicable):** fixes #4725 #4726

**Example entry for `configuration.yaml` (if applicable):**
```yaml
websocket_api:
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
