### PR TITLE
Solve some bugs in the broadlink switch

### DIFF
--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -169,7 +169,7 @@ class BroadlinkRMSwitch(SwitchDevice):
             return True
         try:
             self._device.send_data(packet)
-        except (socket.timeout, ValueError)  as error:
+        except (socket.timeout, ValueError) as error:
             if retry < 1:
                 _LOGGER.error(error)
                 return False

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -57,22 +57,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         config.get(CONF_MAC).encode().replace(b':', b''))
     sensor_type = config.get(CONF_TYPE)
 
-    if sensor_type == "rm":
-        broadlink_device = broadlink.rm((ip_addr, 80), mac_addr)
-        switch = BroadlinkRMSwitch
-    elif sensor_type == "sp1":
-        broadlink_device = broadlink.sp1((ip_addr, 80), mac_addr)
-        switch = BroadlinkSP1Switch
-    elif sensor_type == "sp2":
-        broadlink_device = broadlink.sp2((ip_addr, 80), mac_addr)
-        switch = BroadlinkSP2Switch
-
-    broadlink_device.timeout = config.get(CONF_TIMEOUT)
-    try:
-        broadlink_device.auth()
-    except socket.timeout:
-        _LOGGER.error("Failed to connect to device.")
-
     persistent_notification = loader.get_component('persistent_notification')
 
     @asyncio.coroutine
@@ -103,7 +87,24 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         persistent_notification.async_create(hass,
                                              "Did not received any signal",
                                              title='Broadlink switch')
-    hass.services.register(DOMAIN, SERVICE_LEARN, _learn_command)
+
+    if sensor_type == "rm":
+        broadlink_device = broadlink.rm((ip_addr, 80), mac_addr)
+        switch = BroadlinkRMSwitch
+        hass.services.register(DOMAIN, SERVICE_LEARN + '_' + ip_addr,
+                               _learn_command)
+    elif sensor_type == "sp1":
+        broadlink_device = broadlink.sp1((ip_addr, 80), mac_addr)
+        switch = BroadlinkSP1Switch
+    elif sensor_type == "sp2":
+        broadlink_device = broadlink.sp2((ip_addr, 80), mac_addr)
+        switch = BroadlinkSP2Switch
+
+    broadlink_device.timeout = config.get(CONF_TIMEOUT)
+    try:
+        broadlink_device.auth()
+    except socket.timeout:
+        _LOGGER.error("Failed to connect to device.")
 
     for object_id, device_config in devices.items():
         switches.append(
@@ -153,11 +154,13 @@ class BroadlinkRMSwitch(SwitchDevice):
         """Turn the device on."""
         if self._sendpacket(self._command_on):
             self._state = True
+            self.update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
         if self._sendpacket(self._command_off):
             self._state = False
+            self.update_ha_state()
 
     def _sendpacket(self, packet, retry=2):
         """Send packet to device."""
@@ -166,7 +169,7 @@ class BroadlinkRMSwitch(SwitchDevice):
             return True
         try:
             self._device.send_data(packet)
-        except socket.timeout as error:
+        except (socket.timeout, ValueError)  as error:
             if retry < 1:
                 _LOGGER.error(error)
                 return False
@@ -191,7 +194,7 @@ class BroadlinkSP1Switch(BroadlinkRMSwitch):
         """Send packet to device."""
         try:
             self._device.set_power(packet)
-        except socket.timeout as error:
+        except (socket.timeout, ValueError) as error:
             if retry < 1:
                 _LOGGER.error(error)
                 return False
@@ -227,7 +230,7 @@ class BroadlinkSP2Switch(BroadlinkSP1Switch):
     def _update(self, retry=2):
         try:
             state = self._device.check_power()
-        except socket.timeout as error:
+        except (socket.timeout, ValueError) as error:
             if retry < 1:
                 _LOGGER.error(error)
                 return


### PR DESCRIPTION
**Description:**
If several broadlink devices are used, the learn service should be given separate names.
The learn service is also only needed for rm devices.


The other bugs I have seen have to wait until @mjg59 has merged these prs: https://github.com/mjg59/python-broadlink/pulls/Danielhiversen

**Related issue (if applicable):** fixes parts of #4997

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
