### PR TITLE
Upgrade pip if minimum version not present

### DIFF
--- a/script/bootstrap_server
+++ b/script/bootstrap_server
@@ -7,11 +7,19 @@ set -e
 cd "$(dirname "$0")/.."
 
 echo "Installing dependencies..."
+# Requirements_all.txt states minimum pip version as 7.0.0 however,
+# parameter --only-binary doesn't work with pip < 7.0.0. Causing
+# python3 -m pip install -r requirements_all.txt to fail unless pip upgraded.
+
+if ! python3 -c 'import pkg_resources ; pkg_resources.require(["pip>=7.0.0"])' 2>/dev/null ; then
+  echo "Upgrading pip..."
+  python3 -m pip install -U pip
+fi
 python3 -m pip install -r requirements_all.txt
 
 REQ_STATUS=$?
 
-echo  "Installing development dependencies.."
+echo  "Installing development dependencies..."
 python3 -m pip install -r requirements_test.txt
 
 REQ_DEV_STATUS=$?


### PR DESCRIPTION
**Description:**
This change attempts to upgrade pip if the minimum required version is not present. 
This was found whilst attempting to setup development environment within pyvenv on debian 8.6 where pip version was 1.5.6. 

The `requirements_all.txt` file specifies a need for version 7.0.0 or later, however in the call to pip install `requirements_all.txt` includes a parameter `--only-binary` this doesn't work with pip < 7.0.0 so setup fails.

Changes in collaboration with @armills gitter conversation.