### PR TITLE
[switch.flux] Allow disabling setting the brightness

### DIFF
--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -51,7 +51,7 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Optional(CONF_STOP_CT, default=1900):
         vol.All(vol.Coerce(int), vol.Range(min=1000, max=40000)),
     vol.Optional(CONF_BRIGHTNESS):
-        vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
+        vol.All(vol.Coerce(int), vol.Range(min=-1, max=255)),
     vol.Optional(CONF_MODE, default=DEFAULT_MODE):
         vol.Any(MODE_XY, MODE_MIRED)
 })
@@ -192,6 +192,8 @@ class FluxSwitch(SwitchDevice):
                 temp = self._sunset_colortemp + temp_offset
         x_val, y_val, b_val = color_RGB_to_xy(*color_temperature_to_rgb(temp))
         brightness = self._brightness if self._brightness else b_val
+        if brightness < 0:  # If -1 in config, we disable brightness setting
+            brightness = None
         if self._mode == MODE_XY:
             set_lights_xy(self.hass, self._lights, x_val,
                           y_val, brightness)

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -52,7 +52,7 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Optional(CONF_STOP_CT, default=1900):
         vol.All(vol.Coerce(int), vol.Range(min=1000, max=40000)),
     vol.Optional(CONF_BRIGHTNESS):
-        vol.All(vol.Coerce(int), vol.Range(min=-1, max=255)),
+        vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
     vol.Optional(CONF_DISABLE_BRIGTNESS_ADJUST): cv.boolean,
     vol.Optional(CONF_MODE, default=DEFAULT_MODE):
         vol.Any(MODE_XY, MODE_MIRED)

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -32,6 +32,7 @@ CONF_START_CT = 'start_colortemp'
 CONF_SUNSET_CT = 'sunset_colortemp'
 CONF_STOP_CT = 'stop_colortemp'
 CONF_BRIGHTNESS = 'brightness'
+CONF_DISABLE_BRIGTNESS_ADJUST = 'disable_brightness_adjust'
 CONF_MODE = 'mode'
 
 MODE_XY = 'xy'
@@ -52,6 +53,7 @@ PLATFORM_SCHEMA = vol.Schema({
         vol.All(vol.Coerce(int), vol.Range(min=1000, max=40000)),
     vol.Optional(CONF_BRIGHTNESS):
         vol.All(vol.Coerce(int), vol.Range(min=-1, max=255)),
+    vol.Optional(CONF_DISABLE_BRIGTNESS_ADJUST): cv.boolean,
     vol.Optional(CONF_MODE, default=DEFAULT_MODE):
         vol.Any(MODE_XY, MODE_MIRED)
 })
@@ -88,10 +90,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     sunset_colortemp = config.get(CONF_SUNSET_CT)
     stop_colortemp = config.get(CONF_STOP_CT)
     brightness = config.get(CONF_BRIGHTNESS)
+    disable_brightness_adjust = config.get(CONF_DISABLE_BRIGTNESS_ADJUST)
     mode = config.get(CONF_MODE)
     flux = FluxSwitch(name, hass, False, lights, start_time, stop_time,
                       start_colortemp, sunset_colortemp, stop_colortemp,
-                      brightness, mode)
+                      brightness, disable_brightness_adjust, mode)
     add_devices([flux])
 
     def update(call=None):
@@ -106,7 +109,7 @@ class FluxSwitch(SwitchDevice):
 
     def __init__(self, name, hass, state, lights, start_time, stop_time,
                  start_colortemp, sunset_colortemp, stop_colortemp,
-                 brightness, mode):
+                 brightness, disable_brightness_adjust, mode):
         """Initialize the Flux switch."""
         self._name = name
         self.hass = hass
@@ -118,6 +121,7 @@ class FluxSwitch(SwitchDevice):
         self._sunset_colortemp = sunset_colortemp
         self._stop_colortemp = stop_colortemp
         self._brightness = brightness
+        self._disable_brightness_adjust = disable_brightness_adjust
         self._mode = mode
         self.unsub_tracker = None
 
@@ -192,7 +196,7 @@ class FluxSwitch(SwitchDevice):
                 temp = self._sunset_colortemp + temp_offset
         x_val, y_val, b_val = color_RGB_to_xy(*color_temperature_to_rgb(temp))
         brightness = self._brightness if self._brightness else b_val
-        if brightness < 0:  # If -1 in config, we disable brightness setting
+        if self._disable_brightness_adjust:
             brightness = None
         if self._mode == MODE_XY:
             set_lights_xy(self.hass, self._lights, x_val,


### PR DESCRIPTION
**Description:**
Adds disable_brightness_adjust boolean.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1840


**Example entry for `configuration.yaml` (if applicable):**
```yaml
- platform: flux
  lights:
    - light.x
  name: Fluxer
  start_time: '7:00'
  stop_time: '23:00'
  start_colortemp: 4000
  sunset_colortemp: 3000
  stop_colortemp: 2500
  brightness: 200
  disable_brightness_adjust: True
  mode: mired
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
