### PR TITLE
[camera.mjpeg] Fixed optional mjpeg still image to default to None

### DIFF
--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -32,7 +32,7 @@ DEFAULT_NAME = 'Mjpeg Camera'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_MJPEG_URL): cv.url,
-    vol.Optional(CONF_STILL_IMAGE_URL): cv.url,
+    vol.Optional(CONF_STILL_IMAGE_URL, default=None): cv.url,
     vol.Optional(CONF_AUTHENTICATION, default=HTTP_BASIC_AUTHENTICATION):
         vol.In([HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,


### PR DESCRIPTION
**Description:**
Fixed optional still_image_url to default to None.

Related to PR https://github.com/home-assistant/home-assistant/pull/5440



**Fixes**
```
17-01-23 00:51:59 ERROR (MainThread) [homeassistant.components.camera] Error while setting up platform mjpeg
Traceback (most recent call last):
  File "/usr/src/app/homeassistant/helpers/entity_component.py", line 146, in _async_setup_platform
    entity_platform.async_add_entities, discovery_info
  File "/usr/src/app/homeassistant/components/camera/mjpeg.py", line 48, in async_setup_platform
    yield from async_add_devices([MjpegCamera(hass, config)])
  File "/usr/src/app/homeassistant/components/camera/mjpeg.py", line 74, in __init__
    self._still_image_url = device_info[CONF_STILL_IMAGE_URL]
KeyError: 'still_image_url'
```