### PR TITLE
Persist emulated hue IDs

### DIFF
--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -106,7 +106,7 @@ def hass_hue(loop, hass):
 def hue_client(loop, hass_hue, test_client):
     """Create web client for emulated hue api."""
     web_app = mock_http_component_app(hass_hue)
-    config = Config({'type': 'alexa'})
+    config = Config(None, {'type': 'alexa'})
 
     HueUsernameView().register(web_app.router)
     HueAllLightsStateView(config).register(web_app.router)

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -1,31 +1,44 @@
 """Test the Emulated Hue component."""
-from unittest.mock import patch
+import json
+
+from unittest.mock import patch, Mock, mock_open
 
 from homeassistant.components.emulated_hue import Config, _LOGGER
 
 
 def test_config_google_home_entity_id_to_number():
     """Test config adheres to the type."""
-    conf = Config({
+    conf = Config(Mock(), {
         'type': 'google_home'
     })
 
-    number = conf.entity_id_to_number('light.test')
-    assert number == '1'
+    mop = mock_open(read_data=json.dumps({'1': 'light.test2'}))
+    handle = mop()
 
-    number = conf.entity_id_to_number('light.test')
-    assert number == '1'
+    with patch('homeassistant.components.emulated_hue.open', mop, create=True):
+        number = conf.entity_id_to_number('light.test')
+        assert number == '2'
+        assert handle.write.call_count == 1
+        assert json.loads(handle.write.mock_calls[0][1][0]) == {
+            '1': 'light.test2',
+            '2': 'light.test',
+        }
 
-    number = conf.entity_id_to_number('light.test2')
-    assert number == '2'
+        number = conf.entity_id_to_number('light.test')
+        assert number == '2'
+        assert handle.write.call_count == 1
 
-    entity_id = conf.number_to_entity_id('1')
-    assert entity_id == 'light.test'
+        number = conf.entity_id_to_number('light.test2')
+        assert number == '1'
+        assert handle.write.call_count == 1
+
+        entity_id = conf.number_to_entity_id('1')
+        assert entity_id == 'light.test2'
 
 
 def test_config_alexa_entity_id_to_number():
     """Test config adheres to the type."""
-    conf = Config({
+    conf = Config(None, {
         'type': 'alexa'
     })
 
@@ -45,7 +58,7 @@ def test_config_alexa_entity_id_to_number():
 def test_warning_config_google_home_listen_port():
     """Test we warn when non-default port is used for Google Home."""
     with patch.object(_LOGGER, 'warning') as mock_warn:
-        Config({
+        Config(None, {
             'type': 'google_home',
             'host_ip': '123.123.123.123',
             'listen_port': 8300


### PR DESCRIPTION
**Description:**
Persists given IDs by emulated hue. Allows adding rooms in Google Home.

@cribbstechnologies, can you test this? I did not test this and not sure when I will have time to test it.

**Related issue (if applicable):** fixes #5412, fixes #5048

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
