### PR TITLE
Add away mode for Radio Thermostat/3M Filtrete

### DIFF
--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -23,10 +23,19 @@ ATTR_FAN = 'fan'
 ATTR_MODE = 'mode'
 
 CONF_HOLD_TEMP = 'hold_temp'
+CONF_AWAY_TEMPERATURE_HEAT = 'away_temperature_heat'
+CONF_AWAY_TEMPERATURE_COOL = 'away_temperature_cool'
+
+DEFAULT_AWAY_TEMPERATURE_HEAT = 60
+DEFAULT_AWAY_TEMPERATURE_COOL = 85
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_HOLD_TEMP, default=False): cv.boolean,
+    vol.Optional(CONF_AWAY_TEMPERATURE_HEAT,
+                 default=DEFAULT_AWAY_TEMPERATURE_HEAT): vol.Coerce(float),
+    vol.Optional(CONF_AWAY_TEMPERATURE_COOL,
+                 default=DEFAULT_AWAY_TEMPERATURE_COOL): vol.Coerce(float),
 })
 
 
@@ -45,12 +54,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
     hold_temp = config.get(CONF_HOLD_TEMP)
+    away_temps = [
+        config.get(CONF_AWAY_TEMPERATURE_HEAT),
+        config.get(CONF_AWAY_TEMPERATURE_COOL)
+    ]
     tstats = []
 
     for host in hosts:
         try:
             tstat = radiotherm.get_thermostat(host)
-            tstats.append(RadioThermostat(tstat, hold_temp))
+            tstats.append(RadioThermostat(tstat, hold_temp, away_temps))
         except OSError:
             _LOGGER.exception("Unable to connect to Radio Thermostat: %s",
                               host)
@@ -61,7 +74,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RadioThermostat(ClimateDevice):
     """Representation of a Radio Thermostat."""
 
-    def __init__(self, device, hold_temp):
+    def __init__(self, device, hold_temp, away_temps):
         """Initialize the thermostat."""
         self.device = device
         self.set_time()
@@ -71,7 +84,10 @@ class RadioThermostat(ClimateDevice):
         self._name = None
         self._fmode = None
         self._tmode = None
-        self.hold_temp = hold_temp
+        self._hold_temp = hold_temp
+        self._away = False
+        self._away_temps = away_temps
+        self._prev_temp = None
         self.update()
         self._operation_list = [STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_OFF]
 
@@ -113,6 +129,11 @@ class RadioThermostat(ClimateDevice):
         """Return the temperature we try to reach."""
         return self._target_temperature
 
+    @property
+    def is_away_mode_on(self):
+        """Return true if away mode is on."""
+        return self._away
+
     def update(self):
         """Update the data from the thermostat."""
         self._current_temperature = self.device.temp['raw']
@@ -138,7 +159,7 @@ class RadioThermostat(ClimateDevice):
             self.device.t_cool = round(temperature * 2.0) / 2.0
         elif self._current_operation == STATE_HEAT:
             self.device.t_heat = round(temperature * 2.0) / 2.0
-        if self.hold_temp:
+        if self._hold_temp or self._away:
             self.device.hold = 1
         else:
             self.device.hold = 0
@@ -162,3 +183,23 @@ class RadioThermostat(ClimateDevice):
             self.device.t_cool = round(self._target_temperature * 2.0) / 2.0
         elif operation_mode == STATE_HEAT:
             self.device.t_heat = round(self._target_temperature * 2.0) / 2.0
+
+    def turn_away_mode_on(self):
+        """Turn away on.
+
+        The RTCOA app simulates away mode by using a hold.
+        """
+        away_temp = None
+        if not self._away:
+            self._prev_temp = self._target_temperature
+            if self._current_operation == STATE_HEAT:
+                away_temp = self._away_temps[0]
+            elif self._current_operation == STATE_COOL:
+                away_temp = self._away_temps[1]
+        self._away = True
+        self.set_temperature(temperature=away_temp)
+
+    def turn_away_mode_off(self):
+        """Turn away off."""
+        self._away = False
+        self.set_temperature(temperature=self._prev_temp)


### PR DESCRIPTION
**Description:**
Adds a hold-based away mode to the climate.radiotherm component. This is the same method used by the Radio Thermostat mobile app. Turning off away mode turns off hold (unless `hold_temp` is also set) and restores the previous target temperature, which may need to be adjusted again by the schedule.

(The devices also support a "energy saving" mode which is currently unused).

**Example entry for `configuration.yaml`:**
```yaml
climate:
  platform: radiotherm
  host: thermostat
  hold_temp: False
  away_temperature_heat: 60
  away_temperature_cool: 85
```