### PR TITLE
Fixed invalid response when sending a test-request from Locative iOS app

### DIFF
--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -63,18 +63,18 @@ class LocativeView(HomeAssistantView):
             return ('Device id not specified.',
                     HTTP_UNPROCESSABLE_ENTITY)
 
-        if 'id' not in data:
-            _LOGGER.error('Location id not specified.')
-            return ('Location id not specified.',
-                    HTTP_UNPROCESSABLE_ENTITY)
-
         if 'trigger' not in data:
             _LOGGER.error('Trigger is not specified.')
             return ('Trigger is not specified.',
                     HTTP_UNPROCESSABLE_ENTITY)
 
+        if 'id' not in data and data['trigger'] != 'test':
+            _LOGGER.error('Location id not specified.')
+            return ('Location id not specified.',
+                    HTTP_UNPROCESSABLE_ENTITY)
+
         device = data['device'].replace('-', '')
-        location_name = data['id'].lower()
+        location_name = data['id'].lower() if 'id' in data else 'test'
         direction = data['trigger']
         gps_location = (data[ATTR_LATITUDE], data[ATTR_LONGITUDE])
 

--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -74,7 +74,7 @@ class LocativeView(HomeAssistantView):
                     HTTP_UNPROCESSABLE_ENTITY)
 
         device = data['device'].replace('-', '')
-        location_name = data['id'].lower() if 'id' in data else 'test'
+        location_name = data.get('id', data['trigger']).lower()
         direction = data['trigger']
         gps_location = (data[ATTR_LATITUDE], data[ATTR_LONGITUDE])
 

--- a/tests/components/device_tracker/test_locative.py
+++ b/tests/components/device_tracker/test_locative.py
@@ -108,6 +108,13 @@ class TestLocative(unittest.TestCase):
         req = requests.get(_url(copy))
         self.assertEqual(200, req.status_code)
 
+        # Test message, no location
+        copy = data.copy()
+        copy['trigger'] = 'test'
+        del copy['id']
+        req = requests.get(_url(copy))
+        self.assertEqual(200, req.status_code)
+
         # Unknown trigger
         copy = data.copy()
         copy['trigger'] = 'foobar'


### PR DESCRIPTION
**Description:**

I am using Home Assistant 0.35.3 + Locative component.
The Locative app for iOS returns an error on sending a test-request.
Apparently, Locative app for iOS doesn't include a Device ID when sending a test-request.
Current code base invalidates the request because of it.

The commits in this pull request will allow missing Device ID only when trigger/direction == 'test'.

I wasn't able to get the who unit test suite running om my machine, but was able to succesfully run py.test /path/to/locative.py


--
Sander de Leeuw


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
