### PR TITLE
Pilight Switch rejects alphanumeric IDs

### DIFF
--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -33,7 +33,7 @@ COMMAND_SCHEMA = vol.Schema({
     vol.Optional('off'): cv.positive_int,
     vol.Optional(CONF_UNIT): cv.positive_int,
     vol.Optional(CONF_UNITCODE): cv.positive_int,
-    vol.Optional(CONF_ID): cv.positive_int,
+    vol.Optional(CONF_ID): vol.Any(cv.positive_int, cv.string),
     vol.Optional(CONF_STATE): cv.string,
     vol.Optional(CONF_SYSTEMCODE): cv.positive_int,
 }, extra=vol.ALLOW_EXTRA)


### PR DESCRIPTION
**Description:**
The last PR #5223 stalled, thus this is a minimum change PR fixing regression #5119.

**Related issue (if applicable):** fixes #5119

**Example entry for `configuration.yaml` (if applicable):**
```yaml
pilight:
  host: 127.0.0.1
  port: 5000
switch:
- platform: pilight
  switches:
    light:
      on_code:
        protocol: intertechno_old
        unit: 3
        id: 'A1'
        'on': 1
      off_code:
        protocol: intertechno_old
        unit: 3
        id: 'A2'
        'off': 1
      on_code_receive:
        protocol: daycom
        state: 'off'
      off_code_receive:
        protocol: daycom
        state: 'on'
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - ~~Tests have been added to verify that the new code works.~~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
