### PR TITLE
Added send packet service to broadlink component

### DIFF
--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -28,7 +28,9 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "broadlink"
 DEFAULT_NAME = 'Broadlink switch'
 DEFAULT_TIMEOUT = 10
+DEFAULT_RETRY = 3
 SERVICE_LEARN = "learn_command"
+SERVICE_SEND = "send_packet"
 
 RM_TYPES = ["rm", "rm2", "rm_mini", "rm_pro_phicomm", "rm2_home_plus",
             "rm2_home_plus_gdt", "rm2_pro_plus", "rm2_pro_plus2",
@@ -101,10 +103,30 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                              "Did not received any signal",
                                              title='Broadlink switch')
 
+    @asyncio.coroutine
+    def _send_packet(call):
+        packets = call.data.get('packet', [])
+        for packet in packets:
+            for retry in range(DEFAULT_RETRY):
+                try:
+                    payload = b64decode(packet)
+                    yield from hass.loop.run_in_executor(
+                        None, broadlink_device.send_data, payload)
+                    break
+                except (socket.timeout, ValueError):
+                    try:
+                        yield from hass.loop.run_in_executor(
+                            None, broadlink_device.auth)
+                    except socket.timeout:
+                        if retry == DEFAULT_RETRY-1:
+                            _LOGGER.error("Failed to send packet to device.")
+
     if switch_type in RM_TYPES:
         broadlink_device = broadlink.rm((ip_addr, 80), mac_addr)
-        hass.services.register(DOMAIN, SERVICE_LEARN + '_' + ip_addr,
-                               _learn_command)
+        hass.services.register(DOMAIN, SERVICE_LEARN + '_' +
+                               ip_addr.replace('.', '_'), _learn_command)
+        hass.services.register(DOMAIN, SERVICE_SEND + '_' +
+                               ip_addr.replace('.', '_'), _send_packet)
         switches = []
         for object_id, device_config in devices.items():
             switches.append(


### PR DESCRIPTION
**Description:**

Added send_packet service to directly send ir packets/commands from scripts without the need to define a switch entity for each command.

I also changed the delimiter of the ip suffix of the learn_command service from '.' to '_' because otherwise the name convetion domain.servicename in the yaml config is invalid.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1980

**Example entry for `configuration.yaml` (if applicable):**
```yaml
script:
  tv_select_source:
    sequence:
      - service: broadlink.send_packet_192_168_0_107
        data:
          packet: 
            - "JgCMAJSSFDYUNhQ2FBEUERQRFBEUERQ2FDYUNhQRFBEUERQRFBEUERQRFDYUERQRFBEUERQRFDYUNhQRFDYUNhQ2FDYUNhQABfWUkhQ2FDYUNhQRFBEUERQRFBEUNhQ2FDYUERQRFBEUERQRFBEUERQ2FBEUERQRFBEUERQ2FDYUERQ2FDYUNhQ2FDYUAA0FAAAAAAAAAAAAAAAA"
            - "JgBGAJSTFDUUNhM2ExITEhMSExITEhM2EzYTNhQRFBEUERQRFBEUNRQ2ExITNhMSExITNhMSExITEhM2ExITNhQ1FBEUNhMADQUAAA=="
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
