### PR TITLE
Adding/expanding hold_mode mechanism to generic_thermostat

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -96,6 +96,7 @@ SET_TEMPERATURE_SCHEMA = vol.Schema({
     vol.Inclusive(ATTR_TARGET_TEMP_LOW, 'temperature'): vol.Coerce(float),
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Optional(ATTR_OPERATION_MODE): cv.string,
+    vol.Optional(ATTR_HOLD_MODE): cv.string,
 })
 SET_FAN_MODE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -44,6 +44,11 @@ STATE_AUTO = "auto"
 STATE_DRY = "dry"
 STATE_FAN_ONLY = "fan_only"
 
+HOLD_MODE_AWAY = "away"
+HOLD_MODE_HOME = "home"
+HOLD_MODE_SLEEP = "sleep"
+HOLD_MODE_VACATION = "vacation"
+
 ATTR_CURRENT_TEMPERATURE = "current_temperature"
 ATTR_MAX_TEMP = "max_temp"
 ATTR_MIN_TEMP = "min_temp"
@@ -58,6 +63,7 @@ ATTR_HUMIDITY = "humidity"
 ATTR_MAX_HUMIDITY = "max_humidity"
 ATTR_MIN_HUMIDITY = "min_humidity"
 ATTR_HOLD_MODE = "hold_mode"
+ATTR_HOLD_LIST = "hold_list"
 ATTR_OPERATION_MODE = "operation_mode"
 ATTR_OPERATION_LIST = "operation_list"
 ATTR_SWING_MODE = "swing_mode"
@@ -151,7 +157,7 @@ def set_aux_heat(hass, aux_heat, entity_id=None):
 
 def set_temperature(hass, temperature=None, entity_id=None,
                     target_temp_high=None, target_temp_low=None,
-                    operation_mode=None):
+                    operation_mode=None, hold_mode=None):
     """Set new target temperature."""
     kwargs = {
         key: value for key, value in [
@@ -159,7 +165,8 @@ def set_temperature(hass, temperature=None, entity_id=None,
             (ATTR_TARGET_TEMP_HIGH, target_temp_high),
             (ATTR_TARGET_TEMP_LOW, target_temp_low),
             (ATTR_ENTITY_ID, entity_id),
-            (ATTR_OPERATION_MODE, operation_mode)
+            (ATTR_OPERATION_MODE, operation_mode),
+            (ATTR_HOLD_MODE, hold_mode),
         ] if value is not None
     }
     _LOGGER.debug("set_temperature start data=%s", kwargs)
@@ -445,9 +452,11 @@ class ClimateDevice(Entity):
             if self.operation_list:
                 data[ATTR_OPERATION_LIST] = self.operation_list
 
-        is_hold = self.current_hold_mode
-        if is_hold is not None:
-            data[ATTR_HOLD_MODE] = is_hold
+        hold_mode = self.current_hold_mode
+        if hold_mode is not None:
+            data[ATTR_HOLD_MODE] = hold_mode
+            if self.hold_list:
+                data[ATTR_HOLD_LIST] = self.hold_list
 
         swing_mode = self.current_swing_mode
         if swing_mode is not None:
@@ -523,6 +532,11 @@ class ClimateDevice(Entity):
     @property
     def current_hold_mode(self):
         """Return the current hold mode, e.g., home, away, temp."""
+        return None
+
+    @property
+    def hold_list(self):
+        """List of available hold modes."""
         return None
 
     @property

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -206,14 +206,16 @@ class GenericThermostat(ClimateDevice):
         hold_mode = kwargs.get(ATTR_HOLD_MODE, HOLD_MODE_HOME)
 
         if hold_mode not in HOLD_MODE_LIST:
-            _LOGGER.warning('Hold mode `%s` is not supported, ignoring it.',
+            _LOGGER.warning('Hold mode `%s` is not supported, ignoring.',
                             hold_mode)
             return
 
+        if temperature is None:
+            _LOGGER.warning('Attribute `%s` is not an optional attribute, '
+                            'ignoring service call.', ATTR_TEMPERATURE)
+            return
+
         if hold_mode == HOLD_MODE_HOME:
-            # cannot set None to the default temperature
-            if temperature is None:
-                return
             self._target_temp = temperature
 
         # Store the temperature in the hold_temps dictionary

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -605,6 +605,21 @@ class TestClimateGenericThermostatAwayModeTemp(unittest.TestCase):
         self.assertEqual(SERVICE_TURN_OFF, call.service)
         self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
+    def test_home_heater_on(self):
+        """Test if the heater switches on when hold mode becomes 'home'."""
+        climate.set_hold_mode(self.hass, 'away')
+        self._setup_switch(False)
+        self._setup_sensor(35)
+        self.hass.block_till_done()
+        # Now trigger the temperature
+        climate.set_hold_mode(self.hass, 'home')
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('switch', call.domain)
+        self.assertEqual(SERVICE_TURN_ON, call.service)
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+
     def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
         """Setup the test sensor."""
         self.hass.states.set(ENT_SENSOR, temp, {


### PR DESCRIPTION
**Description:**

This PR adds support for several `hold` modes (currently: `away`, `home` [default], `vacation` and `sleep`). The mode can be set through the recommended mechanism `set_hold_mode`. 

Each `hold_mode` has its own temperature tracking (being the `home` the default one, also called the "target temperature").

Before doing the PR in the documentation I would like to address any issues with the behaviour or the semantics.

**Example entry for `configuration.yaml`:**
```yaml
# Example configuration.yaml entry
climate:
  - platform: generic_thermostat
    name: Study
    heater: switch.study_heater
    target_sensor: sensor.study_temperature
    target_temp: 21.5
    hold_temps:
      away: 16.5
      vacation: 6
```

**Checklist:**

  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully.
