### PR TITLE
Clean up HDMI_CEC [Breaking change]

### DIFF
--- a/homeassistant/components/hdmi_cec.py
+++ b/homeassistant/components/hdmi_cec.py
@@ -13,7 +13,6 @@ from functools import reduce
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant import core
 from homeassistant.components import discovery
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER
 from homeassistant.components.switch import DOMAIN as SWITCH
@@ -23,9 +22,8 @@ from homeassistant.const import (EVENT_HOMEASSISTANT_START, STATE_UNKNOWN,
                                  STATE_OFF, CONF_DEVICES, CONF_PLATFORM,
                                  STATE_PLAYING, STATE_IDLE,
                                  STATE_PAUSED, CONF_HOST)
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers import customize
 
 REQUIREMENTS = ['pyCEC==0.4.13']
 
@@ -34,6 +32,7 @@ DOMAIN = 'hdmi_cec'
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_DISPLAY_NAME = "HomeAssistant"
+CONF_TYPES = 'types'
 
 ICON_UNKNOWN = 'mdi:help'
 ICON_AUDIO = 'mdi:speaker'
@@ -117,11 +116,6 @@ DEVICE_SCHEMA = vol.Schema({
                                       cv.string)
 })
 
-CUSTOMIZE_SCHEMA = vol.Schema({
-    vol.Optional(CONF_PLATFORM, default=MEDIA_PLAYER): vol.Any(MEDIA_PLAYER,
-                                                               SWITCH)
-})
-
 CONF_DISPLAY_NAME = 'osd_name'
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -133,6 +127,8 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_PLATFORM): vol.Any(SWITCH, MEDIA_PLAYER),
         vol.Optional(CONF_HOST): cv.string,
         vol.Optional(CONF_DISPLAY_NAME): cv.string,
+        vol.Optional(CONF_TYPES, default={}):
+        vol.Schema({cv.entity_id: vol.Any(MEDIA_PLAYER, SWITCH)})
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -254,11 +250,9 @@ def setup(hass: HomeAssistant, base_config):
             command = CecCommand(cmd, dst, src, att)
         hdmi_network.send_command(command)
 
-    @callback
     def _standby(call):
         hdmi_network.standby()
 
-    @callback
     def _power_on(call):
         hdmi_network.power_on()
 
@@ -295,16 +289,13 @@ def setup(hass: HomeAssistant, base_config):
         """
         hdmi_network.scan()
 
-    @callback
     def _new_device(device):
         """Called when new device is detected by HDMI network."""
         key = DOMAIN + '.' + device.name
         hass.data[key] = device
+        ent_platform = base_config[DOMAIN][CONF_TYPES].get(key, platform)
         discovery.load_platform(
-            hass,
-            customize.get_overrides(hass, core.DOMAIN, key).get(
-                CONF_PLATFORM, platform),
-            DOMAIN, discovered={ATTR_NEW: [key]},
+            hass, ent_platform, DOMAIN, discovered={ATTR_NEW: [key]},
             hass_config=base_config)
 
     def _shutdown(call):


### PR DESCRIPTION
**Description:**
HDMI-CEC component was incorrectly using customize to configure itself. Moved that to the component config.

It was also using `@callback` annotations for it's own callbacks, which is also incorrect.

Old wrong config:

```
homeassistant:
  customize:
    hdmi_cec.hdmi_5:
      platform: media_player
```

New ok config:

```
hdmi_cec:
  types:
    hdmi_cec.hdmi_5: media_player
```