### PR TITLE
[sensor/netatmo] Fix if none data is present for a sensor.

### DIFF
--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import TEMP_CELSIUS, STATE_UNKNOWN
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.loader import get_component
@@ -142,7 +142,12 @@ class NetAtmoSensor(Entity):
     def update(self):
         """Get the latest data from NetAtmo API and updates the states."""
         self.netatmo_data.update()
-        data = self.netatmo_data.data[self.module_name]
+        data = self.netatmo_data.data.get(self.module_name)
+
+        if data is None:
+            _LOGGER.warning("No data found for %s", self.module_name)
+            self._state = STATE_UNKNOWN
+            return
 
         if self.type == 'temperature':
             self._state = round(data['Temperature'], 1)


### PR DESCRIPTION
**Description:**

My station going down (reason unknown) but after that I have a lot of trace in my log. After 8 hours it was present automatic after I restart my station. I don't see that on my entity, but it don't change here value anymore. Now we see that on entity too (going state unknown) and don't floot the log anymore.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
