### PR TITLE
Add new 'custom_ui' component for loading polymer components.

### DIFF
--- a/homeassistant/components/custom_ui.py
+++ b/homeassistant/components/custom_ui.py
@@ -1,0 +1,61 @@
+"""
+Register a custom polymer ui block.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/custom_ui/
+"""
+import logging
+import os
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.frontend import register_custom_ui
+
+DOMAIN = 'custom_ui'
+DEPENDENCIES = ['frontend']
+
+CONF_COMPONENT_NAME = 'name'
+CONF_URL_PATH = 'url_path'
+CONF_CONFIG = 'config'
+CONF_WEBCOMPONENT_PATH = 'webcomponent_path'
+
+CUSTOM_UI_DIR = 'custom_ui'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.All(cv.ensure_list, [{
+        vol.Required(CONF_COMPONENT_NAME): cv.string,
+        vol.Optional(CONF_URL_PATH): cv.string,
+        vol.Optional(CONF_CONFIG): cv.match_all,
+        vol.Optional(CONF_WEBCOMPONENT_PATH): cv.isfile,
+    }])
+}, extra=vol.ALLOW_EXTRA)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup(hass, config):
+    """Initialize custom ui."""
+    success = False
+
+    for custom_ui_config in config.get(DOMAIN):
+        name = custom_ui_config.get(CONF_COMPONENT_NAME)
+        path = custom_ui_config.get(CONF_WEBCOMPONENT_PATH)
+
+        if path is None:
+            path = hass.config.path(CUSTOM_UI_DIR, '{}.html'.format(name))
+
+        if not os.path.isfile(path):
+            _LOGGER.error('Unable to find custom ui component for %s at: %s',
+                          name, path)
+            continue
+
+        register_custom_ui(
+            hass, name, path,
+            url_path=custom_ui_config.get(CONF_URL_PATH),
+            config=custom_ui_config.get(CONF_CONFIG),
+        )
+
+        success = True
+
+    return success

--- a/tests/components/test_custom_ui.py
+++ b/tests/components/test_custom_ui.py
@@ -1,0 +1,84 @@
+"""The tests for the custom_ui component."""
+import os
+import shutil
+import unittest
+from unittest.mock import Mock, patch
+
+from homeassistant import bootstrap
+from homeassistant.components import custom_ui
+
+from tests.common import get_test_home_assistant
+
+
+@patch('homeassistant.components.frontend.setup',
+       autospec=True, return_value=True)
+class TestCustomUi(unittest.TestCase):
+    """Test the panel_custom component."""
+
+    hass = None
+
+    def setup_method(self, method):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+        shutil.rmtree(self.hass.config.path(custom_ui.CUSTOM_UI_DIR),
+                      ignore_errors=True)
+
+    @patch('homeassistant.components.custom_ui.register_custom_ui')
+    def test_webcomponent_dir(self, mock_register, _mock_setup):
+        """Test if a web component is found in config custom_ui dir."""
+        config = {
+            'custom_ui': {
+                'name': 'custom_name',
+            }
+        }
+
+        assert not bootstrap.setup_component(self.hass, 'custom_ui', config)
+        assert not mock_register.called
+
+        path = self.hass.config.path(custom_ui.CUSTOM_UI_DIR)
+        os.mkdir(path)
+
+        with open(os.path.join(path, 'custom_name.html'), 'a'):
+            assert bootstrap.setup_component(self.hass, 'custom_ui', config)
+            assert mock_register.called
+
+    @patch('homeassistant.components.custom_ui.register_custom_ui')
+    def test_webcomponent_custom_path(self, mock_register, _mock_setup):
+        """Test if a web component is found in custom config dir."""
+        filename = 'mock.file'
+
+        config = {
+            'custom_ui': {
+                'name': 'custom_name',
+                'webcomponent_path': filename,
+                'url_path': 'nice_url',
+                'config': 5,
+            }
+        }
+
+        with patch('os.path.isfile', Mock(return_value=False)):
+            assert not bootstrap.setup_component(
+                self.hass, 'custom_ui', config
+            )
+            assert not mock_register.called
+
+        with patch('os.path.isfile', Mock(return_value=True)):
+            with patch('os.access', Mock(return_value=True)):
+                assert bootstrap.setup_component(
+                    self.hass, 'custom_ui', config
+                )
+
+                assert mock_register.called
+
+                args = mock_register.mock_calls[0][1]
+                assert args == (self.hass, 'custom_name', filename)
+
+                kwargs = mock_register.mock_calls[0][2]
+                assert kwargs == {
+                    'config': 5,
+                    'url_path': 'nice_url',
+                }

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -2,11 +2,12 @@
 # pylint: disable=protected-access
 import re
 import unittest
-
+from unittest.mock import Mock, patch
 import requests
 
 import homeassistant.bootstrap as bootstrap
 from homeassistant.components import http
+from homeassistant.components.frontend import register_custom_ui
 from homeassistant.const import HTTP_HEADER_HA_AUTH
 
 from tests.common import get_test_instance_port, get_test_home_assistant
@@ -16,6 +17,7 @@ SERVER_PORT = get_test_instance_port()
 HTTP_BASE_URL = "http://127.0.0.1:{}".format(SERVER_PORT)
 HA_HEADERS = {HTTP_HEADER_HA_AUTH: API_PASSWORD}
 
+# pylint: disable=invalid-name
 hass = None
 
 
@@ -87,3 +89,51 @@ class TestFrontend(unittest.TestCase):
         hass.states.set('group.existing', 'on', {'view': True})
         req = requests.get(_url("/states/group.existing"))
         self.assertEqual(200, req.status_code)
+
+    def test_api_bootstrap_require_auth(self):
+        """Test that /api/bootstrap path requires auth."""
+        req = requests.get(_url("/api/bootstrap"))
+        self.assertEqual(401, req.status_code)
+
+    def test_api_bootstrap_has_cutom_ui_field(self):
+        """Test /api/bootstrap path."""
+        req = requests.get(_url("/api/bootstrap"), headers=HA_HEADERS)
+        self.assertEqual(200, req.status_code)
+        self.assertIn('custom_ui', req.json())
+
+    def test_register_custom_ui(self):
+        """Test register_custom_ui."""
+        with patch('os.path.isfile', Mock(return_value=True)):
+            register_custom_ui(hass, 'custom_name', 'fake.path')
+        req = requests.get(_url("/api/bootstrap"), headers=HA_HEADERS)
+        self.assertEqual(200, req.status_code)
+        custom_uis = req.json().get('custom_ui')
+        self.assertIn('custom_name', custom_uis)
+        custom_ui = custom_uis.get('custom_name')
+        self.assertEqual('custom_name', custom_ui.get('component_name'))
+        self.assertEqual(
+            '/frontend/custom_ui/custom_name.html', custom_ui.get('url'))
+
+    def test_register_custom_ui_url_path(self):
+        """Test register_custom_ui on specific url path."""
+        with patch('os.path.isfile', Mock(return_value=True)):
+            register_custom_ui(
+                hass, 'custom_name', 'fake.path', url_path='/some.url')
+        req = requests.get(_url("/api/bootstrap"), headers=HA_HEADERS)
+        self.assertEqual(200, req.status_code)
+        custom_uis = req.json().get('custom_ui')
+        self.assertIn('custom_name', custom_uis)
+        custom_ui = custom_uis.get('custom_name')
+        self.assertEqual('/some.url', custom_ui.get('url'))
+
+    def test_register_custom_ui_config(self):
+        """Test register_custom_ui with config."""
+        with patch('os.path.isfile', Mock(return_value=True)):
+            register_custom_ui(
+                hass, 'custom_name', 'fake.path', config={'key': 'value'})
+        req = requests.get(_url("/api/bootstrap"), headers=HA_HEADERS)
+        self.assertEqual(200, req.status_code)
+        custom_uis = req.json().get('custom_ui')
+        self.assertIn('custom_name', custom_uis)
+        custom_ui = custom_uis.get('custom_name')
+        self.assertEqual({'key': 'value'}, custom_ui.get('config'))


### PR DESCRIPTION
**Description:**

Add new 'custom_ui' component for loading polymer components.
This PR makes Homeassistant serve provided html files and add their list to /api/bootstrap
home-assistant/home-assistant-js#27 will provide this data to Polymer.
home-assistant/home-assistant-polymer#175 will load those file according to what the user did in `customize:` 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here> WIP

**Example entry for `configuration.yaml` (if applicable):**
```yaml
homeassistant:
  customize:
    light.ceiling_lights:
      custom_ui_card: custom_light
custom_ui:
  - name: custom_light
    config:
      hello: world
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New files were added to `.coveragerc`.

