### PR TITLE
Don't build Adafruit_BBIO - doesn't work on all platforms.

### DIFF
--- a/homeassistant/components/bbb_gpio.py
+++ b/homeassistant/components/bbb_gpio.py
@@ -19,6 +19,7 @@ DOMAIN = 'bbb_gpio'
 # pylint: disable=no-member
 def setup(hass, config):
     """Setup the Beaglebone black GPIO component."""
+    # pylint: disable=import-error
     import Adafruit_BBIO.GPIO as GPIO
 
     def cleanup_gpio(event):
@@ -33,33 +34,41 @@ def setup(hass, config):
     return True
 
 
+# noqa: F821
+
 def setup_output(pin):
     """Setup a GPIO as output."""
+    # pylint: disable=import-error,undefined-variable
     import Adafruit_BBIO.GPIO as GPIO
     GPIO.setup(pin, GPIO.OUT)
 
 
 def setup_input(pin, pull_mode):
     """Setup a GPIO as input."""
+    # pylint: disable=import-error,undefined-variable
     import Adafruit_BBIO.GPIO as GPIO
-    GPIO.setup(pin, GPIO.IN,
-               GPIO.PUD_DOWN if pull_mode == 'DOWN' else GPIO.PUD_UP)
+    GPIO.setup(pin, GPIO.IN,                            # noqa: F821
+               GPIO.PUD_DOWN if pull_mode == 'DOWN'     # noqa: F821
+               else GPIO.PUD_UP)                        # noqa: F821
 
 
 def write_output(pin, value):
     """Write a value to a GPIO."""
+    # pylint: disable=import-error,undefined-variable
     import Adafruit_BBIO.GPIO as GPIO
     GPIO.output(pin, value)
 
 
 def read_input(pin):
     """Read a value from a GPIO."""
+    # pylint: disable=import-error,undefined-variable
     import Adafruit_BBIO.GPIO as GPIO
     return GPIO.input(pin)
 
 
 def edge_detect(pin, event_callback, bounce):
     """Add detection for RISING and FALLING events."""
+    # pylint: disable=import-error,undefined-variable
     import Adafruit_BBIO.GPIO as GPIO
     GPIO.add_event_detect(
         pin,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -13,7 +13,7 @@ async_timeout==1.1.0
 --only-binary=all http://github.com/getSenic/nuimo-linux-python/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip#nuimo==1.0.0
 
 # homeassistant.components.bbb_gpio
-Adafruit_BBIO==1.0.0
+# Adafruit_BBIO==1.0.0
 
 # homeassistant.components.isy994
 PyISY==1.0.7

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -10,6 +10,7 @@ COMMENT_REQUIREMENTS = (
     'RPi.GPIO',
     'rpi-rf',
     'Adafruit_Python_DHT',
+    'Adafruit_BBIO',
     'fritzconnection',
     'pybluez',
     'bluepy',


### PR DESCRIPTION
**Description:**
Fixes the OSX build (and I assume on some other platforms).

I think I did as suggested by @balloob 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
