### PR TITLE
improve error msg for invalid config

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -606,7 +606,7 @@ def async_log_exception(ex, domain, config, hass):
         message += '{}.'.format(humanize_error(config, ex))
 
     domain_config = config.get(domain, config)
-    message += " (See {}:{}). ".format(
+    message += " (See {}, line {}). ".format(
         getattr(domain_config, '__config_file__', '?'),
         getattr(domain_config, '__line__', '?'))
 


### PR DESCRIPTION
**Description:**
improve error msg for invalid config
Make it more clear that the last number is the line number. 

But according to the user [here](https://community.home-assistant.io/t/why-is-triger-is-an-invalid-option-for-automation/8885) it is not always the line number. How can that be??
