### PR TITLE
Add media position support and trailer type to Emby

### DIFF
--- a/homeassistant/components/media_player/emby.py
+++ b/homeassistant/components/media_player/emby.py
@@ -253,13 +253,7 @@ class EmbyClient(MediaPlayerDevice):
     @property
     def media_position(self):
         """Position of current playing media in seconds."""
-        if self.media_duration is None:
-            return None
-
-        try:
-            return int(self.session['PlayState']['PositionTicks']) / 10000000
-        except KeyError:
-            return None
+        return self.media_status_last
 
     @property
     def media_position_updated_at(self):

--- a/homeassistant/components/media_player/emby.py
+++ b/homeassistant/components/media_player/emby.py
@@ -122,7 +122,7 @@ class EmbyClient(MediaPlayerDevice):
         self.update_sessions = update_sessions
         self.client = client
         self.set_device(device)
-        self.media_status_last = None
+        self.media_status_last_position = None
         self.media_status_received = None
 
     def set_device(self, device):
@@ -188,10 +188,12 @@ class EmbyClient(MediaPlayerDevice):
             position = self.session['PlayState']['PositionTicks']
         except (KeyError, TypeError):
             position = None
+            self.media_status_last_position = position
+            self.media_status_received = None
         else:
             position = int(position) / 10000000
-            if position != self.media_status_last:
-                self.media_status_last = position
+            if position != self.media_status_last_position:
+                self.media_status_last_position = position
                 self.media_status_received = dt_util.utcnow()
 
     def play_percent(self):
@@ -253,7 +255,7 @@ class EmbyClient(MediaPlayerDevice):
     @property
     def media_position(self):
         """Position of current playing media in seconds."""
-        return self.media_status_last
+        return self.media_status_last_position
 
     @property
     def media_position_updated_at(self):

--- a/homeassistant/components/media_player/emby.py
+++ b/homeassistant/components/media_player/emby.py
@@ -187,8 +187,7 @@ class EmbyClient(MediaPlayerDevice):
         try:
             position = self.session['PlayState']['PositionTicks']
         except (KeyError, TypeError):
-            position = None
-            self.media_status_last_position = position
+            self.media_status_last_position = None
             self.media_status_received = None
         else:
             position = int(position) / 10000000

--- a/homeassistant/components/media_player/emby.py
+++ b/homeassistant/components/media_player/emby.py
@@ -20,11 +20,14 @@ from homeassistant.const import (
     STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING, STATE_UNKNOWN)
 from homeassistant.helpers.event import (track_utc_time_change)
 from homeassistant.util import Throttle
+import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['pyemby==0.1']
+REQUIREMENTS = ['pyemby==0.2']
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
+
+MEDIA_TYPE_TRAILER = 'trailer'
 
 DEFAULT_PORT = 8096
 
@@ -119,6 +122,8 @@ class EmbyClient(MediaPlayerDevice):
         self.update_sessions = update_sessions
         self.client = client
         self.set_device(device)
+        self.media_status_last = None
+        self.media_status_received = None
 
     def set_device(self, device):
         """Set the device property."""
@@ -178,6 +183,15 @@ class EmbyClient(MediaPlayerDevice):
         """Get the latest details."""
         self.update_devices(no_throttle=True)
         self.update_sessions(no_throttle=True)
+        # Check if we should update progress
+        try:
+            position = int(
+                self.session['PlayState']['PositionTicks']) / 10000000
+            if position != self.media_status_last:
+                self.media_status_last = position
+                self.media_status_received = dt_util.utcnow()
+        except KeyError:
+            _LOGGER.debug("Error checking emby media position.")
 
     def play_percent(self):
         """Return current media percent complete."""
@@ -220,6 +234,8 @@ class EmbyClient(MediaPlayerDevice):
                 return MEDIA_TYPE_TVSHOW
             elif media_type == 'Movie':
                 return MEDIA_TYPE_VIDEO
+            elif media_type == 'Trailer':
+                return MEDIA_TYPE_TRAILER
             return None
         except KeyError:
             return None
@@ -234,18 +250,37 @@ class EmbyClient(MediaPlayerDevice):
                 return None
 
     @property
+    def media_position(self):
+        """Position of current playing media in seconds."""
+        if self.media_duration is None:
+            return None
+
+        try:
+            return int(self.session['PlayState']['PositionTicks']) / 10000000
+        except KeyError:
+            return None
+
+    @property
+    def media_position_updated_at(self):
+        """
+        When was the position of the current playing media valid.
+
+        Returns value from homeassistant.util.dt.utcnow().
+        """
+        return self.media_status_received
+
+    @property
     def media_image_url(self):
         """Image url of current playing media."""
         if self.now_playing_item is not None:
             try:
                 return self.client.get_image(
-                    self.now_playing_item['ThumbItemId'], 'Thumb',
-                    self.play_percent())
+                    self.now_playing_item['ThumbItemId'], 'Thumb', 0)
             except KeyError:
                 try:
                     return self.client.get_image(
-                        self.now_playing_item['PrimaryImageItemId'], 'Primary',
-                        self.play_percent())
+                        self.now_playing_item[
+                            'PrimaryImageItemId'], 'Primary', 0)
                 except KeyError:
                     return None
 

--- a/homeassistant/components/media_player/emby.py
+++ b/homeassistant/components/media_player/emby.py
@@ -185,13 +185,14 @@ class EmbyClient(MediaPlayerDevice):
         self.update_sessions(no_throttle=True)
         # Check if we should update progress
         try:
-            position = int(
-                self.session['PlayState']['PositionTicks']) / 10000000
+            position = self.session['PlayState']['PositionTicks']
+        except (KeyError, TypeError):
+            position = None
+        else:
+            position = int(position) / 10000000
             if position != self.media_status_last:
                 self.media_status_last = position
                 self.media_status_received = dt_util.utcnow()
-        except KeyError:
-            _LOGGER.debug("Error checking emby media position.")
 
     def play_percent(self):
         """Return current media percent complete."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -390,7 +390,7 @@ pycmus==0.1.0
 pydispatcher==2.0.5
 
 # homeassistant.components.media_player.emby
-pyemby==0.1
+pyemby==0.2
 
 # homeassistant.components.envisalink
 pyenvisalink==1.9


### PR DESCRIPTION
**Description:**

Add support for the new media position properties to Emby and remove the old hacked media position gained by pulling the image from the Emby server.  Also add support for the trailer media type and update to latest pyEmby version.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
No Change.

**Example entry for `configuration.yaml` (if applicable):**
No Change.

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [ x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ x ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ x ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ x ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

