### PR TITLE
Fix missing openzwave configs in Docker

### DIFF
--- a/script/setup_docker_prereqs
+++ b/script/setup_docker_prereqs
@@ -35,7 +35,7 @@ apt-get install -y --no-install-recommends ${PACKAGES[@]} ${PACKAGES_DEV[@]}
 # Build and install openzwave
 script/build_python_openzwave
 mkdir -p /usr/local/share/python-openzwave
-ln -sf /usr/src/app/build/python-openzwave/openzwave/config /usr/local/share/python-openzwave/config
+cp -R /usr/src/app/build/python-openzwave/openzwave/config /usr/local/share/python-openzwave/config
 
 # Build and install libcec
 script/build_libcec


### PR DESCRIPTION
**Description:**

This fixes issue #5328 by copying the config files from `build/` before they are deleted.

**Related issue (if applicable):** fixes #5328

**Checklist:**

n/a