### PR TITLE
Upgrade pyowm to 2.6.1

### DIFF
--- a/homeassistant/components/sensor/openweathermap.py
+++ b/homeassistant/components/sensor/openweathermap.py
@@ -17,7 +17,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyowm==2.6.0']
+REQUIREMENTS = ['pyowm==2.6.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyowm==2.6.0']
+REQUIREMENTS = ['pyowm==2.6.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -485,7 +485,7 @@ pynx584==0.4
 
 # homeassistant.components.sensor.openweathermap
 # homeassistant.components.weather.openweathermap
-pyowm==2.6.0
+pyowm==2.6.1
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.4


### PR DESCRIPTION
## 2.6.1
- 2.6.0 was not packaging resource files (eg. city IDs text files)

Tested with the following configuration:

``` yaml
sensor:
  - platform: openweathermap
    api_key: !secret owm_api
    forecast: 0
    monitored_conditions:
      - weather
      - temperature
      - wind_speed
      - humidity
      - pressure
```
