### PR TITLE
Update keyboard_remote.py

### DIFF
--- a/homeassistant/components/keyboard_remote.py
+++ b/homeassistant/components/keyboard_remote.py
@@ -50,10 +50,7 @@ def setup(hass, config):
 
     if not config.get(DEVICE_DESCRIPTOR) and\
        not config.get(DEVICE_NAME):
-        _LOGGER.error(
-            'No device_descriptor\
-             or device_name found.'
-            )
+        _LOGGER.error('No device_descriptor or device_name found.')
         return
 
     keyboard_remote = KeyboardRemote(

--- a/homeassistant/components/keyboard_remote.py
+++ b/homeassistant/components/keyboard_remote.py
@@ -50,8 +50,8 @@ def setup(hass, config):
 
     if not config.get(DEVICE_DESCRIPTOR) and\
        not config.get(DEVICE_NAME):
-        _LOGGER.debug(
-            'Error: No device_descriptor\
+        _LOGGER.error(
+            'No device_descriptor\
              or device_name found.'
             )
         return

--- a/homeassistant/components/keyboard_remote.py
+++ b/homeassistant/components/keyboard_remote.py
@@ -50,7 +50,7 @@ def setup(hass, config):
 
     if not config.get(DEVICE_DESCRIPTOR) and\
        not config.get(DEVICE_NAME):
-        _LOGGER.warn(
+        _LOGGER.debug(
             'KeyboardRemote: Error: No device_descriptor\
              or device_name found.'
             )
@@ -90,14 +90,14 @@ class KeyboardRemote(threading.Thread):
         self.device_name = config.get(DEVICE_NAME)
         self.dev = self._get_keyboard_device()
         if self.dev is not None:
-            _LOGGER.warn(
+            _LOGGER.debug(
                 'KeyboardRemote: keyboard connected'
                 )
         else:
             id_folder = '/dev/input/by-id/'
             device_names = [InputDevice(file_name).name
                             for file_name in list_devices()]
-            _LOGGER.warn(
+            _LOGGER.debug(
                 'KeyboardRemote: keyboard not connected.\
                 Check /dev/input/event* permissions.\
                 Possible device names are:\n %s.\n \
@@ -152,7 +152,7 @@ class KeyboardRemote(threading.Thread):
                     self.hass.bus.fire(
                         KEYBOARD_REMOTE_CONNECTED
                     )
-                    _LOGGER.warn('KeyboardRemote: keyboard re-connected')
+                    _LOGGER.debug('KeyboardRemote: keyboard re-connected')
                 else:
                     continue
 
@@ -163,7 +163,7 @@ class KeyboardRemote(threading.Thread):
                 self.hass.bus.fire(
                     KEYBOARD_REMOTE_DISCONNECTED
                 )
-                _LOGGER.warn('KeyboardRemote: keyboard disconnected')
+                _LOGGER.debug('KeyboardRemote: keyboard disconnected')
                 continue
 
             if not event:


### PR DESCRIPTION
I changed the way the component refers to the keyboard: not by "descriptor", but by name.
The fact is that the udev system doesn't always give a name link in /dev/input/by-id folder and the actual /dev/input/eventX file changes automatically. 
For example, if I had my keyboard on /dev/input/event13 and then it disconnected, if something else connects to the system it will get the first input file available, that is /dev/input/event13. If the keyboard then reconnects, it will get /dev/input/event14, thus breaking the configuration.
Now it searches every time for the right input file.
The problem might be that, in case of ha upgrade, the pre-existing configuration won't work. I think there are some guidelines here, but I am not sure.
But I think it's inevitable: the initial idea to use a /dev/input/by-id/ symbolic link was good, but unfortunately it doesn't seem to work with bluetooth devices.

I haven't updated the documentation yet: I'm waiting for some ok about the change in configuration key names.

**Description:**


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
