### PR TITLE
Protect add_job

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -184,6 +184,8 @@ class HomeAssistant(object):
         target: target to call.
         args: parameters for method to call.
         """
+        if target is None:
+            raise ValueError("Don't call add_job with None.")
         self.loop.call_soon_threadsafe(self.async_add_job, target, *args)
 
     @callback

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock
 from datetime import datetime, timedelta
 
 import pytz
+import pytest
 
 import homeassistant.core as ha
 from homeassistant.exceptions import InvalidEntityFormatError
@@ -213,6 +214,11 @@ class TestHomeAssistant(unittest.TestCase):
 
         assert len(self.hass._pending_tasks) == 0
         assert len(call_count) == 2
+
+    def test_add_job_with_none(self):
+        """Try to add a job with None as function."""
+        with pytest.raises(ValueError):
+            self.hass.add_job(None, 'test_arg')
 
 
 class TestEvent(unittest.TestCase):


### PR DESCRIPTION
**Description:**

Since 0.34 I see follow error in my logs.

```
16-12-15 16:10:53 homeassistant.core: Error doing job: Exception in callback HomeAssistant._async_add_job(None)
Traceback (most recent call last):
  File "/usr/lib/python3.4/asyncio/events.py", line 120, in _run
    self._callback(*self._args)
  File "/opt/hass/lib/python3.4/site-packages/homeassistant/core.py", line 200, in _async_add_job
    elif is_callback(target):
  File "/opt/hass/lib/python3.4/site-packages/homeassistant/core.py", line 85, in is_callback
    return '_hass_callback' in func.__dict__
AttributeError: 'NoneType' object has no attribute '__dict__'
```

Since we use `loop.call_soon_threadsafe` we can not see who is calling add_job with `None`. I add a check for raise a error inside origin context to find component which use `add_job` in wrong way.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

