### PR TITLE
Fix the BLE device tracker

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -486,7 +486,7 @@ class Device(Entity):
             return None
 
         # prevent lookup of invalid macs
-        if not len(self.mac.split(':')) == 6:
+        if not len(self.mac) == 17:
             return 'unknown'
 
         # we only need the first 3 bytes of the mac for a lookup


### PR DESCRIPTION
**Description:**
Currently the BLE tracker doesn't work because the MAC address is prefixed with "BLE_" and this gets passed to the mac_vendor code which blows up. This checks the total length of the MAC address to ignore the BLE_ MACs all together verses checking the number of fields returned when splitting the MAC on `:`

~~I haven't had a chance to test this, but its pretty straightforward.~~ Tested, and works.

**Related issue (if applicable):** fixes # https://community.home-assistant.io/t/bluetooth-le-tracker-issues-with-hassbian-image/8078


**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
