### PR TITLE
Update vlc.py

### DIFF
--- a/homeassistant/components/media_player/vlc.py
+++ b/homeassistant/components/media_player/vlc.py
@@ -34,7 +34,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the vlc platform."""
-    add_devices([VlcDevice(config.get(CONF_NAME), config.get(ADDITIONAL_ARGS))])
+    add_devices([VlcDevice(config.get(CONF_NAME),
+                           config.get(ADDITIONAL_ARGS))])
 
 
 class VlcDevice(MediaPlayerDevice):

--- a/homeassistant/components/media_player/vlc.py
+++ b/homeassistant/components/media_player/vlc.py
@@ -20,14 +20,14 @@ REQUIREMENTS = ['python-vlc==1.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 
-ADDITIONAL_ARGS = 'arguments'
+CONF_ARGUMENTS = 'arguments'
 
 SUPPORT_VLC = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
     SUPPORT_PLAY_MEDIA | SUPPORT_PLAY
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(ADDITIONAL_ARGS): cv.string,
+    vol.Optional(CONF_ARGUMENTS): cv.string,
 })
 
 
@@ -35,7 +35,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the vlc platform."""
     add_devices([VlcDevice(config.get(CONF_NAME),
-                           config.get(ADDITIONAL_ARGS))])
+                           config.get(CONF_ARGUMENTS))])
 
 
 class VlcDevice(MediaPlayerDevice):

--- a/homeassistant/components/media_player/vlc.py
+++ b/homeassistant/components/media_player/vlc.py
@@ -27,7 +27,7 @@ SUPPORT_VLC = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_ARGUMENTS): cv.string,
+    vol.Optional(CONF_ARGUMENTS, default=''): cv.string,
 })
 
 

--- a/homeassistant/components/media_player/vlc.py
+++ b/homeassistant/components/media_player/vlc.py
@@ -20,28 +20,30 @@ REQUIREMENTS = ['python-vlc==1.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 
+ADDITIONAL_ARGS = 'arguments'
 
 SUPPORT_VLC = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
     SUPPORT_PLAY_MEDIA | SUPPORT_PLAY
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(ADDITIONAL_ARGS): cv.string,
 })
 
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the vlc platform."""
-    add_devices([VlcDevice(config.get(CONF_NAME))])
+    add_devices([VlcDevice(config.get(CONF_NAME), config.get(ADDITIONAL_ARGS))])
 
 
 class VlcDevice(MediaPlayerDevice):
     """Representation of a vlc player."""
 
-    def __init__(self, name):
+    def __init__(self, name, arguments):
         """Initialize the vlc device."""
         import vlc
-        self._instance = vlc.Instance()
+        self._instance = vlc.Instance(arguments)
         self._vlc = self._instance.media_player_new()
         self._name = name
         self._volume = None


### PR DESCRIPTION
**Description:**

Added support for additional optional configuration

arguments:

to send to vlc.
It is useful for special configurations of VLC.
For example, I have two sound cards on my server, so I defined two vlc media players:

```yaml
media_player:
- platform: vlc
  name: speaker_1
  arguments: '--alsa-audio-device=hw:1,0'
- platform: vlc
  name: speaker_2
  arguments: '--alsa-audio-device=hw:0,0'
```

This way, by specifying the corresponding entity_id, I can send the output to the desired speaker.
It is also useful for TTS.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1771

**Example entry for `configuration.yaml` (if applicable):**
```yaml

media_player:
- platform: vlc
  name: speaker_1
  arguments: '--alsa-audio-device=hw:1,0'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
