### PR TITLE
Add support for remote (TCP/IP) DSMR sensors (i.e. via ser2net)

### DIFF
--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -70,7 +70,6 @@ def create_dsmr_connection(host, port, dsmr_version,telegram_callback,
     from dsmr_parser import telegram_specifications
     from dsmr_parser.parsers import TelegramParser, TelegramParserV2_2
     from dsmr_parser.protocol import DSMRProtocol
-    import socket
     from functools import partial
 
     if dsmr_version == '2.2':
@@ -80,7 +79,7 @@ def create_dsmr_connection(host, port, dsmr_version,telegram_callback,
         specifications = telegram_specifications.V4
         telegram_parser = TelegramParser
 
-    protocol = partial(DSMRProtocol, loop, telegram_parser(specifications),
+    protocol = partial(DSMRProtocol, loop, telegram_parser(specifications), 
                        telegram_callback=telegram_callback)
 
     conn = loop.create_connection(protocol, host, port)

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -60,7 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         cv.string, vol.In(['4', '2.2'])),
 })
 
-def create_dsmr_connection(host, port, dsmr_version,telegram_callback,
+def create_dsmr_connection(host, port, dsmr_version, telegram_callback,
                            loop=None):
     """
     Creates a DSMR asyncio protocol coroutine which connects
@@ -79,7 +79,7 @@ def create_dsmr_connection(host, port, dsmr_version,telegram_callback,
         specifications = telegram_specifications.V4
         telegram_parser = TelegramParser
 
-    protocol = partial(DSMRProtocol, loop, telegram_parser(specifications), 
+    protocol = partial(DSMRProtocol, loop, telegram_parser(specifications),
                        telegram_callback=telegram_callback)
 
     conn = loop.create_connection(protocol, host, port)


### PR DESCRIPTION
Adds DSMR support for connecting remotely to a host which is connected to a Smartmeter and has a serial to network proxy running (i.e. ser2net).

This PR adds a **host** configuration variable which is empty by default. When it's empty, the **port** variable is used to connect locally to a serial or USB port (just like it used to). When it contains a host's IP address, the **port** variable is used as a TCP port and a remote connection to \<**host**\>:\<**port**\> is  being setup.

Example entry for `configuration.yaml`:
```yaml
# Example configuration.yaml entry for remote (TCP/IP, i.e. via ser2net) connection to host which is connected to Smartmeter
sensor:
  - platform: dsmr
    host: 192.168.1.13
    port: 2001
    dsmr_version: 4

group:
  meter_readings:
    name: Meter readings
    entities:
      - sensor.power_consumption_low
      - sensor.power_consumption_normal
      - sensor.power_production_low
      - sensor.power_production_normal
      - sensor.gas_consumption
```
