### PR TITLE
Use local timezone for fluxer update

### DIFF
--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -14,7 +14,7 @@ from homeassistant.components.light import is_on, turn_on
 from homeassistant.components.sun import next_setting, next_rising
 from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
-from homeassistant.helpers.event import track_utc_time_change
+from homeassistant.helpers.event import track_time_change
 from homeassistant.util.color import (
     color_temperature_to_rgb, color_RGB_to_xy,
     color_temperature_kelvin_to_mired, HASS_COLOR_MIN, HASS_COLOR_MAX)
@@ -135,8 +135,8 @@ class FluxSwitch(SwitchDevice):
     def turn_on(self, **kwargs):
         """Turn on flux."""
         self._state = True
-        self.unsub_tracker = track_utc_time_change(self.hass, self.flux_update,
-                                                   second=[0, 30], local=True)
+        self.unsub_tracker = track_time_change(self.hass, self.flux_update,
+                                               second=[0, 30])
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -136,7 +136,7 @@ class FluxSwitch(SwitchDevice):
         """Turn on flux."""
         self._state = True
         self.unsub_tracker = track_utc_time_change(self.hass, self.flux_update,
-                                                   second=[0, 30])
+                                                   second=[0, 30], local=True)
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):


### PR DESCRIPTION
**Description:**
Use proper timezone when updating Flux switch.

I was experiance really annoying issues with my fluxers. I have `start_time` set to 7AM, sometimes I'd stay up until ~2AM and all of the sudden my lights go from very warm to daylight. Before we went off daylight savings time, it happened at 3AM. I'm GMT-5 (GMT-4 during DST) which explained the issue. Basically when `flux_update` is called with UTC time, and all of the `datetime.replace()` calls assume that the `start_time` and `stop_time` are in the same timezone as the `now` time.

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**