### PR TITLE
[script/check_config]: Add support for packages

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -27,7 +27,9 @@ MOCKS = {
     'get': ("homeassistant.loader.get_component", loader.get_component),
     'secrets': ("homeassistant.util.yaml._secret_yaml", yaml._secret_yaml),
     'except': ("homeassistant.bootstrap.async_log_exception",
-               bootstrap.async_log_exception)
+               bootstrap.async_log_exception),
+    'package_error': ("homeassistant.config._log_pkg_error",
+                      config_util._log_pkg_error),
 }
 SILENCE = (
     'homeassistant.bootstrap.clear_secret_cache',
@@ -213,6 +215,15 @@ def check(config_path):
         MOCKS['except'][1](ex, domain, config, hass)
         res['except'][domain] = config.get(domain, config)
 
+    def mock_package_error(  # pylint: disable=unused-variable
+            package, component, config, message):
+        """Mock config_util._log_pkg_error."""
+        MOCKS['package_error'][1](package, component, config, message)
+
+        pkg_key = 'homeassistant.packages.{}'.format(package)
+        res['except'][pkg_key] = config.get('homeassistant', {}) \
+            .get('packages', {}).get(package)
+
     # Patches to skip functions
     for sil in SILENCE:
         PATCHES[sil] = patch(sil)
@@ -247,25 +258,24 @@ def check(config_path):
     return res
 
 
+def line_info(obj, **kwargs):
+    """Display line config source."""
+    if hasattr(obj, '__config_file__'):
+        return color('cyan', "[source {}:{}]"
+                     .format(obj.__config_file__, obj.__line__ or '?'),
+                     **kwargs)
+    return '?'
+
+
 def dump_dict(layer, indent_count=3, listi=False, **kwargs):
     """Display a dict.
 
     A friendly version of print yaml.yaml.dump(config).
     """
-    def line_src(this):
-        """Display line config source."""
-        if hasattr(this, '__config_file__'):
-            return color('cyan', "[source {}:{}]"
-                         .format(this.__config_file__, this.__line__ or '?'),
-                         **kwargs)
-        return ''
-
     def sort_dict_key(val):
         """Return the dict key for sorting."""
-        skey = str.lower(val[0])
-        if str(skey) == 'platform':
-            skey = '0'
-        return skey
+        key = str.lower(val[0])
+        return '0' if key == 'platform' else key
 
     indent_str = indent_count * ' '
     if listi or isinstance(layer, list):
@@ -273,7 +283,7 @@ def dump_dict(layer, indent_count=3, listi=False, **kwargs):
     if isinstance(layer, Dict):
         for key, value in sorted(layer.items(), key=sort_dict_key):
             if isinstance(value, dict) or isinstance(value, list):
-                print(indent_str, key + ':', line_src(value))
+                print(indent_str, key + ':', line_info(value, **kwargs))
                 dump_dict(value, indent_count + 2)
             else:
                 print(indent_str, key + ':', value)

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -180,3 +180,24 @@ class TestCheckConfig(unittest.TestCase):
                 'secrets': {'http_pw': 'abc123'},
                 'yaml_files': ['.../secret.yaml', '.../secrets.yaml']
             }, res)
+
+    def test_package_invalid(self): \
+            # pylint: disable=no-self-use,invalid-name
+        """Test a valid platform setup."""
+        files = {
+            'bad.yaml': BASE_CONFIG + ('  packages:\n'
+                                       '    p1:\n'
+                                       '      group: ["a"]'),
+        }
+        with patch_yaml_files(files):
+            res = check_config.check(get_test_config_dir('bad.yaml'))
+            change_yaml_files(res)
+
+            err = res['except'].pop('homeassistant.packages.p1')
+            assert res['except'] == {}
+            assert err == {'group': ['a']}
+            assert res['yaml_files'] == ['.../bad.yaml']
+
+            assert res['components'] == {}
+            assert res['secret_cache'] == {}
+            assert res['secrets'] == {}


### PR DESCRIPTION
**Description:**
Add support for packages in the check_config script

**Example entry for `configuration.yaml` (if applicable):**
```yaml
homeassistant:
  ...
  packages:
    p3:
      group: [1]
```
test with 
```bash
$ hass --script check_config
```
will output

```
17-01-26 21:10:04 ERROR (MainThread) [homeassistant.config] Package p3 setup failed. Component group cannot be merged. Expected a dict. (See /home/pi/.homeassistant/configuration.yaml:35).
Failed config
  homeassistant.packages.p3:
    group: [source /home/pi/.homeassistant/configuration.yaml:35]
      - 1
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
