### PR TITLE
Added resolution support to Amcrest cameras

### DIFF
--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -20,9 +20,9 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_RESOLUTION = 'resolution'
 
-DEFAULT_RESOLUTION = 'high'
 DEFAULT_NAME = 'Amcrest Camera'
 DEFAULT_PORT = 80
+DEFAULT_RESOLUTION = 'high'
 
 NOTIFICATION_ID = 'amcrest_notification'
 NOTIFICATION_TITLE = 'Amcrest Camera Setup'

--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -18,16 +18,26 @@ REQUIREMENTS = ['amcrest==1.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_PORT = 80
+CONF_RESOLUTION = 'resolution'
+
+DEFAULT_RESOLUTION = 'high'
 DEFAULT_NAME = 'Amcrest Camera'
+DEFAULT_PORT = 80
 
 NOTIFICATION_ID = 'amcrest_notification'
 NOTIFICATION_TITLE = 'Amcrest Camera Setup'
+
+RESOLUTION_LIST = {
+    'high': 0,
+    'low': 1,
+}
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_RESOLUTION, default=DEFAULT_RESOLUTION):
+        vol.All(vol.In(RESOLUTION_LIST)),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
 })
@@ -64,13 +74,14 @@ class AmcrestCam(Camera):
     def __init__(self, device_info, data):
         """Initialize an Amcrest camera."""
         super(AmcrestCam, self).__init__()
-        self._name = device_info.get(CONF_NAME)
         self._data = data
+        self._name = device_info.get(CONF_NAME)
+        self._resolution = RESOLUTION_LIST[device_info.get(CONF_RESOLUTION)]
 
     def camera_image(self):
         """Return a still image reponse from the camera."""
         # Send the request to snap a picture and return raw jpg data
-        response = self._data.camera.snapshot()
+        response = self._data.camera.snapshot(channel=self._resolution)
         return response.data
 
     @property


### PR DESCRIPTION
**Description:**

Added documentation to Amcrest camera to support high/low camera resolution. 

This parameter allows you to specify the camera resolution. For a high resolution (1080/720p), specify the option `high`. For VGA resolution (640x480p), specify the option `low`. If omitted, it defaults to *high*.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1584

**Example entry for `configuration.yaml` (if applicable):**

```yaml
camera:
  - platform: amcrest
    name: Living Room
    host: 192.168.0.11
    port: 80
    username: admin
    password: secret
    resolution: high

  - platform: amcrest
    name: Patio
    host: 192.168.0.10
    port: 80
    username: admin
    password: password
    resolution: low 
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
 