### PR TITLE
Upgrade rpi-rf to 0.9.6

### DIFF
--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -12,7 +12,7 @@ from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_NAME, CONF_SWITCHES)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['rpi-rf==0.9.5']
+REQUIREMENTS = ['rpi-rf==0.9.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -564,7 +564,7 @@ pyzabbix==0.7.4
 radiotherm==1.2
 
 # homeassistant.components.switch.rpi_rf
-# rpi-rf==0.9.5
+# rpi-rf==0.9.6
 
 # homeassistant.components.media_player.yamaha
 rxv==0.4.0


### PR DESCRIPTION
**Description:**
Update our requirement to 0.9.6 to avoid issues when users do a `pip install rpi-rf`.

**Related issue (if applicable):** fixes #5604
