### PR TITLE
Allow setting base url

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -18,7 +18,7 @@ from aiohttp.web_exceptions import HTTPUnauthorized, HTTPMovedPermanently
 
 import homeassistant.helpers.config_validation as cv
 import homeassistant.remote as rem
-from homeassistant.util import get_local_ip
+import homeassistant.util as hass_util
 from homeassistant.components import persistent_notification
 from homeassistant.const import (
     SERVER_PORT, CONTENT_TYPE_JSON, ALLOWED_CORS_HEADERS,
@@ -41,6 +41,7 @@ REQUIREMENTS = ('aiohttp_cors==0.5.0',)
 CONF_API_PASSWORD = 'api_password'
 CONF_SERVER_HOST = 'server_host'
 CONF_SERVER_PORT = 'server_port'
+CONF_BASE_URL = 'base_url'
 CONF_DEVELOPMENT = 'development'
 CONF_SSL_CERTIFICATE = 'ssl_certificate'
 CONF_SSL_KEY = 'ssl_key'
@@ -84,6 +85,7 @@ HTTP_SCHEMA = vol.Schema({
     vol.Optional(CONF_SERVER_HOST, default=DEFAULT_SERVER_HOST): cv.string,
     vol.Optional(CONF_SERVER_PORT, default=SERVER_PORT):
         vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
+    vol.Optional(CONF_BASE_URL): cv.string,
     vol.Optional(CONF_DEVELOPMENT, default=DEFAULT_DEVELOPMENT): cv.string,
     vol.Optional(CONF_SSL_CERTIFICATE, default=None): cv.isfile,
     vol.Optional(CONF_SSL_KEY, default=None): cv.isfile,
@@ -155,9 +157,17 @@ def async_setup(hass, config):
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, start_server)
 
     hass.http = server
-    hass.config.api = rem.API(server_host if server_host != '0.0.0.0'
-                              else get_local_ip(),
-                              api_password, server_port,
+
+    host = conf.get(CONF_BASE_URL)
+
+    if host:
+        pass
+    elif server_host != DEFAULT_SERVER_HOST:
+        host = server_host
+    else:
+        host = hass_util.get_local_ip()
+
+    hass.config.api = rem.API(host, api_password, server_port,
                               ssl_certificate is not None)
 
     return True

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -1,6 +1,7 @@
 """The tests for the Home Assistant HTTP component."""
 import asyncio
 import requests
+from unittest.mock import MagicMock
 
 from homeassistant import bootstrap, const
 import homeassistant.components.http as http
@@ -154,3 +155,49 @@ def test_registering_view_while_running(hass, test_client):
 
     text = yield from resp.text()
     assert text == 'hello'
+
+
+def test_api_base_url(loop):
+    """Test setting api url."""
+
+    hass = MagicMock()
+    hass.loop = loop
+
+    assert loop.run_until_complete(
+        bootstrap.async_setup_component(hass, 'http', {
+            'http': {
+                'base_url': 'example.com'
+            }
+        })
+    )
+
+    assert hass.config.api.base_url == 'http://example.com:8123'
+
+    assert loop.run_until_complete(
+        bootstrap.async_setup_component(hass, 'http', {
+            'http': {
+                'server_host': '1.1.1.1'
+            }
+        })
+    )
+
+    assert hass.config.api.base_url == 'http://1.1.1.1:8123'
+
+    assert loop.run_until_complete(
+        bootstrap.async_setup_component(hass, 'http', {
+            'http': {
+                'server_host': '1.1.1.1'
+            }
+        })
+    )
+
+    assert hass.config.api.base_url == 'http://1.1.1.1:8123'
+
+    assert loop.run_until_complete(
+        bootstrap.async_setup_component(hass, 'http', {
+            'http': {
+            }
+        })
+    )
+
+    assert hass.config.api.base_url == 'http://127.0.0.1:8123'


### PR DESCRIPTION
**Description:**
Adds option to set base url for API

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
