### PR TITLE
Fix exception that asyncio throws on GC

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -365,7 +365,14 @@ def main() -> int:
 
     if args.script is not None:
         from homeassistant import scripts
-        return scripts.run(args.script)
+        # https://github.com/python/asyncio/pull/456
+        # Bug in asyncio throws exception unless loop is closed.
+        import asyncio
+        res = scripts.run(args.script)
+        loop = asyncio.get_event_loop()
+        if loop is not None:
+            loop.close()
+        return res
 
     config_dir = os.path.join(os.getcwd(), args.config)
     ensure_config_path(config_dir)


### PR DESCRIPTION
**Description:**

`check_config` script, which is now run during restart prints an exception due to asyncio/python bug: https://github.com/python/asyncio/pull/456
```
Exception ignored in: <bound method _UnixSelectorEventLoop.__del__ of <_UnixSelectorEventLoop running=False closed=True debug=False>>
Traceback (most recent call last):
  File "/srv/hass/lib/python3.4/site-packages/asyncio/base_events.py", line 361, in __del__
  File "/srv/hass/lib/python3.4/site-packages/asyncio/unix_events.py", line 57, in close
  File "/srv/hass/lib/python3.4/site-packages/asyncio/unix_events.py", line 138, in remove_signal_handler
TypeError: signal handler must be signal.SIG_IGN, signal.SIG_DFL, or a callable object
```

This PR works around it by closing the asyncio loop before exit.
