### PR TITLE
Fix hue lightgroups not syncing state

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -200,7 +200,8 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
 
         for light_id, info in api_lights.items():
             if light_id not in lights:
-                lights[light_id] = HueLight(int(light_id), info,
+                lights[light_id] = HueLight(hass,
+                                            int(light_id), info,
                                             bridge, update_lights,
                                             bridge_type, allow_unreachable,
                                             allow_in_emulated_hue)
@@ -218,6 +219,7 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
 
             if lightgroup_id not in lightgroups:
                 lightgroups[lightgroup_id] = HueLight(
+                    hass,
                     int(lightgroup_id), info, bridge, update_lights,
                     bridge_type, allow_unreachable, allow_in_emulated_hue,
                     True)
@@ -280,10 +282,11 @@ def request_configuration(host, hass, add_devices, filename,
 class HueLight(Light):
     """Representation of a Hue light."""
 
-    def __init__(self, light_id, info, bridge, update_lights,
+    def __init__(self, hass, light_id, info, bridge, update_lights,
                  bridge_type, allow_unreachable, allow_in_emulated_hue,
                  is_group=False):
         """Initialize the light."""
+        self.hass = hass
         self.light_id = light_id
         self.info = info
         self.bridge = bridge


### PR DESCRIPTION
**Description:**
Fix for Hue lightgroups not syncing state with the following error:

```
17-02-01 19:55:42 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/lib/python3.5/asyncio/tasks.py", line 241, in _step
    result = coro.throw(exc)
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/helpers/entity_component.py", line 387, in _update_entity_states
    yield from update_coro
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/helpers/entity.py", line 204, in async_update_ha_state
    yield from self.hass.loop.run_in_executor(None, self.update)
  File "/usr/lib/python3.5/asyncio/futures.py", line 361, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.5/asyncio/tasks.py", line 296, in _wakeup
    future.result()
  File "/usr/lib/python3.5/asyncio/futures.py", line 274, in result
    raise self._exception
  File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/components/light/hue.py", line 421, in update
    self.update_lights(no_throttle=True)
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/util/__init__.py", line 296, in wrapper
    result = method(*args, **kwargs)
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/util/__init__.py", line 296, in wrapper
    result = method(*args, **kwargs)
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/components/light/hue.py", line 227, in update_lights
    lightgroups[lightgroup_id].schedule_update_ha_state()
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/helpers/entity.py", line 278, in schedule_update_ha_state
    self.hass.add_job(self.async_update_ha_state(force_refresh))
AttributeError: 'NoneType' object has no attribute 'add_job'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
