### PR TITLE
Bugfix segfault with new helper track_time_interval

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -166,6 +166,7 @@ def async_track_sunrise(hass, action, offset=None):
     """Add a listener that will fire a specified offset from sunrise daily."""
     from homeassistant.components import sun
     offset = offset or timedelta()
+    remove = None
 
     def next_rise():
         """Return the next sunrise."""
@@ -201,6 +202,7 @@ def async_track_sunset(hass, action, offset=None):
     """Add a listener that will fire a specified offset from sunset daily."""
     from homeassistant.components import sun
     offset = offset or timedelta()
+    remove = None
 
     def next_set():
         """Return next sunrise."""

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -135,6 +135,8 @@ track_point_in_utc_time = threaded_listener_factory(
 
 def async_track_time_interval(hass, action, interval):
     """Add a listener that fires repetitively at every timedelta interval."""
+    remove = None
+
     def next_interval():
         """Return the next interval."""
         return dt_util.utcnow() + interval


### PR DESCRIPTION
**Description:**

Some reports sigfault with py34 with the new helper. I think it is a cpython/GC trouble by code analysing with not existent pointer on some time.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
