### PR TITLE
[bugfix zwave]Catch RuntimeError

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -603,7 +603,12 @@ class ZWaveDeviceEntity:
             const.ATTR_NODE_ID: self._value.node.node_id,
         }
 
-        battery_level = self._value.node.get_battery_level()
+        try:
+            battery_level = self._value.node.get_battery_level()
+        except RuntimeError:
+            # If we get an runtime error the dict has changed while
+            # we was looking for a value, just do it again
+            battery_level = self._value.node.get_battery_level()
 
         if battery_level is not None:
             attrs[ATTR_BATTERY_LEVEL] = battery_level


### PR DESCRIPTION
**Description:**
Catch RuntimeError for zwave battery_level.
Sometimes the python-openzwave fails with RuntimeError when trying to fetch battery_level for nodes.
This should prevent it.

**Related issue (if applicable):** fixes #4945 
