### PR TITLE
Upgrade psutil to 5.1.3

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==5.1.2']
+REQUIREMENTS = ['psutil==5.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -385,7 +385,7 @@ pmsensor==0.3
 proliphix==0.4.1
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.1.2
+psutil==5.1.3
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.0


### PR DESCRIPTION
## 5.1.3

Bug fixes

- [Linux] sensors_temperatures() didn't work on CentOS 7.
- cpu_percent() may raise ZeroDivisionError.

Tested with the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: load_1m
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
```