### PR TITLE
Bugfix create a task from a task in component update

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -115,7 +115,7 @@ def async_setup(hass, config):
             update_coro = hass.loop.create_task(
                 alarm.async_update_ha_state(True))
             if hasattr(alarm, 'async_update'):
-                update_tasks.append(hass.loop.create_task(update_coro))
+                update_tasks.append(update_coro)
             else:
                 yield from update_coro
 

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -253,7 +253,7 @@ def async_setup(hass, config):
             update_coro = hass.loop.create_task(
                 light.async_update_ha_state(True))
             if hasattr(light, 'async_update'):
-                update_tasks.append(hass.loop.create_task(update_coro))
+                update_tasks.append(update_coro)
             else:
                 yield from update_coro
 

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -115,7 +115,7 @@ def async_setup(hass, config):
             update_coro = hass.loop.create_task(
                 remote.async_update_ha_state(True))
             if hasattr(remote, 'async_update'):
-                update_tasks.append(hass.loop.create_task(update_coro))
+                update_tasks.append(update_coro)
             else:
                 yield from update_coro
 

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -98,7 +98,7 @@ def async_setup(hass, config):
             update_coro = hass.loop.create_task(
                 switch.async_update_ha_state(True))
             if hasattr(switch, 'async_update'):
-                update_tasks.append(hass.loop.create_task(update_coro))
+                update_tasks.append(update_coro)
             else:
                 yield from update_coro
 


### PR DESCRIPTION
**Description:**

Don't task a task on component service updates

**Related issue (if applicable):** fixes #5029

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
