### PR TITLE
History error during get_states

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -118,10 +118,12 @@ def run_information(point_in_time: Optional[datetime]=None):
             start=_INSTANCE.recording_start,
             closed_incorrect=False)
 
-    with session_scope():
-        return query('RecorderRuns').filter(
+    with session_scope() as session:
+        res = query(recorder_runs).filter(
             (recorder_runs.start < point_in_time) &
             (recorder_runs.end > point_in_time)).first()
+        session.expunge(res)
+        return res
 
 
 def setup(hass: HomeAssistant, config: ConfigType) -> bool:


### PR DESCRIPTION
**Description:**
This only happens with previous closed runs, so missed by unit testing

CC: @turbokongen @cyberjunky @mezz64 @lwis - please let me know if this helps!



**Related issue (if applicable):** fixes: #5607 - gitter reported
