### PR TITLE
[device_tracker] Don't clear GPS coordinates when using two device trackers.

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -426,12 +426,11 @@ class Device(Entity):
         if attributes:
             self._attributes.update(attributes)
 
-        self.gps = None
-
         if gps is not None:
             try:
                 self.gps = float(gps[0]), float(gps[1])
             except (ValueError, TypeError, IndexError):
+                self.gps = None
                 _LOGGER.warning('Could not parse gps value for %s: %s',
                                 self.dev_id, gps)
 


### PR DESCRIPTION
**Description:**

When using two device trackers for a single device, the GPS information may be dropped if not present.

**Related issue (if applicable):** fixes #4841

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**