### PR TITLE
Load mqtt_eventstream before most other components.

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -177,6 +177,8 @@ def load_order_components(components: Sequence[str]) -> OrderedSet:
     - Will ensure that all components that do not directly depend on
       the group component will be loaded before the group component.
     - returns an OrderedSet load order.
+    - Makes sure MQTT eventstream is available for publish before
+      components start updating states.
 
     Async friendly.
     """
@@ -193,7 +195,8 @@ def load_order_components(components: Sequence[str]) -> OrderedSet:
         load_order.update(comp_load_order)
 
     # Push some to first place in load order
-    for comp in ('logger', 'recorder', 'introduction'):
+    for comp in ('mqtt_eventstream', 'mqtt', 'logger',
+                 'recorder', 'introduction'):
         if comp in load_order:
             load_order.promote(comp)
 


### PR DESCRIPTION
**Description:** This ensures that initial state changes for components are broadcasted on the MQTT bus.
