### PR TITLE
USPS sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -321,6 +321,7 @@ omit =
     homeassistant/components/sensor/transmission.py
     homeassistant/components/sensor/twitch.py
     homeassistant/components/sensor/uber.py
+    homeassistant/components/sensor/usps.py
     homeassistant/components/sensor/vasttrafik.py
     homeassistant/components/sensor/waqi.py
     homeassistant/components/sensor/xbox_live.py

--- a/homeassistant/components/sensor/usps.py
+++ b/homeassistant/components/sensor/usps.py
@@ -56,7 +56,7 @@ class USPSSensor(Entity):
         self._profile = myusps.get_profile(session)
         self._packages = None
         self.update = Throttle(interval)(self._update)
-        self._update()
+        self.update()
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/usps.py
+++ b/homeassistant/components/sensor/usps.py
@@ -1,0 +1,92 @@
+"""
+Sensor for USPS packages.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.usps/
+"""
+from collections import defaultdict
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, ATTR_ATTRIBUTION
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import slugify
+from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['myusps==1.0.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_UPDATE_INTERVAL = 'update_interval'
+ICON = 'mdi:package-variant-closed'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=1800)): (
+        vol.All(cv.time_period, cv.positive_timedelta)),
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the USPS platform."""
+    import myusps
+    try:
+        session = myusps.get_session(config.get(CONF_USERNAME),
+                                     config.get(CONF_PASSWORD))
+    except myusps.USPSError:
+        _LOGGER.exception('Could not connect to My USPS')
+        return False
+
+    add_devices([USPSSensor(session, config.get(CONF_UPDATE_INTERVAL))])
+
+
+class USPSSensor(Entity):
+    """USPS Sensor."""
+
+    def __init__(self, session, interval):
+        """Initialize the sensor."""
+        import myusps
+        self._session = session
+        self._profile = myusps.get_profile(session)
+        self._packages = None
+        self.update = Throttle(interval)(self._update)
+        self._update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._profile.get('address')
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return len(self._packages)
+
+    def _update(self):
+        """Update device state."""
+        import myusps
+        self._packages = myusps.get_packages(self._session)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        import myusps
+        status_counts = defaultdict(int)
+        for package in self._packages:
+            status_counts[slugify(package['status'])] += 1
+        attributes = {
+            ATTR_ATTRIBUTION: myusps.ATTRIBUTION
+        }
+        attributes.update(status_counts)
+        return attributes
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return ICON

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -303,6 +303,9 @@ mficlient==0.3.0
 # homeassistant.components.sensor.miflora
 miflora==0.1.14
 
+# homeassistant.components.sensor.usps
+myusps==1.0.0
+
 # homeassistant.components.discovery
 netdisco==0.8.1
 


### PR DESCRIPTION
**Description:**
Get status of packages being delivered to you via USPS. Scrapes [MyUSPS](https://my.usps.com/mobileWeb/pages/intro/start.action), a USPS service that, once you're registered and validated, lists all packages being delivered to you. Produces a sensor with an attribute with a count for each package status. The state is the total number of packages being tracked.

Suggestions for improvement welcome. Tracking numbers, last location and date are also available. Since this is based on a scraper, I've set the default update interval to 30 minutes.

Attributes example:
```
arrived at post office                                     1
departed shipping partner facility usps awaiting item      2
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1722

**Example entry for `configuration.yaml` (if applicable):**
```yaml
- platform: usps
  username: test
  password: test
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
