### PR TITLE
Update keyboard_remote.py

### DIFF
--- a/homeassistant/components/keyboard_remote.py
+++ b/homeassistant/components/keyboard_remote.py
@@ -48,6 +48,8 @@ REQUIREMENTS = ['evdev==0.6.1']
 _LOGGER = logging.getLogger(__name__)
 ICON = 'mdi:remote'
 KEYBOARD_REMOTE_COMMAND_RECEIVED = 'keyboard_remote_command_received'
+KEYBOARD_REMOTE_CONNECTED = 'keyboard_remote_connected'
+KEYBOARD_REMOTE_DISCONNECTED = 'keyboard_remote_disconnected'
 KEY_CODE = 'key_code'
 KEY_VALUE = {'key_up': 0, 'key_down': 1, 'key_hold': 2}
 TYPE = 'type'
@@ -151,13 +153,19 @@ class KeyboardRemote(threading.Thread):
                     self.keyboard_connected = True
                     _LOGGER.debug('KeyboardRemote: keyboard re-connected, %s',
                                   self.device_descriptor)
+                    self.hass.bus.fire(
+                        KEYBOARD_REMOTE_CONNECTED
+                    )
 
             try:
                 event = self.dev.read_one()
             except IOError:  # Keyboard Disconnected
                 self.keyboard_connected = False
-                _LOGGER.debug('KeyboardRemote: keyard disconnected, %s',
+                _LOGGER.debug('KeyboardRemote: keyboard disconnected, %s',
                               self.device_descriptor)
+                self.hass.bus.fire(
+                    KEYBOARD_REMOTE_DISCONNECTED
+                )
                 continue
 
             if not event:


### PR DESCRIPTION
Now it fires events in case the keyboard disconnects and/or disconnects

**Description:**


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1774

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
