### PR TITLE
Rewrite influxdb metrics to be more consistent

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -92,7 +92,7 @@ def setup(hass, config):
         if state is None or state.entity_id in blacklist:
             return
 
-        if len(whitelist) > 0 and state.entity_id not in whitelist:
+        if whitelist and state.entity_id not in whitelist:
             return
 
         try:
@@ -125,7 +125,7 @@ def setup(hass, config):
             if isinstance(value, (int, float)):
                 state_fields[key] = float(value)
 
-        if len(state_fields) > 0:
+        if state_fields:
             json_body.append(
                 {
                     'measurement': "hass.state",

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -9,9 +9,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.const import (
-    EVENT_STATE_CHANGED, STATE_UNAVAILABLE, STATE_UNKNOWN, CONF_HOST,
-    CONF_PORT, CONF_SSL, CONF_VERIFY_SSL, CONF_USERNAME, CONF_BLACKLIST,
-    CONF_PASSWORD, CONF_WHITELIST)
+    EVENT_STATE_CHANGED, CONF_HOST, CONF_PORT, CONF_SSL, CONF_VERIFY_SSL,
+    CONF_USERNAME, CONF_BLACKLIST, CONF_PASSWORD, CONF_WHITELIST)
 from homeassistant.helpers import state as state_helper
 import homeassistant.helpers.config_validation as cv
 
@@ -38,7 +37,6 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_DB_NAME, default=DEFAULT_DATABASE): cv.string,
         vol.Optional(CONF_PORT): cv.port,
         vol.Optional(CONF_SSL): cv.boolean,
-        vol.Optional(CONF_DEFAULT_MEASUREMENT): cv.string,
         vol.Optional(CONF_TAGS, default={}):
             vol.Schema({cv.string: cv.string}),
         vol.Optional(CONF_WHITELIST, default=[]):
@@ -78,7 +76,6 @@ def setup(hass, config):
     blacklist = conf.get(CONF_BLACKLIST)
     whitelist = conf.get(CONF_WHITELIST)
     tags = conf.get(CONF_TAGS)
-    default_measurement = conf.get(CONF_DEFAULT_MEASUREMENT)
 
     try:
         influx = InfluxDBClient(**kwargs)


### PR DESCRIPTION
**Description:**
This should be the final update required to influxDB to fix all the inconsistencies and errors. This moves all state changes to go two only 2 different measurements (hass.state and hass.state.count) instead of nearly every entity going to it's own measurement making it impossible to do merged queries of multiple entities.

Every state change no matter what the data type will go to hass.state.count with a value of just 1. This allows for counters for all state changes not just influxdb friendly values.

If a state or attribute contains a numeric value then those values will be sent to hass.state as well.

See #4696 for more details on the changes. I have been running this change for 2 days without a single error from influxdb or hass.

**THIS IS A BREAKING CHANGE!** All existing metrics will stop getting updates and all metrics will now start to go to hass.state.count and hass.state

This issue will not require any changes to the influxdb database for the user. It will just start sending metrics to a different series resulting in any existing queries to need updating.


**Related issue (if applicable):** addresses #4696 
