### PR TITLE
Z Wave force_update support

### DIFF
--- a/tests/components/test_zwave.py
+++ b/tests/components/test_zwave.py
@@ -51,7 +51,8 @@ class TestComponentZwave(unittest.TestCase):
             zwave.CONF_POLLING_INTENSITY: 10,
             zwave.CONF_IGNORED: 1,
             zwave.CONF_REFRESH_VALUE: 1,
-            zwave.CONF_REFRESH_DELAY: 10}}})
+            zwave.CONF_REFRESH_DELAY: 10,
+            zwave.CONF_FORCE_UPDATE: True}}})
 
     def test_full_customize_list(self):
         """Test full customize as list."""
@@ -60,7 +61,8 @@ class TestComponentZwave(unittest.TestCase):
             zwave.CONF_POLLING_INTENSITY: 10,
             zwave.CONF_IGNORED: 1,
             zwave.CONF_REFRESH_VALUE: 1,
-            zwave.CONF_REFRESH_DELAY: 10}]})
+            zwave.CONF_REFRESH_DELAY: 10,
+            zwave.CONF_FORCE_UPDATE: True}]})
 
     def test_bad_customize(self):
         """Test customize with extra keys."""


### PR DESCRIPTION
**Description:**
This change set enables force_update as part of the zwave customization on a per device basis.

**Related issue (if applicable):** fixes #1938

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1938

**Example entry for `configuration.yaml` (if applicable):**
```yaml
zwave:
  usb_path: /dev/ttyACM0
  config_path: /srv/hass/src/python-openzwave/openzwave/config
  polling_interval: 60000
  customize:
    binary_sensor.binary_sensor_entity_id:
      polling_intensity: 1
      force_update: True
   switch.switch_entity_id:
     polling_intensity: 5
     # force_update: Defaults to False
  lock.lock_entity_id:
    force_update: False
```
In the yaml above, only the binary_sensor with the stated entity ID should have force_update enabled on it. The others should respond as they do today and only update on actual changes.
**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
