### PR TITLE
Fixed proximity zone incorrectly using name instead of zone setting.

### DIFF
--- a/homeassistant/components/proximity.py
+++ b/homeassistant/components/proximity.py
@@ -63,7 +63,7 @@ def setup_proximity_component(hass, name, config):
     proximity_zone = name
     unit_of_measurement = config.get(
         CONF_UNIT_OF_MEASUREMENT, hass.config.units.length_unit)
-    zone_id = 'zone.{}'.format(proximity_zone)
+    zone_id = 'zone.{}'.format(config.get(CONF_ZONE))
 
     proximity = Proximity(hass, proximity_zone, DEFAULT_DIST_TO_ZONE,
                           DEFAULT_DIR_OF_TRAVEL, DEFAULT_NEAREST,

--- a/tests/components/test_proximity.py
+++ b/tests/components/test_proximity.py
@@ -394,6 +394,7 @@ class TestProximity(unittest.TestCase):
                         'device_tracker.test2'
                     ],
                     'tolerance': '1',
+                    'zone': 'home'
                 }
             }
         })
@@ -445,7 +446,9 @@ class TestProximity(unittest.TestCase):
                     'devices': [
                         'device_tracker.test1',
                         'device_tracker.test2'
-                    ]
+                    ],
+                    'zone': 'home'
+
                 }
             }
         })
@@ -497,7 +500,8 @@ class TestProximity(unittest.TestCase):
                     'devices': [
                         'device_tracker.test1',
                         'device_tracker.test2'
-                    ]
+                    ],
+                    'zone': 'home'
                 }
             }
         })
@@ -538,7 +542,8 @@ class TestProximity(unittest.TestCase):
                     'devices': [
                         'device_tracker.test1',
                         'device_tracker.test2'
-                    ]
+                    ],
+                    'zone': 'home'
                 }
             }
         })
@@ -601,7 +606,8 @@ class TestProximity(unittest.TestCase):
                     'devices': [
                         'device_tracker.test1'
                     ],
-                    'tolerance': 1000
+                    'tolerance': 1000,
+                    'zone': 'home'
                 }
             }
         })
@@ -654,7 +660,8 @@ class TestProximity(unittest.TestCase):
                     'devices': [
                         'device_tracker.test1',
                         'device_tracker.test2'
-                    ]
+                    ],
+                    'zone': 'home'
                 }
             }
         })


### PR DESCRIPTION
**Description:**

Fixed proximity zone incorrectly using name instead of zone setting.

**Related issue (if applicable):** 

Discussed in forum: https://community.home-assistant.io/t/proximity-with-multiple-users/6411
