### PR TITLE
Update kodi for async and local push via websocket

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -718,8 +718,7 @@ class MediaPlayerDevice(Entity):
 
     def async_volume_up(self):
         """Turn volume up for media player."""
-        if self.volume_level < 1:
-            return self.async_set_volume_level(min(1, self.volume_level + .1))
+        return self.async_set_volume_level(min(1, self.volume_level + .1))
 
     def volume_down(self):
         """Turn volume down for media player."""
@@ -728,8 +727,7 @@ class MediaPlayerDevice(Entity):
 
     def async_volume_down(self):
         """Turn volume down for media player."""
-        if self.volume_level > 0:
-            return self.async_set_volume_level(max(0, self.volume_level - .1))
+        return self.async_set_volume_level(max(0, self.volume_level - .1))
 
     def media_play_pause(self):
         """Play or pause the media player."""

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -215,7 +215,7 @@ class KodiEntity(MediaPlayerDevice):
             data = json.loads(msg)
             if data[ATTR_METHOD] in EXIT_NOTIFICATIONS:
                 self._players = None
-                yield from self.async_update_ha_state()
+                self.hass.async_add_job(self.async_update_ha_state())
                 continue
 
             if data[ATTR_METHOD] in APPLICATION_NOTIFICATIONS:
@@ -240,7 +240,8 @@ class KodiEntity(MediaPlayerDevice):
                     if (data[ATTR_PARAMS]['data']['player']['playerid']
                             is not None):
                         # Media just started playing. Full update required
-                        yield from self.async_update_ha_state(True)
+                        self.hass.async_add_job(
+                            self.async_update_ha_state(True))
                 except KeyError:
                     pass
                 continue
@@ -249,7 +250,7 @@ class KodiEntity(MediaPlayerDevice):
                 self._players = []
                 self._properties = None
                 self._item = None
-                yield from self.async_update_ha_state()
+                self.hass.async_add_job(self.async_update_ha_state())
                 continue
 
             try:
@@ -267,13 +268,13 @@ class KodiEntity(MediaPlayerDevice):
             try:
                 if data[ATTR_PARAMS]['data']['item']['id'] != self._item['id']:
                     # New item is playing. Perform full update.
-                    yield from self.async_update_ha_state(True)
+                    self.hass.async_add_job(self.async_update_ha_state(True))
                     continue
             except KeyError:
                 pass
 
             # Update HA with changed state
-            yield from self.async_update_ha_state()
+            self.hass.async_add_job(self.async_update_ha_state())
 
         # Exiting websocket loop
         try:

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -4,9 +4,13 @@ Support for interfacing with the XBMC/Kodi JSON-RPC API.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.kodi/
 """
+import asyncio
+import json
 import logging
 import urllib
+import uuid
 
+import aiohttp
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
@@ -15,19 +19,48 @@ from homeassistant.components.media_player import (
     SUPPORT_TURN_OFF, MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING, CONF_HOST, CONF_NAME,
-    CONF_PORT, CONF_USERNAME, CONF_PASSWORD)
+    CONF_PORT, CONF_USERNAME, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['jsonrpc-requests==0.3']
+REQUIREMENTS = ['websockets==3.2']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_WEBSOCKET_PORT = 'websocket_port'
 CONF_TURN_OFF_ACTION = 'turn_off_action'
 
 DEFAULT_NAME = 'Kodi'
 DEFAULT_PORT = 8080
+DEFAULT_WEBSOCKET_PORT = 9090
 
 TURN_OFF_ACTION = [None, 'quit', 'hibernate', 'suspend', 'reboot', 'shutdown']
+
+APPLICATION_NOTIFICATIONS = (
+    'Application.OnVolumeChanged',
+)
+
+PLAYER_NOTIFICATIONS = (
+    'Player.OnPause',
+    'Player.OnPlay',
+    'Player.OnPropertyChanged',
+    'Player.OnSeek',
+    'Player.OnSpeedChanged',
+    'Player.OnStop',
+)
+
+EXIT_NOTIFICATIONS = (
+    'System.OnQuit',
+    'System.OnRestart',
+    'System.OnSleep',
+)
+
+JSON_HEADERS = {'content-type': 'application/json'}
+JSONRPC_VERSION = '2.0'
+
+ATTR_JSONRPC = 'jsonrpc'
+ATTR_METHOD = 'method'
+ATTR_PARAMS = 'params'
+ATTR_ID = 'id'
 
 SUPPORT_KODI = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
     SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK | SUPPORT_SEEK | \
@@ -37,82 +70,205 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_WEBSOCKET_PORT, default=DEFAULT_WEBSOCKET_PORT): cv.port,
     vol.Optional(CONF_TURN_OFF_ACTION, default=None): vol.In(TURN_OFF_ACTION),
     vol.Inclusive(CONF_USERNAME, 'auth'): cv.string,
     vol.Inclusive(CONF_PASSWORD, 'auth'): cv.string,
 })
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_entities,
+                         discovery_info=None):
     """Setup the Kodi platform."""
-    url = '{}:{}'.format(config.get(CONF_HOST), config.get(CONF_PORT))
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    websocket_port = config.get(CONF_WEBSOCKET_PORT)
 
-    jsonrpc_url = config.get('url')  # deprecated
-    if jsonrpc_url:
-        url = jsonrpc_url.rstrip('/jsonrpc')
+    if host.startswith('http://') or host.startswith('https://'):
+        host = host.lstrip('http://').lstrip('https://')
+        _LOGGER.warning(
+            "Kodi host name should no longer conatin http:// See updated "
+            "definitions here: "
+            "https://home-assistant.io/components/media_player.kodi/")
 
-    username = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
+    entity = KodiEntity(
+        hass,
+        name=config.get(CONF_NAME),
+        host=host, port=port, websocket_port=websocket_port,
+        username=config.get(CONF_USERNAME),
+        password=config.get(CONF_PASSWORD),
+        turn_off_action=config.get(CONF_TURN_OFF_ACTION))
 
-    if username is not None:
-        auth = (username, password)
-    else:
-        auth = None
-
-    add_devices([
-        KodiDevice(
-            config.get(CONF_NAME),
-            url,
-            auth=auth,
-            turn_off_action=config.get(CONF_TURN_OFF_ACTION)),
-    ])
+    yield from async_add_entities([entity], update_before_add=True)
 
 
-class KodiDevice(MediaPlayerDevice):
+class KodiEntity(MediaPlayerDevice):
     """Representation of a XBMC/Kodi device."""
 
-    def __init__(self, name, url, auth=None, turn_off_action=None):
+    def __init__(self, hass, name, host, port, websocket_port, username=None,
+                 password=None, turn_off_action=None):
         """Initialize the Kodi device."""
-        import jsonrpc_requests
+        self.hass = hass
         self._name = name
-        self._url = url
-        self._basic_auth_url = None
-
-        kwargs = {'timeout': 5}
-
-        if auth is not None:
-            kwargs['auth'] = auth
-            scheme, netloc, path, query, fragment = urllib.parse.urlsplit(url)
-            self._basic_auth_url = \
-                urllib.parse.urlunsplit((scheme, '{}:{}@{}'.format
-                                         (auth[0], auth[1], netloc),
-                                         path, query, fragment))
-
-        self._server = jsonrpc_requests.Server(
-            '{}/jsonrpc'.format(self._url), **kwargs)
-
         self._turn_off_action = turn_off_action
+
+        if username:
+            auth = aiohttp.BasicAuth(username, password)
+            image_auth_string = "{}:{}@".format(username, password)
+        else:
+            auth = None
+            image_auth_string = ""
+
+        self._http_url = 'http://{}:{}/jsonrpc'.format(host, port)
+        self._image_url = 'http://{}{}:{}/image'.format(
+            image_auth_string, host, port)
+        self._ws_url = 'ws://{}:{}/jsonrpc'.format(host, websocket_port)
+
+        self._session = aiohttp.ClientSession(
+            auth=auth, headers=JSON_HEADERS, loop=hass.loop)
+        hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_STOP, self._close_session)
+        self._websocket = None
+
         self._players = list()
         self._properties = None
         self._item = None
         self._app_properties = None
-        self.update()
+
+    @asyncio.coroutine
+    def _close_session(self, event):
+        yield from self._session.close()
+        if self._websocket:
+            yield from self._websocket.close()
 
     @property
     def name(self):
         """Return the name of the device."""
         return self._name
 
-    def _get_players(self):
-        """Return the active player objects or None."""
-        import jsonrpc_requests
+    @asyncio.coroutine
+    def async_json_request(self, method, *args):
+        """Request json information from Kodi.
+
+        Returns None if connection failed.
+        """
+        data = {
+            ATTR_JSONRPC: JSONRPC_VERSION,
+            ATTR_METHOD: method,
+            ATTR_ID: str(uuid.uuid4()),
+        }
+        if len(args) > 0:
+            data[ATTR_PARAMS] = args
+
+        response = None
         try:
-            return self._server.Player.GetActivePlayers()
-        except jsonrpc_requests.jsonrpc.TransportError:
-            if self._players is not None:
-                _LOGGER.warning('Unable to fetch kodi data')
-                _LOGGER.debug('Unable to fetch kodi data', exc_info=True)
+            response = yield from self._session.post(
+                self._http_url, data=json.dumps(data), timeout=5)
+
+            if response.status == 401:
+                _LOGGER.error(
+                    "Error fetching Kodi data. HTTP %d Unauthorized. "
+                    "Password is incorrect.", response.status)
+                return None
+            if response.status != 200:
+                _LOGGER.error(
+                    "Error fetching Kodi data. HTTP %d", response.status)
+                return None
+
+            response_json = yield from response.json()
+            if 'error' in response_json:
+                _LOGGER.error(
+                    "RPC Error Code %d: %s",
+                    response_json['error']['code'],
+                    response_json['error']['message'])
+                return None
+            return response_json['result']
+        except (aiohttp.errors.ClientOSError,
+                aiohttp.errors.ClientTimeoutError,
+                ConnectionRefusedError):
             return None
+        finally:
+            if response:
+                response.close()
+
+    @asyncio.coroutine
+    def async_websocket_loop(self):
+        """Check websocket for push events from Kodi."""
+        import websockets
+
+        while True:
+            try:
+                msg = yield from self._websocket.recv()
+            except websockets.exceptions.ConnectionClosed:
+                break
+
+            data = json.loads(msg)
+            if data[ATTR_METHOD] in EXIT_NOTIFICATIONS:
+                self._players = None
+                yield from self.async_update_ha_state()
+                continue
+
+            if data[ATTR_METHOD] in APPLICATION_NOTIFICATIONS:
+                if self._app_properties is None:
+                    continue
+                try:
+                    self._app_properties['volume'] = \
+                        data[ATTR_PARAMS]['data']['volume']
+                except KeyError:
+                    pass
+                try:
+                    self._app_properties['muted'] = \
+                        data[ATTR_PARAMS]['data']['muted']
+                except KeyError:
+                    pass
+
+            if data[ATTR_METHOD] not in PLAYER_NOTIFICATIONS:
+                continue
+
+            if self._players is None or len(self._players) == 0:
+                try:
+                    if (data[ATTR_PARAMS]['data']['player']['playerid']
+                            is not None):
+                        # Media just started playing. Full update required
+                        yield from self.async_update_ha_state(True)
+                except KeyError:
+                    pass
+                continue
+
+            if data[ATTR_METHOD] == "Player.OnStop":
+                self._players = []
+                self._properties = None
+                self._item = None
+                yield from self.async_update_ha_state()
+                continue
+
+            try:
+                self._properties['speed'] = \
+                    data[ATTR_PARAMS]['data']['player']['speed']
+            except KeyError:
+                pass
+
+            try:
+                self._properties['time'] = \
+                    data[ATTR_PARAMS]['data']['player']['time']
+            except KeyError:
+                pass
+
+            try:
+                if data[ATTR_PARAMS]['data']['item']['id'] != self._item['id']:
+                    # New item is playing. Perform full update.
+                    yield from self.async_update_ha_state(True)
+                    continue
+            except KeyError:
+                pass
+
+            # Update HA with changed state
+            yield from self.async_update_ha_state()
+
+        # Exiting websocket loop
+        yield from self._websocket.close()
+        self._websocket = None
 
     @property
     def state(self):
@@ -128,32 +284,49 @@ class KodiDevice(MediaPlayerDevice):
         else:
             return STATE_PLAYING
 
-    def update(self):
+    @asyncio.coroutine
+    def async_update(self):
         """Retrieve latest state."""
-        self._players = self._get_players()
+        import websockets
 
-        if self._players is not None and len(self._players) > 0:
+        self._app_properties = (yield from self.async_json_request(
+            "Application.GetProperties",
+            ['volume', 'muted']
+        ))
+
+        self._players = yield from self.async_json_request(
+            "Player.GetActivePlayers")
+
+        if self._players is None:
+            return
+
+        if len(self._players) == 0:
+            self._properties = None
+            self._item = None
+        else:
             player_id = self._players[0]['playerid']
 
             assert isinstance(player_id, int)
 
-            self._properties = self._server.Player.GetProperties(
-                player_id,
+            self._properties = (yield from self.async_json_request(
+                "Player.GetProperties", player_id,
                 ['time', 'totaltime', 'speed', 'live']
-            )
+            ))
 
-            self._item = self._server.Player.GetItem(
-                player_id,
+            self._item = (yield from self.async_json_request(
+                "Player.GetItem", player_id,
                 ['title', 'file', 'uniqueid', 'thumbnail', 'artist']
-            )['item']
+            ))['item']
 
-            self._app_properties = self._server.Application.GetProperties(
-                ['volume', 'muted']
-            )
-        else:
-            self._properties = None
-            self._item = None
-            self._app_properties = None
+        if self._websocket:
+            return
+
+        try:
+            self._websocket = yield from websockets.connect(
+                self._ws_url)
+            self.hass.loop.create_task(self.async_websocket_loop())
+        except ConnectionRefusedError:
+            self._websocket = None
 
     @property
     def volume_level(self):
@@ -201,13 +374,8 @@ class KodiDevice(MediaPlayerDevice):
         url_components = urllib.parse.urlparse(self._item['thumbnail'])
 
         if url_components.scheme == 'image':
-            if self._basic_auth_url is not None:
-                return '{}/image/{}'.format(
-                    self._basic_auth_url,
-                    urllib.parse.quote_plus(self._item['thumbnail']))
-
-            return '{}/image/{}'.format(
-                self._url,
+            return '{}/{}'.format(
+                self._image_url,
                 urllib.parse.quote_plus(self._item['thumbnail']))
 
     @property
@@ -229,94 +397,107 @@ class KodiDevice(MediaPlayerDevice):
 
         return supported_media_commands
 
-    def turn_off(self):
+    @asyncio.coroutine
+    def async_turn_off(self):
         """Execute turn_off_action to turn off media player."""
         if self._turn_off_action == 'quit':
-            self._server.Application.Quit()
+            yield from self.async_json_request('Application.Quit')
         elif self._turn_off_action == 'hibernate':
-            self._server.System.Hibernate()
+            yield from self.async_json_request('System.Hibernate')
         elif self._turn_off_action == 'suspend':
-            self._server.System.Suspend()
+            yield from self.async_json_request('System.Suspend')
         elif self._turn_off_action == 'reboot':
-            self._server.System.Reboot()
+            yield from self.async_json_request('System.Reboot')
         elif self._turn_off_action == 'shutdown':
-            self._server.System.Shutdown()
+            yield from self.async_json_request('System.Shutdown')
         else:
             _LOGGER.warning('turn_off requested but turn_off_action is none')
 
-        self.update_ha_state()
-
-    def volume_up(self):
+    @asyncio.coroutine
+    def async_volume_up(self):
         """Volume up the media player."""
-        assert self._server.Input.ExecuteAction('volumeup') == 'OK'
-        self.update_ha_state()
+        yield from self.async_json_request(
+            'Input.ExecuteAction', 'volumeup')
 
-    def volume_down(self):
+    @asyncio.coroutine
+    def async_volume_down(self):
         """Volume down the media player."""
-        assert self._server.Input.ExecuteAction('volumedown') == 'OK'
-        self.update_ha_state()
+        yield from self.async_json_request(
+            'Input.ExecuteAction', 'volumedown')
 
-    def set_volume_level(self, volume):
+    @asyncio.coroutine
+    def async_set_volume_level(self, volume):
         """Set volume level, range 0..1."""
-        self._server.Application.SetVolume(int(volume * 100))
-        self.update_ha_state()
+        yield from self.async_json_request(
+            'Application.SetVolume', int(volume * 100))
 
-    def mute_volume(self, mute):
+    @asyncio.coroutine
+    def async_mute_volume(self, mute):
         """Mute (true) or unmute (false) media player."""
-        self._server.Application.SetMute(mute)
-        self.update_ha_state()
+        yield from self.async_json_request(
+            'Application.SetMute', mute)
 
+    @asyncio.coroutine
     def _set_play_state(self, state):
         """Helper method for play/pause/toggle."""
-        players = self._get_players()
+        players = yield from self.async_json_request(
+            "Player.GetActivePlayers")
 
         if len(players) != 0:
-            self._server.Player.PlayPause(players[0]['playerid'], state)
+            yield from self.async_json_request(
+                'Player.PlayPause', players[0]['playerid'], state)
 
-        self.update_ha_state()
-
-    def media_play_pause(self):
+    def async_media_play_pause(self):
         """Pause media on media player."""
-        self._set_play_state('toggle')
+        return self._set_play_state('toggle')
 
-    def media_play(self):
+    def async_media_play(self):
         """Play media."""
-        self._set_play_state(True)
+        return self._set_play_state(True)
 
-    def media_pause(self):
+    def async_media_pause(self):
         """Pause the media player."""
-        self._set_play_state(False)
+        return self._set_play_state(False)
 
-    def media_stop(self):
+    @asyncio.coroutine
+    def async_media_stop(self):
         """Stop the media player."""
-        players = self._get_players()
+        players = yield from self.async_json_request(
+            "Player.GetActivePlayers")
 
         if len(players) != 0:
-            self._server.Player.Stop(players[0]['playerid'])
+            yield from self.async_json_request(
+                'Player.Stop', players[0]['playerid'])
 
+    @asyncio.coroutine
     def _goto(self, direction):
         """Helper method used for previous/next track."""
-        players = self._get_players()
+        players = yield from self.async_json_request(
+            "Player.GetActivePlayers")
 
         if len(players) != 0:
-            self._server.Player.GoTo(players[0]['playerid'], direction)
+            if direction == 'previous':
+                # first seek to position 0. Kodi goes to the beginning of the
+                # current track if the current track is not at the beginning.
+                yield from self.async_json_request(
+                    'Player.Seek', players[0]['playerid'], 0)
 
-        self.update_ha_state()
+            yield from self.async_json_request(
+                'Player.GoTo', players[0]['playerid'], direction)
 
-    def media_next_track(self):
+    def async_media_next_track(self):
         """Send next track command."""
-        self._goto('next')
+        return self._goto('next')
 
-    def media_previous_track(self):
+    def async_media_previous_track(self):
         """Send next track command."""
-        # first seek to position 0, Kodi seems to go to the beginning
-        # of the current track current track is not at the beginning
-        self.media_seek(0)
-        self._goto('previous')
+        return self._goto('previous')
 
-    def media_seek(self, position):
+    @asyncio.coroutine
+    def async_media_seek(self, position):
         """Send seek command."""
-        players = self._get_players()
+        players = yield from self.async_json_request(
+            "Player.GetActivePlayers")
 
         time = {}
 
@@ -332,13 +513,15 @@ class KodiDevice(MediaPlayerDevice):
         time['hours'] = int(position)
 
         if len(players) != 0:
-            self._server.Player.Seek(players[0]['playerid'], time)
+            yield from self.async_json_request(
+                'Player.Seek', players[0]['playerid'], time)
 
-        self.update_ha_state()
-
-    def play_media(self, media_type, media_id, **kwargs):
+    @asyncio.coroutine
+    def async_play_media(self, media_type, media_id, **kwargs):
         """Send the play_media command to the media player."""
         if media_type == "CHANNEL":
-            self._server.Player.Open({"item": {"channelid": int(media_id)}})
+            yield from self.async_json_request(
+                'Player.Open', {"item": {"channelid": int(media_id)}})
         else:
-            self._server.Player.Open({"item": {"file": str(media_id)}})
+            yield from self.async_json_request(
+                'Player.Open', {"item": {"file": str(media_id)}})

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -610,6 +610,9 @@ wakeonlan==0.2.2
 # homeassistant.components.media_player.gpmdp
 websocket-client==0.37.0
 
+# homeassistant.components.media_player.kodi
+websockets==3.2
+
 # homeassistant.components.zigbee
 xbee-helper==0.0.7
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -610,9 +610,6 @@ wakeonlan==0.2.2
 # homeassistant.components.media_player.gpmdp
 websocket-client==0.37.0
 
-# homeassistant.components.media_player.kodi
-websockets==3.2
-
 # homeassistant.components.zigbee
 xbee-helper==0.0.7
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -270,7 +270,6 @@ influxdb==3.0.0
 # homeassistant.components.insteon_hub
 insteon_hub==0.4.5
 
-# homeassistant.components.media_player.kodi
 # homeassistant.components.notify.kodi
 jsonrpc-requests==0.3
 
@@ -610,6 +609,9 @@ wakeonlan==0.2.2
 
 # homeassistant.components.media_player.gpmdp
 websocket-client==0.37.0
+
+# homeassistant.components.media_player.kodi
+websockets==3.2
 
 # homeassistant.components.zigbee
 xbee-helper==0.0.7

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -52,6 +52,27 @@ class TestDemoMediaPlayer(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         assert 'xbox' == state.attributes.get('source')
 
+    @asyncio.coroutine
+    def test_async_source_select(self):
+        """Test the input source service."""
+        entity_id = 'media_player.lounge_room'
+
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
+        state = self.hass.states.get(entity_id)
+        assert 'dvd' == state.attributes.get('source')
+
+        yield from mp.async_select_source(self.hass, None, entity_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(entity_id)
+        assert 'dvd' == state.attributes.get('source')
+
+        yield from mp.async_select_source(self.hass, 'xbox', entity_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(entity_id)
+        assert 'xbox' == state.attributes.get('source')
+
     def test_clear_playlist(self):
         """Test clear playlist."""
         assert setup_component(
@@ -63,13 +84,24 @@ class TestDemoMediaPlayer(unittest.TestCase):
         self.hass.block_till_done()
         assert self.hass.states.is_state(entity_id, 'off')
 
+    @asyncio.coroutine
+    def test_async_clear_playlist(self):
+        """Test clear playlist."""
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
+        assert self.hass.states.is_state(entity_id, 'playing')
+
+        yield from mp.async_clear_playlist(self.hass, entity_id)
+        self.hass.block_till_done()
+        assert self.hass.states.is_state(entity_id, 'off')
+
     def test_volume_services(self):
         """Test the volume service."""
         assert setup_component(
             self.hass, mp.DOMAIN,
             {'media_player': {'platform': 'demo'}})
         state = self.hass.states.get(entity_id)
-        print(state)
         assert 1.0 == state.attributes.get('volume_level')
 
         mp.set_volume_level(self.hass, None, entity_id)
@@ -104,6 +136,47 @@ class TestDemoMediaPlayer(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         assert True is state.attributes.get('is_volume_muted')
 
+    @asyncio.coroutine
+    def test_async_volume_services(self):
+        """Test the volume service."""
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
+        state = self.hass.states.get(entity_id)
+        assert 1.0 == state.attributes.get('volume_level')
+
+        yield from mp.async_set_volume_level(self.hass, None, entity_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(entity_id)
+        assert 1.0 == state.attributes.get('volume_level')
+
+        yield from mp.async_set_volume_level(self.hass, 0.5, entity_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(entity_id)
+        assert 0.5 == state.attributes.get('volume_level')
+
+        yield from mp.async_volume_down(self.hass, entity_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(entity_id)
+        assert 0.4 == state.attributes.get('volume_level')
+
+        yield from mp.async_volume_up(self.hass, entity_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(entity_id)
+        assert 0.5 == state.attributes.get('volume_level')
+
+        assert False is state.attributes.get('is_volume_muted')
+
+        yield from mp.async_mute_volume(self.hass, None, entity_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(entity_id)
+        assert False is state.attributes.get('is_volume_muted')
+
+        yield from mp.async_mute_volume(self.hass, True, entity_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(entity_id)
+        assert True is state.attributes.get('is_volume_muted')
+
     def test_turning_off_and_on(self):
         """Test turn_on and turn_off."""
         assert setup_component(
@@ -121,6 +194,28 @@ class TestDemoMediaPlayer(unittest.TestCase):
         assert self.hass.states.is_state(entity_id, 'playing')
 
         mp.toggle(self.hass, entity_id)
+        self.hass.block_till_done()
+        assert self.hass.states.is_state(entity_id, 'off')
+        assert not mp.is_on(self.hass, entity_id)
+
+    @asyncio.coroutine
+    def test_async_turning_off_and_on(self):
+        """Test turn_on and turn_off."""
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
+        assert self.hass.states.is_state(entity_id, 'playing')
+
+        yield from mp.async_turn_off(self.hass, entity_id)
+        self.hass.block_till_done()
+        assert self.hass.states.is_state(entity_id, 'off')
+        assert not mp.is_on(self.hass, entity_id)
+
+        yield from mp.async_turn_on(self.hass, entity_id)
+        self.hass.block_till_done()
+        assert self.hass.states.is_state(entity_id, 'playing')
+
+        yield from mp.async_toggle(self.hass, entity_id)
         self.hass.block_till_done()
         assert self.hass.states.is_state(entity_id, 'off')
         assert not mp.is_on(self.hass, entity_id)
@@ -145,6 +240,30 @@ class TestDemoMediaPlayer(unittest.TestCase):
         assert self.hass.states.is_state(entity_id, 'paused')
 
         mp.media_play(self.hass, entity_id)
+        self.hass.block_till_done()
+        assert self.hass.states.is_state(entity_id, 'playing')
+
+    @asyncio.coroutine
+    def test_async_playing_pausing(self):
+        """Test media_pause."""
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
+        assert self.hass.states.is_state(entity_id, 'playing')
+
+        yield from mp.async_media_pause(self.hass, entity_id)
+        self.hass.block_till_done()
+        assert self.hass.states.is_state(entity_id, 'paused')
+
+        yield from mp.async_media_play_pause(self.hass, entity_id)
+        self.hass.block_till_done()
+        assert self.hass.states.is_state(entity_id, 'playing')
+
+        yield from mp.async_media_play_pause(self.hass, entity_id)
+        self.hass.block_till_done()
+        assert self.hass.states.is_state(entity_id, 'paused')
+
+        yield from mp.async_media_play(self.hass, entity_id)
         self.hass.block_till_done()
         assert self.hass.states.is_state(entity_id, 'playing')
 
@@ -202,6 +321,61 @@ class TestDemoMediaPlayer(unittest.TestCase):
         assert 0 == (mp.SUPPORT_PREVIOUS_TRACK &
                      state.attributes.get('supported_media_commands'))
 
+    @asyncio.coroutine
+    def test_async_prev_next_track(self):
+        """Test media_next_track and media_previous_track ."""
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
+        state = self.hass.states.get(entity_id)
+        assert 1 == state.attributes.get('media_track')
+        assert 0 == (mp.SUPPORT_PREVIOUS_TRACK &
+                     state.attributes.get('supported_media_commands'))
+
+        yield from mp.async_media_next_track(self.hass, entity_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(entity_id)
+        assert 2 == state.attributes.get('media_track')
+        assert 0 < (mp.SUPPORT_PREVIOUS_TRACK &
+                    state.attributes.get('supported_media_commands'))
+
+        yield from mp.async_media_next_track(self.hass, entity_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(entity_id)
+        assert 3 == state.attributes.get('media_track')
+        assert 0 < (mp.SUPPORT_PREVIOUS_TRACK &
+                    state.attributes.get('supported_media_commands'))
+
+        yield from mp.async_media_previous_track(self.hass, entity_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(entity_id)
+        assert 2 == state.attributes.get('media_track')
+        assert 0 < (mp.SUPPORT_PREVIOUS_TRACK &
+                    state.attributes.get('supported_media_commands'))
+
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
+        ent_id = 'media_player.lounge_room'
+        state = self.hass.states.get(ent_id)
+        assert 1 == state.attributes.get('media_episode')
+        assert 0 == (mp.SUPPORT_PREVIOUS_TRACK &
+                     state.attributes.get('supported_media_commands'))
+
+        yield from mp.async_media_next_track(self.hass, ent_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ent_id)
+        assert 2 == state.attributes.get('media_episode')
+        assert 0 < (mp.SUPPORT_PREVIOUS_TRACK &
+                    state.attributes.get('supported_media_commands'))
+
+        yield from mp.async_media_previous_track(self.hass, ent_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ent_id)
+        assert 1 == state.attributes.get('media_episode')
+        assert 0 == (mp.SUPPORT_PREVIOUS_TRACK &
+                     state.attributes.get('supported_media_commands'))
+
     @patch('homeassistant.components.media_player.demo.DemoYoutubePlayer.'
            'media_seek', autospec=True)
     def test_play_media(self, mock_seek):
@@ -234,6 +408,42 @@ class TestDemoMediaPlayer(unittest.TestCase):
         self.hass.block_till_done()
         assert not mock_seek.called
         mp.media_seek(self.hass, 100, ent_id)
+        self.hass.block_till_done()
+        assert mock_seek.called
+
+    @patch('homeassistant.components.media_player.demo.DemoYoutubePlayer.'
+           'async_media_seek', autospec=True)
+    @asyncio.coroutine
+    def test_async_play_media(self, mock_seek):
+        """Test play_media ."""
+        assert setup_component(
+            self.hass, mp.DOMAIN,
+            {'media_player': {'platform': 'demo'}})
+        ent_id = 'media_player.living_room'
+        state = self.hass.states.get(ent_id)
+        assert 0 < (mp.SUPPORT_PLAY_MEDIA &
+                    state.attributes.get('supported_media_commands'))
+        assert state.attributes.get('media_content_id') is not None
+
+        yield from mp.async_play_media(self.hass, None, 'some_id', ent_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ent_id)
+        assert 0 < (mp.SUPPORT_PLAY_MEDIA &
+                    state.attributes.get('supported_media_commands'))
+        assert not 'some_id' == state.attributes.get('media_content_id')
+
+        yield from mp.async_play_media(self.hass, 'youtube', 'some_id', ent_id)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ent_id)
+        assert 0 < (mp.SUPPORT_PLAY_MEDIA &
+                    state.attributes.get('supported_media_commands'))
+        assert 'some_id' == state.attributes.get('media_content_id')
+
+        assert not mock_seek.called
+        yield from mp.async_media_seek(self.hass, None, ent_id)
+        self.hass.block_till_done()
+        assert not mock_seek.called
+        yield from mp.async_media_seek(self.hass, 100, ent_id)
         self.hass.block_till_done()
         assert mock_seek.called
 

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -203,7 +203,7 @@ class TestDemoMediaPlayer(unittest.TestCase):
                      state.attributes.get('supported_media_commands'))
 
     @patch('homeassistant.components.media_player.demo.DemoYoutubePlayer.'
-           'media_seek')
+           'media_seek', autospec=True)
     def test_play_media(self, mock_seek):
         """Test play_media ."""
         assert setup_component(


### PR DESCRIPTION
**Description:**
This PR converts Kodi to async. Included is an async interface to the Kodi websockets API, which allows push notifications of state changes from Kodi to Home Assistant.

I wasn't able to find a Python asyncio JSON-RPC library that also supports Python 3.4, so JSON-RPC methods are included here. If there is a library I can switch to it, or this functionality can be moved to a helper object if we expect to reuse it.

This change requires that 'http://' be removed from user configurations. This brings Kodi in line with other platform configurations. Code is included to strip it where found and issue a log warning.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
media_player:
  - platform: kodi
    host: 192.168.0.123
    tcp_port: 9090
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in home-assistant/home-assistant.github.io#1624

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
