### PR TITLE
Fix validation of serial port on windows

### DIFF
--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -94,7 +94,7 @@ def is_persistence_file(value):
 def is_serial_port(value):
     """Validate that value is a windows serial port or a unix device."""
     if sys.platform.startswith('win'):
-        ports = ['COM{}'.format(idx + 1) for idx in range(256)]
+        ports = ('COM{}'.format(idx + 1) for idx in range(256))
         if value in ports:
             return value
         else:

--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/sensor.mysensors/
 import logging
 import os
 import socket
+import sys
 
 import voluptuous as vol
 
@@ -91,14 +92,16 @@ def is_persistence_file(value):
 
 
 def is_serial_port(value):
-    """Validate that value is a serial port."""
-    import serial.tools.list_ports as list_ports
-    ports = [port[0] for port in list_ports.comports()]
-    if value in ports:
-        return value
+    """Validate that value is a windows serial port or a unix device."""
+    if sys.platform.startswith('win'):
+        ports = ['COM{}'.format(idx + 1) for idx in range(256)]
+        if value in ports:
+            return value
+        else:
+            raise vol.Invalid(
+                '{} is not a serial port'.format(value))
     else:
-        raise vol.Invalid(
-            '{} is not a serial port'.format(value))
+        return cv.isdevice(value)
 
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -81,15 +81,35 @@ def has_all_unique_files(value):
     return value
 
 
+def is_persistence_file(value):
+    """Validate that persistence file path ends in either .pickle or .json."""
+    if value.endswith(('.json', '.pickle')):
+        return value
+    else:
+        raise vol.Invalid(
+            '{} does not end in either `.json` or `.pickle`'.format(value))
+
+
+def is_serial_port(value):
+    """Validate that value is a serial port."""
+    import serial.tools.list_ports as list_ports
+    ports = [port[0] for port in list_ports.comports()]
+    if value in ports:
+        return value
+    else:
+        raise vol.Invalid(
+            '{} is not a serial port'.format(value))
+
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_GATEWAYS): vol.All(
             cv.ensure_list, has_all_unique_files,
             [{
                 vol.Required(CONF_DEVICE):
-                    vol.Any(cv.isdevice, MQTT_COMPONENT, is_socket_address),
+                    vol.Any(MQTT_COMPONENT, is_socket_address, is_serial_port),
                 vol.Optional(CONF_PERSISTENCE_FILE):
-                    vol.All(cv.string, has_parent_dir),
+                    vol.All(cv.string, is_persistence_file, has_parent_dir),
                 vol.Optional(
                     CONF_BAUD_RATE,
                     default=DEFAULT_BAUD_RATE): cv.positive_int,


### PR DESCRIPTION
**Description:**
* Check that device is valid serial device also on windows.
* Check that persistence file ends with either `.json` or `.pickle`.

**Related issue (if applicable):**
fixes #5661 

**Example entry for `configuration.yaml` (if applicable):**
```yaml
mysensors:
  gateways:
    - device: '/dev/ttyACM0'
```

**Checklist:**
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
