### PR TITLE
MQTT discovery

### DIFF
--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -36,7 +36,12 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the MQTT binary sensor."""
+    """Set up the MQTT binary sensor."""
+    if discovery_info is not None:
+        _LOGGER.info(
+            "New MQTT binary sensor detected: %s", discovery_info[CONF_NAME])
+        config = discovery_info
+
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
         value_template.hass = hass

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -38,9 +38,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the MQTT binary sensor."""
     if discovery_info is not None:
-        _LOGGER.info(
-            "New MQTT binary sensor detected: %s", discovery_info[CONF_NAME])
-        config = discovery_info
+        config = PLATFORM_SCHEMA(discovery_info)
 
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -89,6 +89,7 @@ def valid_discovery_topic(value):
     """Validate a discovery topic."""
     return valid_subscribe_topic(value, invalid_chars='#+\0/')
 
+
 _VALID_QOS_SCHEMA = vol.All(vol.Coerce(int), vol.In([0, 1, 2]))
 
 CLIENT_KEY_AUTH_MSG = 'client_key and client_cert must both be present in ' \

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -329,7 +329,7 @@ def setup(hass, config):
                            descriptions.get(SERVICE_PUBLISH),
                            schema=MQTT_PUBLISH_SCHEMA)
 
-    if conf[CONF_DISCOVERY]:
+    if conf.get(CONF_DISCOVERY):
         _setup_discovery(hass, config)
 
     return True

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -8,14 +8,12 @@ import asyncio
 import json
 import logging
 
-from homeassistant.core import callback
 import homeassistant.components.mqtt as mqtt
 from homeassistant.components.mqtt import DOMAIN
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.const import (
-    CONF_FRIENDLY_NAME, CONF_NAME, CONF_VALUE_TEMPLATE, CONF_SENSOR_CLASS,
-    CONF_PAYLOAD_ON, CONF_PAYLOAD_OFF, CONF_PLATFORM)
-from homeassistant.components.mqtt import CONF_STATE_TOPIC, CONF_QOS
+    CONF_FRIENDLY_NAME, CONF_NAME, CONF_PLATFORM)
+from homeassistant.components.mqtt import CONF_STATE_TOPIC
 from homeassistant.components.binary_sensor.mqtt import (
     DEFAULT_PAYLOAD_OFF, DEFAULT_PAYLOAD_ON)
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -1,0 +1,66 @@
+"""
+Support for MQTT discovery.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/mqtt/#discovery
+"""
+import json
+import logging
+
+import homeassistant.components.mqtt as mqtt
+from homeassistant.components.mqtt import DOMAIN
+from homeassistant.helpers.discovery import load_platform
+from homeassistant.const import (
+    CONF_FRIENDLY_NAME, CONF_NAME, CONF_VALUE_TEMPLATE, CONF_SENSOR_CLASS,
+    CONF_PAYLOAD_ON, CONF_PAYLOAD_OFF)
+from homeassistant.components.mqtt import CONF_STATE_TOPIC, CONF_QOS
+from homeassistant.components.binary_sensor.mqtt import (
+    DEFAULT_PAYLOAD_OFF, DEFAULT_PAYLOAD_ON)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def start(hass, discovery_config):
+    """Initialization of MQTT Discovery."""
+    if discovery_config is None:
+        _LOGGER.warning("Can't setup MQTT discovery")
+        return False
+
+    def device_message_received(topic, payload, qos):
+        """Process the received message."""
+        parts = topic.split('/')
+
+        if parts[3] != 'config':
+            return False
+
+        entity_id = hass.states.get('{}.{}'.format(
+            parts[1], json.loads(payload).get(CONF_NAME)))
+
+        if entity_id is not None:
+            _LOGGER.warning("Configuration update for %s is not supported",
+                            entity_id.attributes[CONF_FRIENDLY_NAME])
+            return False
+
+        try:
+            payload = json.loads(str(payload))
+        except ValueError:
+            _LOGGER.warning("Payload for is not valid JSON")
+
+        if parts[1] == 'binary_sensor':
+            config = {
+                CONF_NAME: payload.get(CONF_NAME, parts[2]),
+                CONF_STATE_TOPIC: '{}/{}/{}/state'.format(
+                    parts[0], parts[1], parts[2]),
+                CONF_VALUE_TEMPLATE: payload.get(CONF_VALUE_TEMPLATE),
+                CONF_SENSOR_CLASS: payload.get(CONF_SENSOR_CLASS),
+                CONF_QOS: qos,
+                CONF_PAYLOAD_ON: payload.get(
+                    CONF_PAYLOAD_ON, DEFAULT_PAYLOAD_ON),
+                CONF_PAYLOAD_OFF: payload.get(
+                    CONF_PAYLOAD_OFF, DEFAULT_PAYLOAD_OFF),
+            }
+            load_platform(hass, 'binary_sensor', DOMAIN, config)
+
+    mqtt.subscribe(hass, discovery_config, device_message_received, 0)
+
+    return True

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -4,63 +4,66 @@ Support for MQTT discovery.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/mqtt/#discovery
 """
+import asyncio
 import json
 import logging
 
+from homeassistant.core import callback
 import homeassistant.components.mqtt as mqtt
 from homeassistant.components.mqtt import DOMAIN
-from homeassistant.helpers.discovery import load_platform
+from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.const import (
     CONF_FRIENDLY_NAME, CONF_NAME, CONF_VALUE_TEMPLATE, CONF_SENSOR_CLASS,
-    CONF_PAYLOAD_ON, CONF_PAYLOAD_OFF)
+    CONF_PAYLOAD_ON, CONF_PAYLOAD_OFF, CONF_PLATFORM)
 from homeassistant.components.mqtt import CONF_STATE_TOPIC, CONF_QOS
 from homeassistant.components.binary_sensor.mqtt import (
     DEFAULT_PAYLOAD_OFF, DEFAULT_PAYLOAD_ON)
 
 _LOGGER = logging.getLogger(__name__)
 
+SUPPORTED_COMPONENTS = ['binary_sensor']
+
 
 def start(hass, discovery_config):
     """Initialization of MQTT Discovery."""
-    if discovery_config is None:
-        _LOGGER.warning("Can't setup MQTT discovery")
-        return False
 
-    def device_message_received(topic, payload, qos):
+    @asyncio.coroutine
+    def async_device_message_received(topic, payload, qos):
         """Process the received message."""
-        parts = topic.split('/')
+        try:
+            main, component, object_id, msg_type = topic.split('/')
+        except ValueError:
+            return
 
-        if parts[3] != 'config':
-            return False
+        if msg_type != 'config':
+            return
+
+        try:
+            payload = json.loads(payload)
+        except ValueError:
+            _LOGGER.warning(
+                "Unable to parse configuration for %s: %s", object_id, payload)
+            return
+
+        if component not in SUPPORTED_COMPONENTS:
+            _LOGGER.warning("Component %s is not supported", component)
+            return
 
         entity_id = hass.states.get('{}.{}'.format(
-            parts[1], json.loads(payload).get(CONF_NAME)))
-
+            component, payload.get(CONF_NAME, object_id)))
         if entity_id is not None:
             _LOGGER.warning("Configuration update for %s is not supported",
                             entity_id.attributes[CONF_FRIENDLY_NAME])
-            return False
+            return
 
-        try:
-            payload = json.loads(str(payload))
-        except ValueError:
-            _LOGGER.warning("Payload for is not valid JSON")
+        if component == 'binary_sensor':
+            payload[CONF_PLATFORM] = component
+            payload[CONF_STATE_TOPIC] = '{}/{}/{}/state'.format(
+                main, component, object_id)
 
-        if parts[1] == 'binary_sensor':
-            config = {
-                CONF_NAME: payload.get(CONF_NAME, parts[2]),
-                CONF_STATE_TOPIC: '{}/{}/{}/state'.format(
-                    parts[0], parts[1], parts[2]),
-                CONF_VALUE_TEMPLATE: payload.get(CONF_VALUE_TEMPLATE),
-                CONF_SENSOR_CLASS: payload.get(CONF_SENSOR_CLASS),
-                CONF_QOS: qos,
-                CONF_PAYLOAD_ON: payload.get(
-                    CONF_PAYLOAD_ON, DEFAULT_PAYLOAD_ON),
-                CONF_PAYLOAD_OFF: payload.get(
-                    CONF_PAYLOAD_OFF, DEFAULT_PAYLOAD_OFF),
-            }
-            load_platform(hass, 'binary_sensor', DOMAIN, config)
+        yield from async_load_platform(
+           hass, component, DOMAIN, payload, discovery_config)
 
-    mqtt.subscribe(hass, discovery_config, device_message_received, 0)
+    mqtt.subscribe(hass, discovery_config, async_device_message_received, 0)
 
     return True

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -14,8 +14,6 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.const import (
     CONF_FRIENDLY_NAME, CONF_NAME, CONF_PLATFORM)
 from homeassistant.components.mqtt import CONF_STATE_TOPIC
-from homeassistant.components.binary_sensor.mqtt import (
-    DEFAULT_PAYLOAD_OFF, DEFAULT_PAYLOAD_ON)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -55,7 +55,7 @@ def async_start(hass, discovery_topic, hass_config):
                 discovery_topic, component, object_id)
 
         yield from async_load_platform(
-           hass, component, DOMAIN, payload, hass_config)
+            hass, component, DOMAIN, payload, hass_config)
 
     mqtt.async_subscribe(hass, discovery_topic + '/#',
                          async_device_message_received, 0)

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -7,59 +7,57 @@ https://home-assistant.io/components/mqtt/#discovery
 import asyncio
 import json
 import logging
+import re
 
+from homeassistant.core import callback
 import homeassistant.components.mqtt as mqtt
 from homeassistant.components.mqtt import DOMAIN
 from homeassistant.helpers.discovery import async_load_platform
-from homeassistant.const import (
-    CONF_FRIENDLY_NAME, CONF_NAME, CONF_PLATFORM)
+from homeassistant.const import CONF_PLATFORM
 from homeassistant.components.mqtt import CONF_STATE_TOPIC
 
 _LOGGER = logging.getLogger(__name__)
 
+TOPIC_MATCHER = re.compile(
+    r'homeassistant/(?P<component>\w+)/(?P<object_id>\w+)/config')
 SUPPORTED_COMPONENTS = ['binary_sensor']
 
 
-def start(hass, discovery_config):
+@callback
+def async_start(hass, discovery_topic, hass_config):
     """Initialization of MQTT Discovery."""
 
     @asyncio.coroutine
     def async_device_message_received(topic, payload, qos):
         """Process the received message."""
-        try:
-            main, component, object_id, msg_type = topic.split('/')
-        except ValueError:
+        match = TOPIC_MATCHER.match(topic)
+
+        if not match:
             return
 
-        if msg_type != 'config':
-            return
+        component, object_id = match.groups()
 
         try:
             payload = json.loads(payload)
         except ValueError:
             _LOGGER.warning(
-                "Unable to parse configuration for %s: %s", object_id, payload)
+                "Unable to parse JSON %s: %s", object_id, payload)
             return
 
         if component not in SUPPORTED_COMPONENTS:
             _LOGGER.warning("Component %s is not supported", component)
             return
 
-        entity_id = hass.states.get('{}.{}'.format(
-            component, payload.get(CONF_NAME, object_id)))
-        if entity_id is not None:
-            _LOGGER.warning("Configuration update for %s is not supported",
-                            entity_id.attributes[CONF_FRIENDLY_NAME])
-            return
-
-        if component == 'binary_sensor':
-            payload[CONF_PLATFORM] = component
+        payload = dict(payload)
+        payload[CONF_PLATFORM] = 'mqtt'
+        if CONF_STATE_TOPIC not in payload:
             payload[CONF_STATE_TOPIC] = '{}/{}/{}/state'.format(
-                main, component, object_id)
+                discovery_topic, component, object_id)
 
         yield from async_load_platform(
-           hass, component, DOMAIN, payload, discovery_config)
+           hass, component, DOMAIN, payload, hass_config)
 
-    mqtt.subscribe(hass, discovery_config, async_device_message_received, 0)
+    mqtt.async_subscribe(hass, discovery_topic + '/#',
+                         async_device_message_received, 0)
 
     return True

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -26,7 +26,6 @@ SUPPORTED_COMPONENTS = ['binary_sensor']
 @callback
 def async_start(hass, discovery_topic, hass_config):
     """Initialization of MQTT Discovery."""
-
     @asyncio.coroutine
     def async_device_message_received(topic, payload, qos):
         """Process the received message."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -161,7 +161,7 @@ def async_fire_mqtt_message(hass, topic, payload, qos=0):
 def fire_mqtt_message(hass, topic, payload, qos=0):
     """Fire the MQTT message."""
     run_callback_threadsafe(
-        hass.loop, async_fire_mqtt_message, topic, payload, qos).result()
+        hass.loop, async_fire_mqtt_message, hass, topic, payload, qos).result()
 
 
 def fire_time_changed(hass, time):

--- a/tests/common.py
+++ b/tests/common.py
@@ -26,6 +26,7 @@ from homeassistant.components import sun, mqtt
 from homeassistant.components.http.auth import auth_middleware
 from homeassistant.components.http.const import (
     KEY_USE_X_FORWARDED_FOR, KEY_BANS_ENABLED, KEY_TRUSTED_NETWORKS)
+from homeassistant.util.async import run_callback_threadsafe
 
 _TEST_INSTANCE_PORT = SERVER_PORT
 _LOGGER = logging.getLogger(__name__)
@@ -147,13 +148,20 @@ def mock_service(hass, domain, service):
     return calls
 
 
-def fire_mqtt_message(hass, topic, payload, qos=0):
+@ha.callback
+def async_fire_mqtt_message(hass, topic, payload, qos=0):
     """Fire the MQTT message."""
-    hass.bus.fire(mqtt.EVENT_MQTT_MESSAGE_RECEIVED, {
+    hass.bus.async_fire(mqtt.EVENT_MQTT_MESSAGE_RECEIVED, {
         mqtt.ATTR_TOPIC: topic,
         mqtt.ATTR_PAYLOAD: payload,
         mqtt.ATTR_QOS: qos,
     })
+
+
+def fire_mqtt_message(hass, topic, payload, qos=0):
+    """Fire the MQTT message."""
+    run_callback_threadsafe(
+        hass.loop, async_fire_mqtt_message, topic, payload, qos).result()
 
 
 def fire_time_changed(hass, time):

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -1,0 +1,74 @@
+"""The tests for the MQTT component."""
+import asyncio
+from unittest.mock import patch
+
+from homeassistant.components.mqtt.discovery import async_start
+
+from tests.common import async_fire_mqtt_message, mock_coro
+
+
+@asyncio.coroutine
+def test_subscribing_config_topic(hass, mqtt_mock):
+    """Test setting up discovery."""
+    hass_config = {}
+    discovery_topic = 'homeassistant'
+    async_start(hass, discovery_topic, hass_config)
+    assert mqtt_mock.subscribe.called
+    call_args = mqtt_mock.subscribe.mock_calls[0][1]
+    assert call_args[0] == discovery_topic + '/#'
+    assert call_args[1] == 0
+
+
+@asyncio.coroutine
+@patch('homeassistant.components.mqtt.discovery.async_load_platform')
+def test_invalid_topic(mock_load_platform, hass, mqtt_mock):
+    """Test sending in invalid JSON."""
+    mock_load_platform.return_value = mock_coro()
+    async_start(hass, 'homeassistant', {})
+
+    async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/not_config',
+                            '{}')
+    yield from hass.async_block_till_done()
+    assert not mock_load_platform.called
+
+
+@asyncio.coroutine
+@patch('homeassistant.components.mqtt.discovery.async_load_platform')
+def test_invalid_json(mock_load_platform, hass, mqtt_mock, caplog):
+    """Test sending in invalid JSON."""
+    mock_load_platform.return_value = mock_coro()
+    async_start(hass, 'homeassistant', {})
+
+    async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
+                            'not json')
+    yield from hass.async_block_till_done()
+    assert 'Unable to parse JSON' in caplog.text
+    assert not mock_load_platform.called
+
+
+@asyncio.coroutine
+@patch('homeassistant.components.mqtt.discovery.async_load_platform')
+def test_only_valid_components(mock_load_platform, hass, mqtt_mock, caplog):
+    """Test sending in invalid JSON."""
+    mock_load_platform.return_value = mock_coro()
+    async_start(hass, 'homeassistant', {})
+
+    async_fire_mqtt_message(hass, 'homeassistant/climate/bla/config', '{}')
+    yield from hass.async_block_till_done()
+    assert 'Component climate is not supported' in caplog.text
+    assert not mock_load_platform.called
+
+
+@asyncio.coroutine
+def test_correct_config_discovery(hass, mqtt_mock, caplog):
+    """Test sending in invalid JSON."""
+    async_start(hass, 'homeassistant', {})
+
+    async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
+                            '{ "name": "Beer" }')
+    yield from hass.async_block_till_done()
+
+    state = hass.states.get('binary_sensor.beer')
+
+    assert state is not None
+    assert state.name == 'Beer'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,14 @@
 """Setup some common test helper things."""
 import functools
 import logging
+from unittest.mock import patch
 
 import pytest
 import requests_mock as _requests_mock
 
-from homeassistant import util
+from homeassistant import util, bootstrap
 from homeassistant.util import location
+from homeassistant.components import mqtt
 
 from .common import async_test_home_assistant
 from .test_util.aiohttp import mock_aiohttp_client
@@ -58,3 +60,18 @@ def aioclient_mock():
     """Fixture to mock aioclient calls."""
     with mock_aiohttp_client() as mock_session:
         yield mock_session
+
+
+@pytest.fixture
+def mqtt_mock(loop, hass):
+    """Fixture to mock MQTT."""
+    with patch('homeassistant.components.mqtt.MQTT') as mock_mqtt:
+        loop.run_until_complete(bootstrap.async_setup_component(
+            hass, mqtt.DOMAIN, {
+                mqtt.DOMAIN: {
+                    mqtt.CONF_BROKER: 'mock-broker',
+                }
+            }))
+        client = mock_mqtt()
+        client.reset_mock()
+        return client

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -101,7 +101,13 @@ class TestCheckConfig(unittest.TestCase):
             res = check_config.check(get_test_config_dir('platform.yaml'))
             change_yaml_files(res)
             self.assertDictEqual(
-                {'mqtt': {'keepalive': 60, 'port': 1883, 'protocol': '3.1.1'},
+                {'mqtt': {
+                    'keepalive': 60,
+                    'port': 1883,
+                    'protocol': '3.1.1',
+                    'discovery': False,
+                    'discovery_prefix': 'homeassistant',
+                },
                  'light': []},
                 res['components']
             )


### PR DESCRIPTION
**Description:**
_This is the successor of https://github.com/home-assistant/home-assistant/pull/4918 as GitHub didn't like my `-f` push to the existing branch._

MQTT Discovery will enable one to use MQTT devices with only minimal configuration effort of Home Assistant. The configuration is done on the device itself. Similar to the  [HTTP binary sensor](https://home-assistant.io/components/binary_sensor.http/) and the [HTTP sensor](https://home-assistant.io/components/sensor.http/).

```bash
$ mosquitto_pub -V mqttv311 -t "hass/binary_sensor/test123/config" -r -m '{"name": "test1234", "sensor_class": "motion"}'
```

```bash
$ mosquitto_pub -V mqttv311 -t "hass/binary_sensor/test123/state" -m ON
```

At the moment only binary sensors are supported. More entities will be added to this PRs.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1952

**Example entry for `configuration.yaml` (if applicable):**
```yaml
mqtt:
  discovery: "home-assistant/#"
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
