### PR TITLE
Add 'wait_template' to script commands / Refactory track_template

### DIFF
--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -10,8 +10,7 @@ import voluptuous as vol
 
 from homeassistant.core import callback
 from homeassistant.const import CONF_VALUE_TEMPLATE, CONF_PLATFORM
-from homeassistant.helpers import condition
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_template
 import homeassistant.helpers.config_validation as cv
 
 
@@ -28,28 +27,16 @@ def async_trigger(hass, config, action):
     value_template = config.get(CONF_VALUE_TEMPLATE)
     value_template.hass = hass
 
-    # Local variable to keep track of if the action has already been triggered
-    already_triggered = False
-
     @callback
-    def state_changed_listener(entity_id, from_s, to_s):
+    def template_listener(entity_id, from_s, to_s):
         """Listen for state changes and calls action."""
-        nonlocal already_triggered
-        template_result = condition.async_template(hass, value_template)
+        hass.async_run_job(action, {
+            'trigger': {
+                'platform': 'template',
+                'entity_id': entity_id,
+                'from_state': from_s,
+                'to_state': to_s,
+            },
+        })
 
-        # Check to see if template returns true
-        if template_result and not already_triggered:
-            already_triggered = True
-            hass.async_run_job(action, {
-                'trigger': {
-                    'platform': 'template',
-                    'entity_id': entity_id,
-                    'from_state': from_s,
-                    'to_state': to_s,
-                },
-            })
-        elif not template_result:
-            already_triggered = False
-
-    return async_track_state_change(hass, value_template.extract_entities(),
-                                    state_changed_listener)
+    return async_track_template(hass, value_template, template_listener)

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -14,7 +14,7 @@ from homeassistant.loader import get_platform
 from homeassistant.const import (
     CONF_PLATFORM, CONF_SCAN_INTERVAL, TEMP_CELSIUS, TEMP_FAHRENHEIT,
     CONF_ALIAS, CONF_ENTITY_ID, CONF_VALUE_TEMPLATE, WEEKDAYS,
-    CONF_CONDITION, CONF_BELOW, CONF_ABOVE, SUN_EVENT_SUNSET,
+    CONF_CONDITION, CONF_BELOW, CONF_ABOVE, CONF_TIMEOUT, SUN_EVENT_SUNSET,
     SUN_EVENT_SUNRISE, CONF_UNIT_SYSTEM_IMPERIAL, CONF_UNIT_SYSTEM_METRIC)
 from homeassistant.core import valid_entity_id
 from homeassistant.exceptions import TemplateError
@@ -524,8 +524,14 @@ _SCRIPT_DELAY_SCHEMA = vol.Schema({
         template)
 })
 
+_SCRIPT_WAIT_SCHEMA = vol.Schema({
+    vol.Optional(CONF_ALIAS): string,
+    vol.Required("wait"): template,
+    vol.Optional(CONF_TIMEOUT): vol.All(time_period, positive_timedelta),
+})
+
 SCRIPT_SCHEMA = vol.All(
     ensure_list,
-    [vol.Any(SERVICE_SCHEMA, _SCRIPT_DELAY_SCHEMA, EVENT_SCHEMA,
-             CONDITION_SCHEMA)],
+    [vol.Any(SERVICE_SCHEMA, _SCRIPT_DELAY_SCHEMA, _SCRIPT_WAIT_SCHEMA,
+             EVENT_SCHEMA, CONDITION_SCHEMA)],
 )

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -526,7 +526,7 @@ _SCRIPT_DELAY_SCHEMA = vol.Schema({
 
 _SCRIPT_WAIT_SCHEMA = vol.Schema({
     vol.Optional(CONF_ALIAS): string,
-    vol.Required("wait"): template,
+    vol.Required("wait_template"): template,
     vol.Optional(CONF_TIMEOUT): vol.All(time_period, positive_timedelta),
 })
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -524,7 +524,7 @@ _SCRIPT_DELAY_SCHEMA = vol.Schema({
         template)
 })
 
-_SCRIPT_WAIT_SCHEMA = vol.Schema({
+_SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema({
     vol.Optional(CONF_ALIAS): string,
     vol.Required("wait_template"): template,
     vol.Optional(CONF_TIMEOUT): vol.All(time_period, positive_timedelta),
@@ -532,6 +532,6 @@ _SCRIPT_WAIT_SCHEMA = vol.Schema({
 
 SCRIPT_SCHEMA = vol.All(
     ensure_list,
-    [vol.Any(SERVICE_SCHEMA, _SCRIPT_DELAY_SCHEMA, _SCRIPT_WAIT_SCHEMA,
-             EVENT_SCHEMA, CONDITION_SCHEMA)],
+    [vol.Any(SERVICE_SCHEMA, _SCRIPT_DELAY_SCHEMA,
+             _SCRIPT_WAIT_TEMPLATE_SCHEMA, EVENT_SCHEMA, CONDITION_SCHEMA)],
 )

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -84,6 +84,26 @@ def async_track_state_change(hass, entity_ids, action, from_state=None,
 track_state_change = threaded_listener_factory(async_track_state_change)
 
 
+def async_track_template(hass, template, action, variables=None):
+    """Add a listener that track state changes with template condition."""
+    from . import condition
+
+    if template.hass is None:
+        template.hass = hass
+
+    @callback
+    def template_condition_listener(entity_id, from_s, to_s):
+        """Check if condition is correct and run action."""
+        if condition.async_template(hass, template, variables):
+            hass.async_run_job(action, entity_id, from_s, to_s)
+
+    return async_track_state_change(
+        hass, template.extract_entities(), template_condition_listener)
+
+
+track_template = threaded_listener_factory(async_track_template)
+
+
 def async_track_point_in_time(hass, action, point_in_time):
     """Add a listener that fires once after a specific point in time."""
     utc_point_in_time = dt_util.as_utc(point_in_time)

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -120,7 +120,7 @@ class Script():
 
                 @callback
                 def async_script_wait(entity_id, from_s, to_s):
-                    """Called after delay is done."""
+                    """Called after template condition is true."""
                     self._async_remove_listener()
                     self.hass.async_add_job(self.async_run(variables))
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -115,7 +115,7 @@ class Script():
 
                 # check if condition allready okay
                 if condition.async_template(
-                       self.hass, wait_template, variables):
+                        self.hass, wait_template, variables):
                     continue
 
                 @callback

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -16,9 +16,11 @@ from homeassistant.helpers.event import (
     track_time_change,
     track_state_change,
     track_time_interval,
+    track_template,
     track_sunrise,
     track_sunset,
 )
+from homeassistant.helpers.template import Template
 from homeassistant.components import sun
 import homeassistant.util.dt as dt_util
 
@@ -187,6 +189,63 @@ class TestEventHelpers(unittest.TestCase):
         self.assertEqual(1, len(specific_runs))
         self.assertEqual(5, len(wildcard_runs))
         self.assertEqual(6, len(wildercard_runs))
+
+    def test_track_template(self):
+        """Test tracking template."""
+        specific_runs = []
+        wildcard_runs = []
+        wildercard_runs = []
+
+        template_condition = Template(
+            "{{states.switch.test.state == 'on'}}",
+            self.hass
+        )
+        template_condition_var = Template(
+            "{{states.switch.test.state == 'on' and test == 5}}",
+            self.hass
+        )
+
+        self.hass.states.set('switch.test', 'off')
+
+        def specific_run_callback(entity_id, old_state, new_state):
+            specific_runs.append(1)
+
+        track_template(self.hass, template_condition, specific_run_callback)
+
+        @ha.callback
+        def wildcard_run_callback(entity_id, old_state, new_state):
+            wildcard_runs.append((old_state, new_state))
+
+        track_template(self.hass, template_condition, wildcard_run_callback)
+
+        @asyncio.coroutine
+        def wildercard_run_callback(entity_id, old_state, new_state):
+            wildercard_runs.append((old_state, new_state))
+
+        track_template(
+            self.hass, template_condition_var, wildercard_run_callback,
+            {'test': 5})
+
+        self.hass.states.set('switch.test', 'on')
+        self.hass.block_till_done()
+
+        self.assertEqual(1, len(specific_runs))
+        self.assertEqual(1, len(wildcard_runs))
+        self.assertEqual(1, len(wildercard_runs))
+
+        self.hass.states.set('switch.test', 'off')
+        self.hass.block_till_done()
+
+        self.assertEqual(1, len(specific_runs))
+        self.assertEqual(1, len(wildcard_runs))
+        self.assertEqual(1, len(wildercard_runs))
+
+        self.hass.states.set('switch.test', 'on')
+        self.hass.block_till_done()
+
+        self.assertEqual(2, len(specific_runs))
+        self.assertEqual(2, len(wildcard_runs))
+        self.assertEqual(2, len(wildercard_runs))
 
     def test_track_time_interval(self):
         """Test tracking time interval."""

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -233,6 +233,20 @@ class TestEventHelpers(unittest.TestCase):
         self.assertEqual(1, len(wildcard_runs))
         self.assertEqual(1, len(wildercard_runs))
 
+        self.hass.states.set('switch.test', 'on')
+        self.hass.block_till_done()
+
+        self.assertEqual(1, len(specific_runs))
+        self.assertEqual(1, len(wildcard_runs))
+        self.assertEqual(1, len(wildercard_runs))
+
+        self.hass.states.set('switch.test', 'off')
+        self.hass.block_till_done()
+
+        self.assertEqual(1, len(specific_runs))
+        self.assertEqual(1, len(wildcard_runs))
+        self.assertEqual(1, len(wildercard_runs))
+
         self.hass.states.set('switch.test', 'off')
         self.hass.block_till_done()
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -131,7 +131,6 @@ class TestScriptHelper(unittest.TestCase):
             {'event': event}]))
 
         script_obj.run()
-
         self.hass.block_till_done()
 
         assert script_obj.is_running
@@ -164,7 +163,6 @@ class TestScriptHelper(unittest.TestCase):
             {'event': event}]))
 
         script_obj.run()
-
         self.hass.block_till_done()
 
         assert script_obj.is_running
@@ -196,7 +194,6 @@ class TestScriptHelper(unittest.TestCase):
             {'event': event}]))
 
         script_obj.run()
-
         self.hass.block_till_done()
 
         assert script_obj.is_running
@@ -213,6 +210,73 @@ class TestScriptHelper(unittest.TestCase):
 
         assert not script_obj.is_running
         assert len(events) == 0
+
+    def test_wait(self):
+        """Test the wait."""
+        event = 'test_event'
+        events = []
+
+        @callback
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        self.hass.states.set('switch.test', 'on')
+
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
+            {'event': event},
+            {'wait': "{{states.switch.test.state == 'off'}}"},
+            {'event': event}]))
+
+        script_obj.run()
+        self.hass.block_till_done()
+
+        assert script_obj.is_running
+        assert script_obj.can_cancel
+        assert script_obj.last_action == event
+        assert len(events) == 1
+
+        self.hass.states.set('switch.test', 'off')
+        self.hass.block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 2
+
+    def test_wait_timeout(self):
+        """Test the wait."""
+        event = 'test_event'
+        events = []
+
+        @callback
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        self.hass.states.set('switch.test', 'on')
+
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
+            {'event': event},
+            {'wait': "{{states.switch.test.state == 'off'}}", 'timeout': 5},
+            {'event': event}]))
+
+        script_obj.run()
+        self.hass.block_till_done()
+
+        assert script_obj.is_running
+        assert script_obj.can_cancel
+        assert script_obj.last_action == event
+        assert len(events) == 1
+
+        future = dt_util.utcnow() + timedelta(seconds=5)
+        fire_time_changed(self.hass, future)
+        self.hass.block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 1
 
     def test_passing_variables_to_script(self):
         """Test if we can pass variables to script."""


### PR DESCRIPTION
**Description:**

```yaml
 - wait_template: "{{ states.media_player.floor.state == 'stop' }}"
   # optional
   timeout: 10
```

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
