### PR TITLE
Bumping external Amcrest module to version 1.1.4

### DIFF
--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import (
     async_get_clientsession, async_aiohttp_proxy_stream)
 
-REQUIREMENTS = ['amcrest==1.1.3']
+REQUIREMENTS = ['amcrest==1.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/amcrest.py
+++ b/homeassistant/components/sensor/amcrest.py
@@ -20,7 +20,7 @@ import homeassistant.loader as loader
 
 from requests.exceptions import HTTPError, ConnectTimeout
 
-REQUIREMENTS = ['amcrest==1.1.3']
+REQUIREMENTS = ['amcrest==1.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -39,7 +39,7 @@ aiohttp_cors==0.5.0
 
 # homeassistant.components.camera.amcrest
 # homeassistant.components.sensor.amcrest
-amcrest==1.1.3
+amcrest==1.1.4
 
 # homeassistant.components.media_player.anthemav
 anthemav==1.1.8


### PR DESCRIPTION
**Description:**
Fixes traceback caused by 3rd party amcrest module. 
```bash
17-01-28 22:15:06 ERROR (MainThread) [homeassistant.components.camera] Error while setting up platform amcrest
Traceback (most recent call last):
  File "/srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages/homeassistant/helpers/entity_component.py", line 151, in _async_setup_platform
    entity_platform.add_entities, discovery_info
  File "/usr/lib/python3.4/asyncio/futures.py", line 388, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.4/asyncio/tasks.py", line 286, in _wakeup
    value = future.result()
  File "/usr/lib/python3.4/asyncio/futures.py", line 277, in result
    raise self._exception
  File "/usr/lib/python3.4/concurrent/futures/thread.py", line 54, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages/homeassistant/components/camera/amcrest.py", line 67, in setup_platform
    config.get(CONF_USERNAME), config.get(CONF_PASSWORD)).camera
  File "/home/homeassistant/.homeassistant/deps/amcrest/amcrest.py", line 32, in __init__
    timeout_protocol=timeout_protocol
  File "/home/homeassistant/.homeassistant/deps/amcrest/http.py", line 55, in __init__
    self.version = get_distribution('amcrest').version
  File "/srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 552, in get_distribution
    dist = get_provider(dist)
  File "/srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 426, in get_provider
    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
  File "/srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 968, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/srv/homeassistant/homeassistant_venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 854, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'amcrest' distribution was not found and is required by the application
```

Please include this fix if you have any errata scheduled for 0.37.1


**Related issue (if applicable):** fixes #5627

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
