### PR TITLE
fix #5157

### DIFF
--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -133,10 +133,13 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
         """Turn on the media player."""
         if self._mac:
             self._wol.send_magic_packet(self._mac)
+            self._state = STATE_ON
 
     def turn_off(self):
         """Turn off media player."""
-        self.send_key('NRC_POWER-ONOFF')
+        if self._state != STATE_OFF:
+            self.send_key('NRC_POWER-ONOFF')
+            self._state = STATE_OFF
 
     def volume_up(self):
         """Volume up the media player."""


### PR DESCRIPTION
**Description:**
This pull request fixes the panasonic viera media player component's turn off. It currently toggles the power (for tv's that support it).

**Related issue (if applicable):** fixes #5157

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
