### PR TITLE
Reduce battery drain on Nuki Lock

### DIFF
--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -14,7 +14,7 @@ from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
 
-REQUIREMENTS = ['pynuki==1.2.1']
+REQUIREMENTS = ['pynuki==1.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class NukiLock(LockDevice):
     @Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):
         """Update the nuki lock properties."""
-        self._nuki_lock.update()
+        self._nuki_lock.update(aggressive=False)
         self._name = self._nuki_lock.name
         self._locked = self._nuki_lock.is_locked
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -499,7 +499,7 @@ pynetgear==0.3.3
 pynetio==0.1.6
 
 # homeassistant.components.lock.nuki
-pynuki==1.2.1
+pynuki==1.2.2
 
 # homeassistant.components.sensor.nut
 pynut2==2.1.2


### PR DESCRIPTION
**Description:**
Someone from the Nuki.io team reached out to me and informed me that the way I implemented the lock state polling was not very battery friendly. I implemented a non-aggressive update method in [pynuki 1.2.2](https://pypi.python.org/pypi/pynuki/1.2.2).


**Example entry for `configuration.yaml` (if applicable):**
```yaml
lock:
  - platform: nuki
    host: !secret nuki_bridge
    token: !secret nuki_token
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
