### PR TITLE
Add ability to set rpi_rf `tx_repeats` attribute

### DIFF
--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -21,16 +21,17 @@ CONF_CODE_ON = 'code_on'
 CONF_GPIO = 'gpio'
 CONF_PROTOCOL = 'protocol'
 CONF_PULSELENGTH = 'pulselength'
-CONF_REPEATS = 'repeats'
+CONF_SIGNAL_REPETITIONS = 'signal_repetitions'
 
 DEFAULT_PROTOCOL = 1
-DEFAULT_REPEATS = 10
+DEFAULT_SIGNAL_REPETITIONS = 10
 
 SWITCH_SCHEMA = vol.Schema({
     vol.Required(CONF_CODE_OFF): cv.positive_int,
     vol.Required(CONF_CODE_ON): cv.positive_int,
     vol.Optional(CONF_PULSELENGTH): cv.positive_int,
-    vol.Optional(CONF_REPEATS, default=DEFAULT_REPEATS): cv.positive_int,
+    vol.Optional(CONF_SIGNAL_REPETITIONS,
+                 default=DEFAULT_SIGNAL_REPETITIONS): cv.positive_int,
     vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL): cv.positive_int,
 })
 
@@ -58,7 +59,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 rfdevice,
                 properties.get(CONF_PROTOCOL),
                 properties.get(CONF_PULSELENGTH),
-                properties.get(CONF_REPEATS),
+                properties.get(CONF_SIGNAL_REPETITIONS),
                 properties.get(CONF_CODE_ON),
                 properties.get(CONF_CODE_OFF)
             )
@@ -72,8 +73,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiRFSwitch(SwitchDevice):
     """Representation of a GPIO RF switch."""
 
-    def __init__(self, hass, name, rfdevice, protocol, pulselength, repeats,
-                 code_on, code_off):
+    def __init__(self, hass, name, rfdevice, protocol, pulselength,
+                 signal_repetitions, code_on, code_off):
         """Initialize the switch."""
         self._hass = hass
         self._name = name
@@ -83,7 +84,7 @@ class RPiRFSwitch(SwitchDevice):
         self._pulselength = pulselength
         self._code_on = code_on
         self._code_off = code_off
-        self._rfdevice.tx_repeat = repeats
+        self._rfdevice.tx_repeat = signal_repetitions
 
     @property
     def should_poll(self):

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -21,13 +21,16 @@ CONF_CODE_ON = 'code_on'
 CONF_GPIO = 'gpio'
 CONF_PROTOCOL = 'protocol'
 CONF_PULSELENGTH = 'pulselength'
+CONF_REPEATS = 'repeats'
 
 DEFAULT_PROTOCOL = 1
+DEFAULT_REPEATS = 10
 
 SWITCH_SCHEMA = vol.Schema({
     vol.Required(CONF_CODE_OFF): cv.positive_int,
     vol.Required(CONF_CODE_ON): cv.positive_int,
     vol.Optional(CONF_PULSELENGTH): cv.positive_int,
+    vol.Optional(CONF_REPEATS, default=DEFAULT_REPEATS): cv.positive_int,
     vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL): cv.positive_int,
 })
 
@@ -55,6 +58,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 rfdevice,
                 properties.get(CONF_PROTOCOL),
                 properties.get(CONF_PULSELENGTH),
+                properties.get(CONF_REPEATS),
                 properties.get(CONF_CODE_ON),
                 properties.get(CONF_CODE_OFF)
             )
@@ -68,7 +72,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiRFSwitch(SwitchDevice):
     """Representation of a GPIO RF switch."""
 
-    def __init__(self, hass, name, rfdevice, protocol, pulselength,
+    def __init__(self, hass, name, rfdevice, protocol, pulselength, repeats,
                  code_on, code_off):
         """Initialize the switch."""
         self._hass = hass
@@ -79,6 +83,7 @@ class RPiRFSwitch(SwitchDevice):
         self._pulselength = pulselength
         self._code_on = code_on
         self._code_off = code_off
+        self._rfdevice.tx_repeat = repeats
 
     @property
     def should_poll(self):


### PR DESCRIPTION
**Description:**
Allows user to configure [`rpi_rf`'s `tx_repeats` attribute](https://github.com/milaq/rpi-rf/blob/6c81df133c89c417b5f6a17b9bd1fe4344903d08/rpi_rf/rpi_rf.py#L42) to customize the number of transmissions sent, making it possible to increase the number from default of 10 to improve reliability.

- Uses the current `rpi_rf` default of 10

**Related issue (if applicable):** fixes #5069

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1655

**Example entry for `configuration.yaml` (if applicable):**
```yaml
platform: rpi_rf
gpio: 17
  switches:
    my switch:
      code_on: 12345
      code_off: 54321
      protocol: 1
      pulselength: 190
      repeats: 20
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
