### PR TITLE
Fixes moldindicator sensor after switch to async state handling

### DIFF
--- a/homeassistant/components/sensor/mold_indicator.py
+++ b/homeassistant/components/sensor/mold_indicator.py
@@ -163,7 +163,7 @@ class MoldIndicator(Entity):
             self._indoor_hum = MoldIndicator._update_hum_sensor(new_state)
 
         self.update()
-        self.update_ha_state()
+        self.schedule_update_ha_state()
 
     def _calc_dewpoint(self):
         """Calculate the dewpoint for the indoor air."""


### PR DESCRIPTION
**Description:**
Changed call "update_ha_state()" to "schedule_update_ha_state()" as mold_indicator
stopped working.

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51