### PR TITLE
Setup DarkSky platform when offline during init

### DIFF
--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -110,6 +110,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         longitude=hass.config.longitude,
         units=units,
         interval=config.get(CONF_UPDATE_INTERVAL))
+    forecast_data.update()
+    forecast_data.update_currently()
+
+    # If connection failed don't setup platform.
+    if forecast_data.data is None:
+        return False
 
     name = config.get(CONF_NAME)
 

--- a/tests/components/sensor/test_darksky.py
+++ b/tests/components/sensor/test_darksky.py
@@ -17,6 +17,15 @@ from tests.common import load_fixture, get_test_home_assistant
 class TestDarkSkySetup(unittest.TestCase):
     """Test the Dark Sky platform."""
 
+    def add_entities(self, new_entities, update_before_add=False):
+        """Mock add entities."""
+        if update_before_add:
+            for entity in new_entities:
+                entity.update()
+
+        for entity in new_entities:
+            self.entities.append(entity)
+
     def setUp(self):
         """Initialize values for this testcase class."""
         self.hass = get_test_home_assistant()
@@ -30,6 +39,7 @@ class TestDarkSkySetup(unittest.TestCase):
         self.lon = -122.423
         self.hass.config.latitude = self.lat
         self.hass.config.longitude = self.lon
+        self.entities = []
 
     def test_setup_with_config(self):
         """Test the platform setup with configuration."""
@@ -63,6 +73,7 @@ class TestDarkSkySetup(unittest.TestCase):
                r'(-?\d+\.?\d*),(-?\d+\.?\d*)')
         mock_req.get(re.compile(uri),
                      text=load_fixture('darksky.json'))
-        darksky.setup_platform(self.hass, self.config, MagicMock())
+        darksky.setup_platform(self.hass, self.config, self.add_entities)
         self.assertTrue(mock_get_forecast.called)
         self.assertEqual(mock_get_forecast.call_count, 1)
+        self.assertEqual(len(self.entities), 2)


### PR DESCRIPTION
**Description:**
This changes the DarkSky platform so that it is initialized whether or not the initial connection was successful. The following two scenarios are improved:

* If the network is not ready when Home Assistant is started, the DarkSky platform is still setup and will start working once the connection is ready.
* With the current implementation, if the connection to DarkSky is lost after the platform was previously setup, `ValueError` exceptions were raised with each update. Now this produces a log error, and the sensor states are set to `None`. They display `unknown` on the frontend.