### PR TITLE
Add listing and selection of available MPD playlists

### DIFF
--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -209,7 +209,7 @@ class MpdDevice(MediaPlayerDevice):
     def turn_on(self):
         """Service to send the MPD the command to start playing."""
         self.client.play()
-        self._update_playlists()
+        self._update_playlists(no_throttle=True)
 
     @Throttle(PLAYLIST_UPDATE_INTERVAL)
     def _update_playlists(self):

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -212,7 +212,7 @@ class MpdDevice(MediaPlayerDevice):
         self._update_playlists(no_throttle=True)
 
     @Throttle(PLAYLIST_UPDATE_INTERVAL)
-    def _update_playlists(self):
+    def _update_playlists(self, **kwargs):
         """Update available MPD playlists."""
         self.playlists = []
         for playlist_data in self.client.listplaylists():


### PR DESCRIPTION
**Description:**
The [MPD](https://home-assistant.io/components/media_player.mpd/) component is a client to a  MPD/mopidy music server. The server has a list of playlists available that can currently be played through home-assistant actions. This PR adds puts the list of available playlists in the GUI via the Source Input field common to media players with the `SUPPORT_SELECT_SOURCE` capability. Since the MPD client can only interact through playlists, this is a natural place for the UI to be. 

Note that if you're using the mopidy-spotify extension, all saved Spotify playlists will indeed show up in this drop-down menu and will play when selected. 


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** 
No change to docs because this feature will be easily discoverable. 

**Example entry for `configuration.yaml` (if applicable):** 
No new configuration. 

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
