### PR TITLE
bump python-yeelight version

### DIFF
--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -22,7 +22,7 @@ from homeassistant.components.light import (
     Light, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['yeelight==0.2.1']
+REQUIREMENTS = ['yeelight==0.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -712,7 +712,7 @@ yahoo-finance==1.4.0
 yahooweather==0.8
 
 # homeassistant.components.light.yeelight
-yeelight==0.2.1
+yeelight==0.2.2
 
 # homeassistant.components.light.zengge
 zengge==0.2


### PR DESCRIPTION
**Description:**
This PR just bumps the required version of python-yeelight library, which most notably fixes the music mode of these bulbs when it's active on multiple bulbs. Upstream issue: https://gitlab.com/stavros/python-yeelight/issues/7