### PR TITLE
Add support for new netdisco detection of Samsung Smart TV.

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -37,6 +37,7 @@ SERVICE_HANDLERS = {
     'logitech_mediaserver': ('media_player', 'squeezebox'),
     'directv': ('media_player', 'directv'),
     'denonavr': ('media_player', 'denonavr'),
+    'samsung_tv': ('media_player', 'samsungtv'),
 }
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.samsungtv/
 """
 import logging
+import socket
 
 import voluptuous as vol
 
@@ -26,6 +27,8 @@ DEFAULT_NAME = 'Samsung TV Remote'
 DEFAULT_PORT = 55000
 DEFAULT_TIMEOUT = 0
 
+KNOWN_DEVICES_KEY = 'samsungtv_known_devices'
+
 SUPPORT_SAMSUNGTV = SUPPORT_PAUSE | SUPPORT_VOLUME_STEP | \
     SUPPORT_VOLUME_MUTE | SUPPORT_PREVIOUS_TRACK | \
     SUPPORT_NEXT_TRACK | SUPPORT_TURN_OFF
@@ -41,25 +44,42 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Samsung TV platform."""
-    name = config.get(CONF_NAME)
+    known_devices = hass.data.get(KNOWN_DEVICES_KEY)
+    if known_devices is None:
+        known_devices = set()
+        hass.data[KNOWN_DEVICES_KEY] = known_devices
 
-    # Generate a configuration for the Samsung library
-    remote_config = {
-        'name': 'HomeAssistant',
-        'description': config.get(CONF_NAME),
-        'id': 'ha.component.samsung',
-        'port': config.get(CONF_PORT),
-        'host': config.get(CONF_HOST),
-        'timeout': config.get(CONF_TIMEOUT),
-    }
+    # Is this a manual configuration?
+    if config.get(CONF_HOST) is not None:
+        host = config.get(CONF_HOST)
+        port = config.get(CONF_PORT)
+        name = config.get(CONF_NAME)
+        timeout = config.get(CONF_TIMEOUT)
+    elif discovery_info is not None:
+        tv_name, model, host = discovery_info
+        name = "{} ({})".format(tv_name, model)
+        port = DEFAULT_PORT
+        timeout = DEFAULT_TIMEOUT
+    else:
+        _LOGGER.warning(
+            'Internal error on samsungtv component. Cannot determine device')
+        return
 
-    add_devices([SamsungTVDevice(name, remote_config)])
+    # Only add a device once, so discovered devices do not override manual
+    # config.
+    ip_addr = socket.gethostbyname(host)
+    if ip_addr not in known_devices:
+        known_devices.add(ip_addr)
+        add_devices([SamsungTVDevice(host, port, name, timeout)])
+        _LOGGER.info("Samsung TV %s:%d added as '%s'", host, port, name)
+    else:
+        _LOGGER.info("Ignoring duplicate Samsung TV %s:%d", host, port)
 
 
 class SamsungTVDevice(MediaPlayerDevice):
     """Representation of a Samsung TV."""
 
-    def __init__(self, name, config):
+    def __init__(self, host, port, name, timeout):
         """Initialize the Samsung device."""
         from samsungctl import Remote
         # Save a reference to the imported class
@@ -71,7 +91,15 @@ class SamsungTVDevice(MediaPlayerDevice):
         self._playing = True
         self._state = STATE_UNKNOWN
         self._remote = None
-        self._config = config
+        # Generate a configuration for the Samsung library
+        self._config = {
+            'name': 'HomeAssistant',
+            'description': name,
+            'id': 'ha.component.samsung',
+            'port': port,
+            'host': host,
+            'timeout': timeout,
+        }
 
     def update(self):
         """Retrieve the latest data."""


### PR DESCRIPTION
**Description:**
Add support for new netdisco detection of Samsung Smart TV.


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

