### PR TITLE
Added use of insteon-hub streaming functionality

### DIFF
--- a/homeassistant/components/insteon_hub.py
+++ b/homeassistant/components/insteon_hub.py
@@ -13,7 +13,7 @@ from homeassistant.const import (CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME)
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['insteon_hub==0.7.0']
+REQUIREMENTS = ['insteon_hub==0.7.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/insteon_hub.py
+++ b/homeassistant/components/insteon_hub.py
@@ -5,6 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/insteon_hub/
 """
 import logging
+import threading
 
 import voluptuous as vol
 
@@ -12,11 +13,12 @@ from homeassistant.const import (CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME)
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['insteon_hub==0.4.5']
+REQUIREMENTS = ['insteon_hub==0.7.0']
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'insteon_hub'
+CONF_POLL = 'poll_hub'
 INSTEON = None
 
 CONFIG_SCHEMA = vol.Schema({
@@ -24,6 +26,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_API_KEY): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Required(CONF_USERNAME): cv.string,
+        vol.Optional(CONF_POLL): cv.boolean,
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -33,10 +36,6 @@ def setup(hass, config):
 
     This will automatically import associated lights.
     """
-    _LOGGER.warning('Component disabled at request from Insteon. '
-                    'For more information: https://goo.gl/zLJaic')
-    return False
-    # pylint: disable=unreachable
     import insteon
 
     username = config[DOMAIN][CONF_USERNAME]
@@ -50,6 +49,17 @@ def setup(hass, config):
         _LOGGER.error("Could not connect to Insteon service")
         return False
 
-    discovery.load_platform(hass, 'light', DOMAIN, {}, config)
+    discovery.load_platform(
+        hass,
+        'light',
+        DOMAIN,
+        {CONF_POLL: config[DOMAIN][CONF_POLL]},
+        config
+    )
+    for insteon_house in INSTEON.houses:
+        threading.Thread(
+            target=insteon_house.stream,
+            args=(True, INSTEON.devices)
+        ).start()
 
     return True

--- a/homeassistant/components/light/insteon_hub.py
+++ b/homeassistant/components/light/insteon_hub.py
@@ -22,12 +22,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Insteon Hub light platform."""
     devs = []
     for device in INSTEON.devices:
-        if device.DeviceCategory in SUPPORTED_LIGHT_DEVICES:
-            new_device = InsteonToggleDevice(device, discovery_info[CONF_POLL])
-            INSTEON.houses[0].add_stream_callback(
-                device,
-                new_device.insteon_update)
-            devs.append(new_device)
+        if device.DeviceCategory not in SUPPORTED_LIGHT_DEVICES:
+            continue
+        new_device = InsteonToggleDevice(device, discovery_info[CONF_POLL])
+        INSTEON.houses[0].add_stream_callback(
+            device,
+            new_device.insteon_update)
+        devs.append(new_device)
     add_devices(devs)
 
 
@@ -56,8 +57,8 @@ class InsteonToggleDevice(Light):
         return self._value / 100 * 255
 
     def insteon_update(self, _):
-        """Callback for an update from the hosue streaming endpoint"""
-        self.update_ha_state()
+        """Callback for an update from the hosue streaming endpoint."""
+        self.schedule_update_ha_state()
 
     def update(self):
         """Update state of the sensor."""
@@ -92,10 +93,10 @@ class InsteonToggleDevice(Light):
         else:
             self._value = 100
             self.node.send_command('on')
-        self.update_ha_state()
+        self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn device off."""
         self.node.send_command('off')
         self._value = 0
-        self.update_ha_state()
+        self.schedule_update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -269,7 +269,7 @@ https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 influxdb==3.0.0
 
 # homeassistant.components.insteon_hub
-insteon_hub==0.4.5
+insteon_hub==0.7.0
 
 # homeassistant.components.media_player.kodi
 # homeassistant.components.notify.kodi

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -269,7 +269,7 @@ https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 influxdb==3.0.0
 
 # homeassistant.components.insteon_hub
-insteon_hub==0.7.0
+insteon_hub==0.7.2
 
 # homeassistant.components.media_player.kodi
 # homeassistant.components.notify.kodi


### PR DESCRIPTION
**Description:**


This adds the use of the Insteon streaming endpoint for physical device changes. It also defaults the system to not poll Insteon cloud to check device changes.

Since that is different than most other home automation toggleable status checking systems I would suggest that we make sure users are very informed as to why we decided to do this, and how they can change it if they would like.

I'd also like to not I have a ticket open with Insteon and will follow up with them on this approach. I would love feedback on this.  

**Related issue (if applicable):** fixes #3811 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1626

**Example entry for `configuration.yaml` (if applicable):**
```yaml
insteon_hub:
  username: YOUR_USERNAME
  password: YOUR_PASSWORD
  api_key: YOUR_API_KEY
  poll: SHOULD_POLL_CLOUD
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
