### PR TITLE
Bugfix media_player volume_ up and down

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -748,29 +748,29 @@ class MediaPlayerDevice(Entity):
         else:
             return self.async_turn_off()
 
-    def volume_up(self):
-        """Turn volume up for media player."""
-        if self.volume_level < 1:
-            self.set_volume_level(min(1, self.volume_level + .1))
-
     def async_volume_up(self):
         """Turn volume up for media player.
 
         This method must be run in the event loop and returns a coroutine.
         """
-        return self.hass.loop.run_in_executor(None, self.volume_up)
+        if hasattr(self, 'volume_up'):
+            return self.hass.run_in_executor(None, self.volume_up)
 
-    def volume_down(self):
-        """Turn volume down for media player."""
-        if self.volume_level > 0:
-            self.set_volume_level(max(0, self.volume_level - .1))
+        if self.volume_level < 1:
+            return self.async_set_volume_level(min(1, self.volume_level + .1))
+        return self.async_set_volume_level(self.volume_level)
 
     def async_volume_down(self):
         """Turn volume down for media player.
 
         This method must be run in the event loop and returns a coroutine.
         """
-        return self.hass.loop.run_in_executor(None, self.volume_down)
+        if hasattr(self, 'volume_down'):
+            return self.hass.run_in_executor(None, self.volume_down)
+
+        if self.volume_level > 0:
+            return self.async_set_volume_level(max(0, self.volume_level - .1))
+        return self.async_set_volume_level(self.volume_level)
 
     def media_play_pause(self):
         """Play or pause the media player."""

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -754,6 +754,7 @@ class MediaPlayerDevice(Entity):
         This method must be run in the event loop and returns a coroutine.
         """
         if hasattr(self, 'volume_up'):
+            # pylint: disable=no-member
             return self.hass.run_in_executor(None, self.volume_up)
 
         if self.volume_level < 1:
@@ -766,6 +767,7 @@ class MediaPlayerDevice(Entity):
         This method must be run in the event loop and returns a coroutine.
         """
         if hasattr(self, 'volume_down'):
+            # pylint: disable=no-member
             return self.hass.run_in_executor(None, self.volume_down)
 
         if self.volume_level > 0:

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -748,31 +748,33 @@ class MediaPlayerDevice(Entity):
         else:
             return self.async_turn_off()
 
+    @asyncio.coroutine
     def async_volume_up(self):
         """Turn volume up for media player.
 
-        This method must be run in the event loop and returns a coroutine.
+        This method is a coroutine.
         """
         if hasattr(self, 'volume_up'):
             # pylint: disable=no-member
-            return self.hass.run_in_executor(None, self.volume_up)
+            yield from self.hass.run_in_executor(None, self.volume_up)
 
         if self.volume_level < 1:
-            return self.async_set_volume_level(min(1, self.volume_level + .1))
-        return self.async_set_volume_level(self.volume_level)
+            yield from self.async_set_volume_level(
+                min(1, self.volume_level + .1))
 
+    @asyncio.coroutine
     def async_volume_down(self):
         """Turn volume down for media player.
 
-        This method must be run in the event loop and returns a coroutine.
+        This method is a coroutine.
         """
         if hasattr(self, 'volume_down'):
             # pylint: disable=no-member
-            return self.hass.run_in_executor(None, self.volume_down)
+            yield from self.hass.run_in_executor(None, self.volume_down)
 
         if self.volume_level > 0:
-            return self.async_set_volume_level(max(0, self.volume_level - .1))
-        return self.async_set_volume_level(self.volume_level)
+            yield from self.async_set_volume_level(
+                max(0, self.volume_level - .1))
 
     def media_play_pause(self):
         """Play or pause the media player."""


### PR DESCRIPTION
**Description:**

I think that should be a better fix as #5265. It move logic to async like `async_toggle`. Some platform have overwrite that with device api stuff. So ee need support to overwrite that too.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
