### PR TITLE
Bugfix upc with aiohttp 1.2 (cookies)

### DIFF
--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -37,11 +37,9 @@ class AiohttpClientMocker:
             content = b''
         if params:
             url = str(yarl.URL(url).with_query(params))
-        if cookies:
-            self._cookies.update(cookies)
 
         self._mocks.append(AiohttpClientMockResponse(
-            method, url, status, content, exc))
+            method, url, status, content, cookies, exc))
 
     def get(self, *args, **kwargs):
         """Register a mock get request."""
@@ -68,10 +66,6 @@ class AiohttpClientMocker:
         """Number of requests made."""
         return len(self.mock_calls)
 
-    def filter_cookies(self, host):
-        """Return hosts cookies."""
-        return self._cookies
-
     def clear_requests(self):
         """Reset mock calls."""
         self._mocks.clear()
@@ -97,7 +91,7 @@ class AiohttpClientMocker:
 class AiohttpClientMockResponse:
     """Mock Aiohttp client response."""
 
-    def __init__(self, method, url, status, response, exc=None):
+    def __init__(self, method, url, status, response, cookies=None, exc=None):
         """Initialize a fake response."""
         self.method = method
         self._url = url
@@ -106,6 +100,14 @@ class AiohttpClientMockResponse:
         self.status = status
         self.response = response
         self.exc = exc
+
+        self._cookies = {}
+
+        if cookies:
+            for name, data in cookies.items():
+                cookie = mock.MagicMock()
+                cookie.value = data
+                self._cookies[name] = cookie
 
     def match_request(self, method, url, params=None):
         """Test if response answers request."""
@@ -140,6 +142,11 @@ class AiohttpClientMockResponse:
 
         return True
 
+    @property
+    def cookies(self):
+        """Return dict of cookies."""
+        return self._cookies
+
     @asyncio.coroutine
     def read(self):
         """Return mock response."""
@@ -160,6 +167,10 @@ class AiohttpClientMockResponse:
         """Mock release."""
         pass
 
+    def close(self):
+        """Mock close."""
+        pass
+
 
 @contextmanager
 def mock_aiohttp_client():
@@ -172,7 +183,5 @@ def mock_aiohttp_client():
         for method in ('get', 'post', 'put', 'options', 'delete'):
             setattr(instance, method,
                     functools.partial(mocker.match_request, method))
-
-        instance.cookie_jar.filter_cookies = mocker.filter_cookies
 
         yield mocker


### PR DESCRIPTION
**Description:**

Bugfix cookie handling with 1.2 aiohttp.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
