### PR TITLE
Update neurio library version & catch Keyerror

### DIFF
--- a/homeassistant/components/sensor/neurio_energy.py
+++ b/homeassistant/components/sensor/neurio_energy.py
@@ -14,7 +14,7 @@ from homeassistant.const import (CONF_API_KEY, CONF_NAME)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['neurio==0.2.10']
+REQUIREMENTS = ['neurio==0.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class NeurioEnergy(Entity):
 
     @property
     def name(self):
-        """Return the name of th sensor."""
+        """Return the name of the sensor."""
         return self._name
 
     @property
@@ -94,5 +94,5 @@ class NeurioEnergy(Entity):
             sample = neurio_client.get_samples_live_last(
                 sensor_id=self.sensor_id)
             self._state = sample['consumptionPower']
-        except (requests.exceptions.RequestException, ValueError):
+        except (requests.exceptions.RequestException, ValueError, KeyError):
             _LOGGER.warning('Could not update status for %s', self.name)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -326,7 +326,7 @@ myusps==1.0.2
 netdisco==0.8.1
 
 # homeassistant.components.sensor.neurio_energy
-neurio==0.2.10
+neurio==0.3.1
 
 # homeassistant.components.google
 oauth2client==3.0.0


### PR DESCRIPTION
**Description:**
The Neurio API endpoint has become less reliable over recent months and as a result sometimes the request doesn't complete resulting in an empty response.  This PR updates to the latest version of the neurio library and catches the keyerror that occurs when the api does not return.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable): N/A

**Example entry for `configuration.yaml` (if applicable):** N/A

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
