### PR TITLE
[recorder] Run end model changed in session scope

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -420,8 +420,8 @@ class Recorder(threading.Thread):
 
     def _close_run(self):
         """Save end time for current run."""
-        self._run.end = dt_util.utcnow()
         with session_scope() as session:
+            self._run.end = dt_util.utcnow()
             self._commit(session, self._run)
         self._run = None
 


### PR DESCRIPTION
**Description:**
Modifying the `_run` RecorderRun model should be done in the session scope