### PR TITLE
Bugfix sonos / refactor of sonos function for TTS

### DIFF
--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -154,10 +154,14 @@ clear_playlist:
       description: Name(s) of entites to change source on
       example: 'media_player.living_room_chromecast'
 
-sonos_group_players:
-  description: Send Sonos media player the command for grouping all players into one (party mode).
+sonos_join:
+  description: Group player toggether.
 
   fields:
+    master:
+      description: this player is the coordinator of the group. Platform dependent.
+      example: 'media_player.living_room_sonos'
+
     entity_id:
       description: Name(s) of entites that will coordinate the grouping. Platform dependent.
       example: 'media_player.living_room_sonos'
@@ -178,6 +182,10 @@ sonos_snapshot:
       description: Name(s) of entites that will be snapshot. Platform dependent.
       example: 'media_player.living_room_sonos'
 
+    with_group:
+      description: True (default) or False. Snapshot with all group attributes.
+      example: 'true'
+
 sonos_restore:
   description: Restore a snapshot of the media player.
 
@@ -185,6 +193,10 @@ sonos_restore:
     entity_id:
       description: Name(s) of entites that will be restored. Platform dependent.
       example: 'media_player.living_room_sonos'
+
+    with_group:
+      description: True (default) or False. Restore with all group attributes.
+      example: 'true'
 
 sonos_set_sleep_timer:
   description: Set a Sonos timer

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -155,11 +155,11 @@ clear_playlist:
       example: 'media_player.living_room_chromecast'
 
 sonos_join:
-  description: Group player toggether.
+  description: Group player together.
 
   fields:
     master:
-      description: this player is the coordinator of the group. Platform dependent.
+      description: Entity ID of the player that should become the coordinator of the group.
       example: 'media_player.living_room_sonos'
 
     entity_id:

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -42,12 +42,14 @@ SUPPORT_SONOS = SUPPORT_STOP | SUPPORT_PAUSE | SUPPORT_VOLUME_SET |\
     SUPPORT_PLAY_MEDIA | SUPPORT_SEEK | SUPPORT_CLEAR_PLAYLIST |\
     SUPPORT_SELECT_SOURCE | SUPPORT_PLAY
 
-SERVICE_GROUP_PLAYERS = 'sonos_group_players'
+SERVICE_JOIN = 'sonos_join'
 SERVICE_UNJOIN = 'sonos_unjoin'
 SERVICE_SNAPSHOT = 'sonos_snapshot'
 SERVICE_RESTORE = 'sonos_restore'
 SERVICE_SET_TIMER = 'sonos_set_sleep_timer'
 SERVICE_CLEAR_TIMER = 'sonos_clear_sleep_timer'
+
+DATA_SONOS = 'sonos'
 
 SUPPORT_SOURCE_LINEIN = 'Line-in'
 SUPPORT_SOURCE_TV = 'TV'
@@ -57,6 +59,8 @@ CONF_INTERFACE_ADDR = 'interface_addr'
 
 # Service call validation schemas
 ATTR_SLEEP_TIME = 'sleep_time'
+ATTR_MASTER = 'master'
+ATTR_WITH_GROUP = 'with_group'
 
 ATTR_IS_COORDINATOR = 'is_coordinator'
 
@@ -70,19 +74,26 @@ SONOS_SCHEMA = vol.Schema({
     ATTR_ENTITY_ID: cv.entity_ids,
 })
 
-SONOS_SET_TIMER_SCHEMA = SONOS_SCHEMA.extend({
-    vol.Required(ATTR_SLEEP_TIME): vol.All(vol.Coerce(int),
-                                           vol.Range(min=0, max=86399))
+SONOS_JOIN_SCHEMA = SONOS_SCHEMA.extend({
+    vol.Required(ATTR_MASTER): cv.entity_id,
 })
 
-# List of devices that have been registered
-DEVICES = []
+SONOS_STATES_SCHEMA = SONOS_SCHEMA.extend({
+    vol.Optional(ATTR_WITH_GROUP, default=True): cv.boolean,
+})
+
+SONOS_SET_TIMER_SCHEMA = SONOS_SCHEMA.extend({
+    vol.Required(ATTR_SLEEP_TIME):
+        vol.All(vol.Coerce(int), vol.Range(min=0, max=86399))
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Sonos platform."""
     import soco
-    global DEVICES
+
+    if DATA_SONOS not in hass.data:
+        hass.data[DATA_SONOS] = []
 
     advertise_addr = config.get(CONF_ADVERTISE_ADDR, None)
     if advertise_addr:
@@ -92,154 +103,91 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         player = soco.SoCo(discovery_info)
 
         # if device allready exists by config
-        if player.uid in [x.unique_id for x in DEVICES]:
-            return True
+        if player.uid in [x.unique_id for x in hass.data[DATA_SONOS]]:
+            return
 
         if player.is_visible:
             device = SonosDevice(hass, player)
             add_devices([device], True)
-            if not DEVICES:
-                register_services(hass)
-            DEVICES.append(device)
-            return True
-        return False
+            hass.data[DATA_SONOS].append(device)
+            if len(hass.data[DATA_SONOS]) > 1:
+                return
+    else:
+        players = None
+        hosts = config.get(CONF_HOSTS, None)
+        if hosts:
+            # Support retro compatibility with comma separated list of hosts
+            # from config
+            hosts = hosts[0] if len(hosts) == 1 else hosts
+            hosts = hosts.split(',') if isinstance(hosts, str) else hosts
+            players = []
+            for host in hosts:
+                players.append(soco.SoCo(socket.gethostbyname(host)))
 
-    players = None
-    hosts = config.get(CONF_HOSTS, None)
-    if hosts:
-        # Support retro compatibility with comma separated list of hosts
-        # from config
-        hosts = hosts[0] if len(hosts) == 1 else hosts
-        hosts = hosts.split(',') if isinstance(hosts, str) else hosts
-        players = []
-        for host in hosts:
-            players.append(soco.SoCo(socket.gethostbyname(host)))
+        if not players:
+            players = soco.discover(
+                interface_addr=config.get(CONF_INTERFACE_ADDR))
 
-    if not players:
-        players = soco.discover(interface_addr=config.get(CONF_INTERFACE_ADDR))
+        if not players:
+            _LOGGER.warning('No Sonos speakers found.')
+            return
 
-    if not players:
-        _LOGGER.warning('No Sonos speakers found.')
-        return False
+        hass.data[DATA_SONOS] = [SonosDevice(hass, p) for p in players]
+        add_devices(hass.data[DATA_SONOS], True)
+        _LOGGER.info('Added %s Sonos speakers', len(players))
 
-    DEVICES = [SonosDevice(hass, p) for p in players]
-    add_devices(DEVICES, True)
-    register_services(hass)
-    _LOGGER.info('Added %s Sonos speakers', len(players))
-    return True
-
-
-def register_services(hass):
-    """Register all services for sonos devices."""
     descriptions = load_yaml_config_file(
         path.join(path.dirname(__file__), 'services.yaml'))
 
-    hass.services.register(DOMAIN, SERVICE_GROUP_PLAYERS,
-                           _group_players_service,
-                           descriptions.get(SERVICE_GROUP_PLAYERS),
-                           schema=SONOS_SCHEMA)
+    def service_handle(service):
+        """Internal func for applying a service."""
+        entity_ids = service.data.get('entity_id')
 
-    hass.services.register(DOMAIN, SERVICE_UNJOIN,
-                           _unjoin_service,
-                           descriptions.get(SERVICE_UNJOIN),
-                           schema=SONOS_SCHEMA)
-
-    hass.services.register(DOMAIN, SERVICE_SNAPSHOT,
-                           _snapshot_service,
-                           descriptions.get(SERVICE_SNAPSHOT),
-                           schema=SONOS_SCHEMA)
-
-    hass.services.register(DOMAIN, SERVICE_RESTORE,
-                           _restore_service,
-                           descriptions.get(SERVICE_RESTORE),
-                           schema=SONOS_SCHEMA)
-
-    hass.services.register(DOMAIN, SERVICE_SET_TIMER,
-                           _set_sleep_timer_service,
-                           descriptions.get(SERVICE_SET_TIMER),
-                           schema=SONOS_SET_TIMER_SCHEMA)
-
-    hass.services.register(DOMAIN, SERVICE_CLEAR_TIMER,
-                           _clear_sleep_timer_service,
-                           descriptions.get(SERVICE_CLEAR_TIMER),
-                           schema=SONOS_SCHEMA)
-
-
-def _apply_service(service, service_func, *service_func_args):
-    """Internal func for applying a service."""
-    entity_ids = service.data.get('entity_id')
-
-    if entity_ids:
-        _devices = [device for device in DEVICES
-                    if device.entity_id in entity_ids]
-    else:
-        _devices = DEVICES
-
-    for device in _devices:
-        service_func(device, *service_func_args)
-        device.update_ha_state(True)
-
-
-def _group_players_service(service):
-    """Group media players, use player as coordinator."""
-    _apply_service(service, SonosDevice.group_players)
-
-
-def _unjoin_service(service):
-    """Unjoin the player from a group."""
-    _apply_service(service, SonosDevice.unjoin)
-
-
-def _snapshot_service(service):
-    """Take a snapshot."""
-    _apply_service(service, SonosDevice.snapshot)
-
-
-def _restore_service(service):
-    """Restore a snapshot."""
-    _apply_service(service, SonosDevice.restore)
-
-
-def _set_sleep_timer_service(service):
-    """Set a timer."""
-    _apply_service(service,
-                   SonosDevice.set_sleep_timer,
-                   service.data[ATTR_SLEEP_TIME])
-
-
-def _clear_sleep_timer_service(service):
-    """Set a timer."""
-    _apply_service(service,
-                   SonosDevice.clear_sleep_timer)
-
-
-def only_if_coordinator(func):
-    """Decorator for coordinator.
-
-    If used as decorator, avoid calling the decorated method if player is not
-    a coordinator. If not, a grouped speaker (not in coordinator role) will
-    throw soco.exceptions.SoCoSlaveException.
-
-    Also, partially catch exceptions like:
-
-    soco.exceptions.SoCoUPnPException: UPnP Error 701 received:
-    Transition not available from <player ip address>
-    """
-    def wrapper(*args, **kwargs):
-        """Decorator wrapper."""
-        if args[0].is_coordinator:
-            from soco.exceptions import SoCoUPnPException
-            try:
-                func(*args, **kwargs)
-            except SoCoUPnPException:
-                _LOGGER.error('command "%s" for Sonos device "%s" '
-                              'not available in this mode',
-                              func.__name__, args[0].name)
+        if entity_ids:
+            devices = [device for device in hass.data[DATA_SONOS]
+                       if device.entity_id in entity_ids]
         else:
-            _LOGGER.debug('Ignore command "%s" for Sonos device "%s" (%s)',
-                          func.__name__, args[0].name, 'not coordinator')
+            devices = hass.data[DATA_SONOS]
 
-    return wrapper
+        for device in devices:
+            if service.service == SERVICE_JOIN:
+                device.join(service.data[ATTR_MASTER])
+            elif service.service == SERVICE_UNJOIN:
+                device.unjoin()
+            elif service.service == SERVICE_SNAPSHOT:
+                device.snapshot(service.data[ATTR_WITH_GROUP])
+            elif service.service == SERVICE_RESTORE:
+                device.restore(service.data[ATTR_WITH_GROUP])
+            elif service.service == SERVICE_SET_TIMER:
+                device.set_timer(service.data[ATTR_SLEEP_TIME])
+            elif service.service == SERVICE_CLEAR_TIMER:
+                device.clear_timer()
+
+            device.schedule_update_ha_state(True)
+
+    hass.services.register(
+        DOMAIN, SERVICE_JOIN, service_handle,
+        descriptions.get(SERVICE_JOIN), schema=SONOS_JOIN_SCHEMA)
+
+    hass.services.register(
+        DOMAIN, SERVICE_UNJOIN, service_handle,
+        descriptions.get(SERVICE_UNJOIN), schema=SONOS_SCHEMA)
+
+    hass.services.register(
+        DOMAIN, SERVICE_SNAPSHOT, service_handle,
+        descriptions.get(SERVICE_SNAPSHOT), schema=SONOS_STATES_SCHEMA)
+
+    hass.services.register(
+        DOMAIN, SERVICE_RESTORE, service_handle,
+        descriptions.get(SERVICE_RESTORE), schema=SONOS_STATES_SCHEMA)
+
+    hass.services.register(
+        DOMAIN, SERVICE_SET_TIMER, service_handle,
+        descriptions.get(SERVICE_SET_TIMER), schema=SONOS_SET_TIMER_SCHEMA)
+
+    hass.services.register(
+        DOMAIN, SERVICE_CLEAR_TIMER, service_handle,
+        descriptions.get(SERVICE_CLEAR_TIMER), schema=SONOS_SCHEMA)
 
 
 def _parse_timespan(timespan):
@@ -304,6 +252,7 @@ class SonosDevice(MediaPlayerDevice):
         self._favorite_sources = None
         self._source_name = None
         self.soco_snapshot = Snapshot(self._player)
+        self._snapshot_coordinator = None
 
     @property
     def should_poll(self):
@@ -337,6 +286,16 @@ class SonosDevice(MediaPlayerDevice):
     def is_coordinator(self):
         """Return true if player is a coordinator."""
         return self._coordinator is None
+
+    @property
+    def soco_device(self):
+        """Return soco device."""
+        return self._player
+
+    @property
+    def coordinator(self):
+        """Return coordinator of this player."""
+        return self._coordinator
 
     def _is_available(self):
         try:
@@ -408,10 +367,14 @@ class SonosDevice(MediaPlayerDevice):
                 # this speaker is a slave, find the coordinator
                 # the uri of the track is 'x-rincon:{coordinator-id}'
                 coordinator_id = track_info['uri'][9:]
-                coordinators = [device for device in DEVICES
+                coordinators = [device for device in self.hass.data[DATA_SONOS]
                                 if device.unique_id == coordinator_id]
                 self._coordinator = coordinators[0] if coordinators else None
             else:
+                self._coordinator = None
+
+            if self._coordinator == self:
+                _LOGGER.warning("Coordinator loop on: %s", self.unique_id)
                 self._coordinator = None
 
             if not self._coordinator:
@@ -616,10 +579,10 @@ class SonosDevice(MediaPlayerDevice):
                 self._source_name = source_name
 
                 # update state of the whole group
-                # pylint: disable=protected-access
-                for device in [x for x in DEVICES if x._coordinator == self]:
+                for device in [x for x in self.hass.data[DATA_SONOS]
+                               if x.coordinator == self]:
                     if device.entity_id is not self.entity_id:
-                        self.hass.add_job(device.async_update_ha_state)
+                        self.schedule_update_ha_state()
 
                 if self._queue is None and self.entity_id is not None:
                     self._subscribe_to_player_events()
@@ -946,37 +909,56 @@ class SonosDevice(MediaPlayerDevice):
             else:
                 self._player.play_uri(media_id)
 
-    def group_players(self):
-        """Group all players under this coordinator."""
-        if self._coordinator:
-            self._coordinator.group_players()
-        else:
-            self._player.partymode()
+    def join(self, master):
+        """Join the player to a group."""
+        coord = [device.soco_device for device in self.hass.data[DATA_SONOS]
+                 if device.entity_id == master]
 
-    @only_if_coordinator
+        if coord and master != self.entity_id:
+            self._player.join(coord[0])
+        else:
+            _LOGGER.error("Master not found %s", master)
+
     def unjoin(self):
         """Unjoin the player from a group."""
         self._player.unjoin()
 
-    @only_if_coordinator
-    def snapshot(self):
+    def snapshot(self, with_group=True):
         """Snapshot the player."""
+        if with_group and self._coordinator:
+            self._coordinator.snapshot(False)
+            self._snapshot_coordinator = self._coordinator
+        else:
+            self._snapshot_coordinator = None
+
         self.soco_snapshot.snapshot()
 
-    @only_if_coordinator
-    def restore(self):
+    def restore(self, with_group=True):
         """Restore snapshot for the player."""
+        # restore playlist in group
+        if with_group and self._coordinator:
+            self._coordinator.restore(False)
+
         self.soco_snapshot.restore(True)
 
-    @only_if_coordinator
+        # restore original group
+        if with_group and (self._coordinator is None or
+                           self._coordinator != self._snapshot_coordinator):
+            self._player.join(self._snapshot_coordinator.soco_device)
+
     def set_sleep_timer(self, sleep_time):
         """Set the timer on the player."""
-        self._player.set_sleep_timer(sleep_time)
+        if self._coordinator:
+            self._coordinator.set_sleep_timer(sleep_time)
+        else:
+            self._player.set_sleep_timer(sleep_time)
 
-    @only_if_coordinator
     def clear_sleep_timer(self):
         """Clear the timer on the player."""
-        self._player.set_sleep_timer(None)
+        if self._coordinator:
+            self._coordinator.set_sleep_timer(None)
+        else:
+            self._player.set_sleep_timer(None)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -521,6 +521,10 @@ class SonosDevice(MediaPlayerDevice):
                     update_media_position |= rel_time is not None and \
                         self._media_position is None
 
+                    # used only if a media is playing
+                    if self.state != STATE_PLAYING:
+                        update_media_position = None
+
                     # position changed?
                     if rel_time is not None and \
                        self._media_position is not None:
@@ -678,7 +682,7 @@ class SonosDevice(MediaPlayerDevice):
                 self._player_volume_muted = \
                     event.variables['mute'].get('Master') == '1'
 
-        self.update_ha_state(True)
+        self.schedule_update_ha_state(True)
 
         if next_track_image_url:
             self.preload_media_image_url(next_track_image_url)
@@ -945,7 +949,11 @@ class SonosDevice(MediaPlayerDevice):
     def restore(self, with_group=True):
         """Restore snapshot for the player."""
         # restore playlist in group if that have not changed
-        self.soco_snapshot.restore(True)
+        from soco.exceptions import SoCoSlaveException
+        try:
+            self.soco_snapshot.restore(True)
+        except (TypeError, SoCoSlaveException):
+            _LOGGER.debug("Error on restore %s", self.entity_id)
 
         if with_group and self._snapshot_group:
             old = self._snapshot_group

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -949,10 +949,10 @@ class SonosDevice(MediaPlayerDevice):
     def restore(self, with_group=True):
         """Restore snapshot for the player."""
         # restore playlist in group if that have not changed
-        from soco.exceptions import SoCoSlaveException
+        from soco.exceptions import SoCoException
         try:
             self.soco_snapshot.restore(True)
-        except (TypeError, SoCoSlaveException):
+        except (TypeError, SoCoException):
             _LOGGER.debug("Error on restore %s", self.entity_id)
 
         if with_group and self._snapshot_group:
@@ -986,7 +986,7 @@ class SonosDevice(MediaPlayerDevice):
             coordinator = _get_entity_from_soco(self.hass, old.coordinator)
             coordinator.restore(False)
 
-            for s_dev in list(old.coordinator):
+            for s_dev in list(old.members):
                 if s_dev != old.coordinator:
                     s_dev.join(old.coordinator)
 


### PR DESCRIPTION
**Description:**

We support now snapshot/restore in every case with group restore functionality. We have also now join/unjoin support. All this service have make troubles also with TTS. Now we can make realy coole stuff with sonos & TTS

I make a cleanup and remove all globs.

```yaml
service: media_player.sonos_join
data:
  master: media_player.floor
  entity_id:
    - media_player.bad
```

```yaml
service: media_player.sonos_snapshot/restore
data:
  entity_id: media_player.bad
  with_group: true # default is True...
```


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
