### PR TITLE
Pararell execute state restore by domain

### DIFF
--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -178,7 +178,7 @@ def async_reproduce_state(hass, states, blocking=False):
 
     @asyncio.coroutine
     def async_handle_service_calls(coro_list):
-        """Handle service calls per domain sequence."""
+        """Handle service calls by domain sequence."""
         for coro in coro_list:
             yield from coro
 

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -164,11 +164,28 @@ def async_reproduce_state(hass, states, blocking=False):
                json.dumps(dict(state.attributes), sort_keys=True))
         to_call[key].append(state.entity_id)
 
+    domain_tasks = {}
     for (service_domain, service, service_data), entity_ids in to_call.items():
         data = json.loads(service_data)
         data[ATTR_ENTITY_ID] = entity_ids
-        yield from hass.services.async_call(
-            service_domain, service, data, blocking)
+
+        if service_domain not in domain_tasks:
+            domain_tasks[service_domain] = []
+
+        domain_tasks[service_domain].append(
+            hass.services.async_call(service_domain, service, data, blocking)
+        )
+
+    @asyncio.coroutine
+    def async_handle_service_calls(coro_list):
+        """Handle service calls per domain sequence."""
+        for coro in coro_list:
+            yield from coro
+
+    execute_tasks = [async_handle_service_calls(coro_list)
+                     for coro_list in domain_tasks.values()]
+    if execute_tasks:
+        yield from asyncio.wait(execute_tasks, loop=hass.loop)
 
 
 def state_as_number(state):


### PR DESCRIPTION
**Description:**

The state restore function have more async feature. It restore a domain in sequence but all domains pararell for more speed.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

