### PR TITLE
Add support for Avion Bluetooth dimmer switches

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -189,6 +189,7 @@ omit =
     homeassistant/components/joaoapps_join.py
     homeassistant/components/keyboard.py
     homeassistant/components/keyboard_remote.py
+    homeassistant/components/light/avion.py
     homeassistant/components/light/blinksticklight.py
     homeassistant/components/light/flux_led.py
     homeassistant/components/light/hue.py

--- a/homeassistant/components/light/avion.py
+++ b/homeassistant/components/light/avion.py
@@ -1,0 +1,117 @@
+"""
+Support for Avion dimmers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.avion/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_API_KEY, CONF_DEVICES, CONF_NAME
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light,
+    PLATFORM_SCHEMA)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['avion==0.5']
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORT_AVION_LED = (SUPPORT_BRIGHTNESS)
+
+DEVICE_SCHEMA = vol.Schema({
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Required(CONF_API_KEY): cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up an Avion switch."""
+    lights = []
+    for address, device_config in config[CONF_DEVICES].items():
+        device = {}
+        device['name'] = device_config[CONF_NAME]
+        device['key'] = device_config[CONF_API_KEY]
+        device['address'] = address
+        light = AvionLight(device)
+        if light.is_valid:
+            lights.append(light)
+
+    add_devices(lights)
+
+
+class AvionLight(Light):
+    """Representation of an Avion light."""
+
+    def __init__(self, device):
+        """Initialize the light."""
+        import avion
+
+        self._name = device['name']
+        self._address = device['address']
+        self._key = device["key"]
+        self._brightness = 255
+        self._state = False
+        self._switch = avion.avion(self._address, self._key)
+        self._switch.connect()
+        self.is_valid = True
+
+    @property
+    def unique_id(self):
+        """Return the ID of this light."""
+        return "{}.{}".format(self.__class__, self._address)
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return self._brightness
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_AVION_LED
+
+    @property
+    def should_poll(self):
+        """Don't poll."""
+        return False
+
+    @property
+    def assumed_state(self):
+        """We can't read the actual state, so assume it matches."""
+        return True
+
+    def set_state(self, brightness):
+        """Set the state of this lamp to the provided brightness."""
+        self._switch.set_brightness(brightness)
+        return True
+
+    def turn_on(self, **kwargs):
+        """Turn the specified or all lights on."""
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+
+        if brightness is not None:
+            self._brightness = brightness
+
+        self.set_state(self.brightness)
+        self._state = True
+
+    def turn_off(self, **kwargs):
+        """Turn the specified or all lights off."""
+        self.set_state(0)
+        self._state = False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -49,6 +49,9 @@ apns2==0.1.1
 # homeassistant.components.sun
 astral==1.3.3
 
+# homeassistant.components.light.avion
+avion==0.5
+
 # homeassistant.components.sensor.linux_battery
 batinfo==0.4.2
 


### PR DESCRIPTION
GE sell a range of Bluetooth dimmer switches based on Avi-on technology.
Add a module for controlling them. There's also a set of smart switches that
speak the same protocol, but I don't have any of those to test support with.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1811

**Example entry for `configuration.yaml` (if applicable):**
```yaml
light:
  - platform: avion
    devices:
      28:FD:80:80:63:04:
        name: Lights
        api_key: Gr35a/rt3RgaRenl9ag8Ba==


```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
