### PR TITLE
Add color_temp_command_template for mqtt light component

### DIFF
--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -280,8 +280,8 @@ class MqttLight(Light):
             color_temp = int(float((
                 self.templates[CONF_COLOR_TEMP+"_COMMAND"](
                     str(kwargs[ATTR_COLOR_TEMP])))))
-            _LOGGER.debug("Command temp %f mired, coverts to %d K" %
-                          (kwargs[ATTR_COLOR_TEMP], color_temp))
+            _LOGGER.debug("Command temp %f mired, coverts to %d K",
+                          kwargs[ATTR_COLOR_TEMP], color_temp)
             mqtt.publish(
                 self._hass, self._topic[CONF_COLOR_TEMP_COMMAND_TOPIC],
                 color_temp, self._qos, self._retain)

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -90,7 +90,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             CONF_BRIGHTNESS: config.get(CONF_BRIGHTNESS_VALUE_TEMPLATE),
             CONF_RGB: config.get(CONF_RGB_VALUE_TEMPLATE),
             CONF_COLOR_TEMP: config.get(CONF_COLOR_TEMP_VALUE_TEMPLATE),
-            CONF_COLOR_TEMP+"_COMMAND": config.get(CONF_COLOR_TEMP_COMMAND_TEMPLATE)
+            CONF_COLOR_TEMP+"_COMMAND":
+            config.get(CONF_COLOR_TEMP_COMMAND_TEMPLATE)
         },
         config.get(CONF_QOS),
         config.get(CONF_RETAIN),
@@ -191,8 +192,10 @@ class MqttLight(Light):
 
         def color_temp_received(topic, payload, qos):
             """A new MQTT message for color temp has been received."""
-            self._color_temp = int(float((templates[CONF_COLOR_TEMP](payload))))
-            _LOGGER.debug("Received color temp: %f, converts to %d", float(payload), self._color_temp)
+            self._color_temp = \
+                int(float((templates[CONF_COLOR_TEMP](payload))))
+            _LOGGER.debug("Received color temp: %f, converts to %d",
+                          float(payload), self._color_temp)
             self.update_ha_state()
 
         if self._topic[CONF_COLOR_TEMP_STATE_TOPIC] is not None:
@@ -274,8 +277,11 @@ class MqttLight(Light):
 
         if ATTR_COLOR_TEMP in kwargs and \
            self._topic[CONF_COLOR_TEMP_COMMAND_TOPIC] is not None:
-            color_temp = int(float((self.templates[CONF_COLOR_TEMP+"_COMMAND"](str(kwargs[ATTR_COLOR_TEMP])))))
-            _LOGGER.debug("Command temp %f mired, coverts to %d K" % (kwargs[ATTR_COLOR_TEMP], color_temp))
+            color_temp = int(float((
+                self.templates[CONF_COLOR_TEMP+"_COMMAND"](
+                    str(kwargs[ATTR_COLOR_TEMP])))))
+            _LOGGER.debug("Command temp %f mired, coverts to %d K" %
+                          (kwargs[ATTR_COLOR_TEMP], color_temp))
             mqtt.publish(
                 self._hass, self._topic[CONF_COLOR_TEMP_COMMAND_TOPIC],
                 color_temp, self._qos, self._retain)

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -298,7 +298,7 @@ class MqttLight(Light):
             should_update = True
 
         if should_update:
-            self.update_ha_state()
+            self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
@@ -308,4 +308,4 @@ class MqttLight(Light):
         if self._optimistic:
             # Optimistically assume that switch has changed state.
             self._state = False
-            self.update_ha_state()
+            self.schedule_update_ha_state()


### PR DESCRIPTION
**Description:**

Home assistant internal unit for color temperature is Mired but some
systems (e.g., SmartThings through mqtt bridge) use Kelvin. Conversion
between these types can be handled with the value template
concept (used previously to unpack json values).

Added a "color_temp_command_template" configuration option for MQTT
lights that specifies a function to be applied to the HA-internal
color temperature value to get a light-compatible value.

**Related issue (if applicable):** 

n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** 

home-assistant/home-assistant.github.io#1673

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
_n/a code interacts with mqtt devices_

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
