### PR TITLE
The word `router` was misspelt

### DIFF
--- a/homeassistant/components/device_tracker/sky_hub.py
+++ b/homeassistant/components/device_tracker/sky_hub.py
@@ -30,7 +30,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 # pylint: disable=unused-argument
 def get_scanner(hass, config):
-    """Return a Sky Hub 5 scanner if successful."""
+    """Return a Sky Hub scanner if successful."""
     scanner = SkyHubDeviceScanner(config[DOMAIN])
 
     return scanner if scanner.success_init else None
@@ -113,7 +113,7 @@ def _parse_skyhub_response(data_str):
     pattmatch = re.search('attach_dev = \'(.*)\'', data_str)
     if pattmatch is None:
         raise IOError('Error: Impossible to fetch data from' +
-                      ' Sky Hub. Try to reboot the rooter.')
+                      ' Sky Hub. Try to reboot the router.')
     patt = pattmatch.group(1)
 
     dev = [patt1.split(',') for patt1 in patt.split('<lf>')]


### PR DESCRIPTION
fixed as this message is user facing

**Description:**


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
