### PR TITLE
Token tweaks

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -9,6 +9,7 @@ import asyncio
 from datetime import timedelta
 import logging
 import hashlib
+from random import SystemRandom
 
 import aiohttp
 from aiohttp import web
@@ -34,6 +35,8 @@ STATE_STREAMING = 'streaming'
 STATE_IDLE = 'idle'
 
 ENTITY_IMAGE_URL = '/api/camera_proxy/{0}?token={1}'
+
+_RND = SystemRandom()
 
 
 @asyncio.coroutine
@@ -90,7 +93,7 @@ class Camera(Entity):
         """Initialize a camera."""
         self.is_streaming = False
         self._access_token = hashlib.sha256(
-            str.encode(str(id(self)))).hexdigest()
+            str.encode(str(_RND.random()))).hexdigest()
 
     @property
     def access_token(self):
@@ -223,7 +226,8 @@ class CameraView(HomeAssistantView):
         camera = self.entities.get(entity_id)
 
         if camera is None:
-            return web.Response(status=404)
+            status = 404 if request[KEY_AUTHENTICATED] else 401
+            return web.Response(status=status)
 
         authenticated = (request[KEY_AUTHENTICATED] or
                          request.GET.get('token') == camera.access_token)

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -93,7 +93,7 @@ def async_setup(hass, config):
         """Update tokens of the entities."""
         for entity in component.entities.values():
             entity.async_update_token()
-            entity.schedule_update_ha_state(True)
+            hass.async_add_job(entity.async_update_ha_state())
 
     async_track_time_interval(hass, update_tokens, TOKEN_CHANGE_INTERVAL)
     return True
@@ -222,7 +222,8 @@ class Camera(Entity):
     def async_update_token(self):
         """Update the used token."""
         self.access_tokens.append(
-            hashlib.sha256(str.encode(str(_RND.random()))).hexdigest())
+            hashlib.sha256(
+                _RND.getrandbits(256).to_bytes(32, 'little')).hexdigest())
 
 
 class CameraView(HomeAssistantView):

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -405,7 +405,7 @@ class MediaPlayerDevice(Entity):
         """Access token for this media player."""
         if self._access_token is None:
             self._access_token = hashlib.sha256(
-                str.encode(str(_RND.random()))).hexdigest()
+                _RND.getrandbits(256).to_bytes(32, 'little')).hexdigest()
         return self._access_token
 
     @property

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -10,6 +10,7 @@ import functools as ft
 import hashlib
 import logging
 import os
+from random import SystemRandom
 
 from aiohttp import web
 import async_timeout
@@ -32,6 +33,7 @@ from homeassistant.const import (
     SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PREVIOUS_TRACK, SERVICE_MEDIA_SEEK)
 
 _LOGGER = logging.getLogger(__name__)
+_RND = SystemRandom()
 
 DOMAIN = 'media_player'
 DEPENDENCIES = ['http']
@@ -399,7 +401,8 @@ class MediaPlayerDevice(Entity):
     @property
     def access_token(self):
         """Access token for this media player."""
-        return str(id(self))
+        return hashlib.sha256(
+            str.encode(str(_RND.random()))).hexdigest()
 
     @property
     def volume_level(self):
@@ -895,7 +898,8 @@ class MediaPlayerImageView(HomeAssistantView):
         """Start a get request."""
         player = self.entities.get(entity_id)
         if player is None:
-            return web.Response(status=404)
+            status = 404 if request[KEY_AUTHENTICATED] else 401
+            return web.Response(status=status)
 
         authenticated = (request[KEY_AUTHENTICATED] or
                          request.GET.get('token') == player.access_token)

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -391,6 +391,8 @@ def async_setup(hass, config):
 class MediaPlayerDevice(Entity):
     """ABC for media player devices."""
 
+    _access_token = None
+
     # pylint: disable=no-self-use
     # Implement these for your media player
     @property
@@ -401,8 +403,10 @@ class MediaPlayerDevice(Entity):
     @property
     def access_token(self):
         """Access token for this media player."""
-        return hashlib.sha256(
-            str.encode(str(_RND.random()))).hexdigest()
+        if self._access_token is None:
+            self._access_token = hashlib.sha256(
+                str.encode(str(_RND.random()))).hexdigest()
+        return self._access_token
 
     @property
     def volume_level(self):


### PR DESCRIPTION
**Description:**

 - Return 401 when camera/media player not found and no auth provided
 - Use more secure random number for camera and media player album art access tokens
 - Re-generate access token for camera's every 5 minutes
 - For camera's, current and previous auth token are valid.
