### PR TITLE
[tests/device_tracker] Add assert_setup_component

### DIFF
--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -100,8 +100,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
             'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
             hide_if_away=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
-        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
-                                        TEST_PLATFORM))
+        with assert_setup_component(1, device_tracker.DOMAIN):
+            assert setup_component(self.hass, device_tracker.DOMAIN,
+                                   TEST_PLATFORM)
         config = device_tracker.load_config(self.yaml_devices, self.hass,
                                             device.consider_home)[0]
         self.assertEqual(device.dev_id, config.dev_id)
@@ -146,8 +147,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
     def test_setup_without_yaml_file(self):
         """Test with no YAML file."""
-        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
-                                        TEST_PLATFORM))
+        with assert_setup_component(1, device_tracker.DOMAIN):
+            assert setup_component(self.hass, device_tracker.DOMAIN,
+                                   TEST_PLATFORM)
 
     # pylint: disable=invalid-name
     def test_adding_unknown_device_to_config(self):
@@ -156,15 +158,15 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         scanner.reset()
         scanner.come_home('DEV1')
 
-        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN, {
-            device_tracker.DOMAIN: {CONF_PLATFORM: 'test'}}))
+        with assert_setup_component(1, device_tracker.DOMAIN):
+            assert setup_component(self.hass, device_tracker.DOMAIN, {
+                device_tracker.DOMAIN: {CONF_PLATFORM: 'test'}})
 
         # wait for async calls (macvendor) to finish
         self.hass.block_till_done()
 
         config = device_tracker.load_config(self.yaml_devices, self.hass,
                                             timedelta(seconds=0))
-
         assert len(config) == 1
         assert config[0].dev_id == 'dev1'
         assert config[0].track
@@ -280,8 +282,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
         with patch.dict(device_tracker.DISCOVERY_PLATFORMS, {'test': 'test'}):
             with patch.object(scanner, 'scan_devices') as mock_scan:
-                self.assertTrue(setup_component(
-                    self.hass, device_tracker.DOMAIN, TEST_PLATFORM))
+                with assert_setup_component(1, device_tracker.DOMAIN):
+                    assert setup_component(
+                        self.hass, device_tracker.DOMAIN, TEST_PLATFORM)
                 fire_service_discovered(self.hass, 'test', {})
                 self.assertTrue(mock_scan.called)
 
@@ -296,11 +299,12 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
         with patch('homeassistant.components.device_tracker.dt_util.utcnow',
                    return_value=register_time):
-            self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN, {
-                device_tracker.DOMAIN: {
-                    CONF_PLATFORM: 'test',
-                    device_tracker.CONF_CONSIDER_HOME: 59,
-                }}))
+            with assert_setup_component(1, device_tracker.DOMAIN):
+                assert setup_component(self.hass, device_tracker.DOMAIN, {
+                    device_tracker.DOMAIN: {
+                        CONF_PLATFORM: 'test',
+                        device_tracker.CONF_CONSIDER_HOME: 59,
+                    }})
 
         self.assertEqual(STATE_HOME,
                          self.hass.states.get('device_tracker.dev1').state)
@@ -327,8 +331,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
             friendly_name, picture, hide_if_away=True)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
 
-        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
-                                        TEST_PLATFORM))
+        with assert_setup_component(1, device_tracker.DOMAIN):
+            assert setup_component(self.hass, device_tracker.DOMAIN,
+                                   TEST_PLATFORM)
 
         attrs = self.hass.states.get(entity_id).attributes
 
@@ -347,8 +352,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         scanner = get_component('device_tracker.test').SCANNER
         scanner.reset()
 
-        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
-                                        TEST_PLATFORM))
+        with assert_setup_component(1, device_tracker.DOMAIN):
+            assert setup_component(self.hass, device_tracker.DOMAIN,
+                                   TEST_PLATFORM)
 
         self.assertTrue(self.hass.states.get(entity_id)
                         .attributes.get(ATTR_HIDDEN))
@@ -365,8 +371,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         scanner = get_component('device_tracker.test').SCANNER
         scanner.reset()
 
-        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
-                                        TEST_PLATFORM))
+        with assert_setup_component(1, device_tracker.DOMAIN):
+            assert setup_component(self.hass, device_tracker.DOMAIN,
+                                   TEST_PLATFORM)
 
         state = self.hass.states.get(device_tracker.ENTITY_ID_ALL_DEVICES)
         self.assertIsNotNone(state)
@@ -377,8 +384,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     @patch('homeassistant.components.device_tracker.DeviceTracker.async_see')
     def test_see_service(self, mock_see):
         """Test the see service with a unicode dev_id and NO MAC."""
-        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
-                                        TEST_PLATFORM))
+        with assert_setup_component(1, device_tracker.DOMAIN):
+            assert setup_component(self.hass, device_tracker.DOMAIN,
+                                   TEST_PLATFORM)
         params = {
             'dev_id': 'some_device',
             'host_name': 'example.com',
@@ -405,8 +413,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
     def test_new_device_event_fired(self):
         """Test that the device tracker will fire an event."""
-        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
-                                        TEST_PLATFORM))
+        with assert_setup_component(1, device_tracker.DOMAIN):
+            assert setup_component(self.hass, device_tracker.DOMAIN,
+                                   TEST_PLATFORM)
         test_events = []
 
         @callback
@@ -434,8 +443,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     # pylint: disable=invalid-name
     def test_not_write_duplicate_yaml_keys(self):
         """Test that the device tracker will not generate invalid YAML."""
-        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
-                                        TEST_PLATFORM))
+        with assert_setup_component(1, device_tracker.DOMAIN):
+            assert setup_component(self.hass, device_tracker.DOMAIN,
+                                   TEST_PLATFORM)
 
         device_tracker.see(self.hass, 'mac_1', host_name='hello')
         device_tracker.see(self.hass, 'mac_2', host_name='hello')
@@ -449,8 +459,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     # pylint: disable=invalid-name
     def test_not_allow_invalid_dev_id(self):
         """Test that the device tracker will not allow invalid dev ids."""
-        self.assertTrue(setup_component(self.hass, device_tracker.DOMAIN,
-                                        TEST_PLATFORM))
+        with assert_setup_component(1, device_tracker.DOMAIN):
+            assert setup_component(self.hass, device_tracker.DOMAIN,
+                                   TEST_PLATFORM)
 
         device_tracker.see(self.hass, dev_id='hello-world')
 

--- a/tests/components/device_tracker/test_locative.py
+++ b/tests/components/device_tracker/test_locative.py
@@ -9,7 +9,8 @@ import homeassistant.components.device_tracker as device_tracker
 import homeassistant.components.http as http
 from homeassistant.const import CONF_PLATFORM
 
-from tests.common import get_test_home_assistant, get_test_instance_port
+from tests.common import (
+    assert_setup_component, get_test_home_assistant, get_test_instance_port)
 
 SERVER_PORT = get_test_instance_port()
 HTTP_BASE_URL = "http://127.0.0.1:{}".format(SERVER_PORT)
@@ -31,6 +32,7 @@ def setUpModule():
     global hass
 
     hass = get_test_home_assistant()
+    # http is not platform based, assert_setup_component not applicable
     bootstrap.setup_component(hass, http.DOMAIN, {
         http.DOMAIN: {
             http.CONF_SERVER_PORT: SERVER_PORT
@@ -38,11 +40,12 @@ def setUpModule():
     })
 
     # Set up device tracker
-    bootstrap.setup_component(hass, device_tracker.DOMAIN, {
-        device_tracker.DOMAIN: {
-            CONF_PLATFORM: 'locative'
-        }
-    })
+    with assert_setup_component(1, device_tracker.DOMAIN):
+        bootstrap.setup_component(hass, device_tracker.DOMAIN, {
+            device_tracker.DOMAIN: {
+                CONF_PLATFORM: 'locative'
+            }
+        })
 
     hass.start()
 


### PR DESCRIPTION
**Description:**

Add `assert_setup_component` to `device_tracker` tests. For details on `assert_setup_component` please see #3736


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
N/A

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
