### PR TITLE
[sensors/yr] Randomize seconds on which yr will update

### DIFF
--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/sensor.yr/
 import asyncio
 from datetime import timedelta
 import logging
+from random import randrange
 from xml.parsers.expat import ExpatError
 
 import async_timeout
@@ -80,8 +81,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     yield from async_add_devices(dev)
 
     weather = YrData(hass, coordinates, dev)
-    # Update weather on the hour
-    async_track_utc_time_change(hass, weather.async_update, minute=0, second=0)
+    # Update weather on the hour, spread seconds
+    async_track_utc_time_change(hass, weather.async_update, minute=0,
+                                second=randrange(5, 25))
     yield from weather.async_update()
 
 


### PR DESCRIPTION
**Description:**
Randomize seconds on which yr.no will update. Hopefully spread HASS instances and stops #4829 

**Related issue (if applicable):** fixes #4829 

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: yr
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

