### PR TITLE
Add nest hvac state

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -82,7 +82,6 @@ class NestThermostat(ClimateDevice):
         self._temperature = None
         self._temperature_scale = None
         self._mode = None
-        self._hvac_state = None
         self._fan = None
         self._eco_temperature = None
         self._is_locked = None
@@ -221,7 +220,6 @@ class NestThermostat(ClimateDevice):
         self._humidity = self.device.humidity,
         self._temperature = self.device.temperature
         self._mode = self.device.mode
-        self._hvac_state = self.device.hvac_state
         self._target_temperature = self.device.target
         self._fan = self.device.fan
         self._away = self.structure.away == 'away'

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -116,18 +116,6 @@ class NestThermostat(ClimateDevice):
             return STATE_UNKNOWN
 
     @property
-    def current_hvac_state(self):
-        """
-        Return the currently active HVAC state.
-
-        This differs from the current mode in that while the thermostat might
-        be set to Heat it may not currently be blowing heat. The mode indicates
-        it is set to Heat, the state indicates whether or not it is actively
-        heating.
-        """
-        return self._hvac_state
-
-    @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
         if self._mode != STATE_HEAT_COOL and not self.is_away_mode_on:

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -82,6 +82,7 @@ class NestThermostat(ClimateDevice):
         self._temperature = None
         self._temperature_scale = None
         self._mode = None
+        self._hvac_state = None
         self._fan = None
         self._eco_temperature = None
         self._is_locked = None
@@ -113,6 +114,14 @@ class NestThermostat(ClimateDevice):
             return STATE_AUTO
         else:
             return STATE_UNKNOWN
+
+    @property
+    def current_hvac_state(self):
+        """Return the currently active HVAC state. This differs from the
+        current mode in that while the thermostat might be set to Heat it
+        may not currently be blowing heat. The mode indicates it is set to
+        Heat, the state indicates whether or not it is actively heating."""
+        return self._hvac_state
 
     @property
     def target_temperature(self):
@@ -220,6 +229,7 @@ class NestThermostat(ClimateDevice):
         self._humidity = self.device.humidity,
         self._temperature = self.device.temperature
         self._mode = self.device.mode
+        self._hvac_state = self.device.hvac_state
         self._target_temperature = self.device.target
         self._fan = self.device.fan
         self._away = self.structure.away == 'away'

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -117,10 +117,14 @@ class NestThermostat(ClimateDevice):
 
     @property
     def current_hvac_state(self):
-        """Return the currently active HVAC state. This differs from the
-        current mode in that while the thermostat might be set to Heat it
-        may not currently be blowing heat. The mode indicates it is set to
-        Heat, the state indicates whether or not it is actively heating."""
+        """
+        Return the currently active HVAC state.
+
+        This differs from the current mode in that while the thermostat might
+        be set to Heat it may not currently be blowing heat. The mode indicates
+        it is set to Heat, the state indicates whether or not it is actively
+        heating.
+        """
         return self._hvac_state
 
     @property

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -18,7 +18,8 @@ from homeassistant.const import (
 
 DEPENDENCIES = ['nest']
 SENSOR_TYPES = ['humidity',
-                'operation_mode']
+                'operation_mode',
+                'hvac_state']
 
 SENSOR_TYPES_DEPRECATED = ['last_ip',
                            'local_ip',


### PR DESCRIPTION
**Description:** Add an `hvac_state` sensor to Nest


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1559

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Merge/Rebase after #4820 is merged

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
