### PR TITLE
Bugfix default values to timedelta

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/alarm_control_panel/
 """
 import asyncio
+from datetime import timedelta
 import logging
 import os
 
@@ -20,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 
 DOMAIN = 'alarm_control_panel'
-SCAN_INTERVAL = 30
+SCAN_INTERVAL = timedelta(seconds=30)
 ATTR_CHANGED_BY = 'changed_by'
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'

--- a/homeassistant/components/alarm_control_panel/concord232.py
+++ b/homeassistant/components/alarm_control_panel/concord232.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/alarm_control_panel.concord232/
 """
 import datetime
+from datetime import timedelta
 import logging
 
 import requests
@@ -25,7 +26,7 @@ DEFAULT_HOST = 'localhost'
 DEFAULT_NAME = 'CONCORD232'
 DEFAULT_PORT = 5007
 
-SCAN_INTERVAL = 1
+SCAN_INTERVAL = timedelta(seconds=1)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,

--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -5,6 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor/
 """
 import asyncio
+from datetime import timedelta
 import logging
 
 import voluptuous as vol
@@ -15,7 +16,7 @@ from homeassistant.const import (STATE_ON, STATE_OFF)
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 
 DOMAIN = 'binary_sensor'
-SCAN_INTERVAL = 30
+SCAN_INTERVAL = timedelta(seconds=30)
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 SENSOR_CLASSES = [

--- a/homeassistant/components/binary_sensor/command_line.py
+++ b/homeassistant/components/binary_sensor/command_line.py
@@ -4,6 +4,7 @@ Support for custom shell commands to retrieve values.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.command_line/
 """
+from datetime import timedelta
 import logging
 
 import voluptuous as vol
@@ -22,7 +23,7 @@ DEFAULT_NAME = 'Binary Command Sensor'
 DEFAULT_PAYLOAD_ON = 'ON'
 DEFAULT_PAYLOAD_OFF = 'OFF'
 
-SCAN_INTERVAL = 60
+SCAN_INTERVAL = timedelta(seconds=60)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COMMAND): cv.string,

--- a/homeassistant/components/binary_sensor/concord232.py
+++ b/homeassistant/components/binary_sensor/concord232.py
@@ -27,7 +27,7 @@ DEFAULT_NAME = 'Alarm'
 DEFAULT_PORT = '5007'
 DEFAULT_SSL = False
 
-SCAN_INTERVAL = 1
+SCAN_INTERVAL = datetime.timedelta(seconds=1)
 
 ZONE_TYPES_SCHEMA = vol.Schema({
     cv.positive_int: vol.In(SENSOR_CLASSES),

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -6,6 +6,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/camera/
 """
 import asyncio
+from datetime import timedelta
 import logging
 
 from aiohttp import web
@@ -17,7 +18,7 @@ from homeassistant.components.http import HomeAssistantView, KEY_AUTHENTICATED
 
 DOMAIN = 'camera'
 DEPENDENCIES = ['http']
-SCAN_INTERVAL = 30
+SCAN_INTERVAL = timedelta(seconds=30)
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 STATE_RECORDING = 'recording'

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -5,16 +5,17 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/climate/
 """
 import asyncio
+from datetime import timedelta
 import logging
 import os
 import functools as ft
 from numbers import Number
-import voluptuous as vol
 
-from homeassistant.helpers.entity_component import EntityComponent
+import voluptuous as vol
 
 from homeassistant.config import load_yaml_config_file
 from homeassistant.util.temperature import convert as convert_temperature
+from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 import homeassistant.helpers.config_validation as cv
@@ -25,7 +26,7 @@ from homeassistant.const import (
 DOMAIN = "climate"
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
-SCAN_INTERVAL = 60
+SCAN_INTERVAL = timedelta(seconds=60)
 
 SERVICE_SET_AWAY_MODE = "set_away_mode"
 SERVICE_SET_AUX_HEAT = "set_aux_heat"

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover/
 """
 import os
+from datetime import timedelta
 import logging
 
 import voluptuous as vol
@@ -23,7 +24,7 @@ from homeassistant.const import (
 
 
 DOMAIN = 'cover'
-SCAN_INTERVAL = 15
+SCAN_INTERVAL = timedelta(seconds=15)
 
 GROUP_NAME_ALL_COVERS = 'all covers'
 ENTITY_ID_ALL_COVERS = group.ENTITY_ID_FORMAT.format('all_covers')

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -51,10 +51,10 @@ CONF_TRACK_NEW = 'track_new_devices'
 DEFAULT_TRACK_NEW = True
 
 CONF_CONSIDER_HOME = 'consider_home'
-DEFAULT_CONSIDER_HOME = 180
+DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 
 CONF_SCAN_INTERVAL = 'interval_seconds'
-DEFAULT_SCAN_INTERVAL = 12
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=12)
 
 CONF_AWAY_HIDE = 'hide_if_away'
 DEFAULT_AWAY_HIDE = False
@@ -75,7 +75,7 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,
     vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,
     vol.Optional(CONF_CONSIDER_HOME,
-                 default=timedelta(seconds=DEFAULT_CONSIDER_HOME)): vol.All(
+                 default=DEFAULT_CONSIDER_HOME): vol.All(
                      cv.time_period, cv.positive_timedelta)
 })
 
@@ -122,8 +122,7 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
         return False
     else:
         conf = conf[0] if len(conf) > 0 else {}
-        consider_home = conf.get(CONF_CONSIDER_HOME,
-                                 timedelta(seconds=DEFAULT_CONSIDER_HOME))
+        consider_home = conf.get(CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME)
         track_new = conf.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
 
     devices = yield from async_load_config(yaml_path, hass, consider_home)
@@ -640,10 +639,7 @@ def async_setup_scanner_platform(hass: HomeAssistantType, config: ConfigType,
                 seen.add(mac)
             hass.async_add_job(async_see_device(mac=mac, host_name=host_name))
 
-    async_track_time_interval(
-        hass, async_device_tracker_scan,
-        timedelta(seconds=interval))
-
+    async_track_time_interval(hass, async_device_tracker_scan, interval)
     hass.async_add_job(async_device_tracker_scan, None)
 
 

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -4,6 +4,7 @@ Provides functionality to interact with fans.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/fan/
 """
+from datetime import timedelta
 import logging
 import os
 
@@ -21,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 
 
 DOMAIN = 'fan'
-SCAN_INTERVAL = 30
+SCAN_INTERVAL = timedelta(seconds=30)
 
 GROUP_NAME_ALL_FANS = 'all fans'
 ENTITY_ID_ALL_FANS = group.ENTITY_ID_FORMAT.format(GROUP_NAME_ALL_FANS)

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -5,6 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/light/
 """
 import asyncio
+from datetime import timedelta
 import logging
 import os
 import csv
@@ -26,7 +27,7 @@ from homeassistant.util.async import run_callback_threadsafe
 
 
 DOMAIN = "light"
-SCAN_INTERVAL = 30
+SCAN_INTERVAL = timedelta(seconds=30)
 
 GROUP_NAME_ALL_LIGHTS = 'all lights'
 ENTITY_ID_ALL_LIGHTS = group.ENTITY_ID_FORMAT.format('all_lights')

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
 from homeassistant.components import group
 
 DOMAIN = 'lock'
-SCAN_INTERVAL = 30
+SCAN_INTERVAL = timedelta(seconds=30)
 ATTR_CHANGED_BY = 'changed_by'
 
 GROUP_NAME_ALL_LOCKS = 'all locks'

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -5,6 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/media_player/
 """
 import asyncio
+from datetime import timedelta
 import functools as ft
 import hashlib
 import logging
@@ -34,7 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'media_player'
 DEPENDENCIES = ['http']
-SCAN_INTERVAL = 10
+SCAN_INTERVAL = timedelta(seconds=10)
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -36,7 +36,7 @@ GROUP_NAME_ALL_REMOTES = 'all remotes'
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
-SCAN_INTERVAL = 30
+SCAN_INTERVAL = timedelta(seconds=30)
 SERVICE_SEND_COMMAND = 'send_command'
 SERVICE_SYNC = 'sync'
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -5,13 +5,14 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/sensor/
 """
 import asyncio
+from datetime import timedelta
 import logging
 
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 
 DOMAIN = 'sensor'
-SCAN_INTERVAL = 30
+SCAN_INTERVAL = timedelta(seconds=30)
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -4,6 +4,7 @@ Allows to configure custom shell commands to turn a value for a sensor.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.command_line/
 """
+from datetime import timedelta
 import logging
 import subprocess
 
@@ -20,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Command Sensor'
 
-SCAN_INTERVAL = 60
+SCAN_INTERVAL = timedelta(seconds=60)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COMMAND): cv.string,

--- a/homeassistant/components/sensor/eliqonline.py
+++ b/homeassistant/components/sensor/eliqonline.py
@@ -4,6 +4,7 @@ Monitors home energy use for the ELIQ Online service.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.eliqonline/
 """
+from datetime import timedelta
 import logging
 from urllib.error import URLError
 
@@ -24,7 +25,7 @@ DEFAULT_NAME = 'ELIQ Online'
 
 ICON = 'mdi:speedometer'
 
-SCAN_INTERVAL = 60
+SCAN_INTERVAL = timedelta(seconds=60)
 
 UNIT_OF_MEASUREMENT = 'W'
 

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
 from homeassistant.components import group
 
 DOMAIN = 'switch'
-SCAN_INTERVAL = 30
+SCAN_INTERVAL = timedelta(seconds=30)
 
 GROUP_NAME_ALL_SWITCHES = 'all switches'
 ENTITY_ID_ALL_SWITCHES = group.ENTITY_ID_FORMAT.format('all_switches')

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.service import extract_entity_ids
 from homeassistant.util.async import (
     run_callback_threadsafe, run_coroutine_threadsafe)
 
-DEFAULT_SCAN_INTERVAL = 15
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=15)
 
 
 class EntityComponent(object):
@@ -326,8 +326,7 @@ class EntityPlatform(object):
             return
 
         self._async_unsub_polling = async_track_time_interval(
-            self.component.hass, self._update_entity_states,
-            timedelta(seconds=self.scan_interval)
+            self.component.hass, self._update_entity_states, self.scan_interval
         )
 
     @asyncio.coroutine

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -97,7 +97,8 @@ class TestHelpersEntityComponent(unittest.TestCase):
 
     def test_polling_only_updates_entities_it_should_poll(self):
         """Test the polling of only updated entities."""
-        component = EntityComponent(_LOGGER, DOMAIN, self.hass, 20)
+        component = EntityComponent(
+            _LOGGER, DOMAIN, self.hass, timedelta(seconds=20))
 
         no_poll_ent = EntityTest(should_poll=False)
         no_poll_ent.async_update = Mock()
@@ -127,8 +128,7 @@ class TestHelpersEntityComponent(unittest.TestCase):
         ent2.update = lambda *_: component.add_entities([ent1])
 
         fire_time_changed(
-            self.hass, dt_util.utcnow() +
-            timedelta(seconds=DEFAULT_SCAN_INTERVAL)
+            self.hass, dt_util.utcnow() + DEFAULT_SCAN_INTERVAL
         )
         self.hass.block_till_done()
 
@@ -332,7 +332,7 @@ class TestHelpersEntityComponent(unittest.TestCase):
         component.setup({
             DOMAIN: {
                 'platform': 'platform',
-                'scan_interval': 30,
+                'scan_interval': timedelta(seconds=30),
             }
         })
 
@@ -348,7 +348,7 @@ class TestHelpersEntityComponent(unittest.TestCase):
             add_devices([EntityTest(should_poll=True)])
 
         platform = MockPlatform(platform_setup)
-        platform.SCAN_INTERVAL = 30
+        platform.SCAN_INTERVAL = timedelta(seconds=30)
 
         loader.set_component('test_domain.platform', platform)
 


### PR DESCRIPTION
**Description:**

We support now timedelta for SCAN_INTERVAL this PR set all values to timedelta from int.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
