### PR TITLE
Improve Sky Hub error handling

### DIFF
--- a/homeassistant/components/device_tracker/sky_hub.py
+++ b/homeassistant/components/device_tracker/sky_hub.py
@@ -111,6 +111,8 @@ def _get_skyhub_data(url):
 def _parse_skyhub_response(data_str):
     """Parse the Sky Hub data format."""
     pattmatch = re.search('attach_dev = \'(.*)\'', data_str)
+    if pattmatch is None:
+        raise IOError("Error: Impossible to fetch data from Sky Hub. Try to reboot the rooter.")
     patt = pattmatch.group(1)
 
     dev = [patt1.split(',') for patt1 in patt.split('<lf>')]

--- a/homeassistant/components/device_tracker/sky_hub.py
+++ b/homeassistant/components/device_tracker/sky_hub.py
@@ -112,7 +112,8 @@ def _parse_skyhub_response(data_str):
     """Parse the Sky Hub data format."""
     pattmatch = re.search('attach_dev = \'(.*)\'', data_str)
     if pattmatch is None:
-        raise IOError("Error: Impossible to fetch data from Sky Hub. Try to reboot the rooter.")
+        raise IOError('Error: Impossible to fetch data from' +
+                      ' Sky Hub. Try to reboot the rooter.')
     patt = pattmatch.group(1)
 
     dev = [patt1.split(',') for patt1 in patt.split('<lf>')]


### PR DESCRIPTION
**Description:**
Added error handling. The error prompt the user to reboot the sky hub router in case home assistant is not able to fetch data from it. The rebooting has been reported to solve the issue [here](https://community.home-assistant.io/t/error-setting-up-platform-device-tracker-sky-hub/10987).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
