### PR TITLE
eq3btsmart: support modes and clean up the code to use climatedevice's features

### DIFF
--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -8,18 +8,22 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
+from homeassistant.components.climate import (
+    ClimateDevice, PLATFORM_SCHEMA, PRECISION_HALVES,
+    STATE_UNKNOWN, STATE_AUTO, STATE_ON, STATE_OFF,
+)
 from homeassistant.const import (
     CONF_MAC, TEMP_CELSIUS, CONF_DEVICES, ATTR_TEMPERATURE)
-from homeassistant.util.temperature import convert
+
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['bluepy_devices==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_MODE = 'mode'
-ATTR_MODE_READABLE = 'mode_readable'
+STATE_BOOST = "boost"
+STATE_AWAY = "away"
+STATE_MANUAL = "manual"
 
 DEVICE_SCHEMA = vol.Schema({
     vol.Required(CONF_MAC): cv.string,
@@ -48,10 +52,22 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
     def __init__(self, _mac, _name):
         """Initialize the thermostat."""
-        from bluepy_devices.devices import eq3btsmart
+        # we want to avoid name clash with this module..
+        from bluepy_devices.devices import eq3btsmart as eq3
+
+        self.modes = {eq3.EQ3BTSMART_UNKOWN: STATE_UNKNOWN,
+                      eq3.EQ3BTSMART_AUTO: STATE_AUTO,
+                      # away mode is handled separately, leaving here just for commentary
+                      eq3.EQ3BTSMART_AWAY: STATE_AWAY,
+                      eq3.EQ3BTSMART_CLOSED: STATE_OFF,
+                      eq3.EQ3BTSMART_OPEN: STATE_ON,
+                      eq3.EQ3BTSMART_MANUAL: STATE_MANUAL,
+                      eq3.EQ3BTSMART_BOOST: STATE_BOOST}
+
+        self.reverse_modes = {v: k for k, v in self.modes.items()}
 
         self._name = _name
-        self._thermostat = eq3btsmart.EQ3BTSmartThermostat(_mac)
+        self._thermostat = eq3.EQ3BTSmartThermostat(_mac)
 
     @property
     def name(self):
@@ -62,6 +78,11 @@ class EQ3BTSmartThermostat(ClimateDevice):
     def temperature_unit(self):
         """Return the unit of measurement that is used."""
         return TEMP_CELSIUS
+
+    @property
+    def precision(self):
+        """Return eq3bt's precision 0.5"""
+        return PRECISION_HALVES
 
     @property
     def current_temperature(self):
@@ -81,24 +102,41 @@ class EQ3BTSmartThermostat(ClimateDevice):
         self._thermostat.target_temperature = temperature
 
     @property
-    def device_state_attributes(self):
-        """Return the device specific state attributes."""
-        return {
-            ATTR_MODE: self._thermostat.mode,
-            ATTR_MODE_READABLE: self._thermostat.mode_readable,
-        }
+    def current_operation(self):
+        """Current mode."""
+        return self.modes[self._thermostat.mode]
+
+    @property
+    def operation_list(self):
+        """List of available operation modes."""
+        return [x for x in self.modes.values()]
+
+    def set_operation_mode(self, operation_mode):
+        """Set operation mode."""
+        self._thermostat.mode = self.reverse_modes[operation_mode]
+
+    def turn_away_mode_off(self):
+        """Away mode off turns to AUTO mode."""
+        self.set_operation_mode(STATE_AUTO)
+
+    def turn_away_mode_on(self):
+        """Sets away mode on."""
+        self.set_operation_mode(STATE_AWAY)
+
+    @property
+    def is_away_mode_on(self):
+        """Returns whether we are away."""
+        return self.current_operation == STATE_AWAY
 
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        return convert(self._thermostat.min_temp, TEMP_CELSIUS,
-                       self.unit_of_measurement)
+        return self._thermostat.min_temp
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        return convert(self._thermostat.max_temp, TEMP_CELSIUS,
-                       self.unit_of_measurement)
+        return self._thermostat.max_temp
 
     def update(self):
         """Update the data from the thermostat."""

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -25,6 +25,11 @@ STATE_BOOST = "boost"
 STATE_AWAY = "away"
 STATE_MANUAL = "manual"
 
+ATTR_STATE_WINDOW_OPEN = "window_open"
+ATTR_STATE_VALVE = "valve"
+ATTR_STATE_LOCKED = "is_locked"
+ATTR_STATE_LOW_BAT = "low_battery"
+
 DEVICE_SCHEMA = vol.Schema({
     vol.Required(CONF_MAC): cv.string,
 })
@@ -57,7 +62,7 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
         self.modes = {eq3.EQ3BTSMART_UNKOWN: STATE_UNKNOWN,
                       eq3.EQ3BTSMART_AUTO: STATE_AUTO,
-                      # away mode is handled separately, leaving here just for commentary
+                      # away handled separately, here just for reverse mapping
                       eq3.EQ3BTSMART_AWAY: STATE_AWAY,
                       eq3.EQ3BTSMART_CLOSED: STATE_OFF,
                       eq3.EQ3BTSMART_OPEN: STATE_ON,
@@ -137,6 +142,18 @@ class EQ3BTSmartThermostat(ClimateDevice):
     def max_temp(self):
         """Return the maximum temperature."""
         return self._thermostat.max_temp
+
+    @property
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
+        dev_specific = {
+            ATTR_STATE_LOCKED: self._thermostat.locked,
+            ATTR_STATE_LOW_BAT: self._thermostat.low_battery,
+            ATTR_STATE_VALVE: self._thermostat.valve_state,
+            ATTR_STATE_WINDOW_OPEN: self._thermostat.window_open,
+        }
+
+        return dev_specific
 
     def update(self):
         """Update the data from the thermostat."""

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['bluepy_devices==0.3.1']
+REQUIREMENTS = ['python-eq3bt==0.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,22 +58,22 @@ class EQ3BTSmartThermostat(ClimateDevice):
     def __init__(self, _mac, _name):
         """Initialize the thermostat."""
         # we want to avoid name clash with this module..
-        from bluepy_devices.devices import eq3btsmart as eq3
+        import eq3bt as eq3
 
-        self.modes = {None: STATE_UNKNOWN , # to avoid extra if in current_operation.
-                      eq3.EQ3BTSMART_UNKNOWN: STATE_UNKNOWN,
-                      eq3.EQ3BTSMART_AUTO: STATE_AUTO,
+        self.modes = {None: STATE_UNKNOWN,  # When not yet connected.
+                      eq3.Mode.Unknown: STATE_UNKNOWN,
+                      eq3.Mode.Auto: STATE_AUTO,
                       # away handled separately, here just for reverse mapping
-                      eq3.EQ3BTSMART_AWAY: STATE_AWAY,
-                      eq3.EQ3BTSMART_CLOSED: STATE_OFF,
-                      eq3.EQ3BTSMART_OPEN: STATE_ON,
-                      eq3.EQ3BTSMART_MANUAL: STATE_MANUAL,
-                      eq3.EQ3BTSMART_BOOST: STATE_BOOST}
+                      eq3.Mode.Away: STATE_AWAY,
+                      eq3.Mode.Closed: STATE_OFF,
+                      eq3.Mode.Open: STATE_ON,
+                      eq3.Mode.Manual: STATE_MANUAL,
+                      eq3.Mode.Boost: STATE_BOOST}
 
         self.reverse_modes = {v: k for k, v in self.modes.items()}
 
         self._name = _name
-        self._thermostat = eq3.EQ3BTSmartThermostat(_mac)
+        self._thermostat = eq3.Thermostat(_mac)
 
     @property
     def name(self):
@@ -87,7 +87,7 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
     @property
     def precision(self):
-        """Return eq3bt's precision 0.5"""
+        """Return eq3bt's precision 0.5."""
         return PRECISION_HALVES
 
     @property
@@ -126,12 +126,12 @@ class EQ3BTSmartThermostat(ClimateDevice):
         self.set_operation_mode(STATE_AUTO)
 
     def turn_away_mode_on(self):
-        """Sets away mode on."""
+        """Set away mode on."""
         self.set_operation_mode(STATE_AWAY)
 
     @property
     def is_away_mode_on(self):
-        """Returns whether we are away."""
+        """Return if we are away."""
         return self.current_operation == STATE_AWAY
 
     @property

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -60,7 +60,8 @@ class EQ3BTSmartThermostat(ClimateDevice):
         # we want to avoid name clash with this module..
         from bluepy_devices.devices import eq3btsmart as eq3
 
-        self.modes = {eq3.EQ3BTSMART_UNKOWN: STATE_UNKNOWN,
+        self.modes = {None: STATE_UNKNOWN , # to avoid extra if in current_operation.
+                      eq3.EQ3BTSMART_UNKNOWN: STATE_UNKNOWN,
                       eq3.EQ3BTSMART_AUTO: STATE_AUTO,
                       # away handled separately, here just for reverse mapping
                       eq3.EQ3BTSMART_AWAY: STATE_AWAY,

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['bluepy_devices==0.2.0']
+REQUIREMENTS = ['bluepy_devices==0.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -61,9 +61,6 @@ blinkstick==1.1.8
 # homeassistant.components.sensor.bitcoin
 blockchain==1.3.3
 
-# homeassistant.components.climate.eq3btsmart
-# bluepy_devices==0.2.0
-
 # homeassistant.components.notify.aws_lambda
 # homeassistant.components.notify.aws_sns
 # homeassistant.components.notify.aws_sqs
@@ -477,6 +474,9 @@ pysnmp==4.3.2
 
 # homeassistant.components.digital_ocean
 python-digitalocean==1.10.1
+
+# homeassistant.components.climate.eq3btsmart
+python-eq3bt==0.1.2
 
 # homeassistant.components.sensor.darksky
 python-forecastio==1.3.5


### PR DESCRIPTION
**Description:** This patch adds support for modes of eq3 bluetooth smart thermostat.

~~Note: this requires an updated fork of the backend lib (PR https://github.com/bimbar/bluepy_devices/pull/6). The upstream hasn't yet responded.~~

Update: As the upstream did not answer, I decided to clean up the library, fix some issues and upload it into PyPI. This is now ready to be merged.

Update2: The device connections are also not hold anymore, but connections are done when required, so using other means for controlling do also work. Besides that, an issue where the helper util hangs is fixed in the new cleaned up lib.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1618


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
