### PR TITLE
device_tracker.ubus: use dhcp & iwinfo services instead of current multi-step process

### DIFF
--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -66,10 +66,10 @@ class UbusDeviceScanner:
         self.url = 'http://{}/ubus'.format(host)
         self.session_id = None  # lazy init, will be fetched on first error
 
-
     def login(self):
         _LOGGER.debug("Fetching the session id..")
-        self.session_id = _get_session_id(self.url, self.username, self.password)
+        self.session_id = _get_session_id(self.url,
+                                          self.username, self.password)
         _LOGGER.debug("Got session: %s", self.session_id)
 
     def update(self, see):
@@ -86,7 +86,8 @@ class UbusDeviceScanner:
                 client["ip"] = lease[0]["ip"]
                 client["hostname"] = lease[0]["hostname"]
             else:
-                _LOGGER.warning("Couldn't find lease for %s, using mac as name", client["mac"])
+                _LOGGER.warning("No lease found for %s, using mac as name",
+                                client["mac"])
                 client["hostname"] = mac
                 client["ip"] = "<no lease>"
 

--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -30,6 +30,21 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string
 })
 
+# From http://lxr.mein.io/source/ubus/ubusmsg.h#L99
+UBUS_STATUS_OK = 0
+UBUS_STATUS_INVALID_COMMAND = 1
+UBUS_STATUS_INVALID_ARGUMENT = 2
+UBUS_STATUS_METHOD_NOT_FOUND = 3
+UBUS_STATUS_NOT_FOUND = 4
+UBUS_STATUS_NO_DATA = 5
+UBUS_STATUS_PERMISSION_DENIED = 6
+UBUS_STATUS_TIMEOUT = 7
+UBUS_STATUS_NOT_SUPPORTED = 8
+UBUS_STATUS_UNKNOWN_ERROR = 9
+UBUS_STATUS_CONNECTION_FAILED = 10
+UBUS_STATUS_NO_DATA = 5
+UBUS_STATUS_PERMISSION_DENIED = 6
+
 
 def get_scanner(hass, config):
     """Validate the configuration and return an ubus scanner."""
@@ -50,101 +65,92 @@ class UbusDeviceScanner(DeviceScanner):
         host = config[CONF_HOST]
         username, password = config[CONF_USERNAME], config[CONF_PASSWORD]
 
-        self.parse_api_pattern = re.compile(r"(?P<param>\w*) = (?P<value>.*);")
         self.lock = threading.Lock()
         self.last_results = {}
         self.url = 'http://{}/ubus'.format(host)
 
         self.session_id = _get_session_id(self.url, username, password)
-        self.hostapd = []
-        self.leasefile = None
-        self.mac2name = None
         self.success_init = self.session_id is not None
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()
-        return self.last_results
-
-    def get_device_name(self, device):
-        """Return the name of the given device or None if we don't know."""
-        with self.lock:
-            if self.leasefile is None:
-                result = _req_json_rpc(self.url, self.session_id,
-                                       'call', 'uci', 'get',
-                                       config="dhcp", type="dnsmasq")
-                if result:
-                    values = result["values"].values()
-                    self.leasefile = next(iter(values))["leasefile"]
-                else:
-                    return
-
-            if self.mac2name is None:
-                result = _req_json_rpc(self.url, self.session_id,
-                                       'call', 'file', 'read',
-                                       path=self.leasefile)
-                if result:
-                    self.mac2name = dict()
-                    for line in result["data"].splitlines():
-                        hosts = line.split(" ")
-                        self.mac2name[hosts[1].upper()] = hosts[3]
-                else:
-                    # Error, handled in the _req_json_rpc
-                    return
-
-            return self.mac2name.get(device.upper(), None)
+        return self.last_results.keys()
 
     @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
-        """Ensure the information from the Luci router is up to date.
-
-        Returns boolean if scanning successful.
-        """
         if not self.success_init:
             return False
 
         with self.lock:
-            _LOGGER.info("Checking ARP")
+            _LOGGER.info("Checking DHCP leases..")
 
-            if not self.hostapd:
-                hostapd = _req_json_rpc(self.url, self.session_id,
-                                        'list', 'hostapd.*', '')
-                self.hostapd.extend(hostapd.keys())
+            self.last_results.clear()
+            client_macs = []
+            for v in ["ipv4leases", "ipv6leases"]:
+                clients = _req_json_rpc(self.url, self.session_id,
+                                    "call", "dhcp", v)
+                #_LOGGER.error("clients: %s" % clients)
+                for network in clients["device"]:
+                    _LOGGER.debug("Checking network %s" % network)
+                    for lease in clients["device"][network]["leases"]:
+                        _LOGGER.debug("[%s] client: %s" % (network, lease))
+                        client_macs.append(lease["mac"])
+                        self.last_results[lease["mac"]] = lease
 
-            self.last_results = []
-            results = 0
-            for hostapd in self.hostapd:
-                result = _req_json_rpc(self.url, self.session_id,
-                                       'call', hostapd, 'get_clients')
+            _LOGGER.error("Scan found %s clients" % len(client_macs))
 
-                if result:
-                    results = results + 1
-                    self.last_results.extend(result['clients'].keys())
+            return bool(client_macs)
 
-            return bool(results)
+        return False
 
+    def get_device_name(self, device):
+        _LOGGER.info("Getting name for %s", device)
+        return self.last_results[device]["hostname"]
 
 def _req_json_rpc(url, session_id, rpcmethod, subsystem, method, **params):
     """Perform one JSON RPC operation."""
-    data = json.dumps({"jsonrpc": "2.0",
-                       "id": 1,
-                       "method": rpcmethod,
-                       "params": [session_id,
-                                  subsystem,
-                                  method,
-                                  params]})
+
+    data = {"jsonrpc": "2.0",
+            "id": 1,
+            "method": rpcmethod,
+            "params": [session_id,
+                       subsystem,
+                       method,
+                       params]}
+    data_json = json.dumps(data)
+    _LOGGER.debug("> %s (%s)", data["method"], data["params"])
 
     try:
-        res = requests.post(url, data=data, timeout=5)
+        res = requests.post(url, data=data_json, timeout=5)
 
     except requests.exceptions.Timeout:
         return
+
+    _LOGGER.debug("< %s", res)
 
     if res.status_code == 200:
         response = res.json()
 
         if rpcmethod == "call":
-            return response["result"][1]
+            retcode = response["result"][0]
+            if retcode != UBUS_STATUS_OK:
+                if retcode == UBUS_STATUS_PERMISSION_DENIED:
+                    _LOGGER.error("Not enough permissions!")
+                    return
+                elif retcode == UBUS_STATUS_NO_DATA:
+                    _LOGGER.error("Empty leases file!")
+                    return
+                else:
+                    _LOGGER.error("Got ubus error: %s" % retcode)
+                    return
+
+            if "error" in response:
+                _LOGGER.error("Got error from ubus for call %s(%s): %s", data["method"], data["params"], response["error"])
+                return response["error"]
+
+            res = response["result"][1]
+            return res
         else:
             return response["result"]
 
@@ -154,4 +160,6 @@ def _get_session_id(url, username, password):
     res = _req_json_rpc(url, "00000000000000000000000000000000", 'call',
                         'session', 'login', username=username,
                         password=password)
+    #  TODO check for valid login!
+    _LOGGER.error("Request and got token for %s?!: %s" % (username, res))
     return res["ubus_rpc_session"]

--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -30,6 +30,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 # From http://lxr.mein.io/source/ubus/ubusmsg.h#L99
 class UbusStatus(IntEnum):
     """Ubus status codes."""
+
     UBUS_STATUS_OK = 0
     UBUS_STATUS_INVALID_COMMAND = 1
     UBUS_STATUS_INVALID_ARGUMENT = 2
@@ -45,6 +46,7 @@ class UbusStatus(IntEnum):
 
 class UbusException(Exception):
     """UbusException gets raised when receiving errors from ubus."""
+
     pass
 
 
@@ -140,7 +142,6 @@ class UbusDeviceScanner:
 
 def _req_json_rpc(url, session_id, rpcmethod, subsystem, method, **params):
     """Perform one JSON RPC operation."""
-
     data = {"jsonrpc": "2.0",
             "id": 1,
             "method": rpcmethod,

--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -6,21 +6,17 @@ https://home-assistant.io/components/device_tracker.ubus/
 """
 import json
 import logging
-import re
-import threading
-from datetime import timedelta
+from enum import IntEnum
 
 import requests
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
-    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
+    PLATFORM_SCHEMA, DEFAULT_SCAN_INTERVAL, SOURCE_TYPE_ROUTER)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.util import Throttle
-
-# Return cached results if last scan was less then this time ago.
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
+from homeassistant import util
+from homeassistant.helpers.event import track_point_in_utc_time
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,30 +26,29 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string
 })
 
+
 # From http://lxr.mein.io/source/ubus/ubusmsg.h#L99
-UBUS_STATUS_OK = 0
-UBUS_STATUS_INVALID_COMMAND = 1
-UBUS_STATUS_INVALID_ARGUMENT = 2
-UBUS_STATUS_METHOD_NOT_FOUND = 3
-UBUS_STATUS_NOT_FOUND = 4
-UBUS_STATUS_NO_DATA = 5
-UBUS_STATUS_PERMISSION_DENIED = 6
-UBUS_STATUS_TIMEOUT = 7
-UBUS_STATUS_NOT_SUPPORTED = 8
-UBUS_STATUS_UNKNOWN_ERROR = 9
-UBUS_STATUS_CONNECTION_FAILED = 10
-UBUS_STATUS_NO_DATA = 5
-UBUS_STATUS_PERMISSION_DENIED = 6
+class UbusStatus(IntEnum):
+    """Ubus status codes."""
+    UBUS_STATUS_OK = 0
+    UBUS_STATUS_INVALID_COMMAND = 1
+    UBUS_STATUS_INVALID_ARGUMENT = 2
+    UBUS_STATUS_METHOD_NOT_FOUND = 3
+    UBUS_STATUS_NOT_FOUND = 4
+    UBUS_STATUS_NO_DATA = 5
+    UBUS_STATUS_PERMISSION_DENIED = 6
+    UBUS_STATUS_TIMEOUT = 7
+    UBUS_STATUS_NOT_SUPPORTED = 8
+    UBUS_STATUS_UNKNOWN_ERROR = 9
+    UBUS_STATUS_CONNECTION_FAILED = 10
 
 
-def get_scanner(hass, config):
-    """Validate the configuration and return an ubus scanner."""
-    scanner = UbusDeviceScanner(config[DOMAIN])
-
-    return scanner if scanner.success_init else None
+class UbusException(Exception):
+    """UbusException gets raised when receiving errors from ubus."""
+    pass
 
 
-class UbusDeviceScanner(DeviceScanner):
+class UbusDeviceScanner:
     """
     This class queries a wireless router running OpenWrt firmware.
 
@@ -65,48 +60,83 @@ class UbusDeviceScanner(DeviceScanner):
         host = config[CONF_HOST]
         username, password = config[CONF_USERNAME], config[CONF_PASSWORD]
 
-        self.lock = threading.Lock()
-        self.last_results = {}
         self.url = 'http://{}/ubus'.format(host)
-
         self.session_id = _get_session_id(self.url, username, password)
-        self.success_init = self.session_id is not None
 
-    def scan_devices(self):
-        """Scan for new devices and return a list with found device IDs."""
-        self._update_info()
-        return self.last_results.keys()
+    def update(self, see):
+        """Fetch clients and leases from the router."""
+        clients = self._get_devices()
+        leases = self._get_leases()
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
-    def _update_info(self):
-        if not self.success_init:
-            return False
+        for client in clients:
+            mac = client["mac"].replace(":", "").lower()
+            for lease in leases:
+                if lease["mac"] == mac:
+                    lease.update(client)
+                    # example lease
+                    # {'ip': '192.168.250.186', 'inactive': 3530,
+                    # 'hostname': 'XXXX', 'valid': -23916,
+                    # 'mac': '50:C7:BF:XX:XX:XX', 'noise': -95, 'signal': -48}
+                    extra_attrs = {
+                        "ip": lease["ip"],
+                        "signal": lease["signal"],
+                        "noise": lease["noise"]
+                    }
+                    # _LOGGER.info("Seen: %s", lease)
+                    see(mac=lease["mac"], host_name=lease["hostname"],
+                        source_type=SOURCE_TYPE_ROUTER,
+                        attributes=extra_attrs)
 
-        with self.lock:
-            _LOGGER.info("Checking DHCP leases..")
+    def _get_devices(self):
+        """Request all connected devices."""
+        clients = []
 
-            self.last_results.clear()
-            client_macs = []
-            for v in ["ipv4leases", "ipv6leases"]:
-                clients = _req_json_rpc(self.url, self.session_id,
-                                    "call", "dhcp", v)
-                #_LOGGER.error("clients: %s" % clients)
-                for network in clients["device"]:
-                    _LOGGER.debug("Checking network %s" % network)
-                    for lease in clients["device"][network]["leases"]:
-                        _LOGGER.debug("[%s] client: %s" % (network, lease))
-                        client_macs.append(lease["mac"])
-                        self.last_results[lease["mac"]] = lease
+        try:
+            ifaces = _req_json_rpc(self.url, self.session_id,
+                                   "call", "iwinfo", "devices")
+        except UbusException as ex:
+            _LOGGER.error("Unable to fetch interfaces: %s", ex)
+            return
 
-            _LOGGER.error("Scan found %s clients" % len(client_macs))
+        # _LOGGER.debug("Found %s ifaces: %s", len(ifaces), ifaces)
+        for iface in ifaces["devices"]:
+            devices = _req_json_rpc(self.url, self.session_id,
+                                    "call", "iwinfo", "assoclist",
+                                    device=iface)
+            if "results" in devices:
+                for dev in devices["results"]:
+                    # _LOGGER.debug("device: %s", dev)
+                    clients.append(dev)
 
-            return bool(client_macs)
+        # example client
+        # [{'signal': -47, 'inactive': 310,
+        # 'tx': {'mcs': 7, '40mhz': False, 'rate': 65000, 'short_gi': False},
+        # 'mac': 'F0:B4:29:XX:XX:XX',
+        # 'rx': {'mcs': 7, '40mhz': False, 'rate': 72200, 'short_gi': True},
+        # 'noise': -95}]
+        # _LOGGER.info("Found %s clients: %s", len(clients),
+        #             [client["mac"] for client in clients])
 
-        return False
+        return clients
 
-    def get_device_name(self, device):
-        _LOGGER.info("Getting name for %s", device)
-        return self.last_results[device]["hostname"]
+    def _get_leases(self):
+        """Get all DHCP leases to obtain hostnames."""
+        leases = []
+        for ip_version in ["ipv4leases", "ipv6leases"]:
+            lease_res = _req_json_rpc(self.url, self.session_id,
+                                      "call", "dhcp", ip_version)
+            for network in lease_res["device"]:
+                # _LOGGER.debug("Checking network %s" % network)
+                for lease in lease_res["device"][network]["leases"]:
+                    # _LOGGER.debug("[%s] client: %s", network, lease)
+                    leases.append(lease)
+
+        # example lease
+        # {'mac': '286c07xxxxxx', 'valid': -7471,
+        # 'hostname': 'XXXXX','ip': '192.168.250.132'}
+
+        return leases
+
 
 def _req_json_rpc(url, session_id, rpcmethod, subsystem, method, **params):
     """Perform one JSON RPC operation."""
@@ -125,34 +155,36 @@ def _req_json_rpc(url, session_id, rpcmethod, subsystem, method, **params):
         res = requests.post(url, data=data_json, timeout=5)
 
     except requests.exceptions.Timeout:
+        _LOGGER.error("Got got timeout when doing a request on %s", url)
         return
 
-    _LOGGER.debug("< %s", res)
+    _LOGGER.debug("< %s", res.text)
 
-    if res.status_code == 200:
-        response = res.json()
+    if res.status_code != 200:
+        _LOGGER.error("Got invalid status for the call: %s", res.raw)
+        return
 
-        if rpcmethod == "call":
-            retcode = response["result"][0]
-            if retcode != UBUS_STATUS_OK:
-                if retcode == UBUS_STATUS_PERMISSION_DENIED:
-                    _LOGGER.error("Not enough permissions!")
-                    return
-                elif retcode == UBUS_STATUS_NO_DATA:
-                    _LOGGER.error("Empty leases file!")
-                    return
-                else:
-                    _LOGGER.error("Got ubus error: %s" % retcode)
-                    return
+    response = res.json()
 
-            if "error" in response:
-                _LOGGER.error("Got error from ubus for call %s(%s): %s", data["method"], data["params"], response["error"])
-                return response["error"]
+    if rpcmethod == "call":
+        if "error" in response:
+            _LOGGER.error("Got error from ubus for call %s(%s): %s",
+                          data["method"], data["params"], response["error"])
+            raise UbusException(response["error"])
 
-            res = response["result"][1]
-            return res
-        else:
-            return response["result"]
+        if "result" not in response:
+            _LOGGER.error("Ubus reply has no result dict: %s", response)
+            raise UbusException("Got no result: %s" % response)
+
+        retcode = response["result"][0]
+        if retcode != UbusStatus.UBUS_STATUS_OK:
+            _LOGGER.error("Got error from ubus: %s", UbusStatus(retcode))
+            raise UbusException("Got ubus error: %s" % UbusStatus(retcode))
+
+        res = response["result"][1]
+        return res
+    else:
+        return response["result"]
 
 
 def _get_session_id(url, username, password):
@@ -160,6 +192,51 @@ def _get_session_id(url, username, password):
     res = _req_json_rpc(url, "00000000000000000000000000000000", 'call',
                         'session', 'login', username=username,
                         password=password)
-    #  TODO check for valid login!
-    _LOGGER.error("Request and got token for %s?!: %s" % (username, res))
+
+    # example session
+    # note, sessions do not seem to expire..
+    # {'ubus_rpc_session': '95533928ec0bde5603c408c0eaa314d3',
+    # 'acls': {'uci': {'dhcp': ['read']},
+    #          'ubus': {'iwinfo': ['devices', 'assoclist'],
+    #          'session': ['access', 'login'],
+    #          'dhcp': ['ipv4leases', 'ipv6leases']},
+    # 'access-group': {'hass': ['read'], 'unauthenticated': ['read']}},
+    # 'expires': 300, 'timeout': 300, 'data': {'username': 'hass'}}
+
+    _LOGGER.debug("Got session, verifying required permissions: %s", res)
+    if "acls" not in res:
+        raise UbusException("Session does not have acls: %s" % res)
+
+    if not res["acls"]["ubus"]:
+        raise UbusException("Session does not have ubus acl: %s" % res)
+
+    ubus_acls = res["acls"]["ubus"]
+    if not ubus_acls.keys() & {'dhcp', 'iwinfo'}:
+        raise UbusException("ACL 'dhcp' or 'iwinfo' missing: %s" % res)
+
+    _LOGGER.debug("Got necessary permissions, we're good to go!")
+
     return res["ubus_rpc_session"]
+
+
+def setup_scanner(hass, config, see):
+    """Setup an endpoint for the ubus logger."""
+    try:
+        _LOGGER.info("Trying to start the scanner..")
+        scanner = UbusDeviceScanner(config)
+        interval = DEFAULT_SCAN_INTERVAL
+        _LOGGER.info("Started ubustracker with interval=%s", interval)
+
+        def update(now):
+            """Update all the hosts on every interval time."""
+            _LOGGER.info("Update called..")
+            scanner.update(see)
+            track_point_in_utc_time(hass, update, now + interval)
+            return True
+
+        return update(util.dt.utcnow())
+    except UbusException as ex:
+        _LOGGER.error("Got exception: %s", ex)
+        return False
+
+    return True

--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -86,8 +86,8 @@ class UbusDeviceScanner:
                 client["ip"] = lease[0]["ip"]
                 client["hostname"] = lease[0]["hostname"]
             else:
-                _LOGGER.warning("Couldn't find lease for %s", client["mac"])
-                client["hostname"] = "<no lease>"
+                _LOGGER.warning("Couldn't find lease for %s, using mac as name", client["mac"])
+                client["hostname"] = mac
                 client["ip"] = "<no lease>"
 
             extra_attrs = {

--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -75,10 +75,14 @@ class UbusDeviceScanner:
 
     def update(self, see):
         """Fetch clients and leases from the router."""
-        clients = self._get_devices()
-        leases = self._get_leases()
-        _LOGGER.debug("Got %s clients, %s leases", len(clients), len(leases))
+        try:
+            clients = self._get_devices()
+            leases = self._get_leases()
+        except requests.exceptions.ConnectionError as ex:
+            _LOGGER.debug("Got exception from requests: %s", ex)
+            return False
 
+        _LOGGER.debug("Got %s clients, %s leases", len(clients), len(leases))
         # Note, we may have clients who have leases expired..
         for client in clients:
             mac = client["mac"].replace(":", "").lower()


### PR DESCRIPTION
**Description:**
* Converted to use iwinfo & dhcp services, iwinfo allows instantaneous detection of changes in connected devices (coming directly from the wifi radio instead of using leases like before), making this tracker usable.
* This also allows more fine-grained permissions, so no more root user required (see updated documentation) for functionality.
* Better error handling and reporting. debug() reporting for important pieces for future development.
* Adapt to use setup_scanner() API.
Using dhcp service allows getting the wanted information without
reading extra files and giving extra permissions.

**Related issue (if applicable):** fixes #2175, #4495, #1492

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1819

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
