### PR TITLE
Bugfix wait in automation

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -166,7 +166,9 @@ def async_setup(hass, config):
         for entity in component.async_extract_from_service(service_call):
             tasks.append(entity.async_trigger(
                 service_call.data.get(ATTR_VARIABLES), True))
-        yield from asyncio.wait(tasks, loop=hass.loop)
+
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
 
     @asyncio.coroutine
     def turn_onoff_service_handler(service_call):
@@ -175,7 +177,9 @@ def async_setup(hass, config):
         method = 'async_{}'.format(service_call.service)
         for entity in component.async_extract_from_service(service_call):
             tasks.append(getattr(entity, method)())
-        yield from asyncio.wait(tasks, loop=hass.loop)
+
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
 
     @asyncio.coroutine
     def toggle_service_handler(service_call):
@@ -186,7 +190,9 @@ def async_setup(hass, config):
                 tasks.append(entity.async_turn_off())
             else:
                 tasks.append(entity.async_turn_on())
-        yield from asyncio.wait(tasks, loop=hass.loop)
+
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
 
     @asyncio.coroutine
     def reload_service_handler(service_call):


### PR DESCRIPTION
**Description:**

`asyncio.wait` will not support empty lists.

**Related issue (if applicable):** fixes #4980

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
