### PR TITLE
Do not query state property if entity is not available

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -205,26 +205,24 @@ class Entity(object):
 
         start = timer()
 
-        state = self.state
-
-        if state is None:
-            state = STATE_UNKNOWN
-        else:
-            state = str(state)
-
-        attr = self.state_attributes or {}
-
-        device_attr = self.device_state_attributes
-
-        if device_attr is not None:
-            attr.update(device_attr)
-
-        self._attr_setter('unit_of_measurement', str, ATTR_UNIT_OF_MEASUREMENT,
-                          attr)
-
         if not self.available:
             state = STATE_UNAVAILABLE
             attr = {}
+        else:
+            state = self.state
+
+            if state is None:
+                state = STATE_UNKNOWN
+            else:
+                state = str(state)
+
+            attr = self.state_attributes or {}
+            device_attr = self.device_state_attributes
+            if device_attr is not None:
+                attr.update(device_attr)
+
+        self._attr_setter('unit_of_measurement', str, ATTR_UNIT_OF_MEASUREMENT,
+                          attr)
 
         self._attr_setter('name', str, ATTR_FRIENDLY_NAME, attr)
         self._attr_setter('icon', str, ATTR_ICON, attr)


### PR DESCRIPTION
**Description:**
If entity has presented itself as not available by returning `False` in property `available`, do not query `state` property at all.

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/pull/5775#discussion_r99774095

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
