### PR TITLE
Flic: Support ignoring individual click types.

### DIFF
--- a/homeassistant/components/binary_sensor/flic.py
+++ b/homeassistant/components/binary_sensor/flic.py
@@ -17,6 +17,13 @@ REQUIREMENTS = ['https://github.com/soldag/pyflic/archive/0.4.zip#pyflic==0.4']
 _LOGGER = logging.getLogger(__name__)
 
 
+CLICK_TYPE_SINGLE = "single"
+CLICK_TYPE_DOUBLE = "double"
+CLICK_TYPE_HOLD = "hold"
+CLICK_TYPES = [CLICK_TYPE_SINGLE, CLICK_TYPE_DOUBLE, CLICK_TYPE_HOLD]
+
+CONF_IGNORED_CLICK_TYPES = "ignored_click_types"
+
 EVENT_NAME = "flic_click"
 EVENT_DATA_NAME = "button_name"
 EVENT_DATA_ADDRESS = "button_address"
@@ -26,7 +33,9 @@ EVENT_DATA_TYPE = "click_type"
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default='localhost'): cv.string,
     vol.Optional(CONF_PORT, default=5551): cv.port,
-    vol.Optional(CONF_DISCOVERY, default=True): cv.boolean
+    vol.Optional(CONF_DISCOVERY, default=True): cv.boolean,
+    vol.Optional(CONF_IGNORED_CLICK_TYPES): vol.All(cv.ensure_list,
+                                                    [vol.In(CLICK_TYPES)])
 })
 
 
@@ -93,7 +102,8 @@ def start_scanning(hass, config, async_add_entities, client):
 @asyncio.coroutine
 def async_setup_button(hass, config, async_add_entities, client, address):
     """Setup single button device."""
-    button = FlicButton(hass, client, address)
+    ignored_click_types = config.get(CONF_IGNORED_CLICK_TYPES)
+    button = FlicButton(hass, client, address, ignored_click_types)
     _LOGGER.info("Connected to button (%s)", address)
 
     yield from async_add_entities([button])
@@ -117,24 +127,46 @@ def async_get_verified_addresses(client):
 class FlicButton(BinarySensorDevice):
     """Representation of a flic button."""
 
-    def __init__(self, hass, client, address):
+    def __init__(self, hass, client, address, ignored_click_types):
         """Initialize the flic button."""
         import pyflic
 
         self._hass = hass
         self._address = address
         self._is_down = False
-        self._click_types = {
-            pyflic.ClickType.ButtonSingleClick: "single",
-            pyflic.ClickType.ButtonDoubleClick: "double",
-            pyflic.ClickType.ButtonHold: "hold",
+        self._ignored_click_types = ignored_click_types or []
+        self._hass_click_types = {
+            pyflic.ClickType.ButtonClick: CLICK_TYPE_SINGLE,
+            pyflic.ClickType.ButtonSingleClick: CLICK_TYPE_SINGLE,
+            pyflic.ClickType.ButtonDoubleClick: CLICK_TYPE_DOUBLE,
+            pyflic.ClickType.ButtonHold: CLICK_TYPE_HOLD,
         }
 
-        # Initialize connection channel
-        self._channel = pyflic.ButtonConnectionChannel(self._address)
-        self._channel.on_button_up_or_down = self._on_up_down
-        self._channel.on_button_single_or_double_click_or_hold = self._on_click
+        self._channel = self._create_channel()
         client.add_connection_channel(self._channel)
+
+    def _create_channel(self):
+        """Create a new connection channel to the button."""
+        import pyflic
+
+        channel = pyflic.ButtonConnectionChannel(self._address)
+        channel.on_button_up_or_down = self._on_up_down
+
+        # If all types of clicks should be ignored, skip registering callbacks
+        if set(self._ignored_click_types) == set(CLICK_TYPES):
+            return channel
+
+        if CLICK_TYPE_DOUBLE in self._ignored_click_types:
+            # Listen to all but double click type events
+            channel.on_button_click_or_hold = self._on_click
+        elif CLICK_TYPE_HOLD in self._ignored_click_types:
+            # Listen to all but hold click type events
+            channel.on_button_single_or_double_click = self._on_click
+        else:
+            # Listen to all click type events
+            channel.on_button_single_or_double_click_or_hold = self._on_click
+
+        return channel
 
     @property
     def name(self):
@@ -176,13 +208,14 @@ class FlicButton(BinarySensorDevice):
 
     def _on_click(self, channel, click_type, was_queued, time_diff):
         """Fire click event, if event was not queued."""
-        if was_queued:
+        hass_click_type = self._hass_click_types[click_type]
+        if was_queued or hass_click_type in self._ignored_click_types:
             return
 
         self._hass.bus.fire(EVENT_NAME, {
             EVENT_DATA_NAME: self.name,
             EVENT_DATA_ADDRESS: self.address,
-            EVENT_DATA_TYPE: self._click_types[click_type]
+            EVENT_DATA_TYPE: hass_click_type
         })
 
     def _connection_status_changed(self, channel,


### PR DESCRIPTION
**Description:**
Added support for excluding individual click types from triggering events as [suggested](https://github.com/home-assistant/home-assistant/pull/4681#issuecomment-265721313).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1568

**Example entry for `configuration.yaml` (if applicable):**
```yaml
binary_sensor:
  - platform: flic
    ignored_click_types:
      - double
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

