### PR TITLE
Add version test for monkey_patch_asyncio()

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -356,7 +356,8 @@ def try_to_restart() -> None:
 
 def main() -> int:
     """Start Home Assistant."""
-    monkey_patch_asyncio()
+    if not sys.version_info >= (3, 5):
+        monkey_patch_asyncio()
 
     validate_python()
 

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -356,7 +356,7 @@ def try_to_restart() -> None:
 
 def main() -> int:
     """Start Home Assistant."""
-    if not sys.version_info >= (3, 5):
+    if sys.version_info[:3] < (3, 5, 3):
         monkey_patch_asyncio()
 
     validate_python()


### PR DESCRIPTION
**Description:**
Adds version test so `monkey_patch_asyncio()` isn't run on Python 3.6 or later where it isn't required and causes errors. 

**Related issue (if applicable):** fixes #5015