### PR TITLE
[switch.insteon_local] Only check for devices when not defined in config

### DIFF
--- a/homeassistant/components/switch/insteon_local.py
+++ b/homeassistant/components/switch/insteon_local.py
@@ -22,7 +22,7 @@ DOMAIN = 'switch'
 INSTEON_LOCAL_SWITCH_CONF = 'insteon_local_switch.conf'
 
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -36,15 +36,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             setup_switch(
                 device_id, conf_switches[device_id], insteonhub, hass,
                 add_devices)
+    else:
+        linked = insteonhub.get_linked()
 
-    linked = insteonhub.get_linked()
-
-    for device_id in linked:
-        if linked[device_id]['cat_type'] == 'switch'\
-                and device_id not in conf_switches:
-            request_configuration(device_id, insteonhub,
-                                  linked[device_id]['model_name'] + ' ' +
-                                  linked[device_id]['sku'], hass, add_devices)
+        for device_id in linked:
+            if linked[device_id]['cat_type'] == 'switch'\
+                    and device_id not in conf_switches:
+                request_configuration(device_id, insteonhub,
+                                      linked[device_id]['model_name'] + ' ' +
+                                      linked[device_id]['sku'], hass, add_devices)
 
 
 def request_configuration(device_id, insteonhub, model, hass,

--- a/homeassistant/components/switch/insteon_local.py
+++ b/homeassistant/components/switch/insteon_local.py
@@ -44,7 +44,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                     and device_id not in conf_switches:
                 request_configuration(device_id, insteonhub,
                                       linked[device_id]['model_name'] + ' ' +
-                                      linked[device_id]['sku'], hass, add_devices)
+                                      linked[device_id]['sku'],
+                                      hass, add_devices)
 
 
 def request_configuration(device_id, insteonhub, model, hass,


### PR DESCRIPTION
**Description:** Change to only check for insteon devices when config file not present to fix hit to start-up time from slow hub discovery, and increase interval between status scans until client library is updated in order to reduce command collisions


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
