### PR TITLE
Fixed call to object_id()

### DIFF
--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -16,7 +16,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import pywink
 
     for lock in pywink.get_locks():
-        _id = lock.object_id + lock.name()
+        _id = lock.object_id() + lock.name()
         if _id not in hass.data[DOMAIN]['unique_ids']:
             add_devices([WinkLockDevice(lock, hass)])
 


### PR DESCRIPTION
**Description:**
Fixed a typo in the wink lock code.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
