### PR TITLE
Bugfix camera streams

### DIFF
--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -84,9 +84,15 @@ class FFmpegCamera(Camera):
                 if not data:
                     break
                 response.write(data)
+
+        except asyncio.CancelledError:
+            _LOGGER.debug("Close stream by browser.")
+            response = None
+
         finally:
-            self.hass.async_add_job(stream.close())
-            yield from response.write_eof()
+            yield from stream.close()
+            if response is not None:
+                yield from response.write_eof()
 
     @property
     def name(self):

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -126,7 +126,7 @@ class MjpegCamera(Camera):
 
         finally:
             if stream is not None:
-                yield from stream.close()
+                stream.close()
             if response is not None:
                 yield from response.write_eof()
 

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -124,6 +124,10 @@ class MjpegCamera(Camera):
         except asyncio.TimeoutError:
             raise HTTPGatewayTimeout()
 
+        except asyncio.CancelledError:
+            _LOGGER.debug("Close stream by browser.")
+            response = None
+
         finally:
             if stream is not None:
                 stream.close()

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -278,7 +278,7 @@ class SynologyCamera(Camera):
 
         finally:
             if stream is not None:
-                self.hass.async_add_job(stream.release())
+                stream.close()
             if response is not None:
                 yield from response.write_eof()
 

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -276,6 +276,10 @@ class SynologyCamera(Camera):
             _LOGGER.exception("Error on %s", streaming_url)
             raise HTTPGatewayTimeout()
 
+        except asyncio.CancelledError:
+            _LOGGER.debug("Close stream by browser.")
+            response = None
+
         finally:
             if stream is not None:
                 stream.close()


### PR DESCRIPTION
**Description:**

- Use function (not coro) close for stream reader
- Handle asyncio.CancelledError and response are not valid anymore

Should fix: #5300

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
