### PR TITLE
Add support for Mipow Bluetooth bulbs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -198,6 +198,7 @@ omit =
     homeassistant/components/light/hyperion.py
     homeassistant/components/light/lifx.py
     homeassistant/components/light/limitlessled.py
+    homeassistant/components/light/mipow.py
     homeassistant/components/light/osramlightify.py
     homeassistant/components/light/tikteck.py
     homeassistant/components/light/x10.py

--- a/homeassistant/components/light/mipow.py
+++ b/homeassistant/components/light/mipow.py
@@ -1,0 +1,140 @@
+"""
+Support for Mipow Bluetooth smartbulbs.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.mipow/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_DEVICES, CONF_NAME
+from homeassistant.components.light import (
+    ATTR_RGB_COLOR, ATTR_WHITE_VALUE, SUPPORT_RGB_COLOR, SUPPORT_WHITE_VALUE,
+    Light, PLATFORM_SCHEMA)
+from homeassistant.util.color import color_rgb_to_rgbw, color_rgbw_to_rgb
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['https://github.com/mjg59/python-mipow/releases/download/0.3/'
+                'mipow-0.3.tar.gz#mipow==0.3']
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORT_MIPOW_LED = (SUPPORT_RGB_COLOR | SUPPORT_WHITE_VALUE)
+
+DEVICE_SCHEMA = vol.Schema({
+    vol.Optional(CONF_NAME): cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up a Mipow bulb."""
+    lights = []
+    for address, device_config in config[CONF_DEVICES].items():
+        device = {}
+        device['name'] = device_config[CONF_NAME]
+        device['address'] = address
+        light = MipowLight(device)
+        if light.is_valid:
+            lights.append(light)
+
+    add_devices(lights)
+
+
+class MipowLight(Light):
+    """Representation of a Mipow light."""
+
+    def __init__(self, device):
+        """Initialize the light."""
+        # pylint: disable=import-error
+        import mipow
+
+        self._name = device['name']
+        self._address = device['address']
+        self._white = 0
+        self._rgb = (0, 0, 0)
+        self._state = False
+        self._bulb = mipow.mipow(self._address)
+        self._bulb.connect()
+        self.update()
+        self.is_valid = True
+
+    @property
+    def unique_id(self):
+        """Return the ID of this light."""
+        return "{}.{}".format(self.__class__, self._address)
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    @property
+    def rgb_color(self):
+        """Return the colour property."""
+        return color_rgbw_to_rgb(self._rgb[0], self._rgb[1], self._rgb[2],
+                                 self._white)
+
+    @property
+    def white_value(self):
+        """Return the white property."""
+        return self._white
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        if self._bulb.mono:
+            return SUPPORT_WHITE_VALUE
+        else:
+            return SUPPORT_MIPOW_LED
+
+    @property
+    def assumed_state(self):
+        """We can read the actual state."""
+        return False
+
+    def set_rgb(self, red, green, blue):
+        """Set the rgb state."""
+        rgbw = color_rgb_to_rgbw(red, green, blue)
+        self._bulb.set_rgbw(rgbw[0], rgbw[1], rgbw[2], rgbw[3])
+        self.update()
+
+    def set_white(self, white):
+        """Set the white state."""
+        self._bulb.set_white(white)
+        self.update()
+
+    def turn_on(self, **kwargs):
+        """Turn the specified bulb on."""
+        rgb = kwargs.get(ATTR_RGB_COLOR)
+        white = kwargs.get(ATTR_WHITE_VALUE)
+
+        if white is not None:
+            self.set_white(white)
+        elif rgb is not None:
+            self.set_rgb(rgb[0], rgb[1], rgb[2])
+        else:
+            self._bulb.set_rgbw(self._rgb[0], self._rgb[1], self._rgb[2],
+                                self._white)
+
+    def turn_off(self, **kwargs):
+        """Turn the specified or all lights off."""
+        self._state = False
+        self.set_rgb(0, 0, 0)
+
+    def update(self):
+        """Synchronise internal state with that of the bulb."""
+        (red, green, blue, white) = self._bulb.get_rgbw()
+        if red != 0 or green != 0 or blue != 0 or white != 0:
+            self._state = True
+            self._white = white
+            self._rgb = (red, green, blue)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -234,6 +234,9 @@ https://github.com/joopert/nad_receiver/archive/0.0.3.zip#nad_receiver==0.0.3
 # homeassistant.components.media_player.russound_rnet
 https://github.com/laf/russound/archive/0.1.6.zip#russound==0.1.6
 
+# homeassistant.components.light.mipow
+# https://github.com/mjg59/python-mipow/releases/download/0.3/mipow-0.3.tar.gz#mipow==0.3
+
 # homeassistant.components.switch.anel_pwrctrl
 https://github.com/mweinelt/anel-pwrctrl/archive/ed26e8830e28a2bfa4260a9002db23ce3e7e63d7.zip#anel_pwrctrl==0.0.1
 


### PR DESCRIPTION
This adds support for Bluetooth bulbs from Mipow. These are available in
both monochrome and full RGBW versions. This uses a forked version of
python-mipow for now in order to support both types.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
light:
  - platform: mipow
    devices:
      60:f4:4b:11:ac:e6:
        name: Office
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
