### PR TITLE
Use full known command validation for pilight send

### DIFF
--- a/homeassistant/components/pilight.py
+++ b/homeassistant/components/pilight.py
@@ -18,7 +18,7 @@ from homeassistant.util import dt as dt_util
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, CONF_HOST, CONF_PORT,
-    CONF_WHITELIST, CONF_PROTOCOL)
+    CONF_WHITELIST, CONF_PROTOCOL, CONF_ID, CONF_STATE)
 
 REQUIREMENTS = ['pilight==0.1.1']
 
@@ -27,6 +27,10 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_SEND_DELAY = "send_delay"
 
+CONF_UNIT = 'unit'
+CONF_UNITCODE = 'unitcode'
+CONF_SYSTEMCODE = 'systemcode'
+
 DEFAULT_HOST = '127.0.0.1'
 DEFAULT_PORT = 5000
 DEFAULT_SEND_DELAY = 0.0
@@ -34,10 +38,21 @@ DOMAIN = 'pilight'
 
 EVENT = 'pilight_received'
 
+COMMAND_SCHEMA = vol.Schema({
+    vol.Optional(CONF_PROTOCOL): cv.string,
+    vol.Optional('on'): cv.positive_int,
+    vol.Optional('off'): cv.positive_int,
+    vol.Optional(CONF_UNIT): cv.positive_int,
+    vol.Optional(CONF_UNITCODE): cv.positive_int,
+    vol.Optional(CONF_ID): cv.positive_int,
+    vol.Optional(CONF_STATE): cv.string,
+    vol.Optional(CONF_SYSTEMCODE): cv.positive_int,
+}, extra=vol.ALLOW_EXTRA)
+
 # The Pilight code schema depends on the protocol. Thus only require to have
 # the protocol information. Ensure that protocol is in a list otherwise
 # segfault in pilight-daemon, https://github.com/pilight/pilight/issues/296
-RF_CODE_SCHEMA = vol.Schema({
+RF_CODE_SCHEMA = COMMAND_SCHEMA.extend({
     vol.Required(CONF_PROTOCOL): vol.All(cv.ensure_list, [cv.string]),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -11,8 +11,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 import homeassistant.components.pilight as pilight
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_NAME, CONF_ID, CONF_SWITCHES, CONF_STATE,
-                                 CONF_PROTOCOL)
+from homeassistant.const import (CONF_NAME, CONF_SWITCHES)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,31 +19,17 @@ CONF_OFF_CODE = 'off_code'
 CONF_OFF_CODE_RECIEVE = 'off_code_receive'
 CONF_ON_CODE = 'on_code'
 CONF_ON_CODE_RECIEVE = 'on_code_receive'
-CONF_SYSTEMCODE = 'systemcode'
-CONF_UNIT = 'unit'
-CONF_UNITCODE = 'unitcode'
 
 DEPENDENCIES = ['pilight']
 
-COMMAND_SCHEMA = vol.Schema({
-    vol.Optional(CONF_PROTOCOL): cv.string,
-    vol.Optional('on'): cv.positive_int,
-    vol.Optional('off'): cv.positive_int,
-    vol.Optional(CONF_UNIT): cv.positive_int,
-    vol.Optional(CONF_UNITCODE): cv.positive_int,
-    vol.Optional(CONF_ID): cv.positive_int,
-    vol.Optional(CONF_STATE): cv.string,
-    vol.Optional(CONF_SYSTEMCODE): cv.positive_int,
-}, extra=vol.ALLOW_EXTRA)
-
 SWITCHES_SCHEMA = vol.Schema({
-    vol.Required(CONF_ON_CODE): COMMAND_SCHEMA,
-    vol.Required(CONF_OFF_CODE): COMMAND_SCHEMA,
+    vol.Required(CONF_ON_CODE): pilight.COMMAND_SCHEMA,
+    vol.Required(CONF_OFF_CODE): pilight.COMMAND_SCHEMA,
     vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_OFF_CODE_RECIEVE, default=[]): vol.All(cv.ensure_list,
-                                                             [COMMAND_SCHEMA]),
-    vol.Optional(CONF_ON_CODE_RECIEVE, default=[]): vol.All(cv.ensure_list,
-                                                            [COMMAND_SCHEMA])
+    vol.Optional(CONF_OFF_CODE_RECIEVE, default=[]):
+        vol.All(cv.ensure_list, [pilight.COMMAND_SCHEMA]),
+    vol.Optional(CONF_ON_CODE_RECIEVE, default=[]):
+        vol.All(cv.ensure_list, [pilight.COMMAND_SCHEMA])
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/tests/components/test_pilight.py
+++ b/tests/components/test_pilight.py
@@ -131,7 +131,7 @@ class TestPilight(unittest.TestCase):
             self.hass.block_till_done()
             error_log_call = mock_pilight_error.call_args_list[-1]
             service_data['protocol'] = [service_data['protocol']]
-            self.assertTrue(str(service_data) in str(error_log_call))
+            self.assertIn(str(service_data), str(error_log_call))
 
     @patch('pilight.pilight.Client', PilightDaemonSim)
     @patch('homeassistant.components.pilight._LOGGER.error')


### PR DESCRIPTION
**Description:**

We already know the datatypes for certain pilight command data fields.
As it is not always possible for the user, to choose the correct
datatype for a piece of data (see bug #5042), which causes an unhelpful
error message from the pilight daemon, we can use this schema to "fix"
the users command data.

To prevent duplicate definition of the command data, this puts the data
into the pilight hub component and males the rf schema extending it.
this is also consistent as the command schema validates what the send
service of the hub gets as valid data.

**Related issue (if applicable):** fixes #5043 


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
