### PR TITLE
Restore SPEED_MED to fan and ISY

### DIFF
--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -45,6 +45,7 @@ SERVICE_SET_DIRECTION = 'set_direction'
 SPEED_OFF = 'off'
 SPEED_LOW = 'low'
 SPEED_MEDIUM = 'medium'
+SPEED_MED = 'med'
 SPEED_HIGH = 'high'
 
 DIRECTION_FORWARD = 'forward'

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -8,7 +8,7 @@ import logging
 from typing import Callable
 
 from homeassistant.components.fan import (FanEntity, DOMAIN, SPEED_OFF,
-                                          SPEED_LOW, SPEED_MEDIUM,
+                                          SPEED_LOW, SPEED_MED,
                                           SPEED_HIGH)
 import homeassistant.components.isy994 as isy
 from homeassistant.const import STATE_UNKNOWN, STATE_ON, STATE_OFF
@@ -20,8 +20,8 @@ VALUE_TO_STATE = {
     0: SPEED_OFF,
     63: SPEED_LOW,
     64: SPEED_LOW,
-    190: SPEED_MEDIUM,
-    191: SPEED_MEDIUM,
+    190: SPEED_MED,
+    191: SPEED_MED,
     255: SPEED_HIGH,
 }
 
@@ -29,7 +29,7 @@ STATE_TO_VALUE = {}
 for key in VALUE_TO_STATE:
     STATE_TO_VALUE[VALUE_TO_STATE[key]] = key
 
-STATES = [SPEED_OFF, SPEED_LOW, 'med', SPEED_HIGH]
+STATES = [SPEED_OFF, SPEED_LOW, SPEED_MED, SPEED_HIGH]
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
Restore SPEED_MED to fan and ISY

**Description:**
ISY fans failed to discover after #5457. PR #5817 fixed the discover issue, but did not actually make them work entirely again. Speeds off, low and high could be set but medium could not.

This PR undoes the parts of #5457 that applied to ISY based on the information provided by @Teagan42.  ISY fans need `off|low|med|high` to work be discovered and work.  Prior PR #5817 put med back for discovery.  This puts 'med' back for setting speeds (wasn't working even after #5817) by effectively rolling back the `isy994.py` file to its pre #5457 state and adding the `SPEED_MED` back to the higher level `__init__.py`


**Related issue (if applicable):** fixes #5779

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io# N/A


**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51