### PR TITLE
Improve aiohttp default clientsession close with connector

### DIFF
--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -34,7 +34,6 @@ def async_get_clientsession(hass, verify_ssl=True):
             connector=connector,
             headers={USER_AGENT: SERVER_SOFTWARE}
         )
-        _async_register_clientsession_shutdown(hass, clientsession)
         hass.data[key] = clientsession
 
     return hass.data[key]
@@ -111,8 +110,12 @@ def async_cleanup_websession(hass):
     This method is a coroutine.
     """
     tasks = []
+    if DATA_CLIENTSESSION in hass.data:
+        hass.data[DATA_CLIENTSESSION].detach()
     if DATA_CONNECTOR in hass.data:
         tasks.append(hass.data[DATA_CONNECTOR].close())
+    if DATA_CLIENTSESSION_NOTVERIFY in hass.data:
+        hass.data[DATA_CLIENTSESSION_NOTVERIFY].detach()
     if DATA_CONNECTOR_NOTVERIFY in hass.data:
         tasks.append(hass.data[DATA_CONNECTOR_NOTVERIFY].close())
 

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -284,8 +284,7 @@ class TestMediaPlayerWeb(unittest.TestCase):
             def get(self, url):
                 return MockResponse()
 
-            @asyncio.coroutine
-            def close(self):
+            def detach(self):
                 pass
 
         self.hass.data[DATA_CLIENTSESSION] = MockWebsession()


### PR DESCRIPTION
**Description:**

This was the real code befor I rebase the old code from test machine. 

-> #5200 

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
