### PR TITLE
Remove non-working webfont preload

### DIFF
--- a/homeassistant/components/frontend/templates/index.html
+++ b/homeassistant/components/frontend/templates/index.html
@@ -10,9 +10,6 @@
           href='/static/icons/favicon-apple-180x180.png'>
     <link rel="mask-icon" href="/static/icons/home-assistant-icon.svg" color="#3fbbf4">
     <link rel='preload' href='{{ core_url }}' as='script'/>
-    <link rel='prefetch' href='/static/fonts/roboto/Roboto-Regular.ttf'>
-    <link rel='prefetch' href='/static/fonts/roboto/Roboto-Light.ttf'>
-    <link rel='prefetch' href='/static/fonts/roboto/Roboto-Medium.ttf'>
     {% for panel in panels.values() -%}
       <link rel='prefetch' href='{{ panel.url }}'>
     {% endfor -%}


### PR DESCRIPTION
**Description:**
I was trying to follow web best practice and preload the fonts. Tried with both prefetch and preload but in both cases Chrome would not use the cached font but fetch the font again.

So I'm removing this for now while exploring other options.