### PR TITLE
Allow to use data for enhanced messages

### DIFF
--- a/homeassistant/components/notify/facebook.py
+++ b/homeassistant/components/notify/facebook.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
-    ATTR_TARGET, PLATFORM_SCHEMA, BaseNotificationService)
+    ATTR_TARGET, ATTR_DATA, PLATFORM_SCHEMA, BaseNotificationService)
 from homeassistant.const import CONTENT_TYPE_JSON
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,6 +41,15 @@ class FacebookNotificationService(BaseNotificationService):
         """Send some message."""
         payload = {'access_token': self.page_access_token}
         targets = kwargs.get(ATTR_TARGET)
+        data = kwargs.get(ATTR_DATA)
+
+        body_message = {"text": message}
+
+        if data is not None:
+            body_message.update(data)
+            # Only one of text or attachment can be specified
+            if 'attachment' in body_message:
+                body_message.pop('text')
 
         if not targets:
             _LOGGER.error("At least 1 target is required")
@@ -49,7 +58,7 @@ class FacebookNotificationService(BaseNotificationService):
         for target in targets:
             body = {
                 "recipient": {"phone_number": target},
-                "message": {"text": message}
+                "message": body_message
             }
             import json
             resp = requests.post(BASE_URL, data=json.dumps(body),


### PR DESCRIPTION
**Description:**
Add notification data field to the message send to Facebook.
Allows to construct richer messages like cards, quick replies, attach
images, videos, etc


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1979


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
