### PR TITLE
Update python-nest dependency version

### DIFF
--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -19,10 +19,7 @@ from homeassistant.loader import get_component
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = [
-    'http://github.com/technicalpickles/python-nest'
-    '/archive/e6c9d56a8df455d4d7746389811f2c1387e8cb33.zip'  # nest-cam branch
-    '#python-nest==3.0.2']
+REQUIREMENTS = ['python-nest==3.1.0']
 
 DOMAIN = 'nest'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -197,9 +197,6 @@ hikvision==0.4
 # homeassistant.components.sensor.dht
 # http://github.com/adafruit/Adafruit_Python_DHT/archive/310c59b0293354d07d94375f1365f7b9b9110c7d.zip#Adafruit_DHT==1.3.0
 
-# homeassistant.components.nest
-http://github.com/technicalpickles/python-nest/archive/e6c9d56a8df455d4d7746389811f2c1387e8cb33.zip#python-nest==3.0.2
-
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.3.7.zip#pyW215==0.3.7
 
@@ -533,6 +530,9 @@ python-mpd2==0.5.5
 
 # homeassistant.components.switch.mystrom
 python-mystrom==0.3.6
+
+# homeassistant.components.nest
+python-nest==3.1.0
 
 # homeassistant.components.device_tracker.nmap_tracker
 python-nmap==0.6.1


### PR DESCRIPTION
The nest-cam changes have now been merged into the upstream library, so
there is no need to track a specific branch.

Updating to 3.1.0 also fixes a structure parsing bug I was experiencing.

**Description:**


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
