### PR TITLE
Beaglebone black GPIO control by switch v2

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,6 +13,9 @@ omit =
     homeassistant/components/arduino.py
     homeassistant/components/*/arduino.py
 
+    homeassistant/components/bbb_gpio.py
+    homeassistant/components/*/bbb_gpio.py
+
     homeassistant/components/bloomsky.py
     homeassistant/components/*/bloomsky.py
 

--- a/homeassistant/components/bbb_gpio.py
+++ b/homeassistant/components/bbb_gpio.py
@@ -33,36 +33,36 @@ def setup(hass, config):
     return True
 
 
-def setup_output(port):
+def setup_output(pin):
     """Setup a GPIO as output."""
     import Adafruit_BBIO.GPIO as GPIO
-    GPIO.setup(port, GPIO.OUT)
+    GPIO.setup(pin, GPIO.OUT)
 
 
-def setup_input(port, pull_mode):
+def setup_input(pin, pull_mode):
     """Setup a GPIO as input."""
     import Adafruit_BBIO.GPIO as GPIO
-    GPIO.setup(port, GPIO.IN,
+    GPIO.setup(pin, GPIO.IN,
                GPIO.PUD_DOWN if pull_mode == 'DOWN' else GPIO.PUD_UP)
 
 
-def write_output(port, value):
+def write_output(pin, value):
     """Write a value to a GPIO."""
     import Adafruit_BBIO.GPIO as GPIO
-    GPIO.output(port, value)
+    GPIO.output(pin, value)
 
 
-def read_input(port):
+def read_input(pin):
     """Read a value from a GPIO."""
     import Adafruit_BBIO.GPIO as GPIO
-    return GPIO.input(port)
+    return GPIO.input(pin)
 
 
-def edge_detect(port, event_callback, bounce):
+def edge_detect(pin, event_callback, bounce):
     """Add detection for RISING and FALLING events."""
     import Adafruit_BBIO.GPIO as GPIO
     GPIO.add_event_detect(
-        port,
+        pin,
         GPIO.BOTH,
         callback=event_callback,
         bouncetime=bounce)

--- a/homeassistant/components/bbb_gpio.py
+++ b/homeassistant/components/bbb_gpio.py
@@ -4,7 +4,6 @@ Support for controlling GPIO pins of a Beaglebone Black.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/bbb_gpio/
 """
-# pylint: disable=import-error
 import logging
 
 from homeassistant.const import (

--- a/homeassistant/components/bbb_gpio.py
+++ b/homeassistant/components/bbb_gpio.py
@@ -1,0 +1,69 @@
+"""
+Support for controlling GPIO pins of a Beaglebone Black.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/bbb_gpio/
+"""
+# pylint: disable=import-error
+import logging
+
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+
+REQUIREMENTS = ['Adafruit_BBIO==1.0.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'bbb_gpio'
+
+
+# pylint: disable=no-member
+def setup(hass, config):
+    """Setup the Beaglebone black GPIO component."""
+    import Adafruit_BBIO.GPIO as GPIO
+
+    def cleanup_gpio(event):
+        """Stuff to do before stopping."""
+        GPIO.cleanup()
+
+    def prepare_gpio(event):
+        """Stuff to do when home assistant starts."""
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup_gpio)
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, prepare_gpio)
+    return True
+
+
+def setup_output(port):
+    """Setup a GPIO as output."""
+    import Adafruit_BBIO.GPIO as GPIO
+    GPIO.setup(port, GPIO.OUT)
+
+
+def setup_input(port, pull_mode):
+    """Setup a GPIO as input."""
+    import Adafruit_BBIO.GPIO as GPIO
+    GPIO.setup(port, GPIO.IN,
+               GPIO.PUD_DOWN if pull_mode == 'DOWN' else GPIO.PUD_UP)
+
+
+def write_output(port, value):
+    """Write a value to a GPIO."""
+    import Adafruit_BBIO.GPIO as GPIO
+    GPIO.output(port, value)
+
+
+def read_input(port):
+    """Read a value from a GPIO."""
+    import Adafruit_BBIO.GPIO as GPIO
+    return GPIO.input(port)
+
+
+def edge_detect(port, event_callback, bounce):
+    """Add detection for RISING and FALLING events."""
+    import Adafruit_BBIO.GPIO as GPIO
+    GPIO.add_event_detect(
+        port,
+        GPIO.BOTH,
+        callback=event_callback,
+        bouncetime=bounce)

--- a/homeassistant/components/switch/bbb_gpio.py
+++ b/homeassistant/components/switch/bbb_gpio.py
@@ -91,10 +91,10 @@ class BBBGPIOSwitch(ToggleEntity):
         """Turn the device on."""
         bbb_gpio.write_output(self._pin, 0 if self._invert_logic else 1)
         self._state = True
-        self.update_ha_state()
+        self.schedule_update_ha_state()
 
     def turn_off(self):
         """Turn the device off."""
         bbb_gpio.write_output(self._pin, 1 if self._invert_logic else 0)
         self._state = False
-        self.update_ha_state()
+        self.schedule_update_ha_state()

--- a/homeassistant/components/switch/bbb_gpio.py
+++ b/homeassistant/components/switch/bbb_gpio.py
@@ -67,7 +67,7 @@ class BBBGPIOSwitch(ToggleEntity):
 
         bbb_gpio.setup_output(self._pin)
 
-        if self._state == false:
+        if self._state == False:
             bbb_gpio.write_output(self._pin, 1 if self._invert_logic else 0)
         else:
             bbb_gpio.write_output(self._pin, 0 if self._invert_logic else 1)

--- a/homeassistant/components/switch/bbb_gpio.py
+++ b/homeassistant/components/switch/bbb_gpio.py
@@ -47,7 +47,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Beaglebone GPIO devices."""
-
     pins = config.get(CONF_PINS)
 
     switches = []

--- a/homeassistant/components/switch/bbb_gpio.py
+++ b/homeassistant/components/switch/bbb_gpio.py
@@ -1,0 +1,92 @@
+"""
+Allows to configure a switch using BBB GPIO.
+
+Switch example for two GPIOs pins P9_12 and P9_42
+Allowed GPIO pin name is GPIOxxx or Px_x
+
+switch:
+  - platform: bbb_gpio
+    ports:
+      GPIO0_7: LED Red
+      P9_12: LED Green
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.switch import PLATFORM_SCHEMA
+import homeassistant.components.bbb_gpio as bbb_gpio
+from homeassistant.const import DEVICE_DEFAULT_NAME
+from homeassistant.helpers.entity import ToggleEntity
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['bbb_gpio']
+
+CONF_PULL_MODE = 'pull_mode'
+CONF_PORTS = 'ports'
+CONF_INVERT_LOGIC = 'invert_logic'
+
+DEFAULT_INVERT_LOGIC = False
+
+_SWITCHES_SCHEMA = vol.Schema({
+    cv.string: cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_PORTS): _SWITCHES_SCHEMA,
+    vol.Optional(CONF_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Beaglebone GPIO devices."""
+    invert_logic = config.get(CONF_INVERT_LOGIC)
+
+    switches = []
+    ports = config.get(CONF_PORTS)
+    for port, name in ports.items():
+        switches.append(BBBGPIOSwitch(name, port, invert_logic))
+    add_devices(switches)
+
+
+class BBBGPIOSwitch(ToggleEntity):
+    """Representation of a  Beaglebone GPIO."""
+
+    def __init__(self, name, port, invert_logic):
+        """Initialize the pin."""
+        self._name = name or DEVICE_DEFAULT_NAME
+        self._port = port
+        self._invert_logic = invert_logic
+        self._state = False
+        bbb_gpio.setup_output(self._port)
+        bbb_gpio.write_output(self._port, 1 if self._invert_logic else 0)
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    def turn_on(self):
+        """Turn the device on."""
+        bbb_gpio.write_output(self._port, 0 if self._invert_logic else 1)
+        self._state = True
+        self.update_ha_state()
+
+    def turn_off(self):
+        """Turn the device off."""
+        bbb_gpio.write_output(self._port, 1 if self._invert_logic else 0)
+        self._state = False
+        self.update_ha_state()

--- a/homeassistant/components/switch/bbb_gpio.py
+++ b/homeassistant/components/switch/bbb_gpio.py
@@ -7,7 +7,7 @@ Allowed GPIO pin name is GPIOxxx or Px_x
 switch:
   - platform: bbb_gpio
     pins:
-      GPIO0_7: 
+      GPIO0_7:
         name: LED Red
       P9_12:
         name: LED Green
@@ -43,6 +43,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.Schema({cv.string: PIN_SCHEMA}),
 })
 
+
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Beaglebone GPIO devices."""
@@ -67,7 +68,7 @@ class BBBGPIOSwitch(ToggleEntity):
 
         bbb_gpio.setup_output(self._pin)
 
-        if self._state == False:
+        if self._state is False:
             bbb_gpio.write_output(self._pin, 1 if self._invert_logic else 0)
         else:
             bbb_gpio.write_output(self._pin, 0 if self._invert_logic else 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -12,6 +12,9 @@ async_timeout==1.1.0
 # homeassistant.components.nuimo_controller
 --only-binary=all http://github.com/getSenic/nuimo-linux-python/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip#nuimo==1.0.0
 
+# homeassistant.components.bbb_gpio
+Adafruit_BBIO==1.0.0
+
 # homeassistant.components.isy994
 PyISY==1.0.7
 


### PR DESCRIPTION
**Description:**
Added support for controlling GPIO of Beaglebone Black board (see https://beagleboard.org/black). Similar to already created rpi_gpio with slide changes and adding dependency on Adafruit_BBIO library.

**Related issue (if applicable):** 
N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** 
https://github.com/home-assistant/home-assistant.github.io/pull/1765

**Example entry for `configuration.yaml` (if applicable):**
```yaml
   switch:
    - platform: bbb_gpio
      ports:
        GPIO0_7: LED Red
        P9_12: LED Green
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
