### PR TITLE
Fixed pubnubsub-handler version and NoneType error

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -89,7 +89,7 @@ class WinkHub(WinkDevice, BinarySensorDevice, Entity):
 
     def __init(self, wink, hass):
         """Initialize the hub sensor."""
-        WinkDevice.__init__(self, wink, hass)
+        WinkDevice.__init__(wink, hass)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -8,7 +8,6 @@ at https://home-assistant.io/components/binary_sensor.wink/
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.sensor.wink import WinkDevice
 from homeassistant.helpers.entity import Entity
-from homeassistant.loader import get_component
 
 DEPENDENCIES = ['wink']
 
@@ -49,8 +48,7 @@ class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
 
     def __init__(self, wink, hass):
         """Initialize the Wink binary sensor."""
-        super().__init__(wink, hass)
-        wink = get_component('wink')
+        WinkDevice.__init__(self, wink, hass)
         self._unit_of_measurement = self.wink.UNIT
         self.capability = self.wink.capability()
 
@@ -89,7 +87,7 @@ class WinkHub(WinkDevice, BinarySensorDevice, Entity):
 
     def __init(self, wink, hass):
         """Initialize the hub sensor."""
-        WinkDevice.__init__(wink, hass)
+        WinkDevice.__init__(self, wink, hass)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/climate/wink.py
+++ b/homeassistant/components/climate/wink.py
@@ -40,8 +40,7 @@ class WinkThermostat(WinkDevice, ClimateDevice):
 
     def __init__(self, wink, hass, temp_unit):
         """Initialize the Wink device."""
-        super().__init__(wink, hass)
-        wink = get_component('wink')
+        WinkDevice.__init__(self, wink, hass)
         self._config_temp_unit = temp_unit
 
     @property

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -9,7 +9,6 @@ import logging
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.wink import WinkDevice
-from homeassistant.loader import get_component
 
 DEPENDENCIES = ['wink']
 
@@ -40,8 +39,7 @@ class WinkSensorDevice(WinkDevice, Entity):
 
     def __init__(self, wink, hass):
         """Initialize the Wink device."""
-        super().__init__(wink, hass)
-        wink = get_component('wink')
+        WinkDevice.__init__(self, wink, hass)
         self.capability = self.wink.capability()
         if self.wink.UNIT == '°':
             self._unit_of_measurement = TEMP_CELSIUS

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -134,11 +134,6 @@ class WinkDevice(Entity):
             self.update_ha_state(True)
 
     @property
-    def unique_id(self):
-        """Return the ID of this Wink device."""
-        return '{}.{}'.format(self.__class__, self.name)
-
-    @property
     def name(self):
         """Return the name of the device."""
         return self.wink.name()

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-wink==0.12.0', 'pubnubsub-handler==0.0.7']
+REQUIREMENTS = ['python-wink==0.12.0', 'pubnubsub-handler==1.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -112,6 +112,7 @@ class WinkDevice(Entity):
 
     def __init__(self, wink, hass):
         """Initialize the Wink device."""
+        self.hass = hass
         self.wink = wink
         self._battery = self.wink.battery_level
         hass.data[DOMAIN]['pubnub'].add_subscription(
@@ -135,7 +136,7 @@ class WinkDevice(Entity):
     @property
     def unique_id(self):
         """Return the ID of this Wink device."""
-        return '{}.{}'.format(self.__class__, self.wink.device_id())
+        return '{}.{}'.format(self.__class__, self.name)
 
     @property
     def name(self):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-wink==0.12.0', 'pubnubsub-handler==1.0.0']
+REQUIREMENTS = ['python-wink==0.13.0', 'pubnubsub-handler==1.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -363,7 +363,7 @@ proliphix==0.4.1
 psutil==5.0.1
 
 # homeassistant.components.wink
-pubnubsub-handler==0.0.7
+pubnubsub-handler==1.0.0
 
 # homeassistant.components.notify.pushbullet
 pushbullet.py==0.10.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -519,7 +519,7 @@ python-twitch==1.3.0
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==0.12.0
+python-wink==0.13.0
 
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5


### PR DESCRIPTION
**Description:**


**Related issue (if applicable):** Fixes issues reported in this thread https://community.home-assistant.io/t/ha-stops-reporting-wink-state-changes/5884/171

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
