### PR TITLE
Fix universal mp service call wth no child

### DIFF
--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -190,6 +190,10 @@ class UniversalMediaPlayer(MediaPlayerDevice):
             return
 
         active_child = self._child_state
+        if active_child is None:
+            # No child to call service on
+            return
+
         service_data[ATTR_ENTITY_ID] = active_child.entity_id
 
         self.hass.services.call(DOMAIN, service_name, service_data,

--- a/tests/components/media_player/test_universal.py
+++ b/tests/components/media_player/test_universal.py
@@ -538,6 +538,25 @@ class TestMediaPlayer(unittest.TestCase):
 
         self.assertEqual(check_flags, ump.supported_media_commands)
 
+    def test_service_call_no_active_child(self):
+        """Test a service call to children with no active child."""
+        config = self.config_children_only
+        universal.validate_config(config)
+
+        ump = universal.UniversalMediaPlayer(self.hass, **config)
+        ump.entity_id = media_player.ENTITY_ID_FORMAT.format(config['name'])
+        ump.update()
+
+        self.mock_mp_1._state = STATE_OFF
+        self.mock_mp_1.update_ha_state()
+        self.mock_mp_2._state = STATE_OFF
+        self.mock_mp_2.update_ha_state()
+        ump.update()
+
+        ump.turn_off()
+        self.assertEqual(0, len(self.mock_mp_1.service_calls['turn_off']))
+        self.assertEqual(0, len(self.mock_mp_2.service_calls['turn_off']))
+
     def test_service_call_to_child(self):
         """Test service calls that should be routed to a child."""
         config = self.config_children_only


### PR DESCRIPTION
**Description:**
This fixes service calls to a universal media player if no child is active. Currently an attribute error is raised when trying to access `entity_id` from `None`.