### PR TITLE
Added rstrip to URL for media_image_url

### DIFF
--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -261,7 +261,7 @@ class SqueezeBoxDevice(MediaPlayerDevice):
                 port=self._lms.http_port)
 
         url = urllib.parse.urljoin(base_url, media_url)
-
+        url = url.rstrip()
         _LOGGER.debug("Media image url: %s", url)
         return url
 


### PR DESCRIPTION
Added rstrip to URL for media_image_url to fix cases where there was a trailing newline.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>


