### PR TITLE
Support for Nuki.io smart locks

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -209,6 +209,7 @@ omit =
     homeassistant/components/light/piglow.py
     homeassistant/components/light/zengge.py
     homeassistant/components/lirc.py
+    homeassistant/components/lock/nuki.py
     homeassistant/components/media_player/anthemav.py
     homeassistant/components/media_player/aquostv.py
     homeassistant/components/media_player/braviatv.py

--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -64,9 +64,9 @@ class NukiLock(LockDevice):
     def lock(self, **kwargs):
         """Lock the device."""
         self._nuki_lock.lock()
-        self.update_ha_state()
+        self.schedule_update_ha_state()
 
     def unlock(self, **kwargs):
         """Unlock the device."""
         self._nuki_lock.unlock()
-        self.update_ha_state()
+        self.schedule_update_ha_state()

--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -64,9 +64,7 @@ class NukiLock(LockDevice):
     def lock(self, **kwargs):
         """Lock the device."""
         self._nuki_lock.lock()
-        self.schedule_update_ha_state()
 
     def unlock(self, **kwargs):
         """Unlock the device."""
         self._nuki_lock.unlock()
-        self.schedule_update_ha_state()

--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -45,21 +45,25 @@ class NukiLock(LockDevice):
     def __init__(self, nuki_lock):
         """Initialize the lock."""
         self._nuki_lock = nuki_lock
+        self._locked = None
+        self._name = None
 
     @property
     def name(self):
         """Return the name of the lock."""
-        return self._nuki_lock.name
+        return self._name
 
     @property
     def is_locked(self):
         """Return true if lock is locked."""
-        return self._nuki_lock.is_locked
+        return self._locked
 
     @Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):
         """Update the nuki lock properties."""
         self._nuki_lock.update()
+        self._name = self._nuki_lock.name
+        self._locked = self._nuki_lock.is_locked
 
     def lock(self, **kwargs):
         """Lock the device."""

--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -4,13 +4,14 @@ Nuki.io lock platform.
 For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/lock.nuki/
 """
-import logging
-import homeassistant.helpers.config_validation as cv
-import homeassistant.util as util
-import voluptuous as vol
 from datetime import timedelta
+import logging
+import voluptuous as vol
+
 from homeassistant.components.lock import (LockDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_TOKEN)
+from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
 
 
 REQUIREMENTS = ['pynuki==1.1']
@@ -55,7 +56,7 @@ class NukiLock(LockDevice):
         """Return true if lock is locked."""
         return self._nuki_lock.is_locked
 
-    @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
+    @Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):
         """Update the nuki lock properties."""
         self._nuki_lock.update()

--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -45,8 +45,8 @@ class NukiLock(LockDevice):
     def __init__(self, nuki_lock):
         """Initialize the lock."""
         self._nuki_lock = nuki_lock
-        self._locked = None
-        self._name = None
+        self._locked = nuki_lock.is_locked
+        self._name = nuki_lock.name
 
     @property
     def name(self):

--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -14,7 +14,7 @@ from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
 
-REQUIREMENTS = ['pynuki==1.1']
+REQUIREMENTS = ['pynuki==1.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -1,0 +1,71 @@
+"""
+Nuki.io lock platform.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/lock.nuki/
+"""
+import logging
+import homeassistant.helpers.config_validation as cv
+import homeassistant.util as util
+import voluptuous as vol
+from datetime import timedelta
+from homeassistant.components.lock import (LockDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_TOKEN)
+
+
+REQUIREMENTS = ['pynuki==1.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_PORT = 8080
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Required(CONF_TOKEN): cv.string
+})
+
+
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=30)
+MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=5)
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Demo lock platform."""
+    from pynuki import NukiBridge
+    bridge = NukiBridge(config.get(CONF_HOST), config.get(CONF_TOKEN))
+    add_devices([NukiLock(lock) for lock in bridge.locks])
+
+
+class NukiLock(LockDevice):
+    """Representation of a Nuki lock."""
+
+    def __init__(self, nuki_lock):
+        """Initialize the lock."""
+        self._nuki_lock = nuki_lock
+
+    @property
+    def name(self):
+        """Return the name of the lock."""
+        return self._nuki_lock.name
+
+    @property
+    def is_locked(self):
+        """Return true if lock is locked."""
+        return self._nuki_lock.is_locked
+
+    @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
+    def update(self):
+        """Update the nuki lock properties."""
+        self._nuki_lock.update()
+
+    def lock(self, **kwargs):
+        """Lock the device."""
+        self._nuki_lock.lock()
+        self.update_ha_state()
+
+    def unlock(self, **kwargs):
+        """Unlock the device."""
+        self._nuki_lock.unlock()
+        self.update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -470,6 +470,9 @@ pynetgear==0.3.3
 # homeassistant.components.switch.netio
 pynetio==0.1.6
 
+# homeassistant.components.lock.nuki
+pynuki==1.1
+
 # homeassistant.components.sensor.nut
 pynut2==2.1.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -471,7 +471,7 @@ pynetgear==0.3.3
 pynetio==0.1.6
 
 # homeassistant.components.lock.nuki
-pynuki==1.1
+pynuki==1.2
 
 # homeassistant.components.sensor.nut
 pynut2==2.1.2


### PR DESCRIPTION
**Description:**
This PR adds support for the [Nuki.io](https://nuki.io) Smart Locks

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1941

**Example entry for `configuration.yaml` (if applicable):**
```yaml
lock:
￼   - platform: nuki
￼     host: 192.168.1.120
￼     port: 8080
￼     token: fe2345ef
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
