### PR TITLE
Fritz install dependencies fix (device_tracker.fritz)

### DIFF
--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -15,9 +15,7 @@ from homeassistant.components.device_tracker import (
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['https://github.com/deisi/fritzconnection/archive/'
-                'b5c14515e1c8e2652b06b6316a7f3913df942841.zip'
-                '#fritzconnection==0.4.6']
+REQUIREMENTS = ['fritzconnection==0.6']
 
 # Return cached results if last scan was less then this time ago.
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -139,6 +139,9 @@ flux_led==0.12
 # homeassistant.components.notify.free_mobile
 freesms==0.1.1
 
+# homeassistant.components.device_tracker.fritz
+# fritzconnection==0.6
+
 # homeassistant.components.conversation
 fuzzywuzzy==0.14.0
 
@@ -209,9 +212,6 @@ https://github.com/bashwork/pymodbus/archive/d7fc4f1cc975631e0a9011390e8017f64b6
 
 # homeassistant.components.media_player.onkyo
 https://github.com/danieljkemp/onkyo-eiscp/archive/python3.zip#onkyo-eiscp==0.9.2
-
-# homeassistant.components.device_tracker.fritz
-# https://github.com/deisi/fritzconnection/archive/b5c14515e1c8e2652b06b6316a7f3913df942841.zip#fritzconnection==0.4.6
 
 # homeassistant.components.netatmo
 https://github.com/jabesq/netatmo-api-python/archive/v0.9.0.zip#lnetatmo==0.9.0


### PR DESCRIPTION
**Description:**
Use fritzconnection version 0.6 from pypi instead of forked old version. Tested on local network, discovery and initial setup now work as expected.

**Related issue (if applicable):** fixes #5389 

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable.
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

