### PR TITLE
[TTS] options support for service calls

### DIFF
--- a/homeassistant/components/tts/demo.py
+++ b/homeassistant/components/tts/demo.py
@@ -43,7 +43,12 @@ class DemoProvider(Provider):
         """List of supported languages."""
         return SUPPORT_LANGUAGES
 
-    def get_tts_audio(self, message, language):
+    @property
+    def supported_options(self):
+        """List of supported options like voice, emotionen."""
+        return ['voice', 'age']
+
+    def get_tts_audio(self, message, language, options=None):
         """Load TTS from demo."""
         filename = os.path.join(os.path.dirname(__file__), "demo.mp3")
         try:

--- a/homeassistant/components/tts/google.py
+++ b/homeassistant/components/tts/google.py
@@ -70,7 +70,7 @@ class GoogleProvider(Provider):
         return SUPPORT_LANGUAGES
 
     @asyncio.coroutine
-    def async_get_tts_audio(self, message, language):
+    def async_get_tts_audio(self, message, language, options=None):
         """Load TTS from google."""
         from gtts_token import gtts_token
 

--- a/homeassistant/components/tts/picotts.py
+++ b/homeassistant/components/tts/picotts.py
@@ -49,7 +49,7 @@ class PicoProvider(Provider):
         """List of supported languages."""
         return SUPPORT_LANGUAGES
 
-    def get_tts_audio(self, message, language):
+    def get_tts_audio(self, message, language, options=None):
         """Load TTS using pico2wave."""
         with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as tmpf:
             fname = tmpf.name

--- a/homeassistant/components/tts/voicerss.py
+++ b/homeassistant/components/tts/voicerss.py
@@ -114,7 +114,7 @@ class VoiceRSSProvider(Provider):
         return SUPPORT_LANGUAGES
 
     @asyncio.coroutine
-    def async_get_tts_audio(self, message, language):
+    def async_get_tts_audio(self, message, language, options=None):
         """Load TTS from VoiceRSS."""
         websession = async_get_clientsession(self.hass)
         form_data = self._form_data.copy()

--- a/homeassistant/components/tts/yandextts.py
+++ b/homeassistant/components/tts/yandextts.py
@@ -77,7 +77,7 @@ class YandexSpeechKitProvider(Provider):
         return SUPPORT_LANGUAGES
 
     @asyncio.coroutine
-    def async_get_tts_audio(self, message, language):
+    def async_get_tts_audio(self, message, language, options=None):
         """Load TTS from yandex."""
         websession = async_get_clientsession(self.hass)
 

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -82,11 +82,11 @@ class TestTTS(object):
         assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
         assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
             "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_en_demo.mp3") \
+            "_en_-_demo.mp3") \
             != -1
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_-_demo.mp3"))
 
     def test_setup_component_and_test_service_with_config_language(self):
         """Setup the demo platform and call service."""
@@ -111,11 +111,11 @@ class TestTTS(object):
         assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
         assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
             "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_de_demo.mp3") \
+            "_de_-_demo.mp3") \
             != -1
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_de_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_de_-_demo.mp3"))
 
     def test_setup_component_and_test_service_with_wrong_conf_language(self):
         """Setup the demo platform and call service with wrong config."""
@@ -152,11 +152,11 @@ class TestTTS(object):
         assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
         assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
             "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_de_demo.mp3") \
+            "_de_-_demo.mp3") \
             != -1
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_de_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_de_-_demo.mp3"))
 
     def test_setup_component_test_service_with_wrong_service_language(self):
         """Setup the demo platform and call service."""
@@ -180,7 +180,7 @@ class TestTTS(object):
         assert len(calls) == 0
         assert not os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_lang_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_lang_-_demo.mp3"))
 
     def test_setup_component_and_test_service_clear_cache(self):
         """Setup the demo platform and call service clear cache."""
@@ -203,14 +203,14 @@ class TestTTS(object):
         assert len(calls) == 1
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_-_demo.mp3"))
 
         self.hass.services.call(tts.DOMAIN, tts.SERVICE_CLEAR_CACHE, {})
         self.hass.block_till_done()
 
         assert not os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_-_demo.mp3"))
 
     def test_setup_component_and_test_service_with_receive_voice(self):
         """Setup the demo platform and call service and receive voice."""
@@ -278,7 +278,7 @@ class TestTTS(object):
         self.hass.start()
 
         url = ("{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-               "_en_demo.mp3").format(self.hass.config.api.base_url)
+               "_en_-_demo.mp3").format(self.hass.config.api.base_url)
 
         req = requests.get(url)
         assert req.status_code == 404
@@ -297,7 +297,7 @@ class TestTTS(object):
         self.hass.start()
 
         url = ("{}/api/tts_proxy/265944dsk32c1b2a621be5930510bb2cd"
-               "_en_demo.mp3").format(self.hass.config.api.base_url)
+               "_en_-_demo.mp3").format(self.hass.config.api.base_url)
 
         req = requests.get(url)
         assert req.status_code == 404
@@ -324,7 +324,7 @@ class TestTTS(object):
         assert len(calls) == 1
         assert not os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_-_demo.mp3"))
 
     def test_setup_component_test_with_cache_call_service_without_cache(self):
         """Setup demo platform with cache and call service without cache."""
@@ -349,7 +349,7 @@ class TestTTS(object):
         assert len(calls) == 1
         assert not os.path.isfile(os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3"))
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_-_demo.mp3"))
 
     def test_setup_component_test_with_cache_dir(self):
         """Setup demo platform with cache and call service without cache."""
@@ -358,7 +358,7 @@ class TestTTS(object):
         _, demo_data = self.demo_provider.get_tts_audio("bla", 'en')
         cache_file = os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3")
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_-_demo.mp3")
 
         os.mkdir(self.default_tts_cache)
         with open(cache_file, "wb") as voice_file:
@@ -384,7 +384,7 @@ class TestTTS(object):
         assert len(calls) == 1
         assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
             "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_en_demo.mp3") \
+            "_en_-_demo.mp3") \
             != -1
 
     @patch('homeassistant.components.tts.demo.DemoProvider.get_tts_audio',
@@ -414,7 +414,7 @@ class TestTTS(object):
         _, demo_data = self.demo_provider.get_tts_audio("bla", 'en')
         cache_file = os.path.join(
             self.default_tts_cache,
-            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_demo.mp3")
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_-_demo.mp3")
 
         os.mkdir(self.default_tts_cache)
         with open(cache_file, "wb") as voice_file:
@@ -433,7 +433,7 @@ class TestTTS(object):
         self.hass.start()
 
         url = ("{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-               "_en_demo.mp3").format(self.hass.config.api.base_url)
+               "_en_-_demo.mp3").format(self.hass.config.api.base_url)
 
         req = requests.get(url)
         assert req.status_code == 200


### PR DESCRIPTION
**Description:**

TTS component Support now platform deepens options like voice, age or speed. They also usable for service call.

```
service: tts.xy_say
data:
  message: 'That is a test!'
  options:
    motion: angry
    speed: 0.1
    voice: alex
    age: 25
```

Todo:
- [x] unittest

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
