### PR TITLE
Fix name

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -237,7 +237,7 @@ def _setup_discovery(hass, config):
         _LOGGER.error("Unable to load MQTT discovery")
         return None
 
-    success = discovery.start(hass, conf[CONF_DISCOVERY_PREFIX], config)
+    success = discovery.async_start(hass, conf[CONF_DISCOVERY_PREFIX], config)
 
     return success
 


### PR DESCRIPTION
**Description:**

```bash
17-02-12 16:32:43 ERROR (MainThread) [homeassistant.bootstrap] Error during setup of component mqtt
Traceback (most recent call last):
  File "/home/fab/Documents/repos/home-assistant/homeassistant/bootstrap.py", line 152, in _async_setup_component
    None, component.setup, hass, config)
  File "/usr/lib64/python3.5/asyncio/futures.py", line 361, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib64/python3.5/asyncio/tasks.py", line 296, in _wakeup
    future.result()
  File "/usr/lib64/python3.5/asyncio/futures.py", line 274, in result
    raise self._exception
  File "/usr/lib64/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/fab/Documents/repos/home-assistant/homeassistant/components/mqtt/__init__.py", line 334, in setup
    _setup_discovery(hass, config)
  File "/home/fab/Documents/repos/home-assistant/homeassistant/components/mqtt/__init__.py", line 240, in _setup_discovery
    success = discovery.start(hass, conf[CONF_DISCOVERY_PREFIX], config)
AttributeError: module 'homeassistant.components.mqtt.discovery' has no attribute 'start'
```

See also [242](https://community.home-assistant.io/t/device-detection-with-mqtt/242/3).

Related issue (if applicable): fixes #5915 

**Example entry for `configuration.yaml` (if applicable):**
```yaml
mqtt:
  broker: localhost
  discovery: true
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

