### PR TITLE
Fix link to pull request advice for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Everybody is invited and welcome to contribute to Home Assistant. There is a lot
 
 The process is straight-forward.
 
- - Read [How to get faster PR reviews](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md) by Kubernetes (but skip step 0)
+ - Read [How to get faster PR reviews](https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md) by Kubernetes (but skip step 0)
  - Fork the Home Assistant [git repository](https://github.com/home-assistant/home-assistant).
  - Write the code for your device, notification service, sensor, or IoT thing.
  - Ensure tests work.


### PR DESCRIPTION
**Description:**

The Kubernetes guide to faster pull requests has been moved.  While the old link now says *this file has moved to ...*, it's better to use the new one directly!

(And look, I'm following the guide in making multiple smaller PRs - I was reading this with a view to improving a weather platform :smile:)