### PR TITLE
Bump python-nest to fix issue with Nest Cam without activity zones

### DIFF
--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = [
     'http://github.com/technicalpickles/python-nest'
-    '/archive/f0aab00fc484948619f842cc856d1c047a3c6e9a.zip'  # nest-cam branch
+    '/archive/b8391d2b3cb8682f8b0c2bdff477179983609f39.zip'  # nest-cam branch
     '#python-nest==3.0.2']
 
 DOMAIN = 'nest'

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -19,8 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = [
     'http://github.com/technicalpickles/python-nest'
-    '/archive/7a2eb38d391bddeb78079437f001224c370b555a.zip'  # nest-cam branch
-    '#python-nest==3.0.1']
+    '/archive/f0aab00fc484948619f842cc856d1c047a3c6e9a.zip'  # nest-cam branch
+    '#python-nest==3.0.2']
 
 DOMAIN = 'nest'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -167,7 +167,7 @@ hikvision==0.4
 # http://github.com/adafruit/Adafruit_Python_DHT/archive/310c59b0293354d07d94375f1365f7b9b9110c7d.zip#Adafruit_DHT==1.3.0
 
 # homeassistant.components.nest
-http://github.com/technicalpickles/python-nest/archive/7a2eb38d391bddeb78079437f001224c370b555a.zip#python-nest==3.0.1
+http://github.com/technicalpickles/python-nest/archive/b8391d2b3cb8682f8b0c2bdff477179983609f39.zip#python-nest==3.0.2
 
 # homeassistant.components.light.flux_led
 https://github.com/Danielhiversen/flux_led/archive/0.9.zip#flux_led==0.9


### PR DESCRIPTION
**Description:**

I setup a new camera that didn't have any Activity Zones, and got this error:

```
16-12-08 09:41:36 ERROR (MainThread) [homeassistant.components.binary_sensor] Error while setting up platform nest
Traceback (most recent call last):
  File "/Users/technicalpickles/src/picklehome/vendor/home-assistant/homeassistant/helpers/entity_component.py", line 150, in _async_setup_platform
    entity_platform.add_entities, discovery_info
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/asyncio/futures.py", line 361, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/asyncio/tasks.py", line 296, in _wakeup
    future.result()
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/asyncio/futures.py", line 274, in result
    raise self._exception
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/technicalpickles/src/picklehome/vendor/home-assistant/homeassistant/components/binary_sensor/nest.py", line 95, in setup_platform
    for activity_zone in device.activity_zones:
  File "/Users/technicalpickles/src/picklehome/config/deps/nest/nest.py", line 1032, in activity_zones
    for z in self._device['activity_zones']]
KeyError: 'activity_zones'
```

I fixed it in my python-nest branch, and bumped the dependency here.

**Related issue (if applicable):** 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

