### PR TITLE
Expose supported_features of mqtt_json

### DIFF
--- a/homeassistant/components/light/mqtt_json.py
+++ b/homeassistant/components/light/mqtt_json.py
@@ -171,6 +171,11 @@ class MqttJson(Light):
     def assumed_state(self):
         """Return true if we do optimistic updates."""
         return self._optimistic
+    
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_MQTT_JSON
 
     def turn_on(self, **kwargs):
         """Turn the device on."""

--- a/homeassistant/components/light/mqtt_json.py
+++ b/homeassistant/components/light/mqtt_json.py
@@ -171,7 +171,7 @@ class MqttJson(Light):
     def assumed_state(self):
         """Return true if we do optimistic updates."""
         return self._optimistic
-    
+
     @property
     def supported_features(self):
         """Flag supported features."""


### PR DESCRIPTION
**Description:**

Expose supported_features of mqtt_json

Found it was missing as a result of https://github.com/home-assistant/home-assistant-polymer/pull/168

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
