### PR TITLE
Add more validation for mysensors

### DIFF
--- a/homeassistant/components/switch/acer_projector.py
+++ b/homeassistant/components/switch/acer_projector.py
@@ -4,7 +4,6 @@ Use serial protocol of Acer projector to obtain state of the projector.
 For more details about this component, please refer to the documentation
 at https://home-assistant.io/components/switch.acer_projector/
 """
-import os
 import logging
 import re
 
@@ -47,17 +46,8 @@ CMD_DICT = {LAMP: '* 0 Lamp ?\r',
             STATE_OFF: '* 0 IR 002\r'}
 
 
-def isdevice(dev):
-    """Check if dev a real device."""
-    try:
-        os.stat(dev)
-        return str(dev)
-    except OSError:
-        raise vol.Invalid("No device found!")
-
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_FILENAME): isdevice,
+    vol.Required(CONF_FILENAME): cv.isdevice,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     vol.Optional(CONF_WRITE_TIMEOUT, default=DEFAULT_WRITE_TIMEOUT):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -70,6 +70,15 @@ def boolean(value: Any) -> bool:
     return bool(value)
 
 
+def isdevice(value):
+    """Validate that value is a real device."""
+    try:
+        os.stat(value)
+        return str(value)
+    except OSError:
+        raise vol.Invalid('No device at {} found'.format(value))
+
+
 def isfile(value: Any) -> str:
     """Validate that the value is an existing file."""
     if value is None:


### PR DESCRIPTION
**Description:**
* Move isdevice validator under helpers.config_validation.
* Check that all mysensors persistence files are set and are unique if any is set
  by user. This is necessary to avoid file name clashes. This will be a
  **BREAKING CHANGE** in some cases.
* Check that a set persistence file has an existing and writable
  directory.
* Check that a device is either a valid device file, "mqtt", or a valid
  domain name or ip address.

**Related issue (if applicable):**
fixes #3009 

**Checklist:**
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
