### PR TITLE
Add scene validation and refactor hass platform

### DIFF
--- a/homeassistant/components/scene/__init__.py
+++ b/homeassistant/components/scene/__init__.py
@@ -6,28 +6,54 @@ https://home-assistant.io/components/scene/
 """
 import asyncio
 import logging
-from collections import namedtuple
 
 import voluptuous as vol
 
 from homeassistant.const import (
-    ATTR_ENTITY_ID, SERVICE_TURN_ON, CONF_PLATFORM)
-from homeassistant.helpers import extract_domain_configs
+    ATTR_ENTITY_ID, CONF_PLATFORM, SERVICE_TURN_ON)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.state import HASS_DOMAIN
+from homeassistant.loader import get_platform
 
 DOMAIN = 'scene'
 DEPENDENCIES = ['group']
 STATE = 'scening'
+STATES = 'states'
 
-CONF_ENTITIES = "entities"
+
+def _hass_domain_validator(config):
+    """Validate platform in config for homeassistant domain."""
+    if CONF_PLATFORM not in config:
+        config = {
+            CONF_PLATFORM: HASS_DOMAIN, STATES: config}
+
+    return config
+
+
+def _platform_validator(config):
+    """Validate it is a valid  platform."""
+    p_name = config[CONF_PLATFORM]
+    platform = get_platform(DOMAIN, p_name)
+
+    if not hasattr(platform, 'PLATFORM_SCHEMA'):
+        return config
+
+    return getattr(platform, 'PLATFORM_SCHEMA')(config)
+
+PLATFORM_SCHEMA = vol.Schema(
+    vol.All(
+        _hass_domain_validator,
+        vol.Schema({
+            vol.Required(CONF_PLATFORM): cv.platform_validator(DOMAIN)
+        }, extra=vol.ALLOW_EXTRA),
+        _platform_validator
+    ), extra=vol.ALLOW_EXTRA)
 
 SCENE_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
 })
-
-SceneConfig = namedtuple('SceneConfig', ['name', 'states'])
 
 
 def activate(hass, entity_id=None):
@@ -44,21 +70,6 @@ def activate(hass, entity_id=None):
 def async_setup(hass, config):
     """Setup scenes."""
     logger = logging.getLogger(__name__)
-
-    # You are not allowed to mutate the original config so make a copy
-    config = dict(config)
-
-    for config_key in extract_domain_configs(config, DOMAIN):
-        platform_config = config[config_key]
-        if not isinstance(platform_config, list):
-            platform_config = [platform_config]
-
-        if not any(CONF_PLATFORM in entry for entry in platform_config):
-            platform_config = [{'platform': 'homeassistant', 'states': entry}
-                               for entry in platform_config]
-
-        config[config_key] = platform_config
-
     component = EntityComponent(logger, DOMAIN, hass)
 
     yield from component.async_setup(config)

--- a/homeassistant/components/scene/__init__.py
+++ b/homeassistant/components/scene/__init__.py
@@ -42,6 +42,7 @@ def _platform_validator(config):
 
     return getattr(platform, 'PLATFORM_SCHEMA')(config)
 
+
 PLATFORM_SCHEMA = vol.Schema(
     vol.All(
         _hass_domain_validator,

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -34,7 +34,6 @@ from homeassistant.const import (
     STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED, STATE_CLOSED, STATE_LOCKED,
     STATE_OFF, STATE_ON, STATE_OPEN, STATE_PAUSED, STATE_PLAYING,
     STATE_UNKNOWN, STATE_UNLOCKED, SERVICE_SELECT_OPTION, ATTR_OPTION)
-from homeassistant.core import State
 from homeassistant.util.async import run_coroutine_threadsafe
 
 _LOGGER = logging.getLogger(__name__)
@@ -124,9 +123,7 @@ def reproduce_state(hass, states, blocking=False):
 @asyncio.coroutine
 def async_reproduce_state(hass, states, blocking=False):
     """Reproduce given state."""
-    if isinstance(states, State):
-        states = [states]
-
+    states = [state for entities in states for state in entities]
     to_call = defaultdict(list)
 
     for state in states:

--- a/tests/components/scene/test_init.py
+++ b/tests/components/scene/test_init.py
@@ -1,9 +1,11 @@
 """The tests for the Scene component."""
+import io
 import unittest
 
 from homeassistant.bootstrap import setup_component
 from homeassistant import loader
 from homeassistant.components import light, scene
+from homeassistant.util import yaml
 
 from tests.common import get_test_home_assistant
 
@@ -14,6 +16,22 @@ class TestScene(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
+        test_light = loader.get_component('light.test')
+        test_light.init()
+
+        self.assertTrue(setup_component(self.hass, light.DOMAIN, {
+            light.DOMAIN: {'platform': 'test'}
+        }))
+
+        self.light_1, self.light_2 = test_light.DEVICES[0:2]
+
+        light.turn_off(
+            self.hass, [self.light_1.entity_id, self.light_2.entity_id])
+
+        self.hass.block_till_done()
+
+        self.assertFalse(self.light_1.is_on)
+        self.assertFalse(self.light_2.is_on)
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""
@@ -36,19 +54,6 @@ class TestScene(unittest.TestCase):
         reference to the original dictionary, instead of creating a copy, so
         care needs to be taken to not modify the original.
         """
-        test_light = loader.get_component('light.test')
-        test_light.init()
-
-        self.assertTrue(setup_component(self.hass, light.DOMAIN, {
-            light.DOMAIN: {'platform': 'test'}
-        }))
-
-        light_1, light_2 = test_light.DEVICES[0:2]
-
-        light.turn_off(self.hass, [light_1.entity_id, light_2.entity_id])
-
-        self.hass.block_till_done()
-
         entity_state = {
             'state': 'on',
             'brightness': 100,
@@ -57,8 +62,8 @@ class TestScene(unittest.TestCase):
             'scene': [{
                 'name': 'test',
                 'entities': {
-                    light_1.entity_id: entity_state,
-                    light_2.entity_id: entity_state,
+                    self.light_1.entity_id: entity_state,
+                    self.light_2.entity_id: entity_state,
                 }
             }]
         }))
@@ -66,34 +71,45 @@ class TestScene(unittest.TestCase):
         scene.activate(self.hass, 'scene.test')
         self.hass.block_till_done()
 
-        self.assertTrue(light_1.is_on)
-        self.assertTrue(light_2.is_on)
-        self.assertEqual(100,
-                         light_1.last_call('turn_on')[1].get('brightness'))
-        self.assertEqual(100,
-                         light_2.last_call('turn_on')[1].get('brightness'))
+        self.assertTrue(self.light_1.is_on)
+        self.assertTrue(self.light_2.is_on)
+        self.assertEqual(
+            100, self.light_1.last_call('turn_on')[1].get('brightness'))
+        self.assertEqual(
+            100, self.light_2.last_call('turn_on')[1].get('brightness'))
+
+    def test_config_yaml_bool(self):
+        """Test parsing of booleans in yaml config."""
+        config = (
+            'scene:\n'
+            '  - name: test\n'
+            '    entities:\n'
+            '      {0}: on\n'
+            '      {1}:\n'
+            '        state: on\n'
+            '        brightness: 100\n').format(
+                self.light_1.entity_id, self.light_2.entity_id)
+
+        with io.StringIO(config) as file:
+            doc = yaml.yaml.safe_load(file)
+
+        self.assertTrue(setup_component(self.hass, scene.DOMAIN, doc))
+        scene.activate(self.hass, 'scene.test')
+        self.hass.block_till_done()
+
+        self.assertTrue(self.light_1.is_on)
+        self.assertTrue(self.light_2.is_on)
+        self.assertEqual(
+            100, self.light_2.last_call('turn_on')[1].get('brightness'))
 
     def test_activate_scene(self):
         """Test active scene."""
-        test_light = loader.get_component('light.test')
-        test_light.init()
-
-        self.assertTrue(setup_component(self.hass, light.DOMAIN, {
-            light.DOMAIN: {'platform': 'test'}
-        }))
-
-        light_1, light_2 = test_light.DEVICES[0:2]
-
-        light.turn_off(self.hass, [light_1.entity_id, light_2.entity_id])
-
-        self.hass.block_till_done()
-
         self.assertTrue(setup_component(self.hass, scene.DOMAIN, {
             'scene': [{
                 'name': 'test',
                 'entities': {
-                    light_1.entity_id: 'on',
-                    light_2.entity_id: {
+                    self.light_1.entity_id: 'on',
+                    self.light_2.entity_id: {
                         'state': 'on',
                         'brightness': 100,
                     }
@@ -104,7 +120,7 @@ class TestScene(unittest.TestCase):
         scene.activate(self.hass, 'scene.test')
         self.hass.block_till_done()
 
-        self.assertTrue(light_1.is_on)
-        self.assertTrue(light_2.is_on)
-        self.assertEqual(100,
-                         light_2.last_call('turn_on')[1].get('brightness'))
+        self.assertTrue(self.light_1.is_on)
+        self.assertTrue(self.light_2.is_on)
+        self.assertEqual(
+            100, self.light_2.last_call('turn_on')[1].get('brightness'))

--- a/tests/components/scene/test_init.py
+++ b/tests/components/scene/test_init.py
@@ -124,3 +124,27 @@ class TestScene(unittest.TestCase):
         self.assertTrue(self.light_2.is_on)
         self.assertEqual(
             100, self.light_2.last_call('turn_on')[1].get('brightness'))
+
+    def test_activate_state_list(self):
+        """Test activate a scene with a list of states for an entity."""
+        self.assertTrue(setup_component(self.hass, scene.DOMAIN, {
+            'scene': [{
+                'name': 'test',
+                'entities': {
+                    self.light_1.entity_id: 'on',
+                    self.light_2.entity_id: [
+                        {'state': 'on', 'brightness': 100},
+                        {'state': 'off', 'transition': 60}]
+                }
+            }]
+        }))
+
+        scene.activate(self.hass, 'scene.test')
+        self.hass.block_till_done()
+
+        self.assertTrue(self.light_1.is_on)
+        self.assertEqual(
+            100, self.light_2.last_call('turn_on')[1].get('brightness'))
+        self.assertEqual(
+            60,
+            self.light_2.last_call('turn_off')[1].get('transition'))

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -97,7 +97,7 @@ class TestStateHelpers(unittest.TestCase):
         """Test reproduce_state with no entity."""
         calls = mock_service(self.hass, 'light', SERVICE_TURN_ON)
 
-        state.reproduce_state(self.hass, ha.State('light.test', 'on'))
+        state.reproduce_state(self.hass, [[ha.State('light.test', 'on')]])
 
         self.hass.block_till_done()
 
@@ -110,7 +110,7 @@ class TestStateHelpers(unittest.TestCase):
 
         self.hass.states.set('light.test', 'off')
 
-        state.reproduce_state(self.hass, ha.State('light.test', 'on'))
+        state.reproduce_state(self.hass, [[ha.State('light.test', 'on')]])
 
         self.hass.block_till_done()
 
@@ -126,7 +126,7 @@ class TestStateHelpers(unittest.TestCase):
 
         self.hass.states.set('light.test', 'on')
 
-        state.reproduce_state(self.hass, ha.State('light.test', 'off'))
+        state.reproduce_state(self.hass, [[ha.State('light.test', 'off')]])
 
         self.hass.block_till_done()
 
@@ -144,9 +144,9 @@ class TestStateHelpers(unittest.TestCase):
 
         complex_data = ['hello', {'11': '22'}]
 
-        state.reproduce_state(self.hass, ha.State('light.test', 'on', {
+        state.reproduce_state(self.hass, [[ha.State('light.test', 'on', {
             'complex': complex_data
-        }))
+        })]])
 
         self.hass.block_till_done()
 
@@ -165,8 +165,9 @@ class TestStateHelpers(unittest.TestCase):
         media_attributes = {'media_content_type': 'movie',
                             'media_content_id': 'batman'}
 
-        state.reproduce_state(self.hass, ha.State('media_player.test', 'None',
-                                                  media_attributes))
+        state.reproduce_state(
+            self.hass,
+            [[ha.State('media_player.test', 'None', media_attributes)]])
 
         self.hass.block_till_done()
 
@@ -184,7 +185,7 @@ class TestStateHelpers(unittest.TestCase):
         self.hass.states.set('media_player.test', 'off')
 
         state.reproduce_state(
-            self.hass, ha.State('media_player.test', 'playing'))
+            self.hass, [[ha.State('media_player.test', 'playing')]])
 
         self.hass.block_till_done()
 
@@ -202,7 +203,7 @@ class TestStateHelpers(unittest.TestCase):
         self.hass.states.set('media_player.test', 'playing')
 
         state.reproduce_state(
-            self.hass, ha.State('media_player.test', 'paused'))
+            self.hass, [[ha.State('media_player.test', 'paused')]])
 
         self.hass.block_till_done()
 
@@ -219,7 +220,7 @@ class TestStateHelpers(unittest.TestCase):
 
         self.hass.states.set('light.test', 'off')
 
-        state.reproduce_state(self.hass, ha.State('light.test', 'bad'))
+        state.reproduce_state(self.hass, [[ha.State('light.test', 'bad')]])
 
         self.hass.block_till_done()
 
@@ -233,7 +234,7 @@ class TestStateHelpers(unittest.TestCase):
         self.hass.states.set('group.test', 'off', {
             'entity_id': ['light.test1', 'light.test2']})
 
-        state.reproduce_state(self.hass, ha.State('group.test', 'on'))
+        state.reproduce_state(self.hass, [[ha.State('group.test', 'on')]])
 
         self.hass.block_till_done()
 
@@ -252,8 +253,8 @@ class TestStateHelpers(unittest.TestCase):
         self.hass.states.set('light.test2', 'off')
 
         state.reproduce_state(self.hass, [
-            ha.State('light.test1', 'on', {'brightness': 95}),
-            ha.State('light.test2', 'on', {'brightness': 95})])
+            [ha.State('light.test1', 'on', {'brightness': 95})],
+            [ha.State('light.test2', 'on', {'brightness': 95})]])
 
         self.hass.block_till_done()
 


### PR DESCRIPTION
**Description:**
* Add voluptuous config validation to scenes
  * Add platform schema to scene component and homeassistant platform.
  * Clean up code and add constants.
  * Add unit test and clean up tests.
* Add list of states per entity per scene
  * Make it possible to configure a list of states to activate for each
    entity in a scene. The states in the list will not be activated in
    order.
  * Add and update tests for list of state per entity.
  * **Note that the final state of an entity is now unpredictable, and it's
    up to the user to take care not to configure states that conflict, if
    more than one service call is used per entity.**

One further change I've been considering is to call the services in the order of the state items in the list per entity. This would make the final state predictable, but we would no longer be able to group service calls when calling all services for a scene, but would have to make all calls for each entity in order. So it would be less efficient. If we think predictability trumps speed, I can look at making that change also.

**Related issue (if applicable):**
Fixes #5123, fixes #3570, fixes #4849 
Related: #2208
 
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
Will update docs if we want to merge.

**Example entry for `configuration.yaml` (if applicable):**
```yaml
scene:
  - name: Movies
    entities:
      media_player.living_room:
        - volume_level: 50
        - media_content_id: "eyU3bRy2x44"
          media_content_type: movie
```

**Checklist:**
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.