### PR TITLE
[sensor.usps] Add name and update requirements

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -319,7 +319,7 @@ mficlient==0.3.0
 miflora==0.1.14
 
 # homeassistant.components.sensor.usps
-myusps==1.0.1
+myusps==1.0.2
 
 # homeassistant.components.discovery
 netdisco==0.8.1


### PR DESCRIPTION
**Description:**

- Fix for error when no packages are available
- Fix for error when Shipped From field is empty
- Add `name` field to avoid default where sensor name is address

Documentation PR coming to address non-bug user difficulties.

references: https://community.home-assistant.io/t/new-usps-sensor/9740, https://community.home-assistant.io/t/usps-sensor-name/9991

**Example entry for `configuration.yaml` (if applicable):**
```yaml
- platform: usps
  name: 'Deliveries'
  username: !env_var MYUSPS_USERNAME
  password: !env_var MYUSPS_PASSWORD
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
