### PR TITLE
[ffmpeg] Use new 1.0 version / migrate all asyncio

### DIFF
--- a/homeassistant/components/binary_sensor/ffmpeg.py
+++ b/homeassistant/components/binary_sensor/ffmpeg.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/binary_sensor.ffmpeg/
 """
 import asyncio
 import logging
-from os
+import os
 
 import voluptuous as vol
 

--- a/homeassistant/components/binary_sensor/ffmpeg.py
+++ b/homeassistant/components/binary_sensor/ffmpeg.py
@@ -102,7 +102,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         yield from entity.async_shutdown_ffmpeg()
 
     hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, async_shutdown())
+        EVENT_HOMEASSISTANT_STOP, async_shutdown)
 
     # start on startup
     if config.get(CONF_INITIAL_STATE):
@@ -112,7 +112,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             yield from entity.async_start_ffmpeg()
 
         hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_START, async_start())
+            EVENT_HOMEASSISTANT_START, async_start)
 
     # add to system
     yield from async_add_devices([entity])

--- a/homeassistant/components/binary_sensor/ffmpeg.py
+++ b/homeassistant/components/binary_sensor/ffmpeg.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/binary_sensor.ffmpeg/
 """
 import asyncio
 import logging
-from os import path
+from os
 
 import voluptuous as vol
 
@@ -89,9 +89,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     # generate sensor object
     if config.get(CONF_TOOL) == FFMPEG_SENSOR_NOISE:
-        entity = FFmpegNoise(SensorNoise, config)
+        entity = FFmpegNoise(hass, SensorNoise, config)
     else:
-        entity = FFmpegMotion(SensorMotion, config)
+        entity = FFmpegMotion(hass, SensorMotion, config)
 
     @asyncio.coroutine
     def async_shutdown(event):
@@ -110,7 +110,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         EVENT_HOMEASSISTANT_START, async_start())
 
     # add to system
-    yield from async_add_devies([entity])
+    yield from async_add_devices([entity])
     DEVICES.append(entity)
 
     # exists service?
@@ -145,7 +145,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class FFmpegBinarySensor(BinarySensorDevice):
     """A binary sensor which use ffmpeg for noise detection."""
 
-    def __init__(self, ffobj, config):
+    def __init__(self, hass, ffobj, config):
         """Constructor for binary sensor noise detection."""
         self._manager = hass.data[DATA_FFMPEG]
         self._state = False

--- a/homeassistant/components/binary_sensor/services.yaml
+++ b/homeassistant/components/binary_sensor/services.yaml
@@ -1,7 +1,23 @@
 # Describes the format for available binary_sensor services
 
+ffmpeg_start:
+  description: Send a start command to a ffmpeg based sensor.
+
+  fields:
+    entity_id:
+      description: Name(s) of entites that will start. Platform dependent.
+      example: 'binary_sensor.ffmpeg_noise'
+
+ffmpeg_stop:
+  description: Send a stop command to a ffmpeg based sensor.
+
+  fields:
+    entity_id:
+      description: Name(s) of entites that will stop. Platform dependent.
+      example: 'binary_sensor.ffmpeg_noise'
+
 ffmpeg_restart:
-  description: Send a restart command to a ffmpeg based sensor (party mode).
+  description: Send a restart command to a ffmpeg based sensor.
 
   fields:
     entity_id:

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -12,10 +12,9 @@ from aiohttp import web
 
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.components.ffmpeg import (
-    async_run_test, get_binary, CONF_INPUT, CONF_EXTRA_ARGUMENTS)
+    DATA_FFMPEG, CONF_INPUT, CONF_EXTRA_ARGUMENTS)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_NAME
-from homeassistant.util.async import run_coroutine_threadsafe
 
 DEPENDENCIES = ['ffmpeg']
 
@@ -33,7 +32,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup a FFmpeg Camera."""
-    if not async_run_test(hass, config.get(CONF_INPUT)):
+    if not hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_INPUT)):
         return
     yield from async_add_devices([FFmpegCamera(hass, config)])
 
@@ -44,20 +43,17 @@ class FFmpegCamera(Camera):
     def __init__(self, hass, config):
         """Initialize a FFmpeg camera."""
         super().__init__()
+
+        self._manager = hass.data[DATA_FFMPEG]
         self._name = config.get(CONF_NAME)
         self._input = config.get(CONF_INPUT)
         self._extra_arguments = config.get(CONF_EXTRA_ARGUMENTS)
 
-    def camera_image(self):
-        """Return bytes of camera image."""
-        return run_coroutine_threadsafe(
-            self.async_camera_image(), self.hass.loop).result()
-
     @asyncio.coroutine
     def async_camera_image(self):
         """Return a still image response from the camera."""
-        from haffmpeg import ImageSingleAsync, IMAGE_JPEG
-        ffmpeg = ImageSingleAsync(get_binary(), loop=self.hass.loop)
+        from haffmpeg import ImageFrame, IMAGE_JPEG
+        ffmpeg = ImageFrame(self._manager.binary, loop=self.hass.loop)
 
         image = yield from ffmpeg.get_image(
             self._input, output_format=IMAGE_JPEG,
@@ -67,9 +63,9 @@ class FFmpegCamera(Camera):
     @asyncio.coroutine
     def handle_async_mjpeg_stream(self, request):
         """Generate an HTTP MJPEG stream from the camera."""
-        from haffmpeg import CameraMjpegAsync
+        from haffmpeg import CameraMjpeg
 
-        stream = CameraMjpegAsync(get_binary(), loop=self.hass.loop)
+        stream = CameraMjpeg(self._manager.binary, loop=self.hass.loop)
         yield from stream.open_camera(
             self._input, extra_cmd=self._extra_arguments)
 

--- a/homeassistant/components/ffmpeg.py
+++ b/homeassistant/components/ffmpeg.py
@@ -10,12 +10,13 @@ import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util.async import run_coroutine_threadsafe
 
 DOMAIN = 'ffmpeg'
-REQUIREMENTS = ["ha-ffmpeg==0.15"]
+REQUIREMENTS = ["ha-ffmpeg==1.0"]
 
 _LOGGER = logging.getLogger(__name__)
+
+DATA_FFMPEG = 'ffmpeg'
 
 CONF_INPUT = 'input'
 CONF_FFMPEG_BIN = 'ffmpeg_bin'
@@ -34,53 +35,54 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-FFMPEG_CONFIG = {
-    CONF_FFMPEG_BIN: DEFAULT_BINARY,
-    CONF_RUN_TEST: DEFAULT_RUN_TEST,
-}
-FFMPEG_TEST_CACHE = {}
-
-
-def setup(hass, config):
-    """Setup the FFmpeg component."""
-    if DOMAIN in config:
-        FFMPEG_CONFIG.update(config.get(DOMAIN))
-    return True
-
-
-def get_binary():
-    """Return ffmpeg binary from config.
-
-    Async friendly.
-    """
-    return FFMPEG_CONFIG.get(CONF_FFMPEG_BIN)
-
-
-def run_test(hass, input_source):
-    """Run test on this input. TRUE is deactivate or run correct."""
-    return run_coroutine_threadsafe(
-        async_run_test(hass, input_source), hass.loop).result()
-
-
 @asyncio.coroutine
-def async_run_test(hass, input_source):
-    """Run test on this input. TRUE is deactivate or run correct.
+def async_setup(hass, config):
+    """Setup the FFmpeg component."""
+    conf = config.get(DOMAIN, {})
 
-    This method must be run in the event loop.
-    """
-    from haffmpeg import TestAsync
+    hass.data[DATA_FFMPEG] = FFmpegManager(
+        hass,
+        conf.get(CONF_FFMPEG_BIN, DEFAULT_BINARY),
+        conf.get(CONF_RUN_TEST, DEFAULT_RUN_TEST)
+    )
 
-    if FFMPEG_CONFIG.get(CONF_RUN_TEST):
-        # if in cache
-        if input_source in FFMPEG_TEST_CACHE:
-            return FFMPEG_TEST_CACHE[input_source]
-
-        # run test
-        ffmpeg_test = TestAsync(get_binary(), loop=hass.loop)
-        success = yield from ffmpeg_test.run_test(input_source)
-        if not success:
-            _LOGGER.error("FFmpeg '%s' test fails!", input_source)
-            FFMPEG_TEST_CACHE[input_source] = False
-            return False
-        FFMPEG_TEST_CACHE[input_source] = True
     return True
+
+
+class FFmpegManager(object):
+    """Helper for ha-ffmpeg."""
+
+    def __init__(self, hass, ffmpeg_bin, run_test):
+        """Initialize helper."""
+        self.hass = hass
+        self._cache = {}
+        self._bin = ffmpeg_bin
+        self._run_test = run_test
+
+    @property
+    def binary(self):
+        """Return ffmpeg binary from config."""
+        return self._bin
+
+    @asyncio.coroutine
+    def async_run_test(self, input_source):
+        """Run test on this input. TRUE is deactivate or run correct.
+
+        This method must be run in the event loop.
+        """
+        from haffmpeg import Test
+
+        if self._run_test:
+            # if in cache
+            if input_source in self._cache:
+                return self._cache[input_source]
+
+            # run test
+            ffmpeg_test = Test(self.binary, loop=hass.loop)
+            success = yield from ffmpeg_test.run_test(input_source)
+            if not success:
+                _LOGGER.error("FFmpeg '%s' test fails!", input_source)
+                self._cache[input_source] = False
+                return False
+            self._cache[input_source] = True
+        return True

--- a/homeassistant/components/ffmpeg.py
+++ b/homeassistant/components/ffmpeg.py
@@ -78,7 +78,7 @@ class FFmpegManager(object):
                 return self._cache[input_source]
 
             # run test
-            ffmpeg_test = Test(self.binary, loop=hass.loop)
+            ffmpeg_test = Test(self.binary, loop=self.hass.loop)
             success = yield from ffmpeg_test.run_test(input_source)
             if not success:
                 _LOGGER.error("FFmpeg '%s' test fails!", input_source)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -170,7 +170,7 @@ googlemaps==2.4.4
 gps3==0.33.3
 
 # homeassistant.components.ffmpeg
-ha-ffmpeg==0.15
+ha-ffmpeg==1.0
 
 # homeassistant.components.media_player.philips_js
 ha-philipsjs==0.0.1


### PR DESCRIPTION
**Description:**

Use new ha-ffmpeg asyncio library. Cleanup also some global stuff and migrate all ffmpeg stuff to asyncio.

- make it faster
- add new service to binary_sensors to allow control start/stop of entity

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
