### PR TITLE
[*.zwave] Refactor of zwave value_changed

### DIFF
--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -52,8 +52,6 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
 
     def __init__(self, value, temp_unit):
         """Initialize the Z-Wave climate device."""
-        from openzwave.network import ZWaveNetwork
-        from pydispatch import dispatcher
         ZWaveDeviceEntity.__init__(self, value, DOMAIN)
         self._index = value.index
         self._node = value.node
@@ -71,9 +69,6 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
         _LOGGER.debug("temp_unit is %s", self._unit)
         self._zxt_120 = None
         self.update_properties()
-        # register listener
-        dispatcher.connect(
-            self.value_changed, ZWaveNetwork.SIGNAL_VALUE_CHANGED)
         # Make sure that we have values for the key before converting to int
         if (value.node.manufacturer_id.strip() and
                 value.node.product_id.strip()):
@@ -85,16 +80,8 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
                                   " workaround")
                     self._zxt_120 = 1
 
-    def value_changed(self, value):
-        """Called when a value has changed on the network."""
-        if self._value.value_id == value.value_id or \
-           self._value.node == value.node:
-            _LOGGER.debug('Value changed for label %s', self._value.label)
-            self.update_properties()
-            self.schedule_update_ha_state()
-
     def update_properties(self):
-        """Callback on data change for the registered node/value pair."""
+        """Callback on data changes for node values."""
         # Operation Mode
         for value in self._node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_THERMOSTAT_MODE).values():

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -68,7 +68,7 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
         self._unit = temp_unit
         _LOGGER.debug("temp_unit is %s", self._unit)
         self._zxt_120 = None
-        self.update()
+        self.update_properties()
         # Make sure that we have values for the key before converting to int
         if (value.node.manufacturer_id.strip() and
                 value.node.product_id.strip()):
@@ -80,8 +80,8 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
                                   " workaround")
                     self._zxt_120 = 1
 
-    def update(self):
-        """Get the current state of the entity."""
+    def update_properties(self):
+        """Callback on data changes for node values."""
         # Operation Mode
         for value in self._node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_THERMOSTAT_MODE).values():

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -68,7 +68,7 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
         self._unit = temp_unit
         _LOGGER.debug("temp_unit is %s", self._unit)
         self._zxt_120 = None
-        self.update_properties()
+        self.update()
         # Make sure that we have values for the key before converting to int
         if (value.node.manufacturer_id.strip() and
                 value.node.product_id.strip()):
@@ -80,8 +80,8 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
                                   " workaround")
                     self._zxt_120 = 1
 
-    def update_properties(self):
-        """Callback on data changes for node values."""
+    def update(self):
+        """Get the current state of the entity."""
         # Operation Mode
         for value in self._node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_THERMOSTAT_MODE).values():

--- a/homeassistant/components/cover/zwave.py
+++ b/homeassistant/components/cover/zwave.py
@@ -70,8 +70,8 @@ class ZwaveRollershutter(zwave.ZWaveDeviceEntity, CoverDevice):
                     _LOGGER.debug("Controller without positioning feedback")
                     self._workaround = 1
 
-    def update(self):
-        """Get the current state of the entity."""
+    def update_properties(self):
+        """Callback on data changes for node values."""
         # Position value
         for value in self._node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_SWITCH_MULTILEVEL).values():

--- a/homeassistant/components/cover/zwave.py
+++ b/homeassistant/components/cover/zwave.py
@@ -70,8 +70,8 @@ class ZwaveRollershutter(zwave.ZWaveDeviceEntity, CoverDevice):
                     _LOGGER.debug("Controller without positioning feedback")
                     self._workaround = 1
 
-    def update_properties(self):
-        """Callback on data changes for node values."""
+    def update(self):
+        """Get the current state of the entity."""
         # Position value
         for value in self._node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_SWITCH_MULTILEVEL).values():

--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -108,7 +108,7 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
                     _LOGGER.debug("AEOTEC ZW098 workaround enabled")
                     self._zw098 = 1
 
-        self.update()
+        self.update_properties()
 
         # Used for value change event handling
         self._refreshing = False
@@ -116,7 +116,7 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
         _LOGGER.debug('self._refreshing=%s self.delay=%s',
                       self._refresh_value, self._delay)
 
-    def update(self):
+    def update_properties(self):
         """Update internal properties based on zwave values."""
         # Brightness
         self._brightness, self._state = brightness_state(self._value)
@@ -126,7 +126,7 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
         if self._refresh_value:
             if self._refreshing:
                 self._refreshing = False
-                self.schedule_update_ha_state(True)
+                self.update_properties()
             else:
                 def _refresh_value():
                     """Used timer callback for delayed value refresh."""
@@ -138,9 +138,10 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
 
                 self._timer = Timer(self._delay, _refresh_value)
                 self._timer.start()
-                self.schedule_update_ha_state()
+            self.schedule_update_ha_state()
         else:
-            self.schedule_update_ha_state(True)
+            self.update_properties()
+            self.schedule_update_ha_state()
 
     @property
     def brightness(self):
@@ -226,7 +227,7 @@ class ZwaveColorLight(ZwaveDimmer):
             _LOGGER.debug("Zwave node color values found.")
             dispatcher.disconnect(
                 self._value_added, ZWaveNetwork.SIGNAL_VALUE_ADDED)
-            self.update()
+            self.update_properties()
 
     def _value_added(self, value):
         """Called when a value has been added to the network."""
@@ -235,9 +236,9 @@ class ZwaveColorLight(ZwaveDimmer):
         # Check for the missing color values
         self._get_color_values()
 
-    def update(self):
+    def update_properties(self):
         """Update internal properties based on zwave values."""
-        super().update()
+        super().update_properties()
 
         if self._value_color is None:
             return

--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -108,7 +108,7 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
                     _LOGGER.debug("AEOTEC ZW098 workaround enabled")
                     self._zw098 = 1
 
-        self.update_properties()
+        self.update()
 
         # Used for value change event handling
         self._refreshing = False
@@ -116,7 +116,7 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
         _LOGGER.debug('self._refreshing=%s self.delay=%s',
                       self._refresh_value, self._delay)
 
-    def update_properties(self):
+    def update(self):
         """Update internal properties based on zwave values."""
         # Brightness
         self._brightness, self._state = brightness_state(self._value)
@@ -126,7 +126,7 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
         if self._refresh_value:
             if self._refreshing:
                 self._refreshing = False
-                self.update_properties()
+                self.schedule_update_ha_state(True)
             else:
                 def _refresh_value():
                     """Used timer callback for delayed value refresh."""
@@ -138,10 +138,9 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
 
                 self._timer = Timer(self._delay, _refresh_value)
                 self._timer.start()
-            self.schedule_update_ha_state()
+                self.schedule_update_ha_state()
         else:
-            self.update_properties()
-            self.schedule_update_ha_state()
+            self.schedule_update_ha_state(True)
 
     @property
     def brightness(self):
@@ -227,7 +226,7 @@ class ZwaveColorLight(ZwaveDimmer):
             _LOGGER.debug("Zwave node color values found.")
             dispatcher.disconnect(
                 self._value_added, ZWaveNetwork.SIGNAL_VALUE_ADDED)
-            self.update_properties()
+            self.update()
 
     def _value_added(self, value):
         """Called when a value has been added to the network."""
@@ -236,9 +235,9 @@ class ZwaveColorLight(ZwaveDimmer):
         # Check for the missing color values
         self._get_color_values()
 
-    def update_properties(self):
+    def update(self):
         """Update internal properties based on zwave values."""
-        super().update_properties()
+        super().update()
 
         if self._value_color is None:
             return

--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -112,10 +112,10 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
         self._state = None
         self._notification = None
         self._lock_status = None
-        self.update_properties()
+        self.update()
 
-    def update_properties(self):
-        """Callback on data changes for node values."""
+    def update(self):
+        """Get the current state of the entity."""
         for value in self._node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_ALARM).values():
             if value.label != "Access Control":

--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -106,29 +106,16 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
 
     def __init__(self, value):
         """Initialize the Z-Wave switch device."""
-        from openzwave.network import ZWaveNetwork
-        from pydispatch import dispatcher
-
         zwave.ZWaveDeviceEntity.__init__(self, value, DOMAIN)
 
         self._node = value.node
         self._state = None
         self._notification = None
         self._lock_status = None
-        dispatcher.connect(
-            self._value_changed, ZWaveNetwork.SIGNAL_VALUE_CHANGED)
         self.update_properties()
 
-    def _value_changed(self, value):
-        """Called when a value has changed on the network."""
-        if self._value.value_id == value.value_id or \
-           self._value.node == value.node:
-            _LOGGER.debug('Value changed for label %s', self._value.label)
-            self.update_properties()
-            self.schedule_update_ha_state()
-
     def update_properties(self):
-        """Callback on data change for the registered node/value pair."""
+        """Callback on data changes for node values."""
         for value in self._node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_ALARM).values():
             if value.label != "Access Control":

--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -112,10 +112,10 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
         self._state = None
         self._notification = None
         self._lock_status = None
-        self.update()
+        self.update_properties()
 
-    def update(self):
-        """Get the current state of the entity."""
+    def update_properties(self):
+        """Callback on data changes for node values."""
         for value in self._node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_ALARM).values():
             if value.label != "Access Control":

--- a/homeassistant/components/sensor/zwave.py
+++ b/homeassistant/components/sensor/zwave.py
@@ -10,7 +10,6 @@ import logging
 from homeassistant.components.sensor import DOMAIN
 from homeassistant.components import zwave
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
-from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,18 +47,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         add_devices([ZWaveAlarmSensor(value)])
 
 
-class ZWaveSensor(zwave.ZWaveDeviceEntity, Entity):
+class ZWaveSensor(zwave.ZWaveDeviceEntity):
     """Representation of a Z-Wave sensor."""
 
-    def __init__(self, sensor_value):
+    def __init__(self, value):
         """Initialize the sensor."""
-        from openzwave.network import ZWaveNetwork
-        from pydispatch import dispatcher
-
-        zwave.ZWaveDeviceEntity.__init__(self, sensor_value, DOMAIN)
-
-        dispatcher.connect(
-            self.value_changed, ZWaveNetwork.SIGNAL_VALUE_CHANGED)
+        zwave.ZWaveDeviceEntity.__init__(self, value, DOMAIN)
 
     @property
     def state(self):
@@ -70,13 +63,6 @@ class ZWaveSensor(zwave.ZWaveDeviceEntity, Entity):
     def unit_of_measurement(self):
         """Return the unit of measurement the value is expressed in."""
         return self._value.units
-
-    def value_changed(self, value):
-        """Called when a value has changed on the network."""
-        if self._value.value_id == value.value_id or \
-           self._value.node == value.node:
-            _LOGGER.debug('Value changed for label %s', self._value.label)
-            self.schedule_update_ha_state()
 
 
 class ZWaveMultilevelSensor(ZWaveSensor):

--- a/homeassistant/components/switch/zwave.py
+++ b/homeassistant/components/switch/zwave.py
@@ -37,26 +37,12 @@ class ZwaveSwitch(zwave.ZWaveDeviceEntity, SwitchDevice):
 
     def __init__(self, value):
         """Initialize the Z-Wave switch device."""
-        from openzwave.network import ZWaveNetwork
-        from pydispatch import dispatcher
-
         zwave.ZWaveDeviceEntity.__init__(self, value, DOMAIN)
-
-        self._state = value.data
-        dispatcher.connect(
-            self._value_changed, ZWaveNetwork.SIGNAL_VALUE_CHANGED)
-
-    def _value_changed(self, value):
-        """Called when a value has changed on the network."""
-        if self._value.value_id == value.value_id:
-            _LOGGER.debug('Value changed for label %s', self._value.label)
-            self._state = value.data
-            self.schedule_update_ha_state()
 
     @property
     def is_on(self):
         """Return true if device is on."""
-        return self._state
+        return self._value.data
 
     def turn_on(self, **kwargs):
         """Turn the device on."""

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -624,7 +624,12 @@ class ZWaveDeviceEntity(Entity):
 
     def value_changed(self, value):
         """Called when a value for this entity's node has changed."""
-        self.schedule_update_ha_state(True)
+        self.update_properties()
+        self.schedule_update_ha_state()
+
+    def update_properties(self):
+        """Callback on data changes for node values."""
+        pass
 
     @property
     def should_poll(self):

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -624,12 +624,7 @@ class ZWaveDeviceEntity(Entity):
 
     def value_changed(self, value):
         """Called when a value for this entity's node has changed."""
-        self.update_properties()
-        self.schedule_update_ha_state()
-
-    def update_properties(self):
-        """Callback on data changes for node values."""
-        pass
+        self.schedule_update_ha_state(True)
 
     @property
     def should_poll(self):

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -15,6 +15,7 @@ from homeassistant.helpers import discovery
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL, ATTR_LOCATION, ATTR_ENTITY_ID, CONF_CUSTOMIZE,
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_change
 from homeassistant.util import convert, slugify
 import homeassistant.config as conf_util
@@ -600,13 +601,35 @@ def setup(hass, config):
     return True
 
 
-class ZWaveDeviceEntity:
+class ZWaveDeviceEntity(Entity):
     """Representation of a Z-Wave node entity."""
 
     def __init__(self, value, domain):
         """Initialize the z-Wave device."""
+        # pylint: disable=import-error
+        from openzwave.network import ZWaveNetwork
+        from pydispatch import dispatcher
         self._value = value
         self.entity_id = "{}.{}".format(domain, self._object_id())
+
+        dispatcher.connect(
+            self.network_value_changed, ZWaveNetwork.SIGNAL_VALUE_CHANGED)
+
+    def network_value_changed(self, value):
+        """Called when a value has changed on the network."""
+        if self._value.value_id == value.value_id or \
+           self._value.node == value.node:
+            _LOGGER.debug('Value changed for label %s', self._value.label)
+            self.value_changed(value)
+
+    def value_changed(self, value):
+        """Called when a value for this entity's node has changed."""
+        self.update_properties()
+        self.schedule_update_ha_state()
+
+    def update_properties(self):
+        """Callback on data changes for node values."""
+        pass
 
     @property
     def should_poll(self):


### PR DESCRIPTION
**Description:**
This PR pulls some of the conventions and repeated code that has been getting copied among the zwave platforms into the base class `ZWaveEntity`. There shouldn't be any changes exposed to the user.

This has been tested on my system, but I don't have an extensive ZWave network. It would be good to get a test from someone with a variety of device types.