### PR TITLE
Modbus write_register doesn't accept list

### DIFF
--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -59,7 +59,7 @@ ATTR_VALUE = "value"
 SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema({
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
-    vol.Required(ATTR_VALUE): cv.positive_int
+    vol.Required(ATTR_VALUE): vol.All(cv.ensure_list, [cv.positive_int])
 })
 
 


### PR DESCRIPTION
**Description:**
As mentioned in PR #3252 and in the documentation, the write_register service in the modbus component accepts a list for it's value but the voluptuous schema prevents it as it accepts only integers.

Wit a configuration like this:
```
  test_mb_array:
    alias: Test
    sequence:
      - service: modbus.write_register
        data_template:
          unit: 1
          address: 12
          value:
            - 0
            - 0
```
HA throws this error:
ERROR:homeassistant.core:Invalid service data for modbus.write_register: expected int for dictionary value @ data['value']. Got ['0', '0']

I changed the schema to accept a list of ints.

**Checklist:**

If the code does not interact with devices:
  - [ x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
