### PR TITLE
Beaglebone black GPIO control by switch

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,6 +13,9 @@ omit =
     homeassistant/components/arduino.py
     homeassistant/components/*/arduino.py
 
+    homeassistant/components/bbb_gpio.py
+    homeassistant/components/*/bbb_gpio.py
+
     homeassistant/components/bloomsky.py
     homeassistant/components/*/bloomsky.py
 

--- a/homeassistant/components/bbb_gpio.py
+++ b/homeassistant/components/bbb_gpio.py
@@ -10,7 +10,7 @@ import logging
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['Adafruit_BBIO.GPIO==1.0.0']
+REQUIREMENTS = ['Adafruit_BBIO==1.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bbb_gpio.py
+++ b/homeassistant/components/bbb_gpio.py
@@ -1,0 +1,69 @@
+"""
+Support for controlling GPIO pins of a Beaglebone Black.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/bbb_gpio/
+"""
+# pylint: disable=import-error
+import logging
+
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+
+REQUIREMENTS = ['Adafruit_BBIO.GPIO==1.0.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'bbb_gpio'
+
+
+# pylint: disable=no-member
+def setup(hass, config):
+    """Setup the Beaglebone black GPIO component."""
+    import Adafruit_BBIO.GPIO as GPIO
+
+    def cleanup_gpio(event):
+        """Stuff to do before stopping."""
+        GPIO.cleanup()
+
+    def prepare_gpio(event):
+        """Stuff to do when home assistant starts."""
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup_gpio)
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, prepare_gpio)
+    return True
+
+
+def setup_output(port):
+    """Setup a GPIO as output."""
+    import Adafruit_BBIO.GPIO as GPIO
+    GPIO.setup(port, GPIO.OUT)
+
+
+def setup_input(port, pull_mode):
+    """Setup a GPIO as input."""
+    import Adafruit_BBIO.GPIO as GPIO
+    GPIO.setup(port, GPIO.IN,
+               GPIO.PUD_DOWN if pull_mode == 'DOWN' else GPIO.PUD_UP)
+
+
+def write_output(port, value):
+    """Write a value to a GPIO."""
+    import Adafruit_BBIO.GPIO as GPIO
+    GPIO.output(port, value)
+
+
+def read_input(port):
+    """Read a value from a GPIO."""
+    import Adafruit_BBIO.GPIO as GPIO
+    return GPIO.input(port)
+
+
+def edge_detect(port, event_callback, bounce):
+    """Add detection for RISING and FALLING events."""
+    import Adafruit_BBIO.GPIO as GPIO
+    GPIO.add_event_detect(
+        port,
+        GPIO.BOTH,
+        callback=event_callback,
+        bouncetime=bounce)

--- a/homeassistant/components/switch/bbb_gpio.py
+++ b/homeassistant/components/switch/bbb_gpio.py
@@ -1,7 +1,8 @@
 """
 Allows to configure a switch using BBB GPIO.
 
-Switch example for two GPIOs pins P9_12 and P9_42 (GPIOxxx names allowed as well) 
+Switch example for two GPIOs pins P9_12 and P9_42.
+GPIO pin name support GPIOxxx and Px_x format.
 
 switch:
   - platform: bbb_gpio

--- a/homeassistant/components/switch/bbb_gpio.py
+++ b/homeassistant/components/switch/bbb_gpio.py
@@ -1,5 +1,5 @@
 """
-Allows to configure a switch using RPi GPIO.
+Allows to configure a switch using BBB GPIO.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.bbb_gpio/
@@ -25,7 +25,7 @@ CONF_INVERT_LOGIC = 'invert_logic'
 DEFAULT_INVERT_LOGIC = False
 
 _SWITCHES_SCHEMA = vol.Schema({
-    cv.positive_int: cv.string,
+    cv.string: cv.string,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/switch/bbb_gpio.py
+++ b/homeassistant/components/switch/bbb_gpio.py
@@ -1,8 +1,13 @@
 """
 Allows to configure a switch using BBB GPIO.
 
-For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/switch.bbb_gpio/
+Switch example for two GPIOs pins P9_12 and P9_42 (GPIOxxx names allowed as well) 
+
+switch:
+  - platform: bbb_gpio
+    ports:
+      GPIO0_7: LED Red
+      P9_12: LED Green
 """
 import logging
 

--- a/homeassistant/components/switch/bbb_gpio.py
+++ b/homeassistant/components/switch/bbb_gpio.py
@@ -1,0 +1,86 @@
+"""
+Allows to configure a switch using RPi GPIO.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.bbb_gpio/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.switch import PLATFORM_SCHEMA
+import homeassistant.components.bbb_gpio as bbb_gpio
+from homeassistant.const import DEVICE_DEFAULT_NAME
+from homeassistant.helpers.entity import ToggleEntity
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['bbb_gpio']
+
+CONF_PULL_MODE = 'pull_mode'
+CONF_PORTS = 'ports'
+CONF_INVERT_LOGIC = 'invert_logic'
+
+DEFAULT_INVERT_LOGIC = False
+
+_SWITCHES_SCHEMA = vol.Schema({
+    cv.positive_int: cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_PORTS): _SWITCHES_SCHEMA,
+    vol.Optional(CONF_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Beaglebone GPIO devices."""
+    invert_logic = config.get(CONF_INVERT_LOGIC)
+
+    switches = []
+    ports = config.get(CONF_PORTS)
+    for port, name in ports.items():
+        switches.append(BBBGPIOSwitch(name, port, invert_logic))
+    add_devices(switches)
+
+
+class BBBGPIOSwitch(ToggleEntity):
+    """Representation of a  Beaglebone GPIO."""
+
+    def __init__(self, name, port, invert_logic):
+        """Initialize the pin."""
+        self._name = name or DEVICE_DEFAULT_NAME
+        self._port = port
+        self._invert_logic = invert_logic
+        self._state = False
+        bbb_gpio.setup_output(self._port)
+        bbb_gpio.write_output(self._port, 1 if self._invert_logic else 0)
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    def turn_on(self):
+        """Turn the device on."""
+        bbb_gpio.write_output(self._port, 0 if self._invert_logic else 1)
+        self._state = True
+        self.update_ha_state()
+
+    def turn_off(self):
+        """Turn the device off."""
+        bbb_gpio.write_output(self._port, 1 if self._invert_logic else 0)
+        self._state = False
+        self.update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -12,6 +12,9 @@ async_timeout==1.1.0
 # homeassistant.components.nuimo_controller
 --only-binary=all http://github.com/getSenic/nuimo-linux-python/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip#nuimo==1.0.0
 
+# homeassistant.components.bbb_gpio
+Adafruit_BBIO==1.0.0
+
 # homeassistant.components.isy994
 PyISY==1.0.7
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -13,10 +13,7 @@ async_timeout==1.1.0
 --only-binary=all http://github.com/getSenic/nuimo-linux-python/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip#nuimo==1.0.0
 
 # homeassistant.components.bbb_gpio
-Adafruit_BBIO==1.0.0
-
-# homeassistant.components.bbb_gpio
-Adafruit_BBIO==1.0.0
+# Adafruit_BBIO==1.0.0
 
 # homeassistant.components.isy994
 PyISY==1.0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -12,6 +12,9 @@ async_timeout==1.0.0
 # homeassistant.components.nuimo_controller
 --only-binary=all git+https://github.com/getSenic/nuimo-linux-python#nuimo==1.0.0
 
+# homeassistant.components.bbb_gpio
+Adafruit_BBIO==1.0.0
+
 # homeassistant.components.isy994
 PyISY==1.0.7
 


### PR DESCRIPTION
**Description:**
Added support for controlling GPIO of Beaglebone Black board (see https://beagleboard.org/black). Simple change from rpi_gpio with adding dependency on Adafruit_BBIO library.

**Related issue (if applicable):**
N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** 
Not created yet - module has basic info in docstring

**Example entry for `configuration.yaml` (if applicable):**
```
switch:
  - platform: bbb_gpio
    ports:
      GPIO0_7: LED Red
      P9_12: LED Green
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
