### PR TITLE
Add support for the Sonarr URL Base setting

### DIFF
--- a/homeassistant/components/sensor/sonarr.py
+++ b/homeassistant/components/sensor/sonarr.py
@@ -43,7 +43,8 @@ SENSOR_TYPES = {
 ENDPOINTS = {
     'diskspace': 'http{0}://{1}:{2}/{3}api/diskspace?apikey={4}',
     'queue': 'http{0}://{1}:{2}/{3}api/queue?apikey={4}',
-    'upcoming': 'http{0}://{1}:{2}/{3}api/calendar?apikey={4}&start={5}&end={6}',
+    'upcoming': 
+        'http{0}://{1}:{2}/{3}api/calendar?apikey={4}&start={5}&end={6}',
     'wanted': 'http{0}://{1}:{2}/{3}api/wanted/missing?apikey={4}',
     'series': 'http{0}://{1}:{2}/{3}api/series?apikey={4}',
     'commands': 'http{0}://{1}:{2}/{3}api/command?apikey={4}'
@@ -113,7 +114,8 @@ class SonarrSensor(Entity):
         try:
             res = requests.get(
                 ENDPOINTS[self.type].format(
-                    self.ssl, self.host, self.port, self.urlbase, self.apikey, start, end),
+                    self.ssl, self.host, self.port, 
+                    self.urlbase, self.apikey, start, end),
                 timeout=5)
         except OSError:
             _LOGGER.error('Host %s is not available', self.host)
@@ -139,7 +141,8 @@ class SonarrSensor(Entity):
                 data = res.json()
                 res = requests.get('{}&pageSize={}'.format(
                     ENDPOINTS[self.type].format(
-                        self.ssl, self.host, self.port, self.urlbase, self.apikey),
+                        self.ssl, self.host, self.port, 
+                        self.urlbase, self.apikey),
                     data['totalRecords']), timeout=5)
                 self.data = res.json()['records']
                 self._state = len(self.data)

--- a/homeassistant/components/sensor/sonarr.py
+++ b/homeassistant/components/sensor/sonarr.py
@@ -43,7 +43,7 @@ SENSOR_TYPES = {
 ENDPOINTS = {
     'diskspace': 'http{0}://{1}:{2}/{3}api/diskspace?apikey={4}',
     'queue': 'http{0}://{1}:{2}/{3}api/queue?apikey={4}',
-    'upcoming': 
+    'upcoming':
         'http{0}://{1}:{2}/{3}api/calendar?apikey={4}&start={5}&end={6}',
     'wanted': 'http{0}://{1}:{2}/{3}api/wanted/missing?apikey={4}',
     'series': 'http{0}://{1}:{2}/{3}api/series?apikey={4}',
@@ -114,7 +114,7 @@ class SonarrSensor(Entity):
         try:
             res = requests.get(
                 ENDPOINTS[self.type].format(
-                    self.ssl, self.host, self.port, 
+                    self.ssl, self.host, self.port,
                     self.urlbase, self.apikey, start, end),
                 timeout=5)
         except OSError:
@@ -141,7 +141,7 @@ class SonarrSensor(Entity):
                 data = res.json()
                 res = requests.get('{}&pageSize={}'.format(
                     ENDPOINTS[self.type].format(
-                        self.ssl, self.host, self.port, 
+                        self.ssl, self.host, self.port,
                         self.urlbase, self.apikey),
                     data['totalRecords']), timeout=5)
                 self.data = res.json()['records']

--- a/homeassistant/components/sensor/sonarr.py
+++ b/homeassistant/components/sensor/sonarr.py
@@ -85,7 +85,7 @@ class SonarrSensor(Entity):
         self.host = conf.get(CONF_HOST)
         self.port = conf.get(CONF_PORT)
         self.urlbase = conf.get(CONF_URLBASE)
-        if len(self.urlbase):
+        if self.urlbase:
             self.urlbase = "%s/" % self.urlbase.strip('/')
         self.apikey = conf.get(CONF_API_KEY)
         self.included = conf.get(CONF_INCLUDED)


### PR DESCRIPTION
**Description:**
For those of us who have sonarr hidden behind reverse proxy under a path, we need to be able to pass the path

Adds urlbase: XXX to the sonarr yaml... Match it to what you have set in Sonarr (Settings>General>URL Base)

**Related issue (if applicable):**

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1622

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: sonarr
    api_key: XXXXX
    host: HOSTNAME
    port: 80
    urlbase: sonarr
    monitored_conditions:
      - upcoming
    days: 7
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51