### PR TITLE
Fixed typos in wink climate

### DIFF
--- a/homeassistant/components/climate/wink.py
+++ b/homeassistant/components/climate/wink.py
@@ -366,8 +366,8 @@ class WinkAC(WinkDevice, ClimateDevice):
         if target_temp_low is not None:
             data[ATTR_TARGET_TEMP_LOW] = self._convert_for_display(
                 self.target_temperature_low)
-        data["total_consumption"] = self.wink.toatl_consumption()
-        data["schedule_enabled"] = self.wink.toatl_consumption()
+        data["total_consumption"] = self.wink.total_consumption()
+        data["schedule_enabled"] = self.wink.schedule_enabled()
 
         return data
 


### PR DESCRIPTION
**Description:**
If a Wink user has a Arso AC unit, then their push updates will stop functioning soon after startup. Correcting these two typos should prevent this.

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/ha-stops-reporting-wink-state-changes/5884/369

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
