### PR TITLE
Bump flux_led version and make use of PyPi package

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -17,8 +17,7 @@ from homeassistant.components.light import (
     PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['https://github.com/Danielhiversen/flux_led/archive/0.11.zip'
-                '#flux_led==0.11']
+REQUIREMENTS = ['flux_led==0.12']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -132,6 +132,9 @@ fitbit==0.2.3
 # homeassistant.components.sensor.fixer
 fixerio==0.1.1
 
+# homeassistant.components.light.flux_led
+flux_led==0.12
+
 # homeassistant.components.notify.free_mobile
 freesms==0.1.1
 
@@ -179,9 +182,6 @@ hikvision==0.4
 
 # homeassistant.components.nest
 http://github.com/technicalpickles/python-nest/archive/e6c9d56a8df455d4d7746389811f2c1387e8cb33.zip#python-nest==3.0.3
-
-# homeassistant.components.light.flux_led
-flux_led==0.12
 
 # homeassistant.components.switch.tplink
 https://github.com/GadgetReactor/pyHS100/archive/45fc3548882628bcde3e3d365db341849457bef2.zip#pyHS100==0.2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -181,7 +181,7 @@ hikvision==0.4
 http://github.com/technicalpickles/python-nest/archive/e6c9d56a8df455d4d7746389811f2c1387e8cb33.zip#python-nest==3.0.3
 
 # homeassistant.components.light.flux_led
-https://github.com/Danielhiversen/flux_led/archive/0.11.zip#flux_led==0.11
+flux_led==0.12
 
 # homeassistant.components.switch.tplink
 https://github.com/GadgetReactor/pyHS100/archive/45fc3548882628bcde3e3d365db341849457bef2.zip#pyHS100==0.2.2


### PR DESCRIPTION
**Description:**

This PR bumps the flux_led version to 0.12 and make use of flux_led package published at https://pypi.python.org/pypi/flux-led

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`..
