### PR TITLE
Add support for the Open Energy Monitor Thermostat

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -149,9 +149,9 @@ omit =
     homeassistant/components/climate/heatmiser.py
     homeassistant/components/climate/homematic.py
     homeassistant/components/climate/knx.py
+    homeassistant/components/climate/oem.py
     homeassistant/components/climate/proliphix.py
     homeassistant/components/climate/radiotherm.py
-    homeassistant/components/climate/oem.py
     homeassistant/components/cover/garadget.py
     homeassistant/components/cover/homematic.py
     homeassistant/components/cover/myq.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -151,6 +151,7 @@ omit =
     homeassistant/components/climate/knx.py
     homeassistant/components/climate/proliphix.py
     homeassistant/components/climate/radiotherm.py
+    homeassistant/components/climate/oem.py
     homeassistant/components/cover/garadget.py
     homeassistant/components/cover/homematic.py
     homeassistant/components/cover/myq.py

--- a/homeassistant/components/climate/oem.py
+++ b/homeassistant/components/climate/oem.py
@@ -54,8 +54,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     target_temp = config.get(CONF_TARGET_TEMP)
     away_temp = config.get(CONF_AWAY_TEMP)
 
-    therm = Thermostat(host, port=port,
-                       username=username, password=password)
+    # If creating the class raises an exception, it failed to connect or
+    # something else went wrong.
+    try:
+        therm = Thermostat(host, port=port,
+                           username=username, password=password)
+    except Exception:
+        return False
 
     if target_temp:
         therm.setpoint = target_temp

--- a/homeassistant/components/climate/oem.py
+++ b/homeassistant/components/climate/oem.py
@@ -25,7 +25,6 @@ REQUIREMENTS = ['oemthermostat==1.1']
 _LOGGER = logging.getLogger(__name__)
 
 # Local configs
-CONF_TARGET_TEMP = 'target_temp'
 CONF_AWAY_TEMP = 'away_temp'
 
 # Validation of the user's configuration
@@ -35,7 +34,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=80): cv.port,
     vol.Inclusive(CONF_USERNAME, 'authentication'): cv.string,
     vol.Inclusive(CONF_PASSWORD, 'authentication'): cv.string,
-    vol.Optional(CONF_TARGET_TEMP): vol.Coerce(float),
     vol.Optional(CONF_AWAY_TEMP, default=14): vol.Coerce(float)
 })
 
@@ -51,7 +49,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     port = config.get(CONF_PORT)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
-    target_temp = config.get(CONF_TARGET_TEMP)
     away_temp = config.get(CONF_AWAY_TEMP)
 
     # If creating the class raises an exception, it failed to connect or
@@ -61,9 +58,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                            username=username, password=password)
     except (ValueError, AssertionError, requests.RequestException):
         return False
-
-    if target_temp:
-        therm.setpoint = target_temp
 
     # Add devices
     add_devices((ThermostatDevice(hass, therm, name, away_temp), ), True)

--- a/homeassistant/components/climate/oem.py
+++ b/homeassistant/components/climate/oem.py
@@ -9,6 +9,7 @@ https://home-assistant.io/components/climate.oem/
 """
 import logging
 
+import requests
 import voluptuous as vol
 
 # Import the device class from the component that you want to support
@@ -31,10 +32,9 @@ CONF_AWAY_TEMP = 'away_temp'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default="Thermostat"): cv.string,
-    vol.Optional(
-        CONF_PORT, default=80): cv.port,
-    vol.Optional(CONF_USERNAME): cv.string,
-    vol.Optional(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_PORT, default=80): cv.port,
+    vol.Inclusive(CONF_USERNAME, 'authentication'): cv.string,
+    vol.Inclusive(CONF_PASSWORD, 'authentication'): cv.string,
     vol.Optional(CONF_TARGET_TEMP): vol.Coerce(float),
     vol.Optional(CONF_AWAY_TEMP, default=14): vol.Coerce(float)
 })
@@ -59,7 +59,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         therm = Thermostat(host, port=port,
                            username=username, password=password)
-    except Exception:
+    except (ValueError, AssertionError, requests.RequestException):
         return False
 
     if target_temp:

--- a/homeassistant/components/climate/oem.py
+++ b/homeassistant/components/climate/oem.py
@@ -5,7 +5,7 @@ This provides a climate component for the ESP8266 based thermostat sold by
 OpenEnergyMonitor.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/climate.openenergymonitor/
+https://home-assistant.io/components/climate.oem/
 """
 import logging
 
@@ -19,7 +19,7 @@ from homeassistant.const import (CONF_HOST, CONF_USERNAME, CONF_PASSWORD,
 import homeassistant.helpers.config_validation as cv
 
 # Home Assistant depends on 3rd party packages for API specific code.
-REQUIREMENTS = ['oemthermostat==1.0']
+REQUIREMENTS = ['oemthermostat==1.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ CONF_AWAY_TEMP = 'away_temp'
 # Validation of the user's configuration
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_NAME, default="Thermostat"): cv.string,
     vol.Optional(
         CONF_PORT, default=80): cv.port,
     vol.Optional(CONF_USERNAME): cv.string,
@@ -68,7 +68,7 @@ class ThermostatDevice(ClimateDevice):
     """Interface class for the oemthermostat module and HA."""
 
     def __init__(self, hass, thermostat, name, away_temp):
-        """Constructor."""
+        """Initialize the device."""
         self._name = name
         self.hass = hass
 

--- a/homeassistant/components/climate/oem.py
+++ b/homeassistant/components/climate/oem.py
@@ -65,14 +65,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class ThermostatDevice(ClimateDevice):
-    """
-    Interface class for the oemthermostat module and HA.
-    """
+    """Interface class for the oemthermostat module and HA."""
 
     def __init__(self, hass, thermostat, name, away_temp):
-        """
-        Constructor
-        """
+        """Constructor."""
         self._name = name
         self.hass = hass
 
@@ -85,9 +81,14 @@ class ThermostatDevice(ClimateDevice):
         # Set the thermostat mode to manual
         self.thermostat.mode = 2
 
+        # set up internal state varS
+        self._state = None
+        self._temperature = None
+        self._setpoint = None
+
     @property
     def name(self):
-        """Name of this Thermostat"""
+        """Name of this Thermostat."""
         return self._name
 
     @property
@@ -142,7 +143,7 @@ class ThermostatDevice(ClimateDevice):
         self._away = False
 
     def update(self):
-        """Update local state"""
+        """Update local state."""
         self._setpoint = self.thermostat.setpoint
         self._temperature = self.thermostat.temperature
         self._state = self.thermostat.state

--- a/homeassistant/components/climate/oem.py
+++ b/homeassistant/components/climate/oem.py
@@ -1,6 +1,8 @@
 """
-This provides a climate component for the ESP8266 based thermostat sold by Open
-Energy Monitor: https://shop.openenergymonitor.com/wifi-mqtt-relay-thermostat/
+OpenEnergyMonitor Thermostat Support.
+
+This provides a climate component for the ESP8266 based thermostat sold by
+OpenEnergyMonitor.
 """
 import logging
 
@@ -14,7 +16,7 @@ from homeassistant.const import (CONF_HOST, CONF_USERNAME, CONF_PASSWORD,
 import homeassistant.helpers.config_validation as cv
 
 # Home Assistant depends on 3rd party packages for API specific code.
-REQUIREMENTS = ['oemthermostat']
+REQUIREMENTS = ['oemthermostat==1.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,6 +38,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup oemthermostat."""
     from oemthermostat import Thermostat
 
     # Assign configuration variables. The configuration check takes care they
@@ -59,8 +62,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class ThermostatDevice(ClimateDevice):
+    """
+    Interface class for the oemthermostat module and HA.
+    """
 
     def __init__(self, hass, thermostat, name, away_temp):
+        """
+        Constructor
+        """
         self._name = name
         self.hass = hass
 
@@ -75,6 +84,7 @@ class ThermostatDevice(ClimateDevice):
 
     @property
     def name(self):
+        """Name of this Thermostat"""
         return self._name
 
     @property
@@ -101,6 +111,7 @@ class ThermostatDevice(ClimateDevice):
         return self.thermostat.setpoint
 
     def set_temperature(self, **kwargs):
+        """Change the setpoint of the thermostat."""
         # If we are setting the temp, then we don't want away mode anymore.
         self.turn_away_mode_off()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -352,6 +352,9 @@ neurio==0.3.1
 # homeassistant.components.google
 oauth2client==4.0.0
 
+# homeassistant.components.climate.oem
+oemthermostat==1.1
+
 # homeassistant.components.sensor.openevse
 openevsewifi==0.4
 


### PR DESCRIPTION
**Description:**
This adds device support to the climate component to support the thermostat sold my OpenEnergyMontior [here](https://shop.openenergymonitor.com/wifi-mqtt-relay-thermostat/). It uses [this](https://github.com/Cadair/openenergymonitor_thermostat) Python module developed for this purpose.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1889

**Example entry for `configuration.yaml` (if applicable):**
```yaml
climate:
  - platform: oem
    name: Home
    host: 192.168.0.100
    target_temp: 19
    away_temp: 14
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
