### PR TITLE
WIP: [component/recorder] Refactoring & better handling of SQLAlchemy Sessions

### DIFF
--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -64,7 +64,7 @@ def get_significant_states(start_time, end_time=None, entity_id=None,
     """
     entity_ids = (entity_id.lower(), ) if entity_id is not None else None
     states = recorder.get_model('States')
-    query = recorder.query('States').filter(
+    query = recorder.query(states).filter(
         (states.domain.in_(SIGNIFICANT_DOMAINS) |
          (states.last_changed == states.last_updated)) &
         (states.last_updated > start_time))

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -473,6 +473,9 @@ class Recorder(threading.Thread):
             except sqlalchemy.exc.OperationalError as err:
                 session.rollback()
                 log_error(err, retry_wait=QUERY_RETRY_WAIT)
+            except UnicodeEncodeError as err:
+                log_error(err)
+                return False
         if close_session:
             session.close()
         return False


### PR DESCRIPTION
**Description:**
This is a work in progress and would appreciate some feedback from the relevant people reporting the issues 

CC: @rf152 @InterHmai @ktpx @fanaticDavid 

~~You should be able to test by placing [this](https://raw.githubusercontent.com/kellerza/home-assistant/recorder_sessions/homeassistant/components/recorder/__init__.py) file in `~/.homeassistant/custom_components/recorder/__init__.py`~~ This cannot be tested in custom_components, I suggested an alternative below (but you will have to customize for your install location)...

**Related issue (if applicable):** fixes #4779 #5585 #5498 #4225 #4352

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
recorder:
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
