### PR TITLE
Change CONF_DEFAULT_COLOR CV type

### DIFF
--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -28,7 +28,7 @@ SUPPORT_HYPERION = SUPPORT_RGB_COLOR
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_DEFAULT_COLOR, default=DEFAULT_COLOR): cv.string,
+    vol.Optional(CONF_DEFAULT_COLOR, default=DEFAULT_COLOR): cv.ensure_list,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -28,7 +28,9 @@ SUPPORT_HYPERION = SUPPORT_RGB_COLOR
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_DEFAULT_COLOR, default=DEFAULT_COLOR): cv.ensure_list,
+    vol.Optional(CONF_DEFAULT_COLOR, default=DEFAULT_COLOR):
+    vol.All(list, vol.Length(min=3, max=3),
+            [vol.All(vol.Coerce(int), vol.Range(min=0, max=255))]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 


### PR DESCRIPTION
**Description:**
Changed  vol.Optional(CONF_DEFAULT_COLOR, default=DEFAULT_COLOR) from cv.string to cv.ensure_list

This allows the optional parameter default_color to be picked up correctly and to function

the option needs to be specifed as follows:

    default_color: [0,255,0]

Solution provided by @scossa2020 in issue #5338
https://github.com/home-assistant/home-assistant/issues/5338

**Related issue (if applicable):** fixes #5338 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
  - platform: hyperion
    host: 192.168.0.200
    port: 19444
    name: TV Lights
    default_color: [0,255,0]
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
