### PR TITLE
Added support for alternate SSH ports in AsusWRT (#4832)

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -16,8 +16,8 @@ import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
-from homeassistant.const import (CONF_HOST, CONF_PASSWORD,
-    CONF_USERNAME, CONF_PORT)
+from homeassistant.const import (
+    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT)
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
@@ -114,12 +114,17 @@ class AsusWrtDeviceScanner(DeviceScanner):
         self.protocol = config[CONF_PROTOCOL]
         self.mode = config[CONF_MODE]
         self.port = config.get(CONF_PORT)
+        self.ssh_args = {}
 
         if self.protocol == 'ssh':
+
+            if self.port != DEFAULT_SSH_PORT:
+                self.ssh_args['port'] = self.port
+            
             if self.ssh_key:
-                self.ssh_args = {'ssh_key': self.ssh_key, 'port': self.port}
+                self.ssh_args['ssh_key'] = self.ssh_key;                
             elif self.password:
-                self.ssh_args = {'password': self.password, 'port': self.port}
+                self.ssh_args['password'] = self.password;                
             else:
                 _LOGGER.error('No password or private key specified')
                 self.success_init = False

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -16,7 +16,8 @@ import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT
+from homeassistant.const import (CONF_HOST, CONF_PASSWORD,
+    CONF_USERNAME, CONF_PORT)
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -113,18 +113,17 @@ class AsusWrtDeviceScanner(DeviceScanner):
         self.ssh_key = config.get('ssh_key', config.get('pub_key', ''))
         self.protocol = config[CONF_PROTOCOL]
         self.mode = config[CONF_MODE]
-        self.port = config.get(CONF_PORT)
+        self.port = config.get(CONF_PORT, 22)
         self.ssh_args = {}
 
         if self.protocol == 'ssh':
 
             if self.port != DEFAULT_SSH_PORT:
-                self.ssh_args['port'] = self.port
-            
+                self.ssh_args['port'] = self.port     
             if self.ssh_key:
-                self.ssh_args['ssh_key'] = self.ssh_key;                
+                self.ssh_args['ssh_key'] = self.ssh_key
             elif self.password:
-                self.ssh_args['password'] = self.password;                
+                self.ssh_args['password'] = self.password
             else:
                 _LOGGER.error('No password or private key specified')
                 self.success_init = False

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -16,7 +16,7 @@ import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
@@ -25,6 +25,7 @@ MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 CONF_PROTOCOL = 'protocol'
 CONF_MODE = 'mode'
+DEFAULT_SSH_PORT = 22
 CONF_SSH_KEY = 'ssh_key'
 CONF_PUB_KEY = 'pub_key'
 SECRET_GROUP = 'Password or SSH Key'
@@ -38,6 +39,7 @@ PLATFORM_SCHEMA = vol.All(
             vol.In(['ssh', 'telnet']),
         vol.Optional(CONF_MODE, default='router'):
             vol.In(['router', 'ap']),
+        vol.Optional(CONF_PORT, default=DEFAULT_SSH_PORT): cv.port,
         vol.Exclusive(CONF_PASSWORD, SECRET_GROUP): cv.string,
         vol.Exclusive(CONF_SSH_KEY, SECRET_GROUP): cv.isfile,
         vol.Exclusive(CONF_PUB_KEY, SECRET_GROUP): cv.isfile
@@ -110,12 +112,13 @@ class AsusWrtDeviceScanner(DeviceScanner):
         self.ssh_key = config.get('ssh_key', config.get('pub_key', ''))
         self.protocol = config[CONF_PROTOCOL]
         self.mode = config[CONF_MODE]
+        self.port = config.get(CONF_PORT)
 
         if self.protocol == 'ssh':
             if self.ssh_key:
-                self.ssh_secret = {'ssh_key': self.ssh_key}
+                self.ssh_args = {'ssh_key': self.ssh_key, 'port': self.port}
             elif self.password:
-                self.ssh_secret = {'password': self.password}
+                self.ssh_args = {'password': self.password, 'port': self.port}
             else:
                 _LOGGER.error('No password or private key specified')
                 self.success_init = False
@@ -177,7 +180,7 @@ class AsusWrtDeviceScanner(DeviceScanner):
 
         ssh = pxssh.pxssh()
         try:
-            ssh.login(self.host, self.username, **self.ssh_secret)
+            ssh.login(self.host, self.username, **self.ssh_args)
         except exceptions.EOF as err:
             _LOGGER.error('Connection refused. Is SSH enabled?')
             return None

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -14,7 +14,7 @@ from homeassistant.components.device_tracker.asuswrt import (
     CONF_PROTOCOL, CONF_MODE, CONF_PUB_KEY, DOMAIN,
     PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME,
-                                 CONF_HOST)
+                                 CONF_HOST, CONF_PORT)
 
 from tests.common import (
     get_test_home_assistant, get_test_config_dir, assert_setup_component)
@@ -73,6 +73,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
             DOMAIN: {
                 CONF_PLATFORM: 'asuswrt',
                 CONF_HOST: 'fake_host',
+                CONF_PORT: 22,
                 CONF_USERNAME: 'fake_user',
                 CONF_PASSWORD: 'fake_pass',
                 CONF_TRACK_NEW: True,
@@ -98,6 +99,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
             device_tracker.DOMAIN: {
                 CONF_PLATFORM: 'asuswrt',
                 CONF_HOST: 'fake_host',
+                CONF_PORT: 22,
                 CONF_USERNAME: 'fake_user',
                 CONF_PUB_KEY: FAKEFILE,
                 CONF_TRACK_NEW: True,
@@ -122,6 +124,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         conf_dict = PLATFORM_SCHEMA({
             CONF_PLATFORM: 'asuswrt',
             CONF_HOST: 'fake_host',
+            CONF_PORT: 22,
             CONF_USERNAME: 'fake_user',
             CONF_PUB_KEY: FAKEFILE
         })
@@ -147,6 +150,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         conf_dict = PLATFORM_SCHEMA({
             CONF_PLATFORM: 'asuswrt',
             CONF_HOST: 'fake_host',
+            CONF_PORT: 22222,
             CONF_USERNAME: 'fake_user',
             CONF_PASSWORD: 'fake_pass'
         })
@@ -174,6 +178,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         conf_dict = {
             CONF_PLATFORM: 'asuswrt',
             CONF_HOST: 'fake_host',
+            CONF_PORT: 22,
             CONF_USERNAME: 'fake_user',
         }
 

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -14,7 +14,7 @@ from homeassistant.components.device_tracker.asuswrt import (
     CONF_PROTOCOL, CONF_MODE, CONF_PUB_KEY, DOMAIN,
     PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME,
-                                 CONF_HOST, CONF_PORT)
+                                 CONF_HOST)
 
 from tests.common import (
     get_test_home_assistant, get_test_config_dir, assert_setup_component)
@@ -72,8 +72,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         conf_dict = {
             DOMAIN: {
                 CONF_PLATFORM: 'asuswrt',
-                CONF_HOST: 'fake_host',
-                CONF_PORT: 22,
+                CONF_HOST: 'fake_host',                
                 CONF_USERNAME: 'fake_user',
                 CONF_PASSWORD: 'fake_pass',
                 CONF_TRACK_NEW: True,
@@ -98,8 +97,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         conf_dict = {
             device_tracker.DOMAIN: {
                 CONF_PLATFORM: 'asuswrt',
-                CONF_HOST: 'fake_host',
-                CONF_PORT: 22,
+                CONF_HOST: 'fake_host',                
                 CONF_USERNAME: 'fake_user',
                 CONF_PUB_KEY: FAKEFILE,
                 CONF_TRACK_NEW: True,
@@ -123,8 +121,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         self.addCleanup(ssh_mock.stop)
         conf_dict = PLATFORM_SCHEMA({
             CONF_PLATFORM: 'asuswrt',
-            CONF_HOST: 'fake_host',
-            CONF_PORT: 22,
+            CONF_HOST: 'fake_host',            
             CONF_USERNAME: 'fake_user',
             CONF_PUB_KEY: FAKEFILE
         })
@@ -149,8 +146,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         self.addCleanup(ssh_mock.stop)
         conf_dict = PLATFORM_SCHEMA({
             CONF_PLATFORM: 'asuswrt',
-            CONF_HOST: 'fake_host',
-            CONF_PORT: 22222,
+            CONF_HOST: 'fake_host',            
             CONF_USERNAME: 'fake_user',
             CONF_PASSWORD: 'fake_pass'
         })
@@ -177,8 +173,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
 
         conf_dict = {
             CONF_PLATFORM: 'asuswrt',
-            CONF_HOST: 'fake_host',
-            CONF_PORT: 22,
+            CONF_HOST: 'fake_host',            
             CONF_USERNAME: 'fake_user',
         }
 

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -72,7 +72,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         conf_dict = {
             DOMAIN: {
                 CONF_PLATFORM: 'asuswrt',
-                CONF_HOST: 'fake_host',                
+                CONF_HOST: 'fake_host',
                 CONF_USERNAME: 'fake_user',
                 CONF_PASSWORD: 'fake_pass',
                 CONF_TRACK_NEW: True,
@@ -97,7 +97,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         conf_dict = {
             device_tracker.DOMAIN: {
                 CONF_PLATFORM: 'asuswrt',
-                CONF_HOST: 'fake_host',                
+                CONF_HOST: 'fake_host',
                 CONF_USERNAME: 'fake_user',
                 CONF_PUB_KEY: FAKEFILE,
                 CONF_TRACK_NEW: True,
@@ -121,7 +121,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         self.addCleanup(ssh_mock.stop)
         conf_dict = PLATFORM_SCHEMA({
             CONF_PLATFORM: 'asuswrt',
-            CONF_HOST: 'fake_host',            
+            CONF_HOST: 'fake_host',
             CONF_USERNAME: 'fake_user',
             CONF_PUB_KEY: FAKEFILE
         })


### PR DESCRIPTION
**Description:**
My Asus router doesn't run SSH on port 22.  This allows Home Assistant to work now by exposing this the SSH port as a parameter. 

**Related issue (if applicable):** fixes #4832

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1721

**Example entry for `configuration.yaml` (if applicable):**
```yaml

device_tracker:
  - platform: asuswrt
    host: YOUR_ROUTER_IP
    username: YOUR_ADMIN_USERNAME
    password: YOUR_ADMIN_PASSWORD
    protocol: ssh
    port: 22222
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
