### PR TITLE
Upgrade astral to 1.3.3

### DIFF
--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -17,8 +17,7 @@ from homeassistant.util import dt as dt_util
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util as util
 
-
-REQUIREMENTS = ['astral==1.3.2']
+REQUIREMENTS = ['astral==1.3.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -43,7 +43,7 @@ apcaccess==0.0.4
 apns2==0.1.1
 
 # homeassistant.components.sun
-astral==1.3.2
+astral==1.3.3
 
 # homeassistant.components.sensor.linux_battery
 batinfo==0.4.2


### PR DESCRIPTION
1.3.3
----
- Fixed call to twilight_utc as date and direction parameters were reversed.

Tested with the following configuration:

``` yaml
sun:
```