### PR TITLE
[core.config] Support customize in packages

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -529,7 +529,7 @@ def test_merge_customize(hass):
         'elevation': 25,
         'name': 'Huis',
         CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
-        'time_zone': 'America/New_York',
+        'time_zone': 'GMT',
         'customize': {'a.a': {'friendly_name': 'A'}},
         'packages': {'pkg1': {'homeassistant': {'customize': {
             'b.b': {'friendly_name': 'BB'}}}}},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -542,4 +542,5 @@ def test_merge_customize(hass):
     yield from entity.async_update_ha_state()
 
     state = hass.states.get('b.b')
-    assert 'friendly_name' in state.attributes
+    assert state is not None
+    assert state.attributes['friendly_name'] == 'BB'


### PR DESCRIPTION
**Description:**
Support for `homeassistant/customize` in packages

CC: @dale3h 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
homeassistant:
  ...
  customize:
    a: 
      friendly_name: A
  packages:
    pkg1:
      homeassistant:
        customize:
          b: 
            friendly_name: B
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
