### PR TITLE
calendar timezone fixes

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -147,10 +147,10 @@ class CalendarEventDevice(Entity):
         def _get_date(date):
             """Get the dateTime from date or dateTime as a local."""
             if 'date' in date:
-                return dt.as_utc(dt.dt.datetime.combine(
-                    dt.parse_date(date['date']), dt.dt.time()))
+                return dt.start_of_local_day(dt.dt.datetime.combine(
+                    dt.parse_date(date['date']), dt.dt.time.min))
             else:
-                return dt.parse_datetime(date['dateTime'])
+                return dt.as_local(dt.parse_datetime(date['dateTime']))
 
         start = _get_date(self.data.event['start'])
         end = _get_date(self.data.event['end'])

--- a/homeassistant/components/calendar/google.py
+++ b/homeassistant/components/calendar/google.py
@@ -66,7 +66,7 @@ class GoogleCalendarData(object):
         """Get the latest data."""
         service = self.calendar_service.get()
         params = dict(DEFAULT_GOOGLE_SEARCH_PARAMS)
-        params['timeMin'] = dt.utcnow().isoformat('T')
+        params['timeMin'] = dt.start_of_local_day().isoformat('T')
         params['calendarId'] = self.calendar_id
         if self.search:
             params['q'] = self.search

--- a/tests/components/calendar/test_google.py
+++ b/tests/components/calendar/test_google.py
@@ -96,8 +96,8 @@ class TestComponentsGoogleCalendar(unittest.TestCase):
             'message': event['summary'],
             'all_day': True,
             'offset_reached': False,
-            'start_time': '{} 06:00:00'.format(event['start']['date']),
-            'end_time': '{} 06:00:00'.format(event['end']['date']),
+            'start_time': '{} 00:00:00'.format(event['start']['date']),
+            'end_time': '{} 00:00:00'.format(event['end']['date']),
             'location': event['location'],
             'description': event['description']
         })
@@ -416,8 +416,8 @@ class TestComponentsGoogleCalendar(unittest.TestCase):
             'message': event_summary,
             'all_day': True,
             'offset_reached': False,
-            'start_time': '{} 06:00:00'.format(event['start']['date']),
-            'end_time': '{} 06:00:00'.format(event['end']['date']),
+            'start_time': '{} 00:00:00'.format(event['start']['date']),
+            'end_time': '{} 00:00:00'.format(event['end']['date']),
             'location': event['location'],
             'description': event['description']
         })


### PR DESCRIPTION
**Description:**

Fixes calendar timezone issues.
- Times from google are local. Now we treat them as local internally.
- Make sure to capture all-day events starting on the current day.
- All-day events start and end at 00:00:00 (local time).

See relevant thread here: https://community.home-assistant.io/t/google-calendar-and-timezones/8208

cc @mnestor 

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
