### PR TITLE
[sensor/sma] SMA Solar Inverter sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -308,6 +308,7 @@ omit =
     homeassistant/components/sensor/scrape.py
     homeassistant/components/sensor/sensehat.py
     homeassistant/components/sensor/serial_pm.py
+    homeassistant/components/sensor/sma.py
     homeassistant/components/sensor/snmp.py
     homeassistant/components/sensor/sonarr.py
     homeassistant/components/sensor/speedtest.py

--- a/homeassistant/components/sensor/sma.py
+++ b/homeassistant/components/sensor/sma.py
@@ -31,14 +31,6 @@ SENSOR_OPTIONS = ['current_consumption', 'current_power', 'total_consumption',
                   'total_yield']
 
 
-# TODO: candidate for inclusion into config_validation
-def ensure_list(value):
-    """Wrap value in list if it is not one - allow empty lists."""
-    if value is None:
-        return []
-    return value if isinstance(value, list) else [value]
-
-
 def _check_sensor_schema(conf):
     """Check sensors and attributes are valid."""
     valid = list(conf[CONF_CUSTOM].keys())
@@ -58,7 +50,7 @@ PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): str,
     vol.Required(CONF_PASSWORD): str,
     vol.Optional(CONF_GROUP, default=GROUPS[0]): vol.In(GROUPS),
-    vol.Required(CONF_SENSORS): vol.Schema({cv.slug: ensure_list}),
+    vol.Required(CONF_SENSORS): vol.Schema({cv.slug: cv.ensure_list}),
     vol.Optional(CONF_CUSTOM, default={}): vol.Schema({
         cv.slug: {
             vol.Required('key'): vol.All(str, vol.Length(min=13, max=13)),

--- a/homeassistant/components/sensor/sma.py
+++ b/homeassistant/components/sensor/sma.py
@@ -1,0 +1,200 @@
+"""SMA Solar Webconnect interface.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.sma/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STOP, CONF_HOST, CONF_PASSWORD, CONF_SCAN_INTERVAL)
+from homeassistant.helpers.event import async_track_utc_time_change
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['pysma==0.1.3']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_GROUP = 'group'
+CONF_SENSORS = 'sensors'
+CONF_CUSTOM = 'custom'
+
+GROUP_INSTALLER = 'installer'
+GROUP_USER = 'user'
+GROUPS = [GROUP_USER, GROUP_INSTALLER]
+SENSOR_OPTIONS = ['current_consumption', 'current_power', 'total_consumption',
+                  'total_yield']
+
+
+# TODO: candidate for inclusion into config_validation
+def ensure_list(value):
+    """Wrap value in list if it is not one - allow empty lists."""
+    if value is None:
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+def _check_sensor_schema(conf):
+    """Check sensors and attributes are valid."""
+    valid = list(conf[CONF_CUSTOM].keys())
+    valid.extend(SENSOR_OPTIONS)
+    print(valid)
+    for sensor, attrs in conf[CONF_SENSORS].items():
+        if sensor not in valid:
+            raise vol.Invalid("{} does not exist".format(sensor))
+        for attr in attrs:
+            if attr in valid:
+                continue
+            raise vol.Invalid("{} does not exist [{}]".format(attr, sensor))
+    return conf
+
+
+PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): str,
+    vol.Required(CONF_PASSWORD): str,
+    vol.Optional(CONF_GROUP, default=GROUPS[0]): vol.In(GROUPS),
+    vol.Required(CONF_SENSORS): vol.Schema({cv.slug: ensure_list}),
+    vol.Optional(CONF_CUSTOM, default={}): vol.Schema({
+        cv.slug: {
+            vol.Required('key'): vol.All(str, vol.Length(min=13, max=13)),
+            vol.Required('unit'): str
+        }})
+}, extra=vol.PREVENT_EXTRA), _check_sensor_schema)
+
+
+def async_setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up SMA WebConnect sensor."""
+    import pysma
+
+    # Combine sensor_defs from the library and custom config
+    sensor_defs = dict(zip(SENSOR_OPTIONS, [
+        (pysma.KEY_CURRENT_CONSUMPTION_W, 'W'),
+        (pysma.KEY_CURRENT_POWER_W, 'W'),
+        (pysma.KEY_TOTAL_CONSUMPTION_KWH, 'kW/h'),
+        (pysma.KEY_TOTAL_YIELD_KWH, 'kW/h')]))
+    for name, prop in config[CONF_CUSTOM].items():
+        if name in sensor_defs:
+            _LOGGER.warning("Custom sensor %s replace built-in sensor", name)
+        sensor_defs[name] = (prop['key'], prop['unit'])
+
+    # Prepare all HASS sensor entities
+    hass_sensors = []
+    used_sensors = []
+    for name, attr in config[CONF_SENSORS].items():
+        hass_sensors.append(SMAsensor(name, attr, sensor_defs))
+        used_sensors.append(name)
+        used_sensors.extend(attr)
+
+    # Remove sensor_defs not in use
+    sensor_defs = {name: val for name, val in sensor_defs.items()
+                   if name in used_sensors}
+
+    yield from add_devices(hass_sensors)
+
+    # Init the SMA interface
+    session = async_get_clientsession(hass)
+    grp = {GROUP_INSTALLER: pysma.GROUP_INSTALLER,
+           GROUP_USER: pysma.GROUP_USER}[config[CONF_GROUP]]
+    sma = pysma.SMA(session, config[CONF_HOST], config[CONF_PASSWORD],
+                    group=grp)
+    print(sma)
+
+    # Ensure we logout on shutdown
+    @asyncio.coroutine
+    def async_close_session(event):
+        """Close the session."""
+        yield from sma.close_session()
+
+    hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, async_close_session)
+
+    # Read SMA values periodically & update sensors
+    names_to_query = list(sensor_defs.keys())
+    keys_to_query = [sensor_defs[name][0] for name in names_to_query]
+
+    backoff = 0
+
+    @asyncio.coroutine
+    def async_sma(event):
+        """Update all the SMA sensors."""
+        nonlocal backoff
+        if backoff > 1:
+            backoff -= 1
+            return
+
+        print('SMA query:', keys_to_query)
+        values = yield from sma.read(keys_to_query)
+        if values is None:
+            backoff = 3
+            return
+        res = dict(zip(names_to_query, values))
+        print("update sma sensors {} {}".format(values, res))
+        tasks = []
+        for sensor in hass_sensors:
+            task = sensor.async_update_values(res)
+            if task:
+                tasks.append(task)
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
+
+    secs = range(0, 60, config.get(CONF_SCAN_INTERVAL, 5))
+    async_track_utc_time_change(hass, async_sma, second=secs)
+
+
+class SMAsensor(Entity):
+    """Representation of a Bitcoin sensor."""
+
+    def __init__(self, sensor_name, attr, sensor_defs):
+        """Initialize the sensor."""
+        self._name = sensor_name
+        self._key, self._unit_of_measurement = sensor_defs[sensor_name]
+        self._state = None
+        self._sensor_defs = sensor_defs
+        self._attr = {att: "" for att in attr}
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self._unit_of_measurement
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return self._attr
+
+    @property
+    def poll(self):
+        """SMA sensors are updated & don't poll."""
+        return False
+
+    def async_update_values(self, key_values):
+        """Update this sensor using the data."""
+        update = False
+
+        for key, val in self._attr.items():
+            if val.partition(' ')[0] != key_values[key]:
+                update = True
+                self._attr[key] = '{} {}'.format(key_values[key],
+                                                 self._sensor_defs[key][1])
+
+        new_state = key_values[self._name]
+        if new_state != self._state:
+            update = True
+            self._state = new_state
+
+        return self.async_update_ha_state() if update else None \
+            # pylint: disable=protected-access

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -462,6 +462,9 @@ pyqwikswitch==0.4
 # homeassistant.components.switch.acer_projector
 pyserial==3.1.1
 
+# homeassistant.components.sensor.sma
+pysma==0.1.3
+
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
 pysnmp==4.3.2


### PR DESCRIPTION
**Description:**
This is a sensor for an SMA solar inverter with WebConnect.

There are 4 predefined sensors, but new sensor keys can be added in the `custom` section. These values can found by inspecting the local web interface's traffic.

Currently tested on Sunnyboy 1.5 (should be ok for 2.5)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1668

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor sma:
  - platform: sma
    host: 192.168.88.199
    password: !secret sma_password
    group: installer
    sensors:
      current_consumption: [total_consumption]
      current_power: 
      total_yield: 
      some_new_sensor:
    custom:
      some_new_sensor:
        key: 6100_40263ZZZ
        unit: kW
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
