### PR TITLE
Use current Nest mode to determine which temperature attributes to use

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -155,8 +155,8 @@ class NestThermostat(ClimateDevice):
         """Set new target temperature."""
         target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
         target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
-        if target_temp_low is not None and target_temp_high is not None:
-            if self._mode == STATE_HEAT_COOL:
+        if self._mode == STATE_HEAT_COOL:
+            if target_temp_low is not None and target_temp_high is not None:
                 temp = (target_temp_low, target_temp_high)
         else:
             temp = kwargs.get(ATTR_TEMPERATURE)


### PR DESCRIPTION
**Description:**
Use currently configured Nest mode to determine which temperature attributes to use instead of depending on which ones are supplied. Either method will result in an error if there is a mismatch between mode/attributes, but this method allows more flexibility in configuration. As it allows the following config and selects the correct attributes based on which mode the thermostat is in.

**Example entry for `configuration.yaml` (if applicable):**
```yaml
  - service: climate.set_temperature
    data:
      entity_id: climate.apartment
      target_temp_high: 74
      temperature: 74
      target_temp_low: 71
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**