### PR TITLE
Bump pwaqi to 1.4 to fix a typo in the underlying library.

### DIFF
--- a/homeassistant/components/sensor/waqi.py
+++ b/homeassistant/components/sensor/waqi.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pwaqi==1.3']
+REQUIREMENTS = ['pwaqi==1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -384,7 +384,7 @@ pushbullet.py==0.10.0
 pushetta==1.0.15
 
 # homeassistant.components.sensor.waqi
-pwaqi==1.3
+pwaqi==1.4
 
 # homeassistant.components.sensor.cpuspeed
 py-cpuinfo==0.2.3


### PR DESCRIPTION
**Description:**
Version of the underlying pwaqi library was updated to 1.4 to fix an issue leading to UnboundLocalError (thanks to @bepcyc).

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. [travis|https://travis-ci.org/valentinalexeev/home-assistant/builds/197588568]
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.