### PR TITLE
Remove throttle decorator from miflora platform

### DIFF
--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -4,7 +4,6 @@ Support for Xiaomi Mi Flora BLE plant sensor.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.miflora/
 """
-from datetime import timedelta
 import logging
 
 import voluptuous as vol

--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -12,7 +12,6 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util import Throttle
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_MAC)
 
@@ -31,9 +30,7 @@ DEFAULT_MEDIAN = 3
 DEFAULT_NAME = 'Mi Flora'
 DEFAULT_RETRIES = 2
 DEFAULT_TIMEOUT = 10
-
-UPDATE_INTERVAL = 1200
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=UPDATE_INTERVAL)
+DEFAULT_UPDATE_INTERVAL = 1200
 
 # Sensor types are defined like: Name, units
 SENSOR_TYPES = {
@@ -53,7 +50,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     vol.Optional(CONF_RETRIES, default=DEFAULT_RETRIES): cv.positive_int,
-    vol.Optional(CONF_CACHE, default=UPDATE_INTERVAL): cv.positive_int,
+    vol.Optional(CONF_CACHE, default=DEFAULT_UPDATE_INTERVAL): cv.positive_int,
 })
 
 
@@ -122,7 +119,6 @@ class MiFloraSensor(Entity):
         """Force update."""
         return self._force_update
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """
         Update current conditions.


### PR DESCRIPTION


**Description:**
Removing redundant throttle decorator on update method. This ensures the existing 'cache_value' config option is respected. Also, UPDATE_INTERVAL is renamed to DEFAULT_UPDATE_INTERVAL for clarity.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

**Example entry for `configuration.yaml` (if applicable):**
```yaml
cache_value:300
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
