### PR TITLE
Update tp link switch module

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -60,8 +60,14 @@ def setup(hass, config):
     host = conf.get(CONF_HOST)
     port = conf.get(CONF_PORT)
     database = conf.get(CONF_DB_NAME)
-    username = conf.get(CONF_USERNAME)
-    password = conf.get(CONF_PASSWORD)
+    if conf.get(CONF_USERNAME) is None:
+        username = 'root'
+    else:
+        username = conf.get(CONF_USERNAME)
+    if conf.get(CONF_PASSWORD) is None:
+        password = 'root'
+    else:
+        password = conf.get(CONF_PASSWORD)
     ssl = conf.get(CONF_SSL)
     verify_ssl = conf.get(CONF_VERIFY_SSL)
     blacklist = conf.get(CONF_BLACKLIST)

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -15,7 +15,7 @@ from homeassistant.const import (CONF_HOST, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['https://github.com/GadgetReactor/pyHS100/archive/'
-                '1f771b7d8090a91c6a58931532e42730b021cbde.zip#pyHS100==0.2.0']
+                '45fc3548882628bcde3e3d365db341849457bef2.zip#pyHS100==0.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the TPLink switch platform."""
-    from pyHS100.pyHS100 import SmartPlug
+    from pyHS100 import SmartPlug
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
 
@@ -51,8 +51,8 @@ class SmartPlugSwitch(SwitchDevice):
         self.smartplug = smartplug
         self._name = name
         self._state = None
-        self._emeter_present = (smartplug.model == 110)
-        _LOGGER.debug("Setting up TP-Link Smart Plug HS%i", smartplug.model)
+        self._emeter_present = smartplug.has_emeter
+        _LOGGER.debug("Setting up TP-Link Smart Plug")
         # Set up emeter cache
         self._emeter_params = {}
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -173,7 +173,7 @@ http://github.com/technicalpickles/python-nest/archive/2512973b4b390d3965da43529
 https://github.com/Danielhiversen/flux_led/archive/0.9.zip#flux_led==0.9
 
 # homeassistant.components.switch.tplink
-https://github.com/GadgetReactor/pyHS100/archive/1f771b7d8090a91c6a58931532e42730b021cbde.zip#pyHS100==0.2.0
+https://github.com/GadgetReactor/pyHS100/archive/45fc3548882628bcde3e3d365db341849457bef2.zip#pyHS100==0.2.2
 
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.3.7.zip#pyW215==0.3.7


### PR DESCRIPTION
**Description:**
This should fix the issues with TP-Link HS200 switches not appearing
Internal changes in dependent module should resolve issues with HS100/110/200 switches returning chunked responses.

**Related issue (if applicable):** fixes #4045  fixes #4601 

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.