### PR TITLE
Add initial snapcraft packaging

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,31 @@
+name: home-assistant
+summary: Open-source home automation platform running on Python 3
+description: |
+  Home Assistant is an open-source home automation platform running
+  on Python 3. Track and control all devices at home and automate
+  control. Installation in less than a minute.
+  See https://home-assistant.io/ for more details.
+icon: homeassistant/components/frontend/www_static/icons/favicon-512x512.png
+version: 0.34.5
+confinement: strict
+grade: stable
+
+apps:
+  home-assistant:
+    command: hass.wrapper
+    daemon: simple
+    plugs:
+      - network-bind
+  check-config:
+    command: hass.wrapper --script check_config
+
+parts:
+  common:
+    plugin: dump
+    source: virtualization/snap
+    snap:
+      - hass.wrapper
+  home-assistant:
+    plugin: python
+    source: .
+    requirements: requirements_all.txt

--- a/virtualization/snap/hass.wrapper
+++ b/virtualization/snap/hass.wrapper
@@ -1,0 +1,5 @@
+#!/bin/sh
+if [ ! -d $SNAP_DATA/config ] ; then
+	mkdir -p $SNAP_DATA/config
+fi
+exec $SNAP/bin/hass --config $SNAP_DATA/config $@


### PR DESCRIPTION
**Description:**

Add snap packaging support. snaps are a new way of packaging and distributing software on Linux systems. For a more detailed overview please have a look at http://snapcraft.io/ and https://www.ubuntu.com/core

This adds basic support for building a home-assistant snap which will include all software bits needed to install the snap on a snap enabled device and will automatically start home-assistant and make it available on port 8123 as the std. configuration does. All further configuration changes can be made to the configuration file which is placed by default in /var/snap/home-assistant/<revision>/config and with that safe rollbacks to previous versions are possible if a an upgrade breaks an existing configuration.

Next to transactional updates snaps also provide improved security as the home-assistant software will be executed in a small sandbox environment which gives only access to parts of the system it really needs. For the moment it only requires the network-bind interface to be allowed to bind a networking service and communicate with other network components. Later on we can easily add necessary plugs for serial ports or other subsystems needed for specific plugins.

With the ongoing work happening to establish an ecosystem around snaps it will be soon easily possible to publish snaps directly from github to the Ubuntu Store for all supported architectures. If anyone is interested in snap packaging for home-assistant we can work together on getting something like this place.

Posting this here for initial feedback and discussions around snap packging for home-assistant.

