### PR TITLE
Add exit code to check_config script

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -146,7 +146,7 @@ def run(script_args: List) -> int:
             print(' -', skey + ':', sval, color('cyan', '[from:', flatsecret
                                                 .get(skey, 'keyring') + ']'))
 
-    return 0
+    return len(res['except'])
 
 
 def check(config_path):


### PR DESCRIPTION
**Description:**
Properly exit with a code (number of exceptions) when running `--script check_config`. This allows other scripts to run the check and see if it passed or failed.

**Checklist:**

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
