### PR TITLE
Add ffmpeg to Docker from jessie-backports

### DIFF
--- a/script/setup_docker_prereqs
+++ b/script/setup_docker_prereqs
@@ -11,6 +11,12 @@ PACKAGES=(
   libtelldus-core2
 )
 
+# Required debian packages for running hass or components from jessie-backports
+PACKAGES_BACKPORTS=(
+  # homeassistant.components.ffmpeg
+  ffmpeg
+)
+
 # Required debian packages for building dependencies
 PACKAGES_DEV=(
   # python-openzwave
@@ -28,9 +34,13 @@ cd "$(dirname "$0")/.."
 echo "deb http://download.telldus.com/debian/ stable main" >> /etc/apt/sources.list.d/telldus.list
 wget -qO - http://download.telldus.se/debian/telldus-public.key | apt-key add -
 
+# Add jessie-backports
+echo "deb http://httpredir.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
+
 # Install packages
 apt-get update
 apt-get install -y --no-install-recommends ${PACKAGES[@]} ${PACKAGES_DEV[@]}
+apt-get install -y --no-install-recommends -t jessie-backports ${PACKAGES_BACKPORTS[@]}
 
 # Build and install openzwave
 script/build_python_openzwave


### PR DESCRIPTION
**Description:**

[The ffmpeg component requires ffmpeg](https://home-assistant.io/components/ffmpeg/), so that should probably be included in the Docker container.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** n/a

**Example entry for `configuration.yaml` (if applicable):** /na

**Checklist:**

n/a