### PR TITLE
[RFC] Inital MQTT discovery

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -1,0 +1,52 @@
+"""
+Support for MQTT discovery.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/mqtt/#discovery
+"""
+import json
+import logging
+
+import homeassistant.components.mqtt as mqtt
+from homeassistant.components.mqtt import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def start(hass, discovery_config):
+    """Initialization of MQTT Discovery."""
+    if discovery_config is None:
+        _LOGGER.warning("Can't setup MQTT discovery")
+        return False
+
+    def device_message_received(topic, payload, qos):
+        """Process the received message."""
+        parts = topic.split('/')
+        entity_id = '{}.{}_{}'.format(parts[1], DOMAIN, parts[2])
+
+        try:
+            data = json.loads(str(payload))
+        except ValueError:
+            _LOGGER.warning("Payload for %s is not valid JSON", entity_id)
+
+        try:
+            new_state = data.get('state')
+        except AttributeError:
+            pass
+
+        attributes = data.get('attributes')
+        force_update = data.get('force_update', False)
+        attributes['force_update'] = force_update
+        attributes['topic'] = topic
+        attributes['qos'] = qos
+
+        is_new_state = hass.states.get(entity_id) is None
+
+        hass.states.set(entity_id, new_state, attributes, force_update)
+
+        if is_new_state:
+            mqtt.publish(hass, '{}/{}'.format(topic, 'state'), qos)
+
+    mqtt.subscribe(hass, discovery_config, device_message_received, 0)
+
+    return True


### PR DESCRIPTION
**Description:**
MQTT Discovery will enable one to use MQTT devices with minimal Home Assistant configuration. The approach is similar to the REST API which is able to create entities after a [request](https://home-assistant.io/components/binary_sensor.http/) was made. 

I consider the current state as prototype for comments. It's still rough and will need some work work and tests.

```bash
$ mosquitto_pub -t test/binary_sensor/front_door -m '{"state": "off", "attributes": {"friendly_name": "Front door", "sensor_class": "opening"}}'

$ mosquitto_pub -t home-asistant/sensor/kitchen/temp -m '{"state": "26", "attributes": {"friendly_name": "Kitchen Temperature", "unit_of_measurement": "°C", "icon": "mdi:candycane"}}'
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
mqtt:
  discovery: "home-assistant/#"
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

