### PR TITLE
Added new sensor component to monitor OpenEVSE chargers.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -325,6 +325,7 @@ omit =
     homeassistant/components/sensor/nzbget.py
     homeassistant/components/sensor/ohmconnect.py
     homeassistant/components/sensor/onewire.py
+    homeassistant/components/sensor/openevse.py
     homeassistant/components/sensor/openexchangerates.py
     homeassistant/components/sensor/openweathermap.py
     homeassistant/components/sensor/pi_hole.py

--- a/homeassistant/components/sensor/openevse.py
+++ b/homeassistant/components/sensor/openevse.py
@@ -1,0 +1,102 @@
+"""
+Support for monitoring an OpenEVSE Charger.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.openevse/
+"""
+
+import logging
+
+from requests import RequestException
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import TEMP_CELSIUS, CONF_HOST
+from homeassistant.const import CONF_MONITORED_VARIABLES
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+REQUIREMENTS = ['openevsewifi==0.2']
+SENSOR_TYPES = {
+    'status': ['Charging Status', None],
+    'charge_time': ['Charge Time Elapsed', 'minutes'],
+    'ambient_temp': ['Ambient Termperature', TEMP_CELSIUS],
+    'ir_temp': ['IR Temperature', TEMP_CELSIUS],
+    'rtc_temp': ['RTC Temperature', TEMP_CELSIUS],
+    'usage_session': ['Usage this Session', 'kWh'],
+    'usage_total': ['Total Usage', 'kWh']
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_MONITORED_VARIABLES, default=['status']):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the OpenEVSE sensor."""
+    from openevsewifi import openevsewifi
+
+    host = config.get(CONF_HOST)
+    monitored_variables = config.get(CONF_MONITORED_VARIABLES)
+
+    charger = openevsewifi.Charger(host)
+
+    dev = []
+    for variable in monitored_variables:
+        dev.append(OpenEVSESensor(variable, charger))
+
+    add_devices(dev)
+
+
+class OpenEVSESensor(Entity):
+    """Implementation of an OpenEVSE sensor."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, sensor_type, charger):
+        """Initialize the sensor."""
+        self._name = SENSOR_TYPES[sensor_type][0]
+        self.type = sensor_type
+        self._state = None
+        self.charger = charger
+        self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this sensor."""
+        return self._unit_of_measurement
+
+    def update(self):
+        """Get the monitored data from the charger."""
+        try:
+            if self.type == 'status':
+                self._state = self.charger.getStatus()
+            elif self.type == 'charge_time':
+                self._state = self.charger.getChargeTimeElapsed()/60
+            elif self.type == 'ambient_temp':
+                self._state = self.charger.getAmbientTemperature()
+            elif self.type == 'ir_temp':
+                self._state = self.charger.getIRTemperature()
+            elif self.type == 'rtc_temp':
+                self._state = self.charger.getRTCTemperature()
+            elif self.type == 'usage_session':
+                self._state = float(self.charger.getUsageSession())/1000
+            elif self.type == 'usage_total':
+                self._state = float(self.charger.getUsageTotal())/1000
+            else:
+                self._state = 'Unknown'
+        except (RequestException, ValueError, KeyError):
+            _LOGGER.warning('Could not update status for %s', self.name)

--- a/homeassistant/components/sensor/openevse.py
+++ b/homeassistant/components/sensor/openevse.py
@@ -18,7 +18,7 @@ from homeassistant.const import CONF_MONITORED_VARIABLES
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ['openevsewifi==0.2']
+REQUIREMENTS = ['openevsewifi==0.4']
 SENSOR_TYPES = {
     'status': ['Charging Status', None],
     'charge_time': ['Charge Time Elapsed', 'minutes'],
@@ -38,7 +38,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the OpenEVSE sensor."""
-    from openevsewifi import openevsewifi
+    import openevsewifi
 
     host = config.get(CONF_HOST)
     monitored_variables = config.get(CONF_MONITORED_VARIABLES)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -333,6 +333,9 @@ neurio==0.3.1
 # homeassistant.components.google
 oauth2client==3.0.0
 
+# homeassistant.components.sensor.openevse
+openevsewifi==0.2
+
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -334,7 +334,7 @@ neurio==0.3.1
 oauth2client==3.0.0
 
 # homeassistant.components.sensor.openevse
-openevsewifi==0.2
+openevsewifi==0.4
 
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1


### PR DESCRIPTION
**Description:**
This adds sensor components for OpenEVSE chargers equipped with the WiFi Kit.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1947
**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: openevse
    host: openevse.mydomain.com
    monitored_variables:
      - status
      - usage_session
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
