### PR TITLE
Fix for assumed state in command_line

### DIFF
--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -124,8 +124,7 @@ class CommandSwitch(SwitchDevice):
     @property
     def assumed_state(self):
         """Return true if we do optimistic updates."""
-        return (self._command_state is False or
-                self._command_state is None)
+        return self._command_state is None
 
     def _query_state(self):
         """Query for state."""

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -125,7 +125,7 @@ class CommandSwitch(SwitchDevice):
     def assumed_state(self):
         """Return true if we do optimistic updates."""
         return (self._command_state is False or
-                self._command_state is False or None)
+                self._command_state is None)
 
     def _query_state(self):
         """Query for state."""

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -124,7 +124,7 @@ class CommandSwitch(SwitchDevice):
     @property
     def assumed_state(self):
         """Return true if we do optimistic updates."""
-        return self._command_state is False
+        return self._command_state is None
 
     def _query_state(self):
         """Query for state."""

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -124,7 +124,8 @@ class CommandSwitch(SwitchDevice):
     @property
     def assumed_state(self):
         """Return true if we do optimistic updates."""
-        return self._command_state is None
+        return (self._command_state is False or
+                self._command_state is False or None)
 
     def _query_state(self):
         """Query for state."""

--- a/tests/components/switch/test_command_line.py
+++ b/tests/components/switch/test_command_line.py
@@ -159,7 +159,7 @@ class TestCommandSwitch(unittest.TestCase):
             state = self.hass.states.get('switch.test')
             self.assertEqual(STATE_ON, state.state)
 
-    def test_assumed_state_should_be_true_if_command_state_is_false(self):
+    def test_assumed_state_should_be_true_if_command_state_is_none(self):
         """Test with state value."""
         # args: hass, device_name, friendly_name, command_on, command_off,
         #       command_state, value_template
@@ -169,7 +169,7 @@ class TestCommandSwitch(unittest.TestCase):
             "Test friendly name!",
             "echo 'on command'",
             "echo 'off command'",
-            False,
+            None,
             None,
         ]
 


### PR DESCRIPTION
**Description:**
command_line should be sat to assumed if command_state is None.

To set the command_state to False has not been working, since False has been cast to a string