### PR TITLE
Add support for direct MJPEG streams from Amcrest cameras

### DIFF
--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -153,7 +153,7 @@ class AmcrestCam(Camera):
         except (asyncio.TimeoutError, aiohttp.errors.ClientError):
             _LOGGER.exception("Error on %s", streaming_url)
             raise HTTPGatewayTimeout()
-            
+
         except asyncio.CancelledError:
             _LOGGER.debug("Close stream by frontend.")
             response = None

--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -156,7 +156,7 @@ class AmcrestCam(Camera):
 
         finally:
             if stream is not None:
-                self.hass.async_add_job(stream.close())
+                stream.close()
             if response is not None:
                 yield from response.write_eof()
 

--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -153,6 +153,10 @@ class AmcrestCam(Camera):
         except (asyncio.TimeoutError, aiohttp.errors.ClientError):
             _LOGGER.exception("Error on %s", streaming_url)
             raise HTTPGatewayTimeout()
+            
+        except asyncio.CancelledError:
+            _LOGGER.debug("Close stream by frontend.")
+            response = None
 
         finally:
             if stream is not None:

--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -4,8 +4,13 @@ This component provides basic support for Amcrest IP cameras.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/camera.amcrest/
 """
+import asyncio
 import logging
 
+import aiohttp
+from aiohttp import web
+from aiohttp.web_exceptions import HTTPGatewayTimeout
+import async_timeout
 import voluptuous as vol
 
 import homeassistant.loader as loader
@@ -13,16 +18,19 @@ from homeassistant.components.camera import (Camera, PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_PORT)
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 REQUIREMENTS = ['amcrest==1.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_RESOLUTION = 'resolution'
+CONF_STREAM_SOURCE = 'stream_source'
 
 DEFAULT_NAME = 'Amcrest Camera'
 DEFAULT_PORT = 80
 DEFAULT_RESOLUTION = 'high'
+DEFAULT_STREAM_SOURCE = 'mjpeg'
 
 NOTIFICATION_ID = 'amcrest_notification'
 NOTIFICATION_TITLE = 'Amcrest Camera Setup'
@@ -32,6 +40,14 @@ RESOLUTION_LIST = {
     'low': 1,
 }
 
+STREAM_SOURCE_LIST = {
+    'mjpeg': 0,
+    'snapshot': 1
+}
+
+CONTENT_TYPE_HEADER = 'Content-Type'
+TIMEOUT = 5
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
@@ -40,6 +56,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(vol.In(RESOLUTION_LIST)),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_STREAM_SOURCE, default=DEFAULT_STREAM_SOURCE):
+        vol.All(vol.In(STREAM_SOURCE_LIST)),
 })
 
 
@@ -64,25 +82,83 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             notification_id=NOTIFICATION_ID)
         return False
 
-    add_devices([AmcrestCam(config, data)])
+    add_devices([AmcrestCam(hass, config, data)])
     return True
 
 
 class AmcrestCam(Camera):
     """An implementation of an Amcrest IP camera."""
 
-    def __init__(self, device_info, data):
+    def __init__(self, hass, device_info, data):
         """Initialize an Amcrest camera."""
         super(AmcrestCam, self).__init__()
+        self._base_url = '%s://%s:%s/cgi-bin' % (
+            'http',
+            device_info.get(CONF_HOST),
+            device_info.get(CONF_PORT)
+        )
         self._data = data
+        self._hass = hass
         self._name = device_info.get(CONF_NAME)
         self._resolution = RESOLUTION_LIST[device_info.get(CONF_RESOLUTION)]
+        self._stream_source = STREAM_SOURCE_LIST[
+            device_info.get(CONF_STREAM_SOURCE)
+        ]
+        self._token = self._auth = aiohttp.BasicAuth(
+            device_info.get(CONF_USERNAME),
+            password=device_info.get(CONF_PASSWORD)
+        )
+        self._websession = async_create_clientsession(hass)
 
     def camera_image(self):
         """Return a still image reponse from the camera."""
         # Send the request to snap a picture and return raw jpg data
         response = self._data.camera.snapshot(channel=self._resolution)
         return response.data
+
+    @asyncio.coroutine
+    def handle_async_mjpeg_stream(self, request):
+        """Return an MJPEG stream."""
+        # The snapshot implementation is handled by the parent class
+        if self._stream_source == STREAM_SOURCE_LIST['snapshot']:
+            yield from super().handle_async_mjpeg_stream(request)
+            return
+
+        # Otherwise, stream an MJPEG image stream directly from the camera
+        streaming_url = '%s/mjpg/video.cgi?channel=0&subtype=%d' % (
+            self._base_url,
+            self._resolution
+        )
+
+        stream = None
+        response = None
+        try:
+            with async_timeout.timeout(TIMEOUT, loop=self.hass.loop):
+                stream = yield from self._websession.get(
+                    streaming_url,
+                    auth=self._token,
+                    timeout=TIMEOUT
+                )
+            response = web.StreamResponse()
+            response.content_type = stream.headers.get(CONTENT_TYPE_HEADER)
+
+            yield from response.prepare(request)
+
+            while True:
+                data = yield from stream.content.read(16384)
+                if not data:
+                    break
+                response.write(data)
+
+        except (asyncio.TimeoutError, aiohttp.errors.ClientError):
+            _LOGGER.exception("Error on %s", streaming_url)
+            raise HTTPGatewayTimeout()
+
+        finally:
+            if stream is not None:
+                self.hass.async_add_job(stream.release())
+            if response is not None:
+                yield from response.write_eof()
 
     @property
     def name(self):

--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -156,7 +156,7 @@ class AmcrestCam(Camera):
 
         finally:
             if stream is not None:
-                self.hass.async_add_job(stream.release())
+                self.hass.async_add_job(stream.close())
             if response is not None:
                 yield from response.write_eof()
 


### PR DESCRIPTION
## Description

The previous implementation relied on using snapshots from the camera. However,
**some Amcrest models cannot keep up with the large number of requests and
instead timeout, resulting in no video stream**. These cameras do provide MJPEG
streams though, so this commit adds the option to use these instead of creating
one from snapshots.

Unfortunately, some cameras on newer firmwares do not support MJPEG streams at
high resolution - only at low resolution.

By providing users with both a `resolution` and `stream_source` option, we can
allow them to choose whichever combination works for their particular model
and firmware version.

## Development Notes

This implementation was based on code from `SynologyCamera` and uses some of the same dependencies.  No new dependencies were introduced to HA.

Also, although [the `amcrest` library does provide a `mjpg_stream()` method](https://github.com/tchellomello/python-amcrest/blob/master/src/amcrest/special.py#L60), I'm not sure how to continously read/write that data without blocking or how to close/release the connection to the camera once done.  That's why I've chosen to copy the `SynologyCamera` implementation and just hit the camera's URL directly.  If you think that `mjpg_stream()` **can** be used, just give me a couple pointers and I'll gladly make the necessary changes.

## Testing Notes

I've tested this functionality with my Amcrest IP2M-841 ProHD 1080P (1920TVL) Wireless WiFi IP Camera on firmware 2.420.AC00.16.R, build: 2016-09-09.

### Before

| `resolution` | Still Images Work? | Live Streaming Works? |
| --- |  --- |  --- |
| `low` | :white_check_mark: Yes | :o: Not my model, but maybe others |
| `high` | :white_check_mark: Yes | :o: Not my model, but maybe others |


### After

| `resolution` | `stream_type` | Still Images Work? | Live Streaming Works? |
| --- |  --- |  --- |  --- |
| `low` | `mjpeg` | :white_check_mark: Yes | :white_check_mark: Yes |
| `low` | `snapshot` | :white_check_mark: Yes | :o: Not my model, but maybe others |
| `high` | `mjpeg` | :white_check_mark: Yes | :clock3: Older firmwares only |
| `high` | `snapshot` | :white_check_mark: Yes | :o: Not my model, but maybe others |

As a result, this change should expand the degree of compatiblity with different Amcrest models.

-----

**Related issue (if applicable):** https://community.home-assistant.io/t/amcrest-camera-component/7464/14?u=colinodell

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#1735

**Example entry for `configuration.yaml` (if applicable):**

This adds a new `stream_source` config option for Amcrest cameras:

```yaml
camera:
  - name: Living Room
    platform: amcrest
    host: 123.45.67.89
    username: admin
    password: correcthorsebatterystaple
    resolution: low
    stream_source: mjpeg
```

Allowed values are `mjpeg` (default) or `snapshot` (legacy).

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
