### PR TITLE
[mqtt] Embedded MQTT server fix

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -220,7 +220,7 @@ def setup(hass, config):
     client_id = conf.get(CONF_CLIENT_ID)
     keepalive = conf.get(CONF_KEEPALIVE)
 
-    internal_server_config = _setup_server(hass, config)
+    broker_config = _setup_server(hass, config)
 
     if CONF_BROKER in conf:
         broker = conf[CONF_BROKER]
@@ -232,10 +232,9 @@ def setup(hass, config):
         client_cert = conf.get(CONF_CLIENT_CERT)
         tls_insecure = conf.get(CONF_TLS_INSECURE)
         protocol = conf[CONF_PROTOCOL]
-    elif internal_server_config:
+    elif broker_config:
         # If no broker passed in, auto config to internal server
-        broker, port, username, password, certificate, protocol = \
-            internal_server_config
+        broker, port, username, password, certificate, protocol = broker_config
         # Embedded broker doesn't have some ssl variables
         client_key, client_cert, tls_insecure = None, None, None
     else:

--- a/homeassistant/components/mqtt/server.py
+++ b/homeassistant/components/mqtt/server.py
@@ -61,6 +61,7 @@ def start(hass, server_config):
 
 def generate_config(hass, passwd):
     """Generate a configuration based on current Home Assistant instance."""
+    from homeassistant.components.mqtt import PROTOCOL_311
     config = {
         'listeners': {
             'default': {
@@ -98,6 +99,6 @@ def generate_config(hass, passwd):
         username = None
         password = None
 
-    client_config = ('localhost', 1883, username, password, None, '3.1.1')
+    client_config = ('localhost', 1883, username, password, None, PROTOCOL_311)
 
     return config, client_config

--- a/homeassistant/components/mqtt/server.py
+++ b/homeassistant/components/mqtt/server.py
@@ -7,13 +7,26 @@ https://home-assistant.io/components/mqtt/#use-the-embedded-broker
 import logging
 import tempfile
 
+import voluptuous as vol
+
 from homeassistant.core import callback
-from homeassistant.components.mqtt import PROTOCOL_311
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+import homeassistant.helpers.config_validation as cv
 from homeassistant.util.async import run_coroutine_threadsafe
 
 REQUIREMENTS = ['hbmqtt==0.8']
 DEPENDENCIES = ['http']
+
+# None allows custom config to be created through generate_config
+HBMQTT_CONFIG_SCHEMA = vol.Any(None, vol.Schema({
+    vol.Optional('auth'): vol.Schema({
+        vol.Optional('password-file'): cv.isfile,
+    }, extra=vol.ALLOW_EXTRA),
+    vol.Optional('listeners'): vol.Schema({
+        vol.Required('default'): vol.Schema(dict),
+        str: vol.Schema(dict)
+    })
+}, extra=vol.ALLOW_EXTRA))
 
 
 def start(hass, server_config):
@@ -85,6 +98,6 @@ def generate_config(hass, passwd):
         username = None
         password = None
 
-    client_config = ('localhost', 1883, username, password, None, PROTOCOL_311)
+    client_config = ('localhost', 1883, username, password, None, '3.1.1')
 
     return config, client_config


### PR DESCRIPTION
**Description:**
Refactored MQTT setup

* Updated HBMQTT Schema
  * Allows `embedded: None` where hass generates config. Old Schema was `vol.Schema(dict)`
  * Moved to `server.py`
  * More complete HBQTT schema (prevent #3263)

* Tests
  * Add `embedded: None` test
  * Removed `test_setup_protocol_validation` as this is handled by voluptuous

**Related issue (if applicable):** fixes #3263

**Example entry for `configuration.yaml` (if applicable):**
```yaml
mqtt:
  embedded:
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
