### PR TITLE
Rework zoneminder sensor to include monitor status.

### DIFF
--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -10,8 +10,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-        STATE_UNKNOWN, CONF_MONITORED_VARIABLES)
-import homeassistant.helpers.config_validation as cv
+    STATE_UNKNOWN, CONF_MONITORED_VARIABLES)
 from homeassistant.helpers.entity import Entity
 import homeassistant.components.zoneminder as zoneminder
 
@@ -20,9 +19,9 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['zoneminder']
 
 SENSOR_TYPES = {
-        'events',
-        'function',
-        'status'
+    'events',
+    'function',
+    'status'
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -38,7 +37,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     monitors = zoneminder.get_state('api/monitors.json')
     for i in monitors['monitors']:
         for variable in config[CONF_MONITORED_VARIABLES]:
-            sensors.append(ZMSensor(int(i['Monitor']['Id']), i['Monitor']['Name'], variable))
+            sensors.append(ZMSensor(int(i['Monitor']['Id']),
+                                    i['Monitor']['Name'], variable))
 
     add_devices(sensors)
 
@@ -68,7 +68,6 @@ class ZMSensor(Entity):
 
     def update(self):
         """Update the sensor state and status."""
-
         if self._type == "function":
             monitor = zoneminder.get_state(
                 'api/monitors/%i.json' % self._monitor_id
@@ -82,7 +81,7 @@ class ZMSensor(Entity):
             self._state = int(monitor['status'])
         elif self._type == "events":
             event = zoneminder.get_state(
-                    'api/events/index/MonitorId:%i.json' %
-                    (self._monitor_id)
+                'api/events/index/MonitorId:%i.json' %
+                (self._monitor_id)
             )
             self._state = event['pagination']['count']

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -6,13 +6,29 @@ https://home-assistant.io/components/sensor.zoneminder/
 """
 import logging
 
-from homeassistant.const import STATE_UNKNOWN
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+        STATE_UNKNOWN, CONF_MONITORED_VARIABLES)
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import homeassistant.components.zoneminder as zoneminder
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['zoneminder']
+
+SENSOR_TYPES = {
+        'events',
+        'function',
+        'status'
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_MONITORED_VARIABLES, default=[]):
+        [vol.In(SENSOR_TYPES)],
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -21,29 +37,29 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     monitors = zoneminder.get_state('api/monitors.json')
     for i in monitors['monitors']:
-        sensors.append(
-            ZMSensorMonitors(int(i['Monitor']['Id']), i['Monitor']['Name'])
-        )
-        sensors.append(
-            ZMSensorEvents(int(i['Monitor']['Id']), i['Monitor']['Name'])
-        )
+        for variable in config[CONF_MONITORED_VARIABLES]:
+            sensors.append(ZMSensor(int(i['Monitor']['Id']), i['Monitor']['Name'], variable))
 
     add_devices(sensors)
 
 
-class ZMSensorMonitors(Entity):
+class ZMSensor(Entity):
     """Get the status of each ZoneMinder monitor."""
 
-    def __init__(self, monitor_id, monitor_name):
+    def __init__(self, monitor_id, monitor_name, sensor_type):
         """Initiate monitor sensor."""
         self._monitor_id = monitor_id
         self._monitor_name = monitor_name
-        self._state = None
+        self._name = monitor_name + ' ' + sensor_type.capitalize()
+        self._type = sensor_type
+        self._state = STATE_UNKNOWN
+
+        self.update()
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return '{} Status'.format(self._monitor_name)
+        return self._name
 
     @property
     def state(self):
@@ -51,44 +67,22 @@ class ZMSensorMonitors(Entity):
         return self._state
 
     def update(self):
-        """Update the sensor."""
-        monitor = zoneminder.get_state(
-            'api/monitors/%i.json' % self._monitor_id
-        )
-        if monitor['monitor']['Monitor']['Function'] is None:
-            self._state = STATE_UNKNOWN
-        else:
+        """Update the sensor state and status."""
+
+        if self._type == "function":
+            monitor = zoneminder.get_state(
+                'api/monitors/%i.json' % self._monitor_id
+            )
             self._state = monitor['monitor']['Monitor']['Function']
-
-
-class ZMSensorEvents(Entity):
-    """Get the number of events for each monitor."""
-
-    def __init__(self, monitor_id, monitor_name):
-        """Initiate event sensor."""
-        self._monitor_id = monitor_id
-        self._monitor_name = monitor_name
-        self._state = None
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return '{} Events'.format(self._monitor_name)
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement of this entity, if any."""
-        return 'Events'
-
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
-
-    def update(self):
-        """Update the sensor."""
-        event = zoneminder.get_state(
-            'api/events/index/MonitorId:%i.json' % self._monitor_id
-        )
-
-        self._state = event['pagination']['count']
+        elif self._type == "status":
+            monitor = zoneminder.get_state(
+                'api/monitors/alarm/id:%i/command:status.json' %
+                self._monitor_id
+            )
+            self._state = int(monitor['status'])
+        elif self._type == "events":
+            event = zoneminder.get_state(
+                    'api/events/index/MonitorId:%i.json' %
+                    (self._monitor_id)
+            )
+            self._state = event['pagination']['count']


### PR DESCRIPTION
**Description:** Expand the existing ZoneMinder sensor to allow you to choose which variable(s) (monitor event count, monitor function, monitor status) you care about.

This moves what used to be reported as 'state' to 'function', and adds support for per-monitor 'status' (alert, alarm, etc) sensors.

**Related issue (if applicable):** #4794 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** Not yet

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
        - platform: zoneminder
          scan_interval: 5
          monitored_variables:
                  - events
                  - function
                  - status
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

```
ERROR: InvocationError: '/usr/home/kjohnson/home-assistant/.tox/typing/bin/mypy --silent-imports homeassistant'
__________________________________________________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________________________________________________
  py34: commands succeeded
SKIPPED:  py35: InterpreterNotFound: python3.5
  lint: commands succeeded
  requirements: commands succeeded
ERROR:   typing: commands failed
```

  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.



[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51