### PR TITLE
Apply new customize format to Zwave (take 2)

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -17,6 +17,7 @@ from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.util.color import HASS_COLOR_MAX, HASS_COLOR_MIN, \
     color_temperature_mired_to_kelvin, color_temperature_to_rgb, \
     color_rgb_to_rgbw, color_rgbw_to_rgb
+from homeassistant.helpers import customize
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,13 +55,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return
     node = zwave.NETWORK.nodes[discovery_info[zwave.const.ATTR_NODE_ID]]
     value = node.values[discovery_info[zwave.const.ATTR_VALUE_ID]]
-    customize = hass.data['zwave_customize']
     name = '{}.{}'.format(DOMAIN, zwave.object_id(value))
-    node_config = customize.get(name, {})
+    node_config = customize.get_overrides(hass, zwave.DOMAIN, name)
     refresh = node_config.get(zwave.CONF_REFRESH_VALUE)
     delay = node_config.get(zwave.CONF_REFRESH_DELAY)
-    _LOGGER.debug('customize=%s name=%s node_config=%s CONF_REFRESH_VALUE=%s'
-                  ' CONF_REFRESH_DELAY=%s', customize, name, node_config,
+    _LOGGER.debug('name=%s node_config=%s CONF_REFRESH_VALUE=%s'
+                  ' CONF_REFRESH_DELAY=%s', name, node_config,
                   refresh, delay)
     if value.command_class != zwave.const.COMMAND_CLASS_SWITCH_MULTILEVEL:
         return

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT, DEVICE_DEFAULT_NAME, STATE_OFF, STATE_ON,
     STATE_UNAVAILABLE, STATE_UNKNOWN, TEMP_CELSIUS, TEMP_FAHRENHEIT,
     ATTR_ENTITY_PICTURE)
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, DOMAIN as CORE_DOMAIN
 from homeassistant.exceptions import NoEntitySpecifiedError
 from homeassistant.util import ensure_unique_string, slugify
 from homeassistant.util.async import (
@@ -242,7 +242,7 @@ class Entity(object):
                             end - start)
 
         # Overwrite properties that have been set in the config file.
-        attr.update(get_overrides(self.hass, self.entity_id))
+        attr.update(get_overrides(self.hass, CORE_DOMAIN, self.entity_id))
 
         # Remove hidden property if false so it won't show up.
         if not attr.get(ATTR_HIDDEN, True):

--- a/tests/components/test_zwave.py
+++ b/tests/components/test_zwave.py
@@ -1,0 +1,68 @@
+"""The tests for the zwave component."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from homeassistant.bootstrap import setup_component
+from homeassistant.components import zwave
+from tests.common import get_test_home_assistant
+
+
+class TestComponentZwave(unittest.TestCase):
+    """Test the Zwave component."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def _validate_config(self, validator, config):
+        libopenzwave = MagicMock()
+        libopenzwave.__file__ = 'test'
+        with patch.dict('sys.modules', {
+            'libopenzwave': libopenzwave,
+            'openzwave.option': MagicMock(),
+            'openzwave.network': MagicMock(),
+            'openzwave.group': MagicMock(),
+        }):
+            validator(setup_component(self.hass, zwave.DOMAIN, {
+                zwave.DOMAIN: config,
+            }))
+
+    def test_empty_config(self):
+        """Test empty config."""
+        self._validate_config(self.assertTrue, {})
+
+    def test_empty_customize(self):
+        """Test empty customize."""
+        self._validate_config(self.assertTrue, {'customize': {}})
+        self._validate_config(self.assertTrue, {'customize': []})
+
+    def test_empty_customize_content(self):
+        """Test empty customize."""
+        self._validate_config(
+            self.assertTrue, {'customize': {'test.test': {}}})
+
+    def test_full_customize_dict(self):
+        """Test full customize as dict."""
+        self._validate_config(self.assertTrue, {'customize': {'test.test': {
+            zwave.CONF_POLLING_INTENSITY: 10,
+            zwave.CONF_IGNORED: 1,
+            zwave.CONF_REFRESH_VALUE: 1,
+            zwave.CONF_REFRESH_DELAY: 10}}})
+
+    def test_full_customize_list(self):
+        """Test full customize as list."""
+        self._validate_config(self.assertTrue, {'customize': [{
+            'entity_id': 'test.test',
+            zwave.CONF_POLLING_INTENSITY: 10,
+            zwave.CONF_IGNORED: 1,
+            zwave.CONF_REFRESH_VALUE: 1,
+            zwave.CONF_REFRESH_DELAY: 10}]})
+
+    def test_bad_customize(self):
+        """Test customize with extra keys."""
+        self._validate_config(
+            self.assertFalse, {'customize': {'test.test': {'extra_key': 10}}})

--- a/tests/helpers/test_customize.py
+++ b/tests/helpers/test_customize.py
@@ -1,5 +1,7 @@
 """Test the customize helper."""
 import homeassistant.helpers.customize as customize
+from voluptuous import MultipleInvalid
+import pytest
 
 
 class MockHass(object):
@@ -17,8 +19,9 @@ class TestHelpersCustomize(object):
         self.hass = MockHass()
 
     def _get_overrides(self, overrides):
-        customize.set_customize(self.hass, overrides)
-        return customize.get_overrides(self.hass, self.entity_id)
+        test_domain = 'test.domain'
+        customize.set_customize(self.hass, test_domain, overrides)
+        return customize.get_overrides(self.hass, test_domain, self.entity_id)
 
     def test_override_single_value(self):
         """Test entity customization through configuration."""
@@ -75,7 +78,7 @@ class TestHelpersCustomize(object):
             'key3': 'valueDomain'}
 
     def test_override_deep_dict(self):
-        """Test we can overwrite hidden property to True."""
+        """Test we can deep-overwrite a dict."""
         result = self._get_overrides(
             [{'entity_id': [self.entity_id],
               'test': {'key1': 'value1', 'key2': 'value2'}},
@@ -85,3 +88,32 @@ class TestHelpersCustomize(object):
             'key1': 'value1',
             'key2': 'value22',
             'key3': 'value3'}
+
+    def test_schema_bad_schema(self):
+        """Test bad customize schemas."""
+        for value in (
+                {'test.test': 10},
+                {'test.test': ['hello']},
+                {'entity_id': {'a': 'b'}},
+                {'entity_id': 10},
+                [{'test.test': 'value'}],
+        ):
+            with pytest.raises(
+                MultipleInvalid,
+                message="{} should have raised MultipleInvalid".format(
+                    value)):
+                customize.CUSTOMIZE_SCHEMA(value)
+
+    def test_get_customize_schema_allow_extra(self):
+        """Test schema with ALLOW_EXTRA."""
+        for value in (
+                {'test.test': {'hidden': True}},
+                {'test.test': {'key': ['value1', 'value2']}},
+                [{'entity_id': 'id1', 'key': 'value'}],
+        ):
+            customize.CUSTOMIZE_SCHEMA(value)
+
+    def test_get_customize_schema_csv(self):
+        """Test schema with comma separated entity IDs."""
+        assert [{'entity_id': ['id1', 'id2', 'id3']}] == \
+            customize.CUSTOMIZE_SCHEMA([{'entity_id': 'id1,ID2 , id3'}])

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -90,6 +90,7 @@ class TestHelpersEntity(object):
         """Test we can overwrite hidden property to True."""
         set_customize(
             self.hass,
+            entity.CORE_DOMAIN,
             [{'entity_id': [self.entity.entity_id], ATTR_HIDDEN: True}])
         self.entity.update_ha_state()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -234,25 +234,6 @@ class TestConfig(unittest.TestCase):
 
         assert state.attributes['hidden']
 
-    def test_entity_customization_comma_separated(self):
-        """Test entity customization through configuration."""
-        config = {CONF_LATITUDE: 50,
-                  CONF_LONGITUDE: 50,
-                  CONF_NAME: 'Test',
-                  CONF_CUSTOMIZE: [
-                      {'entity_id': 'test.not_test,test,test.not_t*',
-                       'key1': 'value1'},
-                      {'entity_id': 'test.test,not_test,test.not_t*',
-                       'key2': 'value2'},
-                      {'entity_id': 'test.not_test,not_test,test.t*',
-                       'key3': 'value3'}]}
-
-        state = self._compute_state(config)
-
-        assert state.attributes['key1'] == 'value1'
-        assert state.attributes['key2'] == 'value2'
-        assert state.attributes['key3'] == 'value3'
-
     @mock.patch('homeassistant.config.shutil')
     @mock.patch('homeassistant.config.os')
     def test_remove_lib_on_upgrade(self, mock_os, mock_shutil):


### PR DESCRIPTION
**Description:**

Following #5215 that introduced to `customize:` format, this PR applies this format to
```yaml
zwave:
  customize:
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1922

**Example entry for `configuration.yaml` (if applicable):**
```yaml
zwave:
  customize:
    entity_id: sensor.*burglar*
    ignore: true
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
