### PR TITLE
Don't use Debian's httpredir for backports

### DIFF
--- a/script/setup_docker_prereqs
+++ b/script/setup_docker_prereqs
@@ -35,7 +35,7 @@ echo "deb http://download.telldus.com/debian/ stable main" >> /etc/apt/sources.l
 wget -qO - http://download.telldus.se/debian/telldus-public.key | apt-key add -
 
 # Add jessie-backports
-echo "deb http://httpredir.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
+echo "deb http://deb.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
 
 # Install packages
 apt-get update


### PR DESCRIPTION
**Description:**

Over in https://github.com/home-assistant/home-assistant/pull/5322#issuecomment-273041585 @balloob mentioned occassional failures when using Debian's `httpredir` to select a local mirror.  This change ditches `httpredir` in favor of the same source used for the main packages, so hopefully that resolves the issue.


**Related pull request:** #5322