### PR TITLE
Upgrade pyowm to 2.6.0

### DIFF
--- a/homeassistant/components/sensor/openweathermap.py
+++ b/homeassistant/components/sensor/openweathermap.py
@@ -17,7 +17,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyowm==2.5.0']
+REQUIREMENTS = ['pyowm==2.6.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyowm==2.5.0']
+REQUIREMENTS = ['pyowm==2.6.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -449,7 +449,7 @@ pynx584==0.2
 
 # homeassistant.components.sensor.openweathermap
 # homeassistant.components.weather.openweathermap
-pyowm==2.5.0
+pyowm==2.6.0
 
 # homeassistant.components.switch.acer_projector
 pyserial==3.1.1


### PR DESCRIPTION
## 2.6.0
- new method owm25.weather_at_zip_code
- new methods CityIDRegistry.ids_for and CityIDRegistry.locations_for
- introduced deprecation decorators to mark methods that will be removed/modified in future versions
Python 3.6 support
- reverted a breaking interface change wrongly released on 2.5.0
- fixed CityIDRegistry.id_for and CityIDRegistry.location_for methods -> oh man, they were so buggy!
- fixed a bug on Unicode input handling

**Related issue (if applicable):** fixes #3526

Tested with the following configuration:

``` yaml
sensor:
  - platform: openweathermap
    api_key: !secret owm_api
    forecast: 0
    monitored_conditions:
      - weather
      - temperature
      - wind_speed
      - humidity
      - pressure
```
