### PR TITLE
Prevent emulated hue discovery by hue component

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -90,6 +90,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if discovery_info is not None:
         host = urlparse(discovery_info[1]).hostname
+
+        if "HASS Bridge" in discovery_info[0]:
+            pass
+        else:
+            host = urlparse(discovery_info[1]).hostname
     else:
         host = config.get(CONF_HOST, None)
 

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -92,9 +92,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         host = urlparse(discovery_info[1]).hostname
 
         if "HASS Bridge" in discovery_info[0]:
-            pass
-        else:
-            host = urlparse(discovery_info[1]).hostname
+            _LOGGER.info('Emulated hue found, will not add')
+            return False
     else:
         host = config.get(CONF_HOST, None)
 


### PR DESCRIPTION
**Description:**
Add a check to verify discovery_info does not contain "HASS Bridge" as passes if does, otherwise it proceeds as normal.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
#4803 

**Checklist:**



If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.
