### PR TITLE
Match uppercase MAC addresses in asuswrt 'arp -n' output (#4742)

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -286,8 +286,10 @@ class AsusWrtDeviceScanner(object):
 
                 # match mac addresses to IP addresses in ARP table
                 for arp in result.arp:
-                    if match.group('mac').lower() in arp.decode('utf-8'):
-                        arp_match = _ARP_REGEX.search(arp.decode('utf-8'))
+                    if match.group('mac').lower() in \
+                            arp.decode('utf-8').lower():
+                        arp_match = _ARP_REGEX.search(
+                            arp.decode('utf-8').lower())
                         if not arp_match:
                             _LOGGER.warning('Could not parse arp row: %s', arp)
                             continue


### PR DESCRIPTION
**Description:**
The asuswrt device tracker does not detect devices when mode is `ap` on some AsusWRT versions. This is because it expects the output of `arp -n` to be lowercase. Forcing the output to be lowercase resolves this issue.

**Related issue:** fixes #4742 

**Example entry for `configuration.yaml`:**
```yaml
device_tracker:
  - platform: asuswrt
    host: 192.168.4.254
    mode: ap
    protocol: ssh
    username: admin
    ssh_key: /var/opt/homeassistant/id_rsa
```