### PR TITLE
Bugfix value_template for tcp sensors

### DIFF
--- a/homeassistant/components/sensor/tcp.py
+++ b/homeassistant/components/sensor/tcp.py
@@ -57,7 +57,7 @@ class TcpSensor(Entity):
         value_template = config.get(CONF_VALUE_TEMPLATE)
 
         if value_template is not None:
-            value_template = Template(value_template, hass)
+            value_template.hass = hass
 
         self._hass = hass
         self._config = {


### PR DESCRIPTION
Before this fix tcp sensors with value_templates failed to start:
homeassistant/helpers/template.py", line 59, in __init__
raise TypeError('Expected template to be a string')

This takes insperation from the working rest sensor and fixes how
value_template work.

Signed-off-by: Anton Lundin <glance@acc.umu.se>