### PR TITLE
add a small sleep before reading the rpi-gpio sensor

### DIFF
--- a/homeassistant/components/binary_sensor/rpi_gpio.py
+++ b/homeassistant/components/binary_sensor/rpi_gpio.py
@@ -4,6 +4,8 @@ Support for binary sensor using RPi GPIO.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.rpi_gpio/
 """
+from time import sleep
+
 import logging
 
 import voluptuous as vol
@@ -13,8 +15,6 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDevice, PLATFORM_SCHEMA)
 from homeassistant.const import DEVICE_DEFAULT_NAME
 import homeassistant.helpers.config_validation as cv
-
-from time import sleep
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/binary_sensor/rpi_gpio.py
+++ b/homeassistant/components/binary_sensor/rpi_gpio.py
@@ -4,8 +4,6 @@ Support for binary sensor using RPi GPIO.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.rpi_gpio/
 """
-from time import sleep
-
 import logging
 
 import voluptuous as vol
@@ -53,7 +51,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for port_num, port_name in ports.items():
         binary_sensors.append(RPiGPIOBinarySensor(
             port_name, port_num, pull_mode, bouncetime, invert_logic))
-    add_devices(binary_sensors)
+    add_devices(binary_sensors, True)
 
 
 class RPiGPIOBinarySensor(BinarySensorDevice):
@@ -69,8 +67,6 @@ class RPiGPIOBinarySensor(BinarySensorDevice):
         self._invert_logic = invert_logic
 
         rpi_gpio.setup_input(self._port, self._pull_mode)
-        sleep(bouncetime/1000)
-        self._state = rpi_gpio.read_input(self._port)
 
         def read_gpio(port):
             """Read state from GPIO."""
@@ -93,3 +89,7 @@ class RPiGPIOBinarySensor(BinarySensorDevice):
     def is_on(self):
         """Return the state of the entity."""
         return self._state != self._invert_logic
+
+    def update(self):
+        """Update the GPIO state."""
+        self._state = rpi_gpio.read_input(self._port)

--- a/homeassistant/components/binary_sensor/rpi_gpio.py
+++ b/homeassistant/components/binary_sensor/rpi_gpio.py
@@ -65,6 +65,7 @@ class RPiGPIOBinarySensor(BinarySensorDevice):
         self._pull_mode = pull_mode
         self._bouncetime = bouncetime
         self._invert_logic = invert_logic
+        self._state = None
 
         rpi_gpio.setup_input(self._port, self._pull_mode)
 

--- a/homeassistant/components/binary_sensor/rpi_gpio.py
+++ b/homeassistant/components/binary_sensor/rpi_gpio.py
@@ -14,6 +14,8 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import DEVICE_DEFAULT_NAME
 import homeassistant.helpers.config_validation as cv
 
+from time import sleep
+
 _LOGGER = logging.getLogger(__name__)
 
 CONF_BOUNCETIME = 'bouncetime'
@@ -67,6 +69,7 @@ class RPiGPIOBinarySensor(BinarySensorDevice):
         self._invert_logic = invert_logic
 
         rpi_gpio.setup_input(self._port, self._pull_mode)
+        sleep(bouncetime/1000)
         self._state = rpi_gpio.read_input(self._port)
 
         def read_gpio(port):


### PR DESCRIPTION
**Description:**
The read of the sensor might be incorrect if it's read too soon after the setup_input call. It might be isolated to my case where I rely on the the PI internal PULL, but once I added this sleep I never get false initial read. If you think this change is appropriate please merge it.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
