### PR TITLE
Include libav-tools in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "deb http://download.telldus.com/debian/ stable main" >> /etc/apt/sourc
     wget -qO - http://download.telldus.se/debian/telldus-public.key | apt-key add - && \
     apt-get update && \
     apt-get install -y --no-install-recommends nmap net-tools cython3 libudev-dev sudo libglib2.0-dev bluetooth libbluetooth-dev \
-            libtelldus-core2 && \
+            libtelldus-core2 libav-tools && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY script/build_python_openzwave script/build_python_openzwave


### PR DESCRIPTION
**Description:**

[The ffmpeg component requires either ffmpeg or avconv](https://home-assistant.io/components/ffmpeg/), so one of these should probably be included in the Docker container.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** n/a

**Example entry for `configuration.yaml` (if applicable):** /na

**Checklist:**

n/a