### PR TITLE
Add support for Netatmo tags

### DIFF
--- a/homeassistant/components/binary_sensor/netatmo.py
+++ b/homeassistant/components/binary_sensor/netatmo.py
@@ -104,7 +104,6 @@ class WelcomeBinarySensor(BinarySensorDevice):
         self._unique_id = "Welcome_binary_sensor {0} - {1}".format(self._name,
                                                                    camera_id)
         self.update()
-        self.scan_interval = 15
 
     @property
     def name(self):

--- a/homeassistant/components/binary_sensor/netatmo.py
+++ b/homeassistant/components/binary_sensor/netatmo.py
@@ -128,7 +128,7 @@ class WelcomeBinarySensor(BinarySensorDevice):
     def update(self):
         """Request an update from the Netatmo API."""
         self._data.update()
-        self._data.welcomedata.updateEvent(home=self._data.home)
+        self._data.update_event()
 
         if self._sensor_name == "Someone known":
             self._state =\

--- a/homeassistant/components/binary_sensor/netatmo.py
+++ b/homeassistant/components/binary_sensor/netatmo.py
@@ -23,10 +23,12 @@ _LOGGER = logging.getLogger(__name__)
 
 # These are the available sensors mapped to binary_sensor class
 SENSOR_TYPES = {
-    "Someone known": "motion",
-    "Someone unknown": "motion",
-    "Motion": "motion",
-}
+    "Someone known": 'occupancy',
+    "Someone unknown": 'motion',
+    "Motion": 'motion',
+    "Tag Vibration": 'vibration',
+    "Tag Open": 'opening',
+ }
 
 CONF_HOME = 'home'
 CONF_CAMERAS = 'cameras'
@@ -48,6 +50,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     home = config.get(CONF_HOME, None)
     timeout = config.get(CONF_TIMEOUT, 15)
 
+    module_name = None
+
     import lnetatmo
     try:
         data = WelcomeData(netatmo.NETATMO_AUTH, home)
@@ -64,23 +68,34 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                camera_name not in config[CONF_CAMERAS]:
                 continue
         for variable in sensors:
-            add_devices([WelcomeBinarySensor(data, camera_name, home, timeout,
-                                             variable)])
+            if variable in ('Tag Vibration', 'Tag Open'):
+                continue
+            add_devices([WelcomeBinarySensor(data, camera_name, module_name,
+                                             home, timeout, variable)])
 
+        for module_name in data.get_module_names(camera_name):
+            for variable in sensors:
+                if variable in ('Tag Vibration', 'Tag Open'):
+                    add_devices([WelcomeBinarySensor(data, camera_name,
+                                                     module_name, home,
+                                                     timeout, variable)])
 
 class WelcomeBinarySensor(BinarySensorDevice):
     """Represent a single binary sensor in a Netatmo Welcome device."""
 
-    def __init__(self, data, camera_name, home, timeout, sensor):
+    def __init__(self, data, camera_name, module_name, home, timeout, sensor):
         """Setup for access to the Netatmo camera events."""
         self._data = data
         self._camera_name = camera_name
+        self._module_name = module_name
         self._home = home
         self._timeout = timeout
         if home:
             self._name = home + ' / ' + camera_name
         else:
             self._name = camera_name
+        if module_name:
+            self._name += ' / ' +  module_name
         self._sensor_name = sensor
         self._name += ' ' + sensor
         camera_id = data.welcomedata.cameraByName(camera=camera_name,
@@ -129,5 +144,16 @@ class WelcomeBinarySensor(BinarySensorDevice):
                 self._data.welcomedata.motionDetected(self._home,
                                                       self._camera_name,
                                                       self._timeout*60)
+        elif self._sensor_name == "Tag Vibration":
+            self._state =\
+                self._data.welcomedata.moduleMotionDetected(self._home,
+                                                            self._module_name,
+                                                            self._camera_name,
+                                                            self._timeout*60)
+        elif self._sensor_name == "Tag Open":
+            self._state =\
+                self._data.welcomedata.moduleOpened(self._home,
+                                                    self._module_name,
+                                                    self._camera_name)
         else:
             return None

--- a/homeassistant/components/binary_sensor/netatmo.py
+++ b/homeassistant/components/binary_sensor/netatmo.py
@@ -28,7 +28,7 @@ SENSOR_TYPES = {
     "Motion": 'motion',
     "Tag Vibration": 'vibration',
     "Tag Open": 'opening',
- }
+}
 
 CONF_HOME = 'home'
 CONF_CAMERAS = 'cameras'
@@ -80,6 +80,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                                      module_name, home,
                                                      timeout, variable)])
 
+
 class WelcomeBinarySensor(BinarySensorDevice):
     """Represent a single binary sensor in a Netatmo Welcome device."""
 
@@ -95,7 +96,7 @@ class WelcomeBinarySensor(BinarySensorDevice):
         else:
             self._name = camera_name
         if module_name:
-            self._name += ' / ' +  module_name
+            self._name += ' / ' + module_name
         self._sensor_name = sensor
         self._name += ' ' + sensor
         camera_id = data.welcomedata.cameraByName(camera=camera_name,
@@ -103,7 +104,7 @@ class WelcomeBinarySensor(BinarySensorDevice):
         self._unique_id = "Welcome_binary_sensor {0} - {1}".format(self._name,
                                                                    camera_id)
         self.update()
-        self.scan_interval=15
+        self.scan_interval = 15
 
     @property
     def name(self):

--- a/homeassistant/components/binary_sensor/netatmo.py
+++ b/homeassistant/components/binary_sensor/netatmo.py
@@ -103,6 +103,7 @@ class WelcomeBinarySensor(BinarySensorDevice):
         self._unique_id = "Welcome_binary_sensor {0} - {1}".format(self._name,
                                                                    camera_id)
         self.update()
+        self.scan_interval=15
 
     @property
     def name(self):

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -87,6 +87,15 @@ class WelcomeData(object):
                 self.camera_names.append(camera['name'])
         return self.camera_names
 
+    def get_module_names(self, camera_name):
+        self.module_names = []
+        self.update()
+        cam_id = self.welcomedata.cameraByName(camera = camera_name, home = self.home)
+        for module in self.welcomedata.modules.values():
+            if cam_id == module['cam_id']:
+                self.module_names.append(module['name'])
+        return self.module_names
+
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Call the Netatmo API to update the data."""

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -100,4 +100,4 @@ class WelcomeData(object):
     def update(self):
         """Call the Netatmo API to update the data."""
         import lnetatmo
-        self.welcomedata = lnetatmo.WelcomeData(self.auth)
+        self.welcomedata = lnetatmo.WelcomeData(self.auth, size = 100)

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -30,6 +30,7 @@ NETATMO_AUTH = None
 DEFAULT_DISCOVERY = True
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=10)
+MIN_TIME_BETWEEN_EVENT_UPDATES = timedelta(seconds=10)
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -101,3 +102,8 @@ class WelcomeData(object):
         """Call the Netatmo API to update the data."""
         import lnetatmo
         self.welcomedata = lnetatmo.WelcomeData(self.auth, size = 100)
+
+    @Throttle(MIN_TIME_BETWEEN_EVENT_UPDATES)
+    def update_event(self):
+        self.welcomedata.updateEvent(home=self.home)
+

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -18,7 +18,7 @@ from homeassistant.util import Throttle
 
 REQUIREMENTS = [
     'https://github.com/jabesq/netatmo-api-python/archive/'
-    'v0.7.0.zip#lnetatmo==0.7.0']
+    'v0.8.0.zip#lnetatmo==0.8.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,7 +90,7 @@ class WelcomeData(object):
     def get_module_names(self, camera_name):
         self.module_names = []
         self.update()
-        cam_id = self.welcomedata.cameraByName(camera = camera_name, home = self.home)
+        cam_id = self.welcomedata.cameraByName(camera = camera_name, home = self.home)['id']
         for module in self.welcomedata.modules.values():
             if cam_id == module['cam_id']:
                 self.module_names.append(module['name'])

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -73,10 +73,11 @@ class WelcomeData(object):
         self.auth = auth
         self.welcomedata = None
         self.camera_names = []
+        self.module_names = []
         self.home = home
 
     def get_camera_names(self):
-        """Return all module available on the API as a list."""
+        """Return all camera available on the API as a list."""
         self.camera_names = []
         self.update()
         if not self.home:
@@ -89,9 +90,11 @@ class WelcomeData(object):
         return self.camera_names
 
     def get_module_names(self, camera_name):
+        """Return all module available on the API as a list."""
         self.module_names = []
         self.update()
-        cam_id = self.welcomedata.cameraByName(camera = camera_name, home = self.home)['id']
+        cam_id = self.welcomedata.cameraByName(camera=camera_name,
+                                               home=self.home)['id']
         for module in self.welcomedata.modules.values():
             if cam_id == module['cam_id']:
                 self.module_names.append(module['name'])
@@ -101,9 +104,9 @@ class WelcomeData(object):
     def update(self):
         """Call the Netatmo API to update the data."""
         import lnetatmo
-        self.welcomedata = lnetatmo.WelcomeData(self.auth, size = 100)
+        self.welcomedata = lnetatmo.WelcomeData(self.auth, size=100)
 
     @Throttle(MIN_TIME_BETWEEN_EVENT_UPDATES)
     def update_event(self):
+        """Call the Netatmo API to update the list of events."""
         self.welcomedata.updateEvent(home=self.home)
-

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -205,7 +205,7 @@ https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.
 # https://github.com/deisi/fritzconnection/archive/b5c14515e1c8e2652b06b6316a7f3913df942841.zip#fritzconnection==0.4.6
 
 # homeassistant.components.netatmo
-https://github.com/jabesq/netatmo-api-python/archive/v0.7.0.zip#lnetatmo==0.7.0
+https://github.com/jabesq/netatmo-api-python/archive/v0.8.0.zip#lnetatmo==0.8.0
 
 # homeassistant.components.neato
 https://github.com/jabesq/pybotvac/archive/v0.0.1.zip#pybotvac==0.0.1


### PR DESCRIPTION
**Description:**
Netatmo tags are motion sensors linked to a Welcome Camera


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51