### PR TITLE
Use timezone aware timestamp in flux_update

### DIFF
--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -14,12 +14,11 @@ from homeassistant.components.light import is_on, turn_on
 from homeassistant.components.sun import next_setting, next_rising
 from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
-from homeassistant.helpers.event import track_utc_time_change
+from homeassistant.helpers.event import track_time_change
 from homeassistant.util.color import (
     color_temperature_to_rgb, color_RGB_to_xy,
     color_temperature_kelvin_to_mired, HASS_COLOR_MIN, HASS_COLOR_MAX)
 from homeassistant.util.dt import now as dt_now
-from homeassistant.util.dt import as_local
 import homeassistant.helpers.config_validation as cv
 
 DEPENDENCIES = ['sun', 'light']
@@ -135,8 +134,8 @@ class FluxSwitch(SwitchDevice):
     def turn_on(self, **kwargs):
         """Turn on flux."""
         self._state = True
-        self.unsub_tracker = track_utc_time_change(self.hass, self.flux_update,
-                                                   second=[0, 30])
+        self.unsub_tracker = track_time_change(self.hass, self.flux_update,
+                                               second=[0, 30])
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
@@ -197,8 +196,7 @@ class FluxSwitch(SwitchDevice):
             _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, %s%%"
                          " of %s cycle complete at %s", x_val, y_val,
                          brightness, round(
-                             percentage_complete * 100), time_state,
-                         as_local(now))
+                             percentage_complete * 100), time_state, now)
         else:
             # Convert to mired and clamp to allowed values
             mired = color_temperature_kelvin_to_mired(temp)
@@ -206,8 +204,7 @@ class FluxSwitch(SwitchDevice):
             set_lights_temp(self.hass, self._lights, mired, brightness)
             _LOGGER.info("Lights updated to mired:%s brightness:%s, %s%%"
                          " of %s cycle complete at %s", mired, brightness,
-                         round(percentage_complete * 100),
-                         time_state, as_local(now))
+                         round(percentage_complete * 100), time_state, now)
 
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""


### PR DESCRIPTION
**Description:**
The flux switch was mixing timestamps with and without timezones in the `flux_update` function resulting in incorrect offset calculations. I updated the update function to pass a timezone aware timestamp in to match the other values it is compared against.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

**Example entry for `configuration.yaml` (if applicable):**
```yaml
switch:
  platform: flux
  lights:
    - light.desk
    - light.lamp
  name: Fluxer
  start_time: '7:00'
  stop_time: '23:00'
  start_colortemp: 4000
  sunset_colortemp: 3000
  stop_colortemp: 1900
  brightness: 200
  mode: xy
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
