### PR TITLE
[switch.pilight] Implement echo config option

### DIFF
--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -80,13 +80,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 class _ReceiveHandle(object):
     def __init__(self, config, echo):
+        """Initialize the handle."""
         self.config_items = config.items()
         self.echo = echo
 
     def match(self, code):
+        """Test if the received code matches the configured values.
+
+        The received values have to be a subset of the configured options.
+        """
         return self.config_items <= code.items()
 
     def run(self, switch, turn_on):
+        """Change the state of the switch."""
         switch.set_state(turn_on=turn_on, send_code=self.echo)
 
 
@@ -151,6 +157,12 @@ class PilightSwitch(SwitchDevice):
                     break
 
     def set_state(self, turn_on, send_code=True):
+        """Set the state of the switch.
+
+        This sets the state of the switch. If send_code is set to True, then
+        it will call the pilight.send service to actually send the codes
+        to the pilight daemon.
+        """
         if send_code:
             if turn_on:
                 self._hass.services.call(pilight.DOMAIN, pilight.SERVICE_NAME,


### PR DESCRIPTION
**Description:**

Pilight switches can get a receive code configured. If so they act on
received codes. In the current implementation "act on" means not only
to set the internal state, but also to send the code again. If the
receiver is directly parred with the switch, to act even if HA is not
running, this causes it to receive the signal twice because the HA
sends it again.

In my case this causes a dimmer to start dimming until I hit the switch
again.

This implements a "echo" argument for the receive codes that let the
user choose if a received signal should result in any sending or not.
If not, only the status of pilight will be updated.

The echo option defaults to True, as this was the default since now.
Simply set it to halse to disable this behaviour.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1712

**Example entry for `configuration.yaml` (if applicable):**
```yaml
    switch_01:
      on_code:
        protocol: intertechno_switch
        id: 58318848
        unit: 2
        'on': 1
      on_code_receive:
        - protocol: arctech_switch
          id: 58318848
          unit: 2
          state: 'on'
          echo: false
      off_code:
        protocol: intertechno_switch
        id: 58318848
        unit: 2
        'off': 1
      off_code_receive:
        - protocol: arctech_switch
          id: 58318848
          unit: 2
          state: 'off'
          echo: false
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
