### PR TITLE
Added error checking to the MIMEImage encoding for smtp.py

### DIFF
--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -186,9 +186,12 @@ def _build_multipart_msg(message, images):
                     msg.attach(attachment)
                     attachment.add_header('Content-ID', '<{}>'.format(cid))
                 except TypeError:
-                    _LOGGER.warning('Attachment %s has an unkown MIME type. Falling back to file', atch_name)
+                    _LOGGER.warning('Attachment %s has an unkown MIME type.'
+                                    ' Falling back to file', atch_name)
                     attachment = MIMEApplication(file_bytes, Name=atch_name)
-                    attachment['Content-Disposition'] = ('attachment; filename="%s"' % atch_name)
+                    attachment['Content-Disposition'] = ('attachment; '
+                                                         'filename="%s"' %
+                                                         atch_name)
                     msg.attach(attachment)
         except FileNotFoundError:
             _LOGGER.warning('Attachment %s not found. Skipping',


### PR DESCRIPTION
Added fallback to file attachment rather than inline image for images
without a known MIME

**Description:**

Files with funky image headers (in my case a jpg without a JFIF tag) can throw a TypeError and not send. This is because of an underlying bug in imghdr (see https://bugs.python.org/issue16512 )

This catches that error, and then attempts to send the file as a plain attachment, which email clients (and MMS) seem to support well

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ +] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

Tox won't complete with the following:
```
Collecting dweepy==0.2.0 (from -r /home/jesse/projects/home-assistant/requirements_all.txt (line 123))
  Using cached dweepy-0.2.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-pl9v0inv/dweepy/setup.py", line 14, in <module>
        long_description=open('README.rst').read(),
      File "/home/jesse/projects/home-assistant/.tox/py35/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 8404: ordinal not in range(128)
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-pl9v0inv/dweepy/
```
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
