### PR TITLE
Telegram webhooks

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -386,6 +386,7 @@ omit =
     homeassistant/components/switch/tplink.py
     homeassistant/components/switch/transmission.py
     homeassistant/components/switch/wake_on_lan.py
+    homeassistant/components/telegram_webhooks.py
     homeassistant/components/thingspeak.py
     homeassistant/components/tts/amazon_polly.py
     homeassistant/components/tts/picotts.py

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -109,7 +109,7 @@ class TelegramNotificationService(BaseNotificationService):
         elif data is not None and ATTR_DOCUMENT in data:
             return self.send_document(data.get(ATTR_DOCUMENT))
         elif data is not None and ATTR_KEYBOARD in data:
-            keys = data.get(ATTR_KEYBOARD, None)
+            keys = data.get(ATTR_KEYBOARD)
             keys = keys if isinstance(keys, list) else [keys]
             return self.send_keyboard(message, keys)
 
@@ -127,7 +127,6 @@ class TelegramNotificationService(BaseNotificationService):
                                  parse_mode=parse_mode)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending message")
-            return
 
     def send_keyboard(self, message, keys):
         """Display keyboard."""
@@ -140,7 +139,6 @@ class TelegramNotificationService(BaseNotificationService):
                                  reply_markup=keyboard)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending message")
-            return
 
     def send_photo(self, data):
         """Send a photo."""
@@ -159,7 +157,6 @@ class TelegramNotificationService(BaseNotificationService):
                                photo=photo, caption=caption)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending photo")
-            return
 
     def send_document(self, data):
         """Send a document."""
@@ -178,7 +175,6 @@ class TelegramNotificationService(BaseNotificationService):
                                   document=document, caption=caption)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending document")
-            return
 
     def send_location(self, gps):
         """Send a location."""
@@ -192,4 +188,3 @@ class TelegramNotificationService(BaseNotificationService):
                                   latitude=latitude, longitude=longitude)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending location")
-            return

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -22,6 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = ['python-telegram-bot==5.3.0']
 
 ATTR_PHOTO = 'photo'
+ATTR_KEYBOARD = 'keyboard'
 ATTR_DOCUMENT = 'document'
 ATTR_CAPTION = 'caption'
 ATTR_URL = 'url'
@@ -107,6 +108,10 @@ class TelegramNotificationService(BaseNotificationService):
             return self.send_location(data.get(ATTR_LOCATION))
         elif data is not None and ATTR_DOCUMENT in data:
             return self.send_document(data.get(ATTR_DOCUMENT))
+        elif data is not None and ATTR_KEYBOARD in data:
+            keys = data.get(ATTR_KEYBOARD, None)
+            keys = keys if isinstance(keys, list) else [keys]
+            return self.send_keyboard(message, keys)
 
         if title:
             text = '{} {}'.format(title, message)
@@ -120,6 +125,19 @@ class TelegramNotificationService(BaseNotificationService):
             self.bot.sendMessage(chat_id=self._chat_id,
                                  text=text,
                                  parse_mode=parse_mode)
+        except telegram.error.TelegramError:
+            _LOGGER.exception("Error sending message")
+            return
+
+    def send_keyboard(self, message, keys):
+        """Display keyboard."""
+        import telegram
+
+        keyboard = telegram.ReplyKeyboardMarkup([
+            [key.strip() for key in row.split(",")] for row in keys])
+        try:
+            self.bot.sendMessage(chat_id=self._chat_id, text=message,
+                                 reply_markup=keyboard)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending message")
             return

--- a/homeassistant/components/telegram_webhooks.py
+++ b/homeassistant/components/telegram_webhooks.py
@@ -67,7 +67,8 @@ def setup(hass, config):
         bot = telegram.Bot(conf[CONF_API_KEY])
         current_status = bot.getWebhookInfo()
         _LOGGER.debug("telegram webhook status: %s", current_status)
-        handler_url = "{0}{1}".format(hass.config.api.base_url, TELEGRAM_HANDLER_URL)
+        handler_url = "{0}{1}".format(hass.config.api.base_url,
+                                      TELEGRAM_HANDLER_URL)
         if current_status and current_status['url'] != handler_url:
             if bot.setWebhook(handler_url):
                 _LOGGER.info("set new telegram webhook %s", handler_url)

--- a/homeassistant/components/telegram_webhooks.py
+++ b/homeassistant/components/telegram_webhooks.py
@@ -1,0 +1,103 @@
+"""
+Allows utilizing telegram webhooks.
+
+See https://core.telegram.org/bots/webhooks for details
+ about webhooks.
+
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import HTTP_BAD_REQUEST
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.const import CONF_API_KEY
+from homeassistant.components.notify.telegram import REQUIREMENTS as REQ_NOTIFY
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = REQ_NOTIFY
+
+CONF_USER_ID = 'user_id'
+CONF_API_URL = 'api_url'
+
+DEPENDENCIES = ['http']
+DOMAIN = 'telegram_webhooks'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_API_KEY, default=''): cv.string,
+        vol.Optional(CONF_API_URL, default=''): cv.string,
+        vol.Required(CONF_USER_ID): {cv.string: cv.positive_int},
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Setup the telegram_webhooks component.
+
+    register webhook if API_KEY and API_URL specified
+    register /api/telegram_webhooks as web service for telegram bot
+    """
+    import telegram
+
+    config = config[DOMAIN]
+
+    if config.get(CONF_API_KEY, '') and config.get(CONF_API_URL, ''):
+        bot = telegram.Bot(config[CONF_API_KEY])
+        current_status = bot.getWebhookInfo()
+        _LOGGER.debug("telegram webhook status: %s", current_status)
+        if current_status and current_status['url'] != config[CONF_API_URL]:
+            if bot.setWebhook(config[CONF_API_URL]):
+                _LOGGER.info("set new telegram webhook")
+            else:
+                _LOGGER.error("telegram webhook failed")
+
+    hass.http.register_view(TelegrambotPushReceiver(config[CONF_USER_ID]))
+    hass.states.set('{}.command'.format(DOMAIN), '')
+    return True
+
+
+class TelegrambotPushReceiver(HomeAssistantView):
+    """Handle pushes from telegram."""
+
+    requires_auth = False
+    url = "/api/telegram_webhooks"
+    name = "telegram_webhooks"
+
+    def __init__(self, user_id_array):
+        """Initialize users allowed to send messages to bot."""
+        self.users = dict([(user_id, dev_id)
+                           for (dev_id, user_id) in user_id_array.items()])
+        _LOGGER.debug("users allowed: %s", self.users)
+
+    @asyncio.coroutine
+    def post(self, request):
+        """Accept the POST from telegram."""
+        try:
+            data = yield from request.json()
+            data = data['message']
+        except (ValueError, IndexError):
+            return self.json_message('Invalid JSON', HTTP_BAD_REQUEST)
+
+        try:
+            assert data['from']['id'] in self.users
+        except (AssertionError, IndexError):
+            _LOGGER.warning("User not allowed")
+            return self.json_message('Invalid user', HTTP_BAD_REQUEST)
+
+        _LOGGER.debug("Received telegram data: %s", data)
+        try:
+            assert data['text'][0] == '/'
+        except (AssertionError, IndexError):
+            _LOGGER.warning('no command')
+            return self.json({})
+
+        request.app['hass'].states.async_set('{}.command'.format(DOMAIN),
+                                             data['text'], force_update=True)
+        request.app['hass'].states.async_set('{}.user_id'.format(DOMAIN),
+                                             data['from']['id'],
+                                             force_update=True)
+        return self.json({})

--- a/homeassistant/components/telegram_webhooks.py
+++ b/homeassistant/components/telegram_webhooks.py
@@ -108,7 +108,7 @@ class BotPushReceiver(HomeAssistantView):
 
             if data['text'][0] != '/':
                 _LOGGER.warning('no command')
-                return self.json_message('Invalid command', HTTP_BAD_REQUEST)
+                return self.json({})
         except (ValueError, IndexError):
             return self.json_message('Invalid JSON', HTTP_BAD_REQUEST)
 

--- a/homeassistant/components/telegram_webhooks.py
+++ b/homeassistant/components/telegram_webhooks.py
@@ -14,11 +14,10 @@ from homeassistant.const import HTTP_BAD_REQUEST
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import CONF_API_KEY
-from homeassistant.components.notify.telegram import REQUIREMENTS as REQ_NOTIFY
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = REQ_NOTIFY
+REQUIREMENTS = ['python-telegram-bot==5.3.0']
 
 CONF_USER_ID = 'user_id'
 CONF_API_URL = 'api_url'

--- a/homeassistant/components/telegram_webhooks.py
+++ b/homeassistant/components/telegram_webhooks.py
@@ -67,10 +67,10 @@ def setup(hass, config):
         _LOGGER.debug("telegram webhook status: %s", current_status)
         handler_url = hass.config.api.base_url + CONF_HANDLER_URL
         if current_status and current_status['url'] != handler_url:
-            if bot.setWebhook(config[CONF_API_URL]):
+            if bot.setWebhook(handler_url):
                 _LOGGER.info("set new telegram webhook %s", handler_url)
             else:
-                _LOGGER.error("setting telegram webhook failed %s", handler_url)
+                _LOGGER.error("set telegram webhook failed %s", handler_url)
 
     hass.http.register_view(BotPushReceiver(config[CONF_USER_ID],
                                             config[CONF_TRUSTED_NETWORKS]))
@@ -87,8 +87,8 @@ class BotPushReceiver(HomeAssistantView):
     def __init__(self, user_id_array, trusted_networks):
         """Initialize users allowed to send messages to bot."""
         self.trusted_networks = trusted_networks
-        self.users = dict([(user_id, dev_id)
-                           for (dev_id, user_id) in user_id_array.items()])
+        self.users = {user_id: dev_id for dev_id, user_id in
+                      user_id_array.items()}
         _LOGGER.debug("users allowed: %s", self.users)
 
     @asyncio.coroutine

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -546,6 +546,7 @@ python-pushover==0.2
 # homeassistant.components.sensor.synologydsm
 python-synology==0.1.0
 
+# homeassistant.components.telegram_webhooks
 # homeassistant.components.notify.telegram
 python-telegram-bot==5.3.0
 
@@ -646,9 +647,6 @@ tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
 tellduslive==0.3.2
-
-# homeassistant.components.telegram_webhooks
-python-telegram-bot==5.3.0
 
 # homeassistant.components.sensor.temper
 temperusb==1.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -647,6 +647,9 @@ tellcore-py==1.1.2
 # homeassistant.components.tellduslive
 tellduslive==0.3.2
 
+# homeassistant.components.telegram_webhooks
+python-telegram-bot==5.3.0
+
 # homeassistant.components.sensor.temper
 temperusb==1.5.1
 


### PR DESCRIPTION
Telegram webhooks support as described in https://core.telegram.org/bots/webhooks.

With new component telegram_webhooks it is possible to send commands to home assistant via telegram bot. It works well with telegram notification: webhooks receive commands from user and notify send messages to user. 
Webhook responds only:
- to users listed in configuration, in telegram user_id format.
- to telegram servers (listed in webhooks docs) specified in trusted_networks

Telegram webhooks raise an event **telegram.command** with a payload
```
{
 'command': '/thecommand'
 'args': 'strings after command'
 'user_id': 12345
}
```

```yaml
# simpler configuration (manual webhook registration needed)
telegram_webhooks:
  user_id:
    user1: USER_ID
    user2: USER_ID
```
```yaml
# automatic configuration with webhooks registration in telegram bot
telegram_webhooks:
  api_key: ABCDEFGHJKLMNOPQRSTUVXYZ
  trusted_networks:
    - 149.154.167.197/32
    - 149.154.167.198/31
    - 149.154.167.200/29
    - 149.154.167.208/28
    - 149.154.167.224/29
    - 149.154.167.232/31
  user_id:
    user1: USER_ID
    user2: USER_ID
```

Automation example that realize simple test to command/notify interaction
```yaml
alias: 'telegram bot that reply pong to ping'
hide_entity: true
trigger:                                                                                                                                                         [0/400]
  platform: event
  event_type: telegram.command
  event_data:
    command: '/ping'
action:
  - service: notify.telegram
    data:
      message: 'pong'
```

This pull request has also a change to notify/telegram.py to support keyboard display. See an example to display a keyboard on BOT start ...
```yaml
alias: 'telegram bot start'
hide_entity: true
trigger:
  platform: event
  event_type: telegram.command
  event_data:
    command: '/start'
action:
  - service: notify.telegram
    data:
      message: 'commands'
      data:
        keyboard:
          - '/ping, /alarm'
          - '/siren'
```

... and an automation to trigger a related command "/siren 10"
```yaml
hide_entity: true
trigger:
  platform: event
  event_type: telegram.command
  event_data:
    command: '/siren'
action:
  - service: homeassistant.turn_on
    entity_id: switch.vision_zm1601eu5_battery_operated_siren_switch_9_0
  - delay: 
      seconds: "{{ trigger.event.data.args }}"
  - service: homeassistant.turn_off
    entity_id: switch.vision_zm1601eu5_battery_operated_siren_switch_9_0
```
