### PR TITLE
vasttrafik: update token on read error

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -671,7 +671,7 @@ volvooncall==0.1.1
 vsure==0.11.1
 
 # homeassistant.components.sensor.vasttrafik
-vtjp==0.1.11
+vtjp==0.1.14
 
 # homeassistant.components.media_player.panasonic_viera
 # homeassistant.components.media_player.webostv


### PR DESCRIPTION
**Description:**
Updates token when an read error occurs.
Seems like the token sometimes expires before it should. 

**Related issue (if applicable):** fixes #5641

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

