### PR TITLE
Fix dev tag detection in release script

### DIFF
--- a/script/release
+++ b/script/release
@@ -2,7 +2,15 @@
 
 cd "$(dirname "$0")/.."
 
-head -n 3 homeassistant/const.py | tail -n 1 | grep dev
+head -n 5 homeassistant/const.py | tail -n 1 | grep PATCH_VERSION > /dev/null
+
+if [ $? -eq 1 ]
+then
+  echo "Patch version not found on const.py line 5"
+  exit 1
+fi
+
+head -n 5 homeassistant/const.py | tail -n 1 | grep dev > /dev/null
 
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
**Description:**
Our release script is supposed to protect us from accidentally publishing dev versions. That was broken and this fixes it. (I also managed to publish 0.35.dev0 to PyPi last night…) 
