### PR TITLE
Fix load_yaml default value

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -60,7 +60,7 @@ def load_yaml(fname: str) -> Union[List, Dict]:
         with open(fname, encoding='utf-8') as conf_file:
             # If configuration file is empty YAML returns None
             # We convert that to an empty dict
-            return yaml.load(conf_file, Loader=SafeLineLoader) or {}
+            return yaml.load(conf_file, Loader=SafeLineLoader) or OrderedDict()
     except yaml.YAMLError as exc:
         _LOGGER.error(exc)
         raise HomeAssistantError(exc)

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -74,6 +74,12 @@ class TestYaml(unittest.TestCase):
                 doc = yaml.yaml.safe_load(file)
                 assert doc["key"] == "value"
 
+        with patch_yaml_files({'test.yaml': None}):
+            conf = 'key: !include test.yaml'
+            with io.StringIO(conf) as file:
+                doc = yaml.yaml.safe_load(file)
+                assert doc["key"] == {}
+
     @patch('homeassistant.util.yaml.os.walk')
     def test_include_dir_list(self, mock_walk):
         """Test include dir list yaml."""


### PR DESCRIPTION
**Description:**
`load_yaml` would return an empty dict when the file was empty. This was causing `_add_reference` to blow up because it was trying to set an attribute on an immutable dict.

**Related issue (if applicable):** fixes #5354, fixes #5355

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
