### PR TITLE
Add icon_template to template sensor

### DIFF
--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -21,8 +21,11 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_ICON_TEMPLATE = 'icon_template'
+
 SENSOR_SCHEMA = vol.Schema({
     vol.Required(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_ICON_TEMPLATE): cv.template,
     vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
     vol.Optional(ATTR_UNIT_OF_MEASUREMENT): cv.string,
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
@@ -41,12 +44,16 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     for device, device_config in config[CONF_SENSORS].items():
         state_template = device_config[CONF_VALUE_TEMPLATE]
+        icon_template = device_config.get(CONF_ICON_TEMPLATE)
         entity_ids = (device_config.get(ATTR_ENTITY_ID) or
                       state_template.extract_entities())
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         unit_of_measurement = device_config.get(ATTR_UNIT_OF_MEASUREMENT)
 
         state_template.hass = hass
+
+        if icon_template:
+            icon_template.hass = hass
 
         sensors.append(
             SensorTemplate(
@@ -55,6 +62,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                 friendly_name,
                 unit_of_measurement,
                 state_template,
+                icon_template,
                 entity_ids)
             )
     if not sensors:
@@ -69,7 +77,7 @@ class SensorTemplate(Entity):
     """Representation of a Template Sensor."""
 
     def __init__(self, hass, device_id, friendly_name, unit_of_measurement,
-                 state_template, entity_ids):
+                 state_template, icon_template, entity_ids):
         """Initialize the sensor."""
         self.hass = hass
         self.entity_id = async_generate_entity_id(ENTITY_ID_FORMAT, device_id,
@@ -78,6 +86,8 @@ class SensorTemplate(Entity):
         self._unit_of_measurement = unit_of_measurement
         self._template = state_template
         self._state = None
+        self._icon_template = icon_template
+        self._icon = None
 
         @callback
         def template_sensor_state_listener(entity, old_state, new_state):
@@ -96,6 +106,11 @@ class SensorTemplate(Entity):
     def state(self):
         """Return the state of the sensor."""
         return self._state
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return self._icon
 
     @property
     def unit_of_measurement(self):
@@ -120,3 +135,15 @@ class SensorTemplate(Entity):
                 return
             self._state = None
             _LOGGER.error(ex)
+
+        if self._icon_template is not None:
+            try:
+                self._icon = self._icon_template.async_render()
+            except TemplateError as ex:
+                if ex.args and ex.args[0].startswith(
+                        "UndefinedError: 'None' has no attribute"):
+                    # Common during HA startup - so just a warning
+                    _LOGGER.warning(ex)
+                    return
+                self._icon = super().icon
+                _LOGGER.error(ex)

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -52,7 +52,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
         state_template.hass = hass
 
-        if icon_template:
+        if icon_template is not None:
             icon_template.hass = hass
 
         sensors.append(

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -51,7 +51,9 @@ class TestTemplateSensor:
                         'test_template_sensor': {
                             'value_template': "State",
                             'icon_template':
-                                "{% if states.sensor.test_state.state %} mdi:check {% endif %}"
+                                "{% if states.sensor.test_state.state %}"
+                                    "mdi:check"
+                                "{% endif %}"
                         }
                     }
                 }

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -41,6 +41,30 @@ class TestTemplateSensor:
         state = self.hass.states.get('sensor.test_template_sensor')
         assert state.state == 'It Works.'
 
+    def test_icon_template(self):
+        """Test icon template."""
+        with assert_setup_component(1):
+            assert setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test_template_sensor': {
+                            'value_template': "State",
+                            'icon_template':
+                                "{% if states.sensor.test_state.state %} mdi:check {% endif %}"
+                        }
+                    }
+                }
+            })
+
+        state = self.hass.states.get('sensor.test_template_sensor')
+        assert 'icon' not in state.attributes
+
+        self.hass.states.set('sensor.test_state', 'Works')
+        self.hass.block_till_done()
+        state = self.hass.states.get('sensor.test_template_sensor')
+        assert state.attributes['icon'] == 'mdi:check'
+
     def test_template_syntax_error(self):
         """Test templating syntax error."""
         with assert_setup_component(0):

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -52,7 +52,7 @@ class TestTemplateSensor:
                             'value_template': "State",
                             'icon_template':
                                 "{% if states.sensor.test_state.state %}"
-                                    "mdi:check"
+                                "mdi:check"
                                 "{% endif %}"
                         }
                     }

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -51,7 +51,8 @@ class TestTemplateSensor:
                         'test_template_sensor': {
                             'value_template': "State",
                             'icon_template':
-                                "{% if states.sensor.test_state.state == 'Works %}"
+                                "{% if states.sensor.test_state.state == "
+                                "'Works' %}"
                                 "mdi:check"
                                 "{% endif %}"
                         }

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -51,7 +51,7 @@ class TestTemplateSensor:
                         'test_template_sensor': {
                             'value_template': "State",
                             'icon_template':
-                                "{% if states.sensor.test_state.state %}"
+                                "{% if states.sensor.test_state.state == 'Works %}"
                                 "mdi:check"
                                 "{% endif %}"
                         }


### PR DESCRIPTION
**Description:**
Adds an `icon_template` config option to template sensor in order to change the icon based on a template. This can be used to address the following feature request: https://community.home-assistant.io/t/map-device-state-to-an-icon/4085.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1991

**Example entry for `configuration.yaml` (if applicable):**
Note: There is a caveat here, which is that you should **not** use the state of the template sensor itself for the icon template since the value template is rendered asynchronously and may not be finished by the time the icon template is rendered.
```yaml
sensor:
  - platform: template
    sensors:
      dark_sky_template:
        value_template: "{{ states('sensor.dark_sky_summary') }}"
        icon_template: >
          {% if is_state('sensor.dark_sky_icon', 'clear-day') %}
            mdi:weather-sunny
          {% elif is_state('sensor.dark_sky_icon', 'clear-night') %}
            mdi:weather-night
          {% elif is_state('sensor.dark_sky_icon', 'rain') %}
            mdi:weather-rainy
          {% elif is_state('sensor.dark_sky_icon', 'snow') %}
            mdi:weather-snowy
          {% elif is_state('sensor.dark_sky_icon', 'sleet') %}
            mdi:weather-snowy-rainy
          {% elif is_state('sensor.dark_sky_icon', 'wind') %}
            mdi:weather-windy-variant
          {% elif is_state('sensor.dark_sky_icon', 'fog') %}
            mdi:weather-fog
          {% elif is_state('sensor.dark_sky_icon', 'cloudy') %}
            mdi:weather-cloudy
          {% elif is_state('sensor.dark_sky_icon', 'partly-cloudy-day') or is_state('sensor.dark_sky_icon', 'partly-cloudy-night') %}
            mdi:weather-partlycloudy
          {% elif is_state('sensor.dark_sky_icon', 'hail') %}
            mdi:weather-hail
          {% elif is_state('sensor.dark_sky_icon', 'thunderstorm') %}
            mdi:weather-lightning
          {% else %}
            mdi:help-circle
          {% endif %}
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
