### PR TITLE
Don't start test thread until patching is done

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -45,7 +45,6 @@ def get_test_home_assistant():
 
     hass = loop.run_until_complete(async_test_home_assistant(loop))
 
-    # FIXME should not be a daemon. Means hass.stop() not called in teardown
     stop_event = threading.Event()
 
     def run_loop():
@@ -55,8 +54,6 @@ def get_test_home_assistant():
         loop.run_forever()
         loop.close()
         stop_event.set()
-
-    threading.Thread(name="LoopThread", target=run_loop, daemon=True).start()
 
     orig_start = hass.start
     orig_stop = hass.stop
@@ -75,6 +72,9 @@ def get_test_home_assistant():
 
     hass.start = start_hass
     hass.stop = stop_hass
+
+    # FIXME should not be a daemon. Means hass.stop() not called in teardown
+    threading.Thread(name="LoopThread", target=run_loop, daemon=True).start()
 
     return hass
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -73,8 +73,7 @@ def get_test_home_assistant():
     hass.start = start_hass
     hass.stop = stop_hass
 
-    # FIXME should not be a daemon. Means hass.stop() not called in teardown
-    threading.Thread(name="LoopThread", target=run_loop, daemon=True).start()
+    threading.Thread(name="LoopThread", target=run_loop, daemon=False).start()
 
     return hass
 


### PR DESCRIPTION
**Description:**
Probably not ever a practical issue, but we really shouldn't start the thread until we're done patching the `hass` object.