### PR TITLE
Support for python-wink 1.0.0

### DIFF
--- a/homeassistant/components/alarm_control_panel/wink.py
+++ b/homeassistant/components/alarm_control_panel/wink.py
@@ -1,0 +1,68 @@
+"""
+Interfaces with Wink Cameras.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/alarm_control_panel.wink/
+"""
+import logging
+
+import homeassistant.components.alarm_control_panel as alarm
+from homeassistant.const import (STATE_UNKNOWN,
+                                 STATE_ALARM_DISARMED,
+                                 STATE_ALARM_ARMED_HOME,
+                                 STATE_ALARM_ARMED_AWAY)
+from homeassistant.components.wink import WinkDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['wink']
+STATE_ALARM_PRIVACY = 'Private'
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Wink platform."""
+    import pywink
+
+    for camera in pywink.get_cameras():
+        add_devices([WinkCameraDevice(camera, hass)])
+
+
+class WinkCameraDevice(WinkDevice, alarm.AlarmControlPanel):
+    """Representation a Wink camera alarm."""
+
+    def __init__(self, wink, hass):
+        """Initialize the Wink alarm."""
+        WinkDevice.__init__(self, wink, hass)
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        wink_state = self.wink.state()
+        if wink_state == "away":
+            state = STATE_ALARM_ARMED_AWAY
+        elif wink_state == "home":
+            state = STATE_ALARM_DISARMED
+        elif wink_state == "night":
+            state = STATE_ALARM_ARMED_HOME
+        else:
+            state = STATE_UNKNOWN
+        return state
+
+    def alarm_disarm(self, code=None):
+        """Send disarm command."""
+        self.wink.set_mode("home")
+
+    def alarm_arm_home(self, code=None):
+        """Send arm home command."""
+        self.wink.set_mode("night")
+
+    def alarm_arm_away(self, code=None):
+        """Send arm away command."""
+        self.wink.set_mode("away")
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            'private': self.wink.private()
+        }

--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -8,7 +8,6 @@ at https://home-assistant.io/components/binary_sensor.wink/
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.sensor.wink import WinkDevice
 from homeassistant.helpers.entity import Entity
-from homeassistant.loader import get_component
 
 DEPENDENCIES = ['wink']
 
@@ -43,6 +42,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for hub in pywink.get_hubs():
         add_devices([WinkHub(hub, hass)])
 
+    for remote in pywink.get_remotes():
+        add_devices([WinkRemote(remote, hass)])
+
+    for button in pywink.get_buttons():
+        add_devices([WinkButton(button, hass)])
+
+    for gang in pywink.get_gangs():
+        add_devices([WinkGang(gang, hass)])
+
 
 class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
     """Representation of a Wink binary sensor."""
@@ -50,33 +58,13 @@ class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
     def __init__(self, wink, hass):
         """Initialize the Wink binary sensor."""
         super().__init__(wink, hass)
-        wink = get_component('wink')
-        self._unit_of_measurement = self.wink.UNIT
+        self._unit_of_measurement = self.wink.unit()
         self.capability = self.wink.capability()
 
     @property
     def is_on(self):
         """Return true if the binary sensor is on."""
-        if self.capability == "loudness":
-            state = self.wink.loudness_boolean()
-        elif self.capability == "vibration":
-            state = self.wink.vibration_boolean()
-        elif self.capability == "brightness":
-            state = self.wink.brightness_boolean()
-        elif self.capability == "liquid_detected":
-            state = self.wink.liquid_boolean()
-        elif self.capability == "motion":
-            state = self.wink.motion_boolean()
-        elif self.capability == "presence":
-            state = self.wink.presence_boolean()
-        elif self.capability == "co_detected":
-            state = self.wink.co_detected_boolean()
-        elif self.capability == "smoke_detected":
-            state = self.wink.smoke_detected_boolean()
-        else:
-            state = self.wink.state()
-
-        return state
+        return self.wink.state()
 
     @property
     def sensor_class(self):
@@ -92,6 +80,11 @@ class WinkHub(WinkDevice, BinarySensorDevice, Entity):
         WinkDevice.__init__(self, wink, hass)
 
     @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self.wink.state()
+
+    @property
     def device_state_attributes(self):
         """Return the state attributes."""
         return {
@@ -99,7 +92,59 @@ class WinkHub(WinkDevice, BinarySensorDevice, Entity):
             'firmware version': self.wink.firmware_version()
         }
 
+
+class WinkRemote(WinkDevice, BinarySensorDevice, Entity):
+    """Representation of a Wink Lutron Connected bulb remote."""
+
+    def __init(self, wink, hass):
+        """Initialize the hub sensor."""
+        WinkDevice.__init__(self, wink, hass)
+
     @property
     def is_on(self):
         """Return true if the binary sensor is on."""
+        return self.wink.state()
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            'button_on_pressed': self.wink.button_on_pressed(),
+            'button_off_pressed': self.wink.button_off_pressed(),
+            'button_up_pressed': self.wink.button_up_pressed(),
+            'button_down_pressed': self.wink.button_down_pressed()
+        }
+
+
+class WinkButton(WinkDevice, BinarySensorDevice, Entity):
+    """Representation of a Wink Relay button."""
+
+    def __init(self, wink, hass):
+        """Initialize the hub sensor."""
+        WinkDevice.__init__(self, wink, hass)
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self.wink.state()
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            'pressed': self.wink.pressed(),
+            'long_pressed': self.wink.long_pressed()
+        }
+
+
+class WinkGang(WinkDevice, BinarySensorDevice, Entity):
+    """Representation of a Wink Relay gang."""
+
+    def __init(self, wink, hass):
+        """Initialize the gang sensor."""
+        WinkDevice.__init__(self, wink, hass)
+
+    @property
+    def is_on(self):
+        """Return true if the gang is connected."""
         return self.wink.state()

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -23,7 +23,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Wink lights."""
     import pywink
 
-    add_devices(WinkLight(light, hass) for light in pywink.get_bulbs())
+    add_devices(WinkLight(light, hass) for light in pywink.get_light_bulbs())
 
 
 class WinkLight(WinkDevice, Light):

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -17,10 +17,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for switch in pywink.get_switches():
         add_devices([WinkToggleDevice(switch, hass)])
-    for switch in pywink.get_powerstrip_outlets():
+    for switch in pywink.get_powerstrips():
         add_devices([WinkToggleDevice(switch, hass)])
     for switch in pywink.get_sirens():
         add_devices([WinkToggleDevice(switch, hass)])
+    for sprinkler in pywink.get_sprinklers():
+        add_devices([WinkToggleDevice(sprinkler, hass)])
 
 
 class WinkToggleDevice(WinkDevice, ToggleEntity):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-wink==0.12.0', 'pubnubsub-handler==0.0.7']
+REQUIREMENTS = ['python-wink==1.0.0', 'pubnubsub-handler==0.0.7']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,14 +28,16 @@ CONF_CLIENT_ID = 'client_id'
 CONF_CLIENT_SECRET = 'client_secret'
 CONF_USER_AGENT = 'user_agent'
 CONF_OATH = 'oath'
+CONF_APPSPOT = 'appspot'
 CONF_DEFINED_BOTH_MSG = 'Remove access token to use oath2.'
 CONF_MISSING_OATH_MSG = 'Missing oath2 credentials.'
+CONF_TOKEN_URL = "https://winkbearertoken.appspot.com/token"
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Inclusive(CONF_EMAIL, CONF_OATH,
+        vol.Inclusive(CONF_EMAIL, CONF_APPSPOT,
                       msg=CONF_MISSING_OATH_MSG): cv.string,
-        vol.Inclusive(CONF_PASSWORD, CONF_OATH,
+        vol.Inclusive(CONF_PASSWORD, CONF_APPSPOT,
                       msg=CONF_MISSING_OATH_MSG): cv.string,
         vol.Inclusive(CONF_CLIENT_ID, CONF_OATH,
                       msg=CONF_MISSING_OATH_MSG): cv.string,
@@ -45,19 +47,22 @@ CONFIG_SCHEMA = vol.Schema({
                       msg=CONF_DEFINED_BOTH_MSG): cv.string,
         vol.Exclusive(CONF_ACCESS_TOKEN, CONF_OATH,
                       msg=CONF_DEFINED_BOTH_MSG): cv.string,
+        vol.Exclusive(CONF_ACCESS_TOKEN, CONF_APPSPOT,
+                      msg=CONF_DEFINED_BOTH_MSG): cv.string,
         vol.Optional(CONF_USER_AGENT, default=None): cv.string
     })
 }, extra=vol.ALLOW_EXTRA)
 
 WINK_COMPONENTS = [
     'binary_sensor', 'sensor', 'light', 'switch', 'lock', 'cover', 'climate',
-    'fan'
+    'fan', 'alarm_control_panel'
 ]
 
 
 def setup(hass, config):
     """Set up the Wink component."""
     import pywink
+    import requests
     from pubnubsubhandler import PubNubSubscriptionHandler
 
     user_agent = config[DOMAIN].get(CONF_USER_AGENT)
@@ -66,16 +71,24 @@ def setup(hass, config):
         pywink.set_user_agent(user_agent)
 
     access_token = config[DOMAIN].get(CONF_ACCESS_TOKEN)
+    client_id = config[DOMAIN].get('client_id')
 
     if access_token:
         pywink.set_bearer_token(access_token)
-    else:
+    elif client_id:
         email = config[DOMAIN][CONF_EMAIL]
         password = config[DOMAIN][CONF_PASSWORD]
         client_id = config[DOMAIN]['client_id']
         client_secret = config[DOMAIN]['client_secret']
         pywink.set_wink_credentials(email, password, client_id,
                                     client_secret)
+    else:
+        email = config[DOMAIN][CONF_EMAIL]
+        password = config[DOMAIN][CONF_PASSWORD]
+        payload = {'username': email, 'password': password}
+        token_response = requests.post(CONF_TOKEN_URL, data=payload)
+        token = token_response.text.split(':')[1].split()[0].rstrip('<br')
+        pywink.set_bearer_token(token)
 
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN]['entities'] = []
@@ -112,8 +125,9 @@ class WinkDevice(Entity):
 
     def __init__(self, wink, hass):
         """Initialize the Wink device."""
+        self.hass = hass
         self.wink = wink
-        self._battery = self.wink.battery_level
+        self._battery = self.wink.battery_level()
         hass.data[DOMAIN]['pubnub'].add_subscription(
             self.wink.pubnub_channel, self._pubnub_update)
         hass.data[DOMAIN]['entities'].append(self)
@@ -133,11 +147,6 @@ class WinkDevice(Entity):
             self.update_ha_state(True)
 
     @property
-    def unique_id(self):
-        """Return the ID of this Wink device."""
-        return '{}.{}'.format(self.__class__, self.wink.device_id())
-
-    @property
     def name(self):
         """Return the name of the device."""
         return self.wink.name()
@@ -145,7 +154,7 @@ class WinkDevice(Entity):
     @property
     def available(self):
         """True if connection == True."""
-        return self.wink.available
+        return self.wink.available()
 
     def update(self):
         """Update state of the device."""
@@ -167,5 +176,5 @@ class WinkDevice(Entity):
     @property
     def _battery_level(self):
         """Return the battery level."""
-        if self.wink.battery_level is not None:
-            return self.wink.battery_level * 100
+        if self.wink.battery_level() is not None:
+            return self.wink.battery_level() * 100

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -369,7 +369,7 @@ proliphix==0.4.1
 psutil==5.0.1
 
 # homeassistant.components.wink
-pubnubsub-handler==0.0.7
+pubnubsub-handler==1.0.0
 
 # homeassistant.components.notify.pushbullet
 pushbullet.py==0.10.0
@@ -528,7 +528,7 @@ python-twitch==1.3.0
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==0.12.0
+python-wink==1.0.0
 
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5


### PR DESCRIPTION
**Description:**
* Door/windows sensors names have changed to include what is called their capability so what was once `binary_sensor.front_door` will now be called `binary_sensor.front_door_opened`
* Wink Relays will now report three more sensors.
    * the gang's connection status, will most likely be called gang and probably doesn't have much of a purpose.
    * The top button as a binary sensor indicating if the button was pressed.
    * The bottom button as a binary sensor indicating if the button was pressed.
    * Only switches that are connect to a load will show up
* You no longer need to set your user-agent in the home-assistant config to get access to the Wink Relay sensors.
* Lutron connected bulb remotes will show up as a binary_sensor. The status of that sensor will be true if any button on the remote is pressed. The sensor has attributes for each button so new sensors can be made with a template sensor or automations can be made with template triggers. (Pico remotes aren't supported)
* Quirky powerstrips now report three devices
    * Outlet 1
    * Outlet 2
    * The main power strip. Toggling the powerstrip device will turn on/off both outlets at once.
* Canary cameras are support as an alarm control panel. With the following state translations.
    * Disarm = Home
    * Armed = Away
    * Armed Home = Night
    * There is currently no support for setting privacy mode in Home-Assistant (Haven't figured it out yet)
* Nest smoke protectors now report two more sensors
    * Smoke severity (I think in a percentage)
    * CO severity also in a percentage I think.
* Sprinklers are now support should show up as a binary switch
* Door bells are supported as binary sensors
    * Motion
    * Button pressed
* There is a new method of authentication. If you don't have a client_id and client_secret you can add just your email and password to the config and your access token will be pulled from the home-assistant.io site automatically during startup. @balloob You mentioned adding a web service to access the Wink token. If you can, please see if the method I am using is acceptable, I am using the current form on the home-assistant.io site. Once this is vetted we could remove the form and maybe change it to return JSON? This current method also grabs a new token on every restart which is what happens when setting a client_id and client_secret in the config today. 



**Related issue (if applicable):** fixes stuff mentioned here https://community.home-assistant.io/t/ha-stops-reporting-wink-state-changes

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**

Config can now be set in three ways.
The original way, hard coded token requires manual refresh.
```yaml
wink:
  access_token: TOKEN
```
If the user has their own client_id and client_secret, a new token is grabbed at every reboot and python-wink handles a token refresh when it is required.
```yaml
wink:
  email: email
  password: password
  client_id: client_id
  client_secret: client_secret
```

A new token is grabbed from the home-assistant.io site at every startup. No refresh is done during the life time of the running hass instance.
```yaml
wink:
  email: email
  password: password
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
