### PR TITLE
Fix logger level (sensor.netdata)

### DIFF
--- a/homeassistant/components/sensor/netdata.py
+++ b/homeassistant/components/sensor/netdata.py
@@ -66,7 +66,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         response = requests.get(version_url, timeout=10)
         if not response.ok:
-            _LOGGER.error("Response status is '%s'", response.status_code)
+            _LOGGER.debug("Response status is '%s'", response.status_code)
             return False
     except requests.exceptions.ConnectionError:
         _LOGGER.error("No route to resource/endpoint: %s", url)


### PR DESCRIPTION
**Description:**
Set logger level to debug instead of error.

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: netdata
    host: 192.168.0.30
    port: 19999
    condition:
      - disk_space.dm_2
      - ram
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**