### PR TITLE
Make USPS to use absolute path to save cookie

### DIFF
--- a/homeassistant/components/sensor/usps.py
+++ b/homeassistant/components/sensor/usps.py
@@ -22,6 +22,7 @@ REQUIREMENTS = ['myusps==1.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 
+COOKIE = 'usps_cookies.pickle'
 CONF_UPDATE_INTERVAL = 'update_interval'
 ICON = 'mdi:package-variant-closed'
 STATUS_DELIVERED = 'delivered'
@@ -39,8 +40,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the USPS platform."""
     import myusps
     try:
+        cookie = hass.config.path(COOKIE)
         session = myusps.get_session(config.get(CONF_USERNAME),
-                                     config.get(CONF_PASSWORD))
+                                     config.get(CONF_PASSWORD),
+                                     cookie_path=cookie)
     except myusps.USPSError:
         _LOGGER.exception('Could not connect to My USPS')
         return False


### PR DESCRIPTION
**Description:**
This PR fixes issue #5357 and make USPS component to use absolute path to save the cookie file. 
Under some especially configuration environments (especially with symlinks) it can throw some permission errors. 

**Related issue (if applicable):** fixes #5357

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

