### PR TITLE
Add mysensors device tracker and platform discovery

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -139,8 +139,13 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
         yield from asyncio.wait(update_tasks, loop=hass.loop)
 
     @asyncio.coroutine
-    def async_setup_platform(p_type, p_config, disc_info=None):
+    def async_setup_platform(p_type, p_config=None, disc_info=None):
         """Setup a device tracker platform."""
+        if p_config is None:
+            p_config = {}
+        if disc_info is None:
+            disc_info = {}
+
         platform = yield from async_prepare_setup_platform(
             hass, config, DOMAIN, p_type)
         if platform is None:
@@ -158,10 +163,11 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
                     None, platform.get_scanner, hass, {DOMAIN: p_config})
             elif hasattr(platform, 'async_setup_scanner'):
                 setup = yield from platform.async_setup_scanner(
-                    hass, p_config, tracker.async_see)
+                    hass, p_config, tracker.async_see, disc_info)
             elif hasattr(platform, 'setup_scanner'):
                 setup = yield from hass.loop.run_in_executor(
-                    None, platform.setup_scanner, hass, p_config, tracker.see)
+                    None, platform.setup_scanner, hass, p_config, tracker.see,
+                    disc_info)
             else:
                 raise HomeAssistantError("Invalid device_tracker platform.")
 
@@ -192,6 +198,13 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
 
     discovery.async_listen(
         hass, DISCOVERY_PLATFORMS.keys(), async_device_tracker_discovered)
+
+    @asyncio.coroutine
+    def async_platform_discovered(platform, info):
+        """Callback to load a platform."""
+        yield from async_setup_platform(platform, disc_info=info)
+
+    discovery.async_listen_platform(hass, DOMAIN, async_platform_discovered)
 
     # Clean up stale devices
     async_track_utc_time_change(

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -139,13 +139,8 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
         yield from asyncio.wait(update_tasks, loop=hass.loop)
 
     @asyncio.coroutine
-    def async_setup_platform(p_type, p_config=None, disc_info=None):
+    def async_setup_platform(p_type, p_config, disc_info=None):
         """Setup a device tracker platform."""
-        if p_config is None:
-            p_config = {}
-        if disc_info is None:
-            disc_info = {}
-
         platform = yield from async_prepare_setup_platform(
             hass, config, DOMAIN, p_type)
         if platform is None:
@@ -202,7 +197,7 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
     @asyncio.coroutine
     def async_platform_discovered(platform, info):
         """Callback to load a platform."""
-        yield from async_setup_platform(platform, disc_info=info)
+        yield from async_setup_platform(platform, {}, disc_info=info)
 
     discovery.async_listen_platform(hass, DOMAIN, async_platform_discovered)
 

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -49,7 +49,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_scanner(hass, config: dict, see):
+def setup_scanner(hass, config: dict, see, discovery_info=None):
     """Validate the configuration and return an Automatic scanner."""
     try:
         AutomaticDeviceScanner(hass, config, see)

--- a/homeassistant/components/device_tracker/bluetooth_le_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_le_tracker.py
@@ -25,7 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_scanner(hass, config, see):
+def setup_scanner(hass, config, see, discovery_info=None):
     """Setup the Bluetooth LE Scanner."""
     # pylint: disable=import-error
     from gattlib import DiscoveryService

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -21,7 +21,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_scanner(hass, config, see):
+def setup_scanner(hass, config, see, discovery_info=None):
     """Setup the Bluetooth Scanner."""
     # pylint: disable=import-error
     import bluetooth

--- a/homeassistant/components/device_tracker/demo.py
+++ b/homeassistant/components/device_tracker/demo.py
@@ -4,7 +4,7 @@ import random
 from homeassistant.components.device_tracker import DOMAIN
 
 
-def setup_scanner(hass, config, see):
+def setup_scanner(hass, config, see, discovery_info=None):
     """Setup the demo tracker."""
     def offset():
         """Return random offset."""

--- a/homeassistant/components/device_tracker/gpslogger.py
+++ b/homeassistant/components/device_tracker/gpslogger.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['http']
 
 
-def setup_scanner(hass, config, see):
+def setup_scanner(hass, config, see, discovery_info=None):
     """Setup an endpoint for the GPSLogger application."""
     hass.http.register_view(GPSLoggerView(see))
 

--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -71,7 +71,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_scanner(hass, config: dict, see):
+def setup_scanner(hass, config: dict, see, discovery_info=None):
     """Set up the iCloud Scanner."""
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)

--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['http']
 
 
-def setup_scanner(hass, config, see):
+def setup_scanner(hass, config, see, discovery_info=None):
     """Setup an endpoint for the Locative application."""
     hass.http.register_view(LocativeView(see))
 

--- a/homeassistant/components/device_tracker/mqtt.py
+++ b/homeassistant/components/device_tracker/mqtt.py
@@ -23,7 +23,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(mqtt.SCHEMA_BASE).extend({
 })
 
 
-def setup_scanner(hass, config, see):
+def setup_scanner(hass, config, see, discovery_info=None):
     """Setup the MQTT tracker."""
     devices = config[CONF_DEVICES]
     qos = config[CONF_QOS]

--- a/homeassistant/components/device_tracker/mysensors.py
+++ b/homeassistant/components/device_tracker/mysensors.py
@@ -6,23 +6,13 @@ https://home-assistant.io/components/device_tracker.mysensors/
 """
 import logging
 
-import voluptuous as vol
-
 from homeassistant.components import mysensors
-from homeassistant.components.device_tracker import PLATFORM_SCHEMA
 from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
-DEPENDENCIES = ['mysensors']
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_MAX_GPS_ACCURACY, default=0): vol.Coerce(float),
-})
-
-
-def setup_scanner(hass, config, see):
+def setup_scanner(hass, config, see, discovery_info=None):
     """Setup the MySensors tracker."""
     def mysensors_callback(gateway, node_id):
         """Callback for mysensors platform."""
@@ -33,7 +23,8 @@ def setup_scanner(hass, config, see):
 
         pres = gateway.const.Presentation
         set_req = gateway.const.SetReq
-        max_gps_accuracy = config[CONF_MAX_GPS_ACCURACY]
+        max_gps_accuracy = discovery_info.get(
+            mysensors.CONF_MAX_GPS_ACCURACY, 0.0)
 
         for child in node.children.values():
             position = child.values.get(set_req.V_POSITION)

--- a/homeassistant/components/device_tracker/mysensors.py
+++ b/homeassistant/components/device_tracker/mysensors.py
@@ -1,0 +1,71 @@
+"""
+Support for tracking MySensors devices.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.mysensors/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components import mysensors
+from homeassistant.components.device_tracker import PLATFORM_SCHEMA
+from homeassistant.util import slugify
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
+DEPENDENCIES = ['mysensors']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_MAX_GPS_ACCURACY, default=0): vol.Coerce(float),
+})
+
+
+def setup_scanner(hass, config, see):
+    """Setup the MySensors tracker."""
+    def mysensors_callback(gateway, node_id):
+        """Callback for mysensors platform."""
+        node = gateway.sensors[node_id]
+        if node.sketch_name is None:
+            _LOGGER.info('No sketch_name: node %s', node_id)
+            return
+
+        pres = gateway.const.Presentation
+        set_req = gateway.const.SetReq
+        max_gps_accuracy = config[CONF_MAX_GPS_ACCURACY]
+
+        for child in node.children.values():
+            position = child.values.get(set_req.V_POSITION)
+            if child.type != pres.S_GPS or position is None:
+                continue
+            try:
+                latitude, longitude, _ = position.split(',')
+            except ValueError:
+                _LOGGER.error('Payload for V_POSITION %s is not of format '
+                              'latitude,longitude,altitude', position)
+                continue
+            name = '{} {} {}'.format(
+                node.sketch_name, node_id, child.id)
+            attr = {
+                mysensors.ATTR_CHILD_ID: child.id,
+                mysensors.ATTR_DESCRIPTION: child.description,
+                mysensors.ATTR_DEVICE: gateway.device,
+                mysensors.ATTR_NODE_ID: node_id,
+            }
+            see(
+                dev_id=slugify(name),
+                host_name=name,
+                gps=(latitude, longitude),
+                gps_accuracy=max_gps_accuracy,
+                battery=node.battery_level,
+                attributes=attr
+            )
+
+    gateways = hass.data.get(mysensors.MYSENSORS_GATEWAYS)
+    if not gateways:
+        return
+    for gateway in gateways:
+        gateway.platform_callbacks.append(mysensors_callback)
+
+    return True

--- a/homeassistant/components/device_tracker/mysensors.py
+++ b/homeassistant/components/device_tracker/mysensors.py
@@ -9,6 +9,8 @@ import logging
 from homeassistant.components import mysensors
 from homeassistant.util import slugify
 
+DEPENDENCIES = ['mysensors']
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -51,8 +53,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
             )
 
     gateways = hass.data.get(mysensors.MYSENSORS_GATEWAYS)
-    if not gateways:
-        return
+
     for gateway in gateways:
         gateway.platform_callbacks.append(mysensors_callback)
 

--- a/homeassistant/components/device_tracker/mysensors.py
+++ b/homeassistant/components/device_tracker/mysensors.py
@@ -23,8 +23,6 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
         pres = gateway.const.Presentation
         set_req = gateway.const.SetReq
-        max_gps_accuracy = discovery_info.get(
-            mysensors.CONF_MAX_GPS_ACCURACY, 0.0)
 
         for child in node.children.values():
             position = child.values.get(set_req.V_POSITION)
@@ -48,7 +46,6 @@ def setup_scanner(hass, config, see, discovery_info=None):
                 dev_id=slugify(name),
                 host_name=name,
                 gps=(latitude, longitude),
-                gps_accuracy=max_gps_accuracy,
                 battery=node.battery_level,
                 attributes=attr
             )

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -71,7 +71,7 @@ def get_cipher():
     return (KEYLEN, decrypt)
 
 
-def setup_scanner(hass, config, see):
+def setup_scanner(hass, config, see, discovery_info=None):
     """Set up an OwnTracks tracker."""
     max_gps_accuracy = config.get(CONF_MAX_GPS_ACCURACY)
     waypoint_import = config.get(CONF_WAYPOINT_IMPORT)

--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -73,7 +73,7 @@ class Host:
         _LOGGER.debug("ping KO on ip=%s failed=%d", self.ip_address, failed)
 
 
-def setup_scanner(hass, config, see):
+def setup_scanner(hass, config, see, discovery_info=None):
     """Setup the Host objects and return the update function."""
     hosts = [Host(ip, dev_id, hass, config) for (dev_id, ip) in
              config[const.CONF_HOSTS].items()]

--- a/homeassistant/components/device_tracker/trackr.py
+++ b/homeassistant/components/device_tracker/trackr.py
@@ -23,7 +23,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_scanner(hass, config: dict, see):
+def setup_scanner(hass, config: dict, see, discovery_info=None):
     """Validate the configuration and return a TrackR scanner."""
     TrackRDeviceScanner(hass, config, see)
     return True

--- a/homeassistant/components/device_tracker/volvooncall.py
+++ b/homeassistant/components/device_tracker/volvooncall.py
@@ -30,7 +30,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_scanner(hass, config, see):
+def setup_scanner(hass, config, see, discovery_info=None):
     """Validate the configuration and return a scanner."""
     from volvooncall import Connection
     connection = Connection(

--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -31,6 +31,7 @@ CONF_BAUD_RATE = 'baud_rate'
 CONF_DEVICE = 'device'
 CONF_DEBUG = 'debug'
 CONF_GATEWAYS = 'gateways'
+CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
 CONF_PERSISTENCE = 'persistence'
 CONF_PERSISTENCE_FILE = 'persistence_file'
 CONF_TCP_PORT = 'tcp_port'
@@ -126,6 +127,7 @@ CONFIG_SCHEMA = vol.Schema({
             }]
         ),
         vol.Optional(CONF_DEBUG, default=False): cv.boolean,
+        vol.Optional(CONF_MAX_GPS_ACCURACY, default=0): vol.Coerce(float),
         vol.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
         vol.Optional(CONF_PERSISTENCE, default=True): cv.boolean,
         vol.Optional(CONF_RETAIN, default=True): cv.boolean,
@@ -140,6 +142,7 @@ def setup(hass, config):
 
     version = config[DOMAIN].get(CONF_VERSION)
     persistence = config[DOMAIN].get(CONF_PERSISTENCE)
+    gps_accuracy = config[DOMAIN].get(CONF_MAX_GPS_ACCURACY)
 
     def setup_gateway(device, persistence_file, baud_rate, tcp_port, in_prefix,
                       out_prefix):
@@ -233,6 +236,10 @@ def setup(hass, config):
     for component in ['sensor', 'switch', 'light', 'binary_sensor', 'climate',
                       'cover']:
         discovery.load_platform(hass, component, DOMAIN, {}, config)
+
+    discovery.load_platform(
+        hass, 'device_tracker', DOMAIN, {CONF_MAX_GPS_ACCURACY: gps_accuracy},
+        config)
 
     discovery.load_platform(
         hass, 'notify', DOMAIN, {CONF_NAME: DOMAIN}, config)

--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -31,7 +31,6 @@ CONF_BAUD_RATE = 'baud_rate'
 CONF_DEVICE = 'device'
 CONF_DEBUG = 'debug'
 CONF_GATEWAYS = 'gateways'
-CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
 CONF_PERSISTENCE = 'persistence'
 CONF_PERSISTENCE_FILE = 'persistence_file'
 CONF_TCP_PORT = 'tcp_port'
@@ -127,7 +126,6 @@ CONFIG_SCHEMA = vol.Schema({
             }]
         ),
         vol.Optional(CONF_DEBUG, default=False): cv.boolean,
-        vol.Optional(CONF_MAX_GPS_ACCURACY, default=0): vol.Coerce(float),
         vol.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
         vol.Optional(CONF_PERSISTENCE, default=True): cv.boolean,
         vol.Optional(CONF_RETAIN, default=True): cv.boolean,
@@ -142,7 +140,6 @@ def setup(hass, config):
 
     version = config[DOMAIN].get(CONF_VERSION)
     persistence = config[DOMAIN].get(CONF_PERSISTENCE)
-    gps_accuracy = config[DOMAIN].get(CONF_MAX_GPS_ACCURACY)
 
     def setup_gateway(device, persistence_file, baud_rate, tcp_port, in_prefix,
                       out_prefix):
@@ -238,8 +235,7 @@ def setup(hass, config):
         discovery.load_platform(hass, component, DOMAIN, {}, config)
 
     discovery.load_platform(
-        hass, 'device_tracker', DOMAIN, {CONF_MAX_GPS_ACCURACY: gps_accuracy},
-        config)
+        hass, 'device_tracker', DOMAIN, {}, config)
 
     discovery.load_platform(
         hass, 'notify', DOMAIN, {CONF_NAME: DOMAIN}, config)

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -11,6 +11,7 @@ import os
 from homeassistant.components import zone
 from homeassistant.core import callback
 from homeassistant.bootstrap import setup_component
+from homeassistant.helpers import discovery
 from homeassistant.loader import get_component
 from homeassistant.util.async import run_coroutine_threadsafe
 import homeassistant.util.dt as dt_util
@@ -323,6 +324,23 @@ class TestComponentsDeviceTracker(unittest.TestCase):
                         self.hass, device_tracker.DOMAIN, TEST_PLATFORM)
                 fire_service_discovered(self.hass, 'test', {})
                 self.assertTrue(mock_scan.called)
+
+    @patch(
+        'homeassistant.components.device_tracker.DeviceTracker.see')
+    @patch(
+        'homeassistant.components.device_tracker.demo.setup_scanner',
+        autospec=True)
+    def test_discover_platform(self, mock_demo_setup_scanner, mock_see):
+        """Test discovery of device_tracker demo platform."""
+        assert device_tracker.DOMAIN not in self.hass.config.components
+        discovery.load_platform(
+            self.hass, device_tracker.DOMAIN, 'demo', {'test_key': 'test_val'},
+            {})
+        self.hass.block_till_done()
+        assert device_tracker.DOMAIN in self.hass.config.components
+        assert mock_demo_setup_scanner.called
+        assert mock_demo_setup_scanner.call_args[0] == (
+            self.hass, {}, mock_see, {'test_key': 'test_val'})
 
     def test_update_stale(self):
         """Test stalled update."""

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -33,7 +33,7 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
     def test_ensure_device_tracker_platform_validation(self): \
             # pylint: disable=invalid-name
         """Test if platform validation was done."""
-        def mock_setup_scanner(hass, config, see):
+        def mock_setup_scanner(hass, config, see, discovery_info=None):
             """Check that Qos was added by validation."""
             self.assertTrue('qos' in config)
 


### PR DESCRIPTION
**Description:**
* Add mysensors device_tracker platform
* Add discovery of device_tracker platforms
  * Enable discovery of device_tracker platforms that are not
    DeviceScanner.
  * Update signature of setup_scanner function in all affected platforms.
  * Add test.
  * Use discovery for mysensors device_tracker platform.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
https://github.com/home-assistant/home-assistant.github.io/pull/1986

**Example entry for `configuration.yaml` (if applicable):**
```yaml
mysensors:
  gateways:
    - device: '/dev/ttyACM0'
  version: 2.0
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
