### PR TITLE
[*.digital_ocean] Use device_state_attributes

### DIFF
--- a/homeassistant/components/binary_sensor/digital_ocean.py
+++ b/homeassistant/components/binary_sensor/digital_ocean.py
@@ -29,7 +29,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Digital Ocean droplet sensor."""
+    """Set up the Digital Ocean droplet sensor."""
     digital_ocean = get_component('digital_ocean')
     droplets = config.get(CONF_DROPLETS)
 
@@ -68,7 +68,7 @@ class DigitalOceanBinarySensor(BinarySensorDevice):
         return DEFAULT_SENSOR_CLASS
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes of the Digital Ocean droplet."""
         return {
             ATTR_CREATED_AT: self.data.created_at,

--- a/homeassistant/components/binary_sensor/threshold.py
+++ b/homeassistant/components/binary_sensor/threshold.py
@@ -110,7 +110,7 @@ class ThresholdSensor(BinarySensorDevice):
         return self._sensor_class
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes of the sensor."""
         return {
             ATTR_ENTITY_ID: self._entity_id,

--- a/homeassistant/components/switch/digital_ocean.py
+++ b/homeassistant/components/switch/digital_ocean.py
@@ -64,7 +64,7 @@ class DigitalOceanSwitch(SwitchDevice):
         return self.data.status == 'active'
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes of the Digital Ocean droplet."""
         return {
             ATTR_CREATED_AT: self.data.created_at,


### PR DESCRIPTION
**Description:**
Use `device_state_attributes()` instead of `state_attributes()` for the platforms.

**Example entry for `configuration.yaml` (if applicable):**
```yaml
digital_ocean:
  access_token: !secret do_api

binary_sensor:
  - platform: threshold
    threshold: 15
    entity_id: sensor.random
    type: upper
  - platform: digital_ocean
    droplets:
      - 'fedora-512mb-nyc3-01'
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
