### PR TITLE
Fixing issue #4899 (nfandroidtv default color)

### DIFF
--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -77,7 +77,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.In(TRANSPARENCIES.keys()),
     vol.Optional(CONF_COLOR, default=DEFAULT_COLOR):
         vol.In(COLORS.keys()),
-    vol.Optional(CONF_COLOR, default=DEFAULT_COLOR): cv.string,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.Coerce(int),
     vol.Optional(CONF_INTERRUPT, default=DEFAULT_INTERRUPT): cv.boolean,
 })


### PR DESCRIPTION
**Description:**
The default color which can be set in the configuration wan't used. This PR fixes the problem.

**Related issue (if applicable):** fixes #4899

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

