### PR TITLE
Ping device tracker

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -157,6 +157,7 @@ omit =
     homeassistant/components/device_tracker/luci.py
     homeassistant/components/device_tracker/netgear.py
     homeassistant/components/device_tracker/nmap_tracker.py
+    homeassistant/components/device_tracker/ping.py
     homeassistant/components/device_tracker/snmp.py
     homeassistant/components/device_tracker/swisscom.py
     homeassistant/components/device_tracker/thomson.py

--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -1,0 +1,89 @@
+"""
+Tracks devices by sending a ICMP ping.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.ping/
+
+device_tracker:
+  - platform: ping
+    count: 2
+    hosts:
+      host_one: pc.local
+      host_two: 192.168.2.25
+"""
+import logging
+import subprocess
+import sys
+import re
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import (
+    PLATFORM_SCHEMA, DEFAULT_SCAN_INTERVAL)
+from homeassistant.helpers.event import track_point_in_utc_time
+from homeassistant import util
+from homeassistant import const
+import homeassistant.helpers.config_validation as cv
+
+DEPENDENCIES = []
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_PING_COUNT = 'count'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(const.CONF_HOSTS): {cv.string: cv.string},
+    vol.Optional(CONF_PING_COUNT, default=1): cv.positive_int,
+})
+
+
+class Host:
+    """Host object with ping detection"""
+    def __init__(self, ip_address, dev_id, hass, config):
+        self.hass = hass
+        self.ip_address = ip_address
+        self.dev_id = dev_id
+        self._count = config[CONF_PING_COUNT]
+        if sys.platform == "win32":
+            self._ping_cmd = ['ping', '-n 1', '-w 1000', self.ip_address]
+        else:
+            self._ping_cmd = ['ping', '-n', '-q', '-c1', '-W1', self.ip_address]
+
+
+    def ping(self):
+        """Send ICMP ping and return True if success"""
+        pinger = subprocess.Popen(self._ping_cmd, stdout=subprocess.PIPE)
+        try:
+            pinger.communicate()
+            return pinger.returncode == 0
+        except subprocess.CalledProcessError:
+            return False
+
+    def update(self, see):
+        """Update device state by sending one or more ping messages"""
+        failed = 0
+        while failed < self._count:  # check more times if host in unreachable
+            if self.ping():
+                see(dev_id=self.dev_id)
+                return True
+            failed += 1
+
+        _LOGGER.debug("ping KO on ip=%s failed=%d", self.ip_address, failed)
+
+
+def setup_scanner(hass, config, see):
+    hosts = [Host(ip, dev_id, hass, config) for (dev_id, ip) in config[const.CONF_HOSTS].items()]
+    interval = timedelta(seconds=len(hosts) * config[CONF_PING_COUNT] +
+                                 DEFAULT_SCAN_INTERVAL)
+    _LOGGER.info("Started ping tracker with interval=%s on hosts: %s",
+                 interval, ",".join([host.ip_address for host in hosts]))
+
+    def update(now):
+        """This update function gets called every interval time"""
+        for host in hosts:
+            host.update(see)
+        track_point_in_utc_time(hass, update, now + interval)
+        return True
+
+    return update(util.dt.utcnow())


### PR DESCRIPTION
**Description:**
Device tracker that uses ICMP ping messages to detect host status.

This can be useful when devices are running a firewall and is blocking UDP or TCP packets, but responding to ICMP (like Android phones).
This tracker doesn't need to know the mac address, since the host can be on a different subnet. This makes this the ideal solution to detect hosts on a different subnet when nmap or other solutions don't work since arp doesn't work.

Based on the code of @scipioni of PR #4577 and PR #4420, but dropped arp and added command line options to ping for windows, also, the way the hosts are defined isn't a list but key-value pairs.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1723

**Example entry for `configuration.yaml` (if applicable):**
```yaml
device_tracker:
  - platform: ping
    count: 3 # number of packet used for each device (avoid false detection)
    hosts:
      hostone: 192.168.2.10
      hosttwo: 192.168.2.25
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
