### PR TITLE
 Fixes issues #4844 to avoid traceback when self.rest.data is None

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -196,7 +196,7 @@ class WUndergroundSensor(Entity):
     @property
     def entity_picture(self):
         """Return the entity picture."""
-        if self._condition == 'weather':
+        if self.rest.data and self._condition == 'weather':
             url = self.rest.data['icon_url']
             return re.sub(r'^http://', 'https://', url, flags=re.IGNORECASE)
 


### PR DESCRIPTION
**Description:**

Fixed issue #4844 to avoid traceback when self.rest.data is None

```bash
    6-12-09 18:12:30 homeassistant.core: Error doing job: Task exception was never retrieved
    Traceback (most recent call last):
      File "/usr/lib/python3.4/asyncio/tasks.py", line 237, in _step
        result = next(coro)
      File "/srv/hass/hass_venv/lib/python3.4/site-packages/homeassistant/helpers/entity_component.py", line 386, in _update_entity_states
        yield from update_coro
      File "/srv/hass/hass_venv/lib/python3.4/site-packages/homeassistant/helpers/entity.py", line 240, in async_update_ha_state
        self._attr_setter('entity_picture', str, ATTR_ENTITY_PICTURE, attr)
      File "/srv/hass/hass_venv/lib/python3.4/site-packages/homeassistant/helpers/entity.py", line 307, in _attr_setter
        value = getattr(self, name)
      File "/srv/hass/hass_venv/lib/python3.4/site-packages/homeassistant/components/sensor/wunderground.py", line 176, in entity_picture
        url = self.rest.data['icon_url']
    TypeError: 'NoneType' object is not subscriptable
```
**Related issue (if applicable):** fixes #4844 

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
