### PR TITLE
Improve warning message in template rendering

### DIFF
--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -118,7 +118,8 @@ class BinarySensorTemplate(BinarySensorDevice):
             if ex.args and ex.args[0].startswith(
                     "UndefinedError: 'None' has no attribute"):
                 # Common during HA startup - so just a warning
-                _LOGGER.warning(ex)
+                _LOGGER.warning('Could not render template %s, the state is unknown.',
+                                self._name)
                 return
             _LOGGER.error(ex)
             self._state = False

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -118,8 +118,8 @@ class BinarySensorTemplate(BinarySensorDevice):
             if ex.args and ex.args[0].startswith(
                     "UndefinedError: 'None' has no attribute"):
                 # Common during HA startup - so just a warning
-                _LOGGER.warning('Could not render template %s, the state is unknown.',
-                                self._name)
+                _LOGGER.warning('Could not render template %s,'
+                                ' the state is unknown.', self._name)
                 return
             _LOGGER.error('Could not render template %s: %s', self._name, ex)
             self._state = False

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -121,5 +121,5 @@ class BinarySensorTemplate(BinarySensorDevice):
                 _LOGGER.warning('Could not render template %s, the state is unknown.',
                                 self._name)
                 return
-            _LOGGER.error(ex)
+            _LOGGER.error('Could not render template %s: %s', self._name, ex)
             self._state = False

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -131,10 +131,11 @@ class SensorTemplate(Entity):
             if ex.args and ex.args[0].startswith(
                     "UndefinedError: 'None' has no attribute"):
                 # Common during HA startup - so just a warning
-                _LOGGER.warning(ex)
+                _LOGGER.warning('Could not render template %s, the state is unknown.',
+                                self._name)
                 return
             self._state = None
-            _LOGGER.error(ex)
+            _LOGGER.error('Could not render template %s: %s', self._name, ex)
 
         if self._icon_template is not None:
             try:
@@ -144,7 +145,7 @@ class SensorTemplate(Entity):
                         "UndefinedError: 'None' has no attribute"):
                     # Common during HA startup - so just a warning
                     _LOGGER.warning('Could not render template %s, the state is unknown.',
-                                     self._name)
+                                    self._name)
                     return
                 self._icon = super().icon
-                _LOGGER.error(ex)
+                _LOGGER.error('Could not render template %s: %s', self._name, ex)

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -144,9 +144,9 @@ class SensorTemplate(Entity):
                 if ex.args and ex.args[0].startswith(
                         "UndefinedError: 'None' has no attribute"):
                     # Common during HA startup - so just a warning
-                    _LOGGER.warning('Could not render template %s,'
+                    _LOGGER.warning('Could not render icon template %s,'
                                     ' the state is unknown.', self._name)
                     return
                 self._icon = super().icon
-                _LOGGER.error('Could not render template %s: %s',
+                _LOGGER.error('Could not render icon template %s: %s',
                               self._name, ex)

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -143,7 +143,8 @@ class SensorTemplate(Entity):
                 if ex.args and ex.args[0].startswith(
                         "UndefinedError: 'None' has no attribute"):
                     # Common during HA startup - so just a warning
-                    _LOGGER.warning(ex)
+                    _LOGGER.warning('Could not render template %s, the state is unknown.',
+                                     self._name)
                     return
                 self._icon = super().icon
                 _LOGGER.error(ex)

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -131,8 +131,8 @@ class SensorTemplate(Entity):
             if ex.args and ex.args[0].startswith(
                     "UndefinedError: 'None' has no attribute"):
                 # Common during HA startup - so just a warning
-                _LOGGER.warning('Could not render template %s, the state is unknown.',
-                                self._name)
+                _LOGGER.warning('Could not render template %s,'
+                                ' the state is unknown.', self._name)
                 return
             self._state = None
             _LOGGER.error('Could not render template %s: %s', self._name, ex)
@@ -144,8 +144,9 @@ class SensorTemplate(Entity):
                 if ex.args and ex.args[0].startswith(
                         "UndefinedError: 'None' has no attribute"):
                     # Common during HA startup - so just a warning
-                    _LOGGER.warning('Could not render template %s, the state is unknown.',
-                                    self._name)
+                    _LOGGER.warning('Could not render template %s,'
+                                    ' the state is unknown.', self._name)
                     return
                 self._icon = super().icon
-                _LOGGER.error('Could not render template %s: %s', self._name, ex)
+                _LOGGER.error('Could not render template %s: %s',
+                              self._name, ex)


### PR DESCRIPTION
**Description:**
Improve warning and error message in template rendering


Before:
UndefinedError: 'None' has no attribute 'state'
(No indication of which sensor was generating the warning.)

Now:
Could not render template test, the state is unknown.