### PR TITLE
TTS ID3 support

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -76,6 +76,7 @@ SCHEMA_SERVICE_CLEAR_CACHE = vol.Schema({})
 
 REQUIREMENTS = ["pytaglib==1.4.0"]
 
+
 @asyncio.coroutine
 def async_setup(hass, config):
     """Setup TTS."""
@@ -324,8 +325,13 @@ class SpeechManager(object):
         # create file infos
         filename = ("{}.{}".format(key, extension)).lower()
 
-        data = yield from self.async_write_id3_tags(filename, data, provider,
-                                                    message, language, options)
+        data = yield from self.hass.loop.run_in_executor(None,
+                                                         write_tags(filename,
+                                                                    data,
+                                                                    provider,
+                                                                    message,
+                                                                    language,
+                                                                    options))
 
         # save to memory
         self._async_store_to_memcache(key, filename, data)
@@ -416,28 +422,27 @@ class SpeechManager(object):
         content, _ = mimetypes.guess_type(filename)
         return (content, self.mem_cache[key][MEM_CACHE_VOICE])
 
-    @asyncio.coroutine
-    def async_write_id3_tags(self, filename, data, provider, message,
-                             language, options):
-        """Write ID3 tags to file."""
-        import tempfile
-        import taglib
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            voice_file = os.path.join(tmpdirname, filename)
-            with open(voice_file, 'wb') as speech:
-                speech.write(data)
+def write_tags(filename, data, provider, message, language, options):
+    """Write ID3 tags to file."""
+    import tempfile
+    import taglib
 
-            options = options or provider.default_options
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        voice_file = os.path.join(tmpdirname, filename)
+        with open(voice_file, 'wb') as speech:
+            speech.write(data)
 
-            tts = taglib.File(voice_file)
-            tts.tags['ARTIST'] = [options.get('voice', language)]
-            tts.tags['ALBUM'] = [provider.provider_name]
-            tts.tags['TITLE'] = [message]
-            tts.save()
+        options = options or provider.default_options
 
-            with open(voice_file, 'rb') as speech:
-                return speech.read()
+        tts = taglib.File(voice_file)  # pylint: disable=no-member
+        tts.tags['ARTIST'] = [options.get('voice', language)]
+        tts.tags['ALBUM'] = [provider.provider_name]
+        tts.tags['TITLE'] = [message]
+        tts.save()
+
+        with open(voice_file, 'rb') as speech:
+            return speech.read()
 
 
 class Provider(object):

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -429,11 +429,21 @@ def write_tags(filename, data, provider, message, language, options):
     data_bytes.write(data)
     data_bytes.seek(0)
 
-    tts = mutagen.File(data_bytes, easy=True)
-    tts.tags['artist'] = options.get('voice', language)
-    tts.tags['album'] = provider.provider_name
-    tts.tags['title'] = message
-    tts.save(data_bytes)
+    artist = language
+    if options is not None:
+        if options.get('voice') is not None:
+            artist = options.get('voice')
+
+    if provider.default_options is not None:
+        if provider.default_options.get('voice') is not None:
+            artist = provider.default_options.get('voice')
+
+    tts_file = mutagen.File(data_bytes, easy=True)
+    if tts_file is not None:
+        tts_file.tags['artist'] = artist
+        tts_file.tags['album'] = provider.provider_name
+        tts_file.tags['title'] = message
+        tts_file.save(data_bytes)
     return data_bytes.getvalue()
 
 

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -325,8 +325,8 @@ class SpeechManager(object):
         # create file infos
         filename = ("{}.{}".format(key, extension)).lower()
 
-        data = yield from write_tags(filename, data, provider, message,
-                                     language, options)
+        data = yield from write_tags(filename, data, engine, provider,
+                                     message, language, options)
 
         # save to memory
         self._async_store_to_memcache(key, filename, data)
@@ -419,7 +419,8 @@ class SpeechManager(object):
 
 
 @asyncio.coroutine
-def write_tags(filename, data, provider, message, language, options):
+def write_tags(filename, data, engine, provider,
+               message, language, options):
     """Write ID3 tags to file."""
     import mutagen
     import io
@@ -441,7 +442,7 @@ def write_tags(filename, data, provider, message, language, options):
     tts_file = mutagen.File(data_bytes, easy=True)
     if tts_file is not None:
         tts_file.tags['artist'] = artist
-        tts_file.tags['album'] = provider.provider_name
+        tts_file.tags['album'] = provider.provider_name or engine
         tts_file.tags['title'] = message
         tts_file.save(data_bytes)
     return data_bytes.getvalue()

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -16,7 +16,6 @@ import io
 
 from aiohttp import web
 import voluptuous as vol
-import mutagen
 
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.bootstrap import async_prepare_setup_platform
@@ -437,6 +436,8 @@ def write_tags(filename, data, engine, provider,
     if provider.default_options is not None:
         if provider.default_options.get('voice') is not None:
             artist = provider.default_options.get('voice')
+
+    import mutagen
 
     tts_file = mutagen.File(data_bytes, easy=True)
     if tts_file is not None:

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -12,9 +12,11 @@ import logging
 import mimetypes
 import os
 import re
+import io
 
 from aiohttp import web
 import voluptuous as vol
+import mutagen
 
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.bootstrap import async_prepare_setup_platform
@@ -418,13 +420,10 @@ class SpeechManager(object):
         return (content, self.mem_cache[key][MEM_CACHE_VOICE])
 
 
-@asyncio.coroutine
+@callback
 def write_tags(filename, data, engine, provider,
                message, language, options):
     """Write ID3 tags to file."""
-    import mutagen
-    import io
-
     data_bytes = io.BytesIO()
 
     data_bytes.write(data)

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -429,20 +429,26 @@ def write_tags(filename, data, engine, provider,
     data_bytes.seek(0)
 
     artist = language
-    if options is not None:
-        if options.get('voice') is not None:
-            artist = options.get('voice')
 
     if provider.default_options is not None:
         if provider.default_options.get('voice') is not None:
             artist = provider.default_options.get('voice')
+
+    if options is not None:
+        if options.get('voice') is not None:
+            artist = options.get('voice')
+
+    album = engine
+
+    if hasattr(provider, 'provider_name'):
+        album = provider.provider_name
 
     import mutagen
 
     tts_file = mutagen.File(data_bytes, easy=True)
     if tts_file is not None:
         tts_file.tags['artist'] = artist
-        tts_file.tags['album'] = provider.provider_name or engine
+        tts_file.tags['album'] = album
         tts_file.tags['title'] = message
         tts_file.save(data_bytes)
     return data_bytes.getvalue()

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -327,7 +327,7 @@ class SpeechManager(object):
         # create file infos
         filename = ("{}.{}".format(key, extension)).lower()
 
-        data = self._write_tags(
+        data = self.write_tags(
             filename, data, engine, provider, message, language, options)
 
         # save to memory
@@ -420,7 +420,7 @@ class SpeechManager(object):
         return (content, self.mem_cache[key][MEM_CACHE_VOICE])
 
     @staticmethod
-    def _write_tags(filename, data, engine, provider, message, language,
+    def write_tags(filename, data, engine, provider, message, language,
                     options):
         """Write ID3 tags to file.
 

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -279,6 +279,8 @@ class SpeechManager(object):
                 language))
 
         # options
+        if provider.default_options and options:
+            options = provider.default_options.copy().update(options)
         options = options or provider.default_options
         if options is not None:
             invalid_opts = [opt_name for opt_name in options.keys()
@@ -326,8 +328,8 @@ class SpeechManager(object):
         # create file infos
         filename = ("{}.{}".format(key, extension)).lower()
 
-        data = yield from write_tags(filename, data, engine, provider,
-                                     message, language, options)
+        data = write_tags(
+            filename, data, engine, provider, message, language, options)
 
         # save to memory
         self._async_store_to_memcache(key, filename, data)
@@ -430,10 +432,6 @@ def write_tags(filename, data, engine, provider,
 
     artist = language
 
-    if provider.default_options is not None:
-        if provider.default_options.get('voice') is not None:
-            artist = provider.default_options.get('voice')
-
     if options is not None:
         if options.get('voice') is not None:
             artist = options.get('voice')
@@ -458,6 +456,7 @@ class Provider(object):
     """Represent a single provider."""
 
     hass = None
+    provider_name = None
 
     @property
     def default_language(self):

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -443,9 +443,9 @@ class SpeechManager(object):
         try:
             tts_file = mutagen.File(data_bytes, easy=True)
             if tts_file is not None:
-                tts_file.tags['artist'] = artist
-                tts_file.tags['album'] = album
-                tts_file.tags['title'] = message
+                tts_file['artist'] = artist
+                tts_file['album'] = album
+                tts_file['title'] = message
                 tts_file.save(data_bytes)
         except mutagen.MutagenError as err:
             _LOGGER.error("ID3 tag error: %s", err)

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -31,6 +31,7 @@ import homeassistant.helpers.config_validation as cv
 
 DOMAIN = 'tts'
 DEPENDENCIES = ['http']
+REQUIREMENTS = ["mutagen==1.36.2"]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,8 +75,6 @@ SCHEMA_SERVICE_SAY = vol.Schema({
 })
 
 SCHEMA_SERVICE_CLEAR_CACHE = vol.Schema({})
-
-REQUIREMENTS = ["mutagen==1.36.2"]
 
 
 @asyncio.coroutine

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -419,7 +419,8 @@ class SpeechManager(object):
         content, _ = mimetypes.guess_type(filename)
         return (content, self.mem_cache[key][MEM_CACHE_VOICE])
 
-    def _write_tags(self, filename, data, engine, provider, message, language,
+    @staticmethod
+    def _write_tags(filename, data, engine, provider, message, language,
                     options):
         """Write ID3 tags to file.
 

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -428,8 +428,7 @@ class SpeechManager(object):
         """
         import mutagen
 
-        data_bytes = io.BytesIO()
-        data_bytes.write(data)
+        data_bytes = io.BytesIO(data)
         data_bytes.seek(0)
 
         artist = language
@@ -443,7 +442,7 @@ class SpeechManager(object):
         if hasattr(provider, 'provider_name'):
             album = provider.provider_name
 
-        tts_file = mutagen.File(data_bytes, easy=True)
+        tts_file = mutagen.File(fileobj=data_bytes, easy=True)
         if tts_file is not None:
             tts_file.tags['artist'] = artist
             tts_file.tags['album'] = album

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -429,6 +429,7 @@ class SpeechManager(object):
         import mutagen
 
         data_bytes = io.BytesIO(data)
+        data_bytes.name = filename
         data_bytes.seek(0)
 
         artist = language
@@ -442,7 +443,7 @@ class SpeechManager(object):
         if hasattr(provider, 'provider_name'):
             album = provider.provider_name
 
-        tts_file = mutagen.File(fileobj=data_bytes, easy=True)
+        tts_file = mutagen.File(data_bytes, easy=True)
         if tts_file is not None:
             tts_file.tags['artist'] = artist
             tts_file.tags['album'] = album

--- a/homeassistant/components/tts/amazon_polly.py
+++ b/homeassistant/components/tts/amazon_polly.py
@@ -138,6 +138,7 @@ class AmazonPollyProvider(Provider):
         self.supported_langs = supported_languages
         self.all_voices = all_voices
         self.default_voice = self.config.get(CONF_VOICE)
+        self.provider_name = 'Amazon Polly'
 
     @property
     def supported_languages(self):

--- a/homeassistant/components/tts/amazon_polly.py
+++ b/homeassistant/components/tts/amazon_polly.py
@@ -138,7 +138,7 @@ class AmazonPollyProvider(Provider):
         self.supported_langs = supported_languages
         self.all_voices = all_voices
         self.default_voice = self.config.get(CONF_VOICE)
-        self.provider_name = 'Amazon Polly'
+        self.name = 'Amazon Polly'
 
     @property
     def supported_languages(self):

--- a/homeassistant/components/tts/demo.py
+++ b/homeassistant/components/tts/demo.py
@@ -32,6 +32,7 @@ class DemoProvider(Provider):
     def __init__(self, lang):
         """Initialize demo provider."""
         self._lang = lang
+        self.provider_name = 'Demo'
 
     @property
     def default_language(self):

--- a/homeassistant/components/tts/demo.py
+++ b/homeassistant/components/tts/demo.py
@@ -32,7 +32,7 @@ class DemoProvider(Provider):
     def __init__(self, lang):
         """Initialize demo provider."""
         self._lang = lang
-        self.provider_name = 'Demo'
+        self.name = 'Demo'
 
     @property
     def default_language(self):

--- a/homeassistant/components/tts/google.py
+++ b/homeassistant/components/tts/google.py
@@ -58,6 +58,7 @@ class GoogleProvider(Provider):
                            "AppleWebKit/537.36 (KHTML, like Gecko) "
                            "Chrome/47.0.2526.106 Safari/537.36")
         }
+        self.provider_name = 'Google'
 
     @property
     def default_language(self):

--- a/homeassistant/components/tts/google.py
+++ b/homeassistant/components/tts/google.py
@@ -58,7 +58,7 @@ class GoogleProvider(Provider):
                            "AppleWebKit/537.36 (KHTML, like Gecko) "
                            "Chrome/47.0.2526.106 Safari/537.36")
         }
-        self.provider_name = 'Google'
+        self.name = 'Google'
 
     @property
     def default_language(self):

--- a/homeassistant/components/tts/picotts.py
+++ b/homeassistant/components/tts/picotts.py
@@ -38,6 +38,7 @@ class PicoProvider(Provider):
     def __init__(self, lang):
         """Initialize Pico TTS provider."""
         self._lang = lang
+        self.provider_name = 'PicoTTS'
 
     @property
     def default_language(self):

--- a/homeassistant/components/tts/picotts.py
+++ b/homeassistant/components/tts/picotts.py
@@ -38,7 +38,7 @@ class PicoProvider(Provider):
     def __init__(self, lang):
         """Initialize Pico TTS provider."""
         self._lang = lang
-        self.provider_name = 'PicoTTS'
+        self.name = 'PicoTTS'
 
     @property
     def default_language(self):

--- a/homeassistant/components/tts/voicerss.py
+++ b/homeassistant/components/tts/voicerss.py
@@ -95,6 +95,7 @@ class VoiceRSSProvider(Provider):
         self.hass = hass
         self._extension = conf[CONF_CODEC]
         self._lang = conf[CONF_LANG]
+        self.provider_name = 'VoiceRSS'
 
         self._form_data = {
             'key': conf[CONF_API_KEY],

--- a/homeassistant/components/tts/voicerss.py
+++ b/homeassistant/components/tts/voicerss.py
@@ -95,7 +95,7 @@ class VoiceRSSProvider(Provider):
         self.hass = hass
         self._extension = conf[CONF_CODEC]
         self._lang = conf[CONF_LANG]
-        self.provider_name = 'VoiceRSS'
+        self.name = 'VoiceRSS'
 
         self._form_data = {
             'key': conf[CONF_API_KEY],

--- a/homeassistant/components/tts/yandextts.py
+++ b/homeassistant/components/tts/yandextts.py
@@ -82,6 +82,7 @@ class YandexSpeechKitProvider(Provider):
         self._language = conf.get(CONF_LANG)
         self._emotion = conf.get(CONF_EMOTION)
         self._speed = str(conf.get(CONF_SPEED))
+        self.provider_name = 'YandexTTS'
 
     @property
     def default_language(self):

--- a/homeassistant/components/tts/yandextts.py
+++ b/homeassistant/components/tts/yandextts.py
@@ -82,7 +82,7 @@ class YandexSpeechKitProvider(Provider):
         self._language = conf.get(CONF_LANG)
         self._emotion = conf.get(CONF_EMOTION)
         self._speed = str(conf.get(CONF_SPEED))
-        self.provider_name = 'YandexTTS'
+        self.name = 'YandexTTS'
 
     @property
     def default_language(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -328,6 +328,9 @@ mficlient==0.3.0
 # homeassistant.components.sensor.miflora
 miflora==0.1.15
 
+# homeassistant.components.tts
+mutagen==1.36.2
+
 # homeassistant.components.sensor.usps
 myusps==1.0.2
 
@@ -506,9 +509,6 @@ pysma==0.1.3
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
 pysnmp==4.3.3
-
-# homeassistant.components.tts
-pytaglib==1.4.0
 
 # homeassistant.components.digital_ocean
 python-digitalocean==1.10.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -507,6 +507,9 @@ pysma==0.1.3
 # homeassistant.components.sensor.snmp
 pysnmp==4.3.3
 
+# homeassistant.components.tts
+pytaglib==1.4.0
+
 # homeassistant.components.digital_ocean
 python-digitalocean==1.10.1
 

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -2,7 +2,7 @@
 import ctypes
 import os
 import shutil
-from unittest.mock import patch, PropertyMock, MagicMock
+from unittest.mock import patch, PropertyMock
 
 import requests
 
@@ -341,12 +341,10 @@ class TestTTS(object):
         assert len(calls) == 1
         req = requests.get(calls[0].data[ATTR_MEDIA_CONTENT_ID])
         _, demo_data = self.demo_provider.get_tts_audio("bla", 'en')
-        prov_mock = MagicMock()
-        prov_mock.provider_name = 'Demo'
         demo_data = tts.SpeechManager.write_tags(
             "265944c108cbb00b2a621be5930513e03a0bb2cd_en_-_demo.mp3",
-            demo_data, prov_mock, "I person is on front of your door.",
-            'en', None)
+            demo_data, self.demo_provider,
+            "I person is on front of your door.", 'en', None)
         assert req.status_code == 200
         assert req.content == demo_data
 
@@ -374,12 +372,10 @@ class TestTTS(object):
         assert len(calls) == 1
         req = requests.get(calls[0].data[ATTR_MEDIA_CONTENT_ID])
         _, demo_data = self.demo_provider.get_tts_audio("bla", "de")
-        prov_mock = MagicMock()
-        prov_mock.provider_name = 'Demo'
         demo_data = tts.SpeechManager.write_tags(
             "265944c108cbb00b2a621be5930513e03a0bb2cd_de_-_demo.mp3",
-            demo_data, prov_mock, "I person is on front of your door.",
-            'de', None)
+            demo_data, self.demo_provider,
+            "I person is on front of your door.", 'de', None)
         assert req.status_code == 200
         assert req.content == demo_data
 

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -2,7 +2,7 @@
 import ctypes
 import os
 import shutil
-from unittest.mock import patch, PropertyMock
+from unittest.mock import patch, PropertyMock, MagicMock
 
 import requests
 
@@ -341,6 +341,12 @@ class TestTTS(object):
         assert len(calls) == 1
         req = requests.get(calls[0].data[ATTR_MEDIA_CONTENT_ID])
         _, demo_data = self.demo_provider.get_tts_audio("bla", 'en')
+        prov_mock = MagicMock()
+        prov_mock.provider_name = 'Demo'
+        demo_data = tts.SpeechManager.write_tags(
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_en_-_demo.mp3",
+            demo_data, prov_mock, "I person is on front of your door.",
+            'en', None)
         assert req.status_code == 200
         assert req.content == demo_data
 
@@ -351,6 +357,7 @@ class TestTTS(object):
         config = {
             tts.DOMAIN: {
                 'platform': 'demo',
+                'language': 'de',
             }
         }
 
@@ -367,6 +374,12 @@ class TestTTS(object):
         assert len(calls) == 1
         req = requests.get(calls[0].data[ATTR_MEDIA_CONTENT_ID])
         _, demo_data = self.demo_provider.get_tts_audio("bla", "de")
+        prov_mock = MagicMock()
+        prov_mock.provider_name = 'Demo'
+        demo_data = tts.SpeechManager.write_tags(
+            "265944c108cbb00b2a621be5930513e03a0bb2cd_de_-_demo.mp3",
+            demo_data, prov_mock, "I person is on front of your door.",
+            'de', None)
         assert req.status_code == 200
         assert req.content == demo_data
 


### PR DESCRIPTION
**Description:** This adds support for writing ID3 tags to TTS files so that they display better on media players like Sonos (or those that visually display the current playing track metadata). This works whether caching the file or not.

I used Mutagen because it has support for all the formats we currently have and seems to be well adopted (and doesn't require an external library like PyTagLib)

@pvizeli Can you take a look at this?

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
