### PR TITLE
kodi fanart fix (basic auth)

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -76,11 +76,17 @@ class KodiDevice(MediaPlayerDevice):
         import jsonrpc_requests
         self._name = name
         self._url = url
+        self._basic_auth_url = None
 
         kwargs = {'timeout': 5}
 
         if auth is not None:
             kwargs['auth'] = auth
+            scheme, netloc, path, query, fragment = urllib.parse.urlsplit(url)
+            self._basic_auth_url = \
+                urllib.parse.urlunsplit((scheme, '{}:{}@{}'.format
+                                         (auth[0], auth[1], netloc),
+                                         path, query, fragment))
 
         self._server = jsonrpc_requests.Server(
             '{}/jsonrpc'.format(self._url), **kwargs)
@@ -195,6 +201,11 @@ class KodiDevice(MediaPlayerDevice):
         url_components = urllib.parse.urlparse(self._item['thumbnail'])
 
         if url_components.scheme == 'image':
+            if self._basic_auth_url is not None:
+                return '{}/image/{}'.format(
+                    self._basic_auth_url,
+                    urllib.parse.quote_plus(self._item['thumbnail']))
+
             return '{}/image/{}'.format(
                 self._url,
                 urllib.parse.quote_plus(self._item['thumbnail']))


### PR DESCRIPTION
**Description:**
Was unable to retrieve the fanart when username and password was used.
Another url had to be used which included the username/password.

**Related issue (if applicable):** fixes #3383 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [n/a] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [n/a] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [n/a] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [n/a] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [n/a] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
