### PR TITLE
Bugfix group reload

### DIFF
--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -407,7 +407,7 @@ class Group(Entity):
         This method must be run in the event loop.
         """
         # removed
-        if self.entity_id not in self.hass.states.async_entity_ids(DOMAIN):
+        if self._async_unsub_state_changed is None:
             return
 
         self._async_update_group_state(new_state)

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -367,7 +367,7 @@ class Group(Entity):
         """
         if self._async_unsub_state_changed is None:
             self._async_unsub_state_changed = async_track_state_change(
-                self.hass, self.tracking, self._state_changed_listener
+                self.hass, self.tracking, self._async_state_changed_listener
             )
 
     def stop(self):
@@ -400,8 +400,8 @@ class Group(Entity):
 
         yield from super().async_remove()
 
-    @callback
-    def _state_changed_listener(self, entity_id, old_state, new_state):
+    @asyncio.coroutine
+    def _async_state_changed_listener(self, entity_id, old_state, new_state):
         """Respond to a member state changing.
 
         This method must be run in the event loop.
@@ -411,7 +411,7 @@ class Group(Entity):
             return
 
         self._async_update_group_state(new_state)
-        self.hass.async_add_job(self.async_update_ha_state())
+        yield from self.async_update_ha_state()
 
     @property
     def _tracking_states(self):

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -404,6 +404,9 @@ class Group(Entity):
 
         This method must be run in the event loop.
         """
+        # remove
+        if new_state is None:
+            return
         self._async_update_group_state(new_state)
         self.hass.async_add_job(self.async_update_ha_state())
 

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -325,9 +325,11 @@ class EntityPlatform(object):
                    in self.platform_entities):
             return
 
-        self._async_unsub_polling = async_track_time_interval(
-            self.component.hass, self._update_entity_states, self.scan_interval
-        )
+        if self._async_unsub_polling is None:
+            self._async_unsub_polling = async_track_time_interval(
+                self.component.hass, self._update_entity_states,
+                self.scan_interval
+            )
 
     @asyncio.coroutine
     def _async_process_entity(self, new_entity, update_before_add):

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -325,11 +325,9 @@ class EntityPlatform(object):
                    in self.platform_entities):
             return
 
-        if self._async_unsub_polling is None:
-            self._async_unsub_polling = async_track_time_interval(
-                self.component.hass, self._update_entity_states,
-                self.scan_interval
-            )
+        self._async_unsub_polling = async_track_time_interval(
+            self.component.hass, self._update_entity_states, self.scan_interval
+        )
 
     @asyncio.coroutine
     def _async_process_entity(self, new_entity, update_before_add):


### PR DESCRIPTION
**Description:**

After 5 hour bug hunting I found 2 bugs. Now should group work 🎉 

- We had luck that the old sync version remove groups in right order. Now with async we have no choise and I think we can not know in which order the group entity need to remove that the change listener not make a update and re create it on statemachine. I ignor now all remove entity by group state change listener and we need not known the right order or remove the entity.


So I need a 🍺 

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
