### PR TITLE
Eq3bt bump version, expose away attribute

### DIFF
--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 
 import homeassistant.helpers.config_validation as cv
 
-#REQUIREMENTS = ['python-eq3bt==0.1.3']
+REQUIREMENTS = ['python-eq3bt==0.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-eq3bt==0.1.2']
+#REQUIREMENTS = ['python-eq3bt==0.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +29,7 @@ ATTR_STATE_WINDOW_OPEN = "window_open"
 ATTR_STATE_VALVE = "valve"
 ATTR_STATE_LOCKED = "is_locked"
 ATTR_STATE_LOW_BAT = "low_battery"
+ATTR_STATE_AWAY_END = "away_end"
 
 DEVICE_SCHEMA = vol.Schema({
     vol.Required(CONF_MAC): cv.string,
@@ -152,6 +153,7 @@ class EQ3BTSmartThermostat(ClimateDevice):
             ATTR_STATE_LOW_BAT: self._thermostat.low_battery,
             ATTR_STATE_VALVE: self._thermostat.valve_state,
             ATTR_STATE_WINDOW_OPEN: self._thermostat.window_open,
+            ATTR_STATE_AWAY_END: self._thermostat.away_end,
         }
 
         return dev_specific

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -476,7 +476,7 @@ pysnmp==4.3.2
 python-digitalocean==1.10.1
 
 # homeassistant.components.climate.eq3btsmart
-python-eq3bt==0.1.2
+python-eq3bt==0.1.4
 
 # homeassistant.components.sensor.darksky
 python-forecastio==1.3.5


### PR DESCRIPTION
**Description:**
This includes just two changes: bumping the version number of the backend lib, as the old version does not have __init__.py in the package and is thus not importable at all. In its current state the module is not usable from homeassistant at all.

Second one is exposing away_ends attribute.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
