### PR TITLE
Upgrade beautifulsoup4 to 4.5.3

### DIFF
--- a/homeassistant/components/sensor/hydroquebec.py
+++ b/homeassistant/components/sensor/hydroquebec.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['beautifulsoup4==4.5.1']
+REQUIREMENTS = ['beautifulsoup4==4.5.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/scrape.py
+++ b/homeassistant/components/sensor/scrape.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['beautifulsoup4==4.5.1']
+REQUIREMENTS = ['beautifulsoup4==4.5.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -60,7 +60,7 @@ batinfo==0.4.2
 
 # homeassistant.components.sensor.hydroquebec
 # homeassistant.components.sensor.scrape
-beautifulsoup4==4.5.1
+beautifulsoup4==4.5.3
 
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.8


### PR DESCRIPTION
4.5.3 (20170102)
=============
* Fixed foster parenting when html5lib is the tree builder.
* Fixed yet another problem that caused the html5lib tree builder to create a disconnected parse tree.

4.5.2 (20170102)
==========
* Apart from the version number, this release is identical to 4.5.3. Due to user error, it could not be completely uploaded to PyPI. Use 4.5.3 instead.

Tested with the following configuration:
```yaml
sensor:
  - platform: scrape
    resource: https://home-assistant.io/components/
    name: Home Assistant impl.
    select: 'a[href="#all"]'
    value_template: '{{ value.split("(")[1].split(")")[0] }}'
```

@titilambert could you please take a look if 4.5.3 works with the HydroQuebec sensor.
