### PR TITLE
gstreamer media player

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -224,6 +224,7 @@ omit =
     homeassistant/components/media_player/emby.py
     homeassistant/components/media_player/firetv.py
     homeassistant/components/media_player/gpmdp.py
+    homeassistant/components/media_player/gstreamer.py
     homeassistant/components/media_player/hdmi_cec.py
     homeassistant/components/media_player/itunes.py
     homeassistant/components/media_player/kodi.py

--- a/homeassistant/components/media_player/gstreamer.py
+++ b/homeassistant/components/media_player/gstreamer.py
@@ -1,0 +1,162 @@
+"""
+Play media via gstreamer.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.gstreamer/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.media_player import (
+    MEDIA_TYPE_MUSIC, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
+    SUPPORT_PAUSE, SUPPORT_SEEK, SUPPORT_STOP, SUPPORT_PLAY_MEDIA,
+    SUPPORT_PLAY, SUPPORT_NEXT_TRACK, PLATFORM_SCHEMA, MediaPlayerDevice)
+from homeassistant.const import (
+    STATE_IDLE, CONF_NAME, EVENT_HOMEASSISTANT_STOP)
+import homeassistant.helpers.config_validation as cv
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+REQUIREMENTS = ['gstreamer-player==1.0.0']
+DOMAIN = 'gstreamer'
+CONF_PIPELINE = 'pipeline'
+
+
+SUPPORT_GSTREAMER = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
+    SUPPORT_PLAY | SUPPORT_PAUSE | SUPPORT_SEEK | SUPPORT_STOP | \
+    SUPPORT_PLAY_MEDIA | SUPPORT_SEEK | SUPPORT_NEXT_TRACK
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_PIPELINE): cv.string,
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Gstreamer platform."""
+    from gsp import GstreamerPlayer
+    name = config.get(CONF_NAME)
+    pipeline = config.get(CONF_PIPELINE)
+    player = GstreamerPlayer(pipeline)
+
+    def _shutdown(call):
+        """Quit the player on shutdown."""
+        player.quit()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown)
+    add_devices([GstreamerDevice(player, name)])
+
+
+class GstreamerDevice(MediaPlayerDevice):
+    """Representation of a Gstreamer device."""
+
+    def __init__(self, player, name):
+        """Initialize the Gstreamer device."""
+        self._player = player
+        self._name = name or DOMAIN
+        self._state = STATE_IDLE
+        self._volume = None
+        self._duration = None
+        self._position = None
+        self._uri = None
+        self._title = None
+        self._artist = None
+        self._album = None
+
+    def update(self):
+        """Update properties."""
+        self._state = self._player.state
+        self._volume = self._player.volume
+        self._duration = self._player.duration
+        self._position = self._player.position
+        self._uri = self._player.uri
+        self._title = self._player.title
+        self._album = self._player.album
+        self._artist = self._player.artist
+
+    def mute_volume(self, mute):
+        """Send the mute command."""
+        self._player.mute()
+
+    def set_volume_level(self, volume):
+        """Set the volume level."""
+        self._player.volume = volume
+
+    def play_media(self, media_type, media_id, **kwargs):
+        """Play media."""
+        if media_type != MEDIA_TYPE_MUSIC:
+            _LOGGER.error('invalid media type')
+            return
+        self._player.queue(media_id)
+
+    def media_seek(self, position):
+        """Seek."""
+        self._player.position = position
+
+    def media_next_track(self):
+        """Next track."""
+        self._player.next()
+
+    @property
+    def media_content_id(self):
+        """Content ID of currently playing media."""
+        return self._uri
+
+    @property
+    def content_type(self):
+        """Content type of currently playing media."""
+        return MEDIA_TYPE_MUSIC
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def volume_level(self):
+        """Return the volume level."""
+        return self._volume
+
+    @property
+    def is_volume_muted(self):
+        """Volume muted."""
+        return self._volume == 0
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_GSTREAMER
+
+    @property
+    def state(self):
+        """Return the state of the player."""
+        return self._state
+
+    @property
+    def media_duration(self):
+        """Duration of current playing media in seconds."""
+        return self._duration
+
+    @property
+    def media_position(self):
+        """Position of current playing media in seconds."""
+        return self._position
+
+    @property
+    def media_title(self):
+        """Media title."""
+        return self._title
+
+    @property
+    def media_artist(self):
+        """Media artist."""
+        return self._artist
+
+    @property
+    def media_album_name(self):
+        """Media album."""
+        return self._album

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -179,6 +179,9 @@ googlemaps==2.4.4
 # homeassistant.components.sensor.gpsd
 gps3==0.33.3
 
+# homeassistant.components.media_player.gstreamer
+gstreamer-player==1.0.0
+
 # homeassistant.components.ffmpeg
 ha-ffmpeg==1.4
 


### PR DESCRIPTION
**Description:**

Play audio via [gstreamer](https://gstreamer.freedesktop.org/), an audio processing pipeline with Python bindings. This is how Python music player projects like [Mopidy](https://github.com/mopidy/mopidy) and [BPD](https://github.com/beetbox/beets) work. If a pipeline isn't specified, audio will play directly on the local system. This might be desirable for users with a Raspberry Pi and connected speakers. But if you do specify a pipeline, you can transform the audio and pass the stream to other services like [snapcast](https://github.com/badaix/snapcast) or [icecast](http://icecast.org/).

Installing prerequisites (from [mopidy's docs](https://docs.mopidy.com/en/latest/installation/source/)):
```bash
sudo apt-get install python-gst-1.0 \
    gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 \
    gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly \
    gstreamer1.0-tools
```

Technical notes: The Python dependency [`gstreamer-player`](https://github.com/happyleavesaoc/gstreamer-player) uses `multiprocessing` to isolate the `GLib` main loop, which doesn't play nice with Python. That means this is not a single-process integrated audio playing solution, but at least it doesn't require an external service and is opaque to the user.

WIP status because of the multiprocessing complexity and the use of `mutagen` in [`gstreamer-player`](https://github.com/happyleavesaoc/gstreamer-player) to get tags. It has to download the whole file to do so. Looking for feedback in these areas and any others.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2060

**Example entry for `configuration.yaml` (if applicable):**
```yaml
media_player:
  - platform: gstreamer
    name: 'tts'
    pipeline: 'audioresample ! audioconvert ! audio/x-raw,rate=48000,channels=2,format=S16LE ! wavenc ! filesink location=/tmp/snapcast_tts'
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
