### PR TITLE
DSMR: TCP, reconnecting and V4 CRC support

### DIFF
--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -43,6 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = ['dsmr_parser==0.6']
 
 CONF_DSMR_VERSION = 'dsmr_version'
+CONF_RECONNECT_INTERVAL = 'reconnect_interval'
 
 DEFAULT_DSMR_VERSION = '2.2'
 DEFAULT_PORT = '/dev/ttyUSB0'
@@ -60,6 +61,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=None): cv.string,
     vol.Optional(CONF_DSMR_VERSION, default=DEFAULT_DSMR_VERSION): vol.All(
         cv.string, vol.In(['4', '2.2'])),
+    vol.Optional(CONF_RECONNECT_INTERVAL, default=30): int,
 })
 
 
@@ -155,7 +157,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                     stop_listerer()
 
                 # throttle reconnect attempts
-                yield from asyncio.sleep(RECONNECT_INTERVAL)
+                yield from asyncio.sleep(config[CONF_RECONNECT_INTERVAL],
+                                         loop=hass.loop)
 
     hass.loop.create_task(connect_and_reconnect())
 

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -67,7 +67,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the DSMR sensor."""
     # Suppress logging
-    logging.getLogger('dsmr_parser').setLevel(logging.DEBUG)
+    logging.getLogger('dsmr_parser').setLevel(logging.ERROR)
 
     from dsmr_parser import obis_references as obis_ref
     from dsmr_parser.protocol import create_dsmr_reader, create_tcp_dsmr_reader

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -71,6 +71,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     from dsmr_parser import obis_references as obis_ref
     from dsmr_parser.protocol import create_dsmr_reader, create_tcp_dsmr_reader
+    import serial
 
     dsmr_version = config[CONF_DSMR_VERSION]
 
@@ -133,8 +134,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             try:
                 transport, protocol = yield from hass.loop.create_task(
                     reader_factory())
-            # pylint: disable=bare-except
-            except:
+            except (serial.serialutil.SerialException, ConnectionRefusedError,
+                    TimeoutError):
                 # log any error while establishing connection and drop to retry
                 # connection wait
                 _LOGGER.exception('error connecting to DSMR')

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -40,8 +40,7 @@ import voluptuous as vol
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = [('https://github.com/aequitas/dsmr_parser/archive/tcp.zip'
-                 '#dsmr_parser==0.6')]
+REQUIREMENTS = ['dsmr_parser==0.6']
 
 CONF_DSMR_VERSION = 'dsmr_version'
 
@@ -134,7 +133,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             try:
                 transport, protocol = yield from hass.loop.create_task(
                     reader_factory())
+            # pylint: disable=bare-except
             except:
+                # log any error while establishing connection and drop to retry
+                # connection wait
                 _LOGGER.exception('error connecting to DSMR')
                 transport = None
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -99,7 +99,7 @@ dnspython3==1.15.0
 dovado==0.1.15
 
 # homeassistant.components.sensor.dsmr
-dsmr_parser==0.4
+dsmr_parser==0.6
 
 # homeassistant.components.dweet
 # homeassistant.components.sensor.dweet

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -16,3 +16,4 @@ pytest-sugar>=0.7.1
 requests_mock>=1.0
 mock-open>=1.3.1
 flake8-docstrings==1.0.2
+asynctest>=0.8.0

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -19,7 +19,7 @@ from tests.common import assert_setup_component
 
 @pytest.fixture
 def mock_connection_factory(monkeypatch):
-    """Mocks the create functions for serial and TCP Asyncio connections."""
+    """Mock the create functions for serial and TCP Asyncio connections."""
     from dsmr_parser.protocol import DSMRProtocol
     transport = asynctest.Mock(spec=asyncio.Transport)
     protocol = asynctest.Mock(spec=DSMRProtocol)


### PR DESCRIPTION
**Description:** This PR adds TCP connection support and automatic reconnecting on disconnect. Also includes upstream `dsmr_parser` changes which add support for V4 telegram CRC checking.


**Related issue (if applicable):** #5144

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1699

**Example entry for `configuration.yaml` (if applicable):**
```yaml
# Example configuration.yaml entry for remote (TCP/IP, i.e. via ser2net) connection to host which is connected to Smartmeter
sensor:
  - platform: dsmr
    host: 192.168.1.13
    port: 2001
    dsmr_version: 4
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
  - [x] Waiting for changes to be released upstream.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
