### PR TITLE
[script] gen_requirement: Raise an error if REQUIREMENT not pinned

### DIFF
--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -28,6 +28,9 @@ IGNORE_PACKAGES = (
 
 IGNORE_PIN = ('colorlog>2.1,<3', 'keyring>=9.3,<10.0', 'urllib3')
 
+URL_PIN = ('https://home-assistant.io/developers/code_review_platform/'
+           '#1-requirements')
+
 
 def explore_module(package, explore_children):
     """Explore the modules."""
@@ -81,8 +84,9 @@ def gather_modules():
 
         for req in module.REQUIREMENTS:
             if req.partition('==')[1] == '' and req not in IGNORE_PIN:
-                errors.append("{}[Please pin requirement {}]"
-                              .format(package, req))
+                errors.append(
+                    "{}[Please pin requirement {}, see {}]".format(
+                        package, req, URL_PIN))
             reqs.setdefault(req, []).append(package)
 
     for key in reqs:

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -26,6 +26,8 @@ IGNORE_PACKAGES = (
     'homeassistant.components.recorder.models',
 )
 
+IGNORE_PIN = ('colorlog>2.1,<3', 'keyring>=9.3,<10.0', 'urllib3')
+
 
 def explore_module(package, explore_children):
     """Explore the modules."""
@@ -78,6 +80,9 @@ def gather_modules():
             continue
 
         for req in module.REQUIREMENTS:
+            if req.partition('==')[1] == '' and req not in IGNORE_PIN:
+                errors.append("{}[Please pin requirement {}]"
+                              .format(package, req))
             reqs.setdefault(req, []).append(package)
 
     for key in reqs:


### PR DESCRIPTION
**Description:**
Raise an error if a requirement is not pinned. Helps automatically checking pinned requirements.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
