### PR TITLE
Fixed bug with Russound integration and added 2 way state support. (Bumped up to v0.1.7)

### DIFF
--- a/homeassistant/components/media_player/russound_rnet.py
+++ b/homeassistant/components/media_player/russound_rnet.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/media_player.russound_rnet/
 """
 
 import logging
-import time
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
@@ -77,10 +76,11 @@ class RussoundRNETDevice(MediaPlayerDevice):
 
     def __init__(self, hass, russ, sources, zone_id, extra):
         """Initialise the Russound RNET device.
-        Note: now uses the Russound device directly to obtain the state and volume level, and therefore we no longer
+
+        Note: now uses the Russound device directly to obtain the state and
+        volume level, and therefore we no longer
         have properties in this class for these to variables.
         """
-
         self._name = extra['name']
         self._russ = russ
         self._sources = sources
@@ -105,10 +105,13 @@ class RussoundRNETDevice(MediaPlayerDevice):
 
     @property
     def source(self):
-        """Get the currently selected source"""
-        index = self._russ.get_source('1', self._zone_id)  # Returns 0 based index for source
-        # Possibility exists that user has defined list of all sources. If a source is set externally that is beyond
-        # the defined list then an exception will be thrown.  In this case fore it to the first element in sources.
+        """Get the currently selected source."""
+        # Returns 0 based index for source.
+        index = self._russ.get_source('1', self._zone_id)
+        # Possibility exists that user has defined list of all sources.
+        # If a source is set externally that is beyond the defined list then
+        # an exception will be thrown.
+        # In this case fore it to the first element in sources.
         try:
             return self._sources[index]
         except IndexError:
@@ -117,13 +120,17 @@ class RussoundRNETDevice(MediaPlayerDevice):
     @property
     def volume_level(self):
         """Volume level of the media player (0..1).
-        Value is returned based on a range (0..100).  Therefore float divide by 100 to get to the required range.
+
+        Value is returned based on a range (0..100).
+        Therefore float divide by 100 to get to the required range.
         """
         return self._russ.get_volume('1', self._zone_id) / 100.0
 
     def set_volume_level(self, volume):
         """Set volume level.  Volume has a range (0..1).
-        Translate this to a range of (0..100) as expected expected by _russ.set_volume()
+
+        Translate this to a range of (0..100) as expected expected
+        by _russ.set_volume()
         """
         self._russ.set_volume('1', self._zone_id, volume * 100)
 
@@ -143,7 +150,8 @@ class RussoundRNETDevice(MediaPlayerDevice):
         """Set the input source."""
         if source in self._sources:
             index = self._sources.index(source)
-            self._russ.set_source('1', self._zone_id, index)  # 0 based value for source
+            # 0 based value for source
+            self._russ.set_source('1', self._zone_id, index)
 
     @property
     def source_list(self):

--- a/homeassistant/components/media_player/russound_rnet.py
+++ b/homeassistant/components/media_player/russound_rnet.py
@@ -89,7 +89,6 @@ class RussoundRNETDevice(MediaPlayerDevice):
 
     def update(self):
         """Retrieve latest state."""
-
         if self._russ.get_power('1', self._zone_id) == 0:
             self._state = STATE_OFF
         else:

--- a/homeassistant/components/media_player/russound_rnet.py
+++ b/homeassistant/components/media_player/russound_rnet.py
@@ -66,7 +66,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if russ.is_connected():
         for zone_id, extra in config[CONF_ZONES].items():
             add_devices([RussoundRNETDevice(
-                hass, russ, sources, zone_id, extra)])
+                hass, russ, sources, zone_id, extra)], True)
     else:
         _LOGGER.error('Not connected to %s:%s', host, port)
 
@@ -114,7 +114,7 @@ class RussoundRNETDevice(MediaPlayerDevice):
 
     @property
     def state(self):
-        """Return the state of the device. directly from the device."""
+        """Return the state of the device."""
         return self._state
 
     @property

--- a/homeassistant/components/media_player/russound_rnet.py
+++ b/homeassistant/components/media_player/russound_rnet.py
@@ -85,8 +85,6 @@ class RussoundRNETDevice(MediaPlayerDevice):
         self._volume = None
         self._source = None
 
-        self.update()
-
     def update(self):
         """Retrieve latest state."""
         if self._russ.get_power('1', self._zone_id) == 0:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -239,7 +239,7 @@ https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad591540925
 https://github.com/joopert/nad_receiver/archive/0.0.3.zip#nad_receiver==0.0.3
 
 # homeassistant.components.media_player.russound_rnet
-https://github.com/laf/russound/archive/0.1.6.zip#russound==0.1.6
+https://github.com/laf/russound/archive/0.1.7.zip#russound==0.1.7
 
 # homeassistant.components.switch.anel_pwrctrl
 https://github.com/mweinelt/anel-pwrctrl/archive/ed26e8830e28a2bfa4260a9002db23ce3e7e63d7.zip#anel_pwrctrl==0.0.1


### PR DESCRIPTION
**Description:**
Fixed bug arising from not supporting TURN_ON state (fixes issue https://github.com/home-assistant/home-assistant/issues/5012)
Implemented state support in 0.1.7 such that component state is returned from the actual AMP. (Still uses polling model though).
Tested it with home-assistant users @laf (original developer of the module) and @hofsta.  Works fine with their Russounds.

fixes https://github.com/home-assistant/home-assistant/issues/5012
