### PR TITLE
Let itunes-api handle playlist matching

### DIFF
--- a/homeassistant/components/media_player/itunes.py
+++ b/homeassistant/components/media_player/itunes.py
@@ -340,6 +340,7 @@ class ItunesDevice(MediaPlayerDevice):
             response = self.client.play_playlist(media_id)
             self.update_state(response)
 
+
 class AirPlayDevice(MediaPlayerDevice):
     """Representation an AirPlay device via an iTunes API instance."""
 


### PR DESCRIPTION
Removes validation of the presence of the submitted playlist to support in-development [fuzzy-playlist matching in `itunes-api`](https://github.com/maddox/itunes-api/pull/26).

While I was here, I fixed one lint warning and also set the player state to `error` if the response is a 4xx or 5xx.

/cc @maddox 