### PR TITLE
Fix tests closing properly

### DIFF
--- a/tests/components/binary_sensor/test_sleepiq.py
+++ b/tests/components/binary_sensor/test_sleepiq.py
@@ -31,6 +31,10 @@ class TestSleepIQBinarySensorSetup(unittest.TestCase):
             'password': self.password,
         }
 
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
+
     @requests_mock.Mocker()
     def test_setup(self, mock):
         """Test for successfully setting up the SleepIQ platform."""

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -47,6 +47,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
 
     def teardown_method(self, _):
         """Stop everything that was started."""
+        self.hass.stop()
         try:
             os.remove(self.hass.config.path(device_tracker.YAML_DEVICES))
         except FileNotFoundError:

--- a/tests/components/device_tracker/test_automatic.py
+++ b/tests/components/device_tracker/test_automatic.py
@@ -210,6 +210,7 @@ class TestAutomatic(unittest.TestCase):
 
     def tearDown(self):
         """Tear down test data."""
+        self.hass.stop()
 
     @patch('requests.get', side_effect=mocked_requests)
     @patch('requests.post', side_effect=mocked_requests)

--- a/tests/components/device_tracker/test_ddwrt.py
+++ b/tests/components/device_tracker/test_ddwrt.py
@@ -43,6 +43,7 @@ class TestDdwrt(unittest.TestCase):
 
     def teardown_method(self, _):
         """Stop everything that was started."""
+        self.hass.stop()
         try:
             os.remove(self.hass.config.path(device_tracker.YAML_DEVICES))
         except FileNotFoundError:

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -24,6 +24,7 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""
+        self.hass.stop()
         try:
             os.remove(self.hass.config.path(device_tracker.YAML_DEVICES))
         except FileNotFoundError:

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -691,6 +691,10 @@ class TestDeviceTrackerOwnTrackConfigs(BaseMQTT):
         self.hass = get_test_home_assistant()
         mock_mqtt_component(self.hass)
 
+    def teardown_method(self, method):
+        """Tear down resources."""
+        self.hass.stop()
+
     def mock_cipher():  # pylint: disable=no-method-argument
         """Return a dummy pickle-based cipher."""
         def mock_decrypt(ciphertext, key):

--- a/tests/components/device_tracker/test_tplink.py
+++ b/tests/components/device_tracker/test_tplink.py
@@ -21,6 +21,7 @@ class TestTplink4DeviceScanner(unittest.TestCase):
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""
+        self.hass.stop()
         try:
             os.remove(self.hass.config.path(device_tracker.YAML_DEVICES))
         except FileNotFoundError:

--- a/tests/components/notify/test_apns.py
+++ b/tests/components/notify/test_apns.py
@@ -14,6 +14,14 @@ from apns2.errors import Unregistered
 class TestApns(unittest.TestCase):
     """Test the APNS component."""
 
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
+
     def test_apns_setup_full(self):
         """Test setup with all data."""
         config = {
@@ -25,9 +33,8 @@ class TestApns(unittest.TestCase):
                 'cert_file': 'test_app.pem'
             }
         }
-        hass = get_test_home_assistant()
 
-        self.assertTrue(notify.setup(hass, config))
+        self.assertTrue(notify.setup(self.hass, config))
 
     def test_apns_setup_missing_name(self):
         """Test setup with missing name."""
@@ -39,8 +46,7 @@ class TestApns(unittest.TestCase):
                 'cert_file': 'test_app.pem'
             }
         }
-        hass = get_test_home_assistant()
-        self.assertFalse(notify.setup(hass, config))
+        self.assertFalse(notify.setup(self.hass, config))
 
     def test_apns_setup_missing_certificate(self):
         """Test setup with missing name."""
@@ -51,8 +57,7 @@ class TestApns(unittest.TestCase):
                 'name': 'test_app'
             }
         }
-        hass = get_test_home_assistant()
-        self.assertFalse(notify.setup(hass, config))
+        self.assertFalse(notify.setup(self.hass, config))
 
     def test_apns_setup_missing_topic(self):
         """Test setup with missing topic."""
@@ -63,8 +68,7 @@ class TestApns(unittest.TestCase):
                 'name': 'test_app'
             }
         }
-        hass = get_test_home_assistant()
-        self.assertFalse(notify.setup(hass, config))
+        self.assertFalse(notify.setup(self.hass, config))
 
     def test_register_new_device(self):
         """Test registering a new device with a name."""
@@ -76,18 +80,17 @@ class TestApns(unittest.TestCase):
                 'cert_file': 'test_app.pem'
             }
         }
-        hass = get_test_home_assistant()
 
-        devices_path = hass.config.path('test_app_apns.yaml')
+        devices_path = self.hass.config.path('test_app_apns.yaml')
         with open(devices_path, 'w+') as out:
             out.write('5678: {name: test device 2}\n')
 
-        notify.setup(hass, config)
-        self.assertTrue(hass.services.call('apns',
-                                           'test_app',
-                                           {'push_id': '1234',
-                                            'name': 'test device'},
-                                           blocking=True))
+        notify.setup(self.hass, config)
+        self.assertTrue(self.hass.services.call('apns',
+                                                'test_app',
+                                                {'push_id': '1234',
+                                                 'name': 'test device'},
+                                                blocking=True))
 
         devices = {str(key): value for (key, value) in
                    load_yaml_config_file(devices_path).items()}
@@ -112,16 +115,15 @@ class TestApns(unittest.TestCase):
                 'cert_file': 'test_app.pem'
             }
         }
-        hass = get_test_home_assistant()
 
-        devices_path = hass.config.path('test_app_apns.yaml')
+        devices_path = self.hass.config.path('test_app_apns.yaml')
         with open(devices_path, 'w+') as out:
             out.write('5678: {name: test device 2}\n')
 
-        notify.setup(hass, config)
-        self.assertTrue(hass.services.call('apns', 'test_app',
-                                           {'push_id': '1234'},
-                                           blocking=True))
+        notify.setup(self.hass, config)
+        self.assertTrue(self.hass.services.call('apns', 'test_app',
+                                                {'push_id': '1234'},
+                                                blocking=True))
 
         devices = {str(key): value for (key, value) in
                    load_yaml_config_file(devices_path).items()}
@@ -143,19 +145,18 @@ class TestApns(unittest.TestCase):
                 'cert_file': 'test_app.pem'
             }
         }
-        hass = get_test_home_assistant()
 
-        devices_path = hass.config.path('test_app_apns.yaml')
+        devices_path = self.hass.config.path('test_app_apns.yaml')
         with open(devices_path, 'w+') as out:
             out.write('1234: {name: test device 1}\n')
             out.write('5678: {name: test device 2}\n')
 
-        notify.setup(hass, config)
-        self.assertTrue(hass.services.call('apns',
-                                           'test_app',
-                                           {'push_id': '1234',
-                                            'name': 'updated device 1'},
-                                           blocking=True))
+        notify.setup(self.hass, config)
+        self.assertTrue(self.hass.services.call('apns',
+                                                'test_app',
+                                                {'push_id': '1234',
+                                                 'name': 'updated device 1'},
+                                                blocking=True))
 
         devices = {str(key): value for (key, value) in
                    load_yaml_config_file(devices_path).items()}
@@ -180,21 +181,20 @@ class TestApns(unittest.TestCase):
                 'cert_file': 'test_app.pem'
             }
         }
-        hass = get_test_home_assistant()
 
-        devices_path = hass.config.path('test_app_apns.yaml')
+        devices_path = self.hass.config.path('test_app_apns.yaml')
         with open(devices_path, 'w+') as out:
             out.write('1234: {name: test device 1, '
                       'tracking_device_id: tracking123}\n')
             out.write('5678: {name: test device 2, '
                       'tracking_device_id: tracking456}\n')
 
-        notify.setup(hass, config)
-        self.assertTrue(hass.services.call('apns',
-                                           'test_app',
-                                           {'push_id': '1234',
-                                            'name': 'updated device 1'},
-                                           blocking=True))
+        notify.setup(self.hass, config)
+        self.assertTrue(self.hass.services.call('apns',
+                                                'test_app',
+                                                {'push_id': '1234',
+                                                 'name': 'updated device 1'},
+                                                blocking=True))
 
         devices = {str(key): value for (key, value) in
                    load_yaml_config_file(devices_path).items()}
@@ -224,23 +224,22 @@ class TestApns(unittest.TestCase):
                 'cert_file': 'test_app.pem'
             }
         }
-        hass = get_test_home_assistant()
 
-        devices_path = hass.config.path('test_app_apns.yaml')
+        devices_path = self.hass.config.path('test_app_apns.yaml')
         with open(devices_path, 'w+') as out:
             out.write('1234: {name: test device 1}\n')
 
-        notify.setup(hass, config)
+        notify.setup(self.hass, config)
 
-        self.assertTrue(hass.services.call('notify', 'test_app',
-                                           {'message': 'Hello',
-                                            'data': {
-                                                'badge': 1,
-                                                'sound': 'test.mp3',
-                                                'category': 'testing'
-                                                }
-                                            },
-                                           blocking=True))
+        self.assertTrue(self.hass.services.call('notify', 'test_app',
+                                                {'message': 'Hello',
+                                                 'data': {
+                                                     'badge': 1,
+                                                     'sound': 'test.mp3',
+                                                     'category': 'testing'
+                                                     }
+                                                 },
+                                                blocking=True))
 
         self.assertTrue(send.called)
         self.assertEqual(1, len(send.mock_calls))
@@ -266,23 +265,22 @@ class TestApns(unittest.TestCase):
                 'cert_file': 'test_app.pem'
             }
         }
-        hass = get_test_home_assistant()
 
-        devices_path = hass.config.path('test_app_apns.yaml')
+        devices_path = self.hass.config.path('test_app_apns.yaml')
         with open(devices_path, 'w+') as out:
             out.write('1234: {name: test device 1, disabled: True}\n')
 
-        notify.setup(hass, config)
+        notify.setup(self.hass, config)
 
-        self.assertTrue(hass.services.call('notify', 'test_app',
-                                           {'message': 'Hello',
-                                            'data': {
-                                                'badge': 1,
-                                                'sound': 'test.mp3',
-                                                'category': 'testing'
-                                            }
-                                            },
-                                           blocking=True))
+        self.assertTrue(self.hass.services.call('notify', 'test_app',
+                                                {'message': 'Hello',
+                                                 'data': {
+                                                     'badge': 1,
+                                                     'sound': 'test.mp3',
+                                                     'category': 'testing'
+                                                 }
+                                                 },
+                                                blocking=True))
 
         self.assertFalse(send.called)
 
@@ -291,9 +289,7 @@ class TestApns(unittest.TestCase):
         """Test updating an existing device."""
         send = mock_client.return_value.send_notification
 
-        hass = get_test_home_assistant()
-
-        devices_path = hass.config.path('test_app_apns.yaml')
+        devices_path = self.hass.config.path('test_app_apns.yaml')
         with open(devices_path, 'w+') as out:
             out.write('1234: {name: test device 1, '
                       'tracking_device_id: tracking123}\n')
@@ -301,7 +297,7 @@ class TestApns(unittest.TestCase):
                       'tracking_device_id: tracking456}\n')
 
         notify_service = ApnsNotificationService(
-            hass,
+            self.hass,
             'test_app',
             'testapp.appname',
             False,
@@ -313,7 +309,7 @@ class TestApns(unittest.TestCase):
             State('device_tracker.tracking456', None),
             State('device_tracker.tracking456', 'home'))
 
-        hass.block_till_done()
+        self.hass.block_till_done()
 
         notify_service.send_message(message='Hello', target='home')
 
@@ -340,17 +336,16 @@ class TestApns(unittest.TestCase):
                 'cert_file': 'test_app.pem'
             }
         }
-        hass = get_test_home_assistant()
 
-        devices_path = hass.config.path('test_app_apns.yaml')
+        devices_path = self.hass.config.path('test_app_apns.yaml')
         with open(devices_path, 'w+') as out:
             out.write('1234: {name: test device 1}\n')
 
-        notify.setup(hass, config)
+        notify.setup(self.hass, config)
 
-        self.assertTrue(hass.services.call('notify', 'test_app',
-                                           {'message': 'Hello'},
-                                           blocking=True))
+        self.assertTrue(self.hass.services.call('notify', 'test_app',
+                                                {'message': 'Hello'},
+                                                blocking=True))
 
         devices = {str(key): value for (key, value) in
                    load_yaml_config_file(devices_path).items()}

--- a/tests/components/sensor/test_darksky.py
+++ b/tests/components/sensor/test_darksky.py
@@ -41,6 +41,10 @@ class TestDarkSkySetup(unittest.TestCase):
         self.hass.config.longitude = self.lon
         self.entities = []
 
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
+
     def test_setup_with_config(self):
         """Test the platform setup with configuration."""
         self.assertTrue(

--- a/tests/components/sensor/test_sleepiq.py
+++ b/tests/components/sensor/test_sleepiq.py
@@ -30,6 +30,10 @@ class TestSleepIQSensorSetup(unittest.TestCase):
             'password': self.password,
         }
 
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
+
     @requests_mock.Mocker()
     def test_setup(self, mock):
         """Test for successfully setting up the SleepIQ platform."""

--- a/tests/components/sensor/test_sonarr.py
+++ b/tests/components/sensor/test_sonarr.py
@@ -572,6 +572,10 @@ class TestSonarrSetup(unittest.TestCase):
         self.hass = get_test_home_assistant()
         self.hass.config.time_zone = 'America/Los_Angeles'
 
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
+
     @unittest.mock.patch('requests.get', side_effect=mocked_requests_get)
     def test_diskspace_no_paths(self, req_mock):
         """Test getting all disk space."""

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -129,6 +129,10 @@ class TestWundergroundSetup(unittest.TestCase):
         self.hass.config.latitude = self.lat
         self.hass.config.longitude = self.lon
 
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
+
     @unittest.mock.patch('requests.get', side_effect=mocked_requests_get)
     def test_setup(self, req_mock):
         """Test that the component is loaded if passed in PWS Id."""

--- a/tests/components/switch/test_command_line.py
+++ b/tests/components/switch/test_command_line.py
@@ -161,8 +161,6 @@ class TestCommandSwitch(unittest.TestCase):
 
     def test_assumed_state_should_be_true_if_command_state_is_false(self):
         """Test with state value."""
-        self.hass = get_test_home_assistant()
-
         # args: hass, device_name, friendly_name, command_on, command_off,
         #       command_state, value_template
         init_args = [
@@ -186,8 +184,6 @@ class TestCommandSwitch(unittest.TestCase):
 
     def test_entity_id_set_correctly(self):
         """Test that entity_id is set correctly from object_id."""
-        self.hass = get_test_home_assistant()
-
         init_args = [
             self.hass,
             "test_device_name",

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -191,15 +191,20 @@ def test_event_schema():
 
 def test_platform_validator():
     """Test platform validation."""
-    # Prepares loading
-    get_test_home_assistant()
+    hass = None
 
-    schema = vol.Schema(cv.platform_validator('light'))
+    try:
+        hass = get_test_home_assistant()
 
-    with pytest.raises(vol.MultipleInvalid):
-        schema('platform_that_does_not_exist')
+        schema = vol.Schema(cv.platform_validator('light'))
 
-    schema('hue')
+        with pytest.raises(vol.MultipleInvalid):
+            schema('platform_that_does_not_exist')
+
+        schema('hue')
+    finally:
+        if hass is not None:
+            hass.stop()
 
 
 def test_icon():


### PR DESCRIPTION
**Description:**
After #5195 I realized there are probably more tests that do not close the HASS instance properly so I went and looked for them. Hacked a counter into `get_test_home_assistant` that makes sure only one is alive at a time. Managed to find A LOT of places that didn't close hass - probably slowing down our tests a lot.
