### PR TITLE
Recorder run can be None

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -124,7 +124,8 @@ def run_information(point_in_time: Optional[datetime]=None):
         res = query(recorder_runs).filter(
             (recorder_runs.start < point_in_time) &
             (recorder_runs.end > point_in_time)).first()
-        session.expunge(res)
+        if res:
+            session.expunge(res)
         return res
 
 


### PR DESCRIPTION
**Description:**
Errors would be logged and history requests would fail if recorder session would not return any rows. Now we only expunge the value if a value was returned.

```
Traceback (most recent call last):
  File "/Users/paulus/dev/python/home-assistant/config/deps/sqlalchemy/orm/session.py", line 1548, in expunge
    state = attributes.instance_state(instance)
AttributeError: 'NoneType' object has no attribute '_sa_instance_state'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/paulus/.pyenv/versions/3.5.2/lib/python3.5/site-packages/aiohttp-1.2.0-py3.5-macosx-10.12-x86_64.egg/aiohttp/web_server.py", line 61, in handle_request
    resp = yield from self._handler(request)
  File "/Users/paulus/.pyenv/versions/3.5.2/lib/python3.5/site-packages/aiohttp-1.2.0-py3.5-macosx-10.12-x86_64.egg/aiohttp/web.py", line 249, in _handle
    resp = yield from handler(request)
  File "/Users/paulus/.pyenv/versions/3.5.2/lib/python3.5/site-packages/asyncio/coroutines.py", line 143, in coro
    res = yield from res
  File "/Users/paulus/.pyenv/versions/3.5.2/lib/python3.5/site-packages/asyncio/coroutines.py", line 143, in coro
    res = yield from res
  File "/Users/paulus/dev/python/home-assistant/homeassistant/components/http/__init__.py", line 427, in handle
    result = yield from result
  File "/Users/paulus/dev/python/home-assistant/homeassistant/components/history.py", line 241, in get
    self.filters)
  File "/Users/paulus/.pyenv/versions/3.5.2/lib/python3.5/site-packages/asyncio/futures.py", line 386, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/Users/paulus/.pyenv/versions/3.5.2/lib/python3.5/site-packages/asyncio/tasks.py", line 287, in _wakeup
    value = future.result()
  File "/Users/paulus/.pyenv/versions/3.5.2/lib/python3.5/site-packages/asyncio/futures.py", line 275, in result
    raise self._exception
  File "/Users/paulus/.pyenv/versions/3.5.2/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/paulus/dev/python/home-assistant/homeassistant/components/history.py", line 83, in get_significant_states
    return states_to_json(states, start_time, entity_id, filters)
  File "/Users/paulus/dev/python/home-assistant/homeassistant/components/history.py", line 153, in states_to_json
    for state in get_states(start_time, entity_ids, filters=filters):
  File "/Users/paulus/dev/python/home-assistant/homeassistant/components/history.py", line 108, in get_states
    run = recorder.run_information(utc_point_in_time)
  File "/Users/paulus/dev/python/home-assistant/homeassistant/components/recorder/__init__.py", line 127, in run_information
    session.expunge(res)
  File "/Users/paulus/dev/python/home-assistant/config/deps/sqlalchemy/orm/session.py", line 1550, in expunge
    raise exc.UnmappedInstanceError(instance)
sqlalchemy.orm.exc.UnmappedInstanceError: Class 'builtins.NoneType' is not mapped
```
