### PR TITLE
[fan.mqtt] Dont set a speed when fan turns on

### DIFF
--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -235,11 +235,12 @@ class MqttFan(FanEntity):
         """Return the oscillation state."""
         return self._oscillation
 
-    def turn_on(self, speed: str=SPEED_MEDIUM) -> None:
+    def turn_on(self, speed: str=None) -> None:
         """Turn on the entity."""
         mqtt.publish(self._hass, self._topic[CONF_COMMAND_TOPIC],
                      self._payload[STATE_ON], self._qos, self._retain)
-        self.set_speed(speed)
+        if speed:
+            self.set_speed(speed)
 
     def turn_off(self) -> None:
         """Turn off the entity."""


### PR DESCRIPTION
I always was annoyed that my fan was set to medium speed every time it turned on. Now I know that I only had myself to blame. I have thoroughly punished myself for this transgression and am submitting this pull request as my penance.

This is the beautiful thing about an open platform. I saw a problem. I fixed it in 30 seconds. I submitted it. Now everyone benefits.