### PR TITLE
pyCEC version 0.4.13: Solves hdmi_cec shutdown issue: konikvranik/pyCEC#40

### DIFF
--- a/homeassistant/components/hdmi_cec.py
+++ b/homeassistant/components/hdmi_cec.py
@@ -26,7 +26,7 @@ from homeassistant.const import (EVENT_HOMEASSISTANT_START, STATE_UNKNOWN,
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyCEC==0.4.12']
+REQUIREMENTS = ['pyCEC==0.4.13']
 
 DOMAIN = 'hdmi_cec'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -390,7 +390,7 @@ pwaqi==1.3
 py-cpuinfo==0.2.3
 
 # homeassistant.components.hdmi_cec
-pyCEC==0.4.12
+pyCEC==0.4.13
 
 # homeassistant.components.switch.tplink
 pyHS100==0.2.3


### PR DESCRIPTION
**Description:**

Solves hdmi_cec shutdown issue.

**Related issue:** fixes konikvranik/pyCEC#40

