### PR TITLE
0.37.1

### DIFF
--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import (
     async_get_clientsession, async_aiohttp_proxy_stream)
 
-REQUIREMENTS = ['amcrest==1.1.3']
+REQUIREMENTS = ['amcrest==1.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/camera/netatmo.py
+++ b/homeassistant/components/camera/netatmo.py
@@ -9,6 +9,7 @@ import logging
 import requests
 import voluptuous as vol
 
+from homeassistant.const import CONF_VERIFY_SSL
 from homeassistant.components.netatmo import CameraData
 from homeassistant.components.camera import (Camera, PLATFORM_SCHEMA)
 from homeassistant.loader import get_component
@@ -22,6 +23,7 @@ CONF_HOME = 'home'
 CONF_CAMERAS = 'cameras'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
     vol.Optional(CONF_HOME): cv.string,
     vol.Optional(CONF_CAMERAS, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
@@ -33,6 +35,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup access to Netatmo cameras."""
     netatmo = get_component('netatmo')
     home = config.get(CONF_HOME)
+    verify_ssl = config.get(CONF_VERIFY_SSL, True)
     import lnetatmo
     try:
         data = CameraData(netatmo.NETATMO_AUTH, home)
@@ -42,7 +45,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 if config[CONF_CAMERAS] != [] and \
                    camera_name not in config[CONF_CAMERAS]:
                     continue
-            add_devices([NetatmoCamera(data, camera_name, home, camera_type)])
+            add_devices([NetatmoCamera(data, camera_name, home,
+                                       camera_type, verify_ssl)])
     except lnetatmo.NoDevice:
         return None
 
@@ -50,11 +54,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class NetatmoCamera(Camera):
     """Representation of the images published from a Netatmo camera."""
 
-    def __init__(self, data, camera_name, home, camera_type):
+    def __init__(self, data, camera_name, home, camera_type, verify_ssl):
         """Setup for access to the Netatmo camera images."""
         super(NetatmoCamera, self).__init__()
         self._data = data
         self._camera_name = camera_name
+        self._verify_ssl = verify_ssl
         if home:
             self._name = home + ' / ' + camera_name
         else:
@@ -74,11 +79,17 @@ class NetatmoCamera(Camera):
             if self._localurl:
                 response = requests.get('{0}/live/snapshot_720.jpg'.format(
                     self._localurl), timeout=10)
-            else:
+            elif self._vpnurl:
                 response = requests.get('{0}/live/snapshot_720.jpg'.format(
-                    self._vpnurl), timeout=10)
+                    self._vpnurl), timeout=10, verify=self._verify_ssl)
+            else:
+                _LOGGER.error('Welcome VPN url is None')
+                self._data.update()
+                (self._vpnurl, self._localurl) = \
+                    self._data.camera_data.cameraUrls(camera=self._camera_name)
+                return None
         except requests.exceptions.RequestException as error:
-            _LOGGER.error('Welcome VPN url changed: %s', error)
+            _LOGGER.error('Welcome url changed: %s', error)
             self._data.update()
             (self._vpnurl, self._localurl) = \
                 self._data.camera_data.cameraUrls(camera=self._camera_name)

--- a/homeassistant/components/device_tracker/upc_connect.py
+++ b/homeassistant/components/device_tracker/upc_connect.py
@@ -92,7 +92,8 @@ class UPCDeviceScanner(DeviceScanner):
         raw = yield from self._async_ws_function(CMD_DEVICES)
 
         try:
-            xml_root = ET.fromstring(raw)
+            xml_root = yield from self.hass.loop.run_in_executor(
+                None, ET.fromstring, raw)
             return [mac.text for mac in xml_root.iter('MACAddr')]
         except (ET.ParseError, TypeError):
             _LOGGER.warning("Can't read device from %s", self.host)

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -59,11 +59,9 @@ DEFAULT_ALLOW_HUE_GROUPS = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
-    vol.Optional(CONF_ALLOW_UNREACHABLE,
-                 default=DEFAULT_ALLOW_UNREACHABLE): cv.boolean,
-    vol.Optional(CONF_FILENAME, default=PHUE_CONFIG_FILE): cv.string,
-    vol.Optional(CONF_ALLOW_IN_EMULATED_HUE,
-                 default=DEFAULT_ALLOW_IN_EMULATED_HUE): cv.boolean,
+    vol.Optional(CONF_ALLOW_UNREACHABLE): cv.boolean,
+    vol.Optional(CONF_FILENAME): cv.string,
+    vol.Optional(CONF_ALLOW_IN_EMULATED_HUE): cv.boolean,
     vol.Optional(CONF_ALLOW_HUE_GROUPS,
                  default=DEFAULT_ALLOW_HUE_GROUPS): cv.boolean,
 })
@@ -98,9 +96,11 @@ def _find_host_from_config(hass, filename=PHUE_CONFIG_FILE):
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Hue lights."""
     # Default needed in case of discovery
-    filename = config.get(CONF_FILENAME)
-    allow_unreachable = config.get(CONF_ALLOW_UNREACHABLE)
-    allow_in_emulated_hue = config.get(CONF_ALLOW_IN_EMULATED_HUE)
+    filename = config.get(CONF_FILENAME, PHUE_CONFIG_FILE)
+    allow_unreachable = config.get(CONF_ALLOW_UNREACHABLE,
+                                   DEFAULT_ALLOW_UNREACHABLE)
+    allow_in_emulated_hue = config.get(CONF_ALLOW_IN_EMULATED_HUE,
+                                       DEFAULT_ALLOW_IN_EMULATED_HUE)
     allow_hue_groups = config.get(CONF_ALLOW_HUE_GROUPS)
 
     if discovery_info is not None:

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -200,7 +200,8 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
 
         for light_id, info in api_lights.items():
             if light_id not in lights:
-                lights[light_id] = HueLight(int(light_id), info,
+                lights[light_id] = HueLight(hass,
+                                            int(light_id), info,
                                             bridge, update_lights,
                                             bridge_type, allow_unreachable,
                                             allow_in_emulated_hue)
@@ -218,6 +219,7 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
 
             if lightgroup_id not in lightgroups:
                 lightgroups[lightgroup_id] = HueLight(
+                    hass,
                     int(lightgroup_id), info, bridge, update_lights,
                     bridge_type, allow_unreachable, allow_in_emulated_hue,
                     True)
@@ -280,10 +282,11 @@ def request_configuration(host, hass, add_devices, filename,
 class HueLight(Light):
     """Representation of a Hue light."""
 
-    def __init__(self, light_id, info, bridge, update_lights,
+    def __init__(self, hass, light_id, info, bridge, update_lights,
                  bridge_type, allow_unreachable, allow_in_emulated_hue,
                  is_group=False):
         """Initialize the light."""
+        self.hass = hass
         self.light_id = light_id
         self.info = info
         self.bridge = bridge

--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -21,10 +21,20 @@ ATTR_NOTIFICATION = 'notification'
 ATTR_LOCK_STATUS = 'lock_status'
 ATTR_CODE_SLOT = 'code_slot'
 ATTR_USERCODE = 'usercode'
+CONFIG_ADVANCED = 'Advanced'
 
 SERVICE_SET_USERCODE = 'set_usercode'
 SERVICE_GET_USERCODE = 'get_usercode'
 SERVICE_CLEAR_USERCODE = 'clear_usercode'
+
+POLYCONTROL = 0x10E
+DANALOCK_V2_BTZE = 0x2
+POLYCONTROL_DANALOCK_V2_BTZE_LOCK = (POLYCONTROL, DANALOCK_V2_BTZE)
+WORKAROUND_V2BTZE = 'v2btze'
+
+DEVICE_MAPPINGS = {
+    POLYCONTROL_DANALOCK_V2_BTZE_LOCK: WORKAROUND_V2BTZE
+}
 
 LOCK_NOTIFICATION = {
     1: 'Manual Lock',
@@ -110,7 +120,7 @@ CLEAR_USERCODE_SCHEMA = vol.Schema({
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Find and return Z-Wave switches."""
+    """Find and return Z-Wave locks."""
     if discovery_info is None or zwave.NETWORK is None:
         return
 
@@ -197,29 +207,61 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
-    """Representation of a Z-Wave switch."""
+    """Representation of a Z-Wave Lock."""
 
     def __init__(self, value):
-        """Initialize the Z-Wave switch device."""
+        """Initialize the Z-Wave lock device."""
         zwave.ZWaveDeviceEntity.__init__(self, value, DOMAIN)
-
         self._node = value.node
         self._state = None
         self._notification = None
         self._lock_status = None
+        self._v2btze = None
+
+        # Enable appropriate workaround flags for our device
+        # Make sure that we have values for the key before converting to int
+        if (value.node.manufacturer_id.strip() and
+                value.node.product_id.strip()):
+            specific_sensor_key = (int(value.node.manufacturer_id, 16),
+                                   int(value.node.product_id, 16))
+            if specific_sensor_key in DEVICE_MAPPINGS:
+                if DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_V2BTZE:
+                    self._v2btze = 1
+                    _LOGGER.debug("Polycontrol Danalock v2 BTZE "
+                                  "workaround enabled")
         self.update_properties()
 
     def update_properties(self):
         """Callback on data changes for node values."""
         for value in self._node.get_values(
+                class_id=zwave.const.COMMAND_CLASS_DOOR_LOCK).values():
+            if value.type != zwave.const.TYPE_BOOL:
+                continue
+            if value.genre != zwave.const.GENRE_USER:
+                continue
+            self._state = value.data
+            _LOGGER.debug('Lock state set from Bool value and'
+                          ' is %s', value.data)
+            break
+
+        for value in self._node.get_values(
                 class_id=zwave.const.COMMAND_CLASS_ALARM).values():
             if value.label != "Access Control":
                 continue
             self._notification = LOCK_NOTIFICATION.get(value.data)
-            if self._notification:
-                self._state = LOCK_STATUS.get(value.data)
-                _LOGGER.debug('Lock state set from Access Control value and'
-                              ' is %s', value.data)
+            notification_data = value.data
+            if self._v2btze:
+                for value in (self._node.get_values(
+                        class_id=zwave.const.COMMAND_CLASS_CONFIGURATION)
+                              .values()):
+                    if value.index != 12:
+                        continue
+                    if value.data == CONFIG_ADVANCED:
+                        self._state = LOCK_STATUS.get(notification_data)
+                        _LOGGER.debug('Lock state set from Access Control '
+                                      'value and is %s', notification_data)
+                    break
+
             break
 
         for value in self._node.get_values(
@@ -227,10 +269,6 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
             if value.label != "Alarm Type":
                 continue
             alarm_type = LOCK_ALARM_TYPE.get(value.data)
-            if alarm_type:
-                self._state = LOCK_STATUS.get(value.data)
-                _LOGGER.debug('Lock state set from Alarm Type value and'
-                              ' is %s', value.data)
             break
 
         for value in self._node.get_values(
@@ -254,18 +292,6 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
                 break
             if alarm_type != 0:
                 self._lock_status = LOCK_ALARM_TYPE.get(alarm_type)
-                break
-
-        if not self._notification and not self._lock_status:
-            for value in self._node.get_values(
-                    class_id=zwave.const.COMMAND_CLASS_DOOR_LOCK).values():
-                if value.type != zwave.const.TYPE_BOOL:
-                    continue
-                if value.genre != zwave.const.GENRE_USER:
-                    continue
-                self._state = value.data
-                _LOGGER.debug('Lock state set from Bool value and'
-                              ' is %s', value.data)
                 break
 
     @property

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -523,10 +523,6 @@ class SonosDevice(MediaPlayerDevice):
                     update_media_position |= rel_time is not None and \
                         self._media_position is None
 
-                    # used only if a media is playing
-                    if self.state != STATE_PLAYING:
-                        update_media_position = None
-
                     # position changed?
                     if rel_time is not None and \
                        self._media_position is not None:
@@ -541,7 +537,7 @@ class SonosDevice(MediaPlayerDevice):
                         update_media_position = \
                             abs(calculated_position - rel_time) > 1.5
 
-                    if update_media_position:
+                    if update_media_position and self.state == STATE_PLAYING:
                         media_position = rel_time
                         media_position_updated_at = utcnow()
                     else:
@@ -830,7 +826,7 @@ class SonosDevice(MediaPlayerDevice):
         """List of available input sources."""
         model_name = self._speaker_info['model_name']
 
-        sources = self._favorite_sources
+        sources = self._favorite_sources.copy()
 
         if 'PLAY:5' in model_name:
             sources += [SUPPORT_SOURCE_LINEIN]

--- a/homeassistant/components/sensor/amcrest.py
+++ b/homeassistant/components/sensor/amcrest.py
@@ -20,7 +20,7 @@ import homeassistant.loader as loader
 
 from requests.exceptions import HTTPError, ConnectTimeout
 
-REQUIREMENTS = ['amcrest==1.1.3']
+REQUIREMENTS = ['amcrest==1.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/tellduslive.py
+++ b/homeassistant/components/sensor/tellduslive.py
@@ -58,7 +58,7 @@ class TelldusLiveSensor(TelldusLiveEntity):
     @property
     def _value(self):
         """Return value of the sensor."""
-        return self.device.value(self._id[1:])
+        return self.device.value(*self._id[1:])
 
     @property
     def _value_as_temperature(self):

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -99,8 +99,12 @@ homematic:
 
     fields:
       entity_id:
-        description: Name(s) of entities to set value
-        example: 'homematic.my_variable'
+        description: Name(s) of homematic central to set value
+        example: 'homematic.ccu2'
+
+      name:
+        description: Name of the varaible to set
+        example: 'testvariable'
 
       value:
         description: New value

--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -33,7 +33,7 @@ COMMAND_SCHEMA = vol.Schema({
     vol.Optional('off'): cv.positive_int,
     vol.Optional(CONF_UNIT): cv.positive_int,
     vol.Optional(CONF_UNITCODE): cv.positive_int,
-    vol.Optional(CONF_ID): cv.positive_int,
+    vol.Optional(CONF_ID): vol.Any(cv.positive_int, cv.string),
     vol.Optional(CONF_STATE): cv.string,
     vol.Optional(CONF_SYSTEMCODE): cv.positive_int,
 }, extra=vol.ALLOW_EXTRA)

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -17,7 +17,7 @@ import voluptuous as vol
 
 DOMAIN = 'tellduslive'
 
-REQUIREMENTS = ['tellduslive==0.1.13']
+REQUIREMENTS = ['tellduslive==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -133,8 +133,8 @@ class TelldusLiveClient(object):
             if device.device_id in known_ids:
                 continue
             if device.is_sensor:
-                for item_id in device.items:
-                    discover((device.device_id,) + item_id,
+                for item in device.items:
+                    discover((device.device_id, item.name, item.scale),
                              'sensor')
             else:
                 discover(device.device_id,
@@ -145,8 +145,7 @@ class TelldusLiveClient(object):
 
     def device(self, device_id):
         """Return device representation."""
-        import tellduslive
-        return tellduslive.Device(self._client, device_id)
+        return self._client.device(device_id)
 
     def is_available(self, device_id):
         """Return device availability."""
@@ -221,5 +220,5 @@ class TelldusLiveEntity(Entity):
     @property
     def _last_updated(self):
         """Return the last update of a device."""
-        return str(datetime.fromtimestamp(self.device.last_updated)) \
-            if self.device.last_updated else None
+        return str(datetime.fromtimestamp(self.device.lastUpdated)) \
+            if self.device.lastUpdated else None

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 37
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 4, 2)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -39,7 +39,7 @@ aiohttp_cors==0.5.0
 
 # homeassistant.components.camera.amcrest
 # homeassistant.components.sensor.amcrest
-amcrest==1.1.3
+amcrest==1.1.4
 
 # homeassistant.components.media_player.anthemav
 anthemav==1.1.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -444,7 +444,7 @@ pyharmony==1.0.12
 pyhik==0.0.7
 
 # homeassistant.components.homematic
-pyhomematic==0.1.20
+pyhomematic==0.1.21
 
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.9.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -620,7 +620,7 @@ steamodd==4.21
 tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
-tellduslive==0.1.13
+tellduslive==0.3.0
 
 # homeassistant.components.sensor.temper
 temperusb==1.5.1

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -314,4 +314,4 @@ class TestSonosMediaPlayer(unittest.TestCase):
         device._snapshot_coordinator.soco_device = SoCoMock('192.0.2.17')
         device.restore()
         self.assertEqual(restoreMock.call_count, 1)
-        self.assertEqual(restoreMock.call_args, mock.call(True))
+        self.assertEqual(restoreMock.call_args, mock.call(False))

--- a/tests/components/test_mqtt_eventstream.py
+++ b/tests/components/test_mqtt_eventstream.py
@@ -1,10 +1,12 @@
 """The tests for the MQTT eventstream component."""
+from collections import namedtuple
 import json
 import unittest
 from unittest.mock import ANY, patch
 
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.mqtt_eventstream as eventstream
+import homeassistant.components.mqtt as mqtt
 from homeassistant.const import EVENT_STATE_CHANGED
 from homeassistant.core import State, callback
 from homeassistant.remote import JSONEncoder
@@ -146,3 +148,44 @@ class TestMqttEventStream(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(1, len(calls))
+
+    @patch('homeassistant.components.mqtt.publish')
+    def test_mqtt_received_event(self, mock_pub):
+        """Don't filter events from the mqtt component about received message.
+
+        Mqtt component sends an event if a message is received. Also
+        messages that originate from an incoming eventstream.
+        Broadcasting these messages result in an infinite loop if two HA
+        instances are crossconfigured for the same mqtt topics.
+
+        """
+        SUB_TOPIC = 'from_slaves'
+        self.assertTrue(
+            self.add_eventstream(
+                pub_topic='bar',
+                sub_topic=SUB_TOPIC))
+        self.hass.block_till_done()
+
+        # Reset the mock because it will have already gotten calls for the
+        # mqtt_eventstream state change on initialization, etc.
+        mock_pub.reset_mock()
+
+        # Use MQTT component message handler to simulate firing message
+        # received event.
+        MQTTMessage = namedtuple('MQTTMessage', ['topic', 'qos', 'payload'])
+        message = MQTTMessage(SUB_TOPIC, 1, 'Hello World!'.encode('utf-8'))
+        mqtt.MQTT._mqtt_on_message(self, None, {'hass': self.hass}, message)
+
+        self.hass.block_till_done()
+
+        # 'normal' incoming mqtt messages should be broadcasted
+        self.assertEqual(mock_pub.call_count, 0)
+
+        MQTTMessage = namedtuple('MQTTMessage', ['topic', 'qos', 'payload'])
+        message = MQTTMessage('test_topic', 1, 'Hello World!'.encode('utf-8'))
+        mqtt.MQTT._mqtt_on_message(self, None, {'hass': self.hass}, message)
+
+        self.hass.block_till_done()
+
+        # but event from the event stream not
+        self.assertEqual(mock_pub.call_count, 1)


### PR DESCRIPTION
- Do not reject alphanumeric IDs for PiLight (@DavidLP)
- Fix broken Hue discovery (@DanielHiversen)
- Fix Amcrest (@tchellomello)
- Fix Telldus Live dim level error on startup (@molobrakos)
- Fix Sonos group coordinators (@pvizeli)
- UPC Connect: Parse XML outside event loop (@pvizeli)
- Fix Netatmo SSL issue with VPN url (@jabesq)
- Homematic: Fix bug with UNREACH device state/restore and variables not updating (@pvizeli)
- Sonos: Prevent duplicate entries in favorite list (@pvizeli)
- Fix Schlage Connect deadbolt integration via Z-Wave (@turbokongen)
- Prevent infinite loop in crossconfigured mqtt event streams (@aequitas)
- Fix Hue lightgroups failing on startup (@tboyce1)