### PR TITLE
Handle templated values as yaml data

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -85,7 +85,11 @@ def async_call_from_config(hass, config, blocking=False, variables=None,
                 return {key: _data_template_creator(item)
                         for key, item in value.items()}
             value.hass = hass
-            return yaml.load(value.async_render(variables))
+            rendered = value.async_render(variables)
+            try:
+                return yaml.load(rendered, yaml.SafeLoader)
+            except yaml.MarkedYAMLError:
+                return rendered
         service_data.update(_data_template_creator(
             config[CONF_SERVICE_DATA_TEMPLATE]))
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -5,6 +5,8 @@ import logging
 # pylint: disable=unused-import
 from typing import Optional  # NOQA
 
+import yaml
+
 import voluptuous as vol
 
 from homeassistant.const import ATTR_ENTITY_ID
@@ -83,7 +85,7 @@ def async_call_from_config(hass, config, blocking=False, variables=None,
                 return {key: _data_template_creator(item)
                         for key, item in value.items()}
             value.hass = hass
-            return value.async_render(variables)
+            return yaml.load(value.async_render(variables))
         service_data.update(_data_template_creator(
             config[CONF_SERVICE_DATA_TEMPLATE]))
 

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -50,6 +50,11 @@ class TestServiceHelpers(unittest.TestCase):
                     'simple': 'simple'
                 },
                 'list': ['{{ \'list\' }}', '2'],
+                'number': {
+                    "simple": 5,
+                    "complex": '{{ 10 }}'
+                },
+
             },
         }
         runs = []
@@ -64,6 +69,8 @@ class TestServiceHelpers(unittest.TestCase):
         self.assertEqual('complex', runs[0].data['data']['value'])
         self.assertEqual('simple', runs[0].data['data']['simple'])
         self.assertEqual('list', runs[0].data['list'][0])
+        self.assertEqual(5, runs[0].data['number']["simple"])
+        self.assertEqual(10, runs[0].data['number']["complex"])
 
     def test_passing_variables_to_templates(self):
         """Test passing variables to templates."""

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -54,6 +54,13 @@ class TestServiceHelpers(unittest.TestCase):
                     "simple": 5,
                     "complex": '{{ 10 }}'
                 },
+                'boolean': {
+                    'simple': True,
+                    'complex': '{{ True }}',
+                    'true_string': 'true',
+                    'on': 'on',
+                    'on_quoted': '\"on\"'
+                }
 
             },
         }
@@ -71,6 +78,11 @@ class TestServiceHelpers(unittest.TestCase):
         self.assertEqual('list', runs[0].data['list'][0])
         self.assertEqual(5, runs[0].data['number']["simple"])
         self.assertEqual(10, runs[0].data['number']["complex"])
+        self.assertEqual(True, runs[0].data['boolean']["simple"])
+        self.assertEqual(True, runs[0].data['boolean']["complex"])
+        self.assertEqual(True, runs[0].data['boolean']["true_string"])
+        self.assertEqual(True, runs[0].data['boolean']["on"])
+        self.assertEqual('on', runs[0].data['boolean']["on_quoted"])
 
     def test_passing_variables_to_templates(self):
         """Test passing variables to templates."""


### PR DESCRIPTION
**Description:**
Interpret templated service data as yaml values

If we use data_templates in the config, the whole service data will be
interpreted as templates. Since templates work only on strings it is
not possible to have other datatyes in templated service datas. This
causes problems on services, that rely on the correct data type given
by the user (as the pilight send service for example).

This fixes this issue by interpreting the templated value again as yaml
document. So a "evaluated" yaml number will be a number again instead
of a string.

This belongs to bug #5042 and #5043.

**Related issue (if applicable):** fixes #5042 


**Example entry for `configuration.yaml` (if applicable):**
```yaml
    service: pilight.send
    data:
      "off": 1
      protocol: elro_800_switch
      unitcode: 0
      systemcode: 8
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
