### PR TITLE
Bugfix asyncio wait

### DIFF
--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -95,7 +95,8 @@ def async_setup(hass, config):
             attr = 'async_toggle'
 
         tasks = [getattr(input_b, attr)() for input_b in target_inputs]
-        yield from asyncio.wait(tasks, loop=hass.loop)
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
 
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_OFF, async_handler_service, schema=SERVICE_SCHEMA)

--- a/homeassistant/components/input_select.py
+++ b/homeassistant/components/input_select.py
@@ -113,7 +113,8 @@ def async_setup(hass, config):
 
         tasks = [input_select.async_select_option(call.data[ATTR_OPTION])
                  for input_select in target_inputs]
-        yield from asyncio.wait(tasks, loop=hass.loop)
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SELECT_OPTION, async_select_option_service,
@@ -126,7 +127,8 @@ def async_setup(hass, config):
 
         tasks = [input_select.async_offset_index(1)
                  for input_select in target_inputs]
-        yield from asyncio.wait(tasks, loop=hass.loop)
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SELECT_NEXT, async_select_next_service,
@@ -139,7 +141,8 @@ def async_setup(hass, config):
 
         tasks = [input_select.async_offset_index(-1)
                  for input_select in target_inputs]
-        yield from asyncio.wait(tasks, loop=hass.loop)
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SELECT_PREVIOUS, async_select_previous_service,

--- a/homeassistant/components/input_slider.py
+++ b/homeassistant/components/input_slider.py
@@ -105,7 +105,8 @@ def async_setup(hass, config):
 
         tasks = [input_slider.async_select_value(call.data[ATTR_VALUE])
                  for input_slider in target_inputs]
-        yield from asyncio.wait(tasks, loop=hass.loop)
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SELECT_VALUE, async_select_value_service,


### PR DESCRIPTION
**Description:**

Fix `asyncio.wait` don't support empty list.


**Related issue (if applicable):** fixes #4943 

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

