### PR TITLE
Only set LANG=C.UTF8 during install.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,13 @@ skip_missing_interpreters = True
 
 [testenv]
 setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}/homeassistant
 ; both temper-python and XBee modules have utf8 in their README files
 ; which get read in from setup.py. If we don't force our locale to a
 ; utf8 one, tox's env is reset. And the install of these 2 packages
 ; fail.
-    LANG=C.UTF-8
-    PYTHONPATH = {toxinidir}:{toxinidir}/homeassistant
+whitelist_externals = /usr/bin/env
+install_command = /usr/bin/env LANG=C.UTF-8 pip install {opts} {packages}
 commands =
      py.test --timeout=30 --duration=10 --cov --cov-report= {posargs}
 deps =


### PR DESCRIPTION
**Description:** For me this solved the issue I have with pytest-sugar on OSX which makes test output completely unreadable. 

By only setting the `LANG` environment variable when it is needed (during install) and not during all commands.

**Related issue (if applicable):** fixes #5305

