### PR TITLE
Prevent infinite loop in crossconfigured mqtt event streams

### DIFF
--- a/homeassistant/components/mqtt_eventstream.py
+++ b/homeassistant/components/mqtt_eventstream.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     ATTR_SERVICE_DATA, EVENT_CALL_SERVICE, EVENT_SERVICE_EXECUTED,
     EVENT_STATE_CHANGED, EVENT_TIME_CHANGED, MATCH_ALL)
 from homeassistant.core import EventOrigin, State
+import homeassistant.helpers.config_validation as cv
 from homeassistant.remote import JSONEncoder
 from .mqtt import EVENT_MQTT_MESSAGE_RECEIVED
 
@@ -23,11 +24,14 @@ DEPENDENCIES = ['mqtt']
 
 CONF_PUBLISH_TOPIC = 'publish_topic'
 CONF_SUBSCRIBE_TOPIC = 'subscribe_topic'
+CONF_PUBLISH_EVENTSTREAM_RECEIVED = 'publish_eventstream_received'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_PUBLISH_TOPIC): valid_publish_topic,
         vol.Optional(CONF_SUBSCRIBE_TOPIC): valid_subscribe_topic,
+        vol.Optional(CONF_PUBLISH_EVENTSTREAM_RECEIVED, default=False):
+            cv.boolean,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -45,8 +49,14 @@ def setup(hass, config):
             return
         if event.event_type == EVENT_TIME_CHANGED:
             return
-        # filter out event from mqtt component about received messages
-        if event.event_type == EVENT_MQTT_MESSAGE_RECEIVED:
+
+        # MQTT fires a bus event for every incoming message, also messages from
+        # eventstream. Disable publishing these messages to other HA instances
+        # and possibly creating an infinite loop if these instances publish
+        # back to this one.
+        if all([not conf.get(CONF_PUBLISH_EVENTSTREAM_RECEIVED),
+                event.event_type == EVENT_MQTT_MESSAGE_RECEIVED,
+                event.data.get('topic') == sub_topic]):
             return
 
         # Filter out the events that were triggered by publishing

--- a/homeassistant/components/mqtt_eventstream.py
+++ b/homeassistant/components/mqtt_eventstream.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     EVENT_STATE_CHANGED, EVENT_TIME_CHANGED, MATCH_ALL)
 from homeassistant.core import EventOrigin, State
 from homeassistant.remote import JSONEncoder
+from .mqtt import EVENT_MQTT_MESSAGE_RECEIVED
 
 DOMAIN = "mqtt_eventstream"
 DEPENDENCIES = ['mqtt']
@@ -43,6 +44,9 @@ def setup(hass, config):
         if event.origin != EventOrigin.local:
             return
         if event.event_type == EVENT_TIME_CHANGED:
+            return
+        # filter out event from mqtt component about received messages
+        if event.event_type == EVENT_MQTT_MESSAGE_RECEIVED:
             return
 
         # Filter out the events that were triggered by publishing

--- a/tests/components/test_mqtt_eventstream.py
+++ b/tests/components/test_mqtt_eventstream.py
@@ -158,7 +158,6 @@ class TestMqttEventStream(unittest.TestCase):
         instances are crossconfigured for the same mqtt topics.
 
         """
-
         self.assertTrue(self.add_eventstream(pub_topic='bar'))
         self.hass.block_till_done()
 

--- a/tests/components/test_mqtt_eventstream.py
+++ b/tests/components/test_mqtt_eventstream.py
@@ -1,10 +1,12 @@
 """The tests for the MQTT eventstream component."""
+from collections import namedtuple
 import json
 import unittest
 from unittest.mock import ANY, patch
 
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.mqtt_eventstream as eventstream
+import homeassistant.components.mqtt as mqtt
 from homeassistant.const import EVENT_STATE_CHANGED
 from homeassistant.core import State, callback
 from homeassistant.remote import JSONEncoder
@@ -146,3 +148,30 @@ class TestMqttEventStream(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(1, len(calls))
+
+    @patch('homeassistant.components.mqtt.publish')
+    def test_ignore_mqtt_received_event(self, mock_pub):
+        """Filter events from the mqtt component about received message.
+
+        Mqtt component sends an event if a message is received. Not
+        filtering these messages result in an infinite loop if two HA
+        instances are crossconfigured for the same mqtt topics.
+
+        """
+
+        self.assertTrue(self.add_eventstream(pub_topic='bar'))
+        self.hass.block_till_done()
+
+        # Reset the mock because it will have already gotten calls for the
+        # mqtt_eventstream state change on initialization, etc.
+        mock_pub.reset_mock()
+
+        # Use MQTT component message handler to simulate firing message
+        # received event.
+        MQTTMessage = namedtuple('MQTTMessage', ['topic', 'qos', 'payload'])
+        message = MQTTMessage('test_topic', 1, 'Hello World!'.encode('utf-8'))
+        mqtt.MQTT._mqtt_on_message(self, None, {'hass': self.hass}, message)
+        self.hass.block_till_done()
+
+        # No event should have been fired.
+        self.assertFalse(mock_pub.called)


### PR DESCRIPTION
**Description:** Prevent events about MQTT messages received to cause infinite loop when two HA instances are crossconfigured for mqtt_eventstream.



**Related issue (if applicable):** fixes #2245

**Example entry for `configuration.yaml` (if applicable):**
```yaml
# master config:
mqtt_eventstream:
  publish_topic: homeassistant/events/master
  subscribe_topic: homeassistant/events/slave

#slave config
mqtt_eventstream:
  publish_topic: homeassistant/events/slave
  subscribe_topic: homeassistant/events/master
```

