### PR TITLE
Upgrade Sphinx to 1.5.1

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
-Sphinx==1.4.9
+Sphinx==1.5.1
 sphinx-autodoc-typehints==1.1.0
 sphinx-autodoc-annotation==1.0.post1


### PR DESCRIPTION
Release 1.5.1
==========

Features added
--------------

* Allow to suppress "unknown mimetype" warnings from epub builder using :confval:`suppress_warnings`.

Bugs fixed
----------

* Can not build in parallel
* AttributeError is raised when toctree has 'self'
* Remove untranslated sphinx locale catalogs (it was covered by untranslated it_IT)
* HTML Builders crashes with docutils-0.13
* more latex problems with references inside parsed-literal directive (``\DUrole``)
* sphinx.util.requests crashes with old pyOpenSSL (< 0.14)
* KeyError when having a duplicate citation
* LaTeX: xref inside desc_name not allowed
* ``build_sphinx`` command crashes when missing dependency
* Ignore updates of catalog files for gettext builder
* Randomized jump box order in generated index page