### PR TITLE
Gracefully exit with async logger

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -298,9 +298,8 @@ class HomeAssistant(object):
         # cleanup async layer from python logging
         if self.data.get(DATA_ASYNCHANDLER):
             handler = self.data.pop(DATA_ASYNCHANDLER)
-            logger = logging.getLogger('')
-            handler.close()
-            logger.removeHandler(handler)
+            logging.getLogger('').removeHandler(handler)
+            yield from handler.async_close(blocking=True)
 
         self.loop.stop()
 

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -59,6 +59,7 @@ class AsyncHandler(object):
 
         if blocking:
             # Python 3.4.4+
+            # pylint: disable=no-member
             if hasattr(self._queue, 'join'):
                 yield from self._queue.join()
             else:
@@ -87,6 +88,8 @@ class AsyncHandler(object):
         while True:
             record = run_coroutine_threadsafe(
                 self._queue.get(), self.loop).result()
+
+            # pylint: disable=no-member
 
             if record is None:
                 self.handler.close()

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -49,6 +49,22 @@ class AsyncHandler(object):
         """Wrap close to handler."""
         self.emit(None)
 
+    @asyncio.coroutine
+    def async_close(self, blocking=False):
+        """Close the handler.
+
+        When blocking=True, will wait till closed.
+        """
+        self.close()
+
+        if blocking:
+            # Python 3.4.4+
+            if hasattr(self._queue, 'join'):
+                yield from self._queue.join()
+            else:
+                while not self._queue.empty():
+                    yield from asyncio.sleep(0, loop=self.loop)
+
     def emit(self, record):
         """Process a record."""
         ident = self.loop.__dict__.get("_thread_ident")
@@ -66,15 +82,21 @@ class AsyncHandler(object):
 
     def _process(self):
         """Process log in a thread."""
+        support_join = hasattr(self._queue, 'task_done')
+
         while True:
             record = run_coroutine_threadsafe(
                 self._queue.get(), self.loop).result()
 
             if record is None:
                 self.handler.close()
+                if support_join:
+                    self.loop.call_soon_threadsafe(self._queue.task_done)
                 return
 
             self.handler.emit(record)
+            if support_join:
+                self.loop.call_soon_threadsafe(self._queue.task_done)
 
     def createLock(self):
         """Ignore lock stuff."""


### PR DESCRIPTION
**Description:**
We would close the event loop too fast, not allowing our async logger to process the exit signal and thus never exiting our logging thread. This fixes it.
