### PR TITLE
Change zeroconf to use local ip not base_url

### DIFF
--- a/homeassistant/components/zeroconf.py
+++ b/homeassistant/components/zeroconf.py
@@ -9,6 +9,7 @@ import socket
 
 import voluptuous as vol
 
+from homeassistant import util
 from homeassistant.const import (EVENT_HOMEASSISTANT_STOP, __version__)
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,16 +41,15 @@ def setup(hass, config):
         'requires_api_password': requires_api_password,
     }
 
+    host_ip = util.get_local_ip()
+
     try:
-        info = ServiceInfo(ZEROCONF_TYPE, zeroconf_name,
-                           socket.inet_pton(
-                               socket.AF_INET, hass.config.api.host),
-                           hass.config.api.port, 0, 0, params)
+        host_ip_pton = socket.inet_pton(socket.AF_INET, host_ip)
     except socket.error:
-        info = ServiceInfo(ZEROCONF_TYPE, zeroconf_name,
-                           socket.inet_pton(
-                               socket.AF_INET6, hass.config.api.host),
-                           hass.config.api.port, 0, 0, params)
+        host_ip_pton = socket.inet_pton(socket.AF_INET6, host_ip)
+
+    info = ServiceInfo(ZEROCONF_TYPE, zeroconf_name, host_ip_pton,
+                       hass.http.server_port, 0, 0, params)
 
     zeroconf.register_service(info)
 


### PR DESCRIPTION
**Description:**
Rather than rely on base_url being unconfigured and therefore be
set as the host ip in the api component, get the local ip directly.

Use server port from the http component instead of the api component
where it will be None if base_url is set.

Change the exception catch meant to check for ipv4 vs ipv6 to wrap the
address encoding only instead of the zeroconf service info declaration.

**Related issue (if applicable):** fixes #5006

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
