### PR TITLE
Updates TP-Link dependency

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -50,10 +50,8 @@ class SmartPlugSwitch(SwitchDevice):
 
         # Use the name set on the device if not set
         if name is None:
-            _LOGGER.debug("No name set. Using device alias")
             self._name = self.smartplug.alias
         else:
-            _LOGGER.debug("Setting name to " + name)
             self._name = name
 
         self._state = None

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -1,5 +1,5 @@
 """
-Support for TPLink HS100/HS110 smart switch.
+Support for TPLink HS100/HS110/HS200 smart switch.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.tplink/

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -50,6 +50,11 @@ class SmartPlugSwitch(SwitchDevice):
         """Initialize the switch."""
         self.smartplug = smartplug
         self._name = name
+
+        # Use the name set on the device if not set
+        if name is None:
+            name = self.smartplug.alias()
+
         self._state = None
         _LOGGER.debug("Setting up TP-Link Smart Plug")
         # Set up emeter cache

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -15,7 +15,7 @@ from homeassistant.const import (CONF_HOST, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['https://github.com/GadgetReactor/pyHS100/archive/'
-                '1f771b7d8090a91c6a58931532e42730b021cbde.zip#pyHS100==0.2.0']
+                '45fc3548882628bcde3e3d365db341849457bef2.zip#pyHS100==0.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the TPLink switch platform."""
-    from pyHS100.pyHS100 import SmartPlug
+    from pyHS100 import SmartPlug
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
 
@@ -51,8 +51,7 @@ class SmartPlugSwitch(SwitchDevice):
         self.smartplug = smartplug
         self._name = name
         self._state = None
-        self._emeter_present = (smartplug.model == 110)
-        _LOGGER.debug("Setting up TP-Link Smart Plug HS%i", smartplug.model)
+        _LOGGER.debug("Setting up TP-Link Smart Plug")
         # Set up emeter cache
         self._emeter_params = {}
 
@@ -64,15 +63,15 @@ class SmartPlugSwitch(SwitchDevice):
     @property
     def is_on(self):
         """Return true if switch is on."""
-        return self._state == 'ON'
+        return self.smartplug.is_on
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""
-        self.smartplug.state = 'ON'
+        self.smartplug.turn_on()
 
     def turn_off(self):
         """Turn the switch off."""
-        self.smartplug.state = 'OFF'
+        self.smartplug.turn_off()
 
     @property
     def device_state_attributes(self):
@@ -84,7 +83,7 @@ class SmartPlugSwitch(SwitchDevice):
         try:
             self._state = self.smartplug.state
 
-            if self._emeter_present:
+            if self.smartplug.has_emeter:
                 emeter_readings = self.smartplug.get_emeter_realtime()
 
                 self._emeter_params[ATTR_CURRENT_CONSUMPTION] \

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -19,8 +19,6 @@ REQUIREMENTS = ['https://github.com/GadgetReactor/pyHS100/archive/'
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_NAME = 'TPLink Switch HS100'
-
 ATTR_CURRENT_CONSUMPTION = 'Current consumption'
 ATTR_TOTAL_CONSUMPTION = 'Total consumption'
 ATTR_DAILY_CONSUMPTION = 'Daily consumption'
@@ -29,7 +27,7 @@ ATTR_CURRENT = 'Current'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
 })
 
 
@@ -49,11 +47,14 @@ class SmartPlugSwitch(SwitchDevice):
     def __init__(self, smartplug, name):
         """Initialize the switch."""
         self.smartplug = smartplug
-        self._name = name
 
         # Use the name set on the device if not set
         if name is None:
-            name = self.smartplug.alias()
+            _LOGGER.debug("No name set. Using device alias")
+            self._name = self.smartplug.alias
+        else:
+            _LOGGER.debug("Setting name to " + name)
+            self._name = name
 
         self._state = None
         _LOGGER.debug("Setting up TP-Link Smart Plug")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -176,7 +176,7 @@ http://github.com/technicalpickles/python-nest/archive/b8391d2b3cb8682f8b0c2bdff
 https://github.com/Danielhiversen/flux_led/archive/0.9.zip#flux_led==0.9
 
 # homeassistant.components.switch.tplink
-https://github.com/GadgetReactor/pyHS100/archive/1f771b7d8090a91c6a58931532e42730b021cbde.zip#pyHS100==0.2.0
+https://github.com/GadgetReactor/pyHS100/archive/45fc3548882628bcde3e3d365db341849457bef2.zip#pyHS100==0.2.2
 
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.3.7.zip#pyW215==0.3.7


### PR DESCRIPTION
**Description:**
This should fix the issues with TP-Link HS200 switches not appearing
Internal changes in dependent module should resolve issues with HS100/110/200 switches returning chunked responses.

**Related issue (if applicable):** fixes #4045  fixes #4601 

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.