### PR TITLE
Add support for customised Kankun SP3 Wifi switches.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -333,6 +333,7 @@ omit =
     homeassistant/components/switch/edimax.py
     homeassistant/components/switch/hikvisioncam.py
     homeassistant/components/switch/hook.py
+    homeassistant/components/switch/kankun.py
     homeassistant/components/switch/mystrom.py
     homeassistant/components/switch/netio.py
     homeassistant/components/switch/orvibo.py

--- a/homeassistant/components/switch/kankun.py
+++ b/homeassistant/components/switch/kankun.py
@@ -113,10 +113,8 @@ class KankunSwitch(SwitchDevice):
         """Turn the device on."""
         if self._switch('on'):
             self._state = True
-            self.update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
         if self._switch('off'):
             self._state = False
-            self.update_ha_state()

--- a/homeassistant/components/switch/kankun.py
+++ b/homeassistant/components/switch/kankun.py
@@ -6,10 +6,31 @@ https://home-assistant.io/components/switch.kankun/
 """
 import logging
 import requests
+import voluptuous as vol
 
-from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, CONF_PORT, CONF_PATH, CONF_USERNAME, CONF_PASSWORD,
+    CONF_SWITCHES)
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
+
+DEFAULT_PORT = 80
+DEFAULT_PATH = "/cgi-bin/json.cgi"
+
+SWITCH_SCHEMA = vol.Schema({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_PATH, default=DEFAULT_PATH): cv.string,
+    vol.Optional(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_PASSWORD): cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SWITCHES): vol.Schema({cv.slug: SWITCH_SCHEMA}),
+})
 
 
 # pylint: disable=unused-argument
@@ -22,12 +43,12 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         devices.append(
             KankunSwitch(
                 hass,
-                properties.get('name', dev_name),
-                properties.get('host', None),
-                properties.get('port', 80),
-                properties.get('path', '/cgi-bin/json.cgi'),
-                properties.get('user', None),
-                properties.get('passwd')))
+                properties.get(CONF_NAME, dev_name),
+                properties.get(CONF_HOST, None),
+                properties.get(CONF_PORT, DEFAULT_PORT),
+                properties.get(CONF_PATH, DEFAULT_PATH),
+                properties.get(CONF_USERNAME, None),
+                properties.get(CONF_PASSWORD)))
 
     add_devices_callback(devices)
 

--- a/homeassistant/components/switch/kankun.py
+++ b/homeassistant/components/switch/kankun.py
@@ -1,0 +1,101 @@
+"""
+Support for customised Kankun SP3 wifi switch.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.kankun/
+"""
+import logging
+import requests
+
+from homeassistant.components.switch import SwitchDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Find and return kankun switches."""
+    switches = config.get('switches', {})
+    devices = []
+
+    for dev_name, properties in switches.items():
+        devices.append(
+            KankunSwitch(
+                hass,
+                properties.get('name', dev_name),
+                properties.get('host', None),
+                properties.get('port', 80),
+                properties.get('path', '/cgi-bin/json.cgi'),
+                properties.get('user', None),
+                properties.get('passwd')))
+
+    add_devices_callback(devices)
+
+
+class KankunSwitch(SwitchDevice):
+    """Represents a Kankun wifi switch."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, hass, name, host, port, path, user, passwd):
+        """Initialise device."""
+        self._hass = hass
+        self._name = name
+        self._state = False
+        self._url = "http://{}:{}{}".format(host, port, path)
+        if user is not None:
+            self._auth = (user, passwd)
+        else:
+            self._auth = None
+
+    def _switch(self, newstate):
+        """Switch on or off."""
+        _LOGGER.info('Switching to state: %s', newstate)
+
+        try:
+            req = requests.get("{}?set={}".format(self._url, newstate),
+                               auth=self._auth)
+            return req.json()['ok']
+        except requests.RequestException:
+            _LOGGER.error('Switching failed.')
+
+    def _query_state(self):
+        """Query switch state."""
+        _LOGGER.info('Querying state from: %s', self._url)
+
+        try:
+            req = requests.get("{}?get=state".format(self._url),
+                               auth=self._auth)
+            return req.json()['state'] == "on"
+        except requests.RequestException:
+            _LOGGER.error('State query failed.')
+
+    @property
+    def should_poll(self):
+        """Switch should always be polled."""
+        return True
+
+    @property
+    def name(self):
+        """The name of the switch."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """True if device is on."""
+        return self._state
+
+    def update(self):
+        """Update device state."""
+        self._state = self._query_state()
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        if self._switch('on'):
+            self._state = True
+            self.update_ha_state()
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        if self._switch('off'):
+            self._state = False
+            self.update_ha_state()


### PR DESCRIPTION
**Description:**
Add support for Kankun SP3 wifi switches.

**Related issue (if applicable):** none

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1665

**Example entry for `configuration.yaml` (if applicable):**
```yaml
switch:
  platform: kankun
    switches:
      bedroom_heating:
        host: hostname_or_ipaddr
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
