### PR TITLE
add c_Elta

### DIFF
--- a/homeassistant/components/c_Elta.py
+++ b/homeassistant/components/c_Elta.py
@@ -1,15 +1,16 @@
-import requests
 import logging
 
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'c_Elta'
-REQUIREMENTS = ['requests==2.13.0','pycountry==17.1.8']
+REQUIREMENTS = [ 'pycountry==17.1.8' ]
 # DEPENDENCIES = []
 ATTR_CODE = 'code'
 DEFAULT_CODE = 'null'
 
 
 def tracking(str):
+    import requests
+
     tracking_number = str
     if len(tracking_number) != 13:
         result = ' the ' ,tracking_number,' dose not seem like an ELTA tracking number...'

--- a/homeassistant/components/c_Elta.py
+++ b/homeassistant/components/c_Elta.py
@@ -4,7 +4,7 @@ import logging
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'c_Elta'
 REQUIREMENTS = ['requests==2.13.0','pycountry==17.1.8']
-#DEPENDENCIES = []
+# DEPENDENCIES = []
 ATTR_CODE = 'code'
 DEFAULT_CODE = 'null'
 
@@ -22,12 +22,14 @@ def tracking(str):
             p_date = t_result[-1]['date']
             p_time = t_result[-1]['time']
             p_status = t_result[-1]['status']
-            result = (p_date +" "+ p_time + " "+ p_status)
+            result = (p_date + " " + p_time + " " + p_status)
         else:
             result = ('wrong number')
-        #Country_origin = pycountry.countries.lookup(tracking_number[-2:])
-        #print ('Origin is: '+ Country_origin.name)
+        # Country_origin = pycountry.countries.lookup(tracking_number[-2:])
+        # print ('Origin is: '+ Country_origin.name)
     return (result)
+
+
 def setup(hass, config):
     code = config[DOMAIN].get(ATTR_CODE, DEFAULT_CODE)
     wd = tracking(code)

--- a/homeassistant/components/c_Elta.py
+++ b/homeassistant/components/c_Elta.py
@@ -16,8 +16,8 @@ def tracking(str):
         result = ' the ', tracking_number,' dose not seem like an ELTA tracking number...'
         _LOGGER.error('Invalid key {0}. Key must be 13 characters'.format(tracking_number))
     else:
-        headers = {'Cookie':'lang=en'}
-        r = requests.post('http://www.elta-courier.gr/track.php', data = {'number': tracking_number}, headers=headers)
+        headers = {'Cookie': 'lang=en'}
+        r = requests.post('http://www.elta-courier.gr/track.php', data={'number': tracking_number}, headers=headers)
         t_result = r.json()['result'][tracking_number]['result']
         if t_result != 'wrong number':
             p_date = t_result[-1]['date']

--- a/homeassistant/components/c_Elta.py
+++ b/homeassistant/components/c_Elta.py
@@ -21,7 +21,10 @@ def tracking(str):
         13 characters'.format(tracking_number))
     else:
         headers = {'Cookie': 'lang=en'}
-        r = requests.post('http://www.elta-courier.gr/track.php', data={'number': tracking_number}, headers=headers)
+        r = requests.post(
+            'http://www.elta-courier.gr/track.php',
+            data={'number': tracking_number},
+            headers=headers)
         t_result = r.json()['result'][tracking_number]['result']
         if t_result != 'wrong number':
             p_date = t_result[-1]['date']

--- a/homeassistant/components/c_Elta.py
+++ b/homeassistant/components/c_Elta.py
@@ -1,13 +1,16 @@
 import requests
 import logging
+
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'c_Elta'
 REQUIREMENTS = ['requests==2.13.0','pycountry==17.1.8']
 #DEPENDENCIES = []
 ATTR_CODE = 'code'
 DEFAULT_CODE = 'null'
+
+
 def tracking(str):
-    tracking_number= str
+    tracking_number = str
     if len(tracking_number) != 13:
         result = ' the ',tracking_number,' dose not seem like an ELTA tracking number...'
         _LOGGER.error('Invalid key {0}. Key must be 13 characters'.format(tracking_number))

--- a/homeassistant/components/c_Elta.py
+++ b/homeassistant/components/c_Elta.py
@@ -1,3 +1,4 @@
+"""HA Elta tracking based on https://github.com/apo-mak/courier."""
 import logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -9,12 +10,15 @@ DEFAULT_CODE = 'null'
 
 
 def tracking(str):
+    """"request for josn web post."""
     import requests
 
     tracking_number = str
     if len(tracking_number) != 13:
-        result = ' the ', tracking_number,' dose not seem like an ELTA tracking number...'
-        _LOGGER.error('Invalid key {0}. Key must be 13 characters'.format(tracking_number))
+        result = ' the ', tracking_number, ' dose not seem like an ELTA \
+        tracking number...'
+        _LOGGER.error('Invalid key {0}. Key must be \
+        13 characters'.format(tracking_number))
     else:
         headers = {'Cookie': 'lang=en'}
         r = requests.post('http://www.elta-courier.gr/track.php', data={'number': tracking_number}, headers=headers)
@@ -32,6 +36,7 @@ def tracking(str):
 
 
 def setup(hass, config):
+    """HA setup."""
     code = config[DOMAIN].get(ATTR_CODE, DEFAULT_CODE)
     wd = tracking(code)
     hass.states.set('c_Elta.trcode', wd)

--- a/homeassistant/components/c_Elta.py
+++ b/homeassistant/components/c_Elta.py
@@ -12,11 +12,11 @@ DEFAULT_CODE = 'null'
 def tracking(str):
     tracking_number = str
     if len(tracking_number) != 13:
-        result = ' the ',tracking_number,' dose not seem like an ELTA tracking number...'
+        result = ' the ' ,tracking_number,' dose not seem like an ELTA tracking number...'
         _LOGGER.error('Invalid key {0}. Key must be 13 characters'.format(tracking_number))
     else:
         headers = {'Cookie': 'lang=en'}
-        r = requests.post('http://www.elta-courier.gr/track.php', data = { 'number': tracking_number}, headers=headers)
+        r = requests.post('http://www.elta-courier.gr/track.php', data = {'number': tracking_number}, headers=headers)
         t_result = r.json()['result'][tracking_number]['result']
         if t_result != 'wrong number':
             p_date = t_result[-1]['date']

--- a/homeassistant/components/c_Elta.py
+++ b/homeassistant/components/c_Elta.py
@@ -2,7 +2,7 @@ import logging
 
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'c_Elta'
-REQUIREMENTS = [ 'pycountry==17.1.8' ]
+REQUIREMENTS = ['pycountry==17.1.8']
 # DEPENDENCIES = []
 ATTR_CODE = 'code'
 DEFAULT_CODE = 'null'
@@ -13,10 +13,10 @@ def tracking(str):
 
     tracking_number = str
     if len(tracking_number) != 13:
-        result = ' the ' ,tracking_number,' dose not seem like an ELTA tracking number...'
+        result = ' the ', tracking_number,' dose not seem like an ELTA tracking number...'
         _LOGGER.error('Invalid key {0}. Key must be 13 characters'.format(tracking_number))
     else:
-        headers = {'Cookie': 'lang=en'}
+        headers = {'Cookie':'lang=en'}
         r = requests.post('http://www.elta-courier.gr/track.php', data = {'number': tracking_number}, headers=headers)
         t_result = r.json()['result'][tracking_number]['result']
         if t_result != 'wrong number':

--- a/homeassistant/components/c_Elta.py
+++ b/homeassistant/components/c_Elta.py
@@ -1,0 +1,40 @@
+import requests
+import logging
+_LOGGER = logging.getLogger(__name__)
+DOMAIN = 'c_Elta'
+REQUIREMENTS = ['requests==2.13.0','pycountry==17.1.8']
+#DEPENDENCIES = []
+ATTR_CODE = 'code'
+DEFAULT_CODE = 'null'
+def tracking(str):
+    tracking_number= str
+    if len(tracking_number) != 13:
+        result = ' the ',tracking_number,' dose not seem like an ELTA tracking number...'
+        _LOGGER.error('Invalid key {0}. Key must be 13 characters'.format(tracking_number))
+    else:
+        headers = {'Cookie': 'lang=en'}
+        r = requests.post('http://www.elta-courier.gr/track.php', data = { 'number': tracking_number}, headers=headers)
+        t_result = r.json()['result'][tracking_number]['result']
+        if t_result != 'wrong number':
+            p_date = t_result[-1]['date']
+            p_time = t_result[-1]['time']
+            p_status = t_result[-1]['status']
+            result = (p_date +" "+ p_time + " "+ p_status)
+        else:
+            result = ('wrong number')
+        #Country_origin = pycountry.countries.lookup(tracking_number[-2:])
+        #print ('Origin is: '+ Country_origin.name)
+    return (result)
+def setup(hass, config):
+    code = config[DOMAIN].get(ATTR_CODE, DEFAULT_CODE)
+    wd = tracking(code)
+    hass.states.set('c_Elta.trcode', wd)
+
+    """Setup is called when Home Assistant is loading our component."""
+    def handle_hello(call):
+        name = call.data.get(ATTR_CODE, DEFAULT_CODE)
+        wd = tracking(name)
+        hass.states.set('c_Elta.trcode', wd)
+    hass.services.register(DOMAIN, 'trcode', handle_hello)
+    # Return boolean to indicate that initialization was successfully.
+    return True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -433,6 +433,9 @@ pychromecast==0.8.0
 # homeassistant.components.media_player.cmus
 pycmus==0.1.0
 
+# homeassistant.components.c_Elta
+pycountry==17.1.8
+
 # homeassistant.components.sensor.cups
 # pycups==1.9.73
 
@@ -585,6 +588,9 @@ qnapstats==0.2.1
 
 # homeassistant.components.climate.radiotherm
 radiotherm==1.2
+
+# homeassistant.components.c_Elta
+requests==2.13.0
 
 # homeassistant.components.rflink
 rflink==0.0.28

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -589,9 +589,6 @@ qnapstats==0.2.1
 # homeassistant.components.climate.radiotherm
 radiotherm==1.2
 
-# homeassistant.components.c_Elta
-requests==2.13.0
-
 # homeassistant.components.rflink
 rflink==0.0.28
 


### PR DESCRIPTION
**Description:**

ELTA postal tracking
Allow tracking from the ELTA system .
like USPS service but for all the ELTA partners.
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1972

**Example entry for `configuration.yaml` (if applicable):**
```yaml
# Example configuration.yaml entry
c_Elta:
    code: YOUR_TRACKING_CODE
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
