### PR TITLE
Added support  to language codes on Weather Underground

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -115,7 +115,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the WUnderground sensor."""
     rest = WUndergroundData(hass,
                             config.get(CONF_API_KEY),
-                            config.get(CONF_PWS_ID, None),
+                            config.get(CONF_PWS_ID),
                             config.get(CONF_LANG))
     sensors = []
     for variable in config[CONF_MONITORED_CONDITIONS]:
@@ -216,7 +216,7 @@ class WUndergroundSensor(Entity):
 class WUndergroundData(object):
     """Get data from WUnderground."""
 
-    def __init__(self, hass, api_key, pws_id=None, lang='EN'):
+    def __init__(self, hass, api_key, pws_id, lang):
         """Initialize the data object."""
         self._hass = hass
         self._api_key = api_key

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -19,12 +19,15 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-_RESOURCE = 'http://api.wunderground.com/api/{}/conditions/q/'
-_ALERTS = 'http://api.wunderground.com/api/{}/alerts/q/'
+_RESOURCE = 'http://api.wunderground.com/api/{}/conditions/{}/q/'
+_ALERTS = 'http://api.wunderground.com/api/{}/alerts/{}/q/'
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ATTRIBUTION = "Data provided by the WUnderground weather service"
 CONF_PWS_ID = 'pws_id'
+CONF_LANG = 'lang'
+
+DEFAULT_LANG = 'EN'
 
 MIN_TIME_BETWEEN_UPDATES_ALERTS = timedelta(minutes=15)
 MIN_TIME_BETWEEN_UPDATES_OBSERVATION = timedelta(minutes=5)
@@ -80,9 +83,29 @@ ALERTS_ATTRS = [
     'message',
 ]
 
+# Language Supported Codes
+LANG_CODES = [
+    'AF', 'AL', 'AR', 'HY', 'AZ', 'EU',
+    'BY', 'BU', 'LI', 'MY', 'CA', 'CN',
+    'TW', 'CR', 'CZ', 'DK', 'DV', 'NL',
+    'EN', 'EO', 'ET', 'FA', 'FI', 'FR',
+    'FC', 'GZ', 'DL', 'KA', 'GR', 'GU',
+    'HT', 'IL', 'HI', 'HU', 'IS', 'IO',
+    'ID', 'IR', 'IT', 'JP', 'JW', 'KM',
+    'KR', 'KU', 'LA', 'LV', 'LT', 'ND',
+    'MK', 'MT', 'GM', 'MI', 'MR', 'MN',
+    'NO', 'OC', 'PS', 'GN', 'PL', 'BR',
+    'PA', 'PU', 'RO', 'RU', 'SR', 'SK',
+    'SL', 'SP', 'SI', 'SW', 'CH', 'TL',
+    'TT', 'TH', 'UA', 'UZ', 'VU', 'CY',
+    'SN', 'JI', 'YI',
+]
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Optional(CONF_PWS_ID): cv.string,
+    vol.Optional(CONF_LANG, default=DEFAULT_LANG):
+        vol.All(vol.In(LANG_CODES)),
     vol.Required(CONF_MONITORED_CONDITIONS, default=[]):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
@@ -92,7 +115,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the WUnderground sensor."""
     rest = WUndergroundData(hass,
                             config.get(CONF_API_KEY),
-                            config.get(CONF_PWS_ID, None))
+                            config.get(CONF_PWS_ID, None),
+                            config.get(CONF_LANG))
     sensors = []
     for variable in config[CONF_MONITORED_CONDITIONS]:
         sensors.append(WUndergroundSensor(rest, variable))
@@ -192,18 +216,19 @@ class WUndergroundSensor(Entity):
 class WUndergroundData(object):
     """Get data from WUnderground."""
 
-    def __init__(self, hass, api_key, pws_id=None):
+    def __init__(self, hass, api_key, pws_id=None, lang='EN'):
         """Initialize the data object."""
         self._hass = hass
         self._api_key = api_key
         self._pws_id = pws_id
+        self._lang = 'lang:{}'.format(lang)
         self._latitude = hass.config.latitude
         self._longitude = hass.config.longitude
         self.data = None
         self.alerts = None
 
     def _build_url(self, baseurl=_RESOURCE):
-        url = baseurl.format(self._api_key)
+        url = baseurl.format(self._api_key, self._lang)
         if self._pws_id:
             url = url + 'pws:{}'.format(self._pws_id)
         else:

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -23,6 +23,16 @@ VALID_CONFIG = {
     ]
 }
 
+INVALID_CONFIG = {
+    'platform': 'wunderground',
+    'api_key': 'BOB',
+    'pws_id': 'bar',
+    'lang': 'foo',
+    'monitored_conditions': [
+        'weather', 'feelslike_c', 'alerts'
+    ]
+}
+
 FEELS_LIKE = '40'
 WEATHER = 'Clear'
 HTTPS_ICON_URL = 'https://icons.wxug.com/i/c/k/clear.gif'
@@ -128,17 +138,9 @@ class TestWundergroundSetup(unittest.TestCase):
         self.assertTrue(
             wunderground.setup_platform(self.hass, VALID_CONFIG,
                                         self.add_devices, None))
-        invalid_config = {
-            'platform': 'wunderground',
-            'api_key': 'BOB',
-            'pws_id': 'bar',
-            'monitored_conditions': [
-                'weather', 'feelslike_c', 'alerts'
-            ]
-        }
 
         self.assertTrue(
-            wunderground.setup_platform(self.hass, invalid_config,
+            wunderground.setup_platform(self.hass, INVALID_CONFIG,
                                         self.add_devices, None))
 
     @unittest.mock.patch('requests.get', side_effect=mocked_requests_get)


### PR DESCRIPTION
**Description:**
Added support to language codes on Weather Underground. All supported languages are listed at https://www.wunderground.com/weather/api/d/docs?d=language-support&MR=1

**Feature requested**: https://community.home-assistant.io/t/weather-underground-wunderground-weather-sensor/1849/72

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1560

**Example entry for `configuration.yaml` (if applicable):**

```yaml
### sensor in Czech
sensor:
  - platform: wunderground
    api_key: !secret wu_key
    pws_id: KNCHOLLY21
    lang: CZ
    monitored_conditions:
      - alerts
      - weather
      - temp_c
```

![image](https://cloud.githubusercontent.com/assets/809840/21002562/70053606-bcf4-11e6-8ccb-92af41ec5893.png)


```yaml
### sensor in Brazilian portuguese
sensor:
  - platform: wunderground
    api_key: !secret wu_key
    pws_id: KNCHOLLY21
    lang: BR
    monitored_conditions:
      - alerts
      - weather
      - temp_c
```

![image](https://cloud.githubusercontent.com/assets/809840/21002536/5d3a1320-bcf4-11e6-88c4-52857fa23000.png)

```yaml
### sensor in French
sensor:
  - platform: wunderground
    api_key: !secret wu_key
    pws_id: KNCHOLLY21
    lang: FR
    monitored_conditions:
      - alerts
      - weather
      - temp_c
```
![image](https://cloud.githubusercontent.com/assets/809840/21002638/ccef02ac-bcf4-11e6-9d9f-061b9c553285.png)


**Supported Language Codes**

AF	Afrikaans
AL	Albanian
AR	Arabic
HY	Armenian
AZ	Azerbaijani
EU	Basque
BY	Belarusian
BU	Bulgarian
LI	British English
MY	Burmese
CA	Catalan
CN	Chinese - Simplified
TW	Chinese - Traditional
CR	Croatian
CZ	Czech
DK	Danish
DV	Dhivehi
NL	Dutch
EN	English
EO	Esperanto
ET	Estonian
FA	Farsi
FI	Finnish
FR	French
FC	French Canadian
GZ	Galician
DL	German
KA	Georgian
GR	Greek
GU	Gujarati
HT	Haitian Creole
IL	Hebrew
HI	Hindi
HU	Hungarian
IS	Icelandic
IO	Ido
ID	Indonesian
IR	Irish Gaelic
IT	Italian
JP	Japanese
JW	Javanese
KM	Khmer
KR	Korean
KU	Kurdish
LA	Latin
LV	Latvian
LT	Lithuanian
ND	Low German
MK	Macedonian
MT	Maltese
GM	Mandinka
MI	Maori
MR	Marathi
MN	Mongolian
NO	Norwegian
OC	Occitan
PS	Pashto
GN	Plautdietsch
PL	Polish
BR	Portuguese
PA	Punjabi
RO	Romanian
RU	Russian
SR	Serbian
SK	Slovak
SL	Slovenian
SP	Spanish
SI	Swahili
SW	Swedish
CH	Swiss
TL	Tagalog
TT	Tatarish
TH	Thai
TR	Turkish
TK	Turkmen
UA	Ukrainian
UZ	Uzbek
VU	Vietnamese
CY	Welsh
SN	Wolof
JI	Yiddish - transliterated
YI	Yiddish - unicode

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

