### PR TITLE
Make tolerance work both ways in generic_thermostat (Climate)

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -221,7 +221,7 @@ class GenericThermostat(ClimateDevice):
             elif is_heating:
                 too_hot = self._cur_temp - self._target_temp > self._tolerance
                 if too_hot:
-                    _LOGGER.info('Turning off heater %s', 
+                    _LOGGER.info('Turning off heater %s',
                                  self.heater_entity_id)
                     switch.turn_off(self.hass, self.heater_entity_id)
 

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -198,31 +198,31 @@ class GenericThermostat(ClimateDevice):
                 return
 
         if self.ac_mode:
-            
+
             is_cooling = self._is_device_active
             if not is_cooling:
                 too_hot = self._cur_temp - self._target_temp > self._tolerance
                 if too_hot:
-                    _LOGGER.info('Turning on AC %s', self.heater_entity_id)
-                    switch.turn_on(self.hass, self.heater_entity_id)
+                  _LOGGER.info('Turning on AC %s', self.heater_entity_id)
+                  switch.turn_on(self.hass, self.heater_entity_id)
             elif is_cooling:
                 too_cold = self._target_temp - self._cur_temp > self._tolerance
                 if too_cold:
-                    _LOGGER.info('Turning off AC %s', self.heater_entity_id)
-                    switch.turn_off(self.hass, self.heater_entity_id)
+                  _LOGGER.info('Turning off AC %s', self.heater_entity_id)
+                  switch.turn_off(self.hass, self.heater_entity_id)
         else:
-            
+
             is_heating = self._is_device_active
             if not is_heating:
                 too_cold = self._target_temp - self._cur_temp > self._tolerance
                 if too_cold:
-                    _LOGGER.info('Turning on heater %s', self.heater_entity_id)
-                    switch.turn_on(self.hass, self.heater_entity_id)
+                  _LOGGER.info('Turning on heater %s', self.heater_entity_id)
+                  switch.turn_on(self.hass, self.heater_entity_id)
             elif is_heating:
                 too_hot = self._cur_temp - self._target_temp > self._tolerance
                 if too_hot:
-                    _LOGGER.info('Turning off heater %s', self.heater_entity_id)
-                    switch.turn_off(self.hass, self.heater_entity_id)
+                  _LOGGER.info('Turning off heater %s', self.heater_entity_id)
+                  switch.turn_off(self.hass, self.heater_entity_id)
 
     @property
     def _is_device_active(self):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -198,24 +198,31 @@ class GenericThermostat(ClimateDevice):
                 return
 
         if self.ac_mode:
-            too_hot = self._cur_temp - self._target_temp > self._tolerance
+            
             is_cooling = self._is_device_active
-            if too_hot and not is_cooling:
-                _LOGGER.info('Turning on AC %s', self.heater_entity_id)
-                switch.turn_on(self.hass, self.heater_entity_id)
-            elif not too_hot and is_cooling:
-                _LOGGER.info('Turning off AC %s', self.heater_entity_id)
-                switch.turn_off(self.hass, self.heater_entity_id)
+            if not is_cooling:
+                too_hot = self._cur_temp - self._target_temp > self._tolerance
+                if too_hot:
+                    _LOGGER.info('Turning on AC %s', self.heater_entity_id)
+                    switch.turn_on(self.hass, self.heater_entity_id)
+            elif is_cooling:
+                too_cold = self._target_temp - self._cur_temp > self._tolerance
+                if too_cold:
+                    _LOGGER.info('Turning off AC %s', self.heater_entity_id)
+                    switch.turn_off(self.hass, self.heater_entity_id)
         else:
-            too_cold = self._target_temp - self._cur_temp > self._tolerance
+            
             is_heating = self._is_device_active
-
-            if too_cold and not is_heating:
-                _LOGGER.info('Turning on heater %s', self.heater_entity_id)
-                switch.turn_on(self.hass, self.heater_entity_id)
-            elif not too_cold and is_heating:
-                _LOGGER.info('Turning off heater %s', self.heater_entity_id)
-                switch.turn_off(self.hass, self.heater_entity_id)
+            if not is_heating:
+                too_cold = self._target_temp - self._cur_temp > self._tolerance
+                if too_cold:
+                    _LOGGER.info('Turning on heater %s', self.heater_entity_id)
+                    switch.turn_on(self.hass, self.heater_entity_id)
+            elif is_heating:
+                too_hot = self._cur_temp - self._target_temp > self._tolerance
+                if too_hot:
+                    _LOGGER.info('Turning off heater %s', self.heater_entity_id)
+                    switch.turn_off(self.hass, self.heater_entity_id)
 
     @property
     def _is_device_active(self):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -198,32 +198,30 @@ class GenericThermostat(ClimateDevice):
                 return
 
         if self.ac_mode:
-
             is_cooling = self._is_device_active
-            if not is_cooling:
-                too_hot = self._cur_temp - self._target_temp > self._tolerance
-                if too_hot:
-                    _LOGGER.info('Turning on AC %s', self.heater_entity_id)
-                    switch.turn_on(self.hass, self.heater_entity_id)
-            elif is_cooling:
+            if is_cooling:
                 too_cold = self._target_temp - self._cur_temp > self._tolerance
                 if too_cold:
                     _LOGGER.info('Turning off AC %s', self.heater_entity_id)
                     switch.turn_off(self.hass, self.heater_entity_id)
-        else:
-
-            is_heating = self._is_device_active
-            if not is_heating:
-                too_cold = self._target_temp - self._cur_temp > self._tolerance
-                if too_cold:
-                    _LOGGER.info('Turning on heater %s', self.heater_entity_id)
+            else:
+                too_hot = self._cur_temp - self._target_temp > self._tolerance
+                if too_hot:
+                    _LOGGER.info('Turning on AC %s', self.heater_entity_id)
                     switch.turn_on(self.hass, self.heater_entity_id)
-            elif is_heating:
+        else:
+            is_heating = self._is_device_active
+            if is_heating:
                 too_hot = self._cur_temp - self._target_temp > self._tolerance
                 if too_hot:
                     _LOGGER.info('Turning off heater %s',
                                  self.heater_entity_id)
                     switch.turn_off(self.hass, self.heater_entity_id)
+            else:
+                too_cold = self._target_temp - self._cur_temp > self._tolerance
+                if too_cold:
+                    _LOGGER.info('Turning on heater %s', self.heater_entity_id)
+                    switch.turn_on(self.hass, self.heater_entity_id)
 
     @property
     def _is_device_active(self):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -221,7 +221,8 @@ class GenericThermostat(ClimateDevice):
             elif is_heating:
                 too_hot = self._cur_temp - self._target_temp > self._tolerance
                 if too_hot:
-                    _LOGGER.info('Turning off heater %s',self.heater_entity_id)
+                    _LOGGER.info('Turning off heater %s', \
+                                 self.heater_entity_id)
                     switch.turn_off(self.hass, self.heater_entity_id)
 
     @property

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -203,26 +203,26 @@ class GenericThermostat(ClimateDevice):
             if not is_cooling:
                 too_hot = self._cur_temp - self._target_temp > self._tolerance
                 if too_hot:
-                  _LOGGER.info('Turning on AC %s', self.heater_entity_id)
-                  switch.turn_on(self.hass, self.heater_entity_id)
+                    _LOGGER.info('Turning on AC %s', self.heater_entity_id)
+                    switch.turn_on(self.hass, self.heater_entity_id)
             elif is_cooling:
                 too_cold = self._target_temp - self._cur_temp > self._tolerance
                 if too_cold:
-                  _LOGGER.info('Turning off AC %s', self.heater_entity_id)
-                  switch.turn_off(self.hass, self.heater_entity_id)
+                    _LOGGER.info('Turning off AC %s', self.heater_entity_id)
+                    switch.turn_off(self.hass, self.heater_entity_id)
         else:
 
             is_heating = self._is_device_active
             if not is_heating:
                 too_cold = self._target_temp - self._cur_temp > self._tolerance
                 if too_cold:
-                  _LOGGER.info('Turning on heater %s', self.heater_entity_id)
-                  switch.turn_on(self.hass, self.heater_entity_id)
+                    _LOGGER.info('Turning on heater %s', self.heater_entity_id)
+                    switch.turn_on(self.hass, self.heater_entity_id)
             elif is_heating:
                 too_hot = self._cur_temp - self._target_temp > self._tolerance
                 if too_hot:
-                  _LOGGER.info('Turning off heater %s', self.heater_entity_id)
-                  switch.turn_off(self.hass, self.heater_entity_id)
+                    _LOGGER.info('Turning off heater %s',self.heater_entity_id)
+                    switch.turn_off(self.hass, self.heater_entity_id)
 
     @property
     def _is_device_active(self):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -221,7 +221,7 @@ class GenericThermostat(ClimateDevice):
             elif is_heating:
                 too_hot = self._cur_temp - self._target_temp > self._tolerance
                 if too_hot:
-                    _LOGGER.info('Turning off heater %s', \
+                    _LOGGER.info('Turning off heater %s', 
                                  self.heater_entity_id)
                     switch.turn_off(self.hass, self.heater_entity_id)
 

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -193,7 +193,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
         self.assertEqual(0, len(self.calls))
 
     def test_temp_change_heater_on_outside_tolerance(self):
-        """Test if temperature change turn heater on outside tolerance."""        
+        """Test if temperature change turn heater on outside tolerance."""
         self._setup_switch(False)
         climate.set_temperature(self.hass, 30)
         self.hass.block_till_done()
@@ -302,7 +302,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         self._setup_switch(True)
         climate.set_temperature(self.hass, 30)
         self.hass.block_till_done()
-        self._setup_sensor(29.7)
+        self._setup_sensor(29.8)
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
 
@@ -326,7 +326,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         self._setup_switch(False)
         climate.set_temperature(self.hass, 25)
         self.hass.block_till_done()
-        self._setup_sensor(25.3)
+        self._setup_sensor(25.2)
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
 

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -181,8 +181,19 @@ class TestClimateGenericThermostat(unittest.TestCase):
         self.assertEqual(SERVICE_TURN_OFF, call.service)
         self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
-    def test_set_temp_change_heater_on(self):
-        """Test if temperature change turn heater on."""
+    def test_temp_change_heater_on_within_tolerance(self):
+        """Test if temperature change doesn't turn heater on within
+        tolerance.
+        """
+        self._setup_switch(False)
+        climate.set_temperature(self.hass, 30)
+        self.hass.block_till_done()
+        self._setup_sensor(29)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
+    def test_temp_change_heater_on_outside_tolerance(self):
+        """Test if temperature change turn heater on outside tolerance."""        
         self._setup_switch(False)
         climate.set_temperature(self.hass, 30)
         self.hass.block_till_done()
@@ -194,36 +205,23 @@ class TestClimateGenericThermostat(unittest.TestCase):
         self.assertEqual(SERVICE_TURN_ON, call.service)
         self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
-    def test_temp_change_heater_off(self):
-        """Test if temperature change turn heater off."""
+    def test_temp_change_heater_off_within_tolerance(self):
+        """Test if temperature change doesn't turn heater off within
+        tolerance.
+        """
         self._setup_switch(True)
-        climate.set_temperature(self.hass, 25)
-        self.hass.block_till_done()
-        self._setup_sensor(30)
-        self.hass.block_till_done()
-        self.assertEqual(1, len(self.calls))
-        call = self.calls[0]
-        self.assertEqual('switch', call.domain)
-        self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
-
-    def test_temp_change_heater_on_within_tolerance(self):
-        """Test if temperature change turn heater on within tolerance."""
-        self._setup_switch(False)
         climate.set_temperature(self.hass, 30)
         self.hass.block_till_done()
-        self._setup_sensor(29)
+        self._setup_sensor(31)
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
 
-    def test_temp_change_heater_on_outside_tolerance(self):
-        """Test if temperature change doesn't turn heater on outside
-        tolerance.
-        """
-        self._setup_switch(False)
+    def test_temp_change_heater_off_outside_tolerance(self):
+        """Test if temperature change turn heater off outside tolerance."""
+        self._setup_switch(True)
         climate.set_temperature(self.hass, 30)
         self.hass.block_till_done()
-        self._setup_sensor(25)
+        self._setup_sensor(35)
         self.hass.block_till_done()
         self.assertEqual(1, len(self.calls))
         call = self.calls[0]
@@ -297,7 +295,18 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         self.assertEqual(SERVICE_TURN_ON, call.service)
         self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
-    def test_set_temp_change_ac_off(self):
+    def test_temp_change_ac_off_within_tolerance(self):
+        """Test if temperature change doesn't turn ac off within
+        tolerance.
+        """
+        self._setup_switch(True)
+        climate.set_temperature(self.hass, 30)
+        self.hass.block_till_done()
+        self._setup_sensor(29.7)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
+    def test_set_temp_change_ac_off_outside_tolerance(self):
         """Test if temperature change turn ac off."""
         self._setup_switch(True)
         climate.set_temperature(self.hass, 30)
@@ -310,7 +319,18 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         self.assertEqual(SERVICE_TURN_OFF, call.service)
         self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
-    def test_temp_change_ac_on(self):
+    def test_temp_change_ac_on_within_tolerance(self):
+        """Test if temperature change doesn't turn ac on within
+        tolerance.
+        """
+        self._setup_switch(False)
+        climate.set_temperature(self.hass, 25)
+        self.hass.block_till_done()
+        self._setup_sensor(25.3)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
+    def test_temp_change_ac_on_outside_tolerance(self):
         """Test if temperature change turn ac on."""
         self._setup_switch(False)
         climate.set_temperature(self.hass, 25)

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -226,7 +226,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
         call = self.calls[0]
         self.assertEqual('switch', call.domain)
-        self.assertEqual(SERVICE_TURN_ON, call.service)
+        self.assertEqual(SERVICE_TURN_OFF, call.service)
         self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def _setup_sensor(self, temp, unit=TEMP_CELSIUS):


### PR DESCRIPTION
**Description:**
Tolerance is the difference when the current temperature and the target temperature are compared. Now the same condition stops and starts the device causing a premature stop before the temperature reaches the target. 
With this modification the device is not switched on or switched off while the current temperature is between target minus tolerance and target plus tolerance. Therefore the maximum difference in temperature will be two times the tolerance. This behavior is called hysteresis for control systems. You can read more about this:
https://en.wikipedia.org/wiki/Hysteresis#Control_systems

**Related issue (if applicable):**

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation :** 
home-assistant/home-assistant.github.io/pull/1569

**Example entry for `configuration.yaml` (if applicable):**

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

