### PR TITLE
switch.tplink: bump to the newest release of pyhs100

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -14,8 +14,7 @@ from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_HOST, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['https://github.com/GadgetReactor/pyHS100/archive/'
-                '45fc3548882628bcde3e3d365db341849457bef2.zip#pyHS100==0.2.2']
+REQUIREMENTS = ['pyHS100==0.2.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -183,9 +183,6 @@ hikvision==0.4
 # homeassistant.components.nest
 http://github.com/technicalpickles/python-nest/archive/e6c9d56a8df455d4d7746389811f2c1387e8cb33.zip#python-nest==3.0.3
 
-# homeassistant.components.switch.tplink
-https://github.com/GadgetReactor/pyHS100/archive/45fc3548882628bcde3e3d365db341849457bef2.zip#pyHS100==0.2.2
-
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.3.7.zip#pyW215==0.3.7
 
@@ -378,6 +375,9 @@ pwaqi==1.3
 
 # homeassistant.components.sensor.cpuspeed
 py-cpuinfo==0.2.3
+
+# homeassistant.components.switch.tplink
+pyHS100==0.2.3
 
 # homeassistant.components.rfxtrx
 pyRFXtrx==0.14.0


### PR DESCRIPTION
**Description:**
Bump the required version, this fixes #4992.

**Related issue (if applicable):** fixes #4992 

**Checklist:**
If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
