### PR TITLE
Core: cleanup timer

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -405,7 +405,7 @@ class EventBus(object):
         listeners = get(MATCH_ALL, []) + get(event_type, [])
 
         event = Event(event_type, event_data, origin)
-        print(event)
+
         if event_type != EVENT_TIME_CHANGED:
             _LOGGER.info("Bus:Handling %s", event)
 
@@ -809,13 +809,13 @@ class ServiceRegistry(object):
         self._hass = hass
         self._async_unsub_call_event = None
 
-        def gen_unique_id():
+        def _gen_unique_id():
             cur_id = 1
             while True:
                 yield '{}-{}'.format(id(self), cur_id)
                 cur_id += 1
 
-        gen = gen_unique_id()
+        gen = _gen_unique_id()
         self._generate_unique_id = lambda: next(gen)
 
     @property

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -404,7 +404,7 @@ class EventBus(object):
         listeners = get(MATCH_ALL, []) + get(event_type, [])
 
         event = Event(event_type, event_data, origin)
-        print(event)
+
         if event_type != EVENT_TIME_CHANGED:
             _LOGGER.info("Bus:Handling %s", event)
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1102,7 +1102,7 @@ def _async_create_timer(hass):
                     nxt = monotonic() + 1
                     slp_seconds = 1
 
-                with timeout(slp_seconds):
+                with timeout(slp_seconds, loop=hass.loop):
                     yield from stop_event.wait()
             except asyncio.TimeoutError:
                 # Raised when timeout expires

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -133,7 +133,7 @@ class HomeAssistant(ha.HomeAssistant):
         self.loop = loop or asyncio.get_event_loop()
         self.executor = ThreadPoolExecutor(max_workers=5)
         self.loop.set_default_executor(self.executor)
-        self.loop.set_exception_handler(self._async_exception_handler)
+        self.loop.set_exception_handler(ha.async_loop_exception_handler)
         self._pending_tasks = []
         self._pending_sheduler = None
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,7 +15,8 @@ import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import (METRIC_SYSTEM)
 from homeassistant.const import (
     __version__, EVENT_STATE_CHANGED, ATTR_FRIENDLY_NAME, CONF_UNIT_SYSTEM,
-    ATTR_NOW, EVENT_TIME_CHANGED)
+    ATTR_NOW, EVENT_TIME_CHANGED, EVENT_HOMEASSISTANT_STOP,
+    EVENT_HOMEASSISTANT_START)
 
 from tests.common import get_test_home_assistant
 
@@ -755,6 +756,9 @@ def test_create_timer(mock_monotonic, loop):
         fire_time_event, start_timer, stop_timer = funcs
 
     assert len(hass.bus.async_listen_once.mock_calls) == 1
+    event_type, callback = hass.bus.async_listen_once.mock_calls[0][1]
+    assert event_type == EVENT_HOMEASSISTANT_START
+    assert callback is start_timer
 
     mock_monotonic.side_effect = 10.2, 10.3
 
@@ -766,6 +770,46 @@ def test_create_timer(mock_monotonic, loop):
     assert len(hass.bus.async_fire.mock_calls) == 1
     assert len(hass.loop.call_later.mock_calls) == 1
 
+    event_type, callback = hass.bus.async_listen_once.mock_calls[1][1]
+    assert event_type == EVENT_HOMEASSISTANT_STOP
+    assert callback is stop_timer
+
+    slp_seconds, callback, nxt = hass.loop.call_later.mock_calls[0][1]
+    assert abs(slp_seconds - 0.9) < 0.001
+    assert callback is fire_time_event
+    assert abs(nxt - 11.2) < 0.001
+
     event_type, event_data = hass.bus.async_fire.mock_calls[0][1]
     assert event_type == EVENT_TIME_CHANGED
     assert event_data[ATTR_NOW] is sentinel.mock_date
+
+
+@patch('homeassistant.core.monotonic')
+def test_timer_out_of_sync(mock_monotonic, loop):
+    """Test create timer."""
+    hass = MagicMock()
+    funcs = []
+    orig_callback = ha.callback
+
+    def mock_callback(func):
+        funcs.append(func)
+        return orig_callback(func)
+
+    with patch.object(ha, 'callback', mock_callback):
+        ha._async_create_timer(hass)
+
+        assert len(funcs) == 3
+        fire_time_event, start_timer, stop_timer = funcs
+
+    mock_monotonic.side_effect = 10.2, 11.3, 11.3
+
+    with patch('homeassistant.core.dt_util.utcnow',
+               return_value=sentinel.mock_date):
+        start_timer(None)
+
+    assert len(hass.loop.call_later.mock_calls) == 1
+
+    slp_seconds, callback, nxt = hass.loop.call_later.mock_calls[0][1]
+    assert slp_seconds == 1
+    assert callback is fire_time_event
+    assert abs(nxt - 12.3) < 0.001


### PR DESCRIPTION
**Description:**
Just a minor cleanup for the core as I'm preparing to make the core more lean in the future: I want to move `hass.config` and `hass.data` out of the core. They are concerns of bootstrap and the ecosystem built on top of it. The core should not know about them.

Biggest cleanup is for timers:
 - I actually know Python now, so clean up the code 💯 
 - Use `monotonic()` to fetch time so we don't get hit by leap seconds 🕐 
 - Take into consideration the time it takes to fire the time changed event 💤 
 - Reset timer and print error when we realize that something has messed up our timer
 - Remove support for custom time intervals (always 1 second now)
