### PR TITLE
Fix proximity issue

### DIFF
--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -142,6 +142,10 @@ class Proximity(Entity):
         for device in self.proximity_devices:
             device_state = self.hass.states.get(device)
 
+            if device_state is None:
+                devices_to_calculate = True
+                continue
+
             if device_state.state not in self.ignored_zones:
                 devices_to_calculate = True
 


### PR DESCRIPTION
**Description:**
Hello, I got the following error in my HA logs:
```
c 28 10:52:30 androlapin hass[9740]: ERROR:homeassistant.core:Error doing job: Future exception was never retrieved
Dec 28 10:52:30 androlapin hass[9740]: Traceback (most recent call last):
Dec 28 10:52:30 androlapin hass[9740]:   File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
Dec 28 10:52:30 androlapin hass[9740]:     result = self.fn(*self.args, **self.kwargs)
Dec 28 10:52:30 androlapin hass[9740]:   File "/usr/local/lib/python3.5/dist-packages/homeassistant/components/proximity.py", line 145, in check_proximity_state_change
Dec 28 10:52:30 androlapin hass[9740]:     if devide_state is None:
Dec 28 10:52:30 androlapin hass[9740]: NameError: name 'devide_state' is not defined
```

This PR fixes this exception, I'm just not sure about the patch.

**Checklist:**
 - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
