### PR TITLE
Rename log message / handle cancellederror on image proxy

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -175,7 +175,7 @@ class Camera(Entity):
                 yield from asyncio.sleep(.5)
 
         except asyncio.CancelledError:
-            _LOGGER.debug("Close stream by browser.")
+            _LOGGER.debug("Close stream by frontend.")
             response = None
 
         finally:
@@ -249,12 +249,16 @@ class CameraImageView(CameraView):
     @asyncio.coroutine
     def handle(self, request, camera):
         """Serve camera image."""
-        image = yield from camera.async_camera_image()
+        try:
+            image = yield from camera.async_camera_image()
 
-        if image is None:
-            return web.Response(status=500)
+            if image is None:
+                return web.Response(status=500)
 
-        return web.Response(body=image)
+            return web.Response(body=image)
+
+        except asyncio.CancelledError:
+            _LOGGER.debug("Close stream by frontend.")
 
 
 class CameraMjpegStream(CameraView):

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -86,7 +86,7 @@ class FFmpegCamera(Camera):
                 response.write(data)
 
         except asyncio.CancelledError:
-            _LOGGER.debug("Close stream by browser.")
+            _LOGGER.debug("Close stream by frontend.")
             response = None
 
         finally:

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -125,7 +125,7 @@ class MjpegCamera(Camera):
             raise HTTPGatewayTimeout()
 
         except asyncio.CancelledError:
-            _LOGGER.debug("Close stream by browser.")
+            _LOGGER.debug("Close stream by frontend.")
             response = None
 
         finally:

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -277,7 +277,7 @@ class SynologyCamera(Camera):
             raise HTTPGatewayTimeout()
 
         except asyncio.CancelledError:
-            _LOGGER.debug("Close stream by browser.")
+            _LOGGER.debug("Close stream by frontend.")
             response = None
 
         finally:


### PR DESCRIPTION
**Description:**

Should fix errors like #5316  they are pressent on executor and async call of `camera_image()` since aiohttp 1.1.6

I change also a debug output.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
