### PR TITLE
Add cover component support to emulated hue

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -38,7 +38,7 @@ DEFAULT_LISTEN_PORT = 8300
 DEFAULT_OFF_MAPS_TO_ON_DOMAINS = ['script', 'scene']
 DEFAULT_EXPOSE_BY_DEFAULT = True
 DEFAULT_EXPOSED_DOMAINS = [
-    'switch', 'light', 'group', 'input_boolean', 'media_player', 'fan'
+    'switch', 'light', 'group', 'input_boolean', 'media_player', 'fan', 'cover'
 ]
 DEFAULT_TYPE = TYPE_ALEXA
 

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -7,6 +7,7 @@ from aiohttp import web
 from homeassistant import core
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON, SERVICE_VOLUME_SET,
+    SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER,
     STATE_ON, STATE_OFF, HTTP_BAD_REQUEST, HTTP_NOT_FOUND,
 )
 from homeassistant.components.light import (
@@ -193,6 +194,12 @@ class HueOneLightChangeView(HomeAssistantView):
                     service = SERVICE_VOLUME_SET
                     # Convert 0-100 to 0.0-1.0
                     data[ATTR_MEDIA_VOLUME_LEVEL] = brightness / 100.0
+        elif entity.domain == "cover":
+            domain = entity.domain
+            if service == SERVICE_TURN_ON:
+                service = SERVICE_OPEN_COVER
+            elif service == SERVICE_TURN_OFF:
+                service = SERVICE_CLOSE_COVER
 
         if entity.domain in config.off_maps_to_on_domains:
             # Map the off command to on

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -205,12 +205,6 @@ class HueOneLightChangeView(HomeAssistantView):
             # as the actual requested command.
             config.cached_states[entity_id] = (result, brightness)
 
-        # Separate call to turn on needed
-        if domain != core.DOMAIN:
-            hass.async_add_job(hass.services.async_call(
-                core.DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id},
-                blocking=True))
-
         hass.async_add_job(hass.services.async_call(
             domain, service, data, blocking=True))
 

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -240,10 +240,10 @@ class TestEmulatedHueExposedByDefault(unittest.TestCase):
             level)
 
     def test_put_light_state_media_player(self):
-        """Test turning on media player and setting volume."""
-        # Turn the music player off first
+        """Test setting media player volume."""
+        # Turn the music player on first
         self.hass.services.call(
-            media_player.DOMAIN, const.SERVICE_TURN_OFF,
+            media_player.DOMAIN, const.SERVICE_TURN_ON,
             {const.ATTR_ENTITY_ID: 'media_player.walkman'},
             blocking=True)
 


### PR DESCRIPTION
Support for turn on/off which will open/close the cover component.
Also add cover to default exposed list.

Signed-off-by: Roi Dayan <roi.dayan@gmail.com>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#1646

**Checklist:**

  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
