### PR TITLE
Reserve a test port for broken api to fix race

### DIFF
--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -23,7 +23,7 @@ HTTP_BASE_URL = 'http://127.0.0.1:{}'.format(MASTER_PORT)
 
 HA_HEADERS = {HTTP_HEADER_HA_AUTH: API_PASSWORD}
 
-broken_api = remote.API('127.0.0.1', "bladiebla")
+broken_api = remote.API('127.0.0.1', "bladiebla", port=get_test_instance_port())
 hass, slave, master_api = None, None, None
 
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -23,7 +23,7 @@ HTTP_BASE_URL = 'http://127.0.0.1:{}'.format(MASTER_PORT)
 
 HA_HEADERS = {HTTP_HEADER_HA_AUTH: API_PASSWORD}
 
-broken_api = remote.API('127.0.0.1', "bladiebla", port=get_test_instance_port())
+broken_api = remote.API('127.0.0.1', "bladybla", port=get_test_instance_port())
 hass, slave, master_api = None, None, None
 
 


### PR DESCRIPTION
**Description:**
Currently `broken_api` tries to connect to the default port, which might still be listening from other tests depending on py.test speed. This change uses `get_test_instance_port()` for the broken remote API to ensure no other test instance is using this port.