### PR TITLE
Add EnGenius Wireless AP support to SNMP device_tracker

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -128,12 +128,21 @@ class SnmpScanner(object):
             for _, val in resrow:
                 mac = binascii.hexlify(val.asOctets()).decode('utf-8')
                 mac = ':'.join([mac[i:i+2] for i in range(0, len(mac), 2)])
-                if re.match('^' + '[\:\-]'.join(['([0-9a-f]{2})']*6) + '$', mac):
+
+                if re.match(
+                        '^' + '[\\:\\-]'.join(['([0-9a-f]{2})']*6) + '$', mac):
+
                     _LOGGER.debug('Found encoded mac %s', mac)
-                elif re.match('^' + '[\:\-]'.join(['([0-9a-f]{2})']*6) + '$', str(val)):
+
+                elif re.match(
+                        '^' + '[\\:\\-]'.join(['([0-9a-f]{2})']*6) + '$',
+                        str(val)):
+
                     mac = str(val)
                     _LOGGER.debug('Found decoded mac %s', mac)
+
                 else:
-                    LOGGER.debug('Cannot decode mac %s', mac)
+                    _LOGGER.debug('Cannot decode mac %s', mac)
+
                 devices.append({'mac': mac})
         return devices

--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -7,6 +7,8 @@ https://home-assistant.io/components/device_tracker.snmp/
 import binascii
 import logging
 import threading
+import re
+
 from datetime import timedelta
 
 import voluptuous as vol
@@ -125,7 +127,13 @@ class SnmpScanner(object):
         for resrow in restable:
             for _, val in resrow:
                 mac = binascii.hexlify(val.asOctets()).decode('utf-8')
-                _LOGGER.debug('Found mac %s', mac)
                 mac = ':'.join([mac[i:i+2] for i in range(0, len(mac), 2)])
+                if re.match('^' + '[\:\-]'.join(['([0-9a-f]{2})']*6) + '$', mac):
+                    _LOGGER.debug('Found encoded mac %s', mac)
+                elif re.match('^' + '[\:\-]'.join(['([0-9a-f]{2})']*6) + '$', str(val)):
+                    mac = str(val)
+                    _LOGGER.debug('Found decoded mac %s', mac)
+                else:
+                    LOGGER.debug('Cannot decode mac %s', mac)
                 devices.append({'mac': mac})
         return devices


### PR DESCRIPTION
**Description:**
Allows for the SNMP device_tracker component to work with routers that have the MAC returned as plain-text.

Tested with EnGenius EAP600, will likely work with all other EnGenius wireless AP products.

**Checklist:**

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

