### PR TITLE
[recorder] Index events time_fired to improve logbook performance

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -305,10 +305,10 @@ class Recorder(threading.Thread):
         models.Base.metadata.create_all(self.engine)
         session_factory = sessionmaker(bind=self.engine)
         Session = scoped_session(session_factory)
-        self._check_schema()
+        self._migrate_schema()
         self.db_ready.set()
 
-    def _check_schema(self):
+    def _migrate_schema(self):
         """Check if the schema needs to be upgraded."""
         import homeassistant.components.recorder.models as models
         schema_changes = models.SchemaChanges
@@ -328,12 +328,12 @@ class Recorder(threading.Thread):
             new_version = version + 1
             _LOGGER.info(
                 "Upgrading recorder db schema to version %d", new_version)
-            self._migrate_schema(new_version)
+            self._apply_update(new_version)
             self._commit(schema_changes(schema_version=new_version))
             _LOGGER.info(
                 "Upgraded recorder db schema to version %d", new_version)
 
-    def _migrate_schema(self, new_version):
+    def _apply_update(self, new_version):
         """Perform operations to bring schema up to date."""
         from sqlalchemy import Index, Table
         import homeassistant.components.recorder.models as models

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -305,36 +305,81 @@ class Recorder(threading.Thread):
         models.Base.metadata.create_all(self.engine)
         session_factory = sessionmaker(bind=self.engine)
         Session = scoped_session(session_factory)
-        self._migrate_schema()
+        self._check_schema()
         self.db_ready.set()
 
-    def _migrate_schema(self):
-        """Perform operations to bring schema up to date."""
+    def _check_schema(self):
+        """Check if the schema needs to be upgraded."""
         import homeassistant.components.recorder.models as models
+        schema_changes = models.SchemaChanges
+        current_version = getattr(Session.query(schema_changes).order_by(
+            schema_changes.change_id.desc()).first(), 'schema_version', None)
+
+        if current_version == models.SCHEMA_VERSION:
+            return
+        _LOGGER.debug("Schema version incorrect: %d", current_version)
+
+        if current_version is None:
+            current_version = self._inspect_schema_version()
+            _LOGGER.debug("No schema version found. Inspected version: %d",
+                          current_version)
+
+        for version in range(current_version, models.SCHEMA_VERSION):
+            new_version = version + 1
+            _LOGGER.info(
+                "Upgrading recorder db schema to version %d", new_version)
+            self._migrate_schema(new_version)
+            self._commit(schema_changes(schema_version=new_version))
+            _LOGGER.info(
+                "Upgraded recorder db schema to version %d", new_version)
+
+    def _migrate_schema(self, new_version):
+        """Perform operations to bring schema up to date."""
         from sqlalchemy import Index, Table
+        import homeassistant.components.recorder.models as models
+
+        if new_version == 1:
+            def create_index(table_name, column_name):
+                """Create an index for the specified table and column."""
+                table = Table(table_name, models.Base.metadata)
+                index_name = "_".join(("ix", table_name, column_name))
+                index = Index(index_name, getattr(table.c, column_name))
+                _LOGGER.debug("Creating index for table %s column %s",
+                              table_name, column_name)
+                index.create(self.engine)
+                _LOGGER.debug("Index creation done for table %s column %s",
+                              table_name, column_name)
+
+            create_index("events", "time_fired")
+        else:
+            raise ValueError("No schema migration defined for version {}"
+                             .format(new_version))
+
+    def _inspect_schema_version(self):
+        """Determine the schema version by inspecting the db structure.
+
+        When the schema verison is not present in the db, either db was just
+        created with the correct schema, or this is a db created before schema
+        versions were tracked. For now, we'll test if the changes for schema
+        version 1 are present to make the determination. Eventually this logic
+        can be removed and we can assume a new db is being created.
+        """
         from sqlalchemy.engine import reflection
+        import homeassistant.components.recorder.models as models
         inspector = reflection.Inspector.from_engine(self.engine)
+        indexes = inspector.get_indexes("events")
+        for index in indexes:
+            if index['column_names'] == ["time_fired"]:
+                # Schema addition from version 1 detected. This is a new db.
+                current_version = models.SchemaChanges(
+                    schema_version=models.SCHEMA_VERSION)
+                self._commit(current_version)
+                return models.SCHEMA_VERSION
 
-        def ensure_column_index(table_name, column_name):
-            """Ensure index exists on table column."""
-            indexes = inspector.get_indexes(table_name)
-            for index in indexes:
-                if index['column_names'] == [column_name]:
-                    # Index already exists
-                    return
-
-            # Index needs to be created
-            table = Table(table_name, models.Base.metadata)
-            index_name = "_".join(("ix", table_name, column_name))
-            index = Index(index_name, getattr(table.c, column_name))
-            _LOGGER.info("Creating index for table %s column %s",
-                         table_name, column_name)
-            self._commit(lambda _: index.create(self.engine))
-            _LOGGER.info("Index creation complete for table %s column %s",
-                         table_name, column_name)
-
-        # Update Schema for v0.38
-        ensure_column_index("events", "time_fired")
+        # Version 1 schema changes not found, this db needs to be migrated.
+        current_version = models.SchemaChanges(schema_version=0)
+        self._commit(current_version)
+        return current_version.schema_version
 
     def _close_connection(self):
         """Close the connection."""

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -16,6 +16,8 @@ from homeassistant.remote import JSONEncoder
 # pylint: disable=invalid-name
 Base = declarative_base()
 
+SCHEMA_VERSION = 1
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -147,6 +149,15 @@ class RecorderRuns(Base):   # type: ignore
     def to_native(self):
         """Return self, native format is this model."""
         return self
+
+
+class SchemaChanges(Base):   # type: ignore
+    """Representation of schema version changes."""
+
+    __tablename__ = 'schema_changes'
+    change_id = Column(Integer, primary_key=True)
+    schema_version = Column(Integer)
+    changed = Column(DateTime(timezone=True), default=datetime.utcnow)
 
 
 def _process_timestamp(ts):

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -27,7 +27,7 @@ class Events(Base):  # type: ignore
     event_type = Column(String(32), index=True)
     event_data = Column(Text)
     origin = Column(String(32))
-    time_fired = Column(DateTime(timezone=True))
+    time_fired = Column(DateTime(timezone=True), index=True)
     created = Column(DateTime(timezone=True), default=datetime.utcnow)
 
     @staticmethod

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -193,25 +193,25 @@ class TestRecorder(unittest.TestCase):
 
     def test_schema_no_recheck(self):
         """Test that schema is not double-checked when up-to-date."""
-        with patch.object(recorder._INSTANCE, '_migrate_schema') as migrate, \
+        with patch.object(recorder._INSTANCE, '_apply_update') as update, \
                 patch.object(recorder._INSTANCE, '_inspect_schema_version') \
                 as inspect:
-            recorder._INSTANCE._check_schema()
-            self.assertEqual(migrate.call_count, 0)
+            recorder._INSTANCE._migrate_schema()
+            self.assertEqual(update.call_count, 0)
             self.assertEqual(inspect.call_count, 0)
 
-    def test_invalid_migrate(self):
+    def test_invalid_update(self):
         """Test that an invalid new version raises an exception."""
         with self.assertRaises(ValueError):
-            recorder._INSTANCE._migrate_schema(-1)
+            recorder._INSTANCE._apply_update(-1)
 
-    def test_schema_migrate_calls(self):
+    def test_schema_update_calls(self):
         """Test that schema migrations occurr in correct order."""
         test_version = recorder.models.SchemaChanges(schema_version=0)
         self.session.add(test_version)
-        with patch.object(recorder._INSTANCE, '_migrate_schema') as migrate:
-            recorder._INSTANCE._check_schema()
-            migrate.assert_has_calls([call(version+1) for version in range(
+        with patch.object(recorder._INSTANCE, '_apply_update') as update:
+            recorder._INSTANCE._migrate_schema()
+            update.assert_has_calls([call(version+1) for version in range(
                 0, recorder.models.SCHEMA_VERSION)])
 
 


### PR DESCRIPTION
**Description:**
This PR adds an index to the time_fired column of the Events table to improve performance of the logbook lookup. I also didn't see any existing logic for schema migration. I've included logic here to add the index to existing databases. I don't have much SQL Alchemy experience though, so feel free to pick this code apart.

**Numbers:**
On my system (spinning disk drives), the hass SQLite db is at 760MiB. Before this change, warm-cache queries for a logbook day took approximately 1.65 seconds. Adding the index raised the db size to 780MiB. With the index the same queries now take 0.55 seconds.