### PR TITLE
Deprecate event decorators

### DIFF
--- a/homeassistant/helpers/event_decorators.py
+++ b/homeassistant/helpers/event_decorators.py
@@ -1,5 +1,6 @@
 """Event Decorators for custom components."""
 import functools
+import logging
 
 # pylint: disable=unused-import
 from typing import Optional  # NOQA
@@ -8,10 +9,14 @@ from homeassistant.core import HomeAssistant  # NOQA
 from homeassistant.helpers import event
 
 HASS = None  # type: Optional[HomeAssistant]
+_LOGGER = logging.getLogger(__name__)
+_MSG = 'Event decorators are deprecated. Support will be removed in 0.40.'
 
 
 def track_state_change(entity_ids, from_state=None, to_state=None):
     """Decorator factory to track state changes for entity id."""
+    _LOGGER.warning(_MSG)
+
     def track_state_change_decorator(action):
         """Decorator to track state changes."""
         event.track_state_change(HASS, entity_ids,
@@ -24,6 +29,8 @@ def track_state_change(entity_ids, from_state=None, to_state=None):
 
 def track_sunrise(offset=None):
     """Decorator factory to track sunrise events."""
+    _LOGGER.warning(_MSG)
+
     def track_sunrise_decorator(action):
         """Decorator to track sunrise events."""
         event.track_sunrise(HASS,
@@ -36,6 +43,8 @@ def track_sunrise(offset=None):
 
 def track_sunset(offset=None):
     """Decorator factory to track sunset events."""
+    _LOGGER.warning(_MSG)
+
     def track_sunset_decorator(action):
         """Decorator to track sunset events."""
         event.track_sunset(HASS,
@@ -49,6 +58,8 @@ def track_sunset(offset=None):
 def track_time_change(year=None, month=None, day=None, hour=None, minute=None,
                       second=None):
     """Decorator factory to track time changes."""
+    _LOGGER.warning(_MSG)
+
     def track_time_change_decorator(action):
         """Decorator to track time changes."""
         event.track_time_change(HASS,
@@ -62,6 +73,8 @@ def track_time_change(year=None, month=None, day=None, hour=None, minute=None,
 def track_utc_time_change(year=None, month=None, day=None, hour=None,
                           minute=None, second=None):
     """Decorator factory to track time changes."""
+    _LOGGER.warning(_MSG)
+
     def track_utc_time_change_decorator(action):
         """Decorator to track time changes."""
         event.track_utc_time_change(HASS,


### PR DESCRIPTION
**Description:**
The event decorators have been broken for async for a while now (due to the use of partial). They also never have been popular because you did not have access to the config when defining the decorators. So deprecating them, intent to remove them in 0.40.
