### PR TITLE
Tellduslive: initialize self._last_brightness

### DIFF
--- a/homeassistant/components/light/tellduslive.py
+++ b/homeassistant/components/light/tellduslive.py
@@ -26,9 +26,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class TelldusLiveLight(TelldusLiveEntity, Light):
     """Representation of a light."""
 
+    def __init__(self, hass, device_id):
+        """Initialize the light."""
+        super().__init__(hass, device_id)
+        self._last_brightness = self.brightness
+
     def changed(self):
         """A property of the device might have changed."""
-        # pylint: disable=attribute-defined-outside-init
         self._last_brightness = self.brightness
         super().changed()
 


### PR DESCRIPTION
**Description:**
Uninitialized variabled was used

**Related issue (if applicable):** fixes #4902

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

