### PR TITLE
Add voicerss for TTS

### DIFF
--- a/homeassistant/components/tts/google.py
+++ b/homeassistant/components/tts/google.py
@@ -92,8 +92,8 @@ class GoogleProvider(Provider):
                     )
 
                     if request.status != 200:
-                        _LOGGER.error("Error %d on load url %s", request.code,
-                                      request.url)
+                        _LOGGER.error("Error %d on load url %s",
+                                      request.status, request.url)
                         return (None, None)
                     data += yield from request.read()
 

--- a/homeassistant/components/tts/voicerss.py
+++ b/homeassistant/components/tts/voicerss.py
@@ -109,8 +109,8 @@ class VoiceRSSProvider(Provider):
                 )
 
                 if request.status != 200:
-                    _LOGGER.error("Error %d on load url %s", request.code,
-                                  request.url)
+                    _LOGGER.error("Error %d on load url %s",
+                                  request.status, request.url)
                     return (None, None)
                 data = yield from request.read()
 

--- a/homeassistant/components/tts/voicerss.py
+++ b/homeassistant/components/tts/voicerss.py
@@ -1,0 +1,125 @@
+"""
+Support for the voicerss speech service.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/tts/voicerss/
+"""
+import asyncio
+import logging
+
+import aiohttp
+import async_timeout
+import voluptuous as vol
+
+from homeassistant.const import CONF_API_KEY, CONF_SSL
+from homeassistant.components.tts import Provider, PLATFORM_SCHEMA, CONF_LANG
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
+
+
+_LOGGER = logging.getLogger(__name__)
+
+VOICERSS_API_URL = "{}://api.voicerss.org/"
+
+SUPPORT_LANGUAGES = [
+    'ca-es', 'zh-cn', 'zh-hk', 'zh-tw', 'da-dk', 'nl-nl', 'en-au', 'en-ca',
+    'en-gb', 'en-in', 'en-us', 'fi-fi', 'fr-ca', 'fr-fr', 'de-de', 'it-it',
+    'ja-jp', 'ko-kr', 'nb-no', 'pl-pl', 'pt-br', 'pt-pt', 'ru-ru', 'es-mx',
+    'es-es', 'sv-se',
+]
+
+SUPPORT_CODECS = [
+    'mp3', 'wav', 'aac', 'ogg', 'caf'
+]
+
+SUPPORT_FORMATS = [
+    '8khz_8bit_mono', '8khz_8bit_stereo', '8khz_16bit_mono',
+    '8khz_16bit_stereo', '11khz_8bit_mono', '11khz_8bit_stereo',
+    '11khz_16bit_mono', '11khz_16bit_stereo', '12khz_8bit_mono',
+    '12khz_8bit_stereo', '12khz_16bit_mono', '12khz_16bit_stereo',
+    '16khz_8bit_mono', '16khz_8bit_stereo', '16khz_16bit_mono',
+    '16khz_16bit_stereo', '22khz_8bit_mono', '22khz_8bit_stereo',
+    '22khz_16bit_mono', '22khz_16bit_stereo', '24khz_8bit_mono',
+    '24khz_8bit_stereo', '24khz_16bit_mono', '24khz_16bit_stereo',
+    '32khz_8bit_mono', '32khz_8bit_stereo', '32khz_16bit_mono',
+    '32khz_16bit_stereo', '44khz_8bit_mono', '44khz_8bit_stereo',
+    '44khz_16bit_mono', '44khz_16bit_stereo', '48khz_8bit_mono',
+    '48khz_8bit_stereo', '48khz_16bit_mono', '48khz_16bit_stereo',
+    'alaw_8khz_mono', 'alaw_8khz_stereo', 'alaw_11khz_mono',
+    'alaw_11khz_stereo', 'alaw_22khz_mono', 'alaw_22khz_stereo',
+    'alaw_44khz_mono', 'alaw_44khz_stereo', 'ulaw_8khz_mono',
+    'ulaw_8khz_stereo', 'ulaw_11khz_mono', 'ulaw_11khz_stereo',
+    'ulaw_22khz_mono', 'ulaw_22khz_stereo', 'ulaw_44khz_mono',
+    'ulaw_44khz_stereo',
+]
+
+CONF_CODEC = 'codec'
+CONF_FORMAT = 'format'
+
+DEFAULT_LANG = 'en-us'
+DEFAULT_CODEC = 'mp3'
+DEFAULT_FORMAT = '8khz_8bit_mono'
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_SSL, default=True): cv.boolean,
+    vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORT_LANGUAGES),
+    vol.Optional(CONF_CODEC, default=DEFAULT_CODEC): vol.In(SUPPORT_CODECS),
+    vol.Optional(CONF_FORMAT, default=DEFAULT_FORMAT): vol.In(SUPPORT_FORMATS),
+})
+
+
+@asyncio.coroutine
+def async_get_engine(hass, config):
+    """Setup VoiceRSS speech component."""
+    return VoiceRSSProvider(hass, config)
+
+
+class VoiceRSSProvider(Provider):
+    """VoiceRSS speech api provider."""
+
+    def __init__(self, hass, conf):
+        """Init VoiceRSS TTS service."""
+        self.hass = hass
+        self.extension = conf.get(CONF_CODEC)
+
+        self.params = {
+            'key': conf.get(CONF_API_KEY),
+            'hl': conf.get(CONF_LANG),
+            'c': (conf.get(CONF_CODEC)).upper(),
+            'f': conf.get(CONF_FORMAT),
+        }
+
+        if conf.get(CONF_SSL):
+            self.url = VOICERSS_API_URL.format('https')
+        else:
+            self.url = VOICERSS_API_URL.format('http')
+
+    @asyncio.coroutine
+    def async_get_tts_audio(self, message):
+        """Load TTS from voicerss."""
+        websession = async_get_clientsession(self.hass)
+
+        request = None
+        try:
+            with async_timeout.timeout(10, loop=self.hass.loop):
+                request = yield from websession.post(
+                    self.url, params=self.params, data=bytes(message, 'utf-8')
+                )
+
+                if request.status != 200:
+                    _LOGGER.error("Error %d on load url %s", request.code,
+                                  request.url)
+                    return (None, None)
+                data = yield from request.read()
+
+        except (asyncio.TimeoutError, aiohttp.errors.ClientError):
+            _LOGGER.error("Timeout for voicerss api.")
+            return (None, None)
+
+        finally:
+            if request is not None:
+                yield from request.release()
+
+        return (self.extension, data)

--- a/homeassistant/components/tts/voicerss.py
+++ b/homeassistant/components/tts/voicerss.py
@@ -11,7 +11,7 @@ import aiohttp
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.const import CONF_API_KEY, CONF_SSL
+from homeassistant.const import CONF_API_KEY
 from homeassistant.components.tts import Provider, PLATFORM_SCHEMA, CONF_LANG
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -19,7 +19,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-VOICERSS_API_URL = "{}://api.voicerss.org/"
+VOICERSS_API_URL = "https://api.voicerss.org/"
 
 SUPPORT_LANGUAGES = [
     'ca-es', 'zh-cn', 'zh-hk', 'zh-tw', 'da-dk', 'nl-nl', 'en-au', 'en-ca',
@@ -63,7 +63,6 @@ DEFAULT_FORMAT = '8khz_8bit_mono'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
-    vol.Optional(CONF_SSL, default=True): cv.boolean,
     vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORT_LANGUAGES),
     vol.Optional(CONF_CODEC, default=DEFAULT_CODEC): vol.In(SUPPORT_CODECS),
     vol.Optional(CONF_FORMAT, default=DEFAULT_FORMAT): vol.In(SUPPORT_FORMATS),
@@ -91,11 +90,6 @@ class VoiceRSSProvider(Provider):
             'f': conf.get(CONF_FORMAT),
         }
 
-        if conf.get(CONF_SSL):
-            self.url = VOICERSS_API_URL.format('https')
-        else:
-            self.url = VOICERSS_API_URL.format('http')
-
     @asyncio.coroutine
     def async_get_tts_audio(self, message):
         """Load TTS from voicerss."""
@@ -105,7 +99,8 @@ class VoiceRSSProvider(Provider):
         try:
             with async_timeout.timeout(10, loop=self.hass.loop):
                 request = yield from websession.post(
-                    self.url, params=self.params, data=bytes(message, 'utf-8')
+                    VOICERSS_API_URL, params=self.params,
+                    data=bytes(message, 'utf-8')
                 )
 
                 if request.status != 200:

--- a/tests/components/tts/test_voicerss.py
+++ b/tests/components/tts/test_voicerss.py
@@ -84,35 +84,6 @@ class TestTTSVoiceRSSPlatform(object):
         assert len(aioclient_mock.mock_calls) == 1
         assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(".mp3") != -1
 
-    def test_service_say_no_ssl(self, aioclient_mock):
-        """Test service call say without ssl."""
-        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
-
-        aioclient_mock.post(
-            "http://api.voicerss.org/", params=self.url_param, status=200,
-            content=b'test'
-        )
-
-        config = {
-            tts.DOMAIN: {
-                'platform': 'voicerss',
-                'api_key': '1234567xx',
-                'ssl': False,
-            }
-        }
-
-        with assert_setup_component(1, tts.DOMAIN):
-            setup_component(self.hass, tts.DOMAIN, config)
-
-        self.hass.services.call(tts.DOMAIN, 'voicerss_say', {
-            tts.ATTR_MESSAGE: "I person is on front of your door.",
-        })
-        self.hass.block_till_done()
-
-        assert len(calls) == 1
-        assert len(aioclient_mock.mock_calls) == 1
-        assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(".mp3") != -1
-
     def test_service_say_german(self, aioclient_mock):
         """Test service call say with german code."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)

--- a/tests/components/tts/test_voicerss.py
+++ b/tests/components/tts/test_voicerss.py
@@ -1,0 +1,190 @@
+"""The tests for the VoiceRSS speech platform."""
+import asyncio
+import os
+import shutil
+
+import homeassistant.components.tts as tts
+from homeassistant.components.media_player import (
+    SERVICE_PLAY_MEDIA, ATTR_MEDIA_CONTENT_ID, DOMAIN as DOMAIN_MP)
+from homeassistant.bootstrap import setup_component
+
+from tests.common import (
+    get_test_home_assistant, assert_setup_component, mock_service)
+
+
+class TestTTSVoiceRSSPlatform(object):
+    """Test the voicerss speech component."""
+
+    def setup_method(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+        self.url = "https://api.voicerss.org/"
+        self.url_param = {
+            'key': '1234567xx',
+            'hl': 'en-us',
+            'c': 'mp3',
+            'f': '8khz_8bit_mono',
+        }
+
+    def teardown_method(self):
+        """Stop everything that was started."""
+        default_tts = self.hass.config.path(tts.DEFAULT_CACHE_DIR)
+        if os.path.isdir(default_tts):
+            shutil.rmtree(default_tts)
+
+        self.hass.stop()
+
+    def test_setup_component(self):
+        """Test setup component."""
+        config = {
+            tts.DOMAIN: {
+                'platform': 'voicerss',
+                'api_key': '1234567xx'
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+    def test_setup_component_without_api_key(self):
+        """Test setup component without api key."""
+        config = {
+            tts.DOMAIN: {
+                'platform': 'voicerss',
+            }
+        }
+
+        assert not setup_component(self.hass, tts.DOMAIN, config)
+
+    def test_service_say(self, aioclient_mock):
+        """Test service call say."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        aioclient_mock.post(
+            self.url, params=self.url_param, status=200, content=b'test')
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'voicerss',
+                'api_key': '1234567xx',
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'voicerss_say', {
+            tts.ATTR_MESSAGE: "I person is on front of your door.",
+        })
+        self.hass.block_till_done()
+
+        assert len(calls) == 1
+        assert len(aioclient_mock.mock_calls) == 1
+        assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(".mp3") != -1
+
+    def test_service_say_no_ssl(self, aioclient_mock):
+        """Test service call say without ssl."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        aioclient_mock.post(
+            "http://api.voicerss.org/", params=self.url_param, status=200,
+            content=b'test'
+        )
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'voicerss',
+                'api_key': '1234567xx',
+                'ssl': False,
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'voicerss_say', {
+            tts.ATTR_MESSAGE: "I person is on front of your door.",
+        })
+        self.hass.block_till_done()
+
+        assert len(calls) == 1
+        assert len(aioclient_mock.mock_calls) == 1
+        assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(".mp3") != -1
+
+    def test_service_say_german(self, aioclient_mock):
+        """Test service call say with german code."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        self.url_param['hl'] = 'de'
+        aioclient_mock.post(
+            self.url, params=self.url_param, status=200, content=b'test')
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'voicerss',
+                'api_key': '1234567xx',
+                'language': 'de-de',
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'voicerss_say', {
+            tts.ATTR_MESSAGE: "I person is on front of your door.",
+        })
+        self.hass.block_till_done()
+
+        assert len(calls) == 1
+        assert len(aioclient_mock.mock_calls) == 1
+
+    def test_service_say_error(self, aioclient_mock):
+        """Test service call say with http response 400."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        aioclient_mock.post(
+            self.url, params=self.url_param, status=400, content=b'test')
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'voicerss',
+                'api_key': '1234567xx',
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'voicerss_say', {
+            tts.ATTR_MESSAGE: "I person is on front of your door.",
+        })
+        self.hass.block_till_done()
+
+        assert len(calls) == 0
+        assert len(aioclient_mock.mock_calls) == 1
+
+    def test_service_say_timeout(self, aioclient_mock):
+        """Test service call say with http timeout."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        aioclient_mock.post(
+            self.url, params=self.url_param, exc=asyncio.TimeoutError())
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'voicerss',
+                'api_key': '1234567xx',
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'voicerss_say', {
+            tts.ATTR_MESSAGE: "I person is on front of your door.",
+        })
+        self.hass.block_till_done()
+
+        assert len(calls) == 0
+        assert len(aioclient_mock.mock_calls) == 1

--- a/tests/components/tts/test_voicerss.py
+++ b/tests/components/tts/test_voicerss.py
@@ -23,7 +23,7 @@ class TestTTSVoiceRSSPlatform(object):
         self.url_param = {
             'key': '1234567xx',
             'hl': 'en-us',
-            'c': 'mp3',
+            'c': 'MP3',
             'f': '8khz_8bit_mono',
         }
 
@@ -55,7 +55,8 @@ class TestTTSVoiceRSSPlatform(object):
             }
         }
 
-        assert not setup_component(self.hass, tts.DOMAIN, config)
+        with assert_setup_component(0, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
 
     def test_service_say(self, aioclient_mock):
         """Test service call say."""
@@ -116,7 +117,7 @@ class TestTTSVoiceRSSPlatform(object):
         """Test service call say with german code."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        self.url_param['hl'] = 'de'
+        self.url_param['hl'] = 'de-de'
         aioclient_mock.post(
             self.url, params=self.url_param, status=200, content=b'test')
 


### PR DESCRIPTION
**Description:**

Add support for free tts provider http://www.voicerss.org/.

- [x]  Add unittest

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1588

**Example entry for `configuration.yaml` (if applicable):**
```yaml
tts:
  platform: voicerss
  api_key: XXXXX
  # optional
  language: en-us
  codec: mp3
  format: 8khz_8bit_mono
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

