### PR TITLE
Pushed to another version of denonavr library with fixes for AVR-nonX…

### DIFF
--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     CONF_NAME, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['denonavr==0.2.2']
+REQUIREMENTS = ['denonavr==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -81,7 +81,7 @@ colorlog>2.1,<3
 concord232==0.14
 
 # homeassistant.components.media_player.denonavr
-denonavr==0.2.2
+denonavr==0.3.0
 
 # homeassistant.components.media_player.directv
 directpy==0.1


### PR DESCRIPTION
**Description:**
Changed version of denonavr to 0.3.0 where I applied some fixes for Denon AVR-nonX devices which have a slightly different structure of theier XML files.

**Related issue (if applicable):** fixes #5019 

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running 

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
