### PR TITLE
ZWave force_update support

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -621,10 +621,12 @@ class ZWaveDeviceEntity:
             name = '{}.{}'.format(domain, self._object_id())
             node_config = customize.get(name, {})
             force_update = node_config.get(CONF_FORCE_UPDATE)
-            _LOGGER.debug('customize=%s name=%s node_config=%s CONF_FORCE_UPDATE=%s',
-                         customize, name, node_config, force_update)
+            _LOGGER.debug("customize=%s name=%s node_config=%s "
+                          "CONF_FORCE_UPDATE=%s", customize, name,
+                          node_config, force_update)
             if force_update is not None:
-                _LOGGER.debug('Setting force_update=%s on zwave node=%s', force_update, name)
+                _LOGGER.debug('Setting force_update=%s on zwave node=%s',
+                              force_update, name)
                 self._force_update = force_update
 
     @property
@@ -682,7 +684,6 @@ class ZWaveDeviceEntity:
         If True, a state change will be triggered anytime the state property is
         updated, not just when the value changes.
 
-        This is controlled by a customization entry in the config for this entity
+        This is controlled by a customization entry in the config file
         """
         return self._force_update
-


### PR DESCRIPTION
**Description:**
Adding support for a force_update customization in ZWave components.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1927

**Example entry for `configuration.yaml` (if applicable):**
```yaml
zwave:
  customization:
    device_identifier:
      force_update: True
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
