### PR TITLE
Pyunifi dep

### DIFF
--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -34,7 +34,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def get_scanner(hass, config):
     """Setup Unifi device_tracker."""
-    from unifi.controller import Controller
+    from pyunifi.controller import Controller
 
     host = config[DOMAIN].get(CONF_HOST)
     username = config[DOMAIN].get(CONF_USERNAME)

--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -14,7 +14,7 @@ from homeassistant.components.device_tracker import DOMAIN, PLATFORM_SCHEMA
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 
 # Unifi package doesn't list urllib3 as a requirement
-REQUIREMENTS = ['urllib3', 'unifi==1.2.5']
+REQUIREMENTS = ['urllib3', 'pyunifi==1.3']
 
 _LOGGER = logging.getLogger(__name__)
 CONF_PORT = 'port'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -567,7 +567,7 @@ twilio==5.4.0
 uber_rides==0.2.7
 
 # homeassistant.components.device_tracker.unifi
-unifi==1.2.5
+pyunifi==1.3
 
 # homeassistant.components.device_tracker.unifi
 urllib3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -69,9 +69,6 @@ boto3==1.3.1
 coinmarketcap==2.0.1
 
 # homeassistant.scripts.check_config
-colorama<=1
-
-# homeassistant.scripts.check_config
 colorlog>2.1,<3
 
 # homeassistant.components.alarm_control_panel.concord232

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -69,6 +69,9 @@ boto3==1.3.1
 coinmarketcap==2.0.1
 
 # homeassistant.scripts.check_config
+colorama<=1
+
+# homeassistant.scripts.check_config
 colorlog>2.1,<3
 
 # homeassistant.components.alarm_control_panel.concord232
@@ -476,6 +479,9 @@ python-twitch==1.3.0
 # homeassistant.components.wink
 python-wink==0.11.0
 
+# homeassistant.components.device_tracker.unifi
+pyunifi==1.3
+
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11
 
@@ -565,9 +571,6 @@ twilio==5.4.0
 
 # homeassistant.components.sensor.uber
 uber_rides==0.2.7
-
-# homeassistant.components.device_tracker.unifi
-pyunifi==1.3
 
 # homeassistant.components.device_tracker.unifi
 urllib3

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -3,7 +3,7 @@ import unittest
 from unittest import mock
 import urllib
 
-from unifi import controller
+from pyunifi import controller
 import voluptuous as vol
 
 from tests.common import get_test_home_assistant


### PR DESCRIPTION
New v4 & v5 of unifi API have possible timeout.  Updated unifi 1.2.5 to relogin if 401 error code value returns.  Forked https://github.com/calmh/unifi-api because it is unmaintained and best fix for issue #4336 involved changes to api software.  Added new repo to pip, i.e. pyunifi, version 1.3.  Updated requirements_all.txt & device_tracker/unifi.py to reflect new pip repo.


**Related issue (if applicable):** fixes #4336 

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass** -> continually fails with error (error at bottom of PR).
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`. -> unifi.py was never in this file AFAIK.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

```
Exception:
Traceback (most recent call last):
  File "c:\users\caleb\documents\homeassistant\home-assistant\.tox\py34\lib\site-packages\pip\basecommand.py", line 215, in main
    status = self.run(options, args)
  File "c:\users\caleb\documents\homeassistant\home-assistant\.tox\py34\lib\site-packages\pip\commands\install.py", line 335, in run
    wb.build(autobuilding=True)
  File "c:\users\caleb\documents\homeassistant\home-assistant\.tox\py34\lib\site-packages\pip\wheel.py", line 749, in build
    self.requirement_set.prepare_files(self.finder)
  File "c:\users\caleb\documents\homeassistant\home-assistant\.tox\py34\lib\site-packages\pip\req\req_set.py", line 380, in prepare_files
    ignore_dependencies=self.ignore_dependencies))
  File "c:\users\caleb\documents\homeassistant\home-assistant\.tox\py34\lib\site-packages\pip\req\req_set.py", line 620, in _prepare_file
    session=self.session, hashes=hashes)
  File "c:\users\caleb\documents\homeassistant\home-assistant\.tox\py34\lib\site-packages\pip\download.py", line 821, in unpack_url
    hashes=hashes
  File "c:\users\caleb\documents\homeassistant\home-assistant\.tox\py34\lib\site-packages\pip\download.py", line 663, in unpack_http_url
    unpack_file(from_path, location, content_type, link)
  File "c:\users\caleb\documents\homeassistant\home-assistant\.tox\py34\lib\site-packages\pip\utils\__init__.py", line 605, in unpack_file
    untar_file(filename, location)
  File "c:\users\caleb\documents\homeassistant\home-assistant\.tox\py34\lib\site-packages\pip\utils\__init__.py", line 577, in untar_file
    with open(path, 'wb') as destfp:
OSError: [Errno 22] Invalid argument: 'C:\\Users\\Caleb\\AppData\\Local\\Temp\\pip-build-y5vb2z0d\\somecomfort\\tests/cassettes/set-attr-hold_heat-17:00:00.json'
```