### PR TITLE
homematic: add MAX shutter contact class

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -68,7 +68,7 @@ HM_DEVICE_TYPES = {
     DISCOVER_BINARY_SENSORS: [
         'ShutterContact', 'Smoke', 'SmokeV2', 'Motion', 'MotionV2',
         'RemoteMotion', 'WeatherSensor', 'TiltSensor', 'IPShutterContact',
-        'HMWIOSwitch'],
+        'HMWIOSwitch', 'MaxShutterContact'],
     DISCOVER_COVER: ['Blind', 'KeyBlind']
 }
 


### PR DESCRIPTION
MAX wireless shutter contacts behave slightly different. Support the special class added in pyhomematic 0.1.20.

The devices are automatically discovered. This change makes supports the new class of shutter devices in home-assistant. 
