### PR TITLE
Added Ledenet protocol support to flux_led

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -35,7 +35,7 @@ DEVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_MODE, default='rgbw'):
         vol.All(cv.string, vol.In(['rgbw', 'rgb'])),
     vol.Optional(CONF_PROTOCOL, default=None):
-        vol.All(cv.string, vol.In(['LEDENET'])),
+        vol.All(cv.string, vol.In(['ledenet'])),
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -10,15 +10,15 @@ import random
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_DEVICES, CONF_NAME
+from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_PROTOCOL
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATTR_EFFECT, EFFECT_RANDOM,
     SUPPORT_BRIGHTNESS, SUPPORT_EFFECT, SUPPORT_RGB_COLOR, Light,
     PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['https://github.com/Danielhiversen/flux_led/archive/0.10.zip'
-                '#flux_led==0.10']
+REQUIREMENTS = ['https://github.com/Danielhiversen/flux_led/archive/0.11.zip'
+                '#flux_led==0.11']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +34,8 @@ DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(ATTR_MODE, default='rgbw'):
         vol.All(cv.string, vol.In(['rgbw', 'rgb'])),
+    vol.Optional(CONF_PROTOCOL, default=None):
+        vol.All(cv.string, vol.In(['LEDENET'])),
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -51,6 +53,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         device = {}
         device['name'] = device_config[CONF_NAME]
         device['ipaddr'] = ipaddr
+        device[CONF_PROTOCOL] = device_config[CONF_PROTOCOL]
         device[ATTR_MODE] = device_config[ATTR_MODE]
         light = FluxLight(device)
         if light.is_valid:
@@ -87,11 +90,14 @@ class FluxLight(Light):
 
         self._name = device['name']
         self._ipaddr = device['ipaddr']
+        self._protocol = device[CONF_PROTOCOL]
         self._mode = device[ATTR_MODE]
         self.is_valid = True
         self._bulb = None
         try:
             self._bulb = flux_led.WifiLedBulb(self._ipaddr)
+            if self._protocol:
+                self._bulb.setProtocol(self._protocol)
         except socket.error:
             self.is_valid = False
             _LOGGER.error(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -178,7 +178,7 @@ hikvision==0.4
 http://github.com/technicalpickles/python-nest/archive/e6c9d56a8df455d4d7746389811f2c1387e8cb33.zip#python-nest==3.0.3
 
 # homeassistant.components.light.flux_led
-https://github.com/Danielhiversen/flux_led/archive/0.10.zip#flux_led==0.10
+https://github.com/Danielhiversen/flux_led/archive/0.11.zip#flux_led==0.11
 
 # homeassistant.components.switch.tplink
 https://github.com/GadgetReactor/pyHS100/archive/45fc3548882628bcde3e3d365db341849457bef2.zip#pyHS100==0.2.2


### PR DESCRIPTION
**Description:**
Adds the new protocol required for the ledenet RGBW wifi controller


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1669

**Example entry for `configuration.yaml` (if applicable):**
```yaml
light:
  - platform: flux_led
    devices:
      192.168.1.159:
        name: rgbw_light_strip
        mode: 'rgbw'
        protocol: 'LEDENET'
```


