### PR TITLE
ups sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -358,6 +358,7 @@ omit =
     homeassistant/components/sensor/transmission.py
     homeassistant/components/sensor/twitch.py
     homeassistant/components/sensor/uber.py
+    homeassistant/components/sensor/ups.py
     homeassistant/components/sensor/usps.py
     homeassistant/components/sensor/vasttrafik.py
     homeassistant/components/sensor/waqi.py

--- a/homeassistant/components/sensor/ups.py
+++ b/homeassistant/components/sensor/ups.py
@@ -1,0 +1,105 @@
+"""
+Sensor for UPS packages.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.usps/
+"""
+from collections import defaultdict
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (CONF_NAME, CONF_USERNAME, CONF_PASSWORD,
+                                 ATTR_ATTRIBUTION)
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import slugify
+from homeassistant.util import Throttle
+from homeassistant.util.dt import now, parse_date
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['upsmychoice==1.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'ups'
+COOKIE = 'upsmychoice_cookies.pickle'
+CONF_UPDATE_INTERVAL = 'update_interval'
+ICON = 'mdi:package-variant-closed'
+STATUS_DELIVERED = 'delivered'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=1800)): (
+        vol.All(cv.time_period, cv.positive_timedelta)),
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the UPS platform."""
+    import upsmychoice
+    try:
+        cookie = hass.config.path(COOKIE)
+        session = upsmychoice.get_session(config.get(CONF_USERNAME),
+                                          config.get(CONF_PASSWORD),
+                                          cookie_path=cookie)
+    except upsmychoice.UPSError:
+        _LOGGER.exception('Could not connect to UPS My Choice')
+        return False
+
+    add_devices([UPSSensor(session, config.get(CONF_NAME),
+                           config.get(CONF_UPDATE_INTERVAL))])
+
+
+class UPSSensor(Entity):
+    """UPS Sensor."""
+
+    def __init__(self, session, name, interval):
+        """Initialize the sensor."""
+        self._session = session
+        self._name = name
+        self._attributes = None
+        self._state = None
+        self.update = Throttle(interval)(self._update)
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name or DOMAIN
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    def _update(self):
+        """Update device state."""
+        import upsmychoice
+        status_counts = defaultdict(int)
+        for package in upsmychoice.get_packages(self._session):
+            status = slugify(package['status'])
+            skip = status == STATUS_DELIVERED and \
+                parse_date(package['delivery_date']) < now().date()
+            if skip:
+                continue
+            status_counts[status] += 1
+        self._attributes = {
+            ATTR_ATTRIBUTION: upsmychoice.ATTRIBUTION
+        }
+        self._attributes.update(status_counts)
+        self._state = sum(status_counts.values())
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return ICON

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -668,6 +668,9 @@ twilio==5.7.0
 # homeassistant.components.sensor.uber
 uber_rides==0.2.7
 
+# homeassistant.components.sensor.ups
+upsmychoice==1.0.1
+
 # homeassistant.components.device_tracker.unifi
 urllib3
 


### PR DESCRIPTION
**Description:**

Track package deliveries by UPS. Same behavior as the USPS sensor.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2045

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: ups
    username: !secret upsmychoice_username
    password: !secret upsmychoice_password
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
