### PR TITLE
Hotfix for netatmo cameras

### DIFF
--- a/homeassistant/components/camera/netatmo.py
+++ b/homeassistant/components/camera/netatmo.py
@@ -74,9 +74,12 @@ class NetatmoCamera(Camera):
             if self._localurl:
                 response = requests.get('{0}/live/snapshot_720.jpg'.format(
                     self._localurl), timeout=10)
-            else:
+            elif self._vpnurl:
                 response = requests.get('{0}/live/snapshot_720.jpg'.format(
                     self._vpnurl), timeout=10, verify=False)
+            else:
+                self._data.update()
+                return None
         except requests.exceptions.RequestException as error:
             _LOGGER.error('Welcome VPN url changed: %s', error)
             self._data.update()

--- a/homeassistant/components/camera/netatmo.py
+++ b/homeassistant/components/camera/netatmo.py
@@ -9,6 +9,7 @@ import logging
 import requests
 import voluptuous as vol
 
+from homeassistant.const import CONF_VERIFY_SSL
 from homeassistant.components.netatmo import CameraData
 from homeassistant.components.camera import (Camera, PLATFORM_SCHEMA)
 from homeassistant.loader import get_component
@@ -20,7 +21,6 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_HOME = 'home'
 CONF_CAMERAS = 'cameras'
-CONF_VERIFY_SSL = 'verify_ssl'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,

--- a/homeassistant/components/camera/netatmo.py
+++ b/homeassistant/components/camera/netatmo.py
@@ -76,7 +76,7 @@ class NetatmoCamera(Camera):
                     self._localurl), timeout=10)
             else:
                 response = requests.get('{0}/live/snapshot_720.jpg'.format(
-                    self._vpnurl), timeout=10)
+                    self._vpnurl), timeout=10, verify=False)
         except requests.exceptions.RequestException as error:
             _LOGGER.error('Welcome VPN url changed: %s', error)
             self._data.update()


### PR DESCRIPTION
Also fix issue with SSL certificate for vpn_url

**Description:**
This PR fix two issue netatmo camera:
  - Welcome tags do not appear in home-assistant 0.38
  - Camera's 'vpn_url' (which is currently used as Netatmo broke the local_url) can create a certificate issue

**Related issue (if applicable):** fixes #5632

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
