### PR TITLE
A tracker component that fetches location directly from Google's servers.

### DIFF
--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -89,10 +89,10 @@ def setup_scanner(hass, config, see):
         scripts = soup.find_all('script')
         script = (scripts[0]).contents[0]
         #print(script.body.attrs)
-        _LOGGER.error(script)
+        #_LOGGER.error(script)
         sdict = json.loads(script[25:-1])
         data['at'] = sdict['SNlM0e']
-        _LOGGER.info(data['at'])
+        #_LOGGER.info(data['at'])
 
     def get_position(_):
         """Get device position."""
@@ -106,19 +106,20 @@ def setup_scanner(hass, config, see):
                 '\n') if "www.google.com/maps/" in line]
             if len(matched_lines) == 0:
                 _LOGGER.error("Google didn't send the location. Updating data['at']")
-                update_data_at()
-
-            line = matched_lines[0]
-            words = line.split(',')
-            latitude = words[12]
-            longitude = words[13]
-            accuracy = words[15]
-
-            see(
-                dev_id=conf_id,
-                gps=(latitude, longitude),
-                gps_accuracy=int(accuracy),
-            )
+                update_data_at()#will try again next time.
+            else:
+                line = matched_lines[0]
+                words = line.split(',')
+                if len(words) > 15:
+                    latitude = words[12]
+                    longitude = words[13]
+                    accuracy = words[15]
+                    see(
+                        dev_id=conf_id,
+                        gps=(latitude, longitude),
+                        gps_accuracy=int(accuracy),)
+                else:
+                    _LOGGER.error("Unexpected. Please file an issue.")
         else:
             _LOGGER.error("Unable to update device position")
 

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -6,7 +6,9 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.gplus/
 """
 import logging
+import json
 import voluptuous as vol
+from bs4 import BeautifulSoup
 import homeassistant.helpers.config_validation as cv
 
 from homeassistant.const import (CONF_SCAN_INTERVAL, CONF_ID, CONF_URL,
@@ -24,8 +26,7 @@ CONF_SID = 'cookie_sid'
 CONF_SSID = 'cookie_ssid'
 CONF_HSID = 'cookie_hsid'
 CONF_FREQ = 'data_freq'
-CONF_AT = 'data_at'
-#CONF_ACCURACY = 'accuracy'
+CONF_HOME_URL = 'home_url'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ID): cv.string,
@@ -34,7 +35,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SSID): cv.string,
     vol.Required(CONF_HSID): cv.string,
     vol.Required(CONF_FREQ): cv.string,
-    vol.Required(CONF_AT): cv.string,
+    vol.Required(CONF_HOME_URL): cv.string,
     #    vol.Optional(CONF_ACCURACY, default=100): cv.positive_int,
     vol.Optional(CONF_INTERVAL, default=1): vol.All(cv.positive_int,
                                                     vol.Range(min=1)),
@@ -55,8 +56,8 @@ def setup_scanner(hass, config, see):
     cookie_hsid = config[CONF_HSID]
     cookie_ssid = config[CONF_SSID]
     data_freq = config[CONF_FREQ]
-    data_at = config[CONF_AT]
     url = config[CONF_URL]
+    hurl = config[CONF_HOME_URL]
 
     headers = {
         'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0',
@@ -75,17 +76,38 @@ def setup_scanner(hass, config, see):
 
     data = {
         'f.req': data_freq,
-        'at': data_at,
+        'at': None,
     }
 
-    def get_position(now):
+    #update data['at'], which may change every 14 days.
+    #Otherwise, Google rejects location queries.
+    #visit the Google plus profile page, and extract the field from the first script in it
+    def update_data_at():
+        api_request = requests.get(
+            hurl, headers=headers, cookies=cookies)
+        soup = BeautifulSoup(api_request.text, 'html.parser')
+        scripts = soup.find_all('script')
+        script = (scripts[0]).contents[0]
+        #print(script.body.attrs)
+        _LOGGER.error(script)
+        sdict = json.loads(script[25:-1])
+        data['at'] = sdict['SNlM0e']
+        _LOGGER.info(data['at'])
+
+    def get_position(_):
         """Get device position."""
+        if data['at'] is None:
+            update_data_at()
         api_request = requests.post(url, headers=headers, cookies=cookies,
                                     data=data, timeout=15)
         if api_request.ok:
             ans = api_request.text
             matched_lines = [line for line in ans.split(
                 '\n') if "www.google.com/maps/" in line]
+            if len(matched_lines) == 0:
+                _LOGGER.error("Google didn't send the location. Updating data['at']")
+                update_data_at()
+
             line = matched_lines[0]
             words = line.split(',')
             latitude = words[12]

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -25,7 +25,6 @@ CONF_SSID = 'cookie_ssid'
 CONF_HSID = 'cookie_hsid'
 CONF_FREQ = 'data_freq'
 CONF_AT = 'data_at'
-CONF_HEADER_HOST = 'header_host'
 #CONF_ACCURACY = 'accuracy'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -36,7 +35,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HSID): cv.string,
     vol.Required(CONF_FREQ): cv.string,
     vol.Required(CONF_AT): cv.string,
-    vol.Optional(CONF_HEADER_HOST, default='plus.google.com'): cv.string,
     #    vol.Optional(CONF_ACCURACY, default=100): cv.positive_int,
     vol.Optional(CONF_INTERVAL, default=1): vol.All(cv.positive_int,
                                                     vol.Range(min=1)),
@@ -59,15 +57,12 @@ def setup_scanner(hass, config, see):
     data_freq = config[CONF_FREQ]
     data_at = config[CONF_AT]
     url = config[CONF_URL]
-    host = config[CONF_HEADER_HOST]
 
     headers = {
-        'Host': host,
         'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0',
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         'Accept-Language': 'en-US,en;q=0.5',
         'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
-        'Referer': 'https://' + host + '/',
         'X-Same-Domain': '1',
         'Connection': 'keep-alive',
     }

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -1,0 +1,96 @@
+""".
+Get location from Google Maps Geolocation API.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.gmaps/
+"""
+import logging
+import voluptuous as vol
+
+from homeassistant.const import (CONF_TOKEN, CONF_ACCURACY,
+                                 CONF_SCAN_INTERVAL, CONF_ID, CONF_URL,
+                                 EVENT_HOMEASSISTANT_START)
+from homeassistant.helpers.event import track_utc_time_change
+from homeassistant.components.device_tracker import (PLATFORM_SCHEMA)
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['requests>=2,<3']
+
+CONF_INTERVAL = 'interval'
+KEEPALIVE_INTERVAL = 1
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ID): vol.Coerce(str),
+    vol.Required(CONF_URL): vol.Coerce(str),
+    vol.Optional(CONF_ACCURACY, default=100): vol.Coerce(int),
+    vol.Optional(CONF_INTERVAL, default=1): vol.All(vol.Coerce(int),
+                                                    vol.Range(min=1)),
+    vol.Optional(CONF_SCAN_INTERVAL, default=1): vol.Coerce(int)
+    })
+
+
+def setup_scanner(hass, config, see):
+    """Define constants."""
+    import requests
+    import json
+    import re
+
+
+
+    cookies = {
+        'SID': 'bunch',
+        'HSID': 'of',
+        'SSID': 'cookies',
+        'APISID': 'go',
+        'NID': 'here',
+        'OGPC': 'omg',
+        'OTZ': 'too',
+        'CONSISTENCY': 'much',
+    }
+    
+    data = {
+      'f.req': 'data',
+      'at': 'help',
+    }
+    
+    headers = {
+        'Host': 'aboutme.google.com',
+        'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+        'X-Same-Domain': '1',
+        'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+        'Referer': 'https://aboutme.google.com/',
+        'DNT': '1',
+        'Connection': 'keep-alive',
+    }
+
+    max_accuracy = config[CONF_ACCURACY]
+    id = config[CONF_ID]
+    url = config[CONF_URL]
+    regex_float = '-?\d+\.\d+'
+
+    def get_position(now):
+        """Get device position."""
+        api_request = requests.post(url, headers=headers, cookies=cookies,
+                                  data=data)
+        if api_request.ok:
+            location = re.findall(regex_float, api_request.text)
+
+            latitude = location[0]
+            longitude = location[1]
+
+            see(
+                dev_id=id,
+                gps=(latitude, longitude),
+                gps_accuracy=max_accuracy,
+            )
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, get_position)
+
+    update_minutes = list(range(0, 60, config[CONF_SCAN_INTERVAL]))
+
+    track_utc_time_change(hass, get_position, second=0, minute=update_minutes)
+
+    return True

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/device_tracker.gmaps/
 import logging
 import voluptuous as vol
 
-from homeassistant.const import (CONF_TOKEN, CONF_ACCURACY,
+from homeassistant.const import (CONF_TOKEN,
                                  CONF_SCAN_INTERVAL, CONF_ID, CONF_URL,
                                  EVENT_HOMEASSISTANT_START)
 from homeassistant.helpers.event import track_utc_time_change
@@ -24,6 +24,7 @@ CONF_SSID = 'cookie_ssid'
 CONF_HSID = 'cookie_hsid'
 CONF_FREQ = 'data_freq'
 CONF_AT = 'data_at'
+CONF_ACCURACY = 'accuracy'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ID): vol.Coerce(str),

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -66,11 +66,10 @@ def setup_scanner(hass, config, see):
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         'Accept-Language': 'en-US,en;q=0.5',
         'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
-        'Referer': 'https://'+host+'/',
+        'Referer': 'https://' + host + '/',
         'X-Same-Domain': '1',
         'Connection': 'keep-alive',
     }
-
 
     cookies = {
         'SID':  cookie_sid,

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -91,12 +91,13 @@ def setup_scanner(hass, config, see):
             words=line.split(',')
             latitude=words[12]
             longitude=words[13]
-            accuracy=words[15]            #_LOGGER.info(api_request.text)
+            accuracy=words[15]
+            #_LOGGER.info(api_request.text)
 
             see(
                 dev_id=id,
                 gps=(latitude, longitude),
-                gps_accuracy=accuracy,
+                gps_accuracy=int(accuracy),
             )
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, get_position)

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -19,6 +19,11 @@ REQUIREMENTS = ['requests>=2,<3']
 
 CONF_INTERVAL = 'interval'
 KEEPALIVE_INTERVAL = 1
+CONF_SID = 'cookie_sid'
+CONF_SSID = 'cookie_ssid'
+CONF_HSID = 'cookie_hsid'
+CONF_FREQ = 'data_freq'
+CONF_AT = 'data_at'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ID): vol.Coerce(str),
@@ -35,21 +40,6 @@ def setup_scanner(hass, config, see):
     import requests
     import re
 
-    cookies = {
-        'SID': 'bunch',
-        'HSID': 'of',
-        'SSID': 'cookies',
-        'APISID': 'go',
-        'NID': 'here',
-        'OGPC': 'omg',
-        'OTZ': 'too',
-        'CONSISTENCY': 'much',
-    }
-
-    data = {
-        'f.req': 'data',
-        'at': 'help',
-    }
 
     headers = {
         'Host': 'aboutme.google.com',
@@ -66,7 +56,24 @@ def setup_scanner(hass, config, see):
     max_accuracy = config[CONF_ACCURACY]
     id = config[CONF_ID]
     url = config[CONF_URL]
+    cookie_sid = config[CONF_SID]
+    cookie_hsid = config[CONF_HSID]
+    cookie_ssid = config[CONF_SSID]
+    data_freq = config[CONF_FREQ]
+    data_at = config[CONF_AT]
+    url = config[CONF_URL]
     regex_float = '-?\d+\.\d+'
+
+    cookies = {
+        'SID':  cookie_sid,
+        'HSID': cookie_hsid,
+        'SSID': cookie_ssid,
+    }
+
+    data = {
+        'f.req': data_freq,
+        'at': data_at,
+    }
 
     def get_position(now):
         """Get device position."""

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -32,7 +32,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ACCURACY, default=100): vol.Coerce(int),
     vol.Optional(CONF_INTERVAL, default=1): vol.All(vol.Coerce(int),
                                                     vol.Range(min=1)),
-    vol.Optional(CONF_SCAN_INTERVAL, default=1): vol.Coerce(int)
+    vol.Optional(CONF_SCAN_INTERVAL, default=100): vol.Coerce(int)
 })
 
 

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -34,18 +34,17 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HSID): vol.Coerce(str),
     vol.Required(CONF_FREQ): vol.Coerce(str),
     vol.Required(CONF_AT): vol.Coerce(str),
-#    vol.Optional(CONF_ACCURACY, default=100): vol.Coerce(int),
+    #    vol.Optional(CONF_ACCURACY, default=100): vol.Coerce(int),
     vol.Optional(CONF_INTERVAL, default=1): vol.All(vol.Coerce(int),
                                                     vol.Range(min=1)),
     vol.Optional(CONF_SCAN_INTERVAL, default=10): vol.All(vol.Coerce(int),
-                                                    vol.Range(min=1,max=59)),
+                                                          vol.Range(min=1, max=59)),
 })
 
 
 def setup_scanner(hass, config, see):
     """Define constants."""
     import requests
-    import re
 
     headers = {
         'Host': 'plus.google.com',
@@ -85,13 +84,14 @@ def setup_scanner(hass, config, see):
         api_request = requests.post(url, headers=headers, cookies=cookies,
                                     data=data)
         if api_request.ok:
-            ans=api_request.text
-            matched_lines = [line for line in ans.split('\n') if "www.google.com/maps/" in line]
-            line=matched_lines[0]
-            words=line.split(',')
-            latitude=words[12]
-            longitude=words[13]
-            accuracy=words[15]
+            ans = api_request.text
+            matched_lines = [line for line in ans.split(
+                '\n') if "www.google.com/maps/" in line]
+            line = matched_lines[0]
+            words = line.split(',')
+            latitude = words[12]
+            longitude = words[13]
+            accuracy = words[15]
             #_LOGGER.info(api_request.text)
 
             see(

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -27,16 +27,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_INTERVAL, default=1): vol.All(vol.Coerce(int),
                                                     vol.Range(min=1)),
     vol.Optional(CONF_SCAN_INTERVAL, default=1): vol.Coerce(int)
-    })
+})
 
 
 def setup_scanner(hass, config, see):
     """Define constants."""
     import requests
-    import json
     import re
-
-
 
     cookies = {
         'SID': 'bunch',
@@ -48,12 +45,12 @@ def setup_scanner(hass, config, see):
         'OTZ': 'too',
         'CONSISTENCY': 'much',
     }
-    
+
     data = {
-      'f.req': 'data',
-      'at': 'help',
+        'f.req': 'data',
+        'at': 'help',
     }
-    
+
     headers = {
         'Host': 'aboutme.google.com',
         'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0',
@@ -74,7 +71,7 @@ def setup_scanner(hass, config, see):
     def get_position(now):
         """Get device position."""
         api_request = requests.post(url, headers=headers, cookies=cookies,
-                                  data=data)
+                                    data=data)
         if api_request.ok:
             location = re.findall(regex_float, api_request.text)
 

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -1,4 +1,5 @@
 """.
+
 Get location from Google Maps Geolocation API.
 
 For more details about this platform, please refer to the documentation at

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -24,6 +24,7 @@ CONF_SSID = 'cookie_ssid'
 CONF_HSID = 'cookie_hsid'
 CONF_FREQ = 'data_freq'
 CONF_AT = 'data_at'
+CONF_HOST = 'header_host'
 #CONF_ACCURACY = 'accuracy'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -34,6 +35,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HSID): vol.Coerce(str),
     vol.Required(CONF_FREQ): vol.Coerce(str),
     vol.Required(CONF_AT): vol.Coerce(str),
+    vol.Optional(CONF_HOST, default='plus.google.com'): vol.Coerce(str),
     #    vol.Optional(CONF_ACCURACY, default=100): vol.Coerce(int),
     vol.Optional(CONF_INTERVAL, default=1): vol.All(vol.Coerce(int),
                                                     vol.Range(min=1)),
@@ -46,17 +48,6 @@ def setup_scanner(hass, config, see):
     """Define constants."""
     import requests
 
-    headers = {
-        'Host': 'plus.google.com',
-        'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0',
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        'Accept-Language': 'en-US,en;q=0.5',
-        'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
-        'Referer': 'https://plus.google.com/',
-        'X-Same-Domain': '1',
-        'Connection': 'keep-alive',
-    }
-
 
 #    max_accuracy = config[CONF_ACCURACY]
     id = config[CONF_ID]
@@ -67,6 +58,19 @@ def setup_scanner(hass, config, see):
     data_freq = config[CONF_FREQ]
     data_at = config[CONF_AT]
     url = config[CONF_URL]
+    host = config[CONF_HOST]
+
+    headers = {
+        'Host': host,
+        'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+        'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+        'Referer': 'https://'+host+'/',
+        'X-Same-Domain': '1',
+        'Connection': 'keep-alive',
+    }
+
 
     cookies = {
         'SID':  cookie_sid,

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -41,7 +41,6 @@ def setup_scanner(hass, config, see):
     import requests
     import re
 
-
     headers = {
         'Host': 'aboutme.google.com',
         'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0',

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -42,16 +42,16 @@ def setup_scanner(hass, config, see):
     import re
 
     headers = {
-        'Host': 'aboutme.google.com',
+        'Host': 'plus.google.com',
         'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0',
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         'Accept-Language': 'en-US,en;q=0.5',
-        'X-Same-Domain': '1',
         'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
-        'Referer': 'https://aboutme.google.com/',
-        'DNT': '1',
+        'Referer': 'https://plus.google.com/',
+        'X-Same-Domain': '1',
         'Connection': 'keep-alive',
     }
+
 
     max_accuracy = config[CONF_ACCURACY]
     id = config[CONF_ID]
@@ -81,7 +81,7 @@ def setup_scanner(hass, config, see):
                                     data=data)
         if api_request.ok:
             location = re.findall(regex_float, api_request.text)
-
+            #_LOGGER.info(api_request.text)
             latitude = location[0]
             longitude = location[1]
 

--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -24,15 +24,21 @@ CONF_SSID = 'cookie_ssid'
 CONF_HSID = 'cookie_hsid'
 CONF_FREQ = 'data_freq'
 CONF_AT = 'data_at'
-CONF_ACCURACY = 'accuracy'
+#CONF_ACCURACY = 'accuracy'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ID): vol.Coerce(str),
     vol.Required(CONF_URL): vol.Coerce(str),
-    vol.Optional(CONF_ACCURACY, default=100): vol.Coerce(int),
+    vol.Required(CONF_SID): vol.Coerce(str),
+    vol.Required(CONF_SSID): vol.Coerce(str),
+    vol.Required(CONF_HSID): vol.Coerce(str),
+    vol.Required(CONF_FREQ): vol.Coerce(str),
+    vol.Required(CONF_AT): vol.Coerce(str),
+#    vol.Optional(CONF_ACCURACY, default=100): vol.Coerce(int),
     vol.Optional(CONF_INTERVAL, default=1): vol.All(vol.Coerce(int),
                                                     vol.Range(min=1)),
-    vol.Optional(CONF_SCAN_INTERVAL, default=100): vol.Coerce(int)
+    vol.Optional(CONF_SCAN_INTERVAL, default=10): vol.All(vol.Coerce(int),
+                                                    vol.Range(min=1,max=59)),
 })
 
 
@@ -53,7 +59,7 @@ def setup_scanner(hass, config, see):
     }
 
 
-    max_accuracy = config[CONF_ACCURACY]
+#    max_accuracy = config[CONF_ACCURACY]
     id = config[CONF_ID]
     url = config[CONF_URL]
     cookie_sid = config[CONF_SID]
@@ -62,7 +68,6 @@ def setup_scanner(hass, config, see):
     data_freq = config[CONF_FREQ]
     data_at = config[CONF_AT]
     url = config[CONF_URL]
-    regex_float = '-?\d+\.\d+'
 
     cookies = {
         'SID':  cookie_sid,
@@ -80,15 +85,18 @@ def setup_scanner(hass, config, see):
         api_request = requests.post(url, headers=headers, cookies=cookies,
                                     data=data)
         if api_request.ok:
-            location = re.findall(regex_float, api_request.text)
-            #_LOGGER.info(api_request.text)
-            latitude = location[0]
-            longitude = location[1]
+            ans=api_request.text
+            matched_lines = [line for line in ans.split('\n') if "www.google.com/maps/" in line]
+            line=matched_lines[0]
+            words=line.split(',')
+            latitude=words[12]
+            longitude=words[13]
+            accuracy=words[15]            #_LOGGER.info(api_request.text)
 
             see(
                 dev_id=id,
                 gps=(latitude, longitude),
-                gps_accuracy=max_accuracy,
+                gps_accuracy=accuracy,
             )
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, get_position)


### PR DESCRIPTION
**Description:**
This is a continuation of 
https://github.com/home-assistant/home-assistant/pull/4131
which had contributions from @sfiorini, @icovada,  and myself.
I have fixed the main criticism cited there. Now, no periodic change should be needed to the config file.
The part that needed to change every 14 days is now computed automatically. 
The values of fields in my new config file are the same as they were a month before, and the component works for me.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

https://github.com/home-assistant/home-assistant.github.io/pull/1387

Because that PR is currently closed, an updated version of the description page can be found at:
https://github.com/aa755/home-assistant.github.io/blob/patch-2/source/_components/device_tracker.google_plus.markdown


**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
