### PR TITLE
Add history_stats sensor

### DIFF
--- a/homeassistant/components/sensor/history_stats.py
+++ b/homeassistant/components/sensor/history_stats.py
@@ -1,0 +1,303 @@
+"""
+Component to make instant statistics about your history.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.history_stats/
+"""
+
+import asyncio
+import logging
+import math
+import re
+import time
+
+import voluptuous as vol
+
+import homeassistant.components.history as history
+import homeassistant.components.recorder as recorder
+import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (CONF_NAME, CONF_ENTITY_ID, CONF_STATE)
+from homeassistant.core import callback
+from homeassistant.exceptions import TemplateError
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_state_change
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'history_stats'
+DEPENDENCIES = ['history']
+
+CONF_START = 'start'
+CONF_END = 'end'
+CONF_DURATION = 'duration'
+CONF_PERIOD_KEYS = [CONF_START, CONF_END, CONF_DURATION]
+
+DEFAULT_NAME = 'unnamed statistics'
+UNIT = 'h'
+UNIT_RATIO = '%'
+ICON = 'mdi:chart-line'
+
+PRINT_START = 'from'
+PRINT_END = 'to'
+PRINT_VALUE = 'value'
+PRINT_RATIO = 'ratio'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ENTITY_ID): cv.entity_id,
+    vol.Required(CONF_STATE): cv.slug,
+    vol.Optional(CONF_START, default=None): cv.template,
+    vol.Optional(CONF_END, default=None): cv.template,
+    vol.Optional(CONF_DURATION, default=None): cv.template,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+# noinspection PyUnusedLocal
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the History Stats sensor."""
+    entity_id = config.get(CONF_ENTITY_ID)
+    entity_state = config.get(CONF_STATE)
+    start = config.get(CONF_START)
+    end = config.get(CONF_END)
+    duration = config.get(CONF_DURATION)
+    name = config.get(CONF_NAME)
+    hsh = HistoryStatsHelper
+
+    params = 0
+    for param in [start, end, duration]:
+        if param is not None:
+            params += 1
+
+    if params != 2:
+        raise _LOGGER.error('You must provide exactly 2 of the following:' +
+                            ' start, end, duration')
+
+    for template in [start, end, duration]:
+        if template is not None:
+            template.hass = hass
+            template.template = hsh.parse_time_expr(template.template)
+            # pylint: disable=protected-access
+            template._compiled_code = None  # Force recompilation
+
+    yield from async_add_devices([HistoryStatsSensor(
+        hass, entity_id, entity_state, start, end, duration, name)], True)
+    return True
+
+
+class HistoryStatsSensor(Entity):
+    """Representation of a HistoryStats sensor."""
+
+    def __init__(
+            self, hass, entity_id, entity_state, start, end, duration, name):
+        """Initialize the HistoryStats sensor."""
+        self._hass = hass
+
+        self._entity_id = entity_id
+        self._entity_state = entity_state
+        self._duration = duration
+        self._start = start
+        self._end = end
+        self._name = name
+        self._unit_of_measurement = UNIT
+
+        self._period = (0.0, 0.0)
+        self.value = 0
+
+        # noinspection PyUnusedLocal
+        # pylint: disable=invalid-name
+        @callback
+        def async_stats_sensor_state_listener(entity, old_state, new_state):
+            """Called when the sensor changes state."""
+            hass.async_add_job(self.async_update_ha_state, True)
+
+        async_track_state_change(
+            hass, entity_id, async_stats_sensor_state_listener)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return round(self.value, 2)
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self._unit_of_measurement
+
+    @property
+    def should_poll(self):
+        """Polling required."""
+        return True
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the sensor."""
+        start_timestamp, end_timestamp = self._period
+        hsh = HistoryStatsHelper
+        return {
+            PRINT_VALUE: hsh.pretty_duration(self.value),
+            PRINT_RATIO: hsh.pretty_ratio(self.value, self._period),
+            PRINT_START: hsh.pretty_datetime(start_timestamp),
+            PRINT_END: hsh.pretty_datetime(end_timestamp),
+        }
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return ICON
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Get the latest data and updates the states."""
+        # Parse templates
+        self.update_period()
+
+        # Convert timestamps to dates
+        start_timestamp, end_timestamp = self._period
+        start = dt_util.utc_from_timestamp(start_timestamp)
+        end = dt_util.utc_from_timestamp(end_timestamp)
+
+        if not HistoryStatsHelper.wait_till_db_ready():
+            _LOGGER.error('Cannot connect to database')
+            return
+
+        # Get history between start and end
+        history_list = history.state_changes_during_period(
+            start, end, str(self._entity_id))
+
+        if self._entity_id not in history_list.keys():
+            return
+
+        # Get the first state
+        last_state = history.get_state(start, self._entity_id)
+        last_state = (last_state is not None and
+                      last_state == self._entity_state)
+        last_time = start_timestamp
+        elapsed = 0
+
+        # Make calculations
+        for item in history_list.get(self._entity_id):
+            current_state = item.state == self._entity_state
+            current_time = item.last_changed.timestamp()
+
+            if last_state:
+                elapsed += current_time - last_time
+
+            last_state = current_state
+            last_time = current_time
+
+        # Save value in hours
+        self.value = elapsed / 3600
+
+    def update_period(self):
+        """Parse the templates and store a timestamp tuple in _period."""
+        start = None
+        end = None
+        duration = None
+
+        try:
+            if self._start is not None:
+                start = math.floor(float(self._start.async_render()))
+            if self._end is not None:
+                end = math.floor(float(self._end.async_render()))
+            if self._duration is not None:
+                duration = math.floor(float(self._duration.async_render()))
+        except TemplateError as ex:
+            HistoryStatsHelper.handle_template_exception(ex)
+        except ValueError:
+            _LOGGER.error('Template value cannot be converted to timestamp ')
+
+        # Calculate start or end using the duration
+        start = end - duration if start is None else start
+        end = start + duration if end is None else end
+
+        self._period = start, end
+
+
+class HistoryStatsHelper:
+    """Static methods to make the HistoryStatsSensor code lighter."""
+
+    @staticmethod
+    def parse_time_expr(expression):
+        """Replace time expressions with functions accepted by templates."""
+        regex = r"(_NOW_(\.replace\([a-z]+=[0-9]+\))*)"
+        replacement = r"as_timestamp(\1)"
+
+        return re.sub(
+            regex, replacement, expression.replace("_THIS_DAY_", "_TODAY_")
+            .replace("_ONE_WEEK_", "604800")
+            .replace("_ONE_DAY_", "86400")
+            .replace("_ONE_HOUR_", "3600")
+            .replace("_ONE_MINUTE_", "60")
+            .replace("_THIS_YEAR_", "_THIS_MONTH_.replace(month=1)")
+            .replace("_THIS_MONTH_", "_TODAY_.replace(day=1)")
+            .replace("_THIS_WEEK_", "_TODAY_ - now().weekday() * 86400")
+            .replace("_TODAY_", "_THIS_HOUR_.replace(hour=0)")
+            .replace("_THIS_HOUR_", "_THIS_MINUTE_.replace(minute=0)")
+            .replace("_THIS_MINUTE_", "_NOW_.replace(second=0)")) \
+            .replace("_NOW_", "now()")
+
+    @staticmethod
+    def pretty_datetime(timestamp):
+        """Format a timestamp to a formatted datetime in the local timezone."""
+        return dt_util.as_local(dt_util.utc_from_timestamp(timestamp)) \
+            .strftime('%Y/%m/%d %H:%M:%S')
+
+    @staticmethod
+    def pretty_duration(hours):
+        """Format a duration in days, hours, minutes, seconds."""
+        seconds = int(3600 * hours)
+        days, seconds = divmod(seconds, 86400)
+        hours, seconds = divmod(seconds, 3600)
+        minutes, seconds = divmod(seconds, 60)
+        if days > 0:
+            return '%dd %dh %dm %ds' % (days, hours, minutes, seconds)
+        elif hours > 0:
+            return '%dh %dm %ds' % (hours, minutes, seconds)
+        elif minutes > 0:
+            return '%dm %ds' % (minutes, seconds)
+        else:
+            return '%ds' % (seconds,)
+
+    @staticmethod
+    def pretty_ratio(value, period):
+        """Format the ratio of value / period duration."""
+        if len(period) != 2:
+            return
+
+        ratio = 3600 * 100 * value / (period[1] - period[0])
+        return str(round(ratio, 1)) + UNIT_RATIO
+
+    @staticmethod
+    def handle_template_exception(ex):
+        """Log an error nicely if the template cannot be interpreted."""
+        if ex.args and ex.args[0].startswith(
+                "UndefinedError: 'None' has no attribute"):
+            # Common during HA startup - so just a warning
+            _LOGGER.warning(ex)
+            return
+        _LOGGER.error(ex)
+
+    # noinspection PyProtectedMember
+    # pylint: disable=protected-access
+    @staticmethod
+    def wait_till_db_ready():
+        """Start recorder connection if not done already."""
+        # Without this method, the recorder does not start its connection
+        # itself, resulting in an infinite loop blocking the boot of home
+        # assistant. It may be a nasty bug.
+        if recorder._INSTANCE.db_ready._flag:
+            return True
+        time.sleep(0.5)  # Wait, just in case db is starting
+        if recorder._INSTANCE.db_ready._flag:
+            return True
+        recorder._INSTANCE._setup_connection()  # Force connection
+        time.sleep(0.5)  # Wait a little
+        return recorder._INSTANCE.db_ready._flag

--- a/homeassistant/components/sensor/history_stats.py
+++ b/homeassistant/components/sensor/history_stats.py
@@ -72,8 +72,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             params += 1
 
     if params != 2:
-        raise _LOGGER.error('You must provide exactly 2 of the following:' +
-                            ' start, end, duration')
+        _LOGGER.error('You must provide exactly 2 of the following:'
+                      + ' start, end, duration')
+        return False
 
     for template in [start, end, duration]:
         if template is not None:
@@ -269,8 +270,8 @@ class HistoryStatsHelper:
     @staticmethod
     def pretty_ratio(value, period):
         """Format the ratio of value / period duration."""
-        if len(period) != 2:
-            return
+        if len(period) != 2 or period[0] == period[1]:
+            return '0,0' + UNIT_RATIO
 
         ratio = 3600 * 100 * value / (period[1] - period[0])
         return str(round(ratio, 1)) + UNIT_RATIO

--- a/homeassistant/components/sensor/history_stats.py
+++ b/homeassistant/components/sensor/history_stats.py
@@ -39,10 +39,10 @@ UNIT = 'h'
 UNIT_RATIO = '%'
 ICON = 'mdi:chart-line'
 
-PRINT_START = 'from'
-PRINT_END = 'to'
-PRINT_VALUE = 'value'
-PRINT_RATIO = 'ratio'
+ATTR_START = 'from'
+ATTR_END = 'to'
+ATTR_VALUE = 'value'
+ATTR_RATIO = 'ratio'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
@@ -138,15 +138,15 @@ class HistoryStatsSensor(Entity):
         return True
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes of the sensor."""
         start_timestamp, end_timestamp = self._period
         hsh = HistoryStatsHelper
         return {
-            PRINT_VALUE: hsh.pretty_duration(self.value),
-            PRINT_RATIO: hsh.pretty_ratio(self.value, self._period),
-            PRINT_START: hsh.pretty_datetime(start_timestamp),
-            PRINT_END: hsh.pretty_datetime(end_timestamp),
+            ATTR_VALUE: hsh.pretty_duration(self.value),
+            ATTR_RATIO: hsh.pretty_ratio(self.value, self._period),
+            ATTR_START: hsh.pretty_datetime(start_timestamp),
+            ATTR_END: hsh.pretty_datetime(end_timestamp),
         }
 
     @property
@@ -249,7 +249,7 @@ class HistoryStatsHelper:
     def pretty_datetime(timestamp):
         """Format a timestamp to a formatted datetime in the local timezone."""
         return dt_util.as_local(dt_util.utc_from_timestamp(timestamp)) \
-            .strftime('%Y/%m/%d %H:%M:%S')
+            .strftime('%Y-%m-%d %H:%M:%S')
 
     @staticmethod
     def pretty_duration(hours):

--- a/homeassistant/components/sensor/history_stats.py
+++ b/homeassistant/components/sensor/history_stats.py
@@ -6,9 +6,9 @@ https://home-assistant.io/components/sensor.history_stats/
 """
 
 import asyncio
+import datetime
 import logging
 import math
-import re
 import time
 
 import voluptuous as vol
@@ -44,14 +44,29 @@ ATTR_END = 'to'
 ATTR_VALUE = 'value'
 ATTR_RATIO = 'ratio'
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+
+def exactly_two_period_keys(conf):
+    """Ensure exactly 2 of CONF_PERIOD_KEYS are provided."""
+    provided = 0
+
+    for param in CONF_PERIOD_KEYS:
+        if param in conf and conf[param] is not None:
+            provided += 1
+
+    if provided != 2:
+        raise vol.Invalid('You must provide exactly 2 of the following:'
+                          ' start, end, duration')
+    return conf
+
+
+PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Required(CONF_STATE): cv.slug,
     vol.Optional(CONF_START, default=None): cv.template,
     vol.Optional(CONF_END, default=None): cv.template,
     vol.Optional(CONF_DURATION, default=None): cv.template,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-})
+}), exactly_two_period_keys)
 
 
 # noinspection PyUnusedLocal
@@ -64,24 +79,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     end = config.get(CONF_END)
     duration = config.get(CONF_DURATION)
     name = config.get(CONF_NAME)
-    hsh = HistoryStatsHelper
-
-    params = 0
-    for param in [start, end, duration]:
-        if param is not None:
-            params += 1
-
-    if params != 2:
-        _LOGGER.error('You must provide exactly 2 of the following:'
-                      + ' start, end, duration')
-        return False
 
     for template in [start, end, duration]:
         if template is not None:
             template.hass = hass
-            template.template = hsh.parse_time_expr(template.template)
-            # pylint: disable=protected-access
-            template._compiled_code = None  # Force recompilation
 
     yield from async_add_devices([HistoryStatsSensor(
         hass, entity_id, entity_state, start, end, duration, name)], True)
@@ -104,7 +105,7 @@ class HistoryStatsSensor(Entity):
         self._name = name
         self._unit_of_measurement = UNIT
 
-        self._period = (0.0, 0.0)
+        self._period = (datetime.datetime.now(), datetime.datetime.now())
         self.value = 0
 
         # noinspection PyUnusedLocal
@@ -140,13 +141,13 @@ class HistoryStatsSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
-        start_timestamp, end_timestamp = self._period
+        start, end = self._period
         hsh = HistoryStatsHelper
         return {
             ATTR_VALUE: hsh.pretty_duration(self.value),
             ATTR_RATIO: hsh.pretty_ratio(self.value, self._period),
-            ATTR_START: hsh.pretty_datetime(start_timestamp),
-            ATTR_END: hsh.pretty_datetime(end_timestamp),
+            ATTR_START: start.strftime('%Y-%m-%d %H:%M:%S'),
+            ATTR_END: end.strftime('%Y-%m-%d %H:%M:%S'),
         }
 
     @property
@@ -159,11 +160,10 @@ class HistoryStatsSensor(Entity):
         """Get the latest data and updates the states."""
         # Parse templates
         self.update_period()
-
-        # Convert timestamps to dates
-        start_timestamp, end_timestamp = self._period
-        start = dt_util.utc_from_timestamp(start_timestamp)
-        end = dt_util.utc_from_timestamp(end_timestamp)
+        start, end = self._period
+        # Convert to UTC
+        start = dt_util.as_utc(start)
+        end = dt_util.as_utc(end)
 
         if not HistoryStatsHelper.wait_till_db_ready():
             _LOGGER.error('Cannot connect to database')
@@ -180,7 +180,7 @@ class HistoryStatsSensor(Entity):
         last_state = history.get_state(start, self._entity_id)
         last_state = (last_state is not None and
                       last_state == self._entity_state)
-        last_time = start_timestamp
+        last_time = dt_util.as_timestamp(start)
         elapsed = 0
 
         # Make calculations
@@ -198,58 +198,67 @@ class HistoryStatsSensor(Entity):
         self.value = elapsed / 3600
 
     def update_period(self):
-        """Parse the templates and store a timestamp tuple in _period."""
+        """Parse the templates and store a datetime tuple in _period."""
         start = None
         end = None
         duration = None
 
-        try:
-            if self._start is not None:
-                start = math.floor(float(self._start.async_render()))
-            if self._end is not None:
-                end = math.floor(float(self._end.async_render()))
-            if self._duration is not None:
+        # Parse start
+        if self._start is not None:
+            try:
+                start_rendered = self._start.async_render()
+            except TemplateError as ex:
+                HistoryStatsHelper.handle_template_exception(ex, 'start')
+                return
+            start = dt_util.parse_datetime(start_rendered)
+            if start is None:
+                try:
+                    start = dt_util.as_local(dt_util.utc_from_timestamp(
+                        math.floor(float(start_rendered))))
+                except ValueError:
+                    _LOGGER.error('PARSING ERROR: start must be a datetime'
+                                  ' or a timestamp.')
+                    return
+
+        # Parse end
+        if self._end is not None:
+            try:
+                end_rendered = self._end.async_render()
+            except TemplateError as ex:
+                HistoryStatsHelper.handle_template_exception(ex, 'end')
+                return
+            end = dt_util.parse_datetime(end_rendered)
+            if end is None:
+                try:
+                    end = dt_util.as_local(dt_util.utc_from_timestamp(
+                        math.floor(float(end_rendered))))
+                except ValueError:
+                    _LOGGER.error('PARSING ERROR: end must be a datetime'
+                                  ' or a timestamp.')
+                    return
+
+        # Parse duration
+        if self._duration is not None:
+            try:
                 duration = math.floor(float(self._duration.async_render()))
-        except TemplateError as ex:
-            HistoryStatsHelper.handle_template_exception(ex)
-        except ValueError:
-            _LOGGER.error('Template value cannot be converted to timestamp ')
+            except TemplateError as ex:
+                HistoryStatsHelper.handle_template_exception(ex, 'duration')
+                return
+            except ValueError:
+                _LOGGER.error('PARSING ERROR: duration must be a number')
+                return
 
         # Calculate start or end using the duration
-        start = end - duration if start is None else start
-        end = start + duration if end is None else end
+        if start is None:
+            start = end - datetime.timedelta(seconds=duration)
+        if end is None:
+            end = start + datetime.timedelta(seconds=duration)
 
         self._period = start, end
 
 
 class HistoryStatsHelper:
     """Static methods to make the HistoryStatsSensor code lighter."""
-
-    @staticmethod
-    def parse_time_expr(expression):
-        """Replace time expressions with functions accepted by templates."""
-        regex = r"(_NOW_(\.replace\([a-z]+=[0-9]+\))*)"
-        replacement = r"as_timestamp(\1)"
-
-        return re.sub(
-            regex, replacement, expression.replace("_THIS_DAY_", "_TODAY_")
-            .replace("_ONE_WEEK_", "604800")
-            .replace("_ONE_DAY_", "86400")
-            .replace("_ONE_HOUR_", "3600")
-            .replace("_ONE_MINUTE_", "60")
-            .replace("_THIS_YEAR_", "_THIS_MONTH_.replace(month=1)")
-            .replace("_THIS_MONTH_", "_TODAY_.replace(day=1)")
-            .replace("_THIS_WEEK_", "_TODAY_ - now().weekday() * 86400")
-            .replace("_TODAY_", "_THIS_HOUR_.replace(hour=0)")
-            .replace("_THIS_HOUR_", "_THIS_MINUTE_.replace(minute=0)")
-            .replace("_THIS_MINUTE_", "_NOW_.replace(second=0)")) \
-            .replace("_NOW_", "now()")
-
-    @staticmethod
-    def pretty_datetime(timestamp):
-        """Format a timestamp to a formatted datetime in the local timezone."""
-        return dt_util.as_local(dt_util.utc_from_timestamp(timestamp)) \
-            .strftime('%Y-%m-%d %H:%M:%S')
 
     @staticmethod
     def pretty_duration(hours):
@@ -273,17 +282,18 @@ class HistoryStatsHelper:
         if len(period) != 2 or period[0] == period[1]:
             return '0,0' + UNIT_RATIO
 
-        ratio = 3600 * 100 * value / (period[1] - period[0])
+        ratio = 100 * 3600 * value / (period[1] - period[0]).total_seconds()
         return str(round(ratio, 1)) + UNIT_RATIO
 
     @staticmethod
-    def handle_template_exception(ex):
+    def handle_template_exception(ex, field):
         """Log an error nicely if the template cannot be interpreted."""
         if ex.args and ex.args[0].startswith(
                 "UndefinedError: 'None' has no attribute"):
             # Common during HA startup - so just a warning
             _LOGGER.warning(ex)
             return
+        _LOGGER.error('Error parsing template for [' + field + ']')
         _LOGGER.error(ex)
 
     # noinspection PyProtectedMember

--- a/tests/components/sensor/test_history_stats.py
+++ b/tests/components/sensor/test_history_stats.py
@@ -1,0 +1,100 @@
+"""The test for the History Statistics sensor platform."""
+# pylint: disable=protected-access
+import unittest
+from unittest.mock import patch
+
+import homeassistant.components.recorder as recorder
+from homeassistant.bootstrap import setup_component
+from homeassistant.components.sensor.history_stats import HistoryStatsHelper
+from tests.common import get_test_home_assistant
+
+
+class TestHistoryStatsSensor(unittest.TestCase):
+    """Test the History Statistics sensor."""
+
+    def setUp(self):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def init_recorder(self):
+        """Initialize the recorder."""
+        db_uri = 'sqlite://'
+        with patch('homeassistant.core.Config.path', return_value=db_uri):
+            setup_component(self.hass, recorder.DOMAIN, {
+                "recorder": {
+                    "db_url": db_uri}})
+        self.hass.start()
+        recorder._INSTANCE.block_till_db_ready()
+        self.hass.block_till_done()
+        recorder._INSTANCE.block_till_done()
+
+    def test_setup(self):
+        """Test the history statistics sensor setup."""
+        self.init_recorder()
+        config = {
+            'history': {
+            },
+            'sensor': {
+                'platform': 'history_stats',
+                'entity_id': 'binary_sensor.test_id',
+                'state': 'on',
+                'start': '\'{{ _TODAY_ }}\'',
+                'end': '\'{{ _NOW_ }}\'',
+            }
+        }
+
+        self.assertTrue(setup_component(self.hass, 'sensor', config))
+
+    def test_template_parsing(self):
+        """Test of template parsing."""
+        h = HistoryStatsHelper
+        expressions = [
+            '_THIS_MINUTE_',
+            '_THIS_HOUR_',
+            '_TODAY_',
+            '_THIS_WEEK_',
+            '_THIS_MONTH_',
+            '_THIS_YEAR_',
+            '_ONE_MINUTE_',
+            '_ONE_HOUR_',
+            '_ONE_DAY_',
+            '_ONE_WEEK_',
+        ]
+
+        expected = [
+            'as_timestamp(now().replace(second=0))',
+            'as_timestamp(now().replace(second=0).replace(minute=0))',
+            'as_timestamp(now().replace(second=0).replace(minute=0).'
+            'replace(hour=0))',
+            'as_timestamp(now().replace(second=0).replace(minute=0).'
+            'replace(hour=0)) - now().weekday() * 86400',
+            'as_timestamp(now().replace(second=0).replace(minute=0).'
+            'replace(hour=0).replace(day=1))',
+            'as_timestamp(now().replace(second=0).replace(minute=0).'
+            'replace(hour=0).replace(day=1).replace(month=1))',
+            '60',
+            '3600',
+            '86400',
+            '604800',
+        ]
+
+        unchanged = [
+            'now()',
+            'as_timestamp(now())',
+            'as_timestamp(now().replace(second=0)) + 3600'
+            '_NOT_A_VALID__ALIAS',
+        ]
+
+        # Check that parsed expression = expected
+        for i, expr in enumerate(expressions):
+            result = h.parse_time_expr(expr)
+            self.assertTrue(result == expected[i])
+
+        # Check that parsing doesn't alter real function
+        for i, expr in enumerate(unchanged):
+            result = h.parse_time_expr(expr)
+            self.assertTrue(result == expr)

--- a/tests/components/sensor/test_history_stats.py
+++ b/tests/components/sensor/test_history_stats.py
@@ -33,7 +33,7 @@ class TestHistoryStatsSensor(unittest.TestCase):
                 'entity_id': 'binary_sensor.test_id',
                 'state': 'on',
                 'start': '{{ now().replace(hour=0)'
-                         + '.replace(minute=0).replace(second=0) }}',
+                         '.replace(minute=0).replace(second=0) }}',
                 'duration': '{{ 3600 * 2 + 60 }}',
                 'name': 'Test',
             }
@@ -197,6 +197,7 @@ class TestHistoryStatsSensor(unittest.TestCase):
         self.assertEqual(self.hass.states.get('sensor.test'), None)
 
     def test_no_recorder(self):
+        """Test Exception when the recorder is not started."""
         config = {
             'history': {
             },
@@ -205,7 +206,7 @@ class TestHistoryStatsSensor(unittest.TestCase):
                 'entity_id': 'binary_sensor.test_id',
                 'state': 'on',
                 'start': '{{ now().replace(hour=0)'
-                         + '.replace(minute=0).replace(second=0) }}',
+                         '.replace(minute=0).replace(second=0) }}',
                 'duration': '{{ 3600 * 2 + 60 }}',
                 'name': 'Test',
             }

--- a/tests/components/sensor/test_history_stats.py
+++ b/tests/components/sensor/test_history_stats.py
@@ -8,6 +8,8 @@ import homeassistant.components.recorder as recorder
 import homeassistant.core as ha
 import homeassistant.util.dt as dt_util
 from homeassistant.bootstrap import setup_component
+from homeassistant.components.sensor.history_stats import HistoryStatsSensor
+from homeassistant.helpers.template import Template
 from tests.common import get_test_home_assistant
 
 
@@ -42,27 +44,33 @@ class TestHistoryStatsSensor(unittest.TestCase):
         self.assertTrue(setup_component(self.hass, 'sensor', config))
 
         state = self.hass.states.get('sensor.test').as_dict()
-
         self.assertEqual(state['state'], '0')
-        self.assertEqual(state['attributes']['from'][-8:], '00:00:00')
-        self.assertEqual(state['attributes']['to'][-8:], '02:01:00')
+
+    def test_period_parsing(self):
+        """Test the conversion from templates to period."""
+        today = Template('{{ now().replace(hour=0).replace(minute=0)'
+                         '.replace(second=0) }}', self.hass)
+        duration = Template('{{ 3600 * 2 + 60 }}', self.hass)
+
+        sensor1 = HistoryStatsSensor(
+            self.hass, 'test', 'on', today, None, duration, 'test')
+        sensor2 = HistoryStatsSensor(
+            self.hass, 'test', 'on', None, today, duration, 'test')
+
+        sensor1.update_period()
+        sensor2.update_period()
+
+        self.assertEqual(
+            sensor1.device_state_attributes['from'][-8:], '00:00:00')
+        self.assertEqual(
+            sensor1.device_state_attributes['to'][-8:], '02:01:00')
+        self.assertEqual(
+            sensor2.device_state_attributes['from'][-8:], '21:59:00')
+        self.assertEqual(
+            sensor2.device_state_attributes['to'][-8:], '00:00:00')
 
     def test_measure(self):
         """Test the history statistics sensor measure."""
-        self.init_recorder()
-        config = {
-            'history': {
-            },
-            'sensor': {
-                'platform': 'history_stats',
-                'entity_id': 'binary_sensor.test_id',
-                'name': 'Test',
-                'state': 'on',
-                'start': '{{ as_timestamp(now()) - 3600 }}',
-                'end': '{{ now() }}',
-            }
-        }
-
         later = dt_util.utcnow() - timedelta(seconds=15)
         earlier = later - timedelta(minutes=30)
 
@@ -73,90 +81,81 @@ class TestHistoryStatsSensor(unittest.TestCase):
             ]
         }
 
+        start = Template('{{ as_timestamp(now()) - 3600 }}', self.hass)
+        end = Template('{{ now() }}', self.hass)
+
+        sensor1 = HistoryStatsSensor(
+            self.hass, 'binary_sensor.test_id', 'on', start, end, None, 'Test')
+
+        sensor2 = HistoryStatsSensor(
+            self.hass, 'unknown.id', 'on', start, end, None, 'Test')
+
         with patch('homeassistant.components.history.'
                    'state_changes_during_period', return_value=fake_states):
-            assert setup_component(self.hass, 'sensor', config)
+            with patch('homeassistant.components.history.get_state',
+                       return_value=None):
+                sensor1.update()
+                sensor2.update()
 
-        state = self.hass.states.get('sensor.test').as_dict()
-        self.assertEqual(state['state'], '0.5')
-        self.assertEqual(state['attributes']['ratio'], '50.0%')
+        self.assertEqual(sensor1.value, 0.5)
+        self.assertEqual(sensor2.value, 0)
+        self.assertEqual(sensor1.device_state_attributes['ratio'], '50.0%')
 
-    def test_wrong_start(self):
-        """Test Exception when start value is not a timestamp or a date."""
-        self.init_recorder()
-        config = {
-            'history': {
-            },
-            'sensor': {
-                'platform': 'history_stats',
-                'entity_id': 'binary_sensor.test_id',
-                'name': 'Test',
-                'state': 'on',
-                'start': '{{ TEST }}',
-                'end': '{{ now() }}',
-            }
-        }
+    def test_wrong_date(self):
+        """Test when start or end value is not a timestamp or a date."""
+        good = Template('{{ now() }}', self.hass)
+        bad = Template('{{ TEST }}', self.hass)
 
-        self.assertRaises(TypeError,
-                          setup_component(self.hass, 'sensor', config))
+        sensor1 = HistoryStatsSensor(
+            self.hass, 'test', 'on', good, bad, None, 'Test')
+        sensor2 = HistoryStatsSensor(
+            self.hass, 'test', 'on', bad, good, None, 'Test')
 
-    def test_wrong_end(self):
-        """Test Exception when end value is not a timestamp or a date."""
-        self.init_recorder()
-        config = {
-            'history': {
-            },
-            'sensor': {
-                'platform': 'history_stats',
-                'entity_id': 'binary_sensor.test_id',
-                'name': 'Test',
-                'state': 'on',
-                'start': '{{ now() }}',
-                'end': '{{ TEST }}',
-            }
-        }
+        before_update1 = sensor1._period
+        before_update2 = sensor2._period
 
-        self.assertRaises(TypeError,
-                          setup_component(self.hass, 'sensor', config))
+        sensor1.update_period()
+        sensor2.update_period()
+
+        self.assertEqual(before_update1, sensor1._period)
+        self.assertEqual(before_update2, sensor2._period)
 
     def test_wrong_duration(self):
-        """Test Exception when duration value is not a number."""
-        self.init_recorder()
+        """Test when duration value is not a number."""
+        start = Template('{{ as_timestamp(now()) - 24 * 3600 }}', self.hass)
+        duration = Template('{{  now() }}', self.hass)
 
-        config = {
-            'history': {
-            },
-            'sensor': {
-                'platform': 'history_stats',
-                'entity_id': 'binary_sensor.test_id',
-                'name': 'Test',
-                'state': 'on',
-                'start': '{{ as_timestamp(now()) - 24 * 3600 }}',
-                'duration': '{{ now() }}',
-            }
-        }
+        sensor = HistoryStatsSensor(
+            self.hass, 'test', 'on', start, None, duration, 'Test')
 
-        self.assertRaises(TypeError,
-                          setup_component(self.hass, 'sensor', config))
+        before_update = sensor._period
+        sensor.update_period()
+        self.assertEqual(before_update, sensor._period)
 
     def test_bad_template(self):
         """Test Exception when the template cannot be parsed."""
-        self.init_recorder()
-        config = {
-            'history': {
-            },
-            'sensor': {
-                'platform': 'history_stats',
-                'entity_id': 'binary_sensor.test_id',
-                'name': 'Test',
-                'state': 'on',
-                'end': '{{ x - 12 }}',  # <= x in undefined
-                'duration': '{{ 3600 }}',
-            }
-        }
+        bad = Template('{{ x - 12 }}', self.hass)  # x is undefined
+        good = Template('{{ now() }}', self.hass)
+        good_duration = Template('{{ 3600 }}', self.hass)
 
-        self.assertRaises(TypeError,
-                          setup_component(self.hass, 'sensor', config))
+        sensor1 = HistoryStatsSensor(
+            self.hass, 'test', 'on', bad, None, good_duration, 'Test')
+        sensor2 = HistoryStatsSensor(
+            self.hass, 'test', 'on', None, bad, good_duration, 'Test')
+        sensor3 = HistoryStatsSensor(
+            self.hass, 'test', 'on', good, None, bad, 'Test')
+
+        before_update1 = sensor1._period
+        before_update2 = sensor2._period
+        before_update3 = sensor3._period
+
+        sensor1.update_period()
+        sensor2.update_period()
+        sensor3.update_period()
+
+        self.assertEqual(before_update1, sensor1._period)
+        self.assertEqual(before_update2, sensor2._period)
+        self.assertEqual(before_update3, sensor3._period)
 
     def test_not_enough_arguments(self):
         """Test config when not enough arguments provided."""
@@ -175,6 +174,8 @@ class TestHistoryStatsSensor(unittest.TestCase):
 
         setup_component(self.hass, 'sensor', config)
         self.assertEqual(self.hass.states.get('sensor.test'), None)
+        self.assertRaises(TypeError,
+                          setup_component(self.hass, 'sensor', config))
 
     def test_too_many_arguments(self):
         """Test config when too many arguments provided."""
@@ -195,27 +196,8 @@ class TestHistoryStatsSensor(unittest.TestCase):
 
         setup_component(self.hass, 'sensor', config)
         self.assertEqual(self.hass.states.get('sensor.test'), None)
-
-    def test_no_recorder(self):
-        """Test Exception when the recorder is not started."""
-        config = {
-            'history': {
-            },
-            'sensor': {
-                'platform': 'history_stats',
-                'entity_id': 'binary_sensor.test_id',
-                'state': 'on',
-                'start': '{{ now().replace(hour=0)'
-                         '.replace(minute=0).replace(second=0) }}',
-                'duration': '{{ 3600 * 2 + 60 }}',
-                'name': 'Test',
-            }
-        }
-
-        with patch('homeassistant.components.recorder.Recorder.'
-                   '_setup_connection', return_value=False):
-            self.assertRaises(Exception,
-                              setup_component(self.hass, 'sensor', config))
+        self.assertRaises(TypeError,
+                          setup_component(self.hass, 'sensor', config))
 
     def init_recorder(self):
         """Initialize the recorder."""


### PR DESCRIPTION
**Add new sensor/history_stats component**


**Feature request**: [History statistics](https://community.home-assistant.io/t/history-statistics-component/10194)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1901

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: history_stats
    name: Lamp ON today
    entity_id: light.my_lamp
    state: 'on'
    start: {{ _TODAY_ }}
    end: {{ _NOW_ }}
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
