### PR TITLE
Improvements to zwave lock platform

### DIFF
--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -6,8 +6,33 @@ https://home-assistant.io/components/lock.zwave/
 """
 # Because we do not compile openzwave on CI
 # pylint: disable=import-error
+import logging
+
 from homeassistant.components.lock import DOMAIN, LockDevice
 from homeassistant.components import zwave
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_NOTIFICATION = 'notification'
+
+LOCK_NOTIFICATION = {
+    1: 'Manual Lock',
+    2: 'Manual Unlock',
+    3: 'RF Lock',
+    4: 'RF Unlock',
+    5: 'Keypad Lock',
+    6: 'Keypad Unlock',
+    254: 'Unknown Event'
+}
+
+LOCK_STATUS = {
+    1: True,
+    2: False,
+    3: True,
+    4: False,
+    5: True,
+    6: False
+}
 
 
 # pylint: disable=unused-argument
@@ -40,15 +65,32 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
 
         zwave.ZWaveDeviceEntity.__init__(self, value, DOMAIN)
 
-        self._state = value.data
+        self._node = value.node
+        self._state = None
+        self._notification = None
         dispatcher.connect(
             self._value_changed, ZWaveNetwork.SIGNAL_VALUE_CHANGED)
+        self.update_properties()
 
     def _value_changed(self, value):
         """Called when a value has changed on the network."""
-        if self._value.value_id == value.value_id:
-            self._state = value.data
-            self.update_ha_state()
+        if self._value.value_id == value.value_id or \
+           self._value.node == value.node:
+            self.update_properties()
+            self.schedule_update_ha_state()
+
+    def update_properties(self):
+        """Callback on data change for the registered node/value pair."""
+        for value in self._node.get_values(
+                class_id=zwave.const.COMMAND_CLASS_ALARM).values():
+            if value.label != "Access Control":
+                continue
+            self._notification = LOCK_NOTIFICATION.get(value.data)
+            if self._notification:
+                self._state = LOCK_STATUS.get(value.data)
+            break
+        if not self._notification:
+            self._state = self._value.data
 
     @property
     def is_locked(self):
@@ -62,3 +104,11 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
     def unlock(self, **kwargs):
         """Unlock the device."""
         self._value.data = False
+
+    @property
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
+        data = super().device_state_attributes
+        if self._notification:
+            data[ATTR_NOTIFICATION] = self._notification
+        return data


### PR DESCRIPTION
**Description:**
Improvements to the zwave lock platform.

Locks that uses the notification cc does not provide state in the old command_class_door_lock.
It is still used as a fallback for devices using this command_class.

Also support for attribute how the lock was locked/unlocked via the notification cc. 
Available datas are:
'Manual Lock',
'Manual Unlock',
'RF Lock',
'RF Unlock',
'Keypad Lock',
'Keypad Unlock',
'Unknown Event'
