### PR TITLE
Add devices detected by ping as SOURCE_TYPE_ROUTER instead of GPS

### DIFF
--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -19,7 +19,7 @@ from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
-    PLATFORM_SCHEMA, DEFAULT_SCAN_INTERVAL)
+    PLATFORM_SCHEMA, DEFAULT_SCAN_INTERVAL, SOURCE_TYPE_ROUTER)
 from homeassistant.helpers.event import track_point_in_utc_time
 from homeassistant import util
 from homeassistant import const
@@ -66,7 +66,7 @@ class Host:
         failed = 0
         while failed < self._count:  # check more times if host in unreachable
             if self.ping():
-                see(dev_id=self.dev_id)
+                see(dev_id=self.dev_id, source_type=SOURCE_TYPE_ROUTER)
                 return True
             failed += 1
 


### PR DESCRIPTION
**Description:**
Devices that are detected by the `device_tracker.ping` component are added as `SOURCE_TYPE_GPS` since that is the default. This change makes adds it as `SOURCE_TYPE_ROUTER`.

