### PR TITLE
[binary_sensor.arest] Fix name for sensor and shorten logger messages

### DIFF
--- a/homeassistant/components/binary_sensor/arest.py
+++ b/homeassistant/components/binary_sensor/arest.py
@@ -30,7 +30,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the aREST binary sensor."""
+    """Set up the aREST binary sensor."""
     resource = config.get(CONF_RESOURCE)
     pin = config.get(CONF_PIN)
     sensor_class = config.get(CONF_SENSOR_CLASS)
@@ -38,13 +38,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         response = requests.get(resource, timeout=10).json()
     except requests.exceptions.MissingSchema:
-        _LOGGER.error('Missing resource or schema in configuration. '
-                      'Add http:// to your URL.')
+        _LOGGER.error("Missing resource or schema in configuration. "
+                      "Add http:// to your URL")
         return False
     except requests.exceptions.ConnectionError:
-        _LOGGER.error('No route to device at %s. '
-                      'Please check the IP address in the configuration file.',
-                      resource)
+        _LOGGER.error("No route to device at %s", resource)
         return False
 
     arest = ArestData(resource, pin)
@@ -67,10 +65,10 @@ class ArestBinarySensor(BinarySensorDevice):
         self.update()
 
         if self._pin is not None:
-            request = requests.get('{}/mode/{}/i'.format
-                                   (self._resource, self._pin), timeout=10)
+            request = requests.get(
+                '{}/mode/{}/i'.format(self._resource, self._pin), timeout=10)
             if request.status_code is not 200:
-                _LOGGER.error("Can't set mode. Is device offline?")
+                _LOGGER.error("Can't set mode of %s", self._resource)
 
     @property
     def name(self):
@@ -109,5 +107,4 @@ class ArestData(object):
                 self._resource, self._pin), timeout=10)
             self.data = {'state': response.json()['return_value']}
         except requests.exceptions.ConnectionError:
-            _LOGGER.error("No route to device '%s'. Is device offline?",
-                          self._resource)
+            _LOGGER.error("No route to device '%s'", self._resource)

--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -29,7 +29,7 @@ CONF_PINS = 'pins'
 DEFAULT_NAME = 'aREST sensor'
 
 PIN_VARIABLE_SCHEMA = vol.Schema({
-    vol.Required(CONF_NAME): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
 })
@@ -89,7 +89,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             renderer = make_renderer(var_data.get(CONF_VALUE_TEMPLATE))
             dev.append(ArestSensor(
                 arest, resource, config.get(CONF_NAME, response[CONF_NAME]),
-                var_data.get(CONF_NAME), variable=variable,
+                var_data.get(CONF_NAME, variable), variable=variable,
                 unit_of_measurement=var_data.get(CONF_UNIT_OF_MEASUREMENT),
                 renderer=renderer))
 

--- a/homeassistant/components/sensor/arest.py
+++ b/homeassistant/components/sensor/arest.py
@@ -29,7 +29,7 @@ CONF_PINS = 'pins'
 DEFAULT_NAME = 'aREST sensor'
 
 PIN_VARIABLE_SCHEMA = vol.Schema({
-    vol.Optional(CONF_NAME): cv.string,
+    vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
 })
@@ -45,7 +45,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the aREST sensor."""
+    """Set up the aREST sensor."""
     resource = config.get(CONF_RESOURCE)
     var_conf = config.get(CONF_MONITORED_VARIABLES)
     pins = config.get(CONF_PINS)
@@ -54,12 +54,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         response = requests.get(resource, timeout=10).json()
     except requests.exceptions.MissingSchema:
         _LOGGER.error("Missing resource or schema in configuration. "
-                      "Add http:// to your URL.")
+                      "Add http:// to your URL")
         return False
     except requests.exceptions.ConnectionError:
-        _LOGGER.error("No route to device at %s. "
-                      "Please check the IP address in the configuration file.",
-                      resource)
+        _LOGGER.error("No route to device at %s", resource)
         return False
 
     arest = ArestData(resource)
@@ -75,7 +73,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             try:
                 return value_template.async_render({'value': value})
             except TemplateError:
-                _LOGGER.exception('Error parsing value')
+                _LOGGER.exception("Error parsing value")
                 return value
 
         return _render
@@ -91,7 +89,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             renderer = make_renderer(var_data.get(CONF_VALUE_TEMPLATE))
             dev.append(ArestSensor(
                 arest, resource, config.get(CONF_NAME, response[CONF_NAME]),
-                variable, variable=variable,
+                var_data.get(CONF_NAME), variable=variable,
                 unit_of_measurement=var_data.get(CONF_UNIT_OF_MEASUREMENT),
                 renderer=renderer))
 
@@ -127,7 +125,7 @@ class ArestSensor(Entity):
             request = requests.get(
                 '{}/mode/{}/i'.format(self._resource, self._pin), timeout=10)
             if request.status_code is not 200:
-                _LOGGER.error("Can't set mode. Is device offline?")
+                _LOGGER.error("Can't set mode of %s", self._resource)
 
     @property
     def name(self):
@@ -184,15 +182,11 @@ class ArestData(object):
                         response = requests.get('{}/analog/{}'.format(
                             self._resource, self._pin[1:]), timeout=10)
                         self.data = {'value': response.json()['return_value']}
-                    else:
-                        _LOGGER.error("Wrong pin naming. "
-                                      "Please check your configuration file.")
                 except TypeError:
                     response = requests.get('{}/digital/{}'.format(
                         self._resource, self._pin), timeout=10)
                     self.data = {'value': response.json()['return_value']}
             self.available = True
         except requests.exceptions.ConnectionError:
-            _LOGGER.error("No route to device %s. Is device offline?",
-                          self._resource)
+            _LOGGER.error("No route to device %s", self._resource)
             self.available = False

--- a/homeassistant/components/switch/arest.py
+++ b/homeassistant/components/switch/arest.py
@@ -36,19 +36,17 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the aREST switches."""
+    """Set up the aREST switches."""
     resource = config.get(CONF_RESOURCE)
 
     try:
         response = requests.get(resource, timeout=10)
     except requests.exceptions.MissingSchema:
         _LOGGER.error("Missing resource or schema in configuration. "
-                      "Add http:// to your URL.")
+                      "Add http:// to your URL")
         return False
     except requests.exceptions.ConnectionError:
-        _LOGGER.error("No route to device at %s. "
-                      "Please check the IP address in the configuration file.",
-                      resource)
+        _LOGGER.error("No route to device at %s", resource)
         return False
 
     dev = []
@@ -105,16 +103,15 @@ class ArestSwitchFunction(ArestSwitchBase):
             '{}/{}'.format(self._resource, self._func), timeout=10)
 
         if request.status_code is not 200:
-            _LOGGER.error("Can't find function. Is device offline?")
+            _LOGGER.error("Can't find function")
             return
 
         try:
             request.json()['return_value']
         except KeyError:
-            _LOGGER.error("No return_value received. "
-                          "Is the function name correct.")
+            _LOGGER.error("No return_value received")
         except ValueError:
-            _LOGGER.error("Response invalid. Is the function name correct?")
+            _LOGGER.error("Response invalid")
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
@@ -125,8 +122,8 @@ class ArestSwitchFunction(ArestSwitchBase):
         if request.status_code == 200:
             self._state = True
         else:
-            _LOGGER.error("Can't turn on function %s at %s. "
-                          "Is device offline?", self._func, self._resource)
+            _LOGGER.error(
+                "Can't turn on function %s at %s", self._func, self._resource)
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
@@ -137,19 +134,18 @@ class ArestSwitchFunction(ArestSwitchBase):
         if request.status_code == 200:
             self._state = False
         else:
-            _LOGGER.error("Can't turn off function %s at %s. "
-                          "Is device offline?", self._func, self._resource)
+            _LOGGER.error(
+                "Can't turn off function %s at %s", self._func, self._resource)
 
     def update(self):
         """Get the latest data from aREST API and update the state."""
         try:
-            request = requests.get('{}/{}'.format(self._resource,
-                                                  self._func), timeout=10)
+            request = requests.get(
+                '{}/{}'.format(self._resource, self._func), timeout=10)
             self._state = request.json()['return_value'] != 0
             self._available = True
         except requests.exceptions.ConnectionError:
-            _LOGGER.warning("No route to device %s. Is device offline?",
-                            self._resource)
+            _LOGGER.warning("No route to device %s", self._resource)
             self._available = False
 
 
@@ -164,7 +160,7 @@ class ArestSwitchPin(ArestSwitchBase):
         request = requests.get(
             '{}/mode/{}/o'.format(self._resource, self._pin), timeout=10)
         if request.status_code is not 200:
-            _LOGGER.error("Can't set mode. Is device offline?")
+            _LOGGER.error("Can't set mode")
             self._available = False
 
     def turn_on(self, **kwargs):
@@ -174,8 +170,8 @@ class ArestSwitchPin(ArestSwitchBase):
         if request.status_code == 200:
             self._state = True
         else:
-            _LOGGER.error("Can't turn on pin %s at %s. Is device offline?",
-                          self._pin, self._resource)
+            _LOGGER.error(
+                "Can't turn on pin %s at %s", self._pin, self._resource)
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
@@ -184,18 +180,16 @@ class ArestSwitchPin(ArestSwitchBase):
         if request.status_code == 200:
             self._state = False
         else:
-            _LOGGER.error("Can't turn off pin %s at %s. Is device offline?",
-                          self._pin, self._resource)
+            _LOGGER.error(
+                "Can't turn off pin %s at %s", self._pin, self._resource)
 
     def update(self):
         """Get the latest data from aREST API and update the state."""
         try:
-            request = requests.get('{}/digital/{}'.format(self._resource,
-                                                          self._pin),
-                                   timeout=10)
+            request = requests.get(
+                '{}/digital/{}'.format(self._resource, self._pin), timeout=10)
             self._state = request.json()['return_value'] != 0
             self._available = True
         except requests.exceptions.ConnectionError:
-            _LOGGER.warning("No route to device %s. Is device offline?",
-                            self._resource)
+            _LOGGER.warning("No route to device %s", self._resource)
             self._available = False


### PR DESCRIPTION
**Description:**
The `name:` was not used but the variable/function name. The sensor platform configuration is now sync with the one from the switch. 

**Related issue (if applicable):** fixes #5226

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1834

**Example entry for `configuration.yaml` (if applicable):**
```yaml
  - platform: arest
    resource: http://192.168.0.18
    monitored_variables:
      temperature:
        name: Outdoor
        unit_of_measurement: '°C'
        value_template: '{{ value | round(1) }}'
      humidity:
        name: hum XYZ
        unit_of_measurement: '%'
        value_template: '{{ value | round(1) }}'
    pins:
      3:
        name: Pin 3 digital
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
