### PR TITLE
Upgrade python-telegram-bot to 5.3.0

### DIFF
--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['python-telegram-bot==5.2.0']
+REQUIREMENTS = ['python-telegram-bot==5.3.0']
 
 ATTR_PHOTO = 'photo'
 ATTR_DOCUMENT = 'document'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -482,7 +482,7 @@ python-pushover==0.2
 python-synology==0.1.0
 
 # homeassistant.components.notify.telegram
-python-telegram-bot==5.2.0
+python-telegram-bot==5.3.0
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.3.0


### PR DESCRIPTION
## 5.3.0
- Implement API changes of November 21st (Bot API 2.3)
- ``JobQueue`` now supports ``datetime.timedelta`` in addition to seconds
- ``JobQueue`` now supports running jobs only on certain days
- New ``Filters.reply`` filter
- Bugfix for ``Message.edit_reply_markup``
- Other bugfixes

Tested with the following configuration:

``` yaml
notify:
  - platform: telegram
    name: telegram
    api_key: !secret telegram_api
    chat_id: !secret telegram_client
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```
