### PR TITLE
Bugfix/waqi sensor pwaqi version bump

### DIFF
--- a/homeassistant/components/sensor/waqi.py
+++ b/homeassistant/components/sensor/waqi.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pwaqi==1.3']
+REQUIREMENTS = ['pwaqi==1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/waqi.py
+++ b/homeassistant/components/sensor/waqi.py
@@ -162,6 +162,7 @@ class WaqiData(object):
         """Get the data from World Air Quality Index and updates the states."""
         import pwaqi
         try:
-            self.data = pwaqi.getStationObservation(self._station_id, self._token)
+            self.data = pwaqi.getStationObservation(
+                self._station_id, self._token)
         except AttributeError:
             _LOGGER.exception("Unable to fetch data from WAQI")

--- a/homeassistant/components/sensor/waqi.py
+++ b/homeassistant/components/sensor/waqi.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pwaqi==1.4']
+REQUIREMENTS = ['pwaqi==2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +33,7 @@ ATTRIBUTION = 'Data provided by the World Air Quality Index project'
 
 CONF_LOCATIONS = 'locations'
 CONF_STATIONS = 'stations'
+CONF_API_TOKEN = 'token'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
 
@@ -42,6 +43,7 @@ SENSOR_TYPES = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_STATIONS): cv.ensure_list,
+    vol.Required(CONF_API_TOKEN): cv.string,
     vol.Required(CONF_LOCATIONS): cv.ensure_list,
 })
 
@@ -51,15 +53,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import pwaqi
 
     dev = []
+    token = config.get(CONF_API_TOKEN)
     station_filter = config.get(CONF_STATIONS)
     for location_name in config.get(CONF_LOCATIONS):
-        station_ids = pwaqi.findStationCodesByCity(location_name)
+        station_ids = pwaqi.findStationCodesByCity(location_name, token)
         _LOGGER.info("The following stations were returned: %s", station_ids)
         for station in station_ids:
-            waqi_sensor = WaqiSensor(WaqiData(station), station)
+            waqi_sensor = WaqiSensor(WaqiData(station, token), station)
             if (not station_filter) or \
                (waqi_sensor.station_name in station_filter):
-                dev.append(WaqiSensor(WaqiData(station), station))
+                dev.append(WaqiSensor(WaqiData(station, token), station))
 
     add_devices(dev)
 
@@ -148,9 +151,10 @@ class WaqiSensor(Entity):
 class WaqiData(object):
     """Get the latest data and update the states."""
 
-    def __init__(self, station_id):
+    def __init__(self, station_id, token):
         """Initialize the data object."""
         self._station_id = station_id
+        self._token = token
         self.data = None
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
@@ -158,6 +162,6 @@ class WaqiData(object):
         """Get the data from World Air Quality Index and updates the states."""
         import pwaqi
         try:
-            self.data = pwaqi.getStationObservation(self._station_id)
+            self.data = pwaqi.getStationObservation(self._station_id, self._token)
         except AttributeError:
             _LOGGER.exception("Unable to fetch data from WAQI")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -384,7 +384,7 @@ pushbullet.py==0.10.0
 pushetta==1.0.15
 
 # homeassistant.components.sensor.waqi
-pwaqi==1.3
+pwaqi==1.4
 
 # homeassistant.components.sensor.cpuspeed
 py-cpuinfo==0.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -397,7 +397,7 @@ pushbullet.py==0.10.0
 pushetta==1.0.15
 
 # homeassistant.components.sensor.waqi
-pwaqi==1.4
+pwaqi==2.0
 
 # homeassistant.components.sensor.cpuspeed
 py-cpuinfo==0.2.3


### PR DESCRIPTION
**Description:**
Update underlying pwaqi library to version 2.0 which uses published AQICN API.
The change fixes stale data on WAQI sensor.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2027
**Example entry for `configuration.yaml` (if applicable):**
```yaml
# Example configuration.yaml entry
sensor:
  - platform: waqi
    token: AQICN_API_TOKEN
    locations:
      - beijing
    stations:
      - Beijing US Embassy
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. https://travis-ci.org/valentinalexeev/home-assistant/builds/201078793
  - [x] New dependencies have been added to the `REQUIREMENTS` variable.
  - [x] New dependencies are only imported inside functions that use them.
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
