### PR TITLE
Emulated_hue: default type to Google [Breaking change]

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -45,7 +45,7 @@ DEFAULT_EXPOSE_BY_DEFAULT = True
 DEFAULT_EXPOSED_DOMAINS = [
     'switch', 'light', 'group', 'input_boolean', 'media_player', 'fan'
 ]
-DEFAULT_TYPE = TYPE_ALEXA
+DEFAULT_TYPE = TYPE_GOOGLE
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -121,6 +121,10 @@ class Config(object):
         self.type = conf.get(CONF_TYPE)
         self.numbers = None
         self.cached_states = {}
+
+        if self.type == TYPE_ALEXA:
+            _LOGGER.warning('Alexa type is deprecated and will be removed in a'
+                            ' future version')
 
         # Get the IP address that will be passed to the Echo during discovery
         self.host_ip_addr = conf.get(CONF_HOST_IP)


### PR DESCRIPTION
**Description:**
With the introduction of https://github.com/home-assistant/home-assistant/pull/5435 we are able to persist the numbers that emulated_hue gives to each entity id. This fixes grouping in Google Home and also makes it work for Alexa. This makes the google_home option now the correct option for all. The same ids for devices, including after reboots.

The alexa option is flawed as it uses entity ids as light ids while Hue is limited to numbers. Alexa supports strings so it worked.

Now that Google Home option is the correct implementation, it is time to switch over the default implementation.

If you are using Alexa and do not want to reconfigure it, update your configuration to be like this:

```yaml
emulated_hue:
  type: alexa
```

A warning has been added that this option will be removed in the future.