### PR TITLE
Add teardown method to pilight tests

### DIFF
--- a/tests/components/test_pilight.py
+++ b/tests/components/test_pilight.py
@@ -70,6 +70,11 @@ class TestPilight(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
+    def tearDown(self):
+        """Stop everything that was started."""
+        if self.hass.is_running:
+            self.hass.stop()
+
     @patch('homeassistant.components.pilight._LOGGER.error')
     def test_connection_failed_error(self, mock_error):
         """Try to connect at 127.0.0.1:5000 with socket error."""
@@ -343,6 +348,11 @@ class TestPilightCallrateThrottler(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        if self.hass.is_running:
+            self.hass.stop()
 
     def test_call_rate_delay_throttle_disabled(self):
         """Test that the limiter is a noop if no delay set."""

--- a/tests/components/test_pilight.py
+++ b/tests/components/test_pilight.py
@@ -69,10 +69,11 @@ class TestPilight(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
+        self.skip_teardown_stop = False
 
     def tearDown(self):
         """Stop everything that was started."""
-        if self.hass.is_running:
+        if not self.skip_teardown_stop:
             self.hass.stop()
 
     @patch('homeassistant.components.pilight._LOGGER.error')
@@ -213,6 +214,7 @@ class TestPilight(unittest.TestCase):
                 'PilightDaemonSim start' in str(error_log_call))
 
             # Test stop
+            self.skip_teardown_stop = True
             self.hass.stop()
             error_log_call = mock_pilight_error.call_args_list[-1]
             self.assertTrue(
@@ -351,8 +353,7 @@ class TestPilightCallrateThrottler(unittest.TestCase):
 
     def tearDown(self):
         """Stop everything that was started."""
-        if self.hass.is_running:
-            self.hass.stop()
+        self.hass.stop()
 
     def test_call_rate_delay_throttle_disabled(self):
         """Test that the limiter is a noop if no delay set."""


### PR DESCRIPTION
**Description:**
This is necessary to stop the HomeAssistant instance that was started
in the setUp method. Without this there happen random test failures.

This is necessary to stabilize the tests for PR #5045.

**Related issue (if applicable):** fixes #5045 


**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
