### PR TITLE
[Hotfix] Fix zwave helper getter not to fail on some None results.

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -646,6 +646,7 @@ class ZWaveDeviceEntity(Entity):
                       method, class_id, index, label, data, member, kwargs)
         values = self._value.node.get_values(**kwargs).values()
         _LOGGER.debug('values=%s', values)
+        results = None
         if not values:
             return None
         for value in values:


### PR DESCRIPTION
**Description:**

Fix zwave helper getter not to fail on some None results.
