### PR TITLE
Notify component for Facebook Messenger

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -219,6 +219,7 @@ omit =
     homeassistant/components/notify/aws_lambda.py
     homeassistant/components/notify/aws_sns.py
     homeassistant/components/notify/aws_sqs.py
+    homeassistant/components/notify/facebook.py
     homeassistant/components/notify/free_mobile.py
     homeassistant/components/notify/gntp.py
     homeassistant/components/notify/group.py

--- a/homeassistant/components/notify/facebook.py
+++ b/homeassistant/components/notify/facebook.py
@@ -13,6 +13,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
     ATTR_TARGET, PLATFORM_SCHEMA, BaseNotificationService)
+from homeassistant.const import CONTENT_TYPE_JSON
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ class FacebookNotificationService(BaseNotificationService):
         targets = kwargs.get(ATTR_TARGET)
 
         if not targets:
-            _LOGGER.info("At least 1 target is required")
+            _LOGGER.error("At least 1 target is required")
             return
 
         for target in targets:
@@ -53,7 +54,8 @@ class FacebookNotificationService(BaseNotificationService):
             import json
             resp = requests.post(BASE_URL, data=json.dumps(body),
                                  params=payload,
-                                 headers={'Content-Type': 'application/json'})
+                                 headers={'Content-Type': CONTENT_TYPE_JSON},
+                                 timeout=10)
             if resp.status_code != 200:
                 obj = resp.json()
                 error_message = obj['error']['message']

--- a/homeassistant/components/notify/facebook.py
+++ b/homeassistant/components/notify/facebook.py
@@ -1,0 +1,61 @@
+"""
+Facebook platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.facebook/
+"""
+import logging
+
+import requests
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.notify import (
+    PLATFORM_SCHEMA, BaseNotificationService)
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ID = 'id'
+CONF_PHONE_NUMBER = 'phone_number'
+CONF_PAGE_ACCESS_TOKEN = 'page_access_token'
+BASE_URL = 'https://graph.facebook.com/v2.6/me/messages'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_PHONE_NUMBER): cv.string,
+    vol.Required(CONF_PAGE_ACCESS_TOKEN): cv.string,
+})
+
+
+def get_service(hass, config):
+    """Get the Twitter notification service."""
+    return FacebookNotificationService(
+        config[CONF_PHONE_NUMBER], config[CONF_PAGE_ACCESS_TOKEN]
+    )
+
+
+class FacebookNotificationService(BaseNotificationService):
+    """Implementation of a notification service for the Twitter service."""
+
+    def __init__(self, id, access_token):
+        """Initialize the service."""
+        self.user_id = id
+        self.page_access_token = access_token
+
+    def send_message(self, message="", **kwargs):
+        """Send some message."""
+        payload = {'access_token': self.page_access_token}
+        body = {
+            "recipient": {"phone_number": self.user_id},
+            "message": {"text": message}
+        }
+        import json
+        resp = requests.post(BASE_URL, data=json.dumps(body), params=payload,
+                             headers={'Content-Type': 'application/json'})
+        if resp.status_code != 200:
+            obj = resp.json()
+            error_message = obj['error']['message']
+            error_code = obj['error']['code']
+            _LOGGER.error("Error %s : %s (Code %s)", resp.status_code,
+                          error_message,
+                          error_code)

--- a/homeassistant/components/notify/facebook.py
+++ b/homeassistant/components/notify/facebook.py
@@ -12,50 +12,52 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
-    PLATFORM_SCHEMA, BaseNotificationService)
+    ATTR_TARGET, PLATFORM_SCHEMA, BaseNotificationService)
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_ID = 'id'
-CONF_PHONE_NUMBER = 'phone_number'
 CONF_PAGE_ACCESS_TOKEN = 'page_access_token'
 BASE_URL = 'https://graph.facebook.com/v2.6/me/messages'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_PHONE_NUMBER): cv.string,
     vol.Required(CONF_PAGE_ACCESS_TOKEN): cv.string,
 })
 
 
 def get_service(hass, config):
-    """Get the Twitter notification service."""
-    return FacebookNotificationService(
-        config[CONF_PHONE_NUMBER], config[CONF_PAGE_ACCESS_TOKEN]
-    )
+    """Get the Facebook notification service."""
+    return FacebookNotificationService(config[CONF_PAGE_ACCESS_TOKEN])
 
 
 class FacebookNotificationService(BaseNotificationService):
-    """Implementation of a notification service for the Twitter service."""
+    """Implementation of a notification service for the Facebook service."""
 
-    def __init__(self, id, access_token):
+    def __init__(self, access_token):
         """Initialize the service."""
-        self.user_id = id
         self.page_access_token = access_token
 
     def send_message(self, message="", **kwargs):
         """Send some message."""
         payload = {'access_token': self.page_access_token}
-        body = {
-            "recipient": {"phone_number": self.user_id},
-            "message": {"text": message}
-        }
-        import json
-        resp = requests.post(BASE_URL, data=json.dumps(body), params=payload,
-                             headers={'Content-Type': 'application/json'})
-        if resp.status_code != 200:
-            obj = resp.json()
-            error_message = obj['error']['message']
-            error_code = obj['error']['code']
-            _LOGGER.error("Error %s : %s (Code %s)", resp.status_code,
-                          error_message,
-                          error_code)
+        targets = kwargs.get(ATTR_TARGET)
+
+        if not targets:
+            _LOGGER.info("At least 1 target is required")
+            return
+
+        for target in targets:
+            body = {
+                "recipient": {"phone_number": target},
+                "message": {"text": message}
+            }
+            import json
+            resp = requests.post(BASE_URL, data=json.dumps(body),
+                                 params=payload,
+                                 headers={'Content-Type': 'application/json'})
+            if resp.status_code != 200:
+                obj = resp.json()
+                error_message = obj['error']['message']
+                error_code = obj['error']['code']
+                _LOGGER.error("Error %s : %s (Code %s)", resp.status_code,
+                              error_message,
+                              error_code)


### PR DESCRIPTION
**Description:**
Notify component for Facebook Messenger.
Sends HASS notifications to facebook messenger.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1683

**Example entry for `configuration.yaml` (if applicable):**
```yaml
# Example configuration.yaml entry
 notify:
   - name: NOTIFIER_NAME
     platform: facebook
     page_access_token: FACEBOOK_PAGE_ACCESS_TOKEN
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
