### PR TITLE
Emulated Hue "host-ip" fails to bind when running in docker without --net=host

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -176,9 +176,11 @@ class Config(object):
             CONF_EXPOSED_DOMAINS, DEFAULT_EXPOSED_DOMAINS)
         
         # Calculated effective advertised IP and port for network isolation
-        self.advertise_ip = conf.get(CONF_ADVERTISE_IP) or self.host_ip_addr
+        self.advertise_ip = conf.get(
+            CONF_ADVERTISE_IP) or self.host_ip_addr
 
-        self.advertise_port = conf.get(CONF_ADVERTISE_PORT) or self.listen_port
+        self.advertise_port = conf.get(
+            CONF_ADVERTISE_PORT) or self.listen_port
 
     def entity_id_to_number(self, entity_id):
         """Get a unique number for the entity id."""

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -174,7 +174,7 @@ class Config(object):
         # True
         self.exposed_domains = conf.get(
             CONF_EXPOSED_DOMAINS, DEFAULT_EXPOSED_DOMAINS)
-        
+
         # Calculated effective advertised IP and port for network isolation
         self.advertise_ip = conf.get(
             CONF_ADVERTISE_IP) or self.host_ip_addr

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -175,7 +175,7 @@ class Config(object):
         self.exposed_domains = conf.get(
             CONF_EXPOSED_DOMAINS, DEFAULT_EXPOSED_DOMAINS)
         
-        # Calculated effective advertised IP and port
+        # Calculated effective advertised IP and port for network isolation
         self.advertise_ip = conf.get(CONF_ADVERTISE_IP) or self.host_ip_addr
 
         self.advertise_port = conf.get(CONF_ADVERTISE_PORT) or self.listen_port

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -29,6 +29,8 @@ NUMBERS_FILE = 'emulated_hue_ids.json'
 
 CONF_HOST_IP = 'host_ip'
 CONF_LISTEN_PORT = 'listen_port'
+CONF_ADVERTISE_IP = 'advertise_ip'
+CONF_ADVERTISE_PORT = 'advertise_port'
 CONF_UPNP_BIND_MULTICAST = 'upnp_bind_multicast'
 CONF_OFF_MAPS_TO_ON_DOMAINS = 'off_maps_to_on_domains'
 CONF_EXPOSE_BY_DEFAULT = 'expose_by_default'
@@ -51,6 +53,9 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_HOST_IP): cv.string,
         vol.Optional(CONF_LISTEN_PORT, default=DEFAULT_LISTEN_PORT):
+            vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
+        vol.Optional(CONF_ADVERTISE_IP): cv.string,
+        vol.Optional(CONF_ADVERTISE_PORT):
             vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
         vol.Optional(CONF_UPNP_BIND_MULTICAST): cv.boolean,
         vol.Optional(CONF_OFF_MAPS_TO_ON_DOMAINS): cv.ensure_list,
@@ -91,7 +96,8 @@ def setup(hass, yaml_config):
 
     upnp_listener = UPNPResponderThread(
         config.host_ip_addr, config.listen_port,
-        config.upnp_bind_multicast)
+        config.upnp_bind_multicast, config.advertise_ip,
+        config.advertise_port)
 
     @asyncio.coroutine
     def stop_emulated_hue_bridge(event):

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -30,6 +30,8 @@ NUMBERS_FILE = 'emulated_hue_ids.json'
 
 CONF_HOST_IP = 'host_ip'
 CONF_LISTEN_PORT = 'listen_port'
+CONF_ADVERTISE_IP = 'advertise_ip'
+CONF_ADVERTISE_PORT = 'advertise_port'
 CONF_UPNP_BIND_MULTICAST = 'upnp_bind_multicast'
 CONF_OFF_MAPS_TO_ON_DOMAINS = 'off_maps_to_on_domains'
 CONF_EXPOSE_BY_DEFAULT = 'expose_by_default'
@@ -52,6 +54,9 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_HOST_IP): cv.string,
         vol.Optional(CONF_LISTEN_PORT, default=DEFAULT_LISTEN_PORT):
+            vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
+        vol.Optional(CONF_ADVERTISE_IP): cv.string,
+        vol.Optional(CONF_ADVERTISE_PORT):
             vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
         vol.Optional(CONF_UPNP_BIND_MULTICAST): cv.boolean,
         vol.Optional(CONF_OFF_MAPS_TO_ON_DOMAINS): cv.ensure_list,
@@ -92,7 +97,8 @@ def setup(hass, yaml_config):
 
     upnp_listener = UPNPResponderThread(
         config.host_ip_addr, config.listen_port,
-        config.upnp_bind_multicast)
+        config.upnp_bind_multicast, config.advertise_ip,
+        config.advertise_port)
 
     @asyncio.coroutine
     def stop_emulated_hue_bridge(event):

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -174,6 +174,11 @@ class Config(object):
         # True
         self.exposed_domains = conf.get(
             CONF_EXPOSED_DOMAINS, DEFAULT_EXPOSED_DOMAINS)
+        
+        # Calculated effective advertised IP and port
+        self.advertise_ip = conf.get(CONF_ADVERTISE_IP) or self.host_ip_addr
+
+        self.advertise_port = conf.get(CONF_ADVERTISE_PORT) or self.listen_port
 
     def entity_id_to_number(self, entity_id):
         """Get a unique number for the entity id."""

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -49,8 +49,16 @@ class DescriptionXmlView(HomeAssistantView):
 </root>
 """
 
+        resp_ip = self.config.advertise_ip if \
+                  self.config.advertise_ip else \
+                  self.config.host_ip_addr
+
+        resp_port = self.config.advertise_port if \
+                    self.config.advertise_port else \
+                    self.config.listen_port
+
         resp_text = xml_template.format(
-            self.config.host_ip_addr, self.config.listen_port)
+            resp_ip, resp_port)
 
         return web.Response(text=resp_text, content_type='text/xml')
 
@@ -60,13 +68,26 @@ class UPNPResponderThread(threading.Thread):
 
     _interrupted = False
 
-    def __init__(self, host_ip_addr, listen_port, upnp_bind_multicast):
+    def __init__(self, host_ip_addr, listen_port, upnp_bind_multicast,
+                 advertise_ip, advertise_port):
         """Initialize the class."""
         threading.Thread.__init__(self)
 
         self.host_ip_addr = host_ip_addr
         self.listen_port = listen_port
         self.upnp_bind_multicast = upnp_bind_multicast
+        self.advertise_ip = advertise_ip
+        self.advertise_port = advertise_port
+
+        # If using the advertisement overides, only
+        # use them for forming the responses
+        resp_ip = self.advertise_ip if \
+                  self.advertise_ip else \
+                  self.host_ip_addr
+        resp_port = self.advertise_port if \
+                    self.advertise_port else \
+                    self.listen_port
+
 
         # Note that the double newline at the end of
         # this string is required per the SSDP spec
@@ -81,7 +102,7 @@ USN: uuid:Socket-1_0-221438K0100073::urn:schemas-upnp-org:device:basic:1
 
 """
 
-        self.upnp_response = resp_template.format(host_ip_addr, listen_port) \
+        self.upnp_response = resp_template.format(resp_ip, resp_port) \
                                           .replace("\n", "\r\n") \
                                           .encode('utf-8')
 

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -82,9 +82,9 @@ USN: uuid:Socket-1_0-221438K0100073::urn:schemas-upnp-org:device:basic:1
 
 """
 
-        self.upnp_response = resp_template.format(advertise_ip, advertise_port) \
-                                          .replace("\n", "\r\n") \
-                                          .encode('utf-8')
+        self.upnp_response = resp_template.format(
+            advertise_ip, advertise_port).replace("\n", "\r\n") \
+                                         .encode('utf-8')
 
         # Set up a pipe for signaling to the receiver that it's time to
         # shutdown. Essentially, we place the SSDP socket into nonblocking

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -49,16 +49,8 @@ class DescriptionXmlView(HomeAssistantView):
 </root>
 """
 
-        resp_ip = self.config.advertise_ip if \
-            self.config.advertise_ip else \
-            self.config.host_ip_addr
-
-        resp_port = self.config.advertise_port if \
-            self.config.advertise_port else \
-            self.config.listen_port
-
         resp_text = xml_template.format(
-            resp_ip, resp_port)
+            self.config.advertise_ip, self.config.advertise_port)
 
         return web.Response(text=resp_text, content_type='text/xml')
 
@@ -76,18 +68,6 @@ class UPNPResponderThread(threading.Thread):
         self.host_ip_addr = host_ip_addr
         self.listen_port = listen_port
         self.upnp_bind_multicast = upnp_bind_multicast
-        self.advertise_ip = advertise_ip
-        self.advertise_port = advertise_port
-
-        # If using the advertisement overides, only
-        # use them for forming the responses
-        resp_ip = self.advertise_ip if \
-            self.advertise_ip else \
-            self.host_ip_addr
-
-        resp_port = self.advertise_port if \
-            self.advertise_port else \
-            self.listen_port
 
         # Note that the double newline at the end of
         # this string is required per the SSDP spec
@@ -102,7 +82,7 @@ USN: uuid:Socket-1_0-221438K0100073::urn:schemas-upnp-org:device:basic:1
 
 """
 
-        self.upnp_response = resp_template.format(resp_ip, resp_port) \
+        self.upnp_response = resp_template.format(advertise_ip, advertise_port) \
                                           .replace("\n", "\r\n") \
                                           .encode('utf-8')
 

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -50,12 +50,12 @@ class DescriptionXmlView(HomeAssistantView):
 """
 
         resp_ip = self.config.advertise_ip if \
-                  self.config.advertise_ip else \
-                  self.config.host_ip_addr
+            self.config.advertise_ip else \
+            self.config.host_ip_addr
 
         resp_port = self.config.advertise_port if \
-                    self.config.advertise_port else \
-                    self.config.listen_port
+            self.config.advertise_port else \
+            self.config.listen_port
 
         resp_text = xml_template.format(
             resp_ip, resp_port)
@@ -82,12 +82,12 @@ class UPNPResponderThread(threading.Thread):
         # If using the advertisement overides, only
         # use them for forming the responses
         resp_ip = self.advertise_ip if \
-                  self.advertise_ip else \
-                  self.host_ip_addr
-        resp_port = self.advertise_port if \
-                    self.advertise_port else \
-                    self.listen_port
+            self.advertise_ip else \
+            self.host_ip_addr
 
+        resp_port = self.advertise_port if \
+            self.advertise_port else \
+            self.listen_port
 
         # Note that the double newline at the end of
         # this string is required per the SSDP spec


### PR DESCRIPTION
**Description:**
Adding the extra configuration item for issue 5508, allowing the override of the ip and port used for emulated_hue upnp.
**Related issue (if applicable):** fixes #5508 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

^Pending.

**Example entry for `configuration.yaml` (if applicable):**
```yaml

host_ip: 0.0.0.0
listen_port: 8300
advertise_ip: 10.0.0.99
advertise_port: 80
off_maps_to_on_domains:
  - script
  - scene
expose_by_default: false
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ n/a] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ n/a] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ n/a] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ n/a] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ n/a] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ n/a] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
