### PR TITLE
Bugfix for ping component now DEFAULT_SCAN_INTERVAL is a timedelta

### DIFF
--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -77,8 +77,8 @@ def setup_scanner(hass, config, see):
     """Setup the Host objects and return the update function."""
     hosts = [Host(ip, dev_id, hass, config) for (dev_id, ip) in
              config[const.CONF_HOSTS].items()]
-    interval = timedelta(seconds=len(hosts) * config[CONF_PING_COUNT] +
-                         DEFAULT_SCAN_INTERVAL)
+    interval = timedelta(seconds=len(hosts) * config[CONF_PING_COUNT]) + \
+        DEFAULT_SCAN_INTERVAL
     _LOGGER.info("Started ping tracker with interval=%s on hosts: %s",
                  interval, ",".join([host.ip_address for host in hosts]))
 


### PR DESCRIPTION
**Description:**
#5193 missed the new `ping` component. This change is required since #5147.

The interval is based on the DEFAULT_SCAN_INTERVAL plus one second for every ping that can fail.