### PR TITLE
Allow selection of bluetooth device to use

### DIFF
--- a/homeassistant/components/device_tracker/bluetooth_le_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_le_tracker.py
@@ -24,9 +24,11 @@ REQUIREMENTS = ['gattlib==0.20150805']
 BLE_PREFIX = 'BLE_'
 MIN_SEEN_NEW = 5
 CONF_SCAN_DURATION = "scan_duration"
+CONF_BLUETOOTH_DEVICE = "device_id"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_SCAN_DURATION, default=10): cv.positive_int
+    vol.Optional(CONF_SCAN_DURATION, default=10): cv.positive_int,
+    vol.Optional(CONF_BLUETOOTH_DEVICE, default="hci0"): cv.string
 })
 
 
@@ -60,7 +62,7 @@ def setup_scanner(hass, config, see):
         """Discover Bluetooth LE devices."""
         _LOGGER.debug("Discovering Bluetooth LE devices")
         try:
-            service = DiscoveryService()
+            service = DiscoveryService(ble_dev_id)
             devices = service.discover(duration)
             _LOGGER.debug("Bluetooth LE devices discovered = %s", devices)
         except RuntimeError as error:
@@ -70,6 +72,7 @@ def setup_scanner(hass, config, see):
 
     yaml_path = hass.config.path(YAML_DEVICES)
     duration = config.get(CONF_SCAN_DURATION)
+    ble_dev_id = config.get(CONF_BLUETOOTH_DEVICE)
     devs_to_track = []
     devs_donot_track = []
 


### PR DESCRIPTION
Adding the device_id key to the bevice tracker component allows selecting the bluetooth device to use in case the default device does not have BLE Capabilities

**Description: Allows user to select the bluetooth device to use with the `device_id`. Default option is hci0.**


**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/5096<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/1672

**Example entry for `configuration.yaml` (if applicable):**
```yaml
device_tracker:
  platform: bluetooth_le_tracker
  device_id: hci1
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
