### PR TITLE
Bugfix stack trace from api

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -133,6 +133,9 @@ class APIEventStream(HomeAssistantView):
                 except asyncio.TimeoutError:
                     yield from to_write.put(STREAM_PING_PAYLOAD)
 
+        except asyncio.CancelledError:
+            _LOGGER.debug('STREAM %s ABORT', id(stop_obj))
+
         finally:
             _LOGGER.debug('STREAM %s RESPONSE CLOSED', id(stop_obj))
             unsub_stream()


### PR DESCRIPTION
**Description:**

Handle client abort of connection.

**Related issue (if applicable):** fixes #5279 #5189 #5007

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
