### PR TITLE
Improve aiohttp default clientsession close with connector

### DIFF
--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -34,7 +34,6 @@ def async_get_clientsession(hass, verify_ssl=True):
             connector=connector,
             headers={USER_AGENT: SERVER_SOFTWARE}
         )
-        _async_register_clientsession_shutdown(hass, clientsession)
         hass.data[key] = clientsession
 
     return hass.data[key]
@@ -111,9 +110,13 @@ def async_cleanup_websession(hass):
     This method is a coroutine.
     """
     tasks = []
-    if DATA_CONNECTOR in hass.data:
+    if DATA_CLIENTSESSION in hass.data:
+        tasks.append(hass.data[DATA_CLIENTSESSION].close())
+    elif DATA_CONNECTOR in hass.data:
         tasks.append(hass.data[DATA_CONNECTOR].close())
-    if DATA_CONNECTOR_NOTVERIFY in hass.data:
+    if DATA_CLIENTSESSION_NOTVERIFY in hass.data:
+        tasks.append(hass.data[DATA_CLIENTSESSION_NOTVERIFY].close())
+    elif DATA_CONNECTOR_NOTVERIFY in hass.data:
         tasks.append(hass.data[DATA_CONNECTOR_NOTVERIFY].close())
 
     if tasks:

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -148,8 +148,14 @@ def mock_aiohttp_client():
     """Context manager to mock aiohttp client."""
     mocker = AiohttpClientMocker()
 
+    @asyncio.coroutine
+    def fake_close():
+        """Fake cleanup."""
+        pass
+
     with mock.patch('aiohttp.ClientSession') as mock_session:
         instance = mock_session()
+        instance.close = fake_close
 
         for method in ('get', 'post', 'put', 'options', 'delete'):
             setattr(instance, method,


### PR DESCRIPTION
**Description:**

Hold default websession and close it with connectors. So you can use out default websession on close Event.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
