### PR TITLE
Upgrade psutil to 5.0.1

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==5.0.0']
+REQUIREMENTS = ['psutil==5.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -351,7 +351,7 @@ pmsensor==0.3
 proliphix==0.4.1
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.0.0
+psutil==5.0.1
 
 # homeassistant.components.wink
 pubnubsub-handler==0.0.5


### PR DESCRIPTION
5.0.1
=====

**Enhncements**

- new Process.oneshot() context manager making Process methods around +2x faster in general and from +2x to +6x faster on Windows.
- better error message in case of version conflict on import.

**Bug fixes**

- [SunOS] psutil does not compile on Solaris 10.
- [Windows] fix compilation error on VS 2013 (patch by Max Bélanger).
- [Linux] cpu_percent() and cpu_times_percent() was calculated incorrectly as "iowait", "guest" and guest_nice" times were not properly taken into account.
- [OpenBSD] psutil.pids() was omitting PID 0.

Tested with the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
```
