### PR TITLE
Fix Nuki lock for Python 3.4

### DIFF
--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -14,7 +14,7 @@ from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
 
-REQUIREMENTS = ['pynuki==1.2']
+REQUIREMENTS = ['pynuki==1.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -487,7 +487,7 @@ pynetgear==0.3.3
 pynetio==0.1.6
 
 # homeassistant.components.lock.nuki
-pynuki==1.2
+pynuki==1.2.1
 
 # homeassistant.components.sensor.nut
 pynut2==2.1.2


### PR DESCRIPTION
**Description:**
The [pynuki](https://github.com/pschmitt/pynuki) library in version < 1.2.1 required Python 3.5+ to work correctly.
As a result a `SyntaxError` was thrown when setting up a Nuki Lock on a system that uses Python 3.4. 

**Example entry for `configuration.yaml` (if applicable):**
```yaml
lock:
￼   - platform: nuki
￼     host: 192.168.1.120
￼     port: 8080
￼     token: fe2345ef
```

**Related issue (if applicable):** fixes the issue reported by @pimbolilu https://github.com/home-assistant/home-assistant/pull/5715