### PR TITLE
Handle connection errors when connecting to Apple TVs

### DIFF
--- a/homeassistant/components/media_player/apple_tv.py
+++ b/homeassistant/components/media_player/apple_tv.py
@@ -4,11 +4,11 @@ Support for Apple TV.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.apple_tv/
 """
-import asyncio
-import aiohttp
 import logging
 import hashlib
 
+import asyncio
+import aiohttp
 import voluptuous as vol
 
 from homeassistant.components.media_player import (

--- a/homeassistant/components/media_player/apple_tv.py
+++ b/homeassistant/components/media_player/apple_tv.py
@@ -4,10 +4,10 @@ Support for Apple TV.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.apple_tv/
 """
+import asyncio
 import logging
 import hashlib
 
-import asyncio
 import aiohttp
 import voluptuous as vol
 

--- a/homeassistant/components/media_player/apple_tv.py
+++ b/homeassistant/components/media_player/apple_tv.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.apple_tv/
 """
 import asyncio
+import aiohttp
 import logging
 import hashlib
 
@@ -21,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
 
-REQUIREMENTS = ['pyatv==0.1.1']
+REQUIREMENTS = ['pyatv==0.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -128,6 +129,8 @@ class AppleTvDevice(MediaPlayerDevice):
             self._playing = playing
         except exceptions.AuthenticationError as ex:
             _LOGGER.warning('%s (bad login id?)', str(ex))
+        except aiohttp.errors.ClientOSError as ex:
+            _LOGGER.error('failed to connect to Apple TV (%s)', str(ex))
         except asyncio.TimeoutError:
             _LOGGER.warning('timed out while connecting to Apple TV')
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -418,7 +418,7 @@ pyasn1-modules==0.0.8
 pyasn1==0.2.2
 
 # homeassistant.components.media_player.apple_tv
-pyatv==0.1.1
+pyatv==0.1.2
 
 # homeassistant.components.device_tracker.bbox
 # homeassistant.components.sensor.bbox


### PR DESCRIPTION
**Description:**
Should fix these kinds of errors:

```
17-02-09 08:23:05 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/opt/home-assistant/virtualenv/lib/python3.4/site-packages/aiohttp/connector.py", line 666, in _create_direct_connection
    local_addr=self._local_addr)
  File "/usr/lib/python3.4/asyncio/base_events.py", line 570, in create_connection
    raise exceptions[0]
  File "/usr/lib/python3.4/asyncio/base_events.py", line 557, in create_connection
    yield from self.sock_connect(sock, address)
  File "/usr/lib/python3.4/asyncio/futures.py", line 388, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.4/asyncio/tasks.py", line 286, in _wakeup
    value = future.result()
  File "/usr/lib/python3.4/asyncio/futures.py", line 277, in result
    raise self._exception
  File "/usr/lib/python3.4/asyncio/selector_events.py", line 382, in _sock_connect_cb
    raise OSError(err, 'Connect call failed %s' % (address,))
ConnectionRefusedError: [Errno 111] Connect call failed ('10.0.10.22', 3689)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/home-assistant/virtualenv/lib/python3.4/site-packages/aiohttp/connector.py", line 350, in connect
    yield from self._create_connection(req)
  File "/opt/home-assistant/virtualenv/lib/python3.4/site-packages/aiohttp/connector.py", line 643, in _create_connection
    transport, proto = yield from self._create_direct_connection(req)
  File "/opt/home-assistant/virtualenv/lib/python3.4/site-packages/aiohttp/connector.py", line 689, in _create_direct_connection
    (req.host, req.port, exc.strerror)) from exc
aiohttp.errors.ClientOSError: [Errno 111] Can not connect to 10.0.10.22:3689 [Connect call failed ('10.0.10.22', 3689)]

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.4/asyncio/tasks.py", line 233, in _step
    result = coro.throw(exc)
  File "/home/pi/home-assistant/homeassistant/helpers/entity_component.py", line 336, in _async_process_entity
    new_entity, self, update_before_add=update_before_add
  File "/home/pi/home-assistant/homeassistant/helpers/entity_component.py", line 181, in async_add_entity
    yield from entity.async_update()
  File "/home/pi/home-assistant/homeassistant/components/media_player/apple_tv.py", line 119, in async_update
    playing = yield from self._atv.metadata.playing()
  File "/opt/home-assistant/virtualenv/lib/python3.4/site-packages/pyatv/internal/apple_tv.py", line 240, in playing
    playstatus = yield from self.apple_tv.playstatus()
  File "/opt/home-assistant/virtualenv/lib/python3.4/site-packages/pyatv/daap.py", line 131, in get
    yield from self._assure_logged_in()
  File "/opt/home-assistant/virtualenv/lib/python3.4/site-packages/pyatv/daap.py", line 185, in _assure_logged_in
    yield from self.login()
  File "/opt/home-assistant/virtualenv/lib/python3.4/site-packages/pyatv/daap.py", line 119, in login
    resp = yield from self._do(_login_request)
  File "/opt/home-assistant/virtualenv/lib/python3.4/site-packages/pyatv/daap.py", line 145, in _do
    resp, status = yield from action()
  File "/opt/home-assistant/virtualenv/lib/python3.4/site-packages/pyatv/daap.py", line 50, in get_data
    url, headers=_DMAP_HEADERS, timeout=self._timeout)
  File "/opt/home-assistant/virtualenv/lib/python3.4/site-packages/aiohttp/client.py", line 577, in __iter__
    resp = yield from self._coro
  File "/opt/home-assistant/virtualenv/lib/python3.4/site-packages/aiohttp/client.py", line 215, in _request
    conn = yield from self._connector.connect(req)
  File "/opt/home-assistant/virtualenv/lib/python3.4/site-packages/aiohttp/connector.py", line 360, in connect
    .format(key, exc.strerror)) from exc
aiohttp.errors.ClientOSError: [Errno 111] Cannot connect to host 10.0.10.22:3689 ssl:False [Can not connect to 10.0.10.22:3689 [Connect call failed ('10.0.10.22', 3689)]]

```

Also bump pyatv to 0.1.2 which fixes a request leak.

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
