### PR TITLE
Initial commit of ZoneMinder Binary Sensor.

### DIFF
--- a/homeassistant/components/binary_sensor/zoneminder.py
+++ b/homeassistant/components/binary_sensor/zoneminder.py
@@ -1,0 +1,67 @@
+"""
+Support for state (idle, alarm) of ZoneMinder monitors
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.zoneminder/
+"""
+import logging
+from homeassistant.components.binary_sensor import BinarySensorDevice
+import homeassistant.components.zoneminder as zoneminder
+from homeassistant.helpers.event import track_time_change
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['zoneminder']
+
+CONF_SECOND = 'second'
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the ZoneMinder sensors."""
+    sensors = []
+
+    _LOGGER.debug("Getting monitors")
+    monitors = zoneminder.get_state('api/monitors.json')
+    for i in monitors['monitors']:
+        sensors.append(
+            ZMBinarySensor(hass, config, int(i['Monitor']['Id']), i['Monitor']['Name'])
+        )
+
+    _LOGGER.debug("Adding devices")
+    add_devices(sensors)
+
+class ZMBinarySensor(BinarySensorDevice):
+    """Get the state of each ZoneMinder monitor."""
+
+    def __init__(self, hass, config, monitor_id, monitor_name):
+        """Initiate monitor sensor."""
+        self._monitor_id = monitor_id
+        self._monitor_name = monitor_name
+        self._sensor_class = 'motion'
+        self._state = False
+        track_time_change(hass, self.update, second=config.get(CONF_SECOND))
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{} Status'.format(self._monitor_name)
+
+    @property
+    def is_on(self):
+        """Return the status of the sensor."""
+        _LOGGER.debug('is on?')
+        return self._state
+
+    def update(self, now):
+        """Return the current status of the monitor."""
+        _LOGGER.debug("getting status")
+        monitor = zoneminder.get_state(
+            'api/monitors/alarm/id:%i/command:status.json' % self._monitor_id
+        )
+        """Refer to the output of `zmu -h` for what these status codes mean"""
+        _LOGGER.debug("got status")
+        if monitor['status'] == '0':
+            self._state = False
+        elif monitor['status'] == '4':
+            self._state = False
+        else:
+            self._state = 'Alarm'

--- a/homeassistant/components/binary_sensor/zoneminder.py
+++ b/homeassistant/components/binary_sensor/zoneminder.py
@@ -15,6 +15,7 @@ DEPENDENCIES = ['zoneminder']
 
 CONF_SECOND = 'second'
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the ZoneMinder sensors."""
     sensors = []
@@ -23,11 +24,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     monitors = zoneminder.get_state('api/monitors.json')
     for i in monitors['monitors']:
         sensors.append(
-            ZMBinarySensor(hass, config, int(i['Monitor']['Id']), i['Monitor']['Name'])
+            ZMBinarySensor(hass, config, int(i['Monitor']['Id']),
+                i['Monitor']['Name'])
         )
 
     _LOGGER.debug("Adding devices")
     add_devices(sensors)
+
 
 class ZMBinarySensor(BinarySensorDevice):
     """Get the state of each ZoneMinder monitor."""

--- a/homeassistant/components/binary_sensor/zoneminder.py
+++ b/homeassistant/components/binary_sensor/zoneminder.py
@@ -1,5 +1,5 @@
 """
-Support for state (idle, alarm) of ZoneMinder monitors
+Support for state (idle, alarm) of ZoneMinder monitors.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.zoneminder/
@@ -55,7 +55,6 @@ class ZMBinarySensor(BinarySensorDevice):
         monitor = zoneminder.get_state(
             'api/monitors/alarm/id:%i/command:status.json' % self._monitor_id
         )
-        """Refer to the output of `zmu -h` for what these status codes mean"""
         _LOGGER.debug("got status")
         if monitor['status'] == '0':
             self._state = False

--- a/homeassistant/components/binary_sensor/zoneminder.py
+++ b/homeassistant/components/binary_sensor/zoneminder.py
@@ -11,6 +11,8 @@ import homeassistant.components.zoneminder as zoneminder
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['zoneminder']
+ZM_IDLE = '0'
+ZM_TAPE = '4'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -56,9 +58,9 @@ class ZMBinarySensor(BinarySensorDevice):
             'api/monitors/alarm/id:%i/command:status.json' % self._monitor_id
         )
         _LOGGER.debug("got status")
-        if monitor['status'] == '0':
+        if monitor['status'] == ZM_IDLE:
             self._state = False
-        elif monitor['status'] == '4':
+        elif monitor['status'] == ZM_TAPE:
             self._state = False
         else:
             self._state = 'Alarm'

--- a/homeassistant/components/binary_sensor/zoneminder.py
+++ b/homeassistant/components/binary_sensor/zoneminder.py
@@ -5,15 +5,12 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.zoneminder/
 """
 import logging
-from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.binary_sensor import (BinarySensorDevice)
 import homeassistant.components.zoneminder as zoneminder
-from homeassistant.helpers.event import track_time_change
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['zoneminder']
-
-CONF_SECOND = 'second'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -24,8 +21,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     monitors = zoneminder.get_state('api/monitors.json')
     for i in monitors['monitors']:
         sensors.append(
-            ZMBinarySensor(hass, config, int(i['Monitor']['Id']),
-                i['Monitor']['Name'])
+            ZMBinarySensor(int(i['Monitor']['Id']), i['Monitor']['Name'])
         )
 
     _LOGGER.debug("Adding devices")
@@ -35,13 +31,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class ZMBinarySensor(BinarySensorDevice):
     """Get the state of each ZoneMinder monitor."""
 
-    def __init__(self, hass, config, monitor_id, monitor_name):
+    def __init__(self, monitor_id, monitor_name):
         """Initiate monitor sensor."""
         self._monitor_id = monitor_id
         self._monitor_name = monitor_name
         self._sensor_class = 'motion'
         self._state = False
-        track_time_change(hass, self.update, second=config.get(CONF_SECOND))
 
     @property
     def name(self):
@@ -54,7 +49,7 @@ class ZMBinarySensor(BinarySensorDevice):
         _LOGGER.debug('is on?')
         return self._state
 
-    def update(self, now):
+    def update(self):
         """Return the current status of the monitor."""
         _LOGGER.debug("getting status")
         monitor = zoneminder.get_state(


### PR DESCRIPTION
**Description:** A binary sensor for ZoneMinder monitors, reporting the status of each monitor as either motion (on) or no motion (off).  Most of the checklist is not complete as I need some help with this before I proceed with the checklist.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** Not yet, will be added once this code is complete.

**Example entry for `configuration.yaml` (if applicable):**
```yaml
binary_sensor:
        - platform: zoneminder
          second:
                  - 10
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
