### PR TITLE
Upgrade thingspeak to 0.4.1 and use the correct API key

### DIFF
--- a/homeassistant/components/thingspeak.py
+++ b/homeassistant/components/thingspeak.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import state as state_helper
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.event as event
 
-REQUIREMENTS = ['thingspeak==0.4.0']
+REQUIREMENTS = ['thingspeak==0.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ def setup(hass, config):
 
     try:
         channel = thingspeak.Channel(
-            channel_id, api_key=api_key, timeout=TIMEOUT)
+            channel_id, write_key=api_key, timeout=TIMEOUT)
         channel.get()
     except RequestException:
         _LOGGER.error("Error while accessing the ThingSpeak channel. "
@@ -52,7 +52,7 @@ def setup(hass, config):
         return False
 
     def thingspeak_listener(entity_id, old_state, new_state):
-        """Listen for new events and send them to thingspeak."""
+        """Listen for new events and send them to Thingspeak."""
         if new_state is None or new_state.state in (
                 STATE_UNKNOWN, '', STATE_UNAVAILABLE):
             return
@@ -65,8 +65,8 @@ def setup(hass, config):
         try:
             channel.update({'field1': _state})
         except RequestException:
-            _LOGGER.error("Error while sending value '%s' to Thingspeak",
-                          _state)
+            _LOGGER.error(
+                "Error while sending value '%s' to Thingspeak", _state)
 
     event.track_state_change(hass, entity, thingspeak_listener)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -652,7 +652,7 @@ tellduslive==0.3.2
 temperusb==1.5.1
 
 # homeassistant.components.thingspeak
-thingspeak==0.4.0
+thingspeak==0.4.1
 
 # homeassistant.components.light.tikteck
 tikteck==0.4


### PR DESCRIPTION
**Description:**
The handling of the API keys in the underlying module is not consistent in all parts. Thus to update values the  `write_key` needs to be used.

**Related issue (if applicable):** fixes #5663

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2017

**Example entry for `configuration.yaml` (if applicable):**
```yaml
thingspeak:
  api_key: !secret thinkspeak_api
  id: 219860
  whitelist: sensor.random
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
