### PR TITLE
Use device_state_attributes() for platforms

### DIFF
--- a/homeassistant/components/sensor/deutsche_bahn.py
+++ b/homeassistant/components/sensor/deutsche_bahn.py
@@ -65,7 +65,7 @@ class DeutscheBahnSensor(Entity):
         return self._state
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes."""
         connections = self.data.connections[0]
         connections['next'] = self.data.connections[1]['departure']

--- a/homeassistant/components/sensor/gpsd.py
+++ b/homeassistant/components/sensor/gpsd.py
@@ -98,7 +98,7 @@ class GpsdSensor(Entity):
             return STATE_UNKNOWN
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes of the GPS."""
         return {
             ATTR_LATITUDE: self.agps_thread.data_stream.lat,

--- a/homeassistant/components/sensor/hddtemp.py
+++ b/homeassistant/components/sensor/hddtemp.py
@@ -83,7 +83,7 @@ class HddTempSensor(Entity):
             return TEMP_FAHRENHEIT
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes of the sensor."""
         return {
             ATTR_DEVICE: self.details[1],

--- a/homeassistant/components/sensor/hp_ilo.py
+++ b/homeassistant/components/sensor/hp_ilo.py
@@ -110,7 +110,7 @@ class HpIloSensor(Entity):
         return self._state
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes."""
         return self._data
 

--- a/homeassistant/components/sensor/imap_email_content.py
+++ b/homeassistant/components/sensor/imap_email_content.py
@@ -159,7 +159,7 @@ class EmailContentSensor(Entity):
         return self._message
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return other state attributes for the message."""
         return self._state_attributes
 

--- a/homeassistant/components/sensor/linux_battery.py
+++ b/homeassistant/components/sensor/linux_battery.py
@@ -98,7 +98,7 @@ class LinuxBatterySensor(Entity):
         return ICON
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes of the sensor."""
         return {
             ATTR_NAME: self._battery_stat.name,

--- a/homeassistant/components/sensor/mold_indicator.py
+++ b/homeassistant/components/sensor/mold_indicator.py
@@ -238,7 +238,7 @@ class MoldIndicator(Entity):
         return self._state
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes."""
         if self._is_metric:
             return {

--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -116,7 +116,7 @@ class StatisticsSensor(Entity):
         return False
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes of the sensor."""
         if not self.is_binary:
             return {

--- a/homeassistant/components/sensor/zamg.py
+++ b/homeassistant/components/sensor/zamg.py
@@ -112,7 +112,7 @@ class ZamgSensor(Entity):
         return SENSOR_TYPES[self.variable][1]
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes."""
         return {
             ATTR_WEATHER_ATTRIBUTION: ATTRIBUTION,

--- a/tests/components/sensor/test_imap_email_content.py
+++ b/tests/components/sensor/test_imap_email_content.py
@@ -129,7 +129,7 @@ class EmailContentSensor(unittest.TestCase):
 
         sensor = imap_email_content.EmailContentSensor(
             self.hass, FakeEMailReader(deque([msg])), 'test_emails_sensor',
-            ['sender@test.com'],None)
+            ['sender@test.com'], None)
 
         sensor.entity_id = 'sensor.emailtest'
         sensor.update()

--- a/tests/components/sensor/test_imap_email_content.py
+++ b/tests/components/sensor/test_imap_email_content.py
@@ -46,8 +46,8 @@ class EmailContentSensor(unittest.TestCase):
     def test_allowed_sender(self):
         """Test emails from allowed sender."""
         test_message = email.message.Message()
-        test_message['From'] = "sender@test.com"
-        test_message['Subject'] = "Test"
+        test_message['From'] = 'sender@test.com'
+        test_message['Subject'] = 'Test'
         test_message['Date'] = datetime.datetime(2016, 1, 1, 12, 44, 57)
         test_message.set_payload("Test Message")
 
@@ -58,19 +58,20 @@ class EmailContentSensor(unittest.TestCase):
             ["sender@test.com"],
             None)
 
-        sensor.entity_id = "sensor.emailtest"
+        sensor.entity_id = 'sensor.emailtest'
         sensor.update()
         self.assertEqual("Test Message", sensor.state)
-        self.assertEqual("sender@test.com", sensor.state_attributes["from"])
-        self.assertEqual("Test", sensor.state_attributes["subject"])
+        self.assertEqual('sender@test.com',
+                         sensor.device_state_attributes['from'])
+        self.assertEqual('Test', sensor.device_state_attributes['subject'])
         self.assertEqual(datetime.datetime(2016, 1, 1, 12, 44, 57),
-                         sensor.state_attributes["date"])
+                         sensor.device_state_attributes['date'])
 
     def test_multi_part_with_text(self):
         """Test multi part emails."""
         msg = MIMEMultipart('alternative')
-        msg['Subject'] = "Link"
-        msg['From'] = "sender@test.com"
+        msg['Subject'] = 'Link'
+        msg['From'] = 'sender@test.com'
 
         text = "Test Message"
         html = "<html><head></head><body>Test Message</body></html>"
@@ -82,11 +83,8 @@ class EmailContentSensor(unittest.TestCase):
         msg.attach(htmlPart)
 
         sensor = imap_email_content.EmailContentSensor(
-            self.hass,
-            FakeEMailReader(deque([msg])),
-            "test_emails_sensor",
-            ["sender@test.com"],
-            None)
+            self.hass,  FakeEMailReader(deque([msg])), 'test_emails_sensor',
+            ['sender@test.com'], None)
 
         sensor.entity_id = "sensor.emailtest"
         sensor.update()
@@ -107,11 +105,11 @@ class EmailContentSensor(unittest.TestCase):
         sensor = imap_email_content.EmailContentSensor(
             self.hass,
             FakeEMailReader(deque([msg])),
-            "test_emails_sensor",
-            ["sender@test.com"],
+            'test_emails_sensor',
+            ['sender@test.com'],
             None)
 
-        sensor.entity_id = "sensor.emailtest"
+        sensor.entity_id = 'sensor.emailtest'
         sensor.update()
         self.assertEqual(
             "<html><head></head><body>Test Message</body></html>",
@@ -120,8 +118,8 @@ class EmailContentSensor(unittest.TestCase):
     def test_multi_part_only_other_text(self):
         """Test multi part emails with only other text."""
         msg = MIMEMultipart('alternative')
-        msg['Subject'] = "Link"
-        msg['From'] = "sender@test.com"
+        msg['Subject'] = 'Link'
+        msg['From'] = 'sender@test.com'
 
         other = "Test Message"
 
@@ -130,13 +128,10 @@ class EmailContentSensor(unittest.TestCase):
         msg.attach(htmlPart)
 
         sensor = imap_email_content.EmailContentSensor(
-            self.hass,
-            FakeEMailReader(deque([msg])),
-            "test_emails_sensor",
-            ["sender@test.com"],
-            None)
+            self.hass, FakeEMailReader(deque([msg])), 'test_emails_sensor',
+            ['sender@test.com'],None)
 
-        sensor.entity_id = "sensor.emailtest"
+        sensor.entity_id = 'sensor.emailtest'
         sensor.update()
         self.assertEqual("Test Message", sensor.state)
 
@@ -145,14 +140,14 @@ class EmailContentSensor(unittest.TestCase):
         states = []
 
         test_message1 = email.message.Message()
-        test_message1['From'] = "sender@test.com"
-        test_message1['Subject'] = "Test"
+        test_message1['From'] = 'sender@test.com'
+        test_message1['Subject'] = 'Test'
         test_message1['Date'] = datetime.datetime(2016, 1, 1, 12, 44, 57)
         test_message1.set_payload("Test Message")
 
         test_message2 = email.message.Message()
-        test_message2['From'] = "sender@test.com"
-        test_message2['Subject'] = "Test 2"
+        test_message2['From'] = 'sender@test.com'
+        test_message2['Subject'] = 'Test 2'
         test_message2['Date'] = datetime.datetime(2016, 1, 1, 12, 44, 57)
         test_message2.set_payload("Test Message 2")
 
@@ -164,18 +159,14 @@ class EmailContentSensor(unittest.TestCase):
                 states_received.set()
 
         track_state_change(
-            self.hass,
-            ["sensor.emailtest"],
-            state_changed_listener)
+            self.hass, ['sensor.emailtest'], state_changed_listener)
 
         sensor = imap_email_content.EmailContentSensor(
             self.hass,
             FakeEMailReader(deque([test_message1, test_message2])),
-            "test_emails_sensor",
-            ["sender@test.com"],
-            None)
+            'test_emails_sensor', ['sender@test.com'], None)
 
-        sensor.entity_id = "sensor.emailtest"
+        sensor.entity_id = 'sensor.emailtest'
         sensor.update()
 
         self.hass.block_till_done()
@@ -189,39 +180,34 @@ class EmailContentSensor(unittest.TestCase):
     def test_sender_not_allowed(self):
         """Test not whitelisted emails."""
         test_message = email.message.Message()
-        test_message['From'] = "sender@test.com"
-        test_message['Subject'] = "Test"
+        test_message['From'] = 'sender@test.com'
+        test_message['Subject'] = 'Test'
         test_message['Date'] = datetime.datetime(2016, 1, 1, 12, 44, 57)
         test_message.set_payload("Test Message")
 
         sensor = imap_email_content.EmailContentSensor(
-            self.hass,
-            FakeEMailReader(deque([test_message])),
-            "test_emails_sensor",
-            ["other@test.com"],
-            None)
+            self.hass, FakeEMailReader(deque([test_message])),
+            'test_emails_sensor', ['other@test.com'], None)
 
-        sensor.entity_id = "sensor.emailtest"
+        sensor.entity_id = 'sensor.emailtest'
         sensor.update()
         self.assertEqual(None, sensor.state)
 
     def test_template(self):
         """Test value template."""
         test_message = email.message.Message()
-        test_message['From'] = "sender@test.com"
-        test_message['Subject'] = "Test"
+        test_message['From'] = 'sender@test.com'
+        test_message['Subject'] = 'Test'
         test_message['Date'] = datetime.datetime(2016, 1, 1, 12, 44, 57)
         test_message.set_payload("Test Message")
 
         sensor = imap_email_content.EmailContentSensor(
-            self.hass,
-            FakeEMailReader(deque([test_message])),
-            "test_emails_sensor",
-            ["sender@test.com"],
+            self.hass, FakeEMailReader(deque([test_message])),
+            'test_emails_sensor', ['sender@test.com'],
             Template("{{ subject }} from {{ from }} with message {{ body }}",
                      self.hass))
 
-        sensor.entity_id = "sensor.emailtest"
+        sensor.entity_id = 'sensor.emailtest'
         sensor.update()
         self.assertEqual(
             "Test from sender@test.com with message Test Message",


### PR DESCRIPTION
**Description:**
Change platforms to use `device_state_attributes()` instead of `state_attributes()`. 

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
