### PR TITLE
eq3btsmart: add reporting for availability

### DIFF
--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -77,6 +77,10 @@ class EQ3BTSmartThermostat(ClimateDevice):
         self._thermostat = eq3.Thermostat(_mac)
 
     @property
+    def available(self) -> bool:
+        return self.current_operation != STATE_UNKNOWN
+
+    @property
     def name(self):
         """Return the name of the device."""
         return self._name

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -78,6 +78,7 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
     @property
     def available(self) -> bool:
+        """Return if thermostat is available."""
         return self.current_operation != STATE_UNKNOWN
 
     @property


### PR DESCRIPTION
**Description:** Report unknown state correctly through available property.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
