### PR TITLE
Cleanup language support on TTS

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -257,11 +257,12 @@ class SpeechManager(object):
         """
         provider = self.providers[engine]
         msg_hash = hashlib.sha1(bytes(message, 'utf-8')).hexdigest()
-        language_key = language or provider.language
+        language_key = language or provider.default_language
         key = KEY_PATTERN.format(msg_hash, language_key, engine).lower()
         use_cache = cache if cache is not None else self.use_cache
 
-        if language_key not in provider.supported_languages:
+        if language_key is None or \
+           language_key not in provider.supported_languages:
             raise HomeAssistantError("Not supported language {0}".format(
                 language_key
             ))
@@ -393,7 +394,7 @@ class Provider(object):
     hass = None
 
     @property
-    def language(self):
+    def default_language(self):
         """Default language."""
         return None
 

--- a/homeassistant/components/tts/demo.py
+++ b/homeassistant/components/tts/demo.py
@@ -43,7 +43,7 @@ class DemoProvider(Provider):
         """List of supported languages."""
         return SUPPORT_LANGUAGES
 
-    def get_tts_audio(self, message, language=None):
+    def get_tts_audio(self, message, language):
         """Load TTS from demo."""
         filename = os.path.join(os.path.dirname(__file__), "demo.mp3")
         try:

--- a/homeassistant/components/tts/demo.py
+++ b/homeassistant/components/tts/demo.py
@@ -34,7 +34,7 @@ class DemoProvider(Provider):
         self._lang = lang
 
     @property
-    def language(self):
+    def default_language(self):
         """Default language."""
         return self._lang
 

--- a/homeassistant/components/tts/demo.py
+++ b/homeassistant/components/tts/demo.py
@@ -6,20 +6,42 @@ https://home-assistant.io/components/demo/
 """
 import os
 
-from homeassistant.components.tts import Provider
+import voluptuous as vol
+
+from homeassistant.components.tts import Provider, PLATFORM_SCHEMA, CONF_LANG
+
+SUPPORT_LANGUAGES = [
+    'en', 'de'
+]
+
+DEFAULT_LANG = 'en'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORT_LANGUAGES),
+})
 
 
 def get_engine(hass, config):
     """Setup Demo speech component."""
-    return DemoProvider()
+    return DemoProvider(config[CONF_LANG])
 
 
 class DemoProvider(Provider):
     """Demo speech api provider."""
 
-    def __init__(self):
-        """Initialize demo provider for TTS."""
-        self.language = 'en'
+    def __init__(self, lang):
+        """Initialize demo provider."""
+        self._lang = lang
+
+    @property
+    def language(self):
+        """Default language."""
+        return self._lang
+
+    @property
+    def supported_languages(self):
+        """List of supported languages."""
+        return SUPPORT_LANGUAGES
 
     def get_tts_audio(self, message, language=None):
         """Load TTS from demo."""
@@ -28,6 +50,6 @@ class DemoProvider(Provider):
             with open(filename, 'rb') as voice:
                 data = voice.read()
         except OSError:
-            return
+            return (None, None)
 
         return ("mp3", data)

--- a/homeassistant/components/tts/google.py
+++ b/homeassistant/components/tts/google.py
@@ -60,7 +60,7 @@ class GoogleProvider(Provider):
         }
 
     @property
-    def language(self):
+    def default_language(self):
         """Default language."""
         return self._lang
 
@@ -81,7 +81,7 @@ class GoogleProvider(Provider):
         # If language is not specified or is not supported - use the language
         # from the config.
         if language not in SUPPORT_LANGUAGES:
-            language = self.language
+            language = self.default_language
 
         data = b''
         for idx, part in enumerate(message_parts):

--- a/homeassistant/components/tts/google.py
+++ b/homeassistant/components/tts/google.py
@@ -70,18 +70,13 @@ class GoogleProvider(Provider):
         return SUPPORT_LANGUAGES
 
     @asyncio.coroutine
-    def async_get_tts_audio(self, message, language=None):
+    def async_get_tts_audio(self, message, language):
         """Load TTS from google."""
         from gtts_token import gtts_token
 
         token = gtts_token.Token()
         websession = async_get_clientsession(self.hass)
         message_parts = self._split_message_to_parts(message)
-
-        # If language is not specified or is not supported - use the language
-        # from the config.
-        if language not in SUPPORT_LANGUAGES:
-            language = self.default_language
 
         data = b''
         for idx, part in enumerate(message_parts):

--- a/homeassistant/components/tts/google.py
+++ b/homeassistant/components/tts/google.py
@@ -42,21 +42,32 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 @asyncio.coroutine
 def async_get_engine(hass, config):
     """Setup Google speech component."""
-    return GoogleProvider(hass)
+    return GoogleProvider(hass, config[CONF_LANG])
 
 
 class GoogleProvider(Provider):
     """Google speech api provider."""
 
-    def __init__(self, hass):
+    def __init__(self, hass, lang):
         """Init Google TTS service."""
         self.hass = hass
+        self._lang = lang
         self.headers = {
             'Referer': "http://translate.google.com/",
             'User-Agent': ("Mozilla/5.0 (Windows NT 10.0; WOW64) "
                            "AppleWebKit/537.36 (KHTML, like Gecko) "
                            "Chrome/47.0.2526.106 Safari/537.36")
         }
+
+    @property
+    def language(self):
+        """Default language."""
+        return self._lang
+
+    @property
+    def supported_languages(self):
+        """List of supported languages."""
+        return SUPPORT_LANGUAGES
 
     @asyncio.coroutine
     def async_get_tts_audio(self, message, language=None):

--- a/homeassistant/components/tts/picotts.py
+++ b/homeassistant/components/tts/picotts.py
@@ -40,7 +40,7 @@ class PicoProvider(Provider):
         self._lang = lang
 
     @property
-    def language(self):
+    def default_language(self):
         """Default language."""
         return self._lang
 
@@ -52,9 +52,11 @@ class PicoProvider(Provider):
     def get_tts_audio(self, message, language=None):
         """Load TTS using pico2wave."""
         if language not in SUPPORT_LANGUAGES:
-            language = self.language
+            language = self.default_language
+
         with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as tmpf:
             fname = tmpf.name
+
         cmd = ['pico2wave', '--wave', fname, '-l', language, message]
         subprocess.call(cmd)
         data = None
@@ -66,6 +68,7 @@ class PicoProvider(Provider):
             return (None, None)
         finally:
             os.remove(fname)
+
         if data:
             return ("wav", data)
         return (None, None)

--- a/homeassistant/components/tts/picotts.py
+++ b/homeassistant/components/tts/picotts.py
@@ -49,11 +49,8 @@ class PicoProvider(Provider):
         """List of supported languages."""
         return SUPPORT_LANGUAGES
 
-    def get_tts_audio(self, message, language=None):
+    def get_tts_audio(self, message, language):
         """Load TTS using pico2wave."""
-        if language not in SUPPORT_LANGUAGES:
-            language = self.default_language
-
         with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as tmpf:
             fname = tmpf.name
 

--- a/homeassistant/components/tts/picotts.py
+++ b/homeassistant/components/tts/picotts.py
@@ -29,11 +29,25 @@ def get_engine(hass, config):
     if shutil.which("pico2wave") is None:
         _LOGGER.error("'pico2wave' was not found")
         return False
-    return PicoProvider()
+    return PicoProvider(config[CONF_LANG])
 
 
 class PicoProvider(Provider):
     """pico speech api provider."""
+
+    def __init__(self, lang):
+        """Initialize pico provider."""
+        self._lang = lang
+
+    @property
+    def language(self):
+        """Default language."""
+        return self._lang
+
+    @property
+    def supported_languages(self):
+        """List of supported languages."""
+        return SUPPORT_LANGUAGES
 
     def get_tts_audio(self, message, language=None):
         """Load TTS using pico2wave."""

--- a/homeassistant/components/tts/voicerss.py
+++ b/homeassistant/components/tts/voicerss.py
@@ -93,20 +93,31 @@ class VoiceRSSProvider(Provider):
     def __init__(self, hass, conf):
         """Init VoiceRSS TTS service."""
         self.hass = hass
-        self.extension = conf.get(CONF_CODEC)
+        self._extension = conf[CONF_CODEC]
+        self._lang = conf[CONF_LANG]
 
-        self.form_data = {
-            'key': conf.get(CONF_API_KEY),
-            'hl': conf.get(CONF_LANG),
-            'c': (conf.get(CONF_CODEC)).upper(),
-            'f': conf.get(CONF_FORMAT),
+        self._form_data = {
+            'key': conf[CONF_API_KEY],
+            'hl': conf[CONF_LANG],
+            'c': (conf[CONF_CODEC]).upper(),
+            'f': conf[CONF_FORMAT],
         }
+
+    @property
+    def language(self):
+        """Default language."""
+        return self._lang
+
+    @property
+    def supported_languages(self):
+        """List of supported languages."""
+        return SUPPORT_LANGUAGES
 
     @asyncio.coroutine
     def async_get_tts_audio(self, message, language=None):
         """Load TTS from voicerss."""
         websession = async_get_clientsession(self.hass)
-        form_data = self.form_data.copy()
+        form_data = self._form_data.copy()
 
         form_data['src'] = message
 
@@ -141,4 +152,4 @@ class VoiceRSSProvider(Provider):
             if request is not None:
                 yield from request.release()
 
-        return (self.extension, data)
+        return (self._extension, data)

--- a/homeassistant/components/tts/voicerss.py
+++ b/homeassistant/components/tts/voicerss.py
@@ -104,7 +104,7 @@ class VoiceRSSProvider(Provider):
         }
 
     @property
-    def language(self):
+    def default_language(self):
         """Default language."""
         return self._lang
 
@@ -123,8 +123,9 @@ class VoiceRSSProvider(Provider):
 
         # If language is specified and supported - use it instead of the
         # language in the config.
-        if language in SUPPORT_LANGUAGES:
-            form_data['hl'] = language
+        if language not in SUPPORT_LANGUAGES:
+            language = self.default_language
+        form_data['hl'] = language
 
         request = None
         try:

--- a/homeassistant/components/tts/voicerss.py
+++ b/homeassistant/components/tts/voicerss.py
@@ -114,17 +114,12 @@ class VoiceRSSProvider(Provider):
         return SUPPORT_LANGUAGES
 
     @asyncio.coroutine
-    def async_get_tts_audio(self, message, language=None):
+    def async_get_tts_audio(self, message, language):
         """Load TTS from voicerss."""
         websession = async_get_clientsession(self.hass)
         form_data = self._form_data.copy()
 
         form_data['src'] = message
-
-        # If language is specified and supported - use it instead of the
-        # language in the config.
-        if language not in SUPPORT_LANGUAGES:
-            language = self.default_language
         form_data['hl'] = language
 
         request = None

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -234,7 +234,7 @@ class TestTTS(object):
 
         assert len(calls) == 1
         req = requests.get(calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        _, demo_data = self.demo_provider.get_tts_audio("bla")
+        _, demo_data = self.demo_provider.get_tts_audio("bla", 'en')
         assert req.status_code == 200
         assert req.content == demo_data
 
@@ -355,7 +355,7 @@ class TestTTS(object):
         """Setup demo platform with cache and call service without cache."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        _, demo_data = self.demo_provider.get_tts_audio("bla")
+        _, demo_data = self.demo_provider.get_tts_audio("bla", 'en')
         cache_file = os.path.join(
             self.default_tts_cache,
             "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3")
@@ -375,7 +375,7 @@ class TestTTS(object):
             setup_component(self.hass, tts.DOMAIN, config)
 
         with patch('homeassistant.components.tts.demo.DemoProvider.'
-                   'get_tts_audio', return_value=None):
+                   'get_tts_audio', return_value=(None, None)):
             self.hass.services.call(tts.DOMAIN, 'demo_say', {
                 tts.ATTR_MESSAGE: "I person is on front of your door.",
             })
@@ -388,7 +388,7 @@ class TestTTS(object):
             != -1
 
     @patch('homeassistant.components.tts.demo.DemoProvider.get_tts_audio',
-           return_value=None)
+           return_value=(None, None))
     def test_setup_component_test_with_error_on_get_tts(self, tts_mock):
         """Setup demo platform with wrong get_tts_audio."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
@@ -411,7 +411,7 @@ class TestTTS(object):
 
     def test_setup_component_load_cache_retrieve_without_mem_cache(self):
         """Setup component and load cache and get without mem cache."""
-        _, demo_data = self.demo_provider.get_tts_audio("bla")
+        _, demo_data = self.demo_provider.get_tts_audio("bla", 'en')
         cache_file = os.path.join(
             self.default_tts_cache,
             "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3")


### PR DESCRIPTION
**Description:**

After we support language also on service call, I make a small refactory of language support for future. Now it is also possible to check language on service call and  protect cache System for produce not correct files.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
