### PR TITLE
Fix check_config script

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -33,6 +33,7 @@ MOCKS = {
 }
 SILENCE = (
     'homeassistant.bootstrap.clear_secret_cache',
+    'homeassistant.bootstrap.async_register_signal_handling',
     'homeassistant.core._LOGGER.info',
     'homeassistant.loader._LOGGER.info',
     'homeassistant.bootstrap._LOGGER.info',

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -58,7 +58,7 @@ class TestBootstrap:
         autospec=True)
     @mock.patch('homeassistant.util.location.detect_location_info',
                 autospec=True, return_value=None)
-    @mock.patch('homeassistant.helpers.signal.async_register_signal_handling')
+    @mock.patch('homeassistant.bootstrap.async_register_signal_handling')
     def test_from_config_file(self, mock_upgrade, mock_detect, mock_signal):
         """Test with configuration file."""
         components = set(['browser', 'conversation', 'script'])
@@ -290,7 +290,7 @@ class TestBootstrap:
         assert 'comp' not in self.hass.config.components
 
     @mock.patch('homeassistant.bootstrap.enable_logging')
-    @mock.patch('homeassistant.helpers.signal.async_register_signal_handling')
+    @mock.patch('homeassistant.bootstrap.async_register_signal_handling')
     def test_home_assistant_core_config_validation(self, log_mock, sig_mock):
         """Test if we pass in wrong information for HA conf."""
         # Extensive HA conf validation testing is done in test_config.py


### PR DESCRIPTION
**Description:**

@andrey-git can you test it? I'm not sure if I mock on correct way.

Should fix this:
```
Exception ignored in: <bound method _UnixSelectorEventLoop.__del__ of <_UnixSelectorEventLoop running=False closed=True debug=False>>
Traceback (most recent call last):
  File "/srv/hass/lib/python3.4/site-packages/asyncio/base_events.py", line 361, in __del__
  File "/srv/hass/lib/python3.4/site-packages/asyncio/unix_events.py", line 57, in close
  File "/srv/hass/lib/python3.4/site-packages/asyncio/unix_events.py", line 138, in remove_signal_handler
TypeError: signal handler must be signal.SIG_IGN, signal.SIG_DFL, or a callable object
```

**Related issue (if applicable):** fixes #5851

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
