### PR TITLE
Fixed crash during light objects initizilation

### DIFF
--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -76,7 +76,7 @@ class TellstickLight(TellstickDevice, Light):
             try:
                 self._state = (self._brightness > 0)
             except AttributeError:
-                self._state = False
+                self._state = True
         else:
             self._state = False
 

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -72,7 +72,11 @@ class TellstickLight(TellstickDevice, Light):
             if brightness is not None:
                 self._brightness = brightness
 
-            self._state = (self._brightness > 0)
+            # _brightness is not defined when called from super
+            try:
+                self._state = (self._brightness > 0)
+            except AttributeError:
+                self._state = False
         else:
             self._state = False
 


### PR DESCRIPTION
**Description:**
Tellstick lights did not work at all because they all crashed because of an update before the subclass property was initialized 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

