### PR TITLE
Store the key file in the config dir

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
 from homeassistant.loader import get_component
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['https://github.com/pschmitt/pylgtv'
+REQUIREMENTS = ['https://github.com/TheRealLink/pylgtv'
                 '/archive/v0.1.3.zip'
                 '#pylgtv==0.1.3',
                 'websockets==3.2',

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -20,13 +20,13 @@ from homeassistant.components.media_player import (
 from homeassistant.const import (
     CONF_HOST, CONF_MAC, CONF_CUSTOMIZE, STATE_OFF,
     STATE_PLAYING, STATE_PAUSED,
-    STATE_UNKNOWN, CONF_NAME)
+    STATE_UNKNOWN, CONF_NAME, CONF_FILENAME)
 from homeassistant.loader import get_component
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['https://github.com/TheRealLink/pylgtv'
-                '/archive/v0.1.2.zip'
-                '#pylgtv==0.1.2',
+REQUIREMENTS = ['https://github.com/pschmitt/pylgtv'
+                '/archive/v0.1.3.zip'
+                '#pylgtv==0.1.3',
                 'websockets==3.2',
                 'wakeonlan==0.2.2']
 
@@ -36,6 +36,8 @@ _LOGGER = logging.getLogger(__name__)
 CONF_SOURCES = 'sources'
 
 DEFAULT_NAME = 'LG webOS Smart TV'
+
+WEBOSTV_CONFIG_FILE = 'webostv.conf'
 
 SUPPORT_WEBOSTV = SUPPORT_TURN_OFF | \
     SUPPORT_NEXT_TRACK | SUPPORT_PAUSE | SUPPORT_PREVIOUS_TRACK | \
@@ -55,6 +57,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_MAC): cv.string,
     vol.Optional(CONF_CUSTOMIZE, default={}): CUSTOMIZE_SCHEMA,
+    vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string
 })
 
 
@@ -77,16 +80,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     mac = config.get(CONF_MAC)
     name = config.get(CONF_NAME)
     customize = config.get(CONF_CUSTOMIZE)
-    setup_tv(host, mac, name, customize, hass, add_devices)
+    config = hass.config.path(config.get(CONF_FILENAME))
+    setup_tv(host, mac, name, customize, config, hass, add_devices)
 
 
-def setup_tv(host, mac, name, customize, hass, add_devices):
+def setup_tv(host, mac, name, customize, config, hass, add_devices):
     """Setup a LG WebOS TV based on host parameter."""
     from pylgtv import WebOsClient
     from pylgtv import PyLGTVPairException
     from websockets.exceptions import ConnectionClosed
 
-    client = WebOsClient(host)
+    client = WebOsClient(host, config)
 
     if not client.is_registered():
         if host in _CONFIGURING:
@@ -113,7 +117,7 @@ def setup_tv(host, mac, name, customize, hass, add_devices):
         configurator = get_component('configurator')
         configurator.request_done(request_id)
 
-    add_devices([LgWebOSDevice(host, mac, name, customize)], True)
+    add_devices([LgWebOSDevice(host, mac, name, customize, config)], True)
 
 
 def request_configuration(
@@ -143,11 +147,11 @@ def request_configuration(
 class LgWebOSDevice(MediaPlayerDevice):
     """Representation of a LG WebOS TV."""
 
-    def __init__(self, host, mac, name, customize):
+    def __init__(self, host, mac, name, customize, config):
         """Initialize the webos device."""
         from pylgtv import WebOsClient
         from wakeonlan import wol
-        self._client = WebOsClient(host)
+        self._client = WebOsClient(host, config)
         self._wol = wol
         self._mac = mac
         self._customize = customize

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -108,7 +108,7 @@ def setup_tv(host, mac, name, customize, config, hass, add_devices):
             # Not registered, request configuration.
             _LOGGER.warning("LG webOS TV %s needs to be paired", host)
             request_configuration(
-                host, mac, name, customize, hass, add_devices)
+                host, mac, name, customize, config, hass, add_devices)
             return
 
     # If we came here and configuring this host, mark as done.
@@ -121,7 +121,7 @@ def setup_tv(host, mac, name, customize, config, hass, add_devices):
 
 
 def request_configuration(
-        host, mac, name, customize, hass, add_devices):
+        host, mac, name, customize, config, hass, add_devices):
     """Request configuration steps from the user."""
     configurator = get_component('configurator')
 
@@ -134,7 +134,7 @@ def request_configuration(
     # pylint: disable=unused-argument
     def lgtv_configuration_callback(data):
         """The actions to do when our configuration callback is called."""
-        setup_tv(host, mac, name, customize, hass, add_devices)
+        setup_tv(host, mac, name, customize, config, hass, add_devices)
 
     _CONFIGURING[host] = configurator.request_config(
         hass, name, lgtv_configuration_callback,

--- a/homeassistant/components/notify/webostv.py
+++ b/homeassistant/components/notify/webostv.py
@@ -11,16 +11,18 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
     BaseNotificationService, PLATFORM_SCHEMA)
-from homeassistant.const import CONF_HOST
+from homeassistant.const import (CONF_FILENAME, CONF_HOST)
 
-REQUIREMENTS = ['https://github.com/TheRealLink/pylgtv/archive/v0.1.2.zip'
-                '#pylgtv==0.1.2']
+REQUIREMENTS = ['https://github.com/pschmitt/pylgtv/archive/v0.1.3.zip'
+                '#pylgtv==0.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 
+WEBOSTV_CONFIG_FILE = 'webostv.conf'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string
 })
 
 
@@ -29,7 +31,8 @@ def get_service(hass, config, discovery_info=None):
     from pylgtv import WebOsClient
     from pylgtv import PyLGTVPairException
 
-    client = WebOsClient(config.get(CONF_HOST))
+    path = hass.config.path(config.get(CONF_FILENAME))
+    client = WebOsClient(config.get(CONF_HOST), key_file_path=path)
 
     try:
         client.register()

--- a/homeassistant/components/notify/webostv.py
+++ b/homeassistant/components/notify/webostv.py
@@ -13,7 +13,7 @@ from homeassistant.components.notify import (
     BaseNotificationService, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_FILENAME, CONF_HOST)
 
-REQUIREMENTS = ['https://github.com/pschmitt/pylgtv/archive/v0.1.3.zip'
+REQUIREMENTS = ['https://github.com/TheRealLink/pylgtv/archive/v0.1.3.zip'
                 '#pylgtv==0.1.3']
 
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -203,6 +203,10 @@ http://github.com/technicalpickles/python-nest/archive/e6c9d56a8df455d4d77463898
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.3.7.zip#pyW215==0.3.7
 
+# homeassistant.components.media_player.webostv
+# homeassistant.components.notify.webostv
+https://github.com/TheRealLink/pylgtv/archive/v0.1.3.zip#pylgtv==0.1.3
+
 # homeassistant.components.sensor.thinkingcleaner
 # homeassistant.components.switch.thinkingcleaner
 https://github.com/TheRealLink/pythinkingcleaner/archive/v0.0.2.zip#pythinkingcleaner==0.0.2
@@ -246,10 +250,6 @@ https://github.com/nkgilley/python-ecobee-api/archive/4856a704670c53afe1882178a8
 # homeassistant.components.joaoapps_join
 # homeassistant.components.notify.joaoapps_join
 https://github.com/nkgilley/python-join-api/archive/3e1e849f1af0b4080f551b62270c6d244d5fbcbd.zip#python-join-api==0.0.1
-
-# homeassistant.components.media_player.webostv
-# homeassistant.components.notify.webostv
-https://github.com/pschmitt/pylgtv/archive/v0.1.3.zip#pylgtv==0.1.3
 
 # homeassistant.components.switch.edimax
 https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f3700.zip#pyedimax==0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -203,10 +203,6 @@ http://github.com/technicalpickles/python-nest/archive/e6c9d56a8df455d4d77463898
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.3.7.zip#pyW215==0.3.7
 
-# homeassistant.components.media_player.webostv
-# homeassistant.components.notify.webostv
-https://github.com/TheRealLink/pylgtv/archive/v0.1.2.zip#pylgtv==0.1.2
-
 # homeassistant.components.sensor.thinkingcleaner
 # homeassistant.components.switch.thinkingcleaner
 https://github.com/TheRealLink/pythinkingcleaner/archive/v0.0.2.zip#pythinkingcleaner==0.0.2
@@ -250,6 +246,10 @@ https://github.com/nkgilley/python-ecobee-api/archive/4856a704670c53afe1882178a8
 # homeassistant.components.joaoapps_join
 # homeassistant.components.notify.joaoapps_join
 https://github.com/nkgilley/python-join-api/archive/3e1e849f1af0b4080f551b62270c6d244d5fbcbd.zip#python-join-api==0.0.1
+
+# homeassistant.components.media_player.webostv
+# homeassistant.components.notify.webostv
+https://github.com/pschmitt/pylgtv/archive/v0.1.3.zip#pylgtv==0.1.3
 
 # homeassistant.components.switch.edimax
 https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f3700.zip#pyedimax==0.1


### PR DESCRIPTION
**Description:**
This PR changes the default path where the `media_player.webostv` and `notify.webostv` store their config (ie. pairing key file). It used to be `$HOME/.pylgtv` and now defaults to `$HASS_CONFIG_DIR/webostv.conf`.

**Related issue (if applicable):** fixes #5645

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1951

**Example entry for `configuration.yaml` (if applicable):**
```yaml
media_player:
  - platform: webostv
    host: mytv.lan
    filename: webostv.conf

notify:
  - platform: webostv
    host: mytv.lan
    filename: webostv.conf
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
