### PR TITLE
Use SHA hash to make token harder to guess

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -8,6 +8,7 @@ https://home-assistant.io/components/camera/
 import asyncio
 from datetime import timedelta
 import logging
+import hashlib
 
 from aiohttp import web
 
@@ -51,7 +52,7 @@ class Camera(Entity):
     @property
     def access_token(self):
         """Access token for this camera."""
-        return str(id(self))
+        return hashlib.sha256(str.encode(str(id(self)))).hexdigest()
 
     @property
     def should_poll(self):

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -48,7 +48,8 @@ class Camera(Entity):
     def __init__(self):
         """Initialize a camera."""
         self.is_streaming = False
-        self._access_token = hashlib.sha256(str.encode(str(id(self)))).hexdigest()
+        self._access_token = hashlib.sha256(
+            str.encode(str(id(self)))).hexdigest()
 
     @property
     def access_token(self):

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -48,11 +48,12 @@ class Camera(Entity):
     def __init__(self):
         """Initialize a camera."""
         self.is_streaming = False
+        self._access_token = hashlib.sha256(str.encode(str(id(self)))).hexdigest()
 
     @property
     def access_token(self):
         """Access token for this camera."""
-        return hashlib.sha256(str.encode(str(id(self)))).hexdigest()
+        return self._access_token
 
     @property
     def should_poll(self):


### PR DESCRIPTION
Use hashlib SHA256 to encode object id instead of using it directly.

**Description:**
Since HA runs 24/7 and there is no rate/error limit it is possible to guess the correct token for the camera stream. To make it harder to brute-force the token let's use a more complex value for it.



If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
