### PR TITLE
Fix #5188 by Closing the stream instead of Releasing it

### DIFF
--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -126,7 +126,7 @@ class MjpegCamera(Camera):
 
         finally:
             if stream is not None:
-                yield stream.close()
+                yield from stream.close()
             if response is not None:
                 yield from response.write_eof()
 

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -126,7 +126,7 @@ class MjpegCamera(Camera):
 
         finally:
             if stream is not None:
-                self.hass.async_add_job(stream.release())
+                yield stream.close()
             if response is not None:
                 yield from response.write_eof()
 


### PR DESCRIPTION
Closing just terminates the connection, release attempts to download all the contents before closing.  Since the MJPEG stream is infinite, it loads and loads content until the python script runs out of memory.

Source: https://github.com/KeepSafe/aiohttp/blob/50b1d30f4128abd895532022c726e97993987c7c/aiohttp/client_reqrep.py#L668-L672

**Related issue (if applicable):** fixes #5188

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
 
