### PR TITLE
iTach Remote Platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -277,6 +277,7 @@ omit =
     homeassistant/components/notify/xmpp.py
     homeassistant/components/nuimo_controller.py
     homeassistant/components/remote/harmony.py
+    homeassistant/components/remote/itach.py
     homeassistant/components/scene/hunterdouglas_powerview.py
     homeassistant/components/sensor/amcrest.py
     homeassistant/components/sensor/arest.py

--- a/homeassistant/components/remote/itach.py
+++ b/homeassistant/components/remote/itach.py
@@ -29,7 +29,7 @@ from homeassistant.const import DEVICE_DEFAULT_NAME
 import homeassistant.components.remote as remote
 from homeassistant.components.remote import ATTR_COMMAND
 
-REQUIREMENTS = ['pyitachip2ir==0.0.4']
+REQUIREMENTS = ['pyitachip2ir==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/remote/itach.py
+++ b/homeassistant/components/remote/itach.py
@@ -13,7 +13,7 @@ import homeassistant.helpers.config_validation as cv
 import homeassistant.components.remote as remote
 from homeassistant.const import (
     DEVICE_DEFAULT_NAME, CONF_NAME, CONF_MAC, CONF_HOST, CONF_PORT,
-    CONF_DEVICES, CONF_FILENAME)
+    CONF_DEVICES)
 from homeassistant.components.remote import (
     PLATFORM_SCHEMA, ATTR_COMMAND)
 
@@ -37,8 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_MODADDR): vol.Coerce(int),
         vol.Required(CONF_CONNADDR): vol.Coerce(int),
-        vol.Optional(CONF_FILENAME): cv.string,
-        vol.Optional(CONF_COMMANDS): vol.All(cv.ensure_list, [{
+        vol.Required(CONF_COMMANDS): vol.All(cv.ensure_list, [{
             vol.Required(CONF_NAME): cv.string,
             vol.Required(CONF_DATA): cv.string
         }])
@@ -63,15 +62,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         name = data.get(CONF_NAME)
         modaddr = int(data.get(CONF_MODADDR, 1))
         connaddr = int(data.get(CONF_CONNADDR, 1))
-        if CONF_FILENAME in data:
-            cmddata = open(
-                hass.config.config_dir + "/" + data.get(CONF_FILENAME), "r"
-            ).read()
-        elif CONF_COMMANDS in data:
-            cmddata = ""
-            for cmd in data.get(CONF_COMMANDS):
-                cmddata += cmd[CONF_NAME] + "\n" + cmd[CONF_DATA] + "\n"
-            print(":"+cmddata+":")
+        cmddata = ""
+        for cmd in data.get(CONF_COMMANDS):
+            cmddata += cmd[CONF_NAME] + "\n" + cmd[CONF_DATA] + "\n"
         itachip2ir.addDevice(name, modaddr, connaddr, cmddata)
         devices.append(ITachIP2IRRemote(itachip2ir, name))
     add_devices(devices, True)

--- a/homeassistant/components/remote/itach.py
+++ b/homeassistant/components/remote/itach.py
@@ -30,7 +30,7 @@ CONF_COMMANDS = 'commands'
 CONF_DATA = 'data'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_MAC, default=None): cv.string,
+    vol.Optional(CONF_MAC): cv.string,
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Required(CONF_DEVICES): vol.All(cv.ensure_list, [{

--- a/homeassistant/components/remote/itach.py
+++ b/homeassistant/components/remote/itach.py
@@ -1,0 +1,98 @@
+"""
+Control an itach ip2ir gateway using libitachip2ir.
+
+Requires a command file with Philips Pronto learned hex formats.
+
+Example command file:
+
+OFF
+0000 006d 0022 0002 0157 00ac 0015 0016 0015 0016 0015 0041 0015
+
+ON
+0000 006d 0022 0002 0157 00ac 0015 0016 0015 0016 0041 0015 0015
+
+Example configuration.yaml section:
+remote living_room:
+  - platform: itach
+    name: Living Room
+    mac: 000C1E023FDC
+    ip: itach023fdc
+    port: 4998
+    devices:
+      - { name: TV,  connaddr: 2, file: Samsung_TV.txt }
+      - { name: DVD, connaddr: 3, file: LG_BR.txt }
+"""
+
+import logging
+
+from homeassistant.const import DEVICE_DEFAULT_NAME
+import homeassistant.components.remote as remote
+from homeassistant.components.remote import ATTR_COMMAND
+
+REQUIREMENTS = ['pyitachip2ir==0.0.4']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_MAC = 'mac'
+CONF_IP = 'ip'
+CONF_PORT = 'port'
+CONF_FILE = 'file'
+CONF_DEVICES = 'devices'
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the ITach connection and devices."""
+    import pyitachip2ir
+    itachip2ir = pyitachip2ir.ITachIP2IR(
+        config.get(CONF_MAC), config.get(CONF_IP), int(config.get(CONF_PORT)))
+    devices = []
+    for data in config.get(CONF_DEVICES):
+        name = data['name']
+        modaddr = int(data.get('modaddr', 1))
+        connaddr = int(data.get('connaddr', 1))
+        cmddata = open(
+            hass.config.config_dir + "/" + data.get('file'), "r").read()
+        itachip2ir.addDevice(name, modaddr, connaddr, cmddata)
+        devices.append(ITachIP2IRRemote(itachip2ir, name))
+    add_devices(devices, True)
+
+
+class ITachIP2IRRemote(remote.RemoteDevice):
+    """Device that sends commands to an ITachIP2IR device."""
+
+    def __init__(self, itachip2ir, name):
+        """Initialize device."""
+        self.itachip2ir = itachip2ir
+        self._power = False
+        self._name = name or DEVICE_DEFAULT_NAME
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._power
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        self._power = True
+        self.itachip2ir.send(self._name, "ON", 1)
+        self.schedule_update_ha_state()
+
+    def turn_off(self):
+        """Turn the device off."""
+        self._power = False
+        self.itachip2ir.send(self._name, "OFF", 1)
+        self.schedule_update_ha_state()
+
+    def send_command(self, **kwargs):
+        """Send a command to one device."""
+        self.itachip2ir.send(self._name, kwargs[ATTR_COMMAND], 1)
+
+    def update(self):
+        """Update the device."""
+        self.itachip2ir.update()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -453,7 +453,7 @@ pyicloud==0.9.1
 pyiss==1.0.1
 
 # homeassistant.components.remote.itach
-pyitachip2ir==0.0.4
+pyitachip2ir==0.0.5
 
 # homeassistant.components.sensor.lastfm
 pylast==1.7.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -452,6 +452,9 @@ pyicloud==0.9.1
 # homeassistant.components.binary_sensor.iss
 pyiss==1.0.1
 
+# homeassistant.components.remote.itach
+pyitachip2ir==0.0.4
+
 # homeassistant.components.sensor.lastfm
 pylast==1.7.0
 


### PR DESCRIPTION
**Description:**
Adds a device which uses an ITach IP2IR gateway to send IR commands.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2023

**Example entry for `configuration.yaml` (if applicable):**
```yaml
remote living_room:
  - platform: itach
     name: Living Room
     mac: 000C1E023FDC
     ip: itach023fdc
     port: 4998
     devices:
       - { name: TV,  connaddr: 2, file: Samsung_TV.txt } # connaddr is which IR port the cable is on
       - { name: DVD, connaddr: 3, file: LG_BR.txt }
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.