### PR TITLE
Update qnapstats library; add support for new verify_ssl config

### DIFF
--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -12,13 +12,13 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
     CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_PORT, CONF_SSL,
-    CONF_MONITORED_CONDITIONS, TEMP_CELSIUS)
+    CONF_VERIFY_SSL, CONF_MONITORED_CONDITIONS, TEMP_CELSIUS)
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
 import voluptuous as vol
 
-REQUIREMENTS = ['qnapstats==0.2.1']
+REQUIREMENTS = ['qnapstats==0.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,6 +86,7 @@ _MONITORED_CONDITIONS = list(_HEALTH_MON_COND.keys()) + \
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_SSL, default=False): cv.boolean,
+    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
@@ -175,7 +176,9 @@ class QNAPStatsAPI(object):
             protocol + "://" + config.get(CONF_HOST),
             config.get(CONF_PORT),
             config.get(CONF_USERNAME),
-            config.get(CONF_PASSWORD))
+            config.get(CONF_PASSWORD),
+            verify_ssl=config.get(CONF_VERIFY_SSL)
+        )
 
         self.data = {}
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -581,7 +581,7 @@ pywemo==0.4.11
 pyzabbix==0.7.4
 
 # homeassistant.components.sensor.qnap
-qnapstats==0.2.1
+qnapstats==0.2.2
 
 # homeassistant.components.climate.radiotherm
 radiotherm==1.2


### PR DESCRIPTION
**Description:**

This resolves several issues with the QNAP sensor:

 - Fixes compatibility with TS-639 models (colinodell/qnapstats#4)
 - Fixes host check logic bug (colinodell/qnapstats#2)
 - Adds `verify_ssl` option to avoid errors with self-signed certs (colinodell/qnapstats#3)

If possible, please merge this into the next minor release.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2020

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Updated dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] Updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
