### PR TITLE
Update generic_thermostat.py

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.generic_thermostat/
 """
 import logging
+import time
 
 import voluptuous as vol
 
@@ -16,7 +17,6 @@ from homeassistant.const import (
 from homeassistant.helpers import condition
 from homeassistant.helpers.event import track_state_change
 import homeassistant.helpers.config_validation as cv
-import time
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -134,8 +134,8 @@ class GenericThermostat(ClimateDevice):
         if temperature is None:
             return
         self._target_temp = temperature
+        self.schedule_update_ha_state()
         self._control_heating()
-        self.update_ha_state()
 
     @property
     def min_temp(self):
@@ -163,8 +163,8 @@ class GenericThermostat(ClimateDevice):
             return
 
         self._update_temp(new_state)
-        self._control_heating()
         self.schedule_update_ha_state()
+        self._control_heating()
 
     def _switch_changed(self, entity_id, old_state, new_state):
         """Called when heater switch changes state."""

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
 from homeassistant.helpers import condition
 from homeassistant.helpers.event import track_state_change
 import homeassistant.helpers.config_validation as cv
+import time
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -222,6 +223,7 @@ class GenericThermostat(ClimateDevice):
                 if too_cold:
                     _LOGGER.info('Turning on heater %s', self.heater_entity_id)
                     switch.turn_on(self.hass, self.heater_entity_id)
+        time.sleep(.1)
 
     @property
     def _is_device_active(self):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.generic_thermostat/
 """
 import logging
-import time
 
 import voluptuous as vol
 
@@ -88,6 +87,7 @@ class GenericThermostat(ClimateDevice):
         self._unit = hass.config.units.temperature_unit
 
         track_state_change(hass, sensor_entity_id, self._sensor_changed)
+        track_state_change(hass, heater_entity_id, self._switch_changed)
 
         sensor_state = hass.states.get(sensor_entity_id)
         if sensor_state:
@@ -166,6 +166,12 @@ class GenericThermostat(ClimateDevice):
         self._control_heating()
         self.schedule_update_ha_state()
 
+    def _switch_changed(self, entity_id, old_state, new_state):
+        """Called when heater switch changes state."""
+        if new_state is None:
+            return
+        self.schedule_update_ha_state()
+
     def _update_temp(self, state):
         """Update thermostat with latest state from sensor."""
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
@@ -223,7 +229,6 @@ class GenericThermostat(ClimateDevice):
                 if too_cold:
                     _LOGGER.info('Turning on heater %s', self.heater_entity_id)
                     switch.turn_on(self.hass, self.heater_entity_id)
-        time.sleep(.1)
 
     @property
     def _is_device_active(self):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -134,8 +134,8 @@ class GenericThermostat(ClimateDevice):
         if temperature is None:
             return
         self._target_temp = temperature
-        self.schedule_update_ha_state()
         self._control_heating()
+        self.schedule_update_ha_state()
 
     @property
     def min_temp(self):
@@ -163,8 +163,8 @@ class GenericThermostat(ClimateDevice):
             return
 
         self._update_temp(new_state)
-        self.schedule_update_ha_state()
         self._control_heating()
+        self.schedule_update_ha_state()
 
     def _switch_changed(self, entity_id, old_state, new_state):
         """Called when heater switch changes state."""


### PR DESCRIPTION
After _control_heating() is executed, current_operation() is correctly called but _is_device_active() still reports the old state of the heater switch, at least in my case. The resulting climate state is incorrect until the next refresh, which apparently occurs only when _sensor_changed() gets called (it can be minutes after).

I think the state of the heater switch should be forced to update at the end of  _control_heating(), but I don't know how to do that...
A simple sleep() fixes it, but obviously it's just a temporary workaround, I'm not really expecting this PR to be actually merged, unless there's no other solution.

**Description:**


**Related issue (if applicable):** fixes #5418

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
