### PR TITLE
added speed and emotion to Yandex tts

### DIFF
--- a/homeassistant/components/tts/yandextts.py
+++ b/homeassistant/components/tts/yandextts.py
@@ -81,7 +81,7 @@ class YandexSpeechKitProvider(Provider):
         self._speaker = conf.get(CONF_VOICE)
         self._language = conf.get(CONF_LANG)
         self._emotion = conf.get(CONF_EMOTION)
-        self._speed = conf.get(CONF_SPEED)
+        self._speed = str(conf.get(CONF_SPEED))
 
     @property
     def default_language(self):

--- a/homeassistant/components/tts/yandextts.py
+++ b/homeassistant/components/tts/yandextts.py
@@ -33,19 +33,34 @@ SUPPORT_VOICES = [
     'jane', 'oksana', 'alyss', 'omazh',
     'zahar', 'ermil'
 ]
+
+SUPPORTED_EMOTION = [
+    'good', 'evil', 'neutral'
+]
+
+MIN_SPEED = 0.1
+MAX_SPEED = 3
+
 CONF_CODEC = 'codec'
 CONF_VOICE = 'voice'
+CONF_EMOTION = 'emotion'
+CONF_SPEED = 'speed'
 
 DEFAULT_LANG = 'en-US'
 DEFAULT_CODEC = 'mp3'
 DEFAULT_VOICE = 'zahar'
-
+DEFAULT_EMOTION = 'neutral'
+DEFAULT_SPEED = 1
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORT_LANGUAGES),
     vol.Optional(CONF_CODEC, default=DEFAULT_CODEC): vol.In(SUPPORT_CODECS),
     vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): vol.In(SUPPORT_VOICES),
+    vol.Optional(CONF_EMOTION, default=DEFAULT_EMOTION):
+        vol.In(SUPPORTED_EMOTION),
+    vol.Optional(CONF_SPEED, default=DEFAULT_SPEED):
+        vol.Range(min=MIN_SPEED, max=MAX_SPEED)
 })
 
 
@@ -65,6 +80,8 @@ class YandexSpeechKitProvider(Provider):
         self._key = conf.get(CONF_API_KEY)
         self._speaker = conf.get(CONF_VOICE)
         self._language = conf.get(CONF_LANG)
+        self._emotion = conf.get(CONF_EMOTION)
+        self._speed = conf.get(CONF_SPEED)
 
     @property
     def default_language(self):
@@ -92,6 +109,8 @@ class YandexSpeechKitProvider(Provider):
                     'key': self._key,
                     'speaker': self._speaker,
                     'format': self._codec,
+                    'emotion': self._emotion,
+                    'speed': self._speed
                 }
 
                 request = yield from websession.get(YANDEX_API_URL,

--- a/tests/components/tts/test_yandextts.py
+++ b/tests/components/tts/test_yandextts.py
@@ -54,10 +54,17 @@ class TestTTSYandexPlatform(object):
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url = "https://tts.voicetech.yandex.net/generate?format=mp3" \
-              "&speaker=zahar&key=1234567xx&text=HomeAssistant&lang=en-US"
+        url_param = {
+            'text': 'HomeAssistant',
+            'lang': 'en-US',
+            'key': '1234567xx',
+            'speaker': 'zahar',
+            'format': 'mp3',
+            'emotion': 'neutral',
+            'speed': 1
+        }
         aioclient_mock.get(
-            url, status=200, content=b'test')
+            self._base_url, status=200, content=b'test', params=url_param)
 
         config = {
             tts.DOMAIN: {
@@ -81,10 +88,17 @@ class TestTTSYandexPlatform(object):
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url = "https://tts.voicetech.yandex.net/generate?format=mp3" \
-              "&speaker=zahar&key=1234567xx&text=HomeAssistant&lang=ru-RU"
+        url_param = {
+            'text': 'HomeAssistant',
+            'lang': 'ru-RU',
+            'key': '1234567xx',
+            'speaker': 'zahar',
+            'format': 'mp3',
+            'emotion': 'neutral',
+            'speed': 1
+        }
         aioclient_mock.get(
-            url, status=200, content=b'test')
+            self._base_url, status=200, content=b'test', params=url_param)
 
         config = {
             tts.DOMAIN: {
@@ -109,10 +123,17 @@ class TestTTSYandexPlatform(object):
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url = "https://tts.voicetech.yandex.net/generate?format=mp3" \
-              "&speaker=zahar&key=1234567xx&text=HomeAssistant&lang=ru-RU"
+        url_param = {
+            'text': 'HomeAssistant',
+            'lang': 'ru-RU',
+            'key': '1234567xx',
+            'speaker': 'zahar',
+            'format': 'mp3',
+            'emotion': 'neutral',
+            'speed': 1
+        }
         aioclient_mock.get(
-            url, status=200, content=b'test')
+            self._base_url, status=200, content=b'test', params=url_param)
 
         config = {
             tts.DOMAIN: {
@@ -137,10 +158,18 @@ class TestTTSYandexPlatform(object):
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url = "https://tts.voicetech.yandex.net/generate?format=mp3" \
-              "&speaker=zahar&key=1234567xx&text=HomeAssistant&lang=en-US"
+        url_param = {
+            'text': 'HomeAssistant',
+            'lang': 'en-US',
+            'key': '1234567xx',
+            'speaker': 'zahar',
+            'format': 'mp3',
+            'emotion': 'neutral',
+            'speed': 1
+        }
         aioclient_mock.get(
-            url, status=200, exc=asyncio.TimeoutError())
+            self._base_url, status=200,
+            exc=asyncio.TimeoutError(), params=url_param)
 
         config = {
             tts.DOMAIN: {
@@ -164,10 +193,17 @@ class TestTTSYandexPlatform(object):
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url = "https://tts.voicetech.yandex.net/generate?format=mp3" \
-              "&speaker=zahar&key=1234567xx&text=HomeAssistant&lang=en-US"
+        url_param = {
+            'text': 'HomeAssistant',
+            'lang': 'en-US',
+            'key': '1234567xx',
+            'speaker': 'zahar',
+            'format': 'mp3',
+            'emotion': 'neutral',
+            'speed': 1
+        }
         aioclient_mock.get(
-            url, status=403, content=b'test')
+            self._base_url, status=403, content=b'test', params=url_param)
 
         config = {
             tts.DOMAIN: {
@@ -190,16 +226,93 @@ class TestTTSYandexPlatform(object):
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url = "https://tts.voicetech.yandex.net/generate?format=mp3" \
-              "&speaker=alyss&key=1234567xx&text=HomeAssistant&lang=en-US"
+        url_param = {
+            'text': 'HomeAssistant',
+            'lang': 'en-US',
+            'key': '1234567xx',
+            'speaker': 'alyss',
+            'format': 'mp3',
+            'emotion': 'neutral',
+            'speed': 1
+        }
         aioclient_mock.get(
-            url, status=200, content=b'test')
+            self._base_url, status=200, content=b'test', params=url_param)
 
         config = {
             tts.DOMAIN: {
                 'platform': 'yandextts',
                 'api_key': '1234567xx',
                 'voice': 'alyss'
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'yandextts_say', {
+            tts.ATTR_MESSAGE: "HomeAssistant",
+        })
+        self.hass.block_till_done()
+
+        assert len(aioclient_mock.mock_calls) == 1
+        assert len(calls) == 1
+
+    def test_service_say_specifed_emotion(self, aioclient_mock):
+        """Test service call say."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        url_param = {
+            'text': 'HomeAssistant',
+            'lang': 'en-US',
+            'key': '1234567xx',
+            'speaker': 'zahar',
+            'format': 'mp3',
+            'emotion': 'evil',
+            'speed': 1
+        }
+        aioclient_mock.get(
+            self._base_url, status=200, content=b'test', params=url_param)
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'yandextts',
+                'api_key': '1234567xx',
+                'emotion': 'evil'
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'yandextts_say', {
+            tts.ATTR_MESSAGE: "HomeAssistant",
+        })
+        self.hass.block_till_done()
+
+        assert len(aioclient_mock.mock_calls) == 1
+        assert len(calls) == 1
+
+    def test_service_say_specifed_speed(self, aioclient_mock):
+        """Test service call say."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        url_param = {
+            'text': 'HomeAssistant',
+            'lang': 'en-US',
+            'key': '1234567xx',
+            'speaker': 'zahar',
+            'format': 'mp3',
+            'emotion': 'neutral',
+            'speed': 2
+        }
+        aioclient_mock.get(
+            self._base_url, status=200, content=b'test', params=url_param)
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'yandextts',
+                'api_key': '1234567xx',
+                'speed': 2
             }
         }
 

--- a/tests/components/tts/test_yandextts.py
+++ b/tests/components/tts/test_yandextts.py
@@ -292,7 +292,42 @@ class TestTTSYandexPlatform(object):
         assert len(aioclient_mock.mock_calls) == 1
         assert len(calls) == 1
 
-    def test_service_say_specifed_speed(self, aioclient_mock):
+    def test_service_say_specified_low_speed(self, aioclient_mock):
+        """Test service call say."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        url_param = {
+            'text': 'HomeAssistant',
+            'lang': 'en-US',
+            'key': '1234567xx',
+            'speaker': 'zahar',
+            'format': 'mp3',
+            'emotion': 'neutral',
+            'speed': '0.1'
+        }
+        aioclient_mock.get(
+            self._base_url, status=200, content=b'test', params=url_param)
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'yandextts',
+                'api_key': '1234567xx',
+                'speed': 0.1
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'yandextts_say', {
+            tts.ATTR_MESSAGE: "HomeAssistant",
+        })
+        self.hass.block_till_done()
+
+        assert len(aioclient_mock.mock_calls) == 1
+        assert len(calls) == 1
+
+    def test_service_say_specified_speed(self, aioclient_mock):
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 


### PR DESCRIPTION
**added speed and emotion to Yandex tts:**

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation :** home-assistant/home-assistant.github.io#1820

**Example entry for `configuration.yaml` (if applicable):**
```yaml
  - platform: yandextts
    api_key: XXXXXXXXXXXXXXXXXc
    language: 'ru-RU'
    voice: oksana
    speed: 0.7
    emotion: evil

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
