### PR TITLE
Emulated hue id issue

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -174,20 +174,19 @@ class Config(object):
         except IOError:
             self.device_json_file = open(self.entity_mapping_file_path, 'w')
 
+        self.json_config = EmulatedHueJson()
         try:
             thawed = json.load(self.device_json_file)
-            self.json_config = EmulatedHueJson()
             self.json_config.__dict__ = thawed
         except ValueError:
             _LOGGER.info('Nothing found in configuration file,' +
-                ' creating a new object')
-
-        json.dump(self.json_config.__dict__, self.device_json_file)
-        self.device_json_file.close();
+            ' creating a new object')
+            self.persist_json_config()        
 
     def persist_json_config(self):
         self.device_json_file = open(self.entity_mapping_file_path, 'w')
         json.dump(self.json_config.__dict__, self.device_json_file)
+        self.device_json_file.close()
 
     def entity_id_to_number(self, entity_id):
         """Get a unique number for the entity id."""

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -7,10 +7,12 @@ https://home-assistant.io/components/emulated_hue/
 import asyncio
 import logging
 import hashlib
+import json
 
 import voluptuous as vol
 
 from homeassistant import util
+from homeassistant.config import get_default_config_dir
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
 )
@@ -116,8 +118,10 @@ class Config(object):
     def __init__(self, conf):
         """Initialize the instance."""
         self.type = conf.get(CONF_TYPE)
-        self.numbers = {}
+        self.json_config = EmulatedHueJson()
         self.cached_states = {}
+
+        self.load_json_config()
 
         # Get the IP address that will be passed to the Echo during discovery
         self.host_ip_addr = conf.get(CONF_HOST_IP)
@@ -161,19 +165,46 @@ class Config(object):
         self.exposed_domains = conf.get(
             CONF_EXPOSED_DOMAINS, DEFAULT_EXPOSED_DOMAINS)
 
+    def load_json_config(self): 
+        configDir = get_default_config_dir();
+        self.entity_mapping_file_path =  configDir + '/emulated_hue.json';
+        #Set up or read the json configuration file
+
+        try:
+            self.device_json_file = open(self.entity_mapping_file_path, 'r+')
+        except IOError:
+            self.device_json_file = open(self.entity_mapping_file_path, 'w')
+
+        try:
+            thawed = json.load(self.device_json_file);
+            self.json_config = EmulatedHueJson()
+            self.json_config.__dict__ = thawed
+        except ValueError:
+            _LOGGER.info("Nothing found in configuration file, creating a new object")
+  
+
+        json.dump(self.json_config.__dict__, self.device_json_file)
+        self.device_json_file.close();
+
+    def persist_json_config(self):
+        self.device_json_file = open(self.entity_mapping_file_path, 'w')
+        json.dump(self.json_config.__dict__, self.device_json_file)
+
     def entity_id_to_number(self, entity_id):
         """Get a unique number for the entity id."""
         if self.type == TYPE_ALEXA:
             return entity_id
 
         # Google Home
-        for number, ent_id in self.numbers.items():
+        for number, ent_id in self.json_config.numbers.items():
             if entity_id == ent_id:
                 return number
 
-        number = hashlib.sha1(entity_id.encode('utf-8')).hexdigest()
-        self.numbers[number] = entity_id
-        return number
+        self.json_config.max_id += 1
+        number = self.json_config.max_id
+        self.json_config.numbers[number] = entity_id
+        self.persist_json_config()
+        return int(number)
 
     def number_to_entity_id(self, number):
         """Convert unique number to entity id."""
@@ -182,7 +213,7 @@ class Config(object):
 
         # Google Home
         assert isinstance(number, str)
-        return self.numbers.get(number)
+        return self.json_config.numbers.get(number)
 
     def is_entity_exposed(self, entity):
         """Determine if an entity should be exposed on the emulated bridge.
@@ -206,3 +237,9 @@ class Config(object):
             domain_exposed_by_default and explicit_expose is not False
 
         return is_default_exposed or explicit_expose
+
+class EmulatedHueJson(object):
+
+    def __init__(self):
+        self.numbers = {}
+        self.max_id = 0

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/emulated_hue/
 """
 import asyncio
 import logging
-import hashlib
 import json
 
 import voluptuous as vol
@@ -165,10 +164,10 @@ class Config(object):
         self.exposed_domains = conf.get(
             CONF_EXPOSED_DOMAINS, DEFAULT_EXPOSED_DOMAINS)
 
-    def load_json_config(self): 
-        configDir = get_default_config_dir();
-        self.entity_mapping_file_path =  configDir + '/emulated_hue.json';
-        #Set up or read the json configuration file
+    def load_json_config(self):
+        configDir = get_default_config_dir()
+        self.entity_mapping_file_path = configDir + '/emulated_hue.json'
+        # Set up or read the json configuration file
 
         try:
             self.device_json_file = open(self.entity_mapping_file_path, 'r+')
@@ -180,8 +179,8 @@ class Config(object):
             self.json_config = EmulatedHueJson()
             self.json_config.__dict__ = thawed
         except ValueError:
-            _LOGGER.info("Nothing found in configuration file, creating a new object")
-  
+            _LOGGER.info('Nothing found in configuration file,' +
+		' creating a new object')
 
         json.dump(self.json_config.__dict__, self.device_json_file)
         self.device_json_file.close();
@@ -237,6 +236,7 @@ class Config(object):
             domain_exposed_by_default and explicit_expose is not False
 
         return is_default_exposed or explicit_expose
+
 
 class EmulatedHueJson(object):
 

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -175,12 +175,12 @@ class Config(object):
             self.device_json_file = open(self.entity_mapping_file_path, 'w')
 
         try:
-            thawed = json.load(self.device_json_file);
+            thawed = json.load(self.device_json_file)
             self.json_config = EmulatedHueJson()
             self.json_config.__dict__ = thawed
         except ValueError:
             _LOGGER.info('Nothing found in configuration file,' +
-		' creating a new object')
+                ' creating a new object')
 
         json.dump(self.json_config.__dict__, self.device_json_file)
         self.device_json_file.close();

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/emulated_hue/
 """
 import asyncio
 import logging
+import hashlib
 
 import voluptuous as vol
 
@@ -170,9 +171,9 @@ class Config(object):
             if entity_id == ent_id:
                 return number
 
-        number = str(len(self.numbers) + 1)
+        number = hashlib.sha1(entity_id.encode('utf-8')).hexdigest() 
         self.numbers[number] = entity_id
-        return number
+        return number 
 
     def number_to_entity_id(self, number):
         """Convert unique number to entity id."""

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -181,7 +181,7 @@ class Config(object):
         except ValueError:
             _LOGGER.info('Nothing found in configuration file,' +
             ' creating a new object')
-            self.persist_json_config()        
+            self.persist_json_config()
 
     def persist_json_config(self):
         self.device_json_file = open(self.entity_mapping_file_path, 'w')

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -171,9 +171,9 @@ class Config(object):
             if entity_id == ent_id:
                 return number
 
-        number = hashlib.sha1(entity_id.encode('utf-8')).hexdigest() 
+        number = hashlib.sha1(entity_id.encode('utf-8')).hexdigest()
         self.numbers[number] = entity_id
-        return number 
+        return number
 
     def number_to_entity_id(self, number):
         """Convert unique number to entity id."""

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -1,5 +1,6 @@
 """Test the Emulated Hue component."""
 from unittest.mock import patch
+import hashlib
 
 from homeassistant.components.emulated_hue import Config, _LOGGER
 
@@ -11,15 +12,15 @@ def test_config_google_home_entity_id_to_number():
     })
 
     number = conf.entity_id_to_number('light.test')
-    assert number == '1'
+    assert number == hashlib.sha1(str('light.test').encode('utf-8')).hexdigest()
 
     number = conf.entity_id_to_number('light.test')
-    assert number == '1'
+    assert number == hashlib.sha1(str('light.test').encode('utf-8')).hexdigest()
 
     number = conf.entity_id_to_number('light.test2')
-    assert number == '2'
+    assert number == hashlib.sha1(str('light.test2').encode('utf-8')).hexdigest()
 
-    entity_id = conf.number_to_entity_id('1')
+    entity_id = conf.number_to_entity_id(hashlib.sha1(str('light.test').encode('utf-8')).hexdigest())
     assert entity_id == 'light.test'
 
 

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -13,7 +13,7 @@ def test_config_google_home_entity_id_to_number():
 
     number = conf.entity_id_to_number('light.test')
     expected = hashlib.sha1(str('light.test').encode('utf-8')).hexdigest()
-    assert number == expected 
+    assert number == expected
 
     number = conf.entity_id_to_number('light.test')
     assert number == expected

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -12,15 +12,17 @@ def test_config_google_home_entity_id_to_number():
     })
 
     number = conf.entity_id_to_number('light.test')
-    assert number == hashlib.sha1(str('light.test').encode('utf-8')).hexdigest()
+    expected = hashlib.sha1(str('light.test').encode('utf-8')).hexdigest()
+    assert number == expected 
 
     number = conf.entity_id_to_number('light.test')
-    assert number == hashlib.sha1(str('light.test').encode('utf-8')).hexdigest()
+    assert number == expected
 
     number = conf.entity_id_to_number('light.test2')
-    assert number == hashlib.sha1(str('light.test2').encode('utf-8')).hexdigest()
+    expected2 = hashlib.sha1(str('light.test2').encode('utf-8')).hexdigest()
+    assert number == expected2
 
-    entity_id = conf.number_to_entity_id(hashlib.sha1(str('light.test').encode('utf-8')).hexdigest())
+    entity_id = conf.number_to_entity_id(expected)
     assert entity_id == 'light.test'
 
 


### PR DESCRIPTION
**Description:**
Changed sequential id generated by emulated hue to use hash. Ids are reassigned to the same entities across restarts now. Google Home does not seem to evict devices from rooms any longer.

**Related issue (if applicable):** fixes #5048

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
