### PR TITLE
Add support for position property for wink covers

### DIFF
--- a/homeassistant/components/cover/wink.py
+++ b/homeassistant/components/cover/wink.py
@@ -40,13 +40,17 @@ class WinkCoverDevice(WinkDevice, CoverDevice):
         """Open the shade."""
         self.wink.set_state(1)
 
+    def set_cover_position(self, position, **kwargs):
+        """Move the roller shutter to a specific position."""
+        self.wink.set_state(float(position)/100)
+
+    @property
+    def current_cover_position(self):
+        """Return the current position of roller shutter."""
+        return int(self.wink.state()*100)
+
     @property
     def is_closed(self):
         """Return if the cover is closed."""
         state = self.wink.state()
-        if state == 0:
-            return True
-        elif state == 1:
-            return False
-        else:
-            return None
+        return bool(state == 0)


### PR DESCRIPTION
**Description:**
Add support for position property for wink covers and fix state when stopped in the middle.


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
