### PR TITLE
Remove build dirs from docker image to keep the layers small

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,13 @@ RUN echo "deb http://download.telldus.com/debian/ stable main" >> /etc/apt/sourc
 
 COPY script/build_python_openzwave script/build_python_openzwave
 RUN script/build_python_openzwave && \
-  mkdir -p /usr/local/share/python-openzwave && \
-  ln -sf /usr/src/app/build/python-openzwave/openzwave/config /usr/local/share/python-openzwave/config
+    mkdir -p /usr/local/share/python-openzwave && \
+    mv /usr/src/app/build/python-openzwave/openzwave/config /usr/local/share/python-openzwave/config && \
+    rm -rf build/
 
 COPY script/build_libcec script/build_libcec
-RUN script/build_libcec
+RUN script/build_libcec && \
+    rm -rf build/
 
 COPY requirements_all.txt requirements_all.txt
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,24 +8,11 @@ WORKDIR /usr/src/app
 
 RUN pip3 install --no-cache-dir colorlog cython
 
-# For the nmap tracker, bluetooth tracker, Z-Wave, tellstick
-RUN echo "deb http://download.telldus.com/debian/ stable main" >> /etc/apt/sources.list.d/telldus.list && \
-    wget -qO - http://download.telldus.se/debian/telldus-public.key | apt-key add - && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends nmap net-tools cython3 libudev-dev sudo libglib2.0-dev bluetooth libbluetooth-dev \
-            libtelldus-core2 cmake libxrandr-dev swig && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Copy build scripts
+COPY script/setup_docker_prereqs script/build_python_openzwave script/build_libcec script/
+RUN script/setup_docker_prereqs
 
-COPY script/build_python_openzwave script/build_python_openzwave
-RUN script/build_python_openzwave && \
-    mkdir -p /usr/local/share/python-openzwave && \
-    mv /usr/src/app/build/python-openzwave/openzwave/config /usr/local/share/python-openzwave/config && \
-    rm -rf build/
-
-COPY script/build_libcec script/build_libcec
-RUN script/build_libcec && \
-    rm -rf build/
-
+# Install hass component dependencies
 COPY requirements_all.txt requirements_all.txt
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
     pip3 install --no-cache-dir mysqlclient psycopg2 uvloop

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ VOLUME /config
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-RUN pip3 install --no-cache-dir colorlog cython
-
 # Copy build scripts
 COPY script/setup_docker_prereqs script/build_python_openzwave script/build_libcec script/
 RUN script/setup_docker_prereqs

--- a/script/build_libcec
+++ b/script/build_libcec
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Sets up and builds libcec to be used with Home Assistant.
 # Dependencies that need to be installed:
-# apt-get install cmake libudev-dev libxrandr-dev python-dev swig
+# apt-get install cmake libudev-dev libxrandr-dev swig
 
 # Stop on errors
 set -e

--- a/script/setup_docker_prereqs
+++ b/script/setup_docker_prereqs
@@ -1,8 +1,22 @@
-#!/bin/sh
+#!/bin/bash
 # Install requirements and build dependencies for Home Assinstant in Docker.
 
-PACKAGES="nmap net-tools sudo libglib2.0-dev bluetooth libbluetooth-dev libtelldus-core2"
-PACKAGES_DEV="cython3 libudev-dev cmake libxrandr-dev swig"
+# Required debian packages for running hass or components
+PACKAGES=(
+  nmap               # homeassistant.components.device_tracker.nmap_tracker
+  net-tools          # homeassistant.components.device_tracker.nmap_tracker
+  bluetooth          # homeassistant.components.device_tracker.bluetooth_tracker
+  libtelldus-core2   # homeassistant.components.tellstick
+)
+
+# Required debian packages for building components
+PACKAGES_DEV=(
+  cython3            # python-openzwave
+  libudev-dev        # python-openzwave, libcec
+  cmake              # libcec
+  libxrandr-dev      # libcec
+  swig               # libcec
+)
 
 # Stop on errors
 set -e
@@ -15,7 +29,7 @@ wget -qO - http://download.telldus.se/debian/telldus-public.key | apt-key add -
 
 # Install packages
 apt-get update
-apt-get install -y --no-install-recommends $PACKAGES $PACKAGES_DEV
+apt-get install -y --no-install-recommends ${PACKAGES[@]} ${PACKAGES_DEV[@]}
 
 # Build and install openzwave
 script/build_python_openzwave
@@ -26,7 +40,7 @@ ln -sf /usr/src/app/build/python-openzwave/openzwave/config /usr/local/share/pyt
 script/build_libcec
 
 # Remove packages
-apt-get remove -y --purge $PACKAGES_DEV
+apt-get remove -y --purge ${PACKAGES_DEV[@]}
 apt-get -y --purge autoremove
 
 # Cleanup

--- a/script/setup_docker_prereqs
+++ b/script/setup_docker_prereqs
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Install requirements and build dependencies for Home Assinstant in Docker.
+
+PACKAGES="nmap net-tools sudo libglib2.0-dev bluetooth libbluetooth-dev libtelldus-core2"
+PACKAGES_DEV="cython3 libudev-dev cmake libxrandr-dev swig"
+
+# Stop on errors
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Add Tellstick repository
+echo "deb http://download.telldus.com/debian/ stable main" >> /etc/apt/sources.list.d/telldus.list
+wget -qO - http://download.telldus.se/debian/telldus-public.key | apt-key add -
+
+# Install packages
+apt-get update
+apt-get install -y --no-install-recommends $PACKAGES $PACKAGES_DEV
+
+# Build and install openzwave
+script/build_python_openzwave
+mkdir -p /usr/local/share/python-openzwave
+ln -sf /usr/src/app/build/python-openzwave/openzwave/config /usr/local/share/python-openzwave/config
+
+# Build and install libcec
+script/build_libcec
+
+# Remove packages
+apt-get remove -y --purge $PACKAGES_DEV
+apt-get -y --purge autoremove
+
+# Cleanup
+apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* build/
+

--- a/script/setup_docker_prereqs
+++ b/script/setup_docker_prereqs
@@ -3,19 +3,20 @@
 
 # Required debian packages for running hass or components
 PACKAGES=(
-  nmap               # homeassistant.components.device_tracker.nmap_tracker
-  net-tools          # homeassistant.components.device_tracker.nmap_tracker
-  bluetooth          # homeassistant.components.device_tracker.bluetooth_tracker
-  libtelldus-core2   # homeassistant.components.tellstick
+  # homeassistant.components.device_tracker.nmap_tracker
+  nmap net-tools
+  # homeassistant.components.device_tracker.bluetooth_tracker
+  bluetooth libglib2.0-dev libbluetooth-dev
+  # homeassistant.components.tellstick
+  libtelldus-core2
 )
 
-# Required debian packages for building components
+# Required debian packages for building dependencies
 PACKAGES_DEV=(
-  cython3            # python-openzwave
-  libudev-dev        # python-openzwave, libcec
-  cmake              # libcec
-  libxrandr-dev      # libcec
-  swig               # libcec
+  # python-openzwave
+  cython3 libudev-dev
+  # libcec
+  cmake swig libxrandr-dev
 )
 
 # Stop on errors

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -22,11 +22,13 @@ RUN echo "deb http://download.telldus.com/debian/ stable main" >> /etc/apt/sourc
 
 COPY script/build_python_openzwave script/build_python_openzwave
 RUN script/build_python_openzwave && \
-  mkdir -p /usr/local/share/python-openzwave && \
-  ln -sf /usr/src/app/build/python-openzwave/openzwave/config /usr/local/share/python-openzwave/config
+    mkdir -p /usr/local/share/python-openzwave && \
+    mv /usr/src/app/build/python-openzwave/openzwave/config /usr/local/share/python-openzwave/config && \
+    rm -rf build/
 
 COPY script/build_libcec script/build_libcec
-RUN script/build_libcec
+RUN script/build_libcec && \
+    rm -rf build/
 
 COPY requirements_all.txt requirements_all.txt
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -12,23 +12,9 @@ WORKDIR /usr/src/app
 
 RUN pip3 install --no-cache-dir colorlog cython
 
-# For the nmap tracker, bluetooth tracker, Z-Wave, tellstick
-RUN echo "deb http://download.telldus.com/debian/ stable main" >> /etc/apt/sources.list.d/telldus.list && \
-    wget -qO - http://download.telldus.se/debian/telldus-public.key | apt-key add - && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends nmap net-tools cython3 libudev-dev sudo libglib2.0-dev bluetooth libbluetooth-dev \
-            libtelldus-core2 cmake libxrandr-dev swig && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-COPY script/build_python_openzwave script/build_python_openzwave
-RUN script/build_python_openzwave && \
-    mkdir -p /usr/local/share/python-openzwave && \
-    mv /usr/src/app/build/python-openzwave/openzwave/config /usr/local/share/python-openzwave/config && \
-    rm -rf build/
-
-COPY script/build_libcec script/build_libcec
-RUN script/build_libcec && \
-    rm -rf build/
+# Copy build scripts
+COPY script/setup_docker_prereqs script/build_python_openzwave script/build_libcec script/
+RUN script/setup_docker_prereqs
 
 COPY requirements_all.txt requirements_all.txt
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
@@ -44,13 +30,10 @@ RUN curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash - && \
 RUN pip3 install --no-cache-dir tox
 
 # Copy over everything required to run tox
-COPY requirements_test.txt .
-COPY setup.cfg .
-COPY setup.py .
-COPY tox.ini .
+COPY requirements_test.txt setup.cfg setup.py tox.ini ./
 COPY homeassistant/const.py homeassistant/const.py
 
-# Get all dependencies
+# Prefetch dependencies for tox
 RUN tox -e py35 --notest
 
 # END: Development additions

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -10,12 +10,11 @@ VOLUME /config
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-RUN pip3 install --no-cache-dir colorlog cython
-
 # Copy build scripts
 COPY script/setup_docker_prereqs script/build_python_openzwave script/build_libcec script/
 RUN script/setup_docker_prereqs
 
+# Install hass component dependencies
 COPY requirements_all.txt requirements_all.txt
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
     pip3 install --no-cache-dir mysqlclient psycopg2 uvloop


### PR DESCRIPTION
**Description:**
Remove the build dir of `script/build_libcec` and `script/build_python_openzwave` from the Docker image. This saves 168 MB.

## Before `rm -rf build/`
```bash
$ docker history home-assistant
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
02b30b578835        6 seconds ago       /bin/sh -c #(nop)  CMD ["python" "-m" "homeas   0 B                 
4ef301ec282a        7 seconds ago       /bin/sh -c #(nop) COPY dir:bd740fb4658fae4fd2   21.75 MB            
09c00b87ca2c        9 seconds ago       /bin/sh -c pip3 install --no-cache-dir -r req   271.8 MB            
b63682b5de86        5 minutes ago       /bin/sh -c #(nop) COPY file:dc1b865eaa2aa9bf6   16.24 kB            
16324eab1258        5 minutes ago       /bin/sh -c script/build_libcec                  12.85 MB            <---
6537d1cdd54d        5 minutes ago       /bin/sh -c #(nop) COPY file:a4027cf23c2eb7375   1.633 kB            
14fb00dc5a84        5 minutes ago       /bin/sh -c script/build_python_openzwave &&     238 MB              <---              
6de3c5b76b43        9 minutes ago       /bin/sh -c #(nop) COPY file:c477b2f2f3970e8f9   702 B               
895812216a1d        9 minutes ago       /bin/sh -c echo "deb http://download.telldus.   90.34 MB            
2d72e86d9b73        6 weeks ago         /bin/sh -c pip3 install --no-cache-dir colorl   31.86 MB            
a3ef84a2e51c        6 weeks ago         /bin/sh -c #(nop)  WORKDIR /usr/src/app         0 B                 
459e745c5712        6 weeks ago         /bin/sh -c mkdir -p /usr/src/app                0 B                 
03cbf1acb362        6 weeks ago         /bin/sh -c #(nop)  VOLUME [/config]             0 B                 
aaaa1646019d        6 weeks ago         /bin/sh -c #(nop)  MAINTAINER Paulus Schoutse   0 B                 
7045ed20ac61        7 weeks ago         /bin/sh -c #(nop)  CMD ["python3"]              0 B                 
...

$ docker images home-assistant
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
home-assistant      latest              02b30b578835        15 seconds ago      1.349 GB
```
## After `rm -rf build/`
```bash
$ docker history home-assistant-rmbuild
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
74c26e9916bc        20 seconds ago      /bin/sh -c #(nop)  CMD ["python" "-m" "homeas   0 B                 
76a6b13070d6        21 seconds ago      /bin/sh -c #(nop) COPY dir:b61ed18e451c6ba996   21.74 MB            
3cd5fe5c8ab4        23 seconds ago      /bin/sh -c pip3 install --no-cache-dir -r req   271.8 MB            
8a3456dc8896        5 minutes ago       /bin/sh -c #(nop) COPY file:dc1b865eaa2aa9bf6   16.24 kB            
7501089a09e8        5 minutes ago       /bin/sh -c script/build_libcec &&     rm -rf    2.687 MB             <---
f4986e886727        5 minutes ago       /bin/sh -c #(nop) COPY file:a4027cf23c2eb7375   1.633 kB            
ba533fb92b99        5 minutes ago       /bin/sh -c script/build_python_openzwave &&     79.52 MB           <---
6de3c5b76b43        21 minutes ago      /bin/sh -c #(nop) COPY file:c477b2f2f3970e8f9   702 B               
895812216a1d        21 minutes ago      /bin/sh -c echo "deb http://download.telldus.   90.34 MB            
2d72e86d9b73        6 weeks ago         /bin/sh -c pip3 install --no-cache-dir colorl   31.86 MB            
a3ef84a2e51c        6 weeks ago         /bin/sh -c #(nop)  WORKDIR /usr/src/app         0 B                 
459e745c5712        6 weeks ago         /bin/sh -c mkdir -p /usr/src/app                0 B                 
03cbf1acb362        6 weeks ago         /bin/sh -c #(nop)  VOLUME [/config]             0 B                 
aaaa1646019d        6 weeks ago         /bin/sh -c #(nop)  MAINTAINER Paulus Schoutse   0 B                 
7045ed20ac61        7 weeks ago         /bin/sh -c #(nop)  CMD ["python3"]              0 B                 
...

$ docker images home-assistant-rmbuild
REPOSITORY               TAG                 IMAGE ID            CREATED             SIZE
home-assistant-rmbuild   latest              74c26e9916bc        28 seconds ago      1.181 GB
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
