### PR TITLE
`yarn setup_js_dev` was deleted

### DIFF
--- a/script/bootstrap_frontend
+++ b/script/bootstrap_frontend
@@ -17,5 +17,4 @@ yarn install
 # Install bower web components. Allow to download the components as root since the user in docker is root.
 ./node_modules/.bin/bower install --allow-root
 
-yarn run setup_js_dev
 cd ../../../../..


### PR DESCRIPTION
**Description:** Since home-assistant/home-assistant-polymer#180 and home-assistant/home-assistant-polymer#188 this is no longer needed

**Related issue (if applicable):** home-assistant/home-assistant-polymer#188