### PR TITLE
Fix network tests to use get_test_instance_port

### DIFF
--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -7,10 +7,12 @@ import pytest
 from homeassistant.bootstrap import setup_component
 from homeassistant.const import ATTR_ENTITY_PICTURE
 import homeassistant.components.camera as camera
+import homeassistant.components.http as http
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.async import run_coroutine_threadsafe
 
-from tests.common import get_test_home_assistant, assert_setup_component
+from tests.common import (
+    get_test_home_assistant, get_test_instance_port, assert_setup_component)
 
 
 class TestSetupCamera(object):
@@ -42,6 +44,10 @@ class TestGetImage(object):
     def setup_method(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
+
+        setup_component(
+            self.hass, http.DOMAIN,
+            {http.DOMAIN: {http.CONF_SERVER_PORT: get_test_instance_port()}})
 
         config = {
             camera.DOMAIN: {

--- a/tests/components/image_processing/test_init.py
+++ b/tests/components/image_processing/test_init.py
@@ -5,9 +5,11 @@ from homeassistant.core import callback
 from homeassistant.const import ATTR_ENTITY_PICTURE
 from homeassistant.bootstrap import setup_component
 from homeassistant.exceptions import HomeAssistantError
+import homeassistant.components.http as http
 import homeassistant.components.image_processing as ip
 
-from tests.common import get_test_home_assistant, assert_setup_component
+from tests.common import (
+    get_test_home_assistant, get_test_instance_port, assert_setup_component)
 
 
 class TestSetupImageProcessing(object):
@@ -52,6 +54,10 @@ class TestImageProcessing(object):
     def setup_method(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
+
+        setup_component(
+            self.hass, http.DOMAIN,
+            {http.DOMAIN: {http.CONF_SERVER_PORT: get_test_instance_port()}})
 
         config = {
             ip.DOMAIN: {

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, PropertyMock
 
 import requests
 
+import homeassistant.components.http as http
 import homeassistant.components.tts as tts
 from homeassistant.components.tts.demo import DemoProvider
 from homeassistant.components.media_player import (
@@ -14,7 +15,8 @@ from homeassistant.components.media_player import (
 from homeassistant.bootstrap import setup_component
 
 from tests.common import (
-    get_test_home_assistant, assert_setup_component, mock_service)
+    get_test_home_assistant, get_test_instance_port, assert_setup_component,
+    mock_service)
 
 
 class TestTTS(object):
@@ -25,6 +27,10 @@ class TestTTS(object):
         self.hass = get_test_home_assistant()
         self.demo_provider = DemoProvider('en')
         self.default_tts_cache = self.hass.config.path(tts.DEFAULT_CACHE_DIR)
+
+        setup_component(
+            self.hass, http.DOMAIN,
+            {http.DOMAIN: {http.CONF_SERVER_PORT: get_test_instance_port()}})
 
     def teardown_method(self):
         """Stop everything that was started."""


### PR DESCRIPTION
**Description:**
I do hass development on the same machine that runs my normal hass instance. This PR ensures that tests using the actual network API use `get_test_instance_port` to choose the port binding. This isn't perfect, but it at least moves them off the default port, and gives us one location to change port determination if necessary.