### PR TITLE
Add support for Hikvision event stream binary sensors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -122,9 +122,11 @@ omit =
     homeassistant/components/alarm_control_panel/simplisafe.py
     homeassistant/components/binary_sensor/arest.py
     homeassistant/components/binary_sensor/concord232.py
+    homeassistant/components/binary_sensor/flic.py
     homeassistant/components/binary_sensor/hikvision.py
     homeassistant/components/binary_sensor/rest.py
     homeassistant/components/browser.py
+    homeassistant/components/camera/amcrest.py
     homeassistant/components/camera/bloomsky.py
     homeassistant/components/camera/foscam.py
     homeassistant/components/camera/mjpeg.py
@@ -183,6 +185,7 @@ omit =
     homeassistant/components/light/x10.py
     homeassistant/components/light/yeelight.py
     homeassistant/components/lirc.py
+    homeassistant/components/media_player/aquostv.py
     homeassistant/components/media_player/braviatv.py
     homeassistant/components/media_player/cast.py
     homeassistant/components/media_player/cmus.py
@@ -241,6 +244,7 @@ omit =
     homeassistant/components/notify/xmpp.py
     homeassistant/components/nuimo_controller.py
     homeassistant/components/openalpr.py
+    homeassistant/components/remote/harmony.py
     homeassistant/components/scene/hunterdouglas_powerview.py
     homeassistant/components/sensor/arest.py
     homeassistant/components/sensor/arwn.py
@@ -279,7 +283,9 @@ omit =
     homeassistant/components/sensor/mhz19.py
     homeassistant/components/sensor/miflora.py
     homeassistant/components/sensor/mqtt_room.py
+    homeassistant/components/sensor/netdata.py
     homeassistant/components/sensor/neurio_energy.py
+    homeassistant/components/sensor/nut.py
     homeassistant/components/sensor/nzbget.py
     homeassistant/components/sensor/ohmconnect.py
     homeassistant/components/sensor/onewire.py
@@ -311,10 +317,11 @@ omit =
     homeassistant/components/sensor/waqi.py
     homeassistant/components/sensor/xbox_live.py
     homeassistant/components/sensor/yweather.py
-    homeassistant/components/sensor/waqi.py
+    homeassistant/components/sensor/zamg.py
     homeassistant/components/switch/acer_projector.py
     homeassistant/components/switch/anel_pwrctrl.py
     homeassistant/components/switch/arest.py
+    homeassistant/components/switch/digitalloggers.py
     homeassistant/components/switch/dlink.py
     homeassistant/components/switch/edimax.py
     homeassistant/components/switch/hikvisioncam.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -122,6 +122,7 @@ omit =
     homeassistant/components/alarm_control_panel/simplisafe.py
     homeassistant/components/binary_sensor/arest.py
     homeassistant/components/binary_sensor/concord232.py
+    homeassistant/components/binary_sensor/hikvision.py
     homeassistant/components/binary_sensor/rest.py
     homeassistant/components/browser.py
     homeassistant/components/camera/bloomsky.py

--- a/homeassistant/components/binary_sensor/hikvision.py
+++ b/homeassistant/components/binary_sensor/hikvision.py
@@ -1,0 +1,243 @@
+"""
+Support for Hikvision event stream events represented as binary sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.hikvision/
+"""
+import logging
+
+from threading import Timer
+import voluptuous as vol
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA, DOMAIN)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (
+    CONF_HOST, CONF_PORT, CONF_NAME, CONF_USERNAME, CONF_PASSWORD,
+    CONF_SSL, EVENT_HOMEASSISTANT_STOP, ATTR_LAST_TRIP_TIME, CONF_CUSTOMIZE)
+
+REQUIREMENTS = ['pyhik==0.0.6', 'pydispatcher==2.0.5']
+_LOGGER = logging.getLogger(__name__)
+
+CONF_IGNORED = 'ignored'
+CONF_DELAY = 'delay'
+
+DEFAULT_PORT = 80
+DEFAULT_IGNORED = False
+DEFAULT_DELAY = 0
+
+SENSOR_CLASS_MAP = {
+    'Motion': 'motion',
+    'Line Crossing': 'motion',
+    'IO Trigger': None,
+    'Field Detection': 'motion',
+    'Video Loss': None,
+    'Tamper Detection': 'motion',
+    'Shelter Alarm': None,
+    'Disk Full': None,
+    'Disk Error': None,
+    'Net Interface Broken': 'connectivity',
+    'IP Conflict': 'connectivity',
+    'Illegal Access': None,
+    'Video Mismatch': None,
+    'Bad Video': None,
+    'PIR Alarm': 'motion',
+    'Face Detection': 'motion',
+}
+
+CUSTOMIZE_SCHEMA = vol.Schema({
+    vol.Optional(CONF_IGNORED, default=DEFAULT_IGNORED): cv.boolean,
+    vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): cv.positive_int
+    })
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=None): cv.string,
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_SSL, default=False): cv.boolean,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_CUSTOMIZE, default={}):
+        vol.Schema({cv.string: CUSTOMIZE_SCHEMA}),
+})
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Setup Hikvision binary sensor devices."""
+    name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+
+    customize = config.get(CONF_CUSTOMIZE)
+
+    if config.get(CONF_SSL):
+        protocol = "https"
+    else:
+        protocol = "http"
+
+    url = '{}://{}'.format(protocol, host)
+
+    data = HikvisionData(hass, url, port, name, username, password)
+
+    if data.sensors is None:
+        _LOGGER.error('Hikvision event stream has no data, unable to setup.')
+        return False
+
+    entities = []
+
+    for sensor in data.sensors:
+        # Build entity name, then parse customize config.
+        sensor_name = ('{}_{}'.format(data.name, sensor)).replace(' ', '_')
+        entity_name = ('{}.{}'.format(DOMAIN, sensor_name)).lower()
+
+        custom = customize.get(entity_name, {})
+        ignore = custom.get(CONF_IGNORED)
+        delay = custom.get(CONF_DELAY)
+
+        _LOGGER.debug('Entity: %s, Options - Ignore: %s, Delay: %s',
+                      entity_name, ignore, delay)
+        if not ignore:
+            entities.append(HikvisionBinarySensor(sensor, data, delay))
+
+    add_entities(entities)
+
+
+class HikvisionData(object):
+    """Hikvision camera event stream object."""
+
+    def __init__(self, hass, url, port, name, username, password):
+        """Initialize the data oject."""
+        from pyhik.hikvision import HikCamera
+        self._url = url
+        self._port = port
+        self._name = name
+        self._username = username
+        self._password = password
+
+        # Establish camera
+        self._cam = HikCamera(self._url, self._port,
+                              self._username, self._password)
+
+        if self._name is None:
+            self._name = self._cam.get_name
+
+        # Start event stream
+        self._cam.start_stream()
+
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, self.stop_hik)
+
+    def stop_hik(self, event):
+        """Shutdown Hikvision subscriptions and subscription thread on exit."""
+        self._cam.disconnect()
+
+    @property
+    def sensors(self):
+        """Return list of available sensors and their states."""
+        return self._cam.current_event_states
+
+    @property
+    def cam_id(self):
+        """Return camera id."""
+        return self._cam.get_id
+
+    @property
+    def name(self):
+        """Return camera name."""
+        return self._name
+
+
+class HikvisionBinarySensor(BinarySensorDevice):
+    """Representation of a Hikvision binary sensor."""
+
+    def __init__(self, sensor, cam, delay):
+        """Initialize the binary_sensor."""
+        from pydispatch import dispatcher
+
+        self._cam = cam
+        self._name = self._cam.name + ' ' + sensor
+        self._id = self._cam.cam_id + '.' + sensor
+        self._sensor = sensor
+
+        if delay is None:
+            self._delay = 0
+        else:
+            self._delay = delay
+
+        self._timer = None
+
+        # Form signal for dispatcher
+        signal = 'ValueChanged.{}'.format(self._cam.cam_id)
+
+        dispatcher.connect(self._update_callback,
+                           signal=signal,
+                           sender=self._sensor)
+
+    def _sensor_state(self):
+        """Extract sensor state."""
+        return self._cam.sensors[self._sensor][0]
+
+    def _sensor_last_update(self):
+        """Extract sensor last update time."""
+        return self._cam.sensors[self._sensor][3]
+
+    @property
+    def name(self):
+        """Return the name of the Hikvision sensor."""
+        return self._name
+
+    @property
+    def unique_id(self):
+        """Return an unique ID."""
+        # return '{}.{}'.format(self.__class__, id(self))
+        return '{}.{}'.format(self.__class__, self._id)
+
+    @property
+    def is_on(self):
+        """Return true if sensor is on."""
+        return self._sensor_state()
+
+    @property
+    def sensor_class(self):
+        """Return the class of this sensor, from SENSOR_CLASSES."""
+        try:
+            return SENSOR_CLASS_MAP[self._sensor]
+        except KeyError:
+            # Sensor must be unknown to us, add as generic
+            return None
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attr = {}
+        attr[ATTR_LAST_TRIP_TIME] = self._sensor_last_update()
+        return attr
+
+    def _update_callback(self, signal, sender):
+        """Update the sensor's state, if needed."""
+        _LOGGER.debug('Dispatcher callback, signal: %s, sender: %s',
+                      signal, sender)
+
+        if sender is not self._sensor:
+            return
+
+        if self._delay > 0 and not self.is_on:
+            # Set timer to wait until updating the state
+            def _delay_update():
+                """Timer callback for sensor update."""
+                _LOGGER.debug('%s Called delayed (%ssec) update.',
+                              self._name, self._delay)
+                self.schedule_update_ha_state()
+
+            if self._timer is not None and self._timer.isAlive():
+                self._timer.cancel()
+
+            self._timer = Timer(self._delay, _delay_update)
+            self._timer.start()
+        else:
+            self.schedule_update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -378,6 +378,7 @@ pycmus==0.1.0
 
 # homeassistant.components.envisalink
 # homeassistant.components.zwave
+# homeassistant.components.binary_sensor.hikvision
 pydispatcher==2.0.5
 
 # homeassistant.components.media_player.emby
@@ -388,6 +389,9 @@ pyenvisalink==1.9
 
 # homeassistant.components.ifttt
 pyfttt==0.3
+
+# homeassistant.components.binary_sensor.hikvision
+pyhik==0.0.6
 
 # homeassistant.components.homematic
 pyhomematic==0.1.16

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,11 +6,11 @@ pip>=7.0.0
 jinja2>=2.8
 voluptuous==0.9.2
 typing>=3,<4
-aiohttp==1.1.5
+aiohttp==1.1.6
 async_timeout==1.1.0
 
 # homeassistant.components.nuimo_controller
---only-binary=all git+https://github.com/getSenic/nuimo-linux-python#nuimo==1.0.0
+--only-binary=all http://github.com/getSenic/nuimo-linux-python/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip#nuimo==1.0.0
 
 # homeassistant.components.isy994
 PyISY==1.0.7
@@ -32,6 +32,9 @@ TwitterAPI==2.4.2
 
 # homeassistant.components.http
 aiohttp_cors==0.5.0
+
+# homeassistant.components.camera.amcrest
+amcrest==1.0.0
 
 # homeassistant.components.apcupsd
 apcaccess==0.0.4
@@ -81,6 +84,9 @@ directpy==0.1
 # homeassistant.components.updater
 distro==1.0.1
 
+# homeassistant.components.switch.digitalloggers
+dlipower==0.7.165
+
 # homeassistant.components.notify.xmpp
 dnspython3==1.15.0
 
@@ -127,9 +133,6 @@ fuzzywuzzy==0.14.0
 # homeassistant.components.device_tracker.bluetooth_le_tracker
 # gattlib==0.20150805
 
-# homeassistant.components.nest
-git+https://github.com/technicalpickles/python-nest.git@nest-cam#python-nest==3.0.0
-
 # homeassistant.components.notify.gntp
 gntp==1.0.3
 
@@ -163,6 +166,9 @@ hikvision==0.4
 # homeassistant.components.sensor.dht
 # http://github.com/adafruit/Adafruit_Python_DHT/archive/310c59b0293354d07d94375f1365f7b9b9110c7d.zip#Adafruit_DHT==1.3.0
 
+# homeassistant.components.nest
+http://github.com/technicalpickles/python-nest/archive/7a2eb38d391bddeb78079437f001224c370b555a.zip#python-nest==3.0.1
+
 # homeassistant.components.light.flux_led
 https://github.com/Danielhiversen/flux_led/archive/0.9.zip#flux_led==0.9
 
@@ -170,7 +176,7 @@ https://github.com/Danielhiversen/flux_led/archive/0.9.zip#flux_led==0.9
 https://github.com/GadgetReactor/pyHS100/archive/1f771b7d8090a91c6a58931532e42730b021cbde.zip#pyHS100==0.2.0
 
 # homeassistant.components.switch.dlink
-https://github.com/LinuxChristian/pyW215/archive/v0.3.6.zip#pyW215==0.3.6
+https://github.com/LinuxChristian/pyW215/archive/v0.3.7.zip#pyW215==0.3.7
 
 # homeassistant.components.media_player.webostv
 # homeassistant.components.notify.webostv
@@ -199,7 +205,7 @@ https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.
 # https://github.com/deisi/fritzconnection/archive/b5c14515e1c8e2652b06b6316a7f3913df942841.zip#fritzconnection==0.4.6
 
 # homeassistant.components.netatmo
-https://github.com/jabesq/netatmo-api-python/archive/v0.7.0.zip#lnetatmo==0.7.0
+https://github.com/jabesq/netatmo-api-python/archive/v0.8.0.zip#lnetatmo==0.8.0
 
 # homeassistant.components.neato
 https://github.com/jabesq/pybotvac/archive/v0.0.1.zip#pybotvac==0.0.1
@@ -234,6 +240,9 @@ https://github.com/robbiet480/pygtfs/archive/00546724e4bbcb3053110d844ca44e22462
 
 # homeassistant.components.scene.hunterdouglas_powerview
 https://github.com/sander76/powerviewApi/archive/246e782d60d5c0addcc98d7899a0186f9d5640b0.zip#powerviewApi==0.3.15
+
+# homeassistant.components.binary_sensor.flic
+https://github.com/soldag/pyflic/archive/0.4.zip#pyflic==0.4
 
 # homeassistant.components.light.osramlightify
 https://github.com/tfriedel/python-lightify/archive/d6eadcf311e6e21746182d1480e97b350dda2b3e.zip#lightify==1.0.4
@@ -290,7 +299,7 @@ mficlient==0.3.0
 miflora==0.1.13
 
 # homeassistant.components.discovery
-netdisco==0.7.7
+netdisco==0.8.0
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.2.10
@@ -337,7 +346,7 @@ proliphix==0.4.1
 psutil==5.0.0
 
 # homeassistant.components.wink
-pubnub==3.8.2
+pubnubsub-handler==0.0.5
 
 # homeassistant.components.notify.pushbullet
 pushbullet.py==0.10.0
@@ -346,7 +355,7 @@ pushbullet.py==0.10.0
 pushetta==1.0.15
 
 # homeassistant.components.sensor.waqi
-pwaqi==1.2
+pwaqi==1.3
 
 # homeassistant.components.sensor.cpuspeed
 py-cpuinfo==0.2.3
@@ -390,11 +399,14 @@ pyenvisalink==1.9
 # homeassistant.components.ifttt
 pyfttt==0.3
 
+# homeassistant.components.remote.harmony
+pyharmony==1.0.12
+
 # homeassistant.components.binary_sensor.hikvision
 pyhik==0.0.6
 
 # homeassistant.components.homematic
-pyhomematic==0.1.16
+pyhomematic==0.1.18
 
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.9.1
@@ -416,6 +428,9 @@ pynetgear==0.3.3
 
 # homeassistant.components.switch.netio
 pynetio==0.1.6
+
+# homeassistant.components.sensor.nut
+pynut2==2.1.2
 
 # homeassistant.components.alarm_control_panel.nx584
 # homeassistant.components.binary_sensor.nx584
@@ -466,7 +481,10 @@ python-telegram-bot==5.2.0
 python-twitch==1.3.0
 
 # homeassistant.components.wink
-python-wink==0.10.0
+python-wink==0.11.0
+
+# homeassistant.components.device_tracker.unifi
+pyunifi==1.3
 
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11
@@ -503,6 +521,9 @@ scsgate==0.1.0
 
 # homeassistant.components.notify.sendgrid
 sendgrid==3.6.3
+
+# homeassistant.components.media_player.aquostv
+sharp-aquos-rc==0.2
 
 # homeassistant.components.notify.slack
 slacker==0.9.30
@@ -554,9 +575,6 @@ twilio==5.4.0
 
 # homeassistant.components.sensor.uber
 uber_rides==0.2.7
-
-# homeassistant.components.device_tracker.unifi
-unifi==1.2.5
 
 # homeassistant.components.device_tracker.unifi
 urllib3


### PR DESCRIPTION
**Description:**

Adds support for utilizing motion and other sensors within Hikvision IP cameras in Home Assistant.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1565

**Example entry for `configuration.yaml` (if applicable):**
```yaml
binary_sensor:
  platform: hikvision
  host: IP_ADDRESS
  username: user
  password: pass
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ x ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ x ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ x ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ x ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ x ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

