### PR TITLE
Fix mysensors platforms version requirement

### DIFF
--- a/homeassistant/components/device_tracker/mysensors.py
+++ b/homeassistant/components/device_tracker/mysensors.py
@@ -55,6 +55,8 @@ def setup_scanner(hass, config, see, discovery_info=None):
     gateways = hass.data.get(mysensors.MYSENSORS_GATEWAYS)
 
     for gateway in gateways:
+        if float(gateway.protocol_version) < 2.0:
+            continue
         gateway.platform_callbacks.append(mysensors_callback)
 
     return True

--- a/homeassistant/components/notify/mysensors.py
+++ b/homeassistant/components/notify/mysensors.py
@@ -19,6 +19,8 @@ def get_service(hass, config, discovery_info=None):
         return
 
     for gateway in gateways:
+        if float(gateway.protocol_version) < 2.0:
+            continue
         pres = gateway.const.Presentation
         set_req = gateway.const.SetReq
         map_sv_types = {


### PR DESCRIPTION
**Description:**
* Notify and device tracker platforms require mysensors version 2.0 or
  greater.

**Related issue (if applicable):**
fixes #5926 

**Example entry for `configuration.yaml` (if applicable):**
```yaml
mysensors:
  gateways:
    - device: '/dev/ttyACM0'
  version: 1.5
```

**Checklist:**
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
