### PR TITLE
sonos set coordinator after join/unjoin

### DIFF
--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -251,7 +251,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
 
         device_master = mock.MagicMock()
         device_master.entity_id = "media_player.test"
-        device_master.soco_device = device
+        device_master.soco_device = mock.MagicMock()
         self.hass.data[sonos.DATA_SONOS].append(device_master)
 
         join_mock.return_value = True


### PR DESCRIPTION
**Description:**

Set internal coordinator to help other function for process faster on master in the group. It will be done self after a update but with this it will it make faster.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
