### PR TITLE
Bug fix in Broadlink

### DIFF
--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -57,22 +57,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         config.get(CONF_MAC).encode().replace(b':', b''))
     sensor_type = config.get(CONF_TYPE)
 
-    if sensor_type == "rm":
-        broadlink_device = broadlink.rm((ip_addr, 80), mac_addr)
-        switch = BroadlinkRMSwitch
-    elif sensor_type == "sp1":
-        broadlink_device = broadlink.sp1((ip_addr, 80), mac_addr)
-        switch = BroadlinkSP1Switch
-    elif sensor_type == "sp2":
-        broadlink_device = broadlink.sp2((ip_addr, 80), mac_addr)
-        switch = BroadlinkSP2Switch
-
-    broadlink_device.timeout = config.get(CONF_TIMEOUT)
-    try:
-        broadlink_device.auth()
-    except socket.timeout:
-        _LOGGER.error("Failed to connect to device.")
-
     persistent_notification = loader.get_component('persistent_notification')
 
     @asyncio.coroutine
@@ -103,7 +87,24 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         persistent_notification.async_create(hass,
                                              "Did not received any signal",
                                              title='Broadlink switch')
-    hass.services.register(DOMAIN, SERVICE_LEARN, _learn_command)
+
+    if sensor_type == "rm":
+        broadlink_device = broadlink.rm((ip_addr, 80), mac_addr)
+        switch = BroadlinkRMSwitch
+        hass.services.register(DOMAIN, SERVICE_LEARN + '_' + ip_addr,
+                               _learn_command)
+    elif sensor_type == "sp1":
+        broadlink_device = broadlink.sp1((ip_addr, 80), mac_addr)
+        switch = BroadlinkSP1Switch
+    elif sensor_type == "sp2":
+        broadlink_device = broadlink.sp2((ip_addr, 80), mac_addr)
+        switch = BroadlinkSP2Switch
+
+    broadlink_device.timeout = config.get(CONF_TIMEOUT)
+    try:
+        broadlink_device.auth()
+    except socket.timeout:
+        _LOGGER.error("Failed to connect to device.")
 
     for object_id, device_config in devices.items():
         switches.append(
@@ -138,11 +139,6 @@ class BroadlinkRMSwitch(SwitchDevice):
     def assumed_state(self):
         """Return true if unable to access real state of entity."""
         return True
-
-    @property
-    def should_poll(self):
-        """No polling needed."""
-        return False
 
     @property
     def is_on(self):
@@ -214,11 +210,6 @@ class BroadlinkSP2Switch(BroadlinkSP1Switch):
     def assumed_state(self):
         """Return true if unable to access real state of entity."""
         return False
-
-    @property
-    def should_poll(self):
-        """Polling needed."""
-        return True
 
     def update(self):
         """Synchronize state with switch."""


### PR DESCRIPTION
**Description:**
If several broadlink devices are used, the learn service should be given separate names.
The learn service is also only needed for rm devices.



**Checklist:**


If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
