### PR TITLE
Fix synologydsm

### DIFF
--- a/homeassistant/components/sensor/synologydsm.py
+++ b/homeassistant/components/sensor/synologydsm.py
@@ -107,7 +107,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         # Handle all Volumes
         volumes = config['volumes']
         if volumes is None:
-            volumes = api.storage().volumes
+            volumes = api.storage.volumes
 
         for volume in volumes:
             sensors += [SynoNasStorageSensor(api, variable,
@@ -119,7 +119,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         # Handle all Disks
         disks = config['disks']
         if disks is None:
-            disks = api.storage().disks
+            disks = api.storage.disks
 
         for disk in disks:
             sensors += [SynoNasStorageSensor(api, variable,


### PR DESCRIPTION
**Description:**
Two references to a property still treated it as a method.

**Related issue (if applicable):** fixes #4883

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

