### PR TITLE
Support for KWB Easyfire sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -314,6 +314,7 @@ omit =
     homeassistant/components/sensor/imap.py
     homeassistant/components/sensor/imap_email_content.py
     homeassistant/components/sensor/influxdb.py
+    homeassistant/components/sensor/kwb.py
     homeassistant/components/sensor/lastfm.py
     homeassistant/components/sensor/linux_battery.py
     homeassistant/components/sensor/loopenergy.py

--- a/homeassistant/components/sensor/kwb.py
+++ b/homeassistant/components/sensor/kwb.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.kwb/
 """
 import logging
-
 import voluptuous as vol
 
 from homeassistant.const import (CONF_HOST, CONF_PORT)
@@ -43,29 +42,29 @@ ETHERNET_SCHEMA = {
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the KWB component."""
-
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
-    type = config.get(CONF_TYPE)
+    connection_type = config.get(CONF_TYPE)
     raw = config.get(CONF_RAW)
-    
-    if (raw == 'on'):
+
+    if raw == 'on':
         raw = True
 
     from pykwb import kwb
 
     _LOGGER.info('KWB: initializing')
 
-    if (type == 'serial'):
+    if connection_type == 'serial':
         easyfire = kwb.KWBEasyfire(MODE_SERIAL, "", 0, port)
-    elif (type == 'tcp'):
+    elif connection_type == 'tcp':
         easyfire = kwb.KWBEasyfire(MODE_TCP, host, port)
     else:
         return False
 
-    sensors=[]
+    sensors = []
     for sensor in easyfire.get_sensors():
-        if ((sensor.sensor_type != kwb.PROP_SENSOR_RAW) or (sensor.sensor_type == kwb.PROP_SENSOR_RAW and raw)):
+        if ((sensor.sensor_type != kwb.PROP_SENSOR_RAW)
+                or (sensor.sensor_type == kwb.PROP_SENSOR_RAW and raw)):
             sensors.append(KWBSensor(easyfire, sensor))
 
     add_devices(sensors)
@@ -80,7 +79,6 @@ class KWBSensor(Entity):
 
     def __init__(self, easyfire, sensor):
         """Initialize the KWB sensor."""
-
         self._easyfire = easyfire
         self._sensor = sensor
         self._client_name = "KWB"

--- a/homeassistant/components/sensor/kwb.py
+++ b/homeassistant/components/sensor/kwb.py
@@ -1,0 +1,93 @@
+"""
+Support for KWB Easyfire.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.kwb/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import (CONF_HOST, CONF_PORT)
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['pykwb==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_HOST = 'localhost'
+DEFAULT_PORT = 23
+DEFAULT_TYPE = 'tcp'
+
+MODE_SERIAL = 0
+MODE_TCP = 1
+
+CONF_TYPE = "type"
+
+SERIAL_SCHEMA = {
+    vol.Required(CONF_PORT): cv.string,
+    vol.Required(CONF_TYPE): 'serial',
+}
+
+ETHERNET_SCHEMA = {
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PORT): cv.positive_int,
+    vol.Required(CONF_TYPE): 'tcp',
+}
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the KWB component."""
+
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    type = config.get(CONF_TYPE)
+
+    from pykwb import kwb
+
+    _LOGGER.info('KWB: initializing')
+
+    if (type == 'serial'):
+        easyfire = kwb.KWBEasyfire(MODE_SERIAL, "", 0, port)
+    elif (type == 'tcp'):
+        easyfire = kwb.KWBEasyfire(MODE_TCP, host, port)
+    else:
+        return False
+
+    sensors=[]
+    for sensor in easyfire.get_sensors():
+        sensors.append(KWBSensor(easyfire, sensor))
+
+    add_devices(sensors)
+
+    _LOGGER.info('KWB: starting thread')
+    easyfire.run_thread()
+    _LOGGER.info('KWB: thread started')
+
+
+class KWBSensor(Entity):
+    """Representation of a KWB Easyfire sensor."""
+
+    def __init__(self, easyfire, sensor):
+        """Initialize the KWB sensor."""
+
+        self._easyfire = easyfire
+        self._sensor = sensor
+        self._client_name = "KWB"
+        self._name = self._sensor.name
+
+    @property
+    def name(self):
+        """Return the name."""
+        return '{} {}'.format(self._client_name, self._name)
+
+    @property
+    def state(self):
+        """Return the state of value."""
+        return self._sensor.value
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._sensor.unit_of_measurement

--- a/homeassistant/components/sensor/kwb.py
+++ b/homeassistant/components/sensor/kwb.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.kwb/
 """
 import logging
+
 import voluptuous as vol
 
 from homeassistant.const import (CONF_HOST, CONF_PORT)
@@ -42,29 +43,29 @@ ETHERNET_SCHEMA = {
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the KWB component."""
+
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
-    connection_type = config.get(CONF_TYPE)
+    type = config.get(CONF_TYPE)
     raw = config.get(CONF_RAW)
-
-    if raw == 'on':
+    
+    if (raw == 'on'):
         raw = True
 
     from pykwb import kwb
 
     _LOGGER.info('KWB: initializing')
 
-    if connection_type == 'serial':
+    if (type == 'serial'):
         easyfire = kwb.KWBEasyfire(MODE_SERIAL, "", 0, port)
-    elif connection_type == 'tcp':
+    elif (type == 'tcp'):
         easyfire = kwb.KWBEasyfire(MODE_TCP, host, port)
     else:
         return False
 
-    sensors = []
+    sensors=[]
     for sensor in easyfire.get_sensors():
-        if ((sensor.sensor_type != kwb.PROP_SENSOR_RAW)
-                or (sensor.sensor_type == kwb.PROP_SENSOR_RAW and raw)):
+        if ((sensor.sensor_type != kwb.PROP_SENSOR_RAW) or (sensor.sensor_type == kwb.PROP_SENSOR_RAW and raw)):
             sensors.append(KWBSensor(easyfire, sensor))
 
     add_devices(sensors)
@@ -79,6 +80,7 @@ class KWBSensor(Entity):
 
     def __init__(self, easyfire, sensor):
         """Initialize the KWB sensor."""
+
         self._easyfire = easyfire
         self._sensor = sensor
         self._client_name = "KWB"

--- a/homeassistant/components/sensor/kwb.py
+++ b/homeassistant/components/sensor/kwb.py
@@ -12,7 +12,7 @@ from homeassistant.const import (CONF_HOST, CONF_PORT)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pykwb==0.0.4']
+REQUIREMENTS = ['pykwb==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/kwb.py
+++ b/homeassistant/components/sensor/kwb.py
@@ -12,28 +12,32 @@ from homeassistant.const import (CONF_HOST, CONF_PORT)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pykwb==0.0.1']
+REQUIREMENTS = ['pykwb==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 23
 DEFAULT_TYPE = 'tcp'
+DEFAULT_RAW = 'off'
 
 MODE_SERIAL = 0
 MODE_TCP = 1
 
-CONF_TYPE = "type"
+CONF_TYPE = 'type'
+CONF_RAW = 'raw'
 
 SERIAL_SCHEMA = {
     vol.Required(CONF_PORT): cv.string,
     vol.Required(CONF_TYPE): 'serial',
+    vol.Optional(CONF_TYPE): 'raw',
 }
 
 ETHERNET_SCHEMA = {
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_PORT): cv.positive_int,
     vol.Required(CONF_TYPE): 'tcp',
+    vol.Optional(CONF_TYPE): 'raw',
 }
 
 
@@ -43,6 +47,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
     type = config.get(CONF_TYPE)
+    raw = config.get(CONF_RAW)
+    
+    if (raw == 'on'):
+        raw = True
 
     from pykwb import kwb
 
@@ -57,7 +65,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     sensors=[]
     for sensor in easyfire.get_sensors():
-        sensors.append(KWBSensor(easyfire, sensor))
+        if ((sensor.sensor_type != kwb.PROP_SENSOR_RAW) or (sensor.sensor_type == kwb.PROP_SENSOR_RAW and raw)):
+            sensors.append(KWBSensor(easyfire, sensor))
 
     add_devices(sensors)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -463,7 +463,7 @@ pyicloud==0.9.1
 pyiss==1.0.1
 
 # homeassistant.components.sensor.kwb
-pykwb==0.0.4
+pykwb==0.0.5
 
 # homeassistant.components.sensor.lastfm
 pylast==1.7.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -463,7 +463,7 @@ pyicloud==0.9.1
 pyiss==1.0.1
 
 # homeassistant.components.sensor.kwb
-pykwb==0.0.5
+pykwb==0.0.4
 
 # homeassistant.components.sensor.lastfm
 pylast==1.7.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -462,6 +462,9 @@ pyicloud==0.9.1
 # homeassistant.components.binary_sensor.iss
 pyiss==1.0.1
 
+# homeassistant.components.sensor.kwb
+pykwb==0.0.4
+
 # homeassistant.components.sensor.lastfm
 pylast==1.7.0
 


### PR DESCRIPTION
**Description:**

KWB Easyfire pellet central heating units with the Comfort3 controller have a RS485 port over which sensor and state information is relayed.
This component supports direct connection via serial or via telnet terminal server. The serial cable has to be attached to the control unit port 25 (which is normally used for detached control terminals).
Since this serial protocol is proprietary and closed, only most temperature sensors and a few control relais are supported, the rest is still WIP (see https://www.mikrocontroller.net/topic/274137).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
  - platform: kwb
    host: <ip>
    port: 23
    type: tcp
    raw: off
```
or
```yaml
  - platform: kwb
    port: "/dev/ttyUSB0"
    type: serial
    raw: off
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
