### PR TITLE
Bugfix sonos group coordinator

### DIFF
--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -314,4 +314,4 @@ class TestSonosMediaPlayer(unittest.TestCase):
         device._snapshot_coordinator.soco_device = SoCoMock('192.0.2.17')
         device.restore()
         self.assertEqual(restoreMock.call_count, 1)
-        self.assertEqual(restoreMock.call_args, mock.call(True))
+        self.assertEqual(restoreMock.call_args, mock.call(False))


### PR DESCRIPTION
**Description:**

- Use `is_coordinator` from soco instead the `group` property for protect that group can be none some times.
- Protect for circulation of coordinator that will end in a endless loop.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
