### PR TITLE
Stop using entity_picture that is known to be bad.

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -923,7 +923,6 @@ def _async_fetch_image(hass, url):
     return content, content_type, is_permanent_failure
 
 
-
 class MediaPlayerImageView(HomeAssistantView):
     """Media player view to serve an image."""
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -871,6 +871,7 @@ class MediaPlayerDevice(Entity):
         should_update = self._last_bad_image_url != url
         self._last_bad_image_url = url
         if should_update:
+            _LOGGER.debug('%s marked as inaccessible', url)
             self.schedule_update_ha_state()
 
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -947,7 +947,7 @@ class MediaPlayerImageView(HomeAssistantView):
                          request.GET.get('token') == player.access_token)
 
         if not authenticated:
-            return web.Response(status=401), 
+            return web.Response(status=401),
 
         url = player.media_image_url
         data, content_type, is_permanent_failure = \

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -296,11 +296,41 @@ class TestMediaPlayerWeb(unittest.TestCase):
         assert req.status_code == 200
         assert req.text == fake_picture_data
 
-    def test_media_image_proxy_unavailable(self):
+    def test_media_image_proxy_500(self):
         """Test the media server image proxy server ."""
         class MockResponse():
             def __init__(self):
                 self.status = 500
+
+            @asyncio.coroutine
+            def release(self):
+                pass
+
+        class MockWebsession():
+
+            @asyncio.coroutine
+            def get(self, url):
+                return MockResponse()
+
+            def detach(self):
+                pass
+
+        self.hass.data[DATA_CLIENTSESSION] = MockWebsession()
+
+        assert self.hass.states.is_state(entity_id, 'playing')
+        state = self.hass.states.get(entity_id)
+        req = requests.get(HTTP_BASE_URL +
+                           state.attributes.get('entity_picture'))
+        assert req.status_code == 500
+        self.hass.block_till_done()
+        assert self.hass.states.get(entity_id).attributes.get(
+            'entity_picture') is not None
+
+    def test_media_image_proxy_404(self):
+        """Test the media server image proxy server ."""
+        class MockResponse():
+            def __init__(self):
+                self.status = 404
 
             @asyncio.coroutine
             def release(self):

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -254,7 +254,7 @@ class TestMediaPlayerWeb(unittest.TestCase):
         assert setup_component(
             self.hass, mp.DOMAIN,
             {'media_player': {'platform': 'demo'}})
-
+        mp.ENTITY_IMAGE_CACHE[mp.ATTR_CACHE_IMAGES].clear()
         self.hass.start()
 
     def tearDown(self):
@@ -295,3 +295,33 @@ class TestMediaPlayerWeb(unittest.TestCase):
                            state.attributes.get('entity_picture'))
         assert req.status_code == 200
         assert req.text == fake_picture_data
+
+    def test_media_image_proxy_unavailable(self):
+        """Test the media server image proxy server ."""
+        class MockResponse():
+            def __init__(self):
+                self.status = 500
+
+            @asyncio.coroutine
+            def release(self):
+                pass
+
+        class MockWebsession():
+
+            @asyncio.coroutine
+            def get(self, url):
+                return MockResponse()
+
+            def detach(self):
+                pass
+
+        self.hass.data[DATA_CLIENTSESSION] = MockWebsession()
+
+        assert self.hass.states.is_state(entity_id, 'playing')
+        state = self.hass.states.get(entity_id)
+        req = requests.get(HTTP_BASE_URL +
+                           state.attributes.get('entity_picture'))
+        assert req.status_code == 500
+        self.hass.block_till_done()
+        assert self.hass.states.get(entity_id).attributes.get(
+            'entity_picture') is None


### PR DESCRIPTION
**Description:**

Stop using entity_picture that is known to be bad.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
