### PR TITLE
Support longer-than-60-second scan_interval and interval_seconds

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -72,7 +72,7 @@ ATTR_BATTERY = 'battery'
 ATTR_ATTRIBUTES = 'attributes'
 
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_SCAN_INTERVAL): cv.positive_int,  # seconds
+    vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,
     vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,
     vol.Optional(CONF_CONSIDER_HOME,
                  default=timedelta(seconds=DEFAULT_CONSIDER_HOME)): vol.All(

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_per_platform, discovery
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.entity_component import process_scan_interval
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import GPSType, ConfigType, HomeAssistantType
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util as util
@@ -640,10 +640,10 @@ def async_setup_scanner_platform(hass: HomeAssistantType, config: ConfigType,
                 seen.add(mac)
             hass.async_add_job(async_see_device(mac=mac, host_name=host_name))
 
-    seconds, minutes, hours = process_scan_interval(interval)
-    async_track_utc_time_change(
-        hass, async_device_tracker_scan,
-        second=seconds, minute=minutes, hour=hours)
+    async_track_time_interval(
+            hass, async_device_tracker_scan,
+            timedelta(seconds=interval)
+    )
 
     hass.async_add_job(async_device_tracker_scan, None)
 

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -641,9 +641,8 @@ def async_setup_scanner_platform(hass: HomeAssistantType, config: ConfigType,
             hass.async_add_job(async_see_device(mac=mac, host_name=host_name))
 
     async_track_time_interval(
-            hass, async_device_tracker_scan,
-            timedelta(seconds=interval)
-    )
+        hass, async_device_tracker_scan,
+        timedelta(seconds=interval))
 
     hass.async_add_job(async_device_tracker_scan, None)
 

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_per_platform, discovery
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import process_scan_interval
 from homeassistant.helpers.typing import GPSType, ConfigType, HomeAssistantType
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util as util
@@ -639,8 +640,10 @@ def async_setup_scanner_platform(hass: HomeAssistantType, config: ConfigType,
                 seen.add(mac)
             hass.async_add_job(async_see_device(mac=mac, host_name=host_name))
 
+    seconds, minutes, hours = process_scan_interval(interval)
     async_track_utc_time_change(
-        hass, async_device_tracker_scan, second=range(0, 60, interval))
+        hass, async_device_tracker_scan,
+        second=seconds, minute=minutes, hour=hours)
 
     hass.async_add_job(async_device_tracker_scan, None)
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -403,8 +403,7 @@ def key_dependency(key, dependency):
 
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): string,
-    vol.Optional(CONF_SCAN_INTERVAL):
-        vol.All(vol.Coerce(int), vol.Range(min=1)),
+    vol.Optional(CONF_SCAN_INTERVAL): time_period
 }, extra=vol.ALLOW_EXTRA)
 
 EVENT_SCHEMA = vol.Schema({

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -326,7 +326,7 @@ class EntityPlatform(object):
             return
 
         async_track_time_interval(
-            self.component.hass, self._update_entity_states, 
+            self.component.hass, self._update_entity_states,
             timedelta(seconds=self.scan_interval)
         )
 

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -392,24 +392,24 @@ class EntityPlatform(object):
 
 
 def process_scan_interval(interval_in_seconds):
-    """Convert the scan interval to the closest available interval.  
-    
+    """Convert the scan interval to the closest available interval.
+
     Scan intervals are set at entity creation so using explicit
     time deltas is a challenge. Instead we find time subsets
     that approximate the interval.
     """
-    if interval_in_seconds<=60:
+    if interval_in_seconds <= 60:
         num_intervals = round(60/interval_in_seconds)
         interval_step = 60//num_intervals
         seconds = range(0, 60, interval_step)
         minutes, hours = None, None
-    elif interval_in_seconds<=3600:
+    elif interval_in_seconds <= 3600:
         num_intervals = round(60/(interval_in_seconds/60.0))
         interval_step = 60//num_intervals
         seconds = [0]
         minutes = range(0, 60, interval_step)
         hours = None
-    elif interval_in_seconds<=24*3600:
+    elif interval_in_seconds <= 24*3600:
         num_intervals = round(24/(interval_in_seconds/3600.0))
         interval_step = 24//num_intervals
         seconds, minutes = [0], [0]
@@ -418,4 +418,3 @@ def process_scan_interval(interval_in_seconds):
         # update once a day, at midnight
         seconds, minutes, hours = [0], [0], [0]
     return seconds, minutes, hours
-    

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -1,5 +1,6 @@
 """Helpers for components that manage entities."""
 import asyncio
+from datetime import timedelta
 
 from homeassistant import config as conf_util
 from homeassistant.bootstrap import (
@@ -12,7 +13,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import get_component
 from homeassistant.helpers import config_per_platform, discovery
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.event import async_track_utc_time_change
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.service import extract_entity_ids
 from homeassistant.util.async import (
     run_callback_threadsafe, run_coroutine_threadsafe)
@@ -323,10 +324,11 @@ class EntityPlatform(object):
            not any(entity.should_poll for entity
                    in self.platform_entities):
             return
-        seconds, minutes, hours = process_scan_interval(self.scan_interval)
-        self._async_unsub_polling = async_track_utc_time_change(
-            self.component.hass, self._update_entity_states,
-            second=seconds, minute=minutes, hour=hours)
+
+        async_track_time_interval(
+            self.component.hass, self._update_entity_states, 
+            timedelta(seconds=self.scan_interval)
+        )
 
     @asyncio.coroutine
     def _async_process_entity(self, new_entity, update_before_add):
@@ -389,32 +391,3 @@ class EntityPlatform(object):
                 yield from asyncio.wait(tasks, loop=self.component.hass.loop)
         finally:
             self._process_updates = False
-
-
-def process_scan_interval(interval_in_seconds):
-    """Convert the scan interval to the closest available interval.
-
-    Scan intervals are set at entity creation so using explicit
-    time deltas is a challenge. Instead we find time subsets
-    that approximate the interval.
-    """
-    if interval_in_seconds <= 60:
-        num_intervals = round(60/interval_in_seconds)
-        interval_step = 60//num_intervals
-        seconds = range(0, 60, interval_step)
-        minutes, hours = None, None
-    elif interval_in_seconds <= 3600:
-        num_intervals = round(60/(interval_in_seconds/60.0))
-        interval_step = 60//num_intervals
-        seconds = [0]
-        minutes = range(0, 60, interval_step)
-        hours = None
-    elif interval_in_seconds <= 24*3600:
-        num_intervals = round(24/(interval_in_seconds/3600.0))
-        interval_step = 24//num_intervals
-        seconds, minutes = [0], [0]
-        hours = range(0, 60, interval_step)
-    else:
-        # update once a day, at midnight
-        seconds, minutes, hours = [0], [0], [0]
-    return seconds, minutes, hours

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -325,7 +325,7 @@ class EntityPlatform(object):
                    in self.platform_entities):
             return
 
-        async_track_time_interval(
+        self._async_unsub_polling = async_track_time_interval(
             self.component.hass, self._update_entity_states,
             timedelta(seconds=self.scan_interval)
         )

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -85,7 +85,7 @@ track_state_change = threaded_listener_factory(async_track_state_change)
 
 
 def async_track_point_in_time(hass, action, point_in_time):
-    """Add a listener that fires once after a spefic point in time."""
+    """Add a listener that fires once after a specific point in time."""
     utc_point_in_time = dt_util.as_utc(point_in_time)
 
     @callback
@@ -131,6 +131,33 @@ def async_track_point_in_utc_time(hass, action, point_in_time):
 
 track_point_in_utc_time = threaded_listener_factory(
     async_track_point_in_utc_time)
+
+
+def async_track_time_interval(hass, action, interval):
+    """Add a listener that fires repetitively at every timedelta interval."""
+    def next_interval():
+        """Return the next interval."""
+        return dt_util.utcnow() + interval
+
+    @callback
+    def interval_listener(now):
+        """Called when when the interval has elapsed."""
+        nonlocal remove
+        remove = async_track_point_in_utc_time(
+            hass, interval_listener, next_interval())
+        hass.async_run_job(action, now)
+
+    remove = async_track_point_in_utc_time(
+        hass, interval_listener, next_interval())
+
+    def remove_listener():
+        """Remove interval listener."""
+        remove()
+
+    return remove_listener
+
+
+track_time_interval = threaded_listener_factory(async_track_time_interval)
 
 
 def async_track_sunrise(hass, action, offset=None):

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -11,7 +11,6 @@ import homeassistant.loader as loader
 from homeassistant.components import group
 from homeassistant.helpers.entity import Entity, generate_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.entity_component import process_scan_interval
 from homeassistant.helpers import discovery
 import homeassistant.util.dt as dt_util
 

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -405,6 +405,7 @@ class TestProcessScanInterval(unittest.TestCase):
     """Test homeassistant.helpers.entity_component scan interval function."""
 
     def test_process_scan_interval(self):
+        """Test scan interval processing."""
         seconds, minutes, hours = process_scan_interval(2)
         self.assertEqual(seconds, range(0, 60, 2))
         self.assertEqual(len(seconds), 30)

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -399,20 +399,3 @@ class TestHelpersEntityComponent(unittest.TestCase):
             return entity
 
         component.add_entities(create_entity(i) for i in range(2))
-
-
-class TestProcessScanInterval(unittest.TestCase):
-    """Test homeassistant.helpers.entity_component scan interval function."""
-
-    def test_process_scan_interval(self):
-        """Test scan interval processing."""
-        seconds, minutes, hours = process_scan_interval(2)
-        self.assertEqual(seconds, range(0, 60, 2))
-        self.assertEqual(len(seconds), 30)
-        self.assertIsNone(minutes)
-        self.assertIsNone(hours)
-
-        seconds, minutes, hours = process_scan_interval(180)
-        self.assertEqual(len(minutes), 20)
-        self.assertEqual(seconds, [0])
-        self.assertEqual(hours, None)

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -10,7 +10,8 @@ import homeassistant.core as ha
 import homeassistant.loader as loader
 from homeassistant.components import group
 from homeassistant.helpers.entity import Entity, generate_entity_id
-from homeassistant.helpers.entity_component import EntityComponent, process_scan_interval
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.entity_component import process_scan_interval
 from homeassistant.helpers import discovery
 import homeassistant.util.dt as dt_util
 
@@ -399,7 +400,10 @@ class TestHelpersEntityComponent(unittest.TestCase):
 
         component.add_entities(create_entity(i) for i in range(2))
 
+
 class TestProcessScanInterval(unittest.TestCase):
+    """Test homeassistant.helpers.entity_component scan interval function."""
+
     def test_process_scan_interval(self):
         seconds, minutes, hours = process_scan_interval(2)
         self.assertEqual(seconds, range(0, 60, 2))

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -10,7 +10,7 @@ import homeassistant.core as ha
 import homeassistant.loader as loader
 from homeassistant.components import group
 from homeassistant.helpers.entity import Entity, generate_entity_id
-from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.entity_component import EntityComponent, process_scan_interval
 from homeassistant.helpers import discovery
 import homeassistant.util.dt as dt_util
 
@@ -398,3 +398,16 @@ class TestHelpersEntityComponent(unittest.TestCase):
             return entity
 
         component.add_entities(create_entity(i) for i in range(2))
+
+class TestProcessScanInterval(unittest.TestCase):
+    def test_process_scan_interval(self):
+        seconds, minutes, hours = process_scan_interval(2)
+        self.assertEqual(seconds, range(0, 60, 2))
+        self.assertEqual(len(seconds), 30)
+        self.assertIsNone(minutes)
+        self.assertIsNone(hours)
+
+        seconds, minutes, hours = process_scan_interval(180)
+        self.assertEqual(len(minutes), 20)
+        self.assertEqual(seconds, [0])
+        self.assertEqual(hours, None)

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.event import (
     track_utc_time_change,
     track_time_change,
     track_state_change,
+    track_time_interval,
     track_sunrise,
     track_sunset,
 )
@@ -186,6 +187,34 @@ class TestEventHelpers(unittest.TestCase):
         self.assertEqual(1, len(specific_runs))
         self.assertEqual(5, len(wildcard_runs))
         self.assertEqual(6, len(wildercard_runs))
+
+    def test_track_time_interval(self):
+        """Test tracking time interval."""
+        specific_runs = []
+
+        utc_now = dt_util.utcnow()
+        unsub = track_time_interval(
+            self.hass, lambda x: specific_runs.append(1),
+            timedelta(seconds=10)
+        )
+
+        self._send_time_changed(utc_now + timedelta(seconds=5))
+        self.hass.block_till_done()
+        self.assertEqual(0, len(specific_runs))
+
+        self._send_time_changed(utc_now + timedelta(seconds=13))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(utc_now + timedelta(minutes=20))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+
+        unsub()
+
+        self._send_time_changed(utc_now + timedelta(seconds=30))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
 
     def test_track_sunrise(self):
         """Test track the sunrise."""


### PR DESCRIPTION
**Description:**
`scan_interval` and `interval_seconds` (on `device_tracker`) will now work for any interval ~~between 1 second and 1 day~~ whereas without this they only work between 1 and 60 seconds. ~~Intervals are not always respected perfectly. For instance, if you want a 25 second interval it is rounded up to a 30 second interval.~~ 

**Related issue (if applicable):** fixes #5080 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** 

**Example entry for `configuration.yaml` (if applicable):**
```yaml
device_tracker:
 - platform: nmap_tracker
   hosts: 192.168.1.1/24
   interval_seconds: 240
   home_interval: 15
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
