### PR TITLE
Avoid traceback for Amcrest cameras/firmware that does not have the software_information API call

### DIFF
--- a/homeassistant/components/sensor/amcrest.py
+++ b/homeassistant/components/sensor/amcrest.py
@@ -122,10 +122,18 @@ class AmcrestSensor(Entity):
 
     def update(self):
         """Get the latest data and updates the state."""
-        version, build_date = self._camera.software_information
-        self._attrs['Build Date'] = build_date.split('=')[-1]
-        self._attrs['Serial Number'] = self._camera.serial_number
-        self._attrs['Version'] = version.split('=')[-1]
+        try:
+            version, build_date = self._camera.software_information
+            self._attrs['Build Date'] = build_date.split('=')[-1]
+            self._attrs['Version'] = version.split('=')[-1]
+        except:
+            self._attrs['Build Date'] = 'Not Available'
+            self._attrs['Version'] = 'Not Available'
+
+        try:
+            self._attrs['Serial Number'] = self._camera.serial_number
+        except:
+            self._attrs['Serial Number'] = 'Not Available'
 
         if self._sensor_type == 'motion_detector':
             self._state = self._camera.is_motion_detected

--- a/homeassistant/components/sensor/amcrest.py
+++ b/homeassistant/components/sensor/amcrest.py
@@ -126,13 +126,13 @@ class AmcrestSensor(Entity):
             version, build_date = self._camera.software_information
             self._attrs['Build Date'] = build_date.split('=')[-1]
             self._attrs['Version'] = version.split('=')[-1]
-        except:
+        except ValueError:
             self._attrs['Build Date'] = 'Not Available'
             self._attrs['Version'] = 'Not Available'
 
         try:
             self._attrs['Serial Number'] = self._camera.serial_number
-        except:
+        except ValueError:
             self._attrs['Serial Number'] = 'Not Available'
 
         if self._sensor_type == 'motion_detector':


### PR DESCRIPTION
**Description:**
Avoid traceback for Amcrest cameras/firmware that does not have the software_information API call

**Related issue (if applicable):** fixes #5864

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.


Thanks @tkvtec for sharing the details and troubleshooting.
