### PR TITLE
Zwave improvements

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -367,6 +367,10 @@ def setup(hass, config):
             workaround_component = workaround.get_device_component_mapping(
                 value)
             if workaround_component and workaround_component != component:
+                if workaround_component == workaround.WORKAROUND_IGNORE:
+                    _LOGGER.info("Ignoring device %s",
+                                 "{}.{}".format(component, object_id(value)))
+                    continue
                 _LOGGER.debug("Using %s instead of %s",
                               workaround_component, component)
                 component = workaround_component

--- a/homeassistant/components/zwave/workaround.py
+++ b/homeassistant/components/zwave/workaround.py
@@ -5,6 +5,7 @@ from . import const
 FIBARO = 0x010f
 PHILIO = 0x013c
 WENZHOU = 0x0118
+SOMFY = 0x47
 
 # Product IDs
 PHILIO_SLIM_SENSOR = 0x0002
@@ -12,32 +13,51 @@ PHILIO_3_IN_1_SENSOR_GEN_4 = 0x000d
 
 # Product Types
 FGFS101_FLOOD_SENSOR_TYPE = 0x0b00
+FGRM222_SHUTTER2 = 0x0301
 PHILIO_SENSOR = 0x0002
+SOMFY_ZRTSI = 0x5a52
 
 # Mapping devices
-PHILIO_SLIM_SENSOR_MOTION = (PHILIO, PHILIO_SENSOR, PHILIO_SLIM_SENSOR, 0)
-PHILIO_3_IN_1_SENSOR_GEN_4_MOTION = (
+PHILIO_SLIM_SENSOR_MOTION_MTII = (PHILIO, PHILIO_SENSOR, PHILIO_SLIM_SENSOR, 0)
+PHILIO_3_IN_1_SENSOR_GEN_4_MOTION_MTII = (
     PHILIO, PHILIO_SENSOR, PHILIO_3_IN_1_SENSOR_GEN_4, 0)
-WENZHOU_SLIM_SENSOR_MOTION = (WENZHOU, PHILIO_SENSOR, PHILIO_SLIM_SENSOR, 0)
+WENZHOU_SLIM_SENSOR_MOTION_MTII = (
+    WENZHOU, PHILIO_SENSOR, PHILIO_SLIM_SENSOR, 0)
 
 # Workarounds
 WORKAROUND_NO_OFF_EVENT = 'trigger_no_off_event'
+WORKAROUND_NO_POSITION = 'workaround_no_position'
+WORKAROUND_REVERSE_OPEN_CLOSE = 'reverse_open_close'
+WORKAROUND_IGNORE = 'workaround_ignore'
 
 # List of workarounds by (manufacturer_id, product_type, product_id, index)
-DEVICE_MAPPINGS = {
-    PHILIO_SLIM_SENSOR_MOTION: WORKAROUND_NO_OFF_EVENT,
-    PHILIO_3_IN_1_SENSOR_GEN_4_MOTION: WORKAROUND_NO_OFF_EVENT,
-    WENZHOU_SLIM_SENSOR_MOTION: WORKAROUND_NO_OFF_EVENT,
+DEVICE_MAPPINGS_MTII = {
+    PHILIO_SLIM_SENSOR_MOTION_MTII: WORKAROUND_NO_OFF_EVENT,
+    PHILIO_3_IN_1_SENSOR_GEN_4_MOTION_MTII: WORKAROUND_NO_OFF_EVENT,
+    WENZHOU_SLIM_SENSOR_MOTION_MTII: WORKAROUND_NO_OFF_EVENT,
 }
+
+SOMFY_ZRTSI_CONTROLLER_MT = (SOMFY, SOMFY_ZRTSI)
+FIBARO_FGRM222_MT = (FIBARO, FGRM222_SHUTTER2)
+
+# List of workarounds by (manufacturer_id, product_type)
+DEVICE_MAPPINGS_MT = {
+    SOMFY_ZRTSI_CONTROLLER_MT: WORKAROUND_NO_POSITION,
+    FIBARO_FGRM222_MT: WORKAROUND_REVERSE_OPEN_CLOSE,
+}
+
 
 # Component mapping devices
 FIBARO_FGFS101_SENSOR_ALARM = (
     FIBARO, FGFS101_FLOOD_SENSOR_TYPE, const.COMMAND_CLASS_SENSOR_ALARM)
+FIBARO_FGRM222_BINARY = (
+    FIBARO, FGRM222_SHUTTER2, const.COMMAND_CLASS_SWITCH_BINARY)
 
 # List of component workarounds by
 # (manufacturer_id, product_type, command_class)
 DEVICE_COMPONENT_MAPPING = {
     FIBARO_FGFS101_SENSOR_ALARM: 'binary_sensor',
+    FIBARO_FGRM222_BINARY: WORKAROUND_IGNORE,
 }
 
 
@@ -61,7 +81,10 @@ def get_device_mapping(value):
         manufacturer_id = int(value.node.manufacturer_id, 16)
         product_type = int(value.node.product_type, 16)
         product_id = int(value.node.product_id, 16)
-        return DEVICE_MAPPINGS.get(
+        result = DEVICE_MAPPINGS_MTII.get(
             (manufacturer_id, product_type, product_id, value.index))
+        if result:
+            return result
+        return DEVICE_MAPPINGS_MT.get((manufacturer_id, product_type))
 
     return None


### PR DESCRIPTION
**Description:**

* Add workaround for ignoring zwave devices based on (manufacturer, type, class)
* Add workaround to reverse open/close of cover devices until this is implemented upstream on OZW: https://github.com/OpenZWave/open-zwave/issues/344

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
