### PR TITLE
Upgrade zeroconf to 0.18.0

### DIFF
--- a/homeassistant/components/zeroconf.py
+++ b/homeassistant/components/zeroconf.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['api']
 DOMAIN = 'zeroconf'
 
-REQUIREMENTS = ['zeroconf==0.17.7']
+REQUIREMENTS = ['zeroconf==0.18.0']
 
 ZEROCONF_TYPE = '_home-assistant._tcp.local.'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -708,4 +708,4 @@ yeelight==0.2.1
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.17.7
+zeroconf==0.18.0


### PR DESCRIPTION
## 0.18.0
- Dropped Python 2.6 support
- Improved error handling inside code executed when Zeroconf object is being closed

Tested with the following configuration:

``` yaml
zeroconf:
```

Discovery is working as expected.

``` bash
$ avahi-discover
Browsing domain 'local' on -1.-1 ...
Browsing for services of type '_home-assistant._tcp' in domain 'local' on 4.0 ...
Found service 'Home' of type '_home-assistant._tcp' in domain 'local' on 4.0.
Service data for service 'Home' of type '_home-assistant._tcp' in domain 'local' on 4.0:
	Host Home._home-assistant._tcp.local (192.168.0.103), port 8123, TXT data: ['base_url=http://192.168.0.103:8123', 'requires_api_password=false', 'version=0.38.0.dev0']

```
