### PR TITLE
Added support for multiple codes executed in a row

### DIFF
--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -27,8 +27,8 @@ DEFAULT_PROTOCOL = 1
 DEFAULT_SIGNAL_REPETITIONS = 10
 
 SWITCH_SCHEMA = vol.Schema({
-    vol.Required(CONF_CODE_OFF): cv.positive_int,
-    vol.Required(CONF_CODE_ON): cv.positive_int,
+    vol.Required(CONF_CODE_OFF): cv.string,
+    vol.Required(CONF_CODE_ON): cv.string,
     vol.Optional(CONF_PULSELENGTH): cv.positive_int,
     vol.Optional(CONF_SIGNAL_REPETITIONS,
                  default=DEFAULT_SIGNAL_REPETITIONS): cv.positive_int,
@@ -84,6 +84,8 @@ class RPiRFSwitch(SwitchDevice):
         self._pulselength = pulselength
         self._code_on = code_on
         self._code_off = code_off
+        self._code_on_list = [int(item_on) for item_on in self._code_on.split(',')]
+        self._code_off_list = [int(item_off) for item_off in self._code_off.split(',')]
         self._rfdevice.tx_repeat = signal_repetitions
 
     @property
@@ -101,22 +103,21 @@ class RPiRFSwitch(SwitchDevice):
         """Return true if device is on."""
         return self._state
 
-    def _send_code(self, code, protocol, pulselength):
-        """Send the code with a specified pulselength."""
-        _LOGGER.info("Sending code: %s", code)
-        res = self._rfdevice.tx_code(code, protocol, pulselength)
-        if not res:
-            _LOGGER.error("Sending code %s failed", code)
-        return res
+    def _send_code(self, code_list, protocol, pulselength):
+        """Send the code(s) with a specified pulselength."""
+        _LOGGER.info("Sending code(s): %s", code_list)
+        for code in code_list:
+            self._rfdevice.tx_code(code, protocol, pulselength)
+        return True
 
     def turn_on(self):
         """Turn the switch on."""
-        if self._send_code(self._code_on, self._protocol, self._pulselength):
+        if self._send_code(self._code_on_list, self._protocol, self._pulselength):
             self._state = True
             self.update_ha_state()
 
     def turn_off(self):
         """Turn the switch off."""
-        if self._send_code(self._code_off, self._protocol, self._pulselength):
+        if self._send_code(self._code_off_list, self._protocol, self._pulselength):
             self._state = False
             self.update_ha_state()

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -27,10 +27,10 @@ DEFAULT_PROTOCOL = 1
 DEFAULT_SIGNAL_REPETITIONS = 10
 
 SWITCH_SCHEMA = vol.Schema({
-    vol.Required(CONF_CODE_OFF): vol.All(cv.string,
-                                vol.Match(r"^[\d]+(,*[\d]*)*$")),
-    vol.Required(CONF_CODE_ON): vol.All(cv.string,
-                                vol.Match(r"^[\d]+(,*[\d]*)*$")),
+    vol.Required(CONF_CODE_OFF):
+        vol.All(cv.string, vol.Match(r"^[\d]+(,*[\d]*)*$")),
+    vol.Required(CONF_CODE_ON):
+        vol.All(cv.string, vol.Match(r"^[\d]+(,*[\d]*)*$")),
     vol.Optional(CONF_PULSELENGTH): cv.positive_int,
     vol.Optional(CONF_SIGNAL_REPETITIONS,
                  default=DEFAULT_SIGNAL_REPETITIONS): cv.positive_int,

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -27,8 +27,10 @@ DEFAULT_PROTOCOL = 1
 DEFAULT_SIGNAL_REPETITIONS = 10
 
 SWITCH_SCHEMA = vol.Schema({
-    vol.Required(CONF_CODE_OFF): vol.All(cv.string, vol.Match(r"^[\d]+(,*[\d]*)*$")),
-    vol.Required(CONF_CODE_ON): vol.All(cv.string, vol.Match(r"^[\d]+(,*[\d]*)*$")),
+    vol.Required(CONF_CODE_OFF): vol.All(cv.string,
+            vol.Match(r"^[\d]+(,*[\d]*)*$")),
+    vol.Required(CONF_CODE_ON): vol.All(cv.string,
+            vol.Match(r"^[\d]+(,*[\d]*)*$")),
     vol.Optional(CONF_PULSELENGTH): cv.positive_int,
     vol.Optional(CONF_SIGNAL_REPETITIONS,
                  default=DEFAULT_SIGNAL_REPETITIONS): cv.positive_int,

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -28,9 +28,9 @@ DEFAULT_SIGNAL_REPETITIONS = 10
 
 SWITCH_SCHEMA = vol.Schema({
     vol.Required(CONF_CODE_OFF):
-        vol.All(cv.string, vol.Match(r"^[\d]+(,*[\d]*)*$")),
+        vol.All(cv.ensure_list_csv, [cv.positive_int]),
     vol.Required(CONF_CODE_ON):
-        vol.All(cv.string, vol.Match(r"^[\d]+(,*[\d]*)*$")),
+        vol.All(cv.ensure_list_csv, [cv.positive_int]),
     vol.Optional(CONF_PULSELENGTH): cv.positive_int,
     vol.Optional(CONF_SIGNAL_REPETITIONS,
                  default=DEFAULT_SIGNAL_REPETITIONS): cv.positive_int,

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -84,8 +84,10 @@ class RPiRFSwitch(SwitchDevice):
         self._pulselength = pulselength
         self._code_on = code_on
         self._code_off = code_off
-        self._code_on_list = [int(item_on) for item_on in self._code_on.split(',')]
-        self._code_off_list = [int(item_off) for item_off in self._code_off.split(',')]
+        self._code_on_list = [int(item_on) for item_on in
+                              self._code_on.split(',')]
+        self._code_off_list = [int(item_off) for item_off in
+                               self._code_off.split(',')]
         self._rfdevice.tx_repeat = signal_repetitions
 
     @property
@@ -112,12 +114,14 @@ class RPiRFSwitch(SwitchDevice):
 
     def turn_on(self):
         """Turn the switch on."""
-        if self._send_code(self._code_on_list, self._protocol, self._pulselength):
+        if self._send_code(self._code_on_list, self._protocol,
+                           self._pulselength):
             self._state = True
             self.update_ha_state()
 
     def turn_off(self):
         """Turn the switch off."""
-        if self._send_code(self._code_off_list, self._protocol, self._pulselength):
+        if self._send_code(self._code_off_list, self._protocol,
+                           self._pulselength):
             self._state = False
             self.update_ha_state()

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -28,9 +28,9 @@ DEFAULT_SIGNAL_REPETITIONS = 10
 
 SWITCH_SCHEMA = vol.Schema({
     vol.Required(CONF_CODE_OFF): vol.All(cv.string,
-            vol.Match(r"^[\d]+(,*[\d]*)*$")),
+                                vol.Match(r"^[\d]+(,*[\d]*)*$")),
     vol.Required(CONF_CODE_ON): vol.All(cv.string,
-            vol.Match(r"^[\d]+(,*[\d]*)*$")),
+                                vol.Match(r"^[\d]+(,*[\d]*)*$")),
     vol.Optional(CONF_PULSELENGTH): cv.positive_int,
     vol.Optional(CONF_SIGNAL_REPETITIONS,
                  default=DEFAULT_SIGNAL_REPETITIONS): cv.positive_int,

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -86,10 +86,6 @@ class RPiRFSwitch(SwitchDevice):
         self._pulselength = pulselength
         self._code_on = code_on
         self._code_off = code_off
-        self._code_on_list = [int(item_on) for item_on in
-                              self._code_on.split(',')]
-        self._code_off_list = [int(item_off) for item_off in
-                               self._code_off.split(',')]
         self._rfdevice.tx_repeat = signal_repetitions
 
     @property
@@ -116,14 +112,12 @@ class RPiRFSwitch(SwitchDevice):
 
     def turn_on(self):
         """Turn the switch on."""
-        if self._send_code(self._code_on_list, self._protocol,
-                           self._pulselength):
+        if self._send_code(self._code_on, self._protocol, self._pulselength):
             self._state = True
             self.update_ha_state()
 
     def turn_off(self):
         """Turn the switch off."""
-        if self._send_code(self._code_off_list, self._protocol,
-                           self._pulselength):
+        if self._send_code(self._code_off, self._protocol, self._pulselength):
             self._state = False
             self.update_ha_state()

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -27,8 +27,8 @@ DEFAULT_PROTOCOL = 1
 DEFAULT_SIGNAL_REPETITIONS = 10
 
 SWITCH_SCHEMA = vol.Schema({
-    vol.Required(CONF_CODE_OFF): cv.string,
-    vol.Required(CONF_CODE_ON): cv.string,
+    vol.Required(CONF_CODE_OFF): vol.All(cv.string, vol.Match(r"^[\d]+(,*[\d]*)*$")),
+    vol.Required(CONF_CODE_ON): vol.All(cv.string, vol.Match(r"^[\d]+(,*[\d]*)*$")),
     vol.Optional(CONF_PULSELENGTH): cv.positive_int,
     vol.Optional(CONF_SIGNAL_REPETITIONS,
                  default=DEFAULT_SIGNAL_REPETITIONS): cv.positive_int,


### PR DESCRIPTION
**Description:**

Apparently, a certain switch I wanted to use with the raspberry pi rf switch component turned out to need not only one, but four individual codes transmitted in sequence for the switch to turn on or off. Since I noticed there is no support for that yet in the current rpi_rf.py implementation, I decided to add it. I also made changes in the docs to explain how to use multiple codes being sequentially executed.
Unfortunately, for performance reasons I had to remove the logger entry for the check if the codes could be transmitted, but since when logging the rpi_rf in debug shows codes that are being transmitted anyways, I don't think this would really be necessary, since it is still easily possible to see if the codes have been transmitted or not.
An additional benefit to this is that there is now the option of turning on / off multiple devices at once, since individual codes of devices can be chained.

Commits:
now codes can be specified either by simply providing a single code, which will then be sent like usual, or multiple codes can be executed in a row, specified in a comma delimited format in the configuration.yaml. For example: 111111,222222,333333,444444 would mean 111111 would be sent first, followed by 222222 and 333333 and 444444.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2018

**Example entry for `configuration.yaml` (if applicable):**
```yaml
switch:
   platform: rpi_rf
   gpio: 17
   switches:
      living_room_light:
        protocol: 5
        code_on: 654321,565874,233555,149874
        code_off: 654320,565873,233554,149873
        signal_repetitions: 15
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
