### PR TITLE
Add exception handling when turning on Onkyo receivers

### DIFF
--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -89,7 +89,7 @@ class OnkyoDevice(MediaPlayerDevice):
         except (ValueError, OSError, AttributeError, AssertionError):
             if self._receiver.command_socket:
                 self._receiver.command_socket = None
-                _LOGGER.info('Reseting connection to %s.', self._name)
+                _LOGGER.info('Resetting connection to %s.', self._name)
             else:
                 _LOGGER.info('%s is disconnected. Attempting to reconnect.',
                              self._name)
@@ -173,7 +173,7 @@ class OnkyoDevice(MediaPlayerDevice):
 
     def turn_on(self):
         """Turn the media player on."""
-        self._receiver.power_on()
+        self.command('system-power on')
 
     def select_source(self, source):
         """Set the input source."""


### PR DESCRIPTION
**Description:**
This fixes the exception handling for the `turn_on` method by calling the same wrapper function as other commands.

**Related issue (if applicable):** fixes #4812 

**Example entry for `configuration.yaml` (if applicable):**
```yaml
media_player:
  - platform: onkyo
    host: onkyo
    name: Receiver
```