### PR TITLE
Reuse default aiohttp session

### DIFF
--- a/homeassistant/components/media_player/apple_tv.py
+++ b/homeassistant/components/media_player/apple_tv.py
@@ -18,11 +18,12 @@ from homeassistant.components.media_player import (
 from homeassistant.const import (
     STATE_IDLE, STATE_PAUSED, STATE_PLAYING, STATE_STANDBY, CONF_HOST,
     CONF_NAME, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
 
-REQUIREMENTS = ['pyatv==0.1.2']
+REQUIREMENTS = ['pyatv==0.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,7 +63,8 @@ def async_setup_platform(hass, config, async_add_entities,
     hass.data[DATA_APPLE_TV].append(host)
 
     details = pyatv.AppleTVDevice(name, host, login_id)
-    atv = pyatv.connect_to_apple_tv(details, hass.loop)
+    session = async_get_clientsession(hass)
+    atv = pyatv.connect_to_apple_tv(details, hass.loop, session=session)
     entity = AppleTvDevice(atv, name)
 
     @asyncio.coroutine

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -418,7 +418,7 @@ pyasn1-modules==0.0.8
 pyasn1==0.2.2
 
 # homeassistant.components.media_player.apple_tv
-pyatv==0.1.2
+pyatv==0.1.3
 
 # homeassistant.components.device_tracker.bbox
 # homeassistant.components.sensor.bbox


### PR DESCRIPTION
**Description:**
As per request from @pvizeli, the default aiohttp session is now used by pyatv which should give a bit lower resource usage.

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
