### PR TITLE
Fix nest min max temperatures

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -16,6 +16,7 @@ from homeassistant.components.climate import (
 from homeassistant.const import (
     TEMP_CELSIUS, TEMP_FAHRENHEIT,
     CONF_SCAN_INTERVAL, STATE_ON, STATE_OFF, STATE_UNKNOWN)
+from homeassistant.util.temperature import convert
 
 DEPENDENCIES = ['nest']
 _LOGGER = logging.getLogger(__name__)
@@ -207,7 +208,7 @@ class NestThermostat(ClimateDevice):
         if self._is_locked:
             return self._locked_temperature[0]
         else:
-            return self.device.eco_temperature.low
+            return convert(9, TEMP_CELSIUS, self.temperature_unit)
 
     @property
     def max_temp(self):
@@ -215,7 +216,7 @@ class NestThermostat(ClimateDevice):
         if self._is_locked:
             return self._locked_temperature[1]
         else:
-            return self.device.target_temperature.high
+            return convert(32, TEMP_CELSIUS, self.temperature_unit)
 
     def update(self):
         """Cache value from Python-nest."""

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -207,7 +207,7 @@ class NestThermostat(ClimateDevice):
         if self._is_locked:
             return self._locked_temperature[0]
         else:
-            return None
+            return self.device.eco_temperature.low
 
     @property
     def max_temp(self):
@@ -215,7 +215,7 @@ class NestThermostat(ClimateDevice):
         if self._is_locked:
             return self._locked_temperature[1]
         else:
-            return None
+            return self.device.target_temperature.high
 
     def update(self):
         """Cache value from Python-nest."""


### PR DESCRIPTION
**Description:**
The current implementation of the Nest climate component doesn't work if the user has not set specific locked temperatures. Most users won't have locked temperatures configured. This fixes empty min and max temperatures if no locked temperatures are set. If the min and max temperatures are empty no temperature can be set via the frontend.

Fixes #4763