### PR TITLE
Replace dots in Alexa built-in intent slots w/ underscores

### DIFF
--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -203,11 +203,12 @@ class AlexaResponse(object):
         self.reprompt = None
         self.session_attributes = {}
         self.should_end_session = True
+        self.variables = {}
         if intent is not None and 'slots' in intent:
-            self.variables = {key: value['value'] for key, value
-                              in intent['slots'].items() if 'value' in value}
-        else:
-            self.variables = {}
+            for key, value in intent['slots'].items():
+                if 'value' in value:
+                    underscored_key = key.replace('.', '_')
+                    self.variables[underscored_key] = value['value']
 
     def add_card(self, card_type, title, content):
         """Add a card to the response."""

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -101,6 +101,12 @@ def setUpModule():
                         "text": "You told us your sign is {{ ZodiacSign }}.",
                     }
                 },
+                "AMAZON.PlaybackAction<object@MusicCreativeWork>": {
+                    "speech": {
+                        "type": "plaintext",
+                        "text": "Playing {{ object_byArtist_name }}.",
+                    }
+                },
                 "CallServiceIntent": {
                     "speech": {
                         "type": "plaintext",
@@ -375,6 +381,65 @@ class TestAlexa(unittest.TestCase):
         req = _intent_req(data)
         self.assertEqual(200, req.status_code)
         self.assertEqual("", req.text)
+
+    def test_intent_from_built_in_intent_library(self):
+        """Test intents from the Built-in Intent Library."""
+        data = {
+            'request': {
+                'intent': {
+                    'name': 'AMAZON.PlaybackAction<object@MusicCreativeWork>',
+                    'slots': {
+                        'object.byArtist.name': {
+                            'name': 'object.byArtist.name',
+                            'value': 'the shins'
+                        },
+                        'object.composer.name': {
+                            'name': 'object.composer.name'
+                        },
+                        'object.contentSource': {
+                            'name': 'object.contentSource'
+                        },
+                        'object.era': {
+                            'name': 'object.era'
+                        },
+                        'object.genre': {
+                            'name': 'object.genre'
+                        },
+                        'object.name': {
+                            'name': 'object.name'
+                        },
+                        'object.owner.name': {
+                            'name': 'object.owner.name'
+                        },
+                        'object.select': {
+                            'name': 'object.select'
+                        },
+                        'object.sort': {
+                            'name': 'object.sort'
+                        },
+                        'object.type': {
+                            'name': 'object.type',
+                            'value': 'music'
+                        }
+                    }
+                },
+                'timestamp': '2016-12-14T23:23:37Z',
+                'type': 'IntentRequest',
+                'requestId': REQUEST_ID,
+
+            },
+            'session': {
+                'sessionId': SESSION_ID,
+                'application': {
+                    'applicationId': APPLICATION_ID
+                }
+            }
+        }
+        req = _intent_req(data)
+        self.assertEqual(200, req.status_code)
+        text = req.json().get("response", {}).get("outputSpeech",
+                                                  {}).get("text")
+        self.assertEqual("Playing the shins.", text)
 
     def test_flash_briefing_invalid_id(self):
         """Test an invalid Flash Briefing ID."""


### PR DESCRIPTION
**Description:**

Replaces the dots in [Alexa built-in intent slot keys](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/built-in-intent-library#built-in-intent-categories) w/ underscores so they can be used in Jinja templates.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** TODO

**Example entry for `configuration.yaml` (if applicable):**
```yaml
alexa:
  AMAZON.PlaybackAction<object@MusicPlaylist>:
    action:
      service: media_player.play_media
      entity_id: media_player.itunes
      data_template:
        media_content_type: playlist
        media_content_id: |
          {{ object_name | default("") }} {{ object_owner_name | default("") }}
```

The above example requires https://github.com/maddox/itunes-api/pull/26 and https://github.com/home-assistant/home-assistant/pull/5091, but they're not required for this PR.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)