### PR TITLE
Bugfix async log handle re-close bug

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -298,8 +298,8 @@ class HomeAssistant(object):
         # cleanup async layer from python logging
         if self.data.get(DATA_ASYNCHANDLER):
             handler = self.data.pop(DATA_ASYNCHANDLER)
-            logging.getLogger('').removeHandler(handler)
             yield from handler.async_close(blocking=True)
+            logging.getLogger('').removeHandler(handler)
 
         self.loop.stop()
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -298,8 +298,8 @@ class HomeAssistant(object):
         # cleanup async layer from python logging
         if self.data.get(DATA_ASYNCHANDLER):
             handler = self.data.pop(DATA_ASYNCHANDLER)
-            yield from handler.async_close(blocking=True)
             logging.getLogger('').removeHandler(handler)
+            yield from handler.async_close(blocking=True)
 
         self.loop.stop()
 

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -57,7 +57,7 @@ class AsyncHandler(object):
         """
         if not self._thread.is_alive():
             return
-        self.close()
+        yield from self._queue.put(None)
 
         if blocking:
             # Python 3.4.4+

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -55,6 +55,8 @@ class AsyncHandler(object):
 
         When blocking=True, will wait till closed.
         """
+        if not self._thread.is_alive():
+            return
         self.close()
 
         if blocking:


### PR DESCRIPTION
**Description:**

We call `async_close` and they will push None to Queue with `call_soon` that will executor some times after check if empty and close the Loop bevor it efective done with it. 

**Related issue (if applicable):** fixes #5027

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
