### PR TITLE
Allow a protocol in the http.base_url parameter

### DIFF
--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -61,7 +61,9 @@ class API(object):
         self.port = port
         self.api_password = api_password
 
-        if use_ssl:
+        if host.startswith(("http://", "https://")):
+            self.base_url = host
+        elif use_ssl:
             self.base_url = "https://{}".format(host)
         else:
             self.base_url = "http://{}".format(host)


### PR DESCRIPTION
**Description:** This allows giving a full URL in the `http.base_url` parameter, including the protocol. Feature request from the forums [here](https://community.home-assistant.io/t/force-https-for-base-url/8623).


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
