### PR TITLE
Add discovery suppport to Apple TV

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -40,6 +40,7 @@ SERVICE_HANDLERS = {
     'samsung_tv': ('media_player', 'samsungtv'),
     'yeelight': ('light', 'yeelight'),
     'flux_led': ('light', 'flux_led'),
+    'apple_tv': ('media_player', 'apple_tv'),
 }
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/media_player/apple_tv.py
+++ b/homeassistant/components/media_player/apple_tv.py
@@ -21,7 +21,7 @@ import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
 
-REQUIREMENTS = ['pyatv==0.0.1']
+REQUIREMENTS = ['pyatv==0.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,17 +44,21 @@ def async_setup_platform(hass, config, async_add_entities,
     """Setup the Apple TV platform."""
     import pyatv
 
+    if discovery_info is not None:
+        name = discovery_info['name']
+        host = discovery_info['host']
+        login_id = discovery_info['hsgid']
+    else:
+        name = config.get(CONF_NAME)
+        host = config.get(CONF_HOST)
+        login_id = config.get(CONF_LOGIN_ID)
+
     if DATA_APPLE_TV not in hass.data:
         hass.data[DATA_APPLE_TV] = []
 
-    name = config.get(CONF_NAME)
-    host = config.get(CONF_HOST)
-    login_id = config.get(CONF_LOGIN_ID)
-
-    key = '{}:{}'.format(host, name)
-    if key in hass.data[DATA_APPLE_TV]:
+    if host in hass.data[DATA_APPLE_TV]:
         return False
-    hass.data[DATA_APPLE_TV].append(key)
+    hass.data[DATA_APPLE_TV].append(host)
 
     details = pyatv.AppleTVDevice(name, host, login_id)
     atv = pyatv.connect_to_apple_tv(details, hass.loop)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -418,7 +418,7 @@ pyasn1-modules==0.0.8
 pyasn1==0.2.2
 
 # homeassistant.components.media_player.apple_tv
-pyatv==0.0.1
+pyatv==0.1.1
 
 # homeassistant.components.device_tracker.bbox
 # homeassistant.components.sensor.bbox


### PR DESCRIPTION
**Description:**
This PR autodiscovers Apple TVs with Home Sharing enabled on the local network. Also bumps pyatv to latest version with lots of fixes. Documentation about this will be in #5698.

**Example entry for `configuration.yaml` (if applicable):**
Just add discovery:
```yaml
discovery:
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
