### PR TITLE
Make brightness display work for rgb devices.

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -121,10 +121,7 @@ class FluxLight(Light):
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        if self._mode == 'rgbw':
-            return self._bulb.getWarmWhite255()
-        else:
-            return self._bulb.brightness
+        return self._bulb.brightness
 
     @property
     def rgb_color(self):

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -121,7 +121,10 @@ class FluxLight(Light):
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        return self._bulb.getWarmWhite255()
+        if self._mode == 'rgbw':
+            return self._bulb.getWarmWhite255()
+        else:
+            return self._bulb.brightness
 
     @property
     def rgb_color(self):


### PR DESCRIPTION
Non rgbw devices return 255 for getWarmWhite255. This is part 2 to make the brightness slider work for these devices.

https://github.com/Danielhiversen/flux_led/pull/25

