### PR TITLE
Add missing support for HMIP-PSM

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -61,7 +61,7 @@ HM_DEVICE_TYPES = {
         'ThermostatWall', 'AreaThermostat', 'RotaryHandleSensor',
         'WaterSensor', 'PowermeterGas', 'LuxSensor', 'WeatherSensor',
         'WeatherStation', 'ThermostatWall2', 'TemperatureDiffSensor',
-        'TemperatureSensor', 'CO2Sensor'],
+        'TemperatureSensor', 'CO2Sensor', 'IPSwitchPowermeter'],
     DISCOVER_CLIMATE: [
         'Thermostat', 'ThermostatWall', 'MAXThermostat', 'ThermostatWall2'],
     DISCOVER_BINARY_SENSORS: [


### PR DESCRIPTION
**Description:**
The HomeMatic HMIP-PSM switch-device is capable of measuring various energy stats. This was already implemented in the dependency, but not included when creating the corresponding sensor-entities in HASS. This PR fixes this and provides device-owners with 5 nifty sensors to monitor energy consumption. :)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
