### PR TITLE
Include .ignore file for search utilities

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,7 @@
+# Patterns matched in this file will be ignored by supported search utilities
+
+# Ignore generated html and javascript files
+/homeassistant/components/frontend/www_static/*.html
+/homeassistant/components/frontend/www_static/panels/*.html
+/homeassistant/components/frontend/www_static/*.js
+/homeassistant/components/frontend/www_static/panels/*.js

--- a/.ignore
+++ b/.ignore
@@ -2,6 +2,5 @@
 
 # Ignore generated html and javascript files
 /homeassistant/components/frontend/www_static/*.html
-/homeassistant/components/frontend/www_static/panels/*.html
 /homeassistant/components/frontend/www_static/*.js
-/homeassistant/components/frontend/www_static/panels/*.js
+/homeassistant/components/frontend/www_static/panels/*.html


### PR DESCRIPTION
**Description:**
This instructs search utilities to ignore generated html/js files.

Currently supported by [ripgrep](https://github.com/BurntSushi/ripgrep) and [ag](https://github.com/ggreer/the_silver_searcher).