### PR TITLE
Upgrade pysnmp to 4.3.3

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -17,24 +17,24 @@ from homeassistant.components.device_tracker import (
 from homeassistant.const import CONF_HOST
 from homeassistant.util import Throttle
 
-# Return cached results if last scan was less then this time ago.
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
-
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ['pysnmp==4.3.2']
 
-CONF_COMMUNITY = "community"
-CONF_AUTHKEY = "authkey"
-CONF_PRIVKEY = "privkey"
-CONF_BASEOID = "baseoid"
+REQUIREMENTS = ['pysnmp==4.3.3']
 
-DEFAULT_COMMUNITY = "public"
+CONF_COMMUNITY = 'community'
+CONF_AUTHKEY = 'authkey'
+CONF_PRIVKEY = 'privkey'
+CONF_BASEOID = 'baseoid'
+
+DEFAULT_COMMUNITY = 'public'
+
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): cv.string,
-    vol.Inclusive(CONF_AUTHKEY, "keys"): cv.string,
-    vol.Inclusive(CONF_PRIVKEY, "keys"): cv.string,
+    vol.Inclusive(CONF_AUTHKEY, 'keys'): cv.string,
+    vol.Inclusive(CONF_PRIVKEY, 'keys'): cv.string,
     vol.Required(CONF_BASEOID): cv.string
 })
 
@@ -119,14 +119,14 @@ class SnmpScanner(DeviceScanner):
             return
         # pylint: disable=no-member
         if errstatus:
-            _LOGGER.error('SNMP error: %s at %s', errstatus.prettyPrint(),
+            _LOGGER.error("SNMP error: %s at %s", errstatus.prettyPrint(),
                           errindex and restable[int(errindex) - 1][0] or '?')
             return
 
         for resrow in restable:
             for _, val in resrow:
                 mac = binascii.hexlify(val.asOctets()).decode('utf-8')
-                _LOGGER.debug('Found mac %s', mac)
+                _LOGGER.debug("Found MAC %s", mac)
                 mac = ':'.join([mac[i:i+2] for i in range(0, len(mac), 2)])
                 devices.append({'mac': mac})
         return devices

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pysnmp==4.3.2']
+REQUIREMENTS = ['pysnmp==4.3.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the SNMP sensor."""
+    """Set up the SNMP sensor."""
     from pysnmp.hlapi import (getCmd, CommunityData, SnmpEngine,
                               UdpTransportTarget, ContextData, ObjectType,
                               ObjectIdentity)
@@ -61,7 +61,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                ObjectType(ObjectIdentity(baseoid))))
 
     if errindication:
-        _LOGGER.error('Please check the details in the configuration file')
+        _LOGGER.error("Please check the details in the configuration file")
         return False
     else:
         data = SnmpData(host, port, community, baseoid)
@@ -128,7 +128,7 @@ class SnmpData(object):
         if errindication:
             _LOGGER.error("SNMP error: %s", errindication)
         elif errstatus:
-            _LOGGER.error('SNMP error: %s at %s', errstatus.prettyPrint(),
+            _LOGGER.error("SNMP error: %s at %s", errstatus.prettyPrint(),
                           errindex and restable[-1][int(errindex) - 1] or '?')
         else:
             for resrow in restable:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -505,7 +505,7 @@ pysma==0.1.3
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
-pysnmp==4.3.2
+pysnmp==4.3.3
 
 # homeassistant.components.digital_ocean
 python-digitalocean==1.10.1


### PR DESCRIPTION
## 4.3.3
- Switched from now unmaintained PyCrypto to PyCryptodome.
- Switched to new-style classes.
- NotificationType now allows additional var-binds specified as MIB objects. A side effect of this change is that additional var-binds can only be added prior to .resolveMibObjects() is run.
- Non-standard (but apparently used by many vendors) Reeder AES192/256 key localization algorithm implemented and set as default for usmAesCfb192Protocol and usmAesCfb256Protocol identifiers. Original and more standard implementation can still be used with the usmAesBlumenthalCfb192Protocol and usmAesBlumenthalCfb192Protocol IDs respectively.
- TextualConvention.prettyOut() improved to produce prettier and more SMI-compliant output.
- TextualConvention.prettyIn() implemented to handle DISPLAY-HINT based value parsing.
- Fix to NotificationType to make additional var-binds overriding MIB objects implicitly included through NOTIFICATION-TYPE OBJECTS.
- Fix to SNMP engine boots counter persistence on Python 3.
- Fix to Pythonized MIBs loading when only .pyc files are present (e.g. py2exe/cx_freeze environments).
- Fix broken 3DES key localization and encryption procedures.
- Updated IP address for demo.snmplabs.com in examples.
- Missing index added to bundled RFC1213::atEntry MIB table.
- Twisted integration made Python3 compatible.
- Accommodated ASN.1 SEQUENCE iteration rules change in upcoming pyasn1 version.
- Author's email changed, copyright extended to 2017.

Tested with the following configuration:

``` yaml
sensor:
  - platform: snmp
    name: SNMP TEST String
    host: demo.snmplabs.com
    community: public
    baseoid: 1.3.6.1.4.1.2021.10.1.3.1
    unit_of_measurement: "load"
```
