### PR TITLE
Added a volume set option and autodiscovery functions to Denon AVR rece…

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.helpers.discovery import load_platform, discover
 
-REQUIREMENTS = ['netdisco==0.8.0']
+REQUIREMENTS = ['netdisco==0.8.1']
 
 DOMAIN = 'discovery'
 
@@ -36,6 +36,7 @@ SERVICE_HANDLERS = {
     'yamaha': ('media_player', 'yamaha'),
     'logitech_mediaserver': ('media_player', 'squeezebox'),
     'directv': ('media_player', 'directv'),
+    'denonavr': ('media_player', 'denonavr'),
 }
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -57,17 +57,21 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         # Check if host not in cache, append it and save for later starting
         if host not in cache:
             cache.add(host)
-            receivers.append((host, name))
-    # 2a. option: discovery using netdisco
+            receivers.append(
+                DenonDevice(denonavr.DenonAVR(host, name)))
+            _LOGGER.info("Denon receiver at host %s initialized", host)
+    # 2. option: discovery using netdisco
     if discovery_info is not None:
         host = discovery_info[0]
         name = discovery_info[1]
         # Check if host not in cache, append it and save for later starting
         if host not in cache:
             cache.add(host)
-            receivers.append((host, name))
-    # 2b. option: discovery using denonavr library
-    else:
+            receivers.append(
+                DenonDevice(denonavr.DenonAVR(host, name)))
+            _LOGGER.info("Denon receiver at host %s initialized", host)
+    # 3. option: discovery using denonavr library
+    if config.get(CONF_HOST) is None and discovery_info is None:
         d_receivers = denonavr.discover()
         # More than one receiver could be discovered by that method
         if d_receivers is not None:
@@ -78,13 +82,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 # starting
                 if host not in cache:
                     cache.add(host)
-                    d_receivers.append((host, name))
+                    receivers.append(
+                        DenonDevice(denonavr.DenonAVR(host, name)))
+                    _LOGGER.info("Denon receiver at host %s initialized", host)
 
     # Add all freshly discovered receivers
-    for receiver in receivers:
-        new_receiver = denonavr.DenonAVR(receiver[0], receiver[1])
-        add_devices([DenonDevice(new_receiver)])
-        _LOGGER.info("Denon receiver at host %s initialized", receiver[0])
+    if receivers:
+        add_devices(receivers)
 
 
 class DenonDevice(MediaPlayerDevice):

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     CONF_NAME, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['denonavr==0.2.1']
+REQUIREMENTS = ['denonavr==0.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,24 +41,33 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Denon platform."""
     import denonavr
 
+    # Initialize name and host
+    host = None
+    name = None
+
+    # Start assignment of host and name
+    # 1. option: manual setting
     if config.get(CONF_HOST) is not None:
         host = config.get(CONF_HOST)
         name = config.get(CONF_NAME)
+    # 2. option: discovery using netdisco
     elif discovery_info is not None:
         host = discovery_info[0]
         name = discovery_info[1]
+    # 3. option: discovery using denonavr library
     else:
         receivers = denonavr.discover()
         if receivers:
             host = receivers[0]["host"]
             name = receivers[0]["friendlyName"]
 
-    if host:
+    if host is not None:
         receiver = denonavr.DenonAVR(host, name)
         add_devices([DenonDevice(receiver)])
         _LOGGER.info("Denon receiver at host %s initialized", host)
     else:
-        _LOGGER.error("Host of Denon AVR neither provided nor discovered")
+        _LOGGER.error(
+            "Host of Denon AVR neither in configuration nor discovered")
 
 
 class DenonDevice(MediaPlayerDevice):

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -13,13 +13,13 @@ from homeassistant.components.media_player import (
     SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP,
     SUPPORT_SELECT_SOURCE, SUPPORT_PLAY_MEDIA, MEDIA_TYPE_CHANNEL,
     MediaPlayerDevice, PLATFORM_SCHEMA, SUPPORT_TURN_ON,
-    MEDIA_TYPE_MUSIC)
+    MEDIA_TYPE_MUSIC, SUPPORT_VOLUME_SET)
 from homeassistant.const import (
     CONF_HOST, STATE_OFF, STATE_PLAYING, STATE_PAUSED,
     CONF_NAME, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['denonavr==0.1.6']
+REQUIREMENTS = ['denonavr==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,10 +29,10 @@ SUPPORT_DENON = SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | \
     SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
     SUPPORT_SELECT_SOURCE | SUPPORT_PLAY_MEDIA | \
     SUPPORT_PAUSE | SUPPORT_PREVIOUS_TRACK | \
-    SUPPORT_NEXT_TRACK
+    SUPPORT_NEXT_TRACK | SUPPORT_VOLUME_SET
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
@@ -41,11 +41,24 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Denon platform."""
     import denonavr
 
-    receiver = denonavr.DenonAVR(config.get(CONF_HOST), config.get(CONF_NAME))
+    if config.get(CONF_HOST) is not None:
+        host = config.get(CONF_HOST)
+        name = config.get(CONF_NAME)
+    elif discovery_info is not None:
+        host = discovery_info[0]
+        name = discovery_info[1]
+    else:
+        receivers = denonavr.discover()
+        if receivers:
+            host = receivers[0]["host"]
+            name = receivers[0]["friendlyName"]
 
-    add_devices([DenonDevice(receiver)])
-    _LOGGER.info("Denon receiver at host %s initialized",
-                 config.get(CONF_HOST))
+    if host:
+        receiver = denonavr.DenonAVR(host, name)
+        add_devices([DenonDevice(receiver)])
+        _LOGGER.info("Denon receiver at host %s initialized", host)
+    else:
+        _LOGGER.error("Host of Denon AVR neither provided nor discovered")
 
 
 class DenonDevice(MediaPlayerDevice):
@@ -107,7 +120,8 @@ class DenonDevice(MediaPlayerDevice):
     @property
     def volume_level(self):
         """Volume level of the media player (0..1)."""
-        # Volume is send in a format like -50.0. Minimum is around -80.0
+        # Volume is sent in a format like -50.0. Minimum is -80.0,
+        # maximum is 18.0
         return (float(self._volume) + 80) / 100
 
     @property
@@ -239,6 +253,22 @@ class DenonDevice(MediaPlayerDevice):
     def volume_down(self):
         """Volume down media player."""
         return self._receiver.volume_down()
+
+    def set_volume_level(self, volume):
+        """Set volume level, range 0..1."""
+        # Volume has to be sent in a format like -50.0. Minimum is -80.0,
+        # maximum is 18.0
+        volume_denon = float((volume * 100) - 80)
+        if volume_denon > 18:
+            volume_denon = float(18)
+        try:
+            if self._receiver.set_volume(volume_denon):
+                self._volume = volume_denon
+                return True
+            else:
+                return False
+        except ValueError:
+            return False
 
     def mute_volume(self, mute):
         """Send mute command."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -69,6 +69,9 @@ boto3==1.3.1
 coinmarketcap==2.0.1
 
 # homeassistant.scripts.check_config
+colorama<=1
+
+# homeassistant.scripts.check_config
 colorlog>2.1,<3
 
 # homeassistant.components.alarm_control_panel.concord232
@@ -76,7 +79,7 @@ colorlog>2.1,<3
 concord232==0.14
 
 # homeassistant.components.media_player.denonavr
-denonavr==0.1.6
+denonavr==0.2.1
 
 # homeassistant.components.media_player.directv
 directpy==0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -79,7 +79,7 @@ colorlog>2.1,<3
 concord232==0.14
 
 # homeassistant.components.media_player.denonavr
-denonavr==0.2.1
+denonavr==0.2.2
 
 # homeassistant.components.media_player.directv
 directpy==0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -69,9 +69,6 @@ boto3==1.3.1
 coinmarketcap==2.0.1
 
 # homeassistant.scripts.check_config
-colorama<=1
-
-# homeassistant.scripts.check_config
 colorlog>2.1,<3
 
 # homeassistant.components.alarm_control_panel.concord232
@@ -302,7 +299,7 @@ mficlient==0.3.0
 miflora==0.1.13
 
 # homeassistant.components.discovery
-netdisco==0.8.0
+netdisco==0.8.1
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.2.10


### PR DESCRIPTION
**Description:**
Basically I added two features Denon AVR receivers:
1. A volume set option
2. Autodiscovery function using netdisco, where I have an open pull request for that feature and an own discovery as backup. The order to get the hostname is 1. manual config, 2. netdisco, 3. own discovery

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1582

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
