### PR TITLE
Switch to maintained LIFX Library

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['liffylights2==0.1.0']
+REQUIREMENTS = ['liffylights22==0.1.0']
 
 BYTE_MAX = 255
 
@@ -61,13 +61,13 @@ class LIFX(object):
     def __init__(self, add_devices_callback, server_addr=None,
                  broadcast_addr=None):
         """Initialize the light."""
-        import liffylights2
+        import liffylights22
 
         self._devices = []
 
         self._add_devices_callback = add_devices_callback
 
-        self._liffylights = liffylights.LiffyLights(
+        self._liffylights2 = liffylights2.LiffyLights(
             self.on_device, self.on_power, self.on_color, server_addr,
             broadcast_addr)
 
@@ -88,7 +88,7 @@ class LIFX(object):
             _LOGGER.debug("new bulb %s %s %d %d %d %d %d",
                           ipaddr, name, power, hue, sat, bri, kel)
             bulb = LIFXLight(
-                self._liffylights, ipaddr, name, power, hue, sat, bri, kel)
+                self._liffylights2, ipaddr, name, power, hue, sat, bri, kel)
             self._devices.append(bulb)
             self._add_devices_callback([bulb])
         else:
@@ -121,7 +121,7 @@ class LIFX(object):
 
     def probe(self, address=None):
         """Probe the light."""
-        self._liffylights.probe(address)
+        self._liffylights2.probe(address)
 
 
 def convert_rgb_to_hsv(rgb):
@@ -143,7 +143,7 @@ class LIFXLight(Light):
         """Initialize the light."""
         _LOGGER.debug("LIFXLight: %s %s", ipaddr, name)
 
-        self._liffylights = liffy
+        self._liffylights2 = liffy
         self._ip = ipaddr
         self.set_name(name)
         self.set_power(power)
@@ -232,9 +232,9 @@ class LIFXLight(Light):
                       hue, saturation, brightness, kelvin, fade)
 
         if self._power == 0:
-            self._liffylights.set_power(self._ip, 65535, fade)
+            self._liffylights2.set_power(self._ip, 65535, fade)
 
-        self._liffylights.set_color(self._ip, hue, saturation,
+        self._liffylights2.set_color(self._ip, hue, saturation,
                                     brightness, kelvin, fade)
 
     def turn_off(self, **kwargs):
@@ -245,7 +245,7 @@ class LIFXLight(Light):
             fade = 0
 
         _LOGGER.debug("turn_off: %s %d", self._ip, fade)
-        self._liffylights.set_power(self._ip, 0, fade)
+        self._liffylights2.set_power(self._ip, 0, fade)
 
     def set_name(self, name):
         """Set name of the light."""

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -61,7 +61,7 @@ class LIFX(object):
     def __init__(self, add_devices_callback, server_addr=None,
                  broadcast_addr=None):
         """Initialize the light."""
-        import liffylights
+        import liffylights2
 
         self._devices = []
 

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -61,7 +61,7 @@ class LIFX(object):
     def __init__(self, add_devices_callback, server_addr=None,
                  broadcast_addr=None):
         """Initialize the light."""
-        import liffylights22
+        import liffylights2
 
         self._devices = []
 

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['liffylights==0.9.4']
+REQUIREMENTS = ['liffylights2==0.1.0']
 
 BYTE_MAX = 255
 

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['liffylights22==0.1.0']
+REQUIREMENTS = ['liffylights2==0.1.0']
 
 BYTE_MAX = 255
 
@@ -67,7 +67,7 @@ class LIFX(object):
 
         self._add_devices_callback = add_devices_callback
 
-        self._liffylights2 = liffylights2.LiffyLights(
+        self._liffylights = liffylights2.LiffyLights(
             self.on_device, self.on_power, self.on_color, server_addr,
             broadcast_addr)
 
@@ -88,7 +88,7 @@ class LIFX(object):
             _LOGGER.debug("new bulb %s %s %d %d %d %d %d",
                           ipaddr, name, power, hue, sat, bri, kel)
             bulb = LIFXLight(
-                self._liffylights2, ipaddr, name, power, hue, sat, bri, kel)
+                self._liffylights, ipaddr, name, power, hue, sat, bri, kel)
             self._devices.append(bulb)
             self._add_devices_callback([bulb])
         else:
@@ -121,7 +121,7 @@ class LIFX(object):
 
     def probe(self, address=None):
         """Probe the light."""
-        self._liffylights2.probe(address)
+        self._liffylights.probe(address)
 
 
 def convert_rgb_to_hsv(rgb):
@@ -143,7 +143,7 @@ class LIFXLight(Light):
         """Initialize the light."""
         _LOGGER.debug("LIFXLight: %s %s", ipaddr, name)
 
-        self._liffylights2 = liffy
+        self._liffylights = liffy
         self._ip = ipaddr
         self.set_name(name)
         self.set_power(power)
@@ -232,9 +232,9 @@ class LIFXLight(Light):
                       hue, saturation, brightness, kelvin, fade)
 
         if self._power == 0:
-            self._liffylights2.set_power(self._ip, 65535, fade)
+            self._liffylights.set_power(self._ip, 65535, fade)
 
-        self._liffylights2.set_color(self._ip, hue, saturation,
+        self._liffylights.set_color(self._ip, hue, saturation,
                                     brightness, kelvin, fade)
 
     def turn_off(self, **kwargs):
@@ -245,7 +245,7 @@ class LIFXLight(Light):
             fade = 0
 
         _LOGGER.debug("turn_off: %s %d", self._ip, fade)
-        self._liffylights2.set_power(self._ip, 0, fade)
+        self._liffylights.set_power(self._ip, 0, fade)
 
     def set_name(self, name):
         """Set name of the light."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -280,7 +280,7 @@ libnacl==1.5.0
 libsoundtouch==0.1.0
 
 # homeassistant.components.light.lifx
-liffylights==0.9.4
+liffylights2==0.1.0
 
 # homeassistant.components.light.limitlessled
 limitlessled==1.0.2


### PR DESCRIPTION
**Description:**
Switch to maintained LIFX LAN Protocol Library for HA.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
Allows for the future maintainence and upgrades to the home assistant LIFX component and associated library. 

Fixes an issue where acknowledgements were not properly being received by the liffylights library, leading to HA to have to poll for changed states it initiated. 

Fixes: #4589 
Potentially Fixes: #3604 (fixed in my environment, but could resurface)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
None

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```
None

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
None

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

Intended to keep active development and debugging of the LIFX LAN
Protocol library used by home assistant.