### PR TITLE
Upgrade psutil to 5.1.1

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -16,33 +16,33 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==5.0.1']
+REQUIREMENTS = ['psutil==5.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 
 SENSOR_TYPES = {
-    'disk_use_percent': ['Disk Use', '%', 'mdi:harddisk'],
-    'disk_use': ['Disk Use', 'GiB', 'mdi:harddisk'],
     'disk_free': ['Disk Free', 'GiB', 'mdi:harddisk'],
-    'memory_use_percent': ['RAM Use', '%', 'mdi:memory'],
-    'memory_use': ['RAM Use', 'MiB', 'mdi:memory'],
-    'memory_free': ['RAM Free', 'MiB', 'mdi:memory'],
-    'processor_use': ['CPU Use', '%', 'mdi:memory'],
-    'process': ['Process', ' ', 'mdi:memory'],
-    'swap_use_percent': ['Swap Use', '%', 'mdi:harddisk'],
-    'swap_use': ['Swap Use', 'GiB', 'mdi:harddisk'],
-    'swap_free': ['Swap Free', 'GiB', 'mdi:harddisk'],
-    'network_out': ['Sent', 'MiB', 'mdi:server-network'],
-    'network_in': ['Received', 'MiB', 'mdi:server-network'],
-    'packets_out': ['Packets sent', ' ', 'mdi:server-network'],
-    'packets_in': ['Packets received', ' ', 'mdi:server-network'],
+    'disk_use': ['Disk Use', 'GiB', 'mdi:harddisk'],
+    'disk_use_percent': ['Disk Use', '%', 'mdi:harddisk'],
     'ipv4_address': ['IPv4 address', '', 'mdi:server-network'],
     'ipv6_address': ['IPv6 address', '', 'mdi:server-network'],
     'last_boot': ['Last Boot', '', 'mdi:clock'],
-    'since_last_boot': ['Since Last Boot', '', 'mdi:clock'],
+    'load_15m': ['Average Load (15m)', '', 'mdi:memory'],
     'load_1m': ['Average Load (1m)', '', 'mdi:memory'],
     'load_5m': ['Average Load (5m)', '', 'mdi:memory'],
-    'load_15m': ['Average Load (15m)', '', 'mdi:memory']
+    'memory_free': ['RAM Free', 'MiB', 'mdi:memory'],
+    'memory_use': ['RAM Use', 'MiB', 'mdi:memory'],
+    'memory_use_percent': ['RAM Use', '%', 'mdi:memory'],
+    'network_in': ['Received', 'MiB', 'mdi:server-network'],
+    'network_out': ['Sent', 'MiB', 'mdi:server-network'],
+    'packets_in': ['Packets received', ' ', 'mdi:server-network'],
+    'packets_out': ['Packets sent', ' ', 'mdi:server-network'],
+    'process': ['Process', ' ', 'mdi:memory'],
+    'processor_use': ['CPU Use', '%', 'mdi:memory'],
+    'since_last_boot': ['Since Last Boot', '', 'mdi:clock'],
+    'swap_free': ['Swap Free', 'GiB', 'mdi:harddisk'],
+    'swap_use': ['Swap Use', 'GiB', 'mdi:harddisk'],
+    'swap_use_percent': ['Swap Use', '%', 'mdi:harddisk'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -382,7 +382,7 @@ pmsensor==0.3
 proliphix==0.4.1
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.0.1
+psutil==5.1.1
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.0


### PR DESCRIPTION
## 5.1.1

### Enhancements

- [Linux] sensors_battery().percent is a float and is more precise.
### Bug fixes

- [Windows] Process.username() and psutil.users() may return badly decoding character on Python 3.
- [Linux] disk_io_counters() may miscalculate sector size and report the wrong number of bytes read and written.
- [Linux] sensors_battery() may fail with "no such file error".
- [Linux] sensors_battery().power_plugged may lie.

## 5.1.0

### Enhancements

- added psutil.Process.cpu_num() (what CPU a process is on).
- added psutil.sensors_temperatures() (Linux only).
- added psutil.cpu_freq() (CPU frequency).
- added psutil.sensors_battery() (Linux, Windows, only).
- cpu_affinity([]) can now be used as an alias to set affinity against all eligible CPUs.
### Bug fixes

- [Linux] pid_exists() no longer returns True if passed a process thread ID.
- cannot install psutil with PYTHONOPTIMIZE=2.
- [Windows] Process.cpu_percent() was calculated incorrectly and showed higher number than real usage.
- [Windows] the uploaded wheels for Python 3.6 64 bit didn't work.
- psutil exception objects could not be pickled.
- Popen.wait() did not return the correct negative exit status if process is ``kill()``ed by a signal.
- [Windows] WindowsService.description() may fail with ERROR_MUI_FILE_NOT_FOUND.

Tested with the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: load_1m
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
```
