### PR TITLE
Fix OwnTracks state names

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -190,7 +190,7 @@ def setup_scanner(hass, config, see):
             return
         # OwnTracks uses - at the start of a beacon zone
         # to switch on 'hold mode' - ignore this
-        location = slugify(data['desc'].lstrip("-"))
+        location = data['desc'].lstrip("-")
         if location.lower() == 'home':
             location = STATE_HOME
 
@@ -198,7 +198,7 @@ def setup_scanner(hass, config, see):
 
         def enter_event():
             """Execute enter event."""
-            zone = hass.states.get("zone.{}".format(location))
+            zone = hass.states.get("zone.{}".format(slugify(location)))
             with LOCK:
                 if zone is None and data.get('t') == 'b':
                     # Not a HA zone, and a beacon so assume mobile
@@ -227,7 +227,7 @@ def setup_scanner(hass, config, see):
 
                 if new_region:
                     # Exit to previous region
-                    zone = hass.states.get("zone.{}".format(new_region))
+                    zone = hass.states.get("zone.{}".format(slugify(new_region)))
                     _set_gps_from_zone(kwargs, new_region, zone)
                     _LOGGER.info("Exit to %s", new_region)
                     see(**kwargs)

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -227,7 +227,8 @@ def setup_scanner(hass, config, see):
 
                 if new_region:
                     # Exit to previous region
-                    zone = hass.states.get("zone.{}".format(slugify(new_region)))
+                    zone = hass.states.get(
+                        "zone.{}".format(slugify(new_region)))
                     _set_gps_from_zone(kwargs, new_region, zone)
                     _LOGGER.info("Exit to %s", new_region)
                     see(**kwargs)

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -377,7 +377,7 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
         message = REGION_ENTER_MESSAGE.copy()
         message['desc'] = "inner 2"
         self.send_message(EVENT_TOPIC, message)
-        self.assert_location_state('inner_2')
+        self.assert_location_state('inner 2')
 
         message = REGION_LEAVE_MESSAGE.copy()
         message['desc'] = "inner 2"


### PR DESCRIPTION
**Description:**
Fixes OwnTracks state names sometimes not matching their corresponding zone.

**Related issue (if applicable):** fixes #5453

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
