### PR TITLE
Revert "[device_tracker] Don't clear GPS coordinates when using two device trackers."

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -426,11 +426,12 @@ class Device(Entity):
         if attributes:
             self._attributes.update(attributes)
 
+        self.gps = None
+
         if gps is not None:
             try:
                 self.gps = float(gps[0]), float(gps[1])
             except (ValueError, TypeError, IndexError):
-                self.gps = None
                 _LOGGER.warning('Could not parse gps value for %s: %s',
                                 self.dev_id, gps)
 


### PR DESCRIPTION
Reverts home-assistant/home-assistant#4848
This needs more thought, since it will break non-gps based tracker by not clearing gps for the update function

Refer to here: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/device_tracker/__init__.py#L458