### PR TITLE
Added myq cover component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -153,6 +153,7 @@ omit =
     homeassistant/components/climate/radiotherm.py
     homeassistant/components/cover/garadget.py
     homeassistant/components/cover/homematic.py
+    homeassistant/components/cover/myq.py
     homeassistant/components/cover/rpi_gpio.py
     homeassistant/components/cover/scsgate.py
     homeassistant/components/cover/wink.py

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -4,13 +4,13 @@ Support for MyQ-Enabled Garage Doors.
 For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/cover.myq/
 """
-
 import logging
+
 import voluptuous as vol
 
 from homeassistant.components.cover import CoverDevice
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, \
-    CONF_TYPE, STATE_CLOSED
+from homeassistant.const import (
+    CONF_USERNAME, CONF_PASSWORD, CONF_TYPE, STATE_CLOSED)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = [
@@ -40,11 +40,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if not myq.is_supported_brand():
         logger.error('MyQ Cover - Unsupported Brand')
-        return False
+        return
 
     if not myq.is_login_valid():
         logger.error('MyQ Cover - Username or Password is incorrect')
-        return False
+        return
 
     try:
         add_devices(MyQDevice(myq, door) for door in myq.get_garage_doors())
@@ -76,11 +76,6 @@ class MyQDevice(CoverDevice):
     def is_closed(self):
         """Return True if cover is closed, else False."""
         return self._status == STATE_CLOSED
-
-    @property
-    def current_cover_position(self):
-        """Return current position of cover."""
-        return 0 if self.is_closed else 100
 
     def close_cover(self):
         """Issue close command to cover."""

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -1,0 +1,95 @@
+"""
+Support for MyQ-Enabled Garage Doors.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/cover.myq/
+"""
+
+import logging
+import voluptuous as vol
+
+from homeassistant.components.cover import CoverDevice
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, \
+    CONF_TYPE, STATE_CLOSED
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = [
+    'https://github.com/arraylabs/pymyq/archive/v0.0.2.zip'
+    '#pymyq==0.0.2']
+
+COVER_SCHEMA = vol.Schema({
+    vol.Required(CONF_TYPE): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string
+})
+
+DEFAULT_NAME = 'myq'
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the MyQ component."""
+    from pymyq import MyQAPI as pymyq
+
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    brand = config.get(CONF_TYPE)
+
+    logger = logging.getLogger(__name__)
+
+    myq = pymyq(username, password, brand)
+
+    if not myq.is_supported_brand():
+        logger.error('MyQ Cover - Unsupported Brand')
+        return False
+
+    if not myq.is_login_valid():
+        logger.error('MyQ Cover - Username or Password is incorrect')
+        return False
+
+    try:
+        add_devices(MyQDevice(myq, door) for door in myq.get_garage_doors())
+    except (TypeError, KeyError, NameError) as ex:
+        logger.error("MyQ Cover - %s", ex)
+
+
+class MyQDevice(CoverDevice):
+    """Representation of a MyQ cover."""
+
+    def __init__(self, myq, device):
+        """Initialize with API object, device id."""
+        self.myq = myq
+        self.device_id = device['deviceid']
+        self._name = device['name']
+        self._status = STATE_CLOSED
+
+    @property
+    def should_poll(self):
+        """Poll for state."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the garage door if any."""
+        return self._name if self._name else DEFAULT_NAME
+
+    @property
+    def is_closed(self):
+        """Return True if cover is closed, else False."""
+        return self._status == STATE_CLOSED
+
+    @property
+    def current_cover_position(self):
+        """Return current position of cover."""
+        return 0 if self.is_closed else 100
+
+    def close_cover(self):
+        """Issue close command to cover."""
+        self.myq.close_device(self.device_id)
+
+    def open_cover(self):
+        """Issue open command to cover."""
+        self.myq.open_device(self.device_id)
+
+    def update(self):
+        """Update status of cover."""
+        self._status = self.myq.get_status(self.device_id)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -214,6 +214,9 @@ https://github.com/Xorso/pyalarmdotcom/archive/0.1.1.zip#pyalarmdotcom==0.1.1
 # homeassistant.components.media_player.braviatv
 https://github.com/aparraga/braviarc/archive/0.3.6.zip#braviarc==0.3.6
 
+# homeassistant.components.cover.myq
+https://github.com/arraylabs/pymyq/archive/v0.0.2.zip#pymyq==0.0.2
+
 # homeassistant.components.media_player.roku
 https://github.com/bah2830/python-roku/archive/3.1.3.zip#roku==3.1.3
 


### PR DESCRIPTION
**Description:**
MyQ Platform for Covers


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2012

**Example entry for `configuration.yaml` (if applicable):**
```
cover:
  - platform: myq
    username: email@email.com
    password: password
    type: chamberlain
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) PR #2012

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.


