### PR TITLE
Updated Roku IDLE state

### DIFF
--- a/homeassistant/components/media_player/roku.py
+++ b/homeassistant/components/media_player/roku.py
@@ -17,8 +17,8 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = [
-    'https://github.com/bah2830/python-roku/archive/3.1.2.zip'
-    '#roku==3.1.2']
+    'https://github.com/bah2830/python-roku/archive/3.1.3.zip'
+    '#roku==3.1.3']
 
 KNOWN_HOSTS = []
 DEFAULT_PORT = 8060
@@ -114,8 +114,8 @@ class RokuDevice(MediaPlayerDevice):
         if self.current_app is None:
             return STATE_UNKNOWN
 
-        idle_list = ["Power Saver", "Screensaver", "screensaver"]
-        if any(idle_type in self.current_app.name for idle_type in idle_list):
+        if (self.current_app.name == "Power Saver" or
+                self.current_app.is_screensaver):
             return STATE_IDLE
         elif self.current_app.name == "Roku":
             return STATE_HOME

--- a/homeassistant/components/media_player/roku.py
+++ b/homeassistant/components/media_player/roku.py
@@ -114,7 +114,8 @@ class RokuDevice(MediaPlayerDevice):
         if self.current_app is None:
             return STATE_UNKNOWN
 
-        if self.current_app.name in ["Power Saver", "Default screensaver"]:
+        idle_list = ["Power Saver", "Screensaver", "screensaver"]
+        if any(idle_type in self.current_app.name for idle_type in idle_list):
             return STATE_IDLE
         elif self.current_app.name == "Roku":
             return STATE_HOME

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -202,7 +202,7 @@ https://github.com/Xorso/pyalarmdotcom/archive/0.1.1.zip#pyalarmdotcom==0.1.1
 https://github.com/aparraga/braviarc/archive/0.3.6.zip#braviarc==0.3.6
 
 # homeassistant.components.media_player.roku
-https://github.com/bah2830/python-roku/archive/3.1.2.zip#roku==3.1.2
+https://github.com/bah2830/python-roku/archive/3.1.3.zip#roku==3.1.3
 
 # homeassistant.components.modbus
 https://github.com/bashwork/pymodbus/archive/d7fc4f1cc975631e0a9011390e8017f64b612661.zip#pymodbus==1.2.0


### PR DESCRIPTION
Updated logic to better handle the IDLE state on Roku devices.  When using a screensaver other than "Default Screensaver," the Roku state is never IDLE.  Instead of checking for a specific app name, this change will search for apps containing the word screensaver/Screensaver.