### PR TITLE
Update after service calls

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -59,8 +59,12 @@ def setup(hass, config):
 
         for alarm in target_alarms:
             getattr(alarm, method)(code)
-            if alarm.should_poll:
-                alarm.update_ha_state(True)
+
+        for alarm in target_alarms:
+            if not alarm.should_poll:
+                continue
+
+            alarm.update_ha_state(True)
 
     descriptions = load_yaml_config_file(
         os.path.join(os.path.dirname(__file__), 'services.yaml'))

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -135,12 +135,19 @@ def setup(hass, config):
         params = service.data.copy()
         params.pop(ATTR_ENTITY_ID, None)
 
-        if method:
-            for cover in component.extract_from_service(service):
-                getattr(cover, method['method'])(**params)
+        if not method:
+            return
 
-                if cover.should_poll:
-                    cover.update_ha_state(True)
+        covers = component.extract_from_service(service)
+
+        for cover in covers:
+            getattr(cover, method['method'])(**params)
+
+        for cover in covers:
+            if not cover.should_poll:
+                continue
+
+            cover.update_ha_state(True)
 
     descriptions = load_yaml_config_file(
         os.path.join(os.path.dirname(__file__), 'services.yaml'))

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -236,7 +236,6 @@ def async_setup(hass, config):
         if color_name is not None:
             params[ATTR_RGB_COLOR] = color_util.color_name_to_rgb(color_name)
 
-        update_tasks = []
         for light in target_lights:
             if service.service == SERVICE_TURN_ON:
                 yield from light.async_turn_on(**params)
@@ -245,12 +244,17 @@ def async_setup(hass, config):
             else:
                 yield from light.async_toggle(**params)
 
-            if light.should_poll:
-                update_coro = light.async_update_ha_state(True)
-                if hasattr(light, 'async_update'):
-                    update_tasks.append(hass.loop.create_task(update_coro))
-                else:
-                    yield from update_coro
+        update_tasks = []
+
+        for light in target_lights:
+            if not light.should_poll:
+                continue
+
+            update_coro = light.async_update_ha_state(True)
+            if hasattr(light, 'async_update'):
+                update_tasks.append(hass.loop.create_task(update_coro))
+            else:
+                yield from update_coro
 
         if update_tasks:
             yield from asyncio.wait(update_tasks, loop=hass.loop)

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -250,7 +250,8 @@ def async_setup(hass, config):
             if not light.should_poll:
                 continue
 
-            update_coro = light.async_update_ha_state(True)
+            update_coro = hass.loop.create_task(
+                light.async_update_ha_state(True))
             if hasattr(light, 'async_update'):
                 update_tasks.append(hass.loop.create_task(update_coro))
             else:

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -85,8 +85,11 @@ def setup(hass, config):
             else:
                 item.unlock(code=code)
 
-            if item.should_poll:
-                item.update_ha_state(True)
+        for item in target_locks:
+            if not item.should_poll:
+                continue
+
+            item.update_ha_state(True)
 
     descriptions = load_yaml_config_file(
         os.path.join(os.path.dirname(__file__), 'services.yaml'))

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -112,7 +112,8 @@ def async_setup(hass, config):
             if not remote.should_poll:
                 continue
 
-            update_coro = remote.async_update_ha_state(True)
+            update_coro = hass.loop.create_task(
+                remote.async_update_ha_state(True))
             if hasattr(remote, 'async_update'):
                 update_tasks.append(hass.loop.create_task(update_coro))
             else:

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -98,7 +98,6 @@ def async_setup(hass, config):
         device = service.data.get(ATTR_DEVICE)
         command = service.data.get(ATTR_COMMAND)
 
-        update_tasks = []
         for remote in target_remotes:
             if service.service == SERVICE_TURN_ON:
                 yield from remote.async_turn_on(activity=activity_id)
@@ -108,12 +107,16 @@ def async_setup(hass, config):
             else:
                 yield from remote.async_turn_off()
 
-            if remote.should_poll:
-                update_coro = remote.async_update_ha_state(True)
-                if hasattr(remote, 'async_update'):
-                    update_tasks.append(hass.loop.create_task(update_coro))
-                else:
-                    yield from update_coro
+        update_tasks = []
+        for remote in target_remotes:
+            if not remote.should_poll:
+                continue
+
+            update_coro = remote.async_update_ha_state(True)
+            if hasattr(remote, 'async_update'):
+                update_tasks.append(hass.loop.create_task(update_coro))
+            else:
+                yield from update_coro
 
         if update_tasks:
             yield from asyncio.wait(update_tasks, loop=hass.loop)

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -82,7 +82,6 @@ def async_setup(hass, config):
         """Handle calls to the switch services."""
         target_switches = component.async_extract_from_service(service)
 
-        update_tasks = []
         for switch in target_switches:
             if service.service == SERVICE_TURN_ON:
                 yield from switch.async_turn_on()
@@ -91,12 +90,16 @@ def async_setup(hass, config):
             else:
                 yield from switch.async_turn_off()
 
-            if switch.should_poll:
-                update_coro = switch.async_update_ha_state(True)
-                if hasattr(switch, 'async_update'):
-                    update_tasks.append(hass.loop.create_task(update_coro))
-                else:
-                    yield from update_coro
+        update_tasks = []
+        for switch in target_switches:
+            if not switch.should_poll:
+                continue
+
+            update_coro = switch.async_update_ha_state(True)
+            if hasattr(switch, 'async_update'):
+                update_tasks.append(hass.loop.create_task(update_coro))
+            else:
+                yield from update_coro
 
         if update_tasks:
             yield from asyncio.wait(update_tasks, loop=hass.loop)

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -95,7 +95,8 @@ def async_setup(hass, config):
             if not switch.should_poll:
                 continue
 
-            update_coro = switch.async_update_ha_state(True)
+            update_coro = hass.loop.create_task(
+                switch.async_update_ha_state(True))
             if hasattr(switch, 'async_update'):
                 update_tasks.append(hass.loop.create_task(update_coro))
             else:


### PR DESCRIPTION
**Description:**
When calling a service, before async came around, we would first call turn_on on each light, after that we would go through each light and call update.

During our migration to async we initially would fire off update tasks as soon as possible while calling turn_on and just wait at the end of the service till all tasks were done. We realized quickly that this was hitting devices too hard and decided to wait till the update was done. We didn't realize by doing so we were now doing: call turn on 1, update 1, call turn on 2, update 2, etc.

This PR fixes it.

**Related issue (if applicable):** fixes #4783

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

