### PR TITLE
Expand MQTT cover platform to support tilting

### DIFF
--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -229,7 +229,7 @@ class CoverDevice(Entity):
         if tilt_closed is None:
             return STATE_UNKNOWN
 
-        return STATE_CLOSED if tilt_closed else STATE_OPEN
+        return STATE_OPEN if tilt_closed else STATE_CLOSED
 
     @property
     def state_attributes(self):

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -51,6 +51,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_CURRENT_POSITION = 'current_position'
 ATTR_CURRENT_TILT_POSITION = 'current_tilt_position'
+ATTR_CURRENT_TILT_STATE = 'current_tilt_state'
 ATTR_POSITION = 'position'
 ATTR_TILT_POSITION = 'tilt_position'
 
@@ -221,6 +222,16 @@ class CoverDevice(Entity):
         return STATE_CLOSED if closed else STATE_OPEN
 
     @property
+    def tilt_state(self):
+        """Return the tilt state of the cover."""
+        tilt_closed = self.current_cover_tilt_position
+
+        if tilt_closed is None:
+            return STATE_UNKNOWN
+
+        return STATE_CLOSED if tilt_closed else STATE_OPEN
+
+    @property
     def state_attributes(self):
         """Return the state attributes."""
         data = {}
@@ -232,6 +243,10 @@ class CoverDevice(Entity):
         current_tilt = self.current_cover_tilt_position
         if current_tilt is not None:
             data[ATTR_CURRENT_TILT_POSITION] = self.current_cover_tilt_position
+
+        current_tilt_state = self.tilt_state
+        if current_tilt_state is not None:
+            data[ATTR_CURRENT_TILT_STATE] = self.tilt_state
 
         return data
 

--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -28,6 +28,18 @@ CONF_PAYLOAD_STOP = 'payload_stop'
 CONF_STATE_OPEN = 'state_open'
 CONF_STATE_CLOSED = 'state_closed'
 
+CONF_TILT_STATE_TOPIC = 'tilt_state_topic'
+CONF_TILT_COMMAND_TOPIC = 'tilt_command_topic'
+CONF_TILT_PAYLOAD_OPEN = 'tilt_payload_open'
+CONF_TILT_PAYLOAD_CLOSE = 'tilt_payload_close'
+CONF_TILT_PAYLOAD_STOP = 'tilt_payload_stop'
+CONF_TILT_STATE_OPEN = 'tilt_state_open'
+CONF_TILT_STATE_CLOSED = 'tilt_state_closed'
+
+CONF_TILT_OPTIMISTIC = 'tilt_optimistic'
+
+CONF_TILT_VALUE_TEMPLATE = 'tilt_value_template'
+
 DEFAULT_NAME = 'MQTT Cover'
 DEFAULT_PAYLOAD_OPEN = 'OPEN'
 DEFAULT_PAYLOAD_CLOSE = 'CLOSE'
@@ -42,7 +54,21 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PAYLOAD_STOP, default=DEFAULT_PAYLOAD_STOP): cv.string,
     vol.Optional(CONF_STATE_OPEN, default=STATE_OPEN): cv.string,
     vol.Optional(CONF_STATE_CLOSED, default=STATE_CLOSED): cv.string,
+    vol.Required(CONF_TILT_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_TILT_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_TILT_PAYLOAD_OPEN,
+                 default=DEFAULT_PAYLOAD_OPEN): cv.string,
+    vol.Optional(CONF_TILT_PAYLOAD_CLOSE,
+                 default=DEFAULT_PAYLOAD_CLOSE): cv.string,
+    vol.Optional(CONF_TILT_PAYLOAD_STOP,
+                 default=DEFAULT_PAYLOAD_STOP): cv.string,
+    vol.Optional(CONF_TILT_STATE_OPEN,
+                 default=STATE_OPEN): cv.string,
+    vol.Optional(CONF_TILT_STATE_CLOSED,
+                 default=STATE_CLOSED): cv.string,
     vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
+    vol.Optional(CONF_TILT_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
+    vol.Optional(CONF_TILT_VALUE_TEMPLATE): cv.template,
 })
 
 
@@ -51,11 +77,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
         value_template.hass = hass
+    tilt_value_template = config.get(CONF_TILT_VALUE_TEMPLATE)
+    if tilt_value_template is not None:
+        tilt_value_template.hass = hass
     add_devices([MqttCover(
         hass,
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_COMMAND_TOPIC),
+        config.get(CONF_TILT_STATE_TOPIC),
+        config.get(CONF_TILT_COMMAND_TOPIC),
         config.get(CONF_QOS),
         config.get(CONF_RETAIN),
         config.get(CONF_STATE_OPEN),
@@ -63,32 +94,53 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         config.get(CONF_PAYLOAD_OPEN),
         config.get(CONF_PAYLOAD_CLOSE),
         config.get(CONF_PAYLOAD_STOP),
+        config.get(CONF_TILT_STATE_OPEN),
+        config.get(CONF_TILT_STATE_CLOSED),
+        config.get(CONF_TILT_PAYLOAD_OPEN),
+        config.get(CONF_TILT_PAYLOAD_CLOSE),
+        config.get(CONF_TILT_PAYLOAD_STOP),
         config.get(CONF_OPTIMISTIC),
+        config.get(CONF_TILT_OPTIMISTIC),
         value_template,
+        tilt_value_template,
     )])
 
 
 class MqttCover(CoverDevice):
     """Representation of a cover that can be controlled using MQTT."""
 
-    def __init__(self, hass, name, state_topic, command_topic, qos,
+    def __init__(self, hass, name, state_topic, command_topic,
+                 tilt_state_topic, tilt_command_topic, qos,
                  retain, state_open, state_closed, payload_open, payload_close,
-                 payload_stop, optimistic, value_template):
+                 payload_stop, tilt_state_open, tilt_state_closed,
+                 tilt_payload_open, tilt_payload_close, tilt_payload_stop,
+                 optimistic, tilt_optimistic, value_template,
+                 tvt):
         """Initialize the cover."""
         self._position = None
         self._state = None
+        self._tilt_position = None
+        self._tilt_state = None
         self._hass = hass
         self._name = name
         self._state_topic = state_topic
         self._command_topic = command_topic
+        self._tilt_state_topic = tilt_state_topic
+        self._tilt_command_topic = tilt_command_topic
         self._qos = qos
         self._payload_open = payload_open
         self._payload_close = payload_close
         self._payload_stop = payload_stop
         self._state_open = state_open
         self._state_closed = state_closed
+        self._tilt_payload_open = tilt_payload_open
+        self._tilt_payload_close = tilt_payload_close
+        self._tilt_payload_stop = tilt_payload_stop
+        self._tilt_state_open = tilt_state_open
+        self._tilt_state_closed = tilt_state_closed
         self._retain = retain
         self._optimistic = optimistic or state_topic is None
+        self._tilt_optimistic = tilt_optimistic or tilt_state_topic is None
 
         @callback
         def message_received(topic, payload, qos):
@@ -121,6 +173,37 @@ class MqttCover(CoverDevice):
             mqtt.subscribe(hass, self._state_topic, message_received,
                            self._qos)
 
+        @callback
+        def tilt_message_received(topic, payload, qos):
+            """A new tilt MQTT message has been received."""
+            if tvt is not None:
+                payload = tvt.async_render_with_possible_json_value(
+                    payload)
+            if payload == self._tilt_state_open:
+                self._tilt_state = False
+                hass.async_add_job(self.async_update_ha_state())
+            elif payload == self._tilt_state_closed:
+                self._tilt_state = True
+                hass.async_add_job(self.async_update_ha_state())
+            elif payload.isnumeric() and 0 <= int(payload) <= 100:
+                if int(payload) > 0:
+                    self._tilt_state = False
+                else:
+                    self._tilt_state = True
+                self._tilt_position = int(payload)
+                hass.async_add_job(self.async_update_ha_state())
+            else:
+                _LOGGER.warning(
+                    "Tilt Payload is not True, False, or integer (0-100): %s",
+                    payload)
+
+        if self._tilt_state_topic is None:
+            # Force into optimistic mode.
+            self._tilt_optimistic = True
+        else:
+            mqtt.subscribe(hass, self._tilt_state_topic, tilt_message_received,
+                           self._qos)
+
     @property
     def should_poll(self):
         """No polling needed."""
@@ -144,6 +227,11 @@ class MqttCover(CoverDevice):
         """
         return self._position
 
+    @property
+    def current_cover_tilt_position(self):
+        """Return the current tilt position of the cover."""
+        return self._tilt_position
+
     def open_cover(self, **kwargs):
         """Move the cover up."""
         mqtt.publish(self.hass, self._command_topic, self._payload_open,
@@ -152,6 +240,15 @@ class MqttCover(CoverDevice):
             # Optimistically assume that cover has changed state.
             self._state = False
             self.schedule_update_ha_state()
+
+    def open_cover_tilt(self, **kwargs):
+        """Open the cover tilt."""
+        mqtt.publish(self.hass, self._tilt_command_topic,
+                     self._tilt_payload_open, self._qos, self._retain)
+        if self._tilt_optimistic:
+            # Optimistically assume that cover has changed state.
+            self._tilt_state = False
+            self.update_ha_state()
 
     def close_cover(self, **kwargs):
         """Move the cover down."""
@@ -162,7 +259,41 @@ class MqttCover(CoverDevice):
             self._state = True
             self.schedule_update_ha_state()
 
+    def close_cover_tilt(self, **kwargs):
+        """Close the cover tilt."""
+        mqtt.publish(self.hass, self._tilt_command_topic,
+                     self._tilt_payload_close, self._qos, self._retain)
+        if self._tilt_optimistic:
+            # Optimistically assume that cover has changed state.
+            self._tilt_state = True
+            self.update_ha_state()
+
     def stop_cover(self, **kwargs):
         """Stop the device."""
         mqtt.publish(self.hass, self._command_topic, self._payload_stop,
                      self._qos, self._retain)
+
+    def stop_cover_tilt(self, **kwargs):
+        """Stop the cover tilt."""
+        mqtt.publish(self.hass, self._tilt_command_topic,
+                     self._tilt_payload_stop, self._qos, self._retain)
+
+    def set_cover_position(self, position, **kwargs):
+        """Move the cover to a specific position."""
+        mqtt.publish(self.hass, self._command_topic, position,
+                     self._qos, self._retain)
+        if self._optimistic:
+            # Optimistically assume that cover has changed state.
+            self._state = False
+            self._position = position
+            self.update_ha_state()
+
+    def set_cover_tilt_position(self, tilt_position, **kwargs):
+        """Move the cover til to a specific position."""
+        mqtt.publish(self.hass, self._tilt_command_topic, tilt_position,
+                     self._qos, self._retain)
+        if self._tilt_optimistic:
+            # Optimistically assume that cover has changed state.
+            self._tilt_state = False
+            self._tilt_position = tilt_position
+            self.update_ha_state()

--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -294,6 +294,6 @@ class MqttCover(CoverDevice):
                      self._qos, self._retain)
         if self._tilt_optimistic:
             # Optimistically assume that cover has changed state.
-            self._tilt_state = position == 0
+            self._tilt_state = tilt_position == 0
             self._tilt_position = tilt_position
             self.update_ha_state()

--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -54,7 +54,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PAYLOAD_STOP, default=DEFAULT_PAYLOAD_STOP): cv.string,
     vol.Optional(CONF_STATE_OPEN, default=STATE_OPEN): cv.string,
     vol.Optional(CONF_STATE_CLOSED, default=STATE_CLOSED): cv.string,
-    vol.Required(CONF_TILT_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_TILT_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_TILT_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_TILT_PAYLOAD_OPEN,
                  default=DEFAULT_PAYLOAD_OPEN): cv.string,

--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -284,7 +284,7 @@ class MqttCover(CoverDevice):
                      self._qos, self._retain)
         if self._optimistic:
             # Optimistically assume that cover has changed state.
-            self._state = False
+            self._state = position == 0
             self._position = position
             self.update_ha_state()
 
@@ -294,6 +294,6 @@ class MqttCover(CoverDevice):
                      self._qos, self._retain)
         if self._tilt_optimistic:
             # Optimistically assume that cover has changed state.
-            self._tilt_state = False
+            self._tilt_state = position == 0
             self._tilt_position = tilt_position
             self.update_ha_state()

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -244,3 +244,253 @@ class TestCoverMQTT(unittest.TestCase):
         current_cover_position = self.hass.states.get(
             'cover.test').attributes['current_position']
         self.assertEqual(50, current_cover_position)
+
+    def test_tilt_state_via_state_topic(self):
+        """Test the controlling state via topic."""
+        self.hass.config.components = set(['mqtt'])
+        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
+            cover.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'qos': 0,
+                'state_topic': 'state-topic',
+                'command_topic': 'command-topic',
+                'payload_open': 'OPEN',
+                'payload_close': 'CLOSE',
+                'payload_stop': 'STOP',
+                'tilt_state_topic': 'tilt-state-topic',
+                'tilt_command_topic': 'tilt-command-topic',
+                'tilt_payload_open': 'TILT-OPEN',
+                'tilt_payload_close': 'TILT-CLOSE',
+                'tilt_payload_stop': 'TILT-STOP'
+            }
+        }))
+
+        state_attributes_dict = self.hass.states.get(
+            'cover.test').attributes
+        self.assertFalse('tilt_state' in state_attributes_dict)
+
+        fire_mqtt_message(self.hass, 'tilt-state-topic', '0')
+        self.hass.block_till_done()
+        current_tilt_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_tilt_position']
+        self.assertEqual(0, current_tilt_cover_position)
+
+        fire_mqtt_message(self.hass, 'tilt-state-topic', '50')
+        self.hass.block_till_done()
+
+        current_tilt_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_tilt_position']
+        self.assertEqual(50, current_tilt_cover_position)
+
+        fire_mqtt_message(self.hass, 'tilt-state-topic', '100')
+        self.hass.block_till_done()
+
+        current_tilt_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_tilt_position']
+        self.assertEqual(100, current_tilt_cover_position)
+
+        fire_mqtt_message(self.hass, 'tilt-state-topic', '0')
+        self.hass.block_till_done()
+
+        current_tilt_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_tilt_position']
+        self.assertEqual(0, current_tilt_cover_position)
+
+        fire_mqtt_message(self.hass, 'tilt-state-topic', '100')
+        self.hass.block_till_done()
+
+        current_tilt_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_tilt_position']
+        self.assertEqual(100, current_tilt_cover_position)
+
+    def test_tilt_state_via_template(self):
+        """Test the controlling state via topic."""
+        self.hass.config.components = set(['mqtt'])
+        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
+            cover.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'state-topic',
+                'command_topic': 'command-topic',
+                'tilt_state_topic': 'tilt-state-topic',
+                'tilt_command_topic': 'tilt-command-topic',
+                'tilt_payload_open': 'TILT-OPEN',
+                'tilt_payload_close': 'TILT-CLOSE',
+                'tilt_payload_stop': 'TILT-STOP',
+                'qos': 0,
+                'tilt_value_template': '{{ (value | multiply(0.01)) | int }}',
+            }
+        }))
+
+        state = self.hass.states.get('cover.test')
+        self.assertEqual(STATE_UNKNOWN, state.state)
+
+        fire_mqtt_message(self.hass, 'tilt-state-topic', '10000')
+        self.hass.block_till_done()
+
+        current_tilt_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_tilt_position']
+        self.assertEqual(100, current_tilt_cover_position)
+
+        fire_mqtt_message(self.hass, 'tilt-state-topic', '99')
+        self.hass.block_till_done()
+
+        current_tilt_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_tilt_position']
+        self.assertEqual(0, current_tilt_cover_position)
+
+    def test_tilt_optimistic_state_change(self):
+        """Test changing state optimistically."""
+        self.hass.config.components = set(['mqtt'])
+        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
+            cover.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'command_topic': 'command-topic',
+                'tilt_state_topic': 'tilt-state-topic',
+                'tilt_command_topic': 'tilt-command-topic',
+                'qos': 0,
+            }
+        }))
+
+        state = self.hass.states.get('cover.test')
+        self.assertEqual(STATE_UNKNOWN, state.state)
+
+        cover.open_cover_tilt(self.hass, 'cover.test')
+        self.hass.block_till_done()
+
+        self.assertEqual(('tilt-command-topic', 'OPEN', 0, False),
+                         self.mock_publish.mock_calls[-1][1])
+
+        cover.close_cover_tilt(self.hass, 'cover.test')
+        self.hass.block_till_done()
+
+        self.assertEqual(('tilt-command-topic', 'CLOSE', 0, False),
+                         self.mock_publish.mock_calls[-1][1])
+
+    def test_tilt_send_open_cover_command(self):
+        """Test the sending of open_cover."""
+        self.hass.config.components = set(['mqtt'])
+        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
+            cover.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'state-topic',
+                'command_topic': 'command-topic',
+                'tilt_state_topic': 'tilt-state-topic',
+                'tilt_command_topic': 'tilt-command-topic',
+                'qos': 2
+            }
+        }))
+
+        state = self.hass.states.get('cover.test')
+        self.assertEqual(STATE_UNKNOWN, state.state)
+
+        cover.open_cover_tilt(self.hass, 'cover.test')
+        self.hass.block_till_done()
+
+        self.assertEqual(('tilt-command-topic', 'OPEN', 2, False),
+                         self.mock_publish.mock_calls[-1][1])
+        state = self.hass.states.get('cover.test')
+        self.assertEqual(STATE_UNKNOWN, state.state)
+
+    def test_tilt_send_close_cover_command(self):
+        """Test the sending of close_cover."""
+        self.hass.config.components = set(['mqtt'])
+        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
+            cover.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'state-topic',
+                'command_topic': 'command-topic',
+                'tilt_state_topic': 'tilt-state-topic',
+                'tilt_command_topic': 'tilt-command-topic',
+                'qos': 2
+            }
+        }))
+
+        state = self.hass.states.get('cover.test')
+        self.assertEqual(STATE_UNKNOWN, state.state)
+
+        cover.close_cover_tilt(self.hass, 'cover.test')
+        self.hass.block_till_done()
+
+        self.assertEqual(('tilt-command-topic', 'CLOSE', 2, False),
+                         self.mock_publish.mock_calls[-1][1])
+        state = self.hass.states.get('cover.test')
+        self.assertEqual(STATE_UNKNOWN, state.state)
+
+    def test_tilt_send_stop__cover_command(self):
+        """Test the sending of stop_cover."""
+        self.hass.config.components = set(['mqtt'])
+        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
+            cover.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'state-topic',
+                'command_topic': 'command-topic',
+                'tilt_state_topic': 'tilt-state-topic',
+                'tilt_command_topic': 'tilt-command-topic',
+                'qos': 2
+            }
+        }))
+
+        state = self.hass.states.get('cover.test')
+        self.assertEqual(STATE_UNKNOWN, state.state)
+
+        cover.stop_cover_tilt(self.hass, 'cover.test')
+        self.hass.block_till_done()
+
+        self.assertEqual(('tilt-command-topic', 'STOP', 2, False),
+                         self.mock_publish.mock_calls[-1][1])
+        state = self.hass.states.get('cover.test')
+        self.assertEqual(STATE_UNKNOWN, state.state)
+
+    def test_tilt_current_cover_position(self):
+        """Test the current cover position."""
+        self.hass.config.components = set(['mqtt'])
+        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
+            cover.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'state-topic',
+                'command_topic': 'command-topic',
+                'payload_open': 'OPEN',
+                'payload_close': 'CLOSE',
+                'payload_stop': 'STOP',
+                'tilt_state_topic': 'tilt-state-topic',
+                'tilt_command_topic': 'tilt-command-topic',
+                'tilt_payload_open': 'TILT-OPEN',
+                'tilt_payload_close': 'TILT-CLOSE',
+                'tilt_payload_stop': 'TILT-STOP'
+            }
+        }))
+
+        state_attributes_dict = self.hass.states.get(
+            'cover.test').attributes
+        self.assertFalse('current_tilt_position' in state_attributes_dict)
+
+        fire_mqtt_message(self.hass, 'tilt-state-topic', '0')
+        self.hass.block_till_done()
+        current_tilt_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_tilt_position']
+        self.assertEqual(0, current_tilt_cover_position)
+
+        fire_mqtt_message(self.hass, 'tilt-state-topic', '50')
+        self.hass.block_till_done()
+        current_tilt_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_tilt_position']
+        self.assertEqual(50, current_tilt_cover_position)
+
+        fire_mqtt_message(self.hass, 'tilt-state-topic', '101')
+        self.hass.block_till_done()
+        current_tilt_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_tilt_position']
+        self.assertEqual(50, current_tilt_cover_position)
+
+        fire_mqtt_message(self.hass, 'tilt-state-topic', 'non-numeric')
+        self.hass.block_till_done()
+        current_tilt_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_tilt_position']
+        self.assertEqual(50, current_tilt_cover_position)


### PR DESCRIPTION
**Description:**
This enables tilting in the MQTT cover platform.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
cover:
  - platform: mqtt
    state_topic: "robbies_bedroom_blinds/cover/state"
    command_topic: "robbies_bedroom_blinds/cover/set"
    tilt_state_topic: "robbies_bedroom_blinds/cover_tilt/state"
    tilt_command_topic: "robbies_bedroom_blinds/cover_tilt/set"
    name: "Robbie's Bedroom Blinds"
    qos: 0
    retain: true
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
