### PR TITLE
Don't thow exception if connection to server is lost

### DIFF
--- a/homeassistant/components/sensor/tellduslive.py
+++ b/homeassistant/components/sensor/tellduslive.py
@@ -85,7 +85,9 @@ class TelldusLiveSensor(TelldusLiveEntity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        if self._type == SENSOR_TYPE_TEMP:
+        if not self.available:
+            return None
+        elif self._type == SENSOR_TYPE_TEMP:
             return self._value_as_temperature
         elif self._type == SENSOR_TYPE_HUMIDITY:
             return self._value_as_humidity

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -17,7 +17,7 @@ import voluptuous as vol
 
 DOMAIN = 'tellduslive'
 
-REQUIREMENTS = ['tellduslive==0.3.0']
+REQUIREMENTS = ['tellduslive==0.3.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -636,7 +636,7 @@ steamodd==4.21
 tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
-tellduslive==0.3.0
+tellduslive==0.3.2
 
 # homeassistant.components.sensor.temper
 temperusb==1.5.1


### PR DESCRIPTION
**Description:**
Don't thow exception if connection to server is lost
Fixes bug reported in https://community.home-assistant.io/t/ble-and-telldus-live-errors-on-new-hass-0-35-3-install-on-rpi3-aio/8859/9

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://community.home-assistant.io/t/ble-and-telldus-live-errors-on-new-hass-0-35-3-install-on-rpi3-aio/8859/9

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
