### PR TITLE
Fix incorrect caching of /api/error_log

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -32,7 +32,7 @@ from .const import (
     KEY_USE_X_FORWARDED_FOR, KEY_TRUSTED_NETWORKS,
     KEY_BANS_ENABLED, KEY_LOGIN_THRESHOLD,
     KEY_DEVELOPMENT, KEY_AUTHENTICATED)
-from .static import GZIP_FILE_SENDER, staticresource_middleware
+from .static import FILE_SENDER, GZIP_FILE_SENDER, staticresource_middleware
 from .util import get_real_ip
 
 DOMAIN = 'http'
@@ -344,7 +344,7 @@ class HomeAssistantView(object):
     def file(self, request, fil):
         """Return a file."""
         assert isinstance(fil, str), 'only string paths allowed'
-        response = yield from GZIP_FILE_SENDER.send(request, Path(fil))
+        response = yield from FILE_SENDER.send(request, Path(fil))
         return response
 
     def register(self, router):

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -63,6 +63,7 @@ class GzipFileSender(FileSender):
 
 
 GZIP_FILE_SENDER = GzipFileSender()
+FILE_SENDER = FileSender()
 
 
 @asyncio.coroutine


### PR DESCRIPTION
**Description:**
Currently when the frontend fetches the log file from /api/error_log it's given a cache time of 31 days.

NEW:
I added a new implementation. I created an alternate FileSender that just uses the aiohttp class. Since dynamic files don't benefit from the gzip modifications or the cache logic, they're just using the unmodified class.

OBSOLETE: 
In this PR I just have `HomeAssistantView`'s file method choose `cache_length` zero, since the error log is the only caller of this function and this would most likely be used by dynamic files anyway. Anything that should be cached is probably registered as a static file.