### PR TITLE
Clean exit without exception if server was not set during initialization

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -323,10 +323,12 @@ class HomeAssistantWSGI(object):
     @asyncio.coroutine
     def stop(self):
         """Stop the wsgi server."""
-        self.server.close()
-        yield from self.server.wait_closed()
+        if self.server:
+            self.server.close()
+            yield from self.server.wait_closed()
         yield from self.app.shutdown()
-        yield from self._handler.finish_connections(60.0)
+        if self._handler:
+            yield from self._handler.finish_connections(60.0)
         yield from self.app.cleanup()
 
 


### PR DESCRIPTION
**Description:**
Clean exit without raising exception if server was not set

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://github.com/home-assistant/home-assistant/pull/4866

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

Cleaner exit by not throwing exception if server was not set during initialization of component (ref https://github.com/home-assistant/home-assistant/pull/4866)