### PR TITLE
Add device_class support to cover component

### DIFF
--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -33,6 +33,11 @@ ENTITY_ID_ALL_COVERS = group.ENTITY_ID_FORMAT.format('all_covers')
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
+DEVICE_CLASSES = [
+    'window',        # Window control
+    'garage',        # Garage door control
+]
+
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_CURRENT_POSITION = 'current_position'

--- a/homeassistant/components/cover/garadget.py
+++ b/homeassistant/components/cover/garadget.py
@@ -168,6 +168,11 @@ class GaradgetCover(CoverDevice):
         else:
             return self._state == STATE_CLOSED
 
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return 'garage'
+
     def get_token(self):
         """Get new token for usage during this session."""
         args = {

--- a/homeassistant/components/cover/zwave.py
+++ b/homeassistant/components/cover/zwave.py
@@ -140,3 +140,8 @@ class ZwaveGarageDoor(zwave.ZWaveDeviceEntity, CoverDevice):
     def open_cover(self):
         """Open the garage door."""
         self._value.data = True
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return 'garage'


### PR DESCRIPTION
**Description:**
This PR adds device_class support to the cover component. It's currently used to differentiate garage doors from other covers. I've also included a window device class. I'm not familiar enough with the other platforms, but if we know it controls a window, (similar to how we know about zwave garage doors) we should set the device_class. It isn't treated differently on the frontend now, but it could be.

As far as user configuration goes, I think we should add device_class to customization, rather than including it in the platform config as we currently do for binary_sensor.

See also:
https://github.com/home-assistant/home-assistant-polymer/pull/202