### PR TITLE
Allow to specify TTS language in the service call.

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -400,7 +400,8 @@ class Provider(object):
         This method is a coroutine.
         """
         extension, data = yield from self.hass.loop.run_in_executor(
-            None, functools.partial(self.get_tts_audio, message, language=language))
+            None,
+            functools.partial(self.get_tts_audio, message, language=language))
         return (extension, data)
 
 

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -247,7 +247,8 @@ class SpeechManager(object):
     def async_register_engine(self, engine, provider, config):
         """Register a TTS provider."""
         provider.hass = self.hass
-        provider.language = config.get(CONF_LANG)
+        if CONF_LANG in config:
+            provider.language = config.get(CONF_LANG)
         self.providers[engine] = provider
 
     @asyncio.coroutine
@@ -257,7 +258,7 @@ class SpeechManager(object):
         This method is a coroutine.
         """
         msg_hash = hashlib.sha1(bytes(message, 'utf-8')).hexdigest()
-        language_key = language or self.providers[engine].language or engine
+        language_key = language or self.providers[engine].language
         key = KEY_PATTERN.format(msg_hash, language_key, engine).lower()
         use_cache = cache if cache is not None else self.use_cache
 

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -5,8 +5,9 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/tts/
 """
 import asyncio
-import logging
+import functools
 import hashlib
+import logging
 import mimetypes
 import os
 import re
@@ -386,12 +387,12 @@ class Provider(object):
     hass = None
     language = None
 
-    def get_tts_audio(self, message, language):
+    def get_tts_audio(self, message, language=None):
         """Load tts audio file from provider."""
         raise NotImplementedError()
 
     @asyncio.coroutine
-    def async_get_tts_audio(self, message, language):
+    def async_get_tts_audio(self, message, language=None):
         """Load tts audio file from provider.
 
         Return a tuple of file extension and data as bytes.
@@ -399,7 +400,7 @@ class Provider(object):
         This method is a coroutine.
         """
         extension, data = yield from self.hass.loop.run_in_executor(
-            None, self.get_tts_audio, message, language)
+            None, functools.partial(self.get_tts_audio, message, language=language))
         return (extension, data)
 
 

--- a/homeassistant/components/tts/demo.py
+++ b/homeassistant/components/tts/demo.py
@@ -17,7 +17,7 @@ def get_engine(hass, config):
 class DemoProvider(Provider):
     """Demo speech api provider."""
 
-    def get_tts_audio(self, message):
+    def get_tts_audio(self, message, language):
         """Load TTS from demo."""
         filename = os.path.join(os.path.dirname(__file__), "demo.mp3")
         try:

--- a/homeassistant/components/tts/demo.py
+++ b/homeassistant/components/tts/demo.py
@@ -17,6 +17,10 @@ def get_engine(hass, config):
 class DemoProvider(Provider):
     """Demo speech api provider."""
 
+    def __init__(self):
+        """Initialize demo provider for TTS."""
+        self.language = 'en'
+
     def get_tts_audio(self, message, language=None):
         """Load TTS from demo."""
         filename = os.path.join(os.path.dirname(__file__), "demo.mp3")

--- a/homeassistant/components/tts/demo.py
+++ b/homeassistant/components/tts/demo.py
@@ -17,7 +17,7 @@ def get_engine(hass, config):
 class DemoProvider(Provider):
     """Demo speech api provider."""
 
-    def get_tts_audio(self, message, language):
+    def get_tts_audio(self, message, language=None):
         """Load TTS from demo."""
         filename = os.path.join(os.path.dirname(__file__), "demo.mp3")
         try:

--- a/homeassistant/components/tts/google.py
+++ b/homeassistant/components/tts/google.py
@@ -59,13 +59,18 @@ class GoogleProvider(Provider):
         }
 
     @asyncio.coroutine
-    def async_get_tts_audio(self, message):
+    def async_get_tts_audio(self, message, language):
         """Load TTS from google."""
         from gtts_token import gtts_token
 
         token = gtts_token.Token()
         websession = async_get_clientsession(self.hass)
         message_parts = self._split_message_to_parts(message)
+
+        # If language is not specified or is not supported - use the language
+        # from the config.
+        if language not in SUPPORT_LANGUAGES:
+            language = self.language
 
         data = b''
         for idx, part in enumerate(message_parts):
@@ -74,7 +79,7 @@ class GoogleProvider(Provider):
 
             url_param = {
                 'ie': 'UTF-8',
-                'tl': self.language,
+                'tl': language,
                 'q': yarl.quote(part),
                 'tk': part_token,
                 'total': len(message_parts),

--- a/homeassistant/components/tts/google.py
+++ b/homeassistant/components/tts/google.py
@@ -59,7 +59,7 @@ class GoogleProvider(Provider):
         }
 
     @asyncio.coroutine
-    def async_get_tts_audio(self, message, language):
+    def async_get_tts_audio(self, message, language=None):
         """Load TTS from google."""
         from gtts_token import gtts_token
 

--- a/homeassistant/components/tts/services.yaml
+++ b/homeassistant/components/tts/services.yaml
@@ -14,5 +14,9 @@ say:
       description: Control file cache of this message.
       example: 'true'
 
+    language:
+      description: Language to use for speech generation.
+      example: 'ru' 
+
 clear_cache:
   description: Remove cache files and RAM cache.

--- a/homeassistant/components/tts/voicerss.py
+++ b/homeassistant/components/tts/voicerss.py
@@ -103,7 +103,7 @@ class VoiceRSSProvider(Provider):
         }
 
     @asyncio.coroutine
-    def async_get_tts_audio(self, message, language):
+    def async_get_tts_audio(self, message, language=None):
         """Load TTS from voicerss."""
         websession = async_get_clientsession(self.hass)
         form_data = self.form_data.copy()

--- a/homeassistant/components/tts/voicerss.py
+++ b/homeassistant/components/tts/voicerss.py
@@ -103,12 +103,17 @@ class VoiceRSSProvider(Provider):
         }
 
     @asyncio.coroutine
-    def async_get_tts_audio(self, message):
+    def async_get_tts_audio(self, message, language):
         """Load TTS from voicerss."""
         websession = async_get_clientsession(self.hass)
         form_data = self.form_data.copy()
 
         form_data['src'] = message
+
+        # If language is specified and supported - use it instead of the
+        # language in the config.
+        if language in SUPPORT_LANGUAGES:
+            form_data['hl'] = language
 
         request = None
         try:

--- a/tests/components/tts/test_google.py
+++ b/tests/components/tts/test_google.py
@@ -134,7 +134,6 @@ class TestTTSGooglePlatform(object):
         assert len(calls) == 1
         assert len(aioclient_mock.mock_calls) == 1
 
-
     @patch('gtts_token.gtts_token.Token.calculate_token', autospec=True,
            return_value=5)
     def test_service_say_error(self, mock_calculate, aioclient_mock):

--- a/tests/components/tts/test_google.py
+++ b/tests/components/tts/test_google.py
@@ -80,8 +80,8 @@ class TestTTSGooglePlatform(object):
 
     @patch('gtts_token.gtts_token.Token.calculate_token', autospec=True,
            return_value=5)
-    def test_service_say_german(self, mock_calculate, aioclient_mock):
-        """Test service call say with german code."""
+    def test_service_say_german_config(self, mock_calculate, aioclient_mock):
+        """Test service call say with german code in the config."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
         self.url_param['tl'] = 'de'
@@ -105,6 +105,35 @@ class TestTTSGooglePlatform(object):
 
         assert len(calls) == 1
         assert len(aioclient_mock.mock_calls) == 1
+
+    @patch('gtts_token.gtts_token.Token.calculate_token', autospec=True,
+           return_value=5)
+    def test_service_say_german_service(self, mock_calculate, aioclient_mock):
+        """Test service call say with german code in the service."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        self.url_param['tl'] = 'de'
+        aioclient_mock.get(
+            self.url, params=self.url_param, status=200, content=b'test')
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'google',
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'google_say', {
+            tts.ATTR_MESSAGE: "I person is on front of your door.",
+            tts.ATTR_LANGUAGE: "de"
+        })
+        self.hass.block_till_done()
+
+        assert len(calls) == 1
+        assert len(aioclient_mock.mock_calls) == 1
+
 
     @patch('gtts_token.gtts_token.Token.calculate_token', autospec=True,
            return_value=5)

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -82,11 +82,11 @@ class TestTTS(object):
         assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
         assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
             "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_demo_demo.mp3") \
+            "_demo_en.mp3") \
             != -1
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3"))
 
     def test_setup_component_and_test_service_with_config_language(self):
         """Setup the demo platform and call service."""
@@ -167,14 +167,14 @@ class TestTTS(object):
         assert len(calls) == 1
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3"))
 
         self.hass.services.call(tts.DOMAIN, tts.SERVICE_CLEAR_CACHE, {})
         self.hass.block_till_done()
 
         assert not os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3"))
 
     def test_setup_component_and_test_service_with_receive_voice(self):
         """Setup the demo platform and call service and receive voice."""
@@ -242,7 +242,7 @@ class TestTTS(object):
         self.hass.start()
 
         url = ("{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-               "_demo_demo.mp3").format(self.hass.config.api.base_url)
+               "_demo_en.mp3").format(self.hass.config.api.base_url)
 
         req = requests.get(url)
         assert req.status_code == 404
@@ -261,7 +261,7 @@ class TestTTS(object):
         self.hass.start()
 
         url = ("{}/api/tts_proxy/265944dsk32c1b2a621be5930510bb2cd"
-               "_demo_demo.mp3").format(self.hass.config.api.base_url)
+               "_demo_en.mp3").format(self.hass.config.api.base_url)
 
         req = requests.get(url)
         assert req.status_code == 404
@@ -288,7 +288,7 @@ class TestTTS(object):
         assert len(calls) == 1
         assert not os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3"))
 
     def test_setup_component_test_with_cache_call_service_without_cache(self):
         """Setup demo platform with cache and call service without cache."""
@@ -313,7 +313,7 @@ class TestTTS(object):
         assert len(calls) == 1
         assert not os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3"))
 
     def test_setup_component_test_with_cache_dir(self):
         """Setup demo platform with cache and call service without cache."""
@@ -322,7 +322,7 @@ class TestTTS(object):
         _, demo_data = self.demo_provider.get_tts_audio("bla")
         cache_file = os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3")
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3")
 
         os.mkdir(self.default_tts_cache)
         with open(cache_file, "wb") as voice_file:
@@ -348,7 +348,7 @@ class TestTTS(object):
         assert len(calls) == 1
         assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
             "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_demo_demo.mp3") \
+            "_demo_en.mp3") \
             != -1
 
     @patch('homeassistant.components.tts.demo.DemoProvider.get_tts_audio',
@@ -378,7 +378,7 @@ class TestTTS(object):
         _, demo_data = self.demo_provider.get_tts_audio("bla")
         cache_file = os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3")
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3")
 
         os.mkdir(self.default_tts_cache)
         with open(cache_file, "wb") as voice_file:
@@ -397,7 +397,7 @@ class TestTTS(object):
         self.hass.start()
 
         url = ("{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-               "_demo_demo.mp3").format(self.hass.config.api.base_url)
+               "_demo_en.mp3").format(self.hass.config.api.base_url)
 
         req = requests.get(url)
         assert req.status_code == 200

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -140,9 +140,36 @@ class TestTTS(object):
 
         assert len(calls) == 1
         req = requests.get(calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        _, demo_data = self.demo_provider.get_tts_audio("bla")
+        _, demo_data = self.demo_provider.get_tts_audio("bla", None)
         assert req.status_code == 200
         assert req.content == demo_data
+
+    def test_setup_component_and_test_service_with_receive_voice_with_language(self):
+        """Setup the demo platform and call service and receive voice."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'demo',
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.start()
+
+        self.hass.services.call(tts.DOMAIN, 'demo_say', {
+            tts.ATTR_MESSAGE: "I person is on front of your door.",
+        })
+        self.hass.block_till_done()
+
+        assert len(calls) == 1
+        req = requests.get(calls[0].data[ATTR_MEDIA_CONTENT_ID])
+        _, demo_data = self.demo_provider.get_tts_audio("bla", "en-bla")
+        assert req.status_code == 200
+        assert req.content == demo_data
+
 
     def test_setup_component_and_web_view_wrong_file(self):
         """Setup the demo platform and receive wrong file from web."""
@@ -235,7 +262,7 @@ class TestTTS(object):
         """Setup demo platform with cache and call service without cache."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        _, demo_data = self.demo_provider.get_tts_audio("bla")
+        _, demo_data = self.demo_provider.get_tts_audio("bla", None)
         cache_file = os.path.join(
             self.default_tts_cache,
             "265944c108cbb00b2a621be5930513e03a0bb2cd_demo.mp3")
@@ -291,7 +318,7 @@ class TestTTS(object):
 
     def test_setup_component_load_cache_retrieve_without_mem_cache(self):
         """Setup component and load cache and get without mem cache."""
-        _, demo_data = self.demo_provider.get_tts_audio("bla")
+        _, demo_data = self.demo_provider.get_tts_audio("bla", None)
         cache_file = os.path.join(
             self.default_tts_cache,
             "265944c108cbb00b2a621be5930513e03a0bb2cd_demo.mp3")

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -140,7 +140,7 @@ class TestTTS(object):
 
         assert len(calls) == 1
         req = requests.get(calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        _, demo_data = self.demo_provider.get_tts_audio("bla", None)
+        _, demo_data = self.demo_provider.get_tts_audio("bla")
         assert req.status_code == 200
         assert req.content == demo_data
 

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -144,7 +144,7 @@ class TestTTS(object):
         assert req.status_code == 200
         assert req.content == demo_data
 
-    def test_setup_component_and_test_service_with_receive_voice_with_language(self):
+    def test_setup_component_and_test_service_with_receive_voice_german(self):
         """Setup the demo platform and call service and receive voice."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -166,7 +166,7 @@ class TestTTS(object):
 
         assert len(calls) == 1
         req = requests.get(calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        _, demo_data = self.demo_provider.get_tts_audio("bla", "en-bla")
+        _, demo_data = self.demo_provider.get_tts_audio("bla", "de")
         assert req.status_code == 200
         assert req.content == demo_data
 

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -261,7 +261,7 @@ class TestTTS(object):
         """Setup demo platform with cache and call service without cache."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        _, demo_data = self.demo_provider.get_tts_audio("bla", None)
+        _, demo_data = self.demo_provider.get_tts_audio("bla")
         cache_file = os.path.join(
             self.default_tts_cache,
             "265944c108cbb00b2a621be5930513e03a0bb2cd_demo.mp3")
@@ -317,7 +317,7 @@ class TestTTS(object):
 
     def test_setup_component_load_cache_retrieve_without_mem_cache(self):
         """Setup component and load cache and get without mem cache."""
-        _, demo_data = self.demo_provider.get_tts_audio("bla", None)
+        _, demo_data = self.demo_provider.get_tts_audio("bla")
         cache_file = os.path.join(
             self.default_tts_cache,
             "265944c108cbb00b2a621be5930513e03a0bb2cd_demo.mp3")

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -170,7 +170,6 @@ class TestTTS(object):
         assert req.status_code == 200
         assert req.content == demo_data
 
-
     def test_setup_component_and_web_view_wrong_file(self):
         """Setup the demo platform and receive wrong file from web."""
         config = {

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -82,11 +82,11 @@ class TestTTS(object):
         assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
         assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
             "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_demo_en.mp3") \
+            "_en_demo.mp3") \
             != -1
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3"))
 
     def test_setup_component_and_test_service_with_config_language(self):
         """Setup the demo platform and call service."""
@@ -167,14 +167,14 @@ class TestTTS(object):
         assert len(calls) == 1
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3"))
 
         self.hass.services.call(tts.DOMAIN, tts.SERVICE_CLEAR_CACHE, {})
         self.hass.block_till_done()
 
         assert not os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3"))
 
     def test_setup_component_and_test_service_with_receive_voice(self):
         """Setup the demo platform and call service and receive voice."""
@@ -242,7 +242,7 @@ class TestTTS(object):
         self.hass.start()
 
         url = ("{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-               "_demo_en.mp3").format(self.hass.config.api.base_url)
+               "_en_demo.mp3").format(self.hass.config.api.base_url)
 
         req = requests.get(url)
         assert req.status_code == 404
@@ -261,7 +261,7 @@ class TestTTS(object):
         self.hass.start()
 
         url = ("{}/api/tts_proxy/265944dsk32c1b2a621be5930510bb2cd"
-               "_demo_en.mp3").format(self.hass.config.api.base_url)
+               "_en_demo.mp3").format(self.hass.config.api.base_url)
 
         req = requests.get(url)
         assert req.status_code == 404
@@ -288,7 +288,7 @@ class TestTTS(object):
         assert len(calls) == 1
         assert not os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3"))
 
     def test_setup_component_test_with_cache_call_service_without_cache(self):
         """Setup demo platform with cache and call service without cache."""
@@ -313,7 +313,7 @@ class TestTTS(object):
         assert len(calls) == 1
         assert not os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3"))
 
     def test_setup_component_test_with_cache_dir(self):
         """Setup demo platform with cache and call service without cache."""
@@ -322,7 +322,7 @@ class TestTTS(object):
         _, demo_data = self.demo_provider.get_tts_audio("bla")
         cache_file = os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3")
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3")
 
         os.mkdir(self.default_tts_cache)
         with open(cache_file, "wb") as voice_file:
@@ -348,7 +348,7 @@ class TestTTS(object):
         assert len(calls) == 1
         assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
             "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_demo_en.mp3") \
+            "_en_demo.mp3") \
             != -1
 
     @patch('homeassistant.components.tts.demo.DemoProvider.get_tts_audio',
@@ -378,7 +378,7 @@ class TestTTS(object):
         _, demo_data = self.demo_provider.get_tts_audio("bla")
         cache_file = os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_en.mp3")
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3")
 
         os.mkdir(self.default_tts_cache)
         with open(cache_file, "wb") as voice_file:
@@ -397,7 +397,7 @@ class TestTTS(object):
         self.hass.start()
 
         url = ("{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-               "_demo_en.mp3").format(self.hass.config.api.base_url)
+               "_en_demo.mp3").format(self.hass.config.api.base_url)
 
         req = requests.get(url)
         assert req.status_code == 200

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -82,11 +82,69 @@ class TestTTS(object):
         assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
         assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
             "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_demo.mp3") \
+            "_demo_demo.mp3") \
             != -1
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3"))
+
+    def test_setup_component_and_test_service_with_config_language(self):
+        """Setup the demo platform and call service."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'demo',
+                'language': 'lang'
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'demo_say', {
+            tts.ATTR_MESSAGE: "I person is on front of your door.",
+        })
+        self.hass.block_till_done()
+
+        assert len(calls) == 1
+        assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
+        assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
+            "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
+            "_lang_demo.mp3") \
+            != -1
+        assert os.path.isfile(os.path.join(
+            self.default_tts_cache,
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_lang_demo.mp3"))
+
+    def test_setup_component_and_test_service_with_service_language(self):
+        """Setup the demo platform and call service."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'demo',
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'demo_say', {
+            tts.ATTR_MESSAGE: "I person is on front of your door.",
+            tts.ATTR_LANGUAGE: "lang",
+        })
+        self.hass.block_till_done()
+
+        assert len(calls) == 1
+        assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
+        assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
+            "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
+            "_lang_demo.mp3") \
+            != -1
+        assert os.path.isfile(os.path.join(
+            self.default_tts_cache,
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_lang_demo.mp3"))
 
     def test_setup_component_and_test_service_clear_cache(self):
         """Setup the demo platform and call service clear cache."""
@@ -109,14 +167,14 @@ class TestTTS(object):
         assert len(calls) == 1
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3"))
 
         self.hass.services.call(tts.DOMAIN, tts.SERVICE_CLEAR_CACHE, {})
         self.hass.block_till_done()
 
         assert not os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3"))
 
     def test_setup_component_and_test_service_with_receive_voice(self):
         """Setup the demo platform and call service and receive voice."""
@@ -140,7 +198,7 @@ class TestTTS(object):
 
         assert len(calls) == 1
         req = requests.get(calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        _, demo_data = self.demo_provider.get_tts_audio("bla", None)
+        _, demo_data = self.demo_provider.get_tts_audio("bla")
         assert req.status_code == 200
         assert req.content == demo_data
 
@@ -184,7 +242,7 @@ class TestTTS(object):
         self.hass.start()
 
         url = ("{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-               "_demo.mp3").format(self.hass.config.api.base_url)
+               "_demo_demo.mp3").format(self.hass.config.api.base_url)
 
         req = requests.get(url)
         assert req.status_code == 404
@@ -203,7 +261,7 @@ class TestTTS(object):
         self.hass.start()
 
         url = ("{}/api/tts_proxy/265944dsk32c1b2a621be5930510bb2cd"
-               "_demo.mp3").format(self.hass.config.api.base_url)
+               "_demo_demo.mp3").format(self.hass.config.api.base_url)
 
         req = requests.get(url)
         assert req.status_code == 404
@@ -230,7 +288,7 @@ class TestTTS(object):
         assert len(calls) == 1
         assert not os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3"))
 
     def test_setup_component_test_with_cache_call_service_without_cache(self):
         """Setup demo platform with cache and call service without cache."""
@@ -255,16 +313,16 @@ class TestTTS(object):
         assert len(calls) == 1
         assert not os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3"))
 
     def test_setup_component_test_with_cache_dir(self):
         """Setup demo platform with cache and call service without cache."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        _, demo_data = self.demo_provider.get_tts_audio("bla", None)
+        _, demo_data = self.demo_provider.get_tts_audio("bla")
         cache_file = os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo.mp3")
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3")
 
         os.mkdir(self.default_tts_cache)
         with open(cache_file, "wb") as voice_file:
@@ -290,7 +348,7 @@ class TestTTS(object):
         assert len(calls) == 1
         assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
             "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_demo.mp3") \
+            "_demo_demo.mp3") \
             != -1
 
     @patch('homeassistant.components.tts.demo.DemoProvider.get_tts_audio',
@@ -317,10 +375,10 @@ class TestTTS(object):
 
     def test_setup_component_load_cache_retrieve_without_mem_cache(self):
         """Setup component and load cache and get without mem cache."""
-        _, demo_data = self.demo_provider.get_tts_audio("bla", None)
+        _, demo_data = self.demo_provider.get_tts_audio("bla")
         cache_file = os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo.mp3")
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_demo_demo.mp3")
 
         os.mkdir(self.default_tts_cache)
         with open(cache_file, "wb") as voice_file:
@@ -339,7 +397,7 @@ class TestTTS(object):
         self.hass.start()
 
         url = ("{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-               "_demo.mp3").format(self.hass.config.api.base_url)
+               "_demo_demo.mp3").format(self.hass.config.api.base_url)
 
         req = requests.get(url)
         assert req.status_code == 200

--- a/tests/components/tts/test_voicerss.py
+++ b/tests/components/tts/test_voicerss.py
@@ -86,8 +86,8 @@ class TestTTSVoiceRSSPlatform(object):
         assert aioclient_mock.mock_calls[0][2] == self.form_data
         assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(".mp3") != -1
 
-    def test_service_say_german(self, aioclient_mock):
-        """Test service call say with german code."""
+    def test_service_say_german_config(self, aioclient_mock):
+        """Test service call say with german code in the config."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
         self.form_data['hl'] = 'de-de'
@@ -113,6 +113,35 @@ class TestTTSVoiceRSSPlatform(object):
         assert len(calls) == 1
         assert len(aioclient_mock.mock_calls) == 1
         assert aioclient_mock.mock_calls[0][2] == self.form_data
+
+    def test_service_say_german_service(self, aioclient_mock):
+        """Test service call say with german code in the service."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        self.form_data['hl'] = 'de-de'
+        aioclient_mock.post(
+            self.url, data=self.form_data, status=200, content=b'test')
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'voicerss',
+                'api_key': '1234567xx',
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'voicerss_say', {
+            tts.ATTR_MESSAGE: "I person is on front of your door.",
+            tts.ATTR_LANGUAGE: "de-de"
+        })
+        self.hass.block_till_done()
+
+        assert len(calls) == 1
+        assert len(aioclient_mock.mock_calls) == 1
+        assert aioclient_mock.mock_calls[0][2] == self.form_data
+
 
     def test_service_say_error(self, aioclient_mock):
         """Test service call say with http response 400."""

--- a/tests/components/tts/test_voicerss.py
+++ b/tests/components/tts/test_voicerss.py
@@ -142,7 +142,6 @@ class TestTTSVoiceRSSPlatform(object):
         assert len(aioclient_mock.mock_calls) == 1
         assert aioclient_mock.mock_calls[0][2] == self.form_data
 
-
     def test_service_say_error(self, aioclient_mock):
         """Test service call say with http response 400."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)


### PR DESCRIPTION
**Description:**


**Related issue (if applicable):** https://community.home-assistant.io/t/multilingual-tts/7945

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1644

**EDIT breaking change for release notes**

This PR change the name of cache files from `hash_provider.xxx` to `hash_lang_provider.xxx`. You can clear the cache to delete stale files or rename al files with you config language in the file name.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
