### PR TITLE
Bugfix aiohttp connector pool close on shutdown

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -30,7 +30,6 @@ from homeassistant.const import (
     SERVICE_HOMEASSISTANT_RESTART, SERVICE_HOMEASSISTANT_STOP, __version__)
 from homeassistant.exceptions import (
     HomeAssistantError, InvalidEntityFormatError, ShuttingDown)
-from homeassistant.helpers.aiohttp_client import async_cleanup_websession
 from homeassistant.util.async import (
     run_coroutine_threadsafe, run_callback_threadsafe)
 import homeassistant.util as util
@@ -289,6 +288,8 @@ class HomeAssistant(object):
 
         This method is a coroutine.
         """
+        import homeassistant.helpers.aiohttp_client as aiohttp_client
+
         self.state = CoreState.stopping
         self.async_track_tasks()
         self.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
@@ -297,7 +298,7 @@ class HomeAssistant(object):
         self.state = CoreState.not_running
 
         # cleanup connector pool from aiohttp
-        yield from async_cleanup_websession(self)
+        yield from aiohttp_client.async_cleanup_websession(self)
 
         # cleanup async layer from python logging
         if self.data.get(DATA_ASYNCHANDLER):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -30,6 +30,7 @@ from homeassistant.const import (
     SERVICE_HOMEASSISTANT_RESTART, SERVICE_HOMEASSISTANT_STOP, __version__)
 from homeassistant.exceptions import (
     HomeAssistantError, InvalidEntityFormatError, ShuttingDown)
+from homeassistant.helpers.aiohttp_client import async_cleanup_websession
 from homeassistant.util.async import (
     run_coroutine_threadsafe, run_callback_threadsafe)
 import homeassistant.util as util
@@ -294,6 +295,9 @@ class HomeAssistant(object):
         yield from self.async_block_till_done()
         self.executor.shutdown()
         self.state = CoreState.not_running
+
+        # cleanup connector pool from aiohttp
+        yield from async_cleanup_websession(self)
 
         # cleanup async layer from python logging
         if self.data.get(DATA_ASYNCHANDLER):

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -105,7 +105,6 @@ def _async_get_connector(hass, verify_ssl=True):
 
 
 @asyncio.coroutine
-# pylint: disable=invalid-name
 def async_cleanup_websession(hass):
     """Cleanup aiohttp connector pool.
 

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -92,33 +92,30 @@ def _async_get_connector(hass, verify_ssl=True):
         if DATA_CONNECTOR not in hass.data:
             connector = aiohttp.TCPConnector(loop=hass.loop)
             hass.data[DATA_CONNECTOR] = connector
-
-            _async_register_connector_shutdown(hass, connector)
         else:
             connector = hass.data[DATA_CONNECTOR]
     else:
         if DATA_CONNECTOR_NOTVERIFY not in hass.data:
             connector = aiohttp.TCPConnector(loop=hass.loop, verify_ssl=False)
             hass.data[DATA_CONNECTOR_NOTVERIFY] = connector
-
-            _async_register_connector_shutdown(hass, connector)
         else:
             connector = hass.data[DATA_CONNECTOR_NOTVERIFY]
 
     return connector
 
 
-@callback
+@asyncio.coroutine
 # pylint: disable=invalid-name
-def _async_register_connector_shutdown(hass, connector):
-    """Register connector pool close on homeassistant shutdown.
+def async_cleanup_websession(hass):
+    """Cleanup aiohttp connector pool.
 
-    This method must be run in the event loop.
+    This method is a coroutine.
     """
-    @asyncio.coroutine
-    def _async_close_connector(event):
-        """Close websession on shutdown."""
-        yield from connector.close()
+    tasks = []
+    if DATA_CONNECTOR in hass.data:
+        tasks.append(hass.data[DATA_CONNECTOR].close())
+    if DATA_CONNECTOR_NOTVERIFY in hass.data:
+        tasks.append(hass.data[DATA_CONNECTOR_NOTVERIFY].close())
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, _async_close_connector)
+    if tasks:
+        yield from asyncio.wait(tasks, loop=hass.loop)


### PR DESCRIPTION
**Description:**

Cleanup connector pool on close and not on STOP event. That allow to use session on shutdown and correct usage of `auto_cleanup` from `async_create_session`.

See on #5118

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
