### PR TITLE
Filter new entities from logbook

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -307,6 +307,10 @@ def _exclude_events(events, config):
         if event.event_type == EVENT_STATE_CHANGED:
             to_state = State.from_dict(event.data.get('new_state'))
             # Do not report on new entities
+            if event.data.get('old_state') is None:
+                continue
+
+            # Do not report on entity removal
             if not to_state:
                 continue
 

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -117,6 +117,50 @@ class TestComponentLogbook(unittest.TestCase):
 
         self.assertEqual(0, len(entries))
 
+    def test_exclude_new_entities(self):
+        """Test if events are excluded on first update."""
+        entity_id = 'sensor.bla'
+        entity_id2 = 'sensor.blu'
+        pointA = dt_util.utcnow()
+        pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
+
+        eventA = self.create_state_changed_event(pointA, entity_id, 10)
+        eventB = self.create_state_changed_event(pointB, entity_id2, 20)
+        eventA.data['old_state'] = None
+
+        events = logbook._exclude_events((ha.Event(EVENT_HOMEASSISTANT_STOP),
+                                          eventA, eventB), self.EMPTY_CONFIG)
+        entries = list(logbook.humanify(events))
+
+        self.assertEqual(2, len(entries))
+        self.assert_entry(
+            entries[0], name='Home Assistant', message='stopped',
+            domain=ha.DOMAIN)
+        self.assert_entry(
+            entries[1], pointB, 'blu', domain='sensor', entity_id=entity_id2)
+
+    def test_exclude_removed_entities(self):
+        """Test if events are excluded on last update."""
+        entity_id = 'sensor.bla'
+        entity_id2 = 'sensor.blu'
+        pointA = dt_util.utcnow()
+        pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
+
+        eventA = self.create_state_changed_event(pointA, entity_id, 10)
+        eventB = self.create_state_changed_event(pointB, entity_id2, 20)
+        eventA.data['new_state'] = None
+
+        events = logbook._exclude_events((ha.Event(EVENT_HOMEASSISTANT_STOP),
+                                          eventA, eventB), self.EMPTY_CONFIG)
+        entries = list(logbook.humanify(events))
+
+        self.assertEqual(2, len(entries))
+        self.assert_entry(
+            entries[0], name='Home Assistant', message='stopped',
+            domain=ha.DOMAIN)
+        self.assert_entry(
+            entries[1], pointB, 'blu', domain='sensor', entity_id=entity_id2)
+
     def test_exclude_events_hidden(self):
         """Test if events are excluded if entity is hidden."""
         entity_id = 'sensor.bla'


### PR DESCRIPTION
**Description:**
It looks like the feature that excludes new entities from the logbook was inadvertently dropped. (See links below) This PR adds this feature back and adds tests for it.

https://github.com/home-assistant/home-assistant/commit/e891f1a26067d573bd96f5f60fbb66e6d6cbf1d7#diff-3e3e5f6505a1c15ccc0c0c5d6265b5d4L177
https://github.com/home-assistant/home-assistant/commit/e891f1a26067d573bd96f5f60fbb66e6d6cbf1d7#diff-3e3e5f6505a1c15ccc0c0c5d6265b5d4R271