### PR TITLE
Add test to ensure device_tracker records state correctly.

### DIFF
--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -457,6 +457,45 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         config = device_tracker.load_config(self.yaml_devices, self.hass,
                                             timedelta(seconds=0))
         assert len(config) == 0
+        
+    def test_see_state(self):
+        """Test device tracker see records state correctly."""
+        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
+                                        TEST_PLATFORM))
+
+        params = {
+            'mac': 'AA:BB:CC:DD:EE:FF',
+            'dev_id': 'some_device',
+            'host_name': 'example.com',
+            'location_name': 'Work',
+            'gps': [.3, .8],
+            'gps_accuracy': 1,
+            'battery': 100,
+            'attributes': {
+                'test': 'test',
+                'number': 1,
+            },
+        }
+
+        device_tracker.see(self.hass, **params)
+        self.hass.block_till_done()
+
+        config = device_tracker.load_config(self.yaml_devices, self.hass,
+                                            timedelta(seconds=0))
+        assert len(config) == 1
+
+        state = self.hass.states.get('device_tracker.examplecom')
+        attrs = state.attributes
+        self.assertEqual(state.state, 'Work')
+        self.assertEqual(state.object_id, 'examplecom')
+        self.assertEqual(state.name, 'example.com')
+        self.assertEqual(attrs['friendly_name'], 'example.com')
+        self.assertEqual(attrs['battery'], 100)
+        self.assertEqual(attrs['latitude'], 0.3)
+        self.assertEqual(attrs['longitude'], 0.8)
+        self.assertEqual(attrs['test'], 'test')
+        self.assertEqual(attrs['gps_accuracy'], 1)
+        self.assertEqual(attrs['number'], 1)
 
     @patch('homeassistant.components.device_tracker._LOGGER.warning')
     def test_see_failures(self, mock_warning):

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -457,7 +457,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         config = device_tracker.load_config(self.yaml_devices, self.hass,
                                             timedelta(seconds=0))
         assert len(config) == 0
-        
+
     def test_see_state(self):
         """Test device tracker see records state correctly."""
         self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,


### PR DESCRIPTION
**Description:**

We had a few PR's yesterday that could have been avoided if we had a test, so I added one.