### PR TITLE
WIP: Firetv: add support for applications

### DIFF
--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -44,7 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    #vol.Optional(CONF_APPS, default=[]): cv.string,
+    # vol.Optional(CONF_APPS, default=[]): cv.string,
 })
 
 
@@ -65,7 +65,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             _LOGGER.info('Device %s accessible and ready for control',
                          device_id)
 
-            _LOGGER.error("APPS: %s %s" % (type(apps), apps))
+            _LOGGER.debug("APPS: %s %s", (type(apps), apps))
             for app, config in apps.items():
                 add_devices([FireTVApp(device, app, config)])
 
@@ -121,7 +121,8 @@ class FireTV(object):
     def app(self, app_id, command):
         try:
             response = requests.get(
-                APPS_BASE_URL.format(self.host, self.port, self.device_id, app_id, command),
+                APPS_BASE_URL.format(self.host, self.port,
+                                     self.device_id, app_id, command),
                 timeout=10).json()
             _LOGGER.debug("response %s", response)
             return response
@@ -135,8 +136,8 @@ class FireTVApp(MediaPlayerDevice):
     def __init__(self, device, app, config):
         self._device = device
         self._name = app
+        _LOGGER.debug("App config: %s", config)
         self._app_id = config['app_id']
-        _LOGGER.warning("FOO: %s" % config)
         if "icon" in config:
             self._icon = config['icon']
 


### PR DESCRIPTION
This commit adds ability to list apps for firetv devices,
each app itself is for hass a MediaPlayerDevice which supports only
turning on and off, plus fetching the current state.

Example configuration can be as follows:
```
- platform: firetv
  name: "My Fire"
  apps:
    Netflix:
      app_id: com.netflix.ninja
```

**Description:**
Depends on new release of python-firetv for fixing bugs, https://github.com/happyleavesaoc/python-firetv/issues/17

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1619

**Example entry for `configuration.yaml` (if applicable):**
```yaml
- platform: firetv
  name: "My Fire"
  apps:
    Netflix:
      app_id: com.netflix.ninja
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [?] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [-] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [-] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
