### PR TITLE
Prevent flic from blocking on event loop

### DIFF
--- a/homeassistant/components/binary_sensor/flic.py
+++ b/homeassistant/components/binary_sensor/flic.py
@@ -55,9 +55,15 @@ def async_setup_platform(hass, config, async_add_entities,
     port = config.get(CONF_PORT)
     discovery = config.get(CONF_DISCOVERY)
 
-    try:
-        client = pyflic.FlicClient(host, port)
-    except ConnectionRefusedError:
+    def get_flic_client():
+        """Connect to the flic server and return FlicClient instance."""
+        try:
+            return pyflic.FlicClient(host, port)
+        except ConnectionRefusedError:
+            return None
+
+    client = yield from hass.loop.run_in_executor(None, get_flic_client)
+    if client is None:
         _LOGGER.error("Failed to connect to flic server.")
         return
 


### PR DESCRIPTION
**Description:**
Currently flic setup blocks on the event loop when connecting to the socket. [See here](https://github.com/soldag/pyflic/blob/master/pyflic/__init__.py#L260). This moves the client creation into an executor thread.
