### PR TITLE
Base url: Fix external port different from internal port

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -161,13 +161,15 @@ def async_setup(hass, config):
     host = conf.get(CONF_BASE_URL)
 
     if host:
-        pass
+        port = None
     elif server_host != DEFAULT_SERVER_HOST:
         host = server_host
+        port = server_port
     else:
         host = hass_util.get_local_ip()
+        port = server_port
 
-    hass.config.api = rem.API(host, api_password, server_port,
+    hass.config.api = rem.API(host, api_password, port,
                               ssl_certificate is not None)
 
     return True

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -54,6 +54,8 @@ frontend:
 http:
   # Uncomment this to add a password (recommended!)
   # api_password: PASSWORD
+  # Uncomment this if you are using SSL or running in Docker etc
+  # base_url: example.duckdns.org:8123
 
 # Checks for available updates
 updater:
@@ -76,6 +78,11 @@ sun:
 # Weather Prediction
 sensor:
   platform: yr
+
+# Text to speech
+tts:
+  platform: google
+
 """
 
 

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -55,15 +55,20 @@ class API(object):
     """Object to pass around Home Assistant API location and credentials."""
 
     def __init__(self, host: str, api_password: Optional[str]=None,
-                 port: Optional[int]=None, use_ssl: bool=False) -> None:
+                 port: Optional[int]=SERVER_PORT, use_ssl: bool=False) -> None:
         """Initalize the API."""
         self.host = host
-        self.port = port or SERVER_PORT
+        self.port = port
         self.api_password = api_password
+
         if use_ssl:
-            self.base_url = "https://{}:{}".format(host, self.port)
+            self.base_url = "https://{}".format(host)
         else:
-            self.base_url = "http://{}:{}".format(host, self.port)
+            self.base_url = "http://{}".format(host)
+
+        if port is not None:
+            self.base_url += ':{}'.format(port)
+
         self.status = None
         self._headers = {
             HTTP_HEADER_CONTENT_TYPE: CONTENT_TYPE_JSON,
@@ -106,8 +111,8 @@ class API(object):
 
     def __repr__(self) -> str:
         """Return the representation of the API."""
-        return "API({}, {}, {})".format(
-            self.host, self.api_password, self.port)
+        return "<API({}, password: {})>".format(
+            self.base_url, 'yes' if self.api_password is not None else 'no')
 
 
 class HomeAssistant(ha.HomeAssistant):

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -171,7 +171,7 @@ def test_api_base_url(loop):
         })
     )
 
-    assert hass.config.api.base_url == 'http://example.com:8123'
+    assert hass.config.api.base_url == 'http://example.com'
 
     assert loop.run_until_complete(
         bootstrap.async_setup_component(hass, 'http', {


### PR DESCRIPTION
**Description:**
TTS would still not work if your internal IP address is on a different port than the base url that you set in the http component. Now we will ignore the port inside the API class if a base url is given.