### PR TITLE
Ecobee detect Smart Away

### DIFF
--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -195,8 +195,11 @@ class Thermostat(ClimateDevice):
         mode = self.mode
         events = self.thermostat['events']
         for event in events:
-            if event['running']:
+            if event['running'] and event['holdClimateRef'] == 'away':
                 mode = event['holdClimateRef']
+                break
+            elif event['running'] and event['type'] == 'autoAway':
+                mode = "away"
                 break
         return 'away' in mode
 

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -195,10 +195,8 @@ class Thermostat(ClimateDevice):
         mode = self.mode
         events = self.thermostat['events']
         for event in events:
-            if event['running'] and event['holdClimateRef'] == 'away':
-                mode = event['holdClimateRef']
-                break
-            elif event['running'] and event['type'] == 'autoAway':
+            if event['holdClimateRef'] == 'away' or \
+               event['type'] == 'autoAway':
                 mode = "away"
                 break
         return 'away' in mode


### PR DESCRIPTION
**Description:**
Ecobee component is not able determine if the thermostat is in Away mode once Smart Away mode has created an away event. When Smart Away mode is enabled, after some time that occupancy is no longer detected, an event will be created with type = autoAway and holdClimateRef = ' '. When Away mode is manually enabled or set via Home-Assistant, type = hold and holdClimateRef = away.

This is a difficult situation to test but I was looking for some more validation and input on this code because I'm sure it's butchered, although it appears to work properly. There may be other cases I am currently not aware of. Normally my device trackers will Ecobee Away mode on and off. I had suspected this was happening months ago but was only able to confirm it while I was on vacation and someone was house sitting for me. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
Somewhat related to #4510 
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51