### PR TITLE
Add support for Wemo CoffeeMaker devices

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import config_validation as cv
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.4.9']
+REQUIREMENTS = ['pywemo==0.4.11']
 
 DOMAIN = 'wemo'
 

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -25,7 +25,8 @@ WEMO_MODEL_DISPATCH = {
     'Maker':   'switch',
     'Sensor':  'binary_sensor',
     'Socket':  'switch',
-    'LightSwitch': 'switch'
+    'LightSwitch': 'switch',
+    'CoffeeMaker': 'switch'
 }
 
 SUBSCRIPTION_REGISTRY = None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -546,7 +546,7 @@ pyvera==0.2.23
 pywebpush==0.6.1
 
 # homeassistant.components.wemo
-pywemo==0.4.9
+pywemo==0.4.11
 
 # homeassistant.components.light.yeelight
 pyyeelight==1.0-beta


### PR DESCRIPTION
**Description:**
Add support for Wemo CoffeeMaker devices

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1869

**Example entry for `configuration.yaml` (if applicable):**
No changes to wemo component configuration should be required.
Example of a template sensor to show coffee maker's state
```
  - name: coffeemaker
    platform: template
    sensors:
      coffeemaker:
        value_template: " {{ states.switch.coffeemaker.attributes.state_detail }} "
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
