### PR TITLE
Upgrade distro to 1.0.2

### DIFF
--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -22,7 +22,7 @@ from homeassistant.const import __version__ as CURRENT_VERSION
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.helpers import event
 
-REQUIREMENTS = ['distro==1.0.1']
+REQUIREMENTS = ['distro==1.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -86,7 +86,7 @@ denonavr==0.2.2
 directpy==0.1
 
 # homeassistant.components.updater
-distro==1.0.1
+distro==1.0.2
 
 # homeassistant.components.switch.digitalloggers
 dlipower==0.7.165


### PR DESCRIPTION
**Description:**

Upgrade to latest distro version.

I'm packaging home-assistant for OpenEmbedded in the [meta-homeassistant](https://github.com/bachp/meta-homeassistant) layer. And distro 1.0.2 has [some changes](https://github.com/nir0s/distro/issues/139) that make it easier to package. If this version could be used for home-assistant 0.36 it would make my life easier.

**Checklist:**

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
