### PR TITLE
Updated ISY component to not overwrite state_attributes.

### DIFF
--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -228,10 +228,6 @@ class ISYDevice(Entity):
         self._change_handler = self._node.status.subscribe('changed',
                                                            self.on_update)
 
-    def __del__(self) -> None:
-        """Cleanup the subscriptions."""
-        self._change_handler.unsubscribe()
-
     # pylint: disable=unused-argument
     def on_update(self, event: object) -> None:
         """Handle the update event from the ISY994 Node."""

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -272,7 +272,7 @@ class ISYDevice(Entity):
         return self._node.status._val
 
     @property
-    def state_attributes(self) -> Dict:
+    def device_state_attributes(self) -> Dict:
         """Get the state attributes for the device."""
         attr = {}
         if hasattr(self._node, 'aux_properties'):

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -10,15 +10,10 @@ from typing import Callable
 from homeassistant.components.light import (
     Light, SUPPORT_BRIGHTNESS)
 import homeassistant.components.isy994 as isy
-from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN
+from homeassistant.const import STATE_ON, STATE_OFF
 from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
-
-VALUE_TO_STATE = {
-    False: STATE_OFF,
-    True: STATE_ON,
-}
 
 UOM = ['2', '51', '78']
 STATES = [STATE_OFF, STATE_ON, 'true', 'false', '%']
@@ -52,12 +47,12 @@ class ISYLightDevice(isy.ISYDevice, Light):
     @property
     def is_on(self) -> bool:
         """Get whether the ISY994 light is on."""
-        return self.state == STATE_ON
+        return self.value > 0
 
     @property
-    def state(self) -> str:
-        """Get the state of the ISY994 light."""
-        return VALUE_TO_STATE.get(bool(self.value), STATE_UNKNOWN)
+    def brightness(self) -> float:
+        """Get the brightness of the ISY994 light."""
+        return self.value
 
     def turn_off(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 light device."""

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -70,11 +70,6 @@ class ISYLightDevice(isy.ISYDevice, Light):
             _LOGGER.debug('Unable to turn on light.')
 
     @property
-    def device_state_attributes(self):
-        """Flag supported attributes."""
-        return {ATTR_BRIGHTNESS: self.value}
-
-    @property
     def supported_features(self):
         """Flag supported features."""
         return SUPPORT_BRIGHTNESS

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -70,7 +70,7 @@ class ISYLightDevice(isy.ISYDevice, Light):
             _LOGGER.debug('Unable to turn on light.')
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Flag supported attributes."""
         return {ATTR_BRIGHTNESS: self.value}
 

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -8,7 +8,7 @@ import logging
 from typing import Callable
 
 from homeassistant.components.light import (
-    Light, SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS)
+    Light, SUPPORT_BRIGHTNESS)
 import homeassistant.components.isy994 as isy
 from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType


### PR DESCRIPTION
**Description:**
The ISY component included an ISYDevice base class that is used by all
of the isy994 platforms. This still overwrote the state_attributes
property instead of the more appropriate device_state_attributes
property. This was also repeated in the isy994 light platform. Both of
these were addressed.

This is an alternative fix to PR #5429 

**Related issue (if applicable):** fixes #5428 

**Checklist:**
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
