### PR TITLE
Fix python-nest version bump

### DIFF
--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = [
     'http://github.com/technicalpickles/python-nest'
-    '/archive/dd628f90772d170b9602f262d5d2e7d61bdd3cf5.zip'  # nest-cam branch
+    '/archive/7a2eb38d391bddeb78079437f001224c370b555a.zip'  # nest-cam branch
     '#python-nest==3.0.1']
 
 DOMAIN = 'nest'

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = [
     'http://github.com/technicalpickles/python-nest'
     '/archive/dd628f90772d170b9602f262d5d2e7d61bdd3cf5.zip'  # nest-cam branch
-    '#python-nest==3.0.0']
+    '#python-nest==3.0.1']
 
 DOMAIN = 'nest'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -167,7 +167,7 @@ hikvision==0.4
 # http://github.com/adafruit/Adafruit_Python_DHT/archive/310c59b0293354d07d94375f1365f7b9b9110c7d.zip#Adafruit_DHT==1.3.0
 
 # homeassistant.components.nest
-http://github.com/technicalpickles/python-nest/archive/dd628f90772d170b9602f262d5d2e7d61bdd3cf5.zip#python-nest==3.0.0
+http://github.com/technicalpickles/python-nest/archive/dd628f90772d170b9602f262d5d2e7d61bdd3cf5.zip#python-nest==3.0.1
 
 # homeassistant.components.light.flux_led
 https://github.com/Danielhiversen/flux_led/archive/0.9.zip#flux_led==0.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -167,7 +167,7 @@ hikvision==0.4
 # http://github.com/adafruit/Adafruit_Python_DHT/archive/310c59b0293354d07d94375f1365f7b9b9110c7d.zip#Adafruit_DHT==1.3.0
 
 # homeassistant.components.nest
-http://github.com/technicalpickles/python-nest/archive/dd628f90772d170b9602f262d5d2e7d61bdd3cf5.zip#python-nest==3.0.1
+http://github.com/technicalpickles/python-nest/archive/7a2eb38d391bddeb78079437f001224c370b555a.zip#python-nest==3.0.1
 
 # homeassistant.components.light.flux_led
 https://github.com/Danielhiversen/flux_led/archive/0.9.zip#flux_led==0.9


### PR DESCRIPTION
**Description:**
The Nest climate component is not working because the python-nest dependancy won't update correct. I have run 'script/setup' several times, but the recent changes in the python-nest dependancy do not install. If the version number is changed the new version of the dependancy will be installed. 

**Related issue:** fixes #4797

