### PR TITLE
Introduced Amcrest camera sensors and bump Amcrest module version

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -262,6 +262,7 @@ omit =
     homeassistant/components/openalpr.py
     homeassistant/components/remote/harmony.py
     homeassistant/components/scene/hunterdouglas_powerview.py
+    homeassistant/components/sensor/amcrest.py
     homeassistant/components/sensor/arest.py
     homeassistant/components/sensor/arwn.py
     homeassistant/components/sensor/bbox.py

--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-REQUIREMENTS = ['amcrest==1.0.0']
+REQUIREMENTS = ['amcrest==1.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/amcrest.py
+++ b/homeassistant/components/sensor/amcrest.py
@@ -1,0 +1,144 @@
+"""
+This component provides HA sensor support for Amcrest IP cameras.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.amcrest/
+"""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, CONF_MONITORED_CONDITIONS,
+    CONF_USERNAME, CONF_PASSWORD, CONF_PORT,
+    STATE_UNKNOWN)
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+import homeassistant.loader as loader
+
+REQUIREMENTS = ['amcrest==1.1.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
+
+NOTIFICATION_ID = 'amcrest_notification'
+NOTIFICATION_TITLE = 'Amcrest Sensor Setup'
+
+DEFAULT_NAME = 'Amcrest'
+DEFAULT_PORT = 80
+
+# Sensor types are defined like: Name, units, icon
+SENSOR_TYPES = {
+    'motion_detector': ['Motion Detected', None, 'run'],
+    'sdcard': ['SD Used', '%', 'sd'],
+    'ptz_preset': ['PTZ Preset', None, 'camera-iris'],
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Required(CONF_MONITORED_CONDITIONS, default=[]):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up a sensor for an Amcrest IP Camera."""
+    from amcrest import AmcrestCamera
+
+    data = AmcrestCamera(
+        config.get(CONF_HOST), config.get(CONF_PORT),
+        config.get(CONF_USERNAME), config.get(CONF_PASSWORD))
+
+    persistent_notification = loader.get_component('persistent_notification')
+    try:
+        data.camera.current_time
+    # pylint: disable=broad-except
+    except Exception as ex:
+        _LOGGER.error("Unable to connect to Amcrest camera: %s", str(ex))
+        persistent_notification.create(
+            hass, 'Error: {}<br />'
+            'You will need to restart hass after fixing.'
+            ''.format(ex),
+            title=NOTIFICATION_TITLE,
+            notification_id=NOTIFICATION_ID)
+        return False
+
+    sensors = []
+    for sensor_type in config.get(CONF_MONITORED_CONDITIONS):
+        sensors.append(AmcrestSensor(config, data, sensor_type))
+
+    add_devices(sensors)
+
+    return True
+
+
+class AmcrestSensor(Entity):
+    """A sensor implementation for Amcrest IP camera."""
+
+    def __init__(self, device_info, data, sensor_type):
+        """Initialize a sensor for Amcrest camera."""
+        super(AmcrestSensor, self).__init__()
+        self._attrs = {}
+        self._data = data
+        self._sensor_type = sensor_type
+        self._name = '{0}_{1}'.format(device_info.get(CONF_NAME),
+                                      SENSOR_TYPES.get(self._sensor_type)[0])
+        self._icon = 'mdi:{}'.format(SENSOR_TYPES.get(self._sensor_type)[2])
+        self._state = STATE_UNKNOWN
+
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._attrs
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def unit_of_measurement(self):
+        """Return the units of measurement."""
+        return SENSOR_TYPES.get(self._sensor_type)[1]
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Get the latest data and updates the state."""
+        version, build_date = self._data.camera.software_information
+        self._attrs['Build Date'] = build_date.split('=')[-1]
+        self._attrs['Serial Number'] = self._data.camera.serial_number
+        self._attrs['Version'] = version.split('=')[-1]
+
+        if self._sensor_type == 'motion_detector':
+            self._state = self._data.camera.is_motion_detected
+            self._attrs['Record Mode'] = self._data.camera.record_mode
+
+        elif self._sensor_type == 'ptz_preset':
+            self._state = self._data.camera.ptz_presets_count
+
+        elif self._sensor_type == 'sdcard':
+            sd_used = self._data.camera.storage_used
+            sd_total = self._data.camera.storage_total
+            self._attrs['Total'] = '{0} {1}'.format(*sd_total)
+            self._attrs['Used'] = '{0} {1}'.format(*sd_used)
+            self._state = self._data.camera.percent(sd_used[0], sd_total[0])

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -39,6 +39,9 @@ aiohttp_cors==0.5.0
 # homeassistant.components.camera.amcrest
 amcrest==1.0.0
 
+# homeassistant.components.sensor.amcrest
+amcrest==1.1.0
+
 # homeassistant.components.apcupsd
 apcaccess==0.0.4
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -37,8 +37,6 @@ TwitterAPI==2.4.3
 aiohttp_cors==0.5.0
 
 # homeassistant.components.camera.amcrest
-amcrest==1.0.0
-
 # homeassistant.components.sensor.amcrest
 amcrest==1.1.0
 


### PR DESCRIPTION
**Description:**
This PR introduces 3 sensors for the Amcrest cameras.  I'm still working to add more sensors soon. 

This change also bumps the version of Amcrest python module. 

* Badges
![amcrest_sensor_badges](https://cloud.githubusercontent.com/assets/809840/21950686/8410d6de-d9cb-11e6-9c3b-12305a75ccd2.png)

* Motion Card
![motion](https://cloud.githubusercontent.com/assets/809840/21950734/dfc076a6-d9cb-11e6-85d3-31adb58ce5c1.png)

* Preset card
![preset](https://cloud.githubusercontent.com/assets/809840/21950735/dfc20692-d9cb-11e6-8474-df3e190acf09.png)

* SD card
![sd_card](https://cloud.githubusercontent.com/assets/809840/21950736/dfc1efea-d9cb-11e6-953c-dad87dac0890.png)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1763

**Example entry for `configuration.yaml` (if applicable):**
```yaml
# sensors.yaml
- platform: amcrest
  name: "Amcrest Living Room"
  host: !secret amcrest_living_room_host
  username: !secret amcrest_living_room_username
  password: !secret amcrest_living_room_password
  monitored_conditions:
    - motion_detector
    - sdcard
    - ptz_preset
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
