### PR TITLE
Fix hue lightgroups not syncing state

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -59,9 +59,11 @@ DEFAULT_ALLOW_HUE_GROUPS = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
-    vol.Optional(CONF_ALLOW_UNREACHABLE): cv.boolean,
-    vol.Optional(CONF_FILENAME): cv.string,
-    vol.Optional(CONF_ALLOW_IN_EMULATED_HUE): cv.boolean,
+    vol.Optional(CONF_ALLOW_UNREACHABLE,
+                 default=DEFAULT_ALLOW_UNREACHABLE): cv.boolean,
+    vol.Optional(CONF_FILENAME, default=PHUE_CONFIG_FILE): cv.string,
+    vol.Optional(CONF_ALLOW_IN_EMULATED_HUE,
+                 default=DEFAULT_ALLOW_IN_EMULATED_HUE): cv.boolean,
     vol.Optional(CONF_ALLOW_HUE_GROUPS,
                  default=DEFAULT_ALLOW_HUE_GROUPS): cv.boolean,
 })
@@ -96,11 +98,9 @@ def _find_host_from_config(hass, filename=PHUE_CONFIG_FILE):
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Hue lights."""
     # Default needed in case of discovery
-    filename = config.get(CONF_FILENAME, PHUE_CONFIG_FILE)
-    allow_unreachable = config.get(CONF_ALLOW_UNREACHABLE,
-                                   DEFAULT_ALLOW_UNREACHABLE)
-    allow_in_emulated_hue = config.get(CONF_ALLOW_IN_EMULATED_HUE,
-                                       DEFAULT_ALLOW_IN_EMULATED_HUE)
+    filename = config.get(CONF_FILENAME)
+    allow_unreachable = config.get(CONF_ALLOW_UNREACHABLE)
+    allow_in_emulated_hue = config.get(CONF_ALLOW_IN_EMULATED_HUE)
     allow_hue_groups = config.get(CONF_ALLOW_HUE_GROUPS)
 
     if discovery_info is not None:


### PR DESCRIPTION
**Description:**
Fix for Hue lightgroups not syncing state with the following error:

```
17-02-01 19:55:42 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/lib/python3.5/asyncio/tasks.py", line 241, in _step
    result = coro.throw(exc)
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/helpers/entity_component.py", line 387, in _update_entity_states
    yield from update_coro
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/helpers/entity.py", line 204, in async_update_ha_state
    yield from self.hass.loop.run_in_executor(None, self.update)
  File "/usr/lib/python3.5/asyncio/futures.py", line 361, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.5/asyncio/tasks.py", line 296, in _wakeup
    future.result()
  File "/usr/lib/python3.5/asyncio/futures.py", line 274, in result
    raise self._exception
  File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/components/light/hue.py", line 421, in update
    self.update_lights(no_throttle=True)
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/util/__init__.py", line 296, in wrapper
    result = method(*args, **kwargs)
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/util/__init__.py", line 296, in wrapper
    result = method(*args, **kwargs)
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/components/light/hue.py", line 227, in update_lights
    lightgroups[lightgroup_id].schedule_update_ha_state()
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/helpers/entity.py", line 278, in schedule_update_ha_state
    self.hass.add_job(self.async_update_ha_state(force_refresh))
AttributeError: 'NoneType' object has no attribute 'add_job'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
