### PR TITLE
Fix TCP sensor to correctly use value_template

### DIFF
--- a/homeassistant/components/sensor/tcp.py
+++ b/homeassistant/components/sensor/tcp.py
@@ -16,7 +16,6 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE)
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.template import Template
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/sensor/tcp.py
+++ b/homeassistant/components/sensor/tcp.py
@@ -57,7 +57,7 @@ class TcpSensor(Entity):
         value_template = config.get(CONF_VALUE_TEMPLATE)
 
         if value_template is not None:
-            value_template = Template(value_template, hass)
+            value_template.hass = hass
 
         self._hass = hass
         self._config = {

--- a/tests/components/sensor/test_tcp.py
+++ b/tests/components/sensor/test_tcp.py
@@ -9,6 +9,7 @@ from tests.common import (get_test_home_assistant, assert_setup_component)
 from homeassistant.bootstrap import setup_component
 from homeassistant.components.sensor import tcp
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.template import Template
 
 TEST_CONFIG = {
     'sensor': {
@@ -19,7 +20,7 @@ TEST_CONFIG = {
         tcp.CONF_TIMEOUT: tcp.DEFAULT_TIMEOUT + 1,
         tcp.CONF_PAYLOAD: 'test_payload',
         tcp.CONF_UNIT_OF_MEASUREMENT: 'test_unit',
-        tcp.CONF_VALUE_TEMPLATE: 'test_template',
+        tcp.CONF_VALUE_TEMPLATE: Template('test_template'),
         tcp.CONF_VALUE_ON: 'test_on',
         tcp.CONF_BUFFER_SIZE: tcp.DEFAULT_BUFFER_SIZE + 1
     },
@@ -252,7 +253,7 @@ class TestTCPSensor(unittest.TestCase):
         mock_socket = mock_socket().__enter__()
         mock_socket.recv.return_value = test_value.encode()
         config = copy(TEST_CONFIG['sensor'])
-        config[tcp.CONF_VALUE_TEMPLATE] = '{{ value }} {{ 1+1 }}'
+        config[tcp.CONF_VALUE_TEMPLATE] = Template('{{ value }} {{ 1+1 }}')
         sensor = tcp.TcpSensor(self.hass, config)
         assert sensor._state == '%s 2' % test_value
 
@@ -265,6 +266,6 @@ class TestTCPSensor(unittest.TestCase):
         mock_socket = mock_socket().__enter__()
         mock_socket.recv.return_value = test_value.encode()
         config = copy(TEST_CONFIG['sensor'])
-        config[tcp.CONF_VALUE_TEMPLATE] = "{{ this won't work"
+        config[tcp.CONF_VALUE_TEMPLATE] = Template("{{ this won't work")
         sensor = tcp.TcpSensor(self.hass, config)
         assert sensor.update() is None


### PR DESCRIPTION
**Description:**

At the moment using a ```value_template``` configuration option with the ```tcp``` sensor component fails with an error regarding template initialisation.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

This issue has reported on:

* The [community forum](https://community.home-assistant.io/t/template-in-tcp-sensor/5580).
* Issue #5186