### PR TITLE
Make EntityComponent update process more robust.

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -366,7 +366,8 @@ class EntityPlatform(object):
         """
         if self._process_updates.locked():
             self.component.logger.warning(
-                'Slow update circle on %d', self.component.domain)
+                "Updating %s took longer than the scheduled update "
+                "interval %s", self.component.domain, self.scan_interval)
             return
 
         with (yield from self._process_updates):


### PR DESCRIPTION
**Description:**

I'm not happy with first version of update circle in entity component. Now it shuld be more robust and one entity that can't be update should not brake all other entity update process. It now also show if the scan_interval to low and it block by core.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
