### PR TITLE
Fix brightness slider for mqtt template lights

### DIFF
--- a/homeassistant/components/light/mqtt_template.py
+++ b/homeassistant/components/light/mqtt_template.py
@@ -284,3 +284,16 @@ class MqttTemplate(Light):
 
         if self._optimistic:
             self.schedule_update_ha_state()
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        features = 0
+        if self._brightness is not None:
+            features = features | SUPPORT_BRIGHTNESS
+        if self._rgb is not None:
+            features = features | SUPPORT_RGB_COLOR
+        if self._effect_list is not None:
+            features = features | SUPPORT_EFFECT
+
+        return features


### PR DESCRIPTION
**Description:**
Add the missing supported_features declaration in mqtt_template to enable the brightness slider in the UI. Also declares if Effects or RGB are supported but this doesn't seem to have any effect.

**Related issue (if applicable):** fixes #5714

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
