### PR TITLE
Bugfix voicerss post api

### DIFF
--- a/homeassistant/components/tts/services.yaml
+++ b/homeassistant/components/tts/services.yaml
@@ -3,12 +3,16 @@ say:
 
   fields:
     entity_id:
-      description: Name(s) of media player entities
+      description: Name(s) of media player entities.
       example: 'media_player.floor'
 
     message:
-      description: Text to speak on devices
+      description: Text to speak on devices.
       example: 'My name is hanna'
+
+    cache:
+      description: Control file cache of this message.
+      example: 'true'
 
 clear_cache:
   description: Remove cache files and RAM cache.

--- a/tests/components/tts/test_voicerss.py
+++ b/tests/components/tts/test_voicerss.py
@@ -20,11 +20,12 @@ class TestTTSVoiceRSSPlatform(object):
         self.hass = get_test_home_assistant()
 
         self.url = "https://api.voicerss.org/"
-        self.url_param = {
+        self.form_data = {
             'key': '1234567xx',
             'hl': 'en-us',
             'c': 'MP3',
             'f': '8khz_8bit_mono',
+            'src': "I person is on front of your door.",
         }
 
     def teardown_method(self):
@@ -63,7 +64,7 @@ class TestTTSVoiceRSSPlatform(object):
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
         aioclient_mock.post(
-            self.url, params=self.url_param, status=200, content=b'test')
+            self.url, data=self.form_data, status=200, content=b'test')
 
         config = {
             tts.DOMAIN: {
@@ -82,6 +83,7 @@ class TestTTSVoiceRSSPlatform(object):
 
         assert len(calls) == 1
         assert len(aioclient_mock.mock_calls) == 1
+        assert aioclient_mock.mock_calls[0][2] == self.form_data
         assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(".mp3") != -1
 
     def test_service_say_german(self, aioclient_mock):
@@ -90,7 +92,7 @@ class TestTTSVoiceRSSPlatform(object):
 
         self.url_param['hl'] = 'de-de'
         aioclient_mock.post(
-            self.url, params=self.url_param, status=200, content=b'test')
+            self.url, data=self.form_data, status=200, content=b'test')
 
         config = {
             tts.DOMAIN: {
@@ -110,13 +112,14 @@ class TestTTSVoiceRSSPlatform(object):
 
         assert len(calls) == 1
         assert len(aioclient_mock.mock_calls) == 1
+        assert aioclient_mock.mock_calls[0][2] == self.form_data
 
     def test_service_say_error(self, aioclient_mock):
         """Test service call say with http response 400."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
         aioclient_mock.post(
-            self.url, params=self.url_param, status=400, content=b'test')
+            self.url, data=self.form_data, status=400, content=b'test')
 
         config = {
             tts.DOMAIN: {
@@ -135,6 +138,7 @@ class TestTTSVoiceRSSPlatform(object):
 
         assert len(calls) == 0
         assert len(aioclient_mock.mock_calls) == 1
+        assert aioclient_mock.mock_calls[0][2] == self.form_data
 
     def test_service_say_timeout(self, aioclient_mock):
         """Test service call say with http timeout."""
@@ -160,3 +164,32 @@ class TestTTSVoiceRSSPlatform(object):
 
         assert len(calls) == 0
         assert len(aioclient_mock.mock_calls) == 1
+        assert aioclient_mock.mock_calls[0][2] == self.form_data
+
+    def test_service_say_error_msg(self, aioclient_mock):
+        """Test service call say with http error api message."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        aioclient_mock.post(
+            self.url, data=self.form_data, status=200,
+            content=b'The subscription does not support SSML!'
+        )
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'voicerss',
+                'api_key': '1234567xx',
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'voicerss_say', {
+            tts.ATTR_MESSAGE: "I person is on front of your door.",
+        })
+        self.hass.block_till_done()
+
+        assert len(calls) == 0
+        assert len(aioclient_mock.mock_calls) == 1
+        assert aioclient_mock.mock_calls[0][2] == self.form_data

--- a/tests/components/tts/test_voicerss.py
+++ b/tests/components/tts/test_voicerss.py
@@ -90,7 +90,7 @@ class TestTTSVoiceRSSPlatform(object):
         """Test service call say with german code."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        self.url_param['hl'] = 'de-de'
+        self.form_data['hl'] = 'de-de'
         aioclient_mock.post(
             self.url, data=self.form_data, status=200, content=b'test')
 
@@ -145,7 +145,7 @@ class TestTTSVoiceRSSPlatform(object):
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
         aioclient_mock.post(
-            self.url, params=self.url_param, exc=asyncio.TimeoutError())
+            self.url, data=self.form_data, exc=asyncio.TimeoutError())
 
         config = {
             tts.DOMAIN: {


### PR DESCRIPTION
**Description:**

I make a misstake on voicerss that with POST is nessesary that all params need to be form encoded. VoiceRSS support not http error code at the moment and I add also his error message to protect service on a error case.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
