### PR TITLE
Avoid TypeError for state (sensor.coinmarketcap)

### DIFF
--- a/homeassistant/components/sensor/coinmarketcap.py
+++ b/homeassistant/components/sensor/coinmarketcap.py
@@ -77,7 +77,7 @@ class CoinMarketCapSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return round(self._ticker.get('price_usd'), 2)
+        return round(float(self._ticker.get('price_usd')), 2)
 
     @property
     def unit_of_measurement(self):


### PR DESCRIPTION
**Description:**
Avoid TypeError for state

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: coinmarketcap
    currency: bitcoin
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
