### PR TITLE
Media playlists attribute & implementation for squeezebox

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -71,6 +71,7 @@ ATTR_MEDIA_SEASON = 'media_season'
 ATTR_MEDIA_EPISODE = 'media_episode'
 ATTR_MEDIA_CHANNEL = 'media_channel'
 ATTR_MEDIA_PLAYLIST = 'media_playlist'
+ATTR_MEDIA_PLAYLISTS = 'media_playlists'
 ATTR_APP_ID = 'app_id'
 ATTR_APP_NAME = 'app_name'
 ATTR_SUPPORTED_MEDIA_COMMANDS = 'supported_media_commands'
@@ -134,6 +135,7 @@ ATTR_TO_PROPERTY = [
     ATTR_MEDIA_EPISODE,
     ATTR_MEDIA_CHANNEL,
     ATTR_MEDIA_PLAYLIST,
+    ATTR_MEDIA_PLAYLISTS,
     ATTR_APP_ID,
     ATTR_APP_NAME,
     ATTR_SUPPORTED_MEDIA_COMMANDS,
@@ -517,6 +519,11 @@ class MediaPlayerDevice(Entity):
     @property
     def media_playlist(self):
         """Title of Playlist currently playing."""
+        return None
+
+    @property
+    def media_playlists(self):
+        """List of available playlists."""
         return None
 
     @property

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -199,6 +199,7 @@ class LogitechMediaServer(object):
                           error)
             return None
 
+
 class SqueezeBoxPlaylist():
     """Representation of a SqueezeBox playlist."""
     def __init__(self, playlist_id):
@@ -228,6 +229,7 @@ class SqueezeBoxPlaylist():
     def display(self):
         """Display of the playlist"""
         return "{}:{}".format(self._name, self._url)
+
 
 class SqueezeBoxDevice(MediaPlayerDevice):
     """Representation of a SqueezeBox device."""

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -111,7 +111,7 @@ class LogitechMediaServer(object):
         return players
 
     def get_playlists(self):
-        """Create a list of the playlists on LMS. (Currently limited to 50)"""
+        """Create a list of the playlists on LMS. (Currently limited to 50)."""
         playlists = []
         prefix_id = "id:"
         prefix_name = "playlist:"
@@ -202,14 +202,16 @@ class LogitechMediaServer(object):
 
 class SqueezeBoxPlaylist():
     """Representation of a SqueezeBox playlist."""
+
     def __init__(self, playlist_id):
+        """Initialize the SqeezeBox playlist."""
         self._id = playlist_id
         self._name = None
         self._url = None
 
     @property
     def name(self):
-        """Name of the playlist"""
+        """Name of the playlist."""
         return self._name
 
     @name.setter
@@ -218,7 +220,7 @@ class SqueezeBoxPlaylist():
 
     @property
     def url(self):
-        """URL of the playlist"""
+        """URL of the playlist."""
         return self._url
 
     @url.setter
@@ -227,7 +229,7 @@ class SqueezeBoxPlaylist():
 
     @property
     def display(self):
-        """Display of the playlist"""
+        """Display of the playlist."""
         return "{}:{}".format(self._name, self._url)
 
 

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -111,7 +111,7 @@ class LogitechMediaServer(object):
         return players
 
     def get_playlists(self):
-        """Create a list of the playlists on LMS."""
+        """Create a list of the playlists on LMS. (Currently limited to 50)"""
         playlists = []
         prefix_id = "id:"
         prefix_name = "playlist:"
@@ -119,7 +119,7 @@ class LogitechMediaServer(object):
         response = self.get('playlists 0 50 tags:u<LF>')
         response = urllib.parse.unquote(response)
         if not response:
-            return {}
+            return playlists
         playlist = None
         for word in response.split():
             if word.startswith(prefix_id):
@@ -346,7 +346,7 @@ class SqueezeBoxDevice(MediaPlayerDevice):
     def media_playlists(self):
         """In LMS Defined playlists."""
         if self._lms.playlists:
-            return '; '.join([str(x.display) for x in self._lms.playlists]) 
+            return '; '.join([x.display for x in self._lms.playlists])
 
     @property
     def supported_media_commands(self):


### PR DESCRIPTION
**Description:**
Added attribute media_playlists to component media_player to provide a list of available playlists.
Implemented for Squeezebox.

I would like to introduce a generic playlist class to be used by the media player component in a future commit / PR, to simplify a later introduction of playlist selection in the media-player more info for the players supporting playlists and play media

**Related issue (if applicable):** fixes my own ideas

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - N/A Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - N/A New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - N/A New dependencies are only imported inside functions that use them ([example][ex-import]).
  - N/A New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - N/A New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
Getting an error: OSError: [Errno 22] Invalid argument: 'C:\Users\...\AppData\Local\Temp\pip-build-m_ip_wks\somecomfort\tests/cassettes/set-attr-hold_heat-17:00:00.json'
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
