### PR TITLE
Add Lannouncer tts notify component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -227,6 +227,7 @@ omit =
     homeassistant/components/notify/instapush.py
     homeassistant/components/notify/joaoapps_join.py
     homeassistant/components/notify/kodi.py
+    homeassistant/components/notify/lannouncer.py
     homeassistant/components/notify/llamalab_automate.py
     homeassistant/components/notify/matrix.py
     homeassistant/components/notify/message_bird.py

--- a/homeassistant/components/notify/lannouncer.py
+++ b/homeassistant/components/notify/lannouncer.py
@@ -6,8 +6,8 @@ https://home-assistant.io/components/notify.lannouncer/
 """
 import logging
 
-from urllib.parse import quote_plus
-import requests
+from urllib.parse import urlencode
+import socket
 import voluptuous as vol
 
 from homeassistant.components.notify import (
@@ -16,8 +16,8 @@ from homeassistant.const import (CONF_HOST, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
 ATTR_METHOD = 'method'
-ATTR_METHOD_SPEAK = 'speak'
-ATTR_METHOD_ALARM = 'alarm'
+ATTR_METHOD_DEFAULT = 'speak'
+ATTR_METHOD_ALLOWED = ['speak', 'alarm']
 
 DEFAULT_PORT = 1035
 
@@ -34,14 +34,15 @@ def get_service(hass, config):
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
 
-    return LannouncerNotificationService(host, port)
+    return LannouncerNotificationService(hass, host, port)
 
 
 class LannouncerNotificationService(BaseNotificationService):
     """Implementation of a notification service for Lannouncer."""
 
-    def __init__(self, host, port):
+    def __init__(self, hass, host, port):
         """Initialize the service."""
+        self._hass = hass
         self._host = host
         self._port = port
 
@@ -51,29 +52,34 @@ class LannouncerNotificationService(BaseNotificationService):
         if data is not None and ATTR_METHOD in data:
             method = data.get(ATTR_METHOD)
         else:
-            method = ATTR_METHOD_SPEAK
+            method = ATTR_METHOD_DEFAULT
 
-        if method == ATTR_METHOD_SPEAK:
-            url = "http://{}:{}/?SPEAK={}&@DONE@".format(
-                self._host, self._port, quote_plus(message))
-
-        elif method == ATTR_METHOD_ALARM:
-            url = "http://{}:{}/?ALARM={}&@DONE@".format(
-                self._host, self._port, quote_plus(message))
-
-        else:
+        if method not in ATTR_METHOD_ALLOWED:
             _LOGGER.error("Unknown method %s", method)
             return None
 
+        cmd = urlencode({method: message})
+
         try:
-            _LOGGER.debug("Sending message to %s", url)
-            requests.get(url)
+            # Open socket
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(10)
+            sock.connect((self._host, self._port))
 
-        except requests.ConnectionError:
-            # Lannouncer doesn't send a HTTP response code,
-            # but just prints the raw string LANnouncer: OK
-            pass
+            # Send message
+            _LOGGER.debug("Sending message: %s", cmd)
+            sock.sendall(cmd.encode())
+            sock.sendall("&@DONE@\n".encode())
 
-        except requests.exceptions.RequestException as err:
-            _LOGGER.exception('Could not send lannouncer notification: %s',
-                              err)
+            # Check response
+            buffer = sock.recv(1024)
+            if buffer != b'LANnouncer: OK':
+                _LOGGER.error('Error sending data to Lannnouncer: %s',
+                              buffer.decode())
+
+            # Close socket
+            sock.close()
+        except socket.gaierror:
+            _LOGGER.error('Unable to connect to host %s', self._host)
+        except socket.error:
+            _LOGGER.exception('Failed to send data to Lannnouncer')

--- a/homeassistant/components/notify/lannouncer.py
+++ b/homeassistant/components/notify/lannouncer.py
@@ -56,7 +56,7 @@ class LannouncerNotificationService(BaseNotificationService):
 
         if method not in ATTR_METHOD_ALLOWED:
             _LOGGER.error("Unknown method %s", method)
-            return None
+            return
 
         cmd = urlencode({method: message})
 

--- a/homeassistant/components/notify/lannouncer.py
+++ b/homeassistant/components/notify/lannouncer.py
@@ -1,0 +1,79 @@
+"""
+Lannouncer platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.lannouncer/
+"""
+import logging
+
+from urllib.parse import quote_plus
+import requests
+import voluptuous as vol
+
+from homeassistant.components.notify import (
+    PLATFORM_SCHEMA, ATTR_DATA, BaseNotificationService)
+from homeassistant.const import (CONF_HOST, CONF_PORT)
+import homeassistant.helpers.config_validation as cv
+
+ATTR_METHOD = 'method'
+ATTR_METHOD_SPEAK = 'speak'
+ATTR_METHOD_ALARM = 'alarm'
+
+DEFAULT_PORT = 1035
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+})
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_service(hass, config):
+    """Get the Lannouncer notification service."""
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+
+    return LannouncerNotificationService(host, port)
+
+
+class LannouncerNotificationService(BaseNotificationService):
+    """Implementation of a notification service for Lannouncer."""
+
+    def __init__(self, host, port):
+        """Initialize the service."""
+        self._host = host
+        self._port = port
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to Lannouncer."""
+        data = kwargs.get(ATTR_DATA)
+        if data is not None and ATTR_METHOD in data:
+            method = data.get(ATTR_METHOD)
+        else:
+            method = ATTR_METHOD_SPEAK
+
+        if method == ATTR_METHOD_SPEAK:
+            url = "http://{}:{}/?SPEAK={}&@DONE@".format(
+                self._host, self._port, quote_plus(message))
+
+        elif method == ATTR_METHOD_ALARM:
+            url = "http://{}:{}/?ALARM={}&@DONE@".format(
+                self._host, self._port, quote_plus(message))
+
+        else:
+            _LOGGER.error("Unknown method %s", method)
+            return None
+
+        try:
+            _LOGGER.debug("Sending message to %s", url)
+            requests.get(url)
+
+        except requests.ConnectionError:
+            # Lannouncer doesn't send a HTTP response code,
+            # but just prints the raw string LANnouncer: OK
+            pass
+
+        except requests.exceptions.RequestException as err:
+            _LOGGER.exception('Could not send lannouncer notification: %s',
+                              err)


### PR DESCRIPTION
**Description:**
This component provides support for [Lannouncer](http://www.keybounce.com/lannouncer/). It's originally written for Samsung SmartThings, but works perfectly on it's own.
Lannouncer is a free Android App that runs as a service in the background and provides TTS service and can play preloaded sounds or custom ones you can configure.

It is using the Android TTS service, so you can configure the voice on the device or install a different TTS engine if you like.

This is really usefull when you have a wall mounted tablet (running hass frontend :)), or an android device that is permanently powered and turned on. I use this to play a doorbell sound on my wall mounted tablet in my living room, and I'm planning to provide some spoken notifications as well.

You can send two type of messages:

```json
{"message": "chime", "data": {"method":"alarm"}}
```

or

```json
{"message": "Sorry, I cannot do that Dave."}
```

I still need to write some documentation, but I'm interested in some feedback on the code in the meantime.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1724

**Example entry for `configuration.yaml` (if applicable):**
```yaml
notify:
- platform: lannouncer
  host: tablet-living.local
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
