### PR TITLE
Fix Hue groups with same names

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -200,8 +200,7 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
 
         for light_id, info in api_lights.items():
             if light_id not in lights:
-                lights[light_id] = HueLight(hass,
-                                            int(light_id), info,
+                lights[light_id] = HueLight(int(light_id), info,
                                             bridge, update_lights,
                                             bridge_type, allow_unreachable,
                                             allow_in_emulated_hue)
@@ -219,7 +218,6 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
 
             if lightgroup_id not in lightgroups:
                 lightgroups[lightgroup_id] = HueLight(
-                    hass,
                     int(lightgroup_id), info, bridge, update_lights,
                     bridge_type, allow_unreachable, allow_in_emulated_hue,
                     True)
@@ -282,11 +280,10 @@ def request_configuration(host, hass, add_devices, filename,
 class HueLight(Light):
     """Representation of a Hue light."""
 
-    def __init__(self, hass, light_id, info, bridge, update_lights,
+    def __init__(self, light_id, info, bridge, update_lights,
                  bridge_type, allow_unreachable, allow_in_emulated_hue,
                  is_group=False):
         """Initialize the light."""
-        self.hass = hass
         self.light_id = light_id
         self.info = info
         self.bridge = bridge

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -302,7 +302,7 @@ class HueLight(Light):
     def unique_id(self):
         """Return the ID of this Hue light."""
         return "{}.{}".format(
-            self.__class__, self.info.get('uniqueid', self.name))
+            self.__class__, self.info.get('uniqueid', self.light_id))
 
     @property
     def name(self):

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -301,8 +301,13 @@ class HueLight(Light):
     @property
     def unique_id(self):
         """Return the ID of this Hue light."""
-        return "{}.{}".format(
-            self.__class__, self.info.get('uniqueid', self.light_id))
+        id = self.info.get('uniqueid')
+
+        if id is None:
+            type = self.info.get('type', 'Group' if self.is_group else 'Light')
+            id = '{}.{}.{}'.format(self.name, type, self.light_id)
+
+        return '{}.{}'.format(self.__class__, id)
 
     @property
     def name(self):

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -304,7 +304,8 @@ class HueLight(Light):
         lid = self.info.get('uniqueid')
 
         if lid is None:
-            ltype = self.info.get('type', 'Group' if self.is_group else 'Light')
+            default_type = 'Group' if self.is_group else 'Light'
+            ltype = self.info.get('type', default_type)
             lid = '{}.{}.{}'.format(self.name, ltype, self.light_id)
 
         return '{}.{}'.format(self.__class__, lid)

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -301,13 +301,13 @@ class HueLight(Light):
     @property
     def unique_id(self):
         """Return the ID of this Hue light."""
-        id = self.info.get('uniqueid')
+        lid = self.info.get('uniqueid')
 
-        if id is None:
-            type = self.info.get('type', 'Group' if self.is_group else 'Light')
-            id = '{}.{}.{}'.format(self.name, type, self.light_id)
+        if lid is None:
+            ltype = self.info.get('type', 'Group' if self.is_group else 'Light')
+            lid = '{}.{}.{}'.format(self.name, type, self.light_id)
 
-        return '{}.{}'.format(self.__class__, id)
+        return '{}.{}'.format(self.__class__, lid)
 
     @property
     def name(self):

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -305,7 +305,7 @@ class HueLight(Light):
 
         if lid is None:
             ltype = self.info.get('type', 'Group' if self.is_group else 'Light')
-            lid = '{}.{}.{}'.format(self.name, type, self.light_id)
+            lid = '{}.{}.{}'.format(self.name, ltype, self.light_id)
 
         return '{}.{}'.format(self.__class__, lid)
 


### PR DESCRIPTION
**Description:**
This fixes the real issue with Hue groups having the same name that was worked around with #5702.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
