### PR TITLE
Update miflora lib and allow specification of bluetooth adapter

### DIFF
--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -14,22 +14,25 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_MAC)
 
-REQUIREMENTS = ['miflora==0.1.14']
+REQUIREMENTS = ['miflora==0.1.15']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_ADAPTER = 'adapter'
 CONF_CACHE = 'cache_value'
 CONF_FORCE_UPDATE = 'force_update'
 CONF_MEDIAN = 'median'
 CONF_RETRIES = 'retries'
 CONF_TIMEOUT = 'timeout'
 
+DEFAULT_ADAPTER = 'hci0'
+DEFAULT_UPDATE_INTERVAL = 1200
 DEFAULT_FORCE_UPDATE = False
 DEFAULT_MEDIAN = 3
 DEFAULT_NAME = 'Mi Flora'
 DEFAULT_RETRIES = 2
 DEFAULT_TIMEOUT = 10
-DEFAULT_UPDATE_INTERVAL = 1200
+
 
 # Sensor types are defined like: Name, units
 SENSOR_TYPES = {
@@ -50,6 +53,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     vol.Optional(CONF_RETRIES, default=DEFAULT_RETRIES): cv.positive_int,
     vol.Optional(CONF_CACHE, default=DEFAULT_UPDATE_INTERVAL): cv.positive_int,
+    vol.Optional(CONF_ADAPTER, default=DEFAULT_ADAPTER): cv.string,
 })
 
 
@@ -59,7 +63,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     cache = config.get(CONF_CACHE)
     poller = miflora_poller.MiFloraPoller(
-        config.get(CONF_MAC), cache_timeout=cache)
+        config.get(CONF_MAC), cache_timeout=cache,
+        adapter=config.get(CONF_ADAPTER))
     force_update = config.get(CONF_FORCE_UPDATE)
     median = config.get(CONF_MEDIAN)
     poller.ble_timeout = config.get(CONF_TIMEOUT)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -319,7 +319,7 @@ messagebird==1.2.0
 mficlient==0.3.0
 
 # homeassistant.components.sensor.miflora
-miflora==0.1.14
+miflora==0.1.15
 
 # homeassistant.components.sensor.usps
 myusps==1.0.2


### PR DESCRIPTION
**Description:**
Update miflora lib and allow specification of bluetooth adapter



**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1942

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
