### PR TITLE
Adds average load to systemmonitor

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.systemmonitor/
 """
 import logging
+import os
 
 import voluptuous as vol
 
@@ -38,7 +39,8 @@ SENSOR_TYPES = {
     'ipv4_address': ['IPv4 address', '', 'mdi:server-network'],
     'ipv6_address': ['IPv6 address', '', 'mdi:server-network'],
     'last_boot': ['Last Boot', '', 'mdi:clock'],
-    'since_last_boot': ['Since Last Boot', '', 'mdi:clock']
+    'since_last_boot': ['Since Last Boot', '', 'mdi:clock'],
+    'load': ['Average Load', '', 'mdi:memory']
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -164,3 +166,5 @@ class SystemMonitorSensor(Entity):
         elif self.type == 'since_last_boot':
             self._state = dt_util.utcnow() - dt_util.utc_from_timestamp(
                 psutil.boot_time())
+        elif self.type == 'load':
+            self._state = '{:.1f}, {:.1f}, {:.1f}'.format(*os.getloadavg())

--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -40,7 +40,9 @@ SENSOR_TYPES = {
     'ipv6_address': ['IPv6 address', '', 'mdi:server-network'],
     'last_boot': ['Last Boot', '', 'mdi:clock'],
     'since_last_boot': ['Since Last Boot', '', 'mdi:clock'],
-    'load': ['Average Load', '', 'mdi:memory']
+    'load_1m': ['Average Load (1m)', '', 'mdi:memory'],
+    'load_5m': ['Average Load (5m)', '', 'mdi:memory'],
+    'load_15m': ['Average Load (15m)', '', 'mdi:memory']
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -166,5 +168,10 @@ class SystemMonitorSensor(Entity):
         elif self.type == 'since_last_boot':
             self._state = dt_util.utcnow() - dt_util.utc_from_timestamp(
                 psutil.boot_time())
-        elif self.type == 'load':
-            self._state = '{:.1f}, {:.1f}, {:.1f}'.format(*os.getloadavg())
+        elif self.type == 'load_1m':
+            self._state = os.getloadavg()[0]
+        elif self.type == 'load_5m':
+            self._state = os.getloadavg()[1]
+        elif self.type == 'load_15m':
+            self._state = os.getloadavg()[2]
+            

--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -174,4 +174,3 @@ class SystemMonitorSensor(Entity):
             self._state = os.getloadavg()[1]
         elif self.type == 'load_15m':
             self._state = os.getloadavg()[2]
-            


### PR DESCRIPTION
**Description:**
Adds the load resource to systemmonitor sensor

**Related issue (if applicable):** 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1954

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: load_1m
      - type: load_5m
      - type: load_15m
  - platform: template
    sensors:
      load:
        value_template: '{{"%.1f"|format(float(states.sensor.average_load_1m.state))}}, {{"%.1f"|format(float(states.sensor.average_load_1m.state))}}, {{"%.1f"|format(float(states.sensor.average_load_1m.state))}}'
        friendly_name: 'Average Load'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

- [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
