### PR TITLE
Revert last change on TTS cache load for more speed

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -302,7 +302,7 @@ class SpeechManager(object):
         # is file store in file cache
         elif use_cache and key in self.file_cache:
             filename = self.file_cache[key]
-            yield from self.async_file_to_mem(key)
+            self.hass.async_add_job(self.async_file_to_mem(key))
         # load speech from provider into memory
         else:
             filename = yield from self.async_get_tts_audio(


### PR DESCRIPTION
**Description:**

I change a thing in the cache flow in last TTS PR. But after some test, that was bad for speed. I revert this to the old stuff.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
