### PR TITLE
Upgrade psutil to 5.1.2

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==5.1.1']
+REQUIREMENTS = ['psutil==5.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -382,7 +382,7 @@ pmsensor==0.3
 proliphix==0.4.1
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.1.1
+psutil==5.1.2
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.0


### PR DESCRIPTION
## 5.1.2

Bug fixes

- [Linux] sensors_battery().power_plugged may erroneously return None on Python 3.
- [Linux] disk_io_counters() raises TypeError on python 3.
- [Linux] sensors_battery()'s name and label fields on Python 3 are bytes instead of str.

Tested with the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: load_1m
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
```
