### PR TITLE
Tado climate device

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -126,6 +126,9 @@ omit =
     homeassistant/components/zabbix.py
     homeassistant/components/*/zabbix.py
 
+    homeassistant/components/tado_v1.py
+    homeassistant/components/*/tado_v1.py
+
     homeassistant/components/alarm_control_panel/alarmdotcom.py
     homeassistant/components/alarm_control_panel/concord232.py
     homeassistant/components/alarm_control_panel/nx584.py

--- a/homeassistant/components/climate/tado_v1.py
+++ b/homeassistant/components/climate/tado_v1.py
@@ -1,0 +1,343 @@
+﻿"""tado component to create a climate device for each zone."""
+
+import logging
+
+from homeassistant.const import TEMP_CELSIUS
+from homeassistant.helpers.event import track_state_change
+
+from homeassistant.components.climate import (
+    ClimateDevice)
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT, ATTR_TEMPERATURE)
+
+CONST_MODE_SMART_SCHEDULE = "SMART_SCHEDULE"  # Default mytado mode
+CONST_MODE_OFF = "OFF"  # Switch off heating in a zone
+
+# When we change the temperature setting, we need an overlay mode
+# wait until tado changes the mode automatic
+CONST_OVERLAY_TADO_MODE = "TADO_MODE"
+# the user has change the temperature or mode manually
+CONST_OVERLAY_MANUAL = "MANUAL"
+# the temperature will be reset after a timespan
+CONST_OVERLAY_TIMER = "TIMER"
+
+
+# will be used when changing temperature
+CONST_DEFAULT_OPERATION_MODE = CONST_OVERLAY_TADO_MODE
+# will be used when switching to CONST_MODE_OFF
+CONST_DEFAULT_OFF_MODE = CONST_OVERLAY_MANUAL
+
+# DOMAIN = 'tado_v1'
+
+_LOGGER = logging.getLogger(__name__)
+SENSOR_TYPES = ['temperature', 'humidity', 'tado mode', 'power', 'overlay']
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the climate platform."""
+    # pylint: disable=W0613
+
+    # get the PyTado object from the hub component
+    tado = hass.data['Mytado']
+
+    try:
+        zones = tado.getZones()
+    except RuntimeError:
+        _LOGGER.error("Unable to get zone info from mytado")
+        return False
+
+    tado_data = TadoData(tado)
+
+    climate_devices = []
+    for zone in zones:
+        climate_devices.append(tado_data.create_climate_device(hass,
+                                                               zone['name'],
+                                                               zone['id']))
+
+    if len(climate_devices) > 0:
+        add_devices(climate_devices)
+        tado_data.activate_tracking(hass)
+        return True
+    else:
+        return False
+
+
+class TadoClimate(ClimateDevice):
+    """Representation of a tado climate device."""
+
+    def __init__(self, tado, zone_name, zone_id,
+                 min_temp, max_temp, target_temp, ac_mode,
+                 tolerance=0.3):
+        """Initialization of TadoClimate device."""
+        self._tado = tado
+        self.zone_name = zone_name
+        self.zone_id = zone_id
+
+        self.ac_mode = ac_mode
+
+        self._active = False
+        self._device_is_active = False
+
+        self._cur_temp = None
+        self._cur_humidity = None
+        self._is_away = False
+        self._min_temp = min_temp
+        self._max_temp = max_temp
+        self._target_temp = target_temp
+        self._tolerance = tolerance
+        self._unit = TEMP_CELSIUS
+
+        self._operation_list = [CONST_OVERLAY_MANUAL, CONST_OVERLAY_TIMER,
+                                CONST_OVERLAY_TADO_MODE,
+                                CONST_MODE_SMART_SCHEDULE, CONST_MODE_OFF]
+        self._current_operation = CONST_MODE_SMART_SCHEDULE
+        self._overlay_mode = self._current_operation
+
+    @property
+    def should_poll(self):
+        """
+        No Polling needed for tado climate device.
+
+        because it reuses sensors
+        """
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self.zone_name
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return self._unit
+
+    @property
+    def state(self):
+        """
+        Return the current temperature as the state.
+
+        instead of operation_mode.
+        """
+        return self._cur_temp
+
+    @property
+    def current_humidity(self):
+        """Return the current humidity."""
+        return self._cur_humidity
+
+    @property
+    def current_temperature(self):
+        """Return the sensor temperature."""
+        return self._cur_temp
+
+    @property
+    def current_operation(self):
+        """Return current operation ie. heat, cool, idle."""
+        return self._current_operation
+
+    @property
+    def operation_list(self):
+        """List of available operation modes."""
+        return self._operation_list
+
+    @property
+    def is_away_mode_on(self):
+        """Return true if away mode is on."""
+        return self._is_away
+
+    @property
+    def _is_device_active(self):
+        """If the toggleable device is currently active."""
+        return self._device_is_active
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self._target_temp
+
+    def set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            return
+
+        self._current_operation = CONST_DEFAULT_OPERATION_MODE
+        self._overlay_mode = None
+        self._target_temp = temperature
+        self._control_heating()
+        self.update_ha_state()
+
+    def set_operation_mode(self, operation_mode):
+        """Set new target temperature."""
+        self._current_operation = operation_mode
+        self._overlay_mode = None
+        self._control_heating()
+        self.update_ha_state()
+
+    @property
+    def min_temp(self):
+        """Return the minimum temperature."""
+        # pylint: disable=no-member
+        if self._min_temp:
+            return self._min_temp
+        else:
+            # get default temp from super class
+            return ClimateDevice.min_temp.fget(self)
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature."""
+        #  pylint: disable=no-member
+        if self._max_temp:
+            return self._max_temp
+        else:
+            #  Get default temp from super class
+            return ClimateDevice.max_temp.fget(self)
+
+    def sensor_changed(self, entity_id, old_state, new_state):
+        #  pylint: disable=W0613
+        """Called when a depending sensor changes."""
+        if new_state is None or new_state.state is None:
+            return
+
+        self.update_state(entity_id, new_state, True)
+
+    def update_state(self, entity_type, state, update_ha):
+        """Update the internal state."""
+        if state.state == "unknown":
+            return
+
+        _LOGGER.info("%s changed to %s", entity_type, state.state)
+
+        try:
+            if entity_type.endswith("temperature"):
+                unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+
+                self._cur_temp = self.hass.config.units.temperature(
+                    float(state.state), unit)
+
+                self._target_temp = self.hass.config.units.temperature(
+                    float(state.attributes.get("setting")), unit)
+
+            elif entity_type.endswith("humidity"):
+                self._cur_humidity = float(state.state)
+
+            elif entity_type.endswith("tado mode"):
+                self._is_away = state.state == "AWAY"
+
+            elif entity_type.endswith("power"):
+                if state.state == "OFF":
+                    self._current_operation = CONST_MODE_OFF
+                    self._device_is_active = False
+                else:
+                    self._device_is_active = True
+
+            elif entity_type.endswith("overlay"):
+                #  if you set mode manualy to off, there will be an overlay
+                #  and a termination, but we want to see the mode "OFF"
+                overlay = state.state
+                termination = state.attributes.get("termination")
+
+                if overlay == "True" and self._device_is_active:
+                    #  there is an overlay the device is on
+                    self._overlay_mode = termination
+                    self._current_operation = termination
+                elif overlay == "False":
+                    #  there is no overlay, the mode will always be
+                    #  "SMART_SCHEDULE"
+                    self._overlay_mode = CONST_MODE_SMART_SCHEDULE
+                    self._current_operation = CONST_MODE_SMART_SCHEDULE
+
+            if update_ha:
+                self.schedule_update_ha_state()
+
+        except ValueError:
+            _LOGGER.error("Unable to update from sensor: %s", entity_type)
+
+    def _control_heating(self):
+        """Send new target temperature to mytado."""
+        if not self._active and None not in (self._cur_temp,
+                                             self._target_temp):
+            self._active = True
+            _LOGGER.info('Obtained current and target temperature. '
+                         'tado thermostat active.')
+
+        if not self._active or self._current_operation == self._overlay_mode:
+            return
+
+        if self._current_operation == CONST_MODE_SMART_SCHEDULE:
+            _LOGGER.info('Switching mytado.com to SCHEDULE (default) '
+                         'for zone %s', self.zone_name)
+            self._tado.resetZoneOverlay(self.zone_id)
+            self._overlay_mode = self._current_operation
+            return
+
+        if self._current_operation == CONST_MODE_OFF:
+            _LOGGER.info('Switching mytado.com to OFF for zone %s',
+                         self.zone_name)
+            self._tado.setZoneOverlay(self.zone_id, CONST_DEFAULT_OFF_MODE)
+            self._overlay_mode = self._current_operation
+            return
+
+        _LOGGER.info("Switching mytado.com to %s mode for zone %s",
+                     self._current_operation, self.zone_name)
+        self._tado.setZoneOverlay(self.zone_id,
+                                  self._current_operation,
+                                  self._target_temp)
+
+        self._overlay_mode = self._current_operation
+
+
+class TadoData(object):
+    """Tado data object to control the tado functionality."""
+
+    def __init__(self, tado):
+        """Initialization of class TadoData."""
+        self._tado = tado
+        self._tracking_active = False
+
+        self.sensors = []
+
+    def create_climate_device(self, hass, name, tado_id):
+        """Create a climate device."""
+        capabilities = self._tado.getCapabilities(tado_id)
+
+        min_temp = float(capabilities["temperatures"]["celsius"]["min"])
+        max_temp = float(capabilities["temperatures"]["celsius"]["max"])
+        target_temp = 21
+        ac_mode = capabilities["type"] != "HEATING"
+
+        device_id = 'climate {} {}'.format(name, tado_id)
+        device = TadoClimate(self._tado, name, tado_id,
+                             min_temp, max_temp, target_temp, ac_mode)
+        sensor = {
+            "id": device_id,
+            "device": device,
+            "sensors": []
+        }
+
+        self.sensors.append(sensor)
+
+        for sensor_type in SENSOR_TYPES:
+            entity_id = 'sensor.{} {}'.format(name, sensor_type)
+            entity_id = entity_id.lower().replace(" ", "_")
+
+            sensor["sensors"].append(entity_id)
+
+            sensor_state = hass.states.get(entity_id)
+            if sensor_state:
+                device.update_state(sensor_type, sensor_state, False)
+
+        return device
+
+    def activate_tracking(self, hass):
+        """Activate tracking of dependend sensors."""
+        if self._tracking_active is False:
+            for data in self.sensors:
+                for entity_id in data["sensors"]:
+                    track_state_change(hass, entity_id,
+                                       data["device"].sensor_changed)
+                    _LOGGER.info("activated state tracking for %s.", entity_id)
+
+        self._tracking_active = True

--- a/homeassistant/components/climate/tado_v1.py
+++ b/homeassistant/components/climate/tado_v1.py
@@ -35,8 +35,6 @@ SENSOR_TYPES = ['temperature', 'humidity', 'tado mode', 'power', 'overlay']
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the climate platform."""
-    # pylint: disable=W0613
-
     # get the PyTado object from the hub component
     tado = hass.data['Mytado']
 

--- a/homeassistant/components/sensor/tado_v1.py
+++ b/homeassistant/components/sensor/tado_v1.py
@@ -108,10 +108,8 @@ class TadoSensor(Entity):
         """Update method called when should_poll is true."""
         self._tado_data.update()
 
-        self.push_update(self._tado_data.get_data(self._data_id), True)
+        data = self._tado_data.get_data(self._data_id)
 
-    def push_update(self, data, update_ha):
-        """Push the update to the current object."""
         # pylint: disable=R0912
         if self.zone_variable == 'temperature':
             if 'sensorDataPoints' in data:
@@ -175,8 +173,7 @@ class TadoSensor(Entity):
                 self._state = False
                 self._state_attributes = {}
 
-        if update_ha:
-            self.schedule_update_ha_state()
+        self.schedule_update_ha_state()
 
 
 class TadoData(object):

--- a/homeassistant/components/sensor/tado_v1.py
+++ b/homeassistant/components/sensor/tado_v1.py
@@ -69,11 +69,6 @@ class TadoSensor(Entity):
         self._state_attributes = None
 
     @property
-    def should_poll(self):
-        """Polling needed for tado sensors."""
-        return True
-
-    @property
     def unique_id(self):
         """Return the unique id."""
         return self._unique_id
@@ -89,7 +84,7 @@ class TadoSensor(Entity):
         return self._state
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes."""
         return self._state_attributes
 
@@ -183,7 +178,7 @@ class TadoSensor(Entity):
                 self._state_attributes = {}
 
         if update_ha:
-            super().update_ha_state()
+            self.schedule_update_ha_state()
 
 
 class TadoData(object):

--- a/homeassistant/components/sensor/tado_v1.py
+++ b/homeassistant/components/sensor/tado_v1.py
@@ -18,8 +18,6 @@ MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the sensor platform."""
-    #  pylint: disable=W0613
-
     #  get the PyTado object from the hub component
     tado = hass.data['Mytado']
 

--- a/homeassistant/components/sensor/tado_v1.py
+++ b/homeassistant/components/sensor/tado_v1.py
@@ -1,0 +1,258 @@
+"""tado component to create some sensors for each zone."""
+
+import logging
+from datetime import timedelta
+
+from homeassistant.const import TEMP_CELSIUS
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+#  DOMAIN = 'tado_v1'
+
+_LOGGER = logging.getLogger(__name__)
+SENSOR_TYPES = ['temperature', 'humidity', 'power',
+                'link', 'heating', 'tado mode', 'overlay']
+
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the sensor platform."""
+    #  pylint: disable=W0613
+
+    #  get the PyTado object from the hub component
+    tado = hass.data['Mytado']
+
+    try:
+        zones = tado.getZones()
+    except RuntimeError:
+        _LOGGER.error("Unable to get zone info from mytado")
+        return False
+
+    tado_data = TadoData(tado, MIN_TIME_BETWEEN_SCANS)
+
+    sensor_items = []
+    for zone in zones:
+        if zone['type'] == 'HEATING':
+            for variable in SENSOR_TYPES:
+                sensor_items.append(tado_data.create_zone_sensor(
+                    zone, zone['name'], zone['id'], variable))
+
+    me_data = tado.getMe()
+    sensor_items.append(tado_data.create_device_sensor(
+        me_data, me_data['homes'][0]['name'],
+        me_data['homes'][0]['id'],
+        "tado bridge status"))
+
+    tado_data.update()
+
+    if len(sensor_items) > 0:
+        add_devices(sensor_items)
+        return True
+    else:
+        return False
+
+
+class TadoSensor(Entity):
+    """Representation of a tado Sensor."""
+
+    def __init__(self, tado_data, zone_name, zone_id, zone_variable, data_id):
+        """Initialization of TadoSensor class."""
+        self._tado_data = tado_data
+        self.zone_name = zone_name
+        self.zone_id = zone_id
+        self.zone_variable = zone_variable
+        self._unique_id = '{} {}'.format(zone_variable, zone_id)
+        self._data_id = data_id
+
+        self._state = None
+        self._state_attributes = None
+
+    @property
+    def should_poll(self):
+        """Polling needed for tado sensors."""
+        return True
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{} {}'.format(self.zone_name, self.zone_variable)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        return self._state_attributes
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        if self.zone_variable == "temperature":
+            return TEMP_CELSIUS
+        elif self.zone_variable == "humidity":
+            return '%'
+        elif self.zone_variable == "heating":
+            return '%'
+
+    @property
+    def icon(self):
+        """Icon for the sensor."""
+        if self.zone_variable == "temperature":
+            return 'mdi:thermometer'
+        elif self.zone_variable == "humidity":
+            return 'mdi:water-percent'
+
+    def update(self):
+        """Update method called when should_poll is true."""
+        self._tado_data.update()
+
+        self.push_update(self._tado_data.get_data(self._data_id), True)
+
+    def push_update(self, data, update_ha):
+        """Push the update to the current object."""
+        # pylint: disable=R0912
+        if self.zone_variable == 'temperature':
+            if 'sensorDataPoints' in data:
+                sensor_data = data['sensorDataPoints']
+                self._state = float(
+                    sensor_data['insideTemperature']['celsius'])
+                self._state_attributes = {
+                    "time":
+                        sensor_data['insideTemperature']['timestamp'],
+                    "setting": 0  # setting is used in climate device
+                }
+
+                # temperature setting will not exist when device is off
+                if 'temperature' in data['setting'] and \
+                        data['setting']['temperature'] is not None:
+                    self._state_attributes["setting"] = float(
+                        data['setting']['temperature']['celsius'])
+
+        elif self.zone_variable == 'humidity':
+            if 'sensorDataPoints' in data:
+                sensor_data = data['sensorDataPoints']
+                self._state = float(
+                    sensor_data['humidity']['percentage'])
+                self._state_attributes = {
+                    "time": sensor_data['humidity']['timestamp'],
+                }
+
+        elif self.zone_variable == 'power':
+            if 'setting' in data:
+                self._state = data['setting']['power']
+
+        elif self.zone_variable == 'link':
+            if 'link' in data:
+                self._state = data['link']['state']
+
+        elif self.zone_variable == 'heating':
+            if 'activityDataPoints' in data:
+                activity_data = data['activityDataPoints']
+                self._state = float(
+                    activity_data['heatingPower']['percentage'])
+                self._state_attributes = {
+                    "time": activity_data['heatingPower']['timestamp'],
+                }
+
+        elif self.zone_variable == 'tado bridge status':
+            if 'connectionState' in data:
+                self._state = data['connectionState']['value']
+
+        elif self.zone_variable == 'tado mode':
+            if 'tadoMode' in data:
+                self._state = data['tadoMode']
+
+        elif self.zone_variable == 'overlay':
+            if 'overlay' in data and data['overlay'] is not None:
+                # pylint: disable=R0204
+                self._state = True
+                self._state_attributes = {
+                    "termination": data['overlay']['termination']['type'],
+                }
+            else:
+                self._state = False
+                self._state_attributes = {}
+
+        if update_ha:
+            super().update_ha_state()
+
+
+class TadoData(object):
+    """Tado data object to control the tado functionality."""
+
+    def __init__(self, tado, interval):
+        """Initialization of TadoData class."""
+        self._tado = tado
+
+        self.sensors = {}
+        self.data = {}
+
+        # Apply throttling to methods using configured interval
+        self.update = Throttle(interval)(self._update)
+
+    def create_zone_sensor(self, zone, name, zone_id, variable):
+        """Create a zone sensor."""
+        data_id = 'zone {} {}'.format(name, zone_id)
+
+        self.sensors[data_id] = {
+            "zone": zone,
+            "name": name,
+            "id": zone_id,
+            "data_id": data_id
+        }
+        self.data[data_id] = None
+
+        return TadoSensor(self, name, zone_id, variable, data_id)
+
+    def create_device_sensor(self, device, name, device_id, variable):
+        """Create a device sensor."""
+        data_id = 'device {} {}'.format(name, device_id)
+
+        self.sensors[data_id] = {
+            "device": device,
+            "name": name,
+            "id": device_id,
+            "data_id": data_id
+        }
+        self.data[data_id] = None
+
+        return TadoSensor(self, name, device_id, variable, data_id)
+
+    def get_data(self, data_id):
+        """Get the cached data."""
+        data = {"error": "no data"}
+
+        if data_id in self.data:
+            data = self.data[data_id]
+
+        return data
+
+    def _update(self):
+        """Update the internal data-array from mytado.com."""
+        for data_id, sensor in self.sensors.items():
+            data = None
+
+            try:
+                if "zone" in sensor:
+                    _LOGGER.info("querying mytado.com for zone %s %s",
+                                 sensor["id"], sensor["name"])
+                    data = self._tado.getState(sensor["id"])
+                if "device" in sensor:
+                    _LOGGER.info("querying mytado.com for device %s %s",
+                                 sensor["id"], sensor["name"])
+                    data = self._tado.getDevices()[0]
+
+            except RuntimeError:
+                _LOGGER.error("Unable to connect to myTado. %s %s",
+                              sensor["id"], sensor["id"])
+
+            self.data[data_id] = data

--- a/homeassistant/components/tado_v1.py
+++ b/homeassistant/components/tado_v1.py
@@ -8,10 +8,12 @@ https://home-assistant.io/components/tado_v1/
 import logging
 import urllib
 
+import voluptuous as vol
+
 from homeassistant.components.discovery import load_platform
 from homeassistant.helpers import config_validation as cv
-
-import voluptuous as vol
+from homeassistant.const import (
+    CONF_USERNAME, CONF_PASSWORD)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,21 +28,18 @@ TADO_V1_COMPONENTS = [
     'sensor', 'climate'
 ]
 
-CONF_MYTADO_USERNAME = 'mytado_username'
-CONF_MYTADO_PASSWORD = 'mytado_password'
-
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_MYTADO_USERNAME, default=''): cv.string,
-        vol.Required(CONF_MYTADO_PASSWORD, default=''): cv.string
+        vol.Required(CONF_USERNAME, default=''): cv.string,
+        vol.Required(CONF_PASSWORD, default=''): cv.string
     })
 }, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
     """Your controller/hub specific code."""
-    username = config[DOMAIN][CONF_MYTADO_USERNAME]
-    password = config[DOMAIN][CONF_MYTADO_PASSWORD]
+    username = config[DOMAIN][CONF_USERNAME]
+    password = config[DOMAIN][CONF_PASSWORD]
 
     from PyTado.interface import Tado
 

--- a/homeassistant/components/tado_v1.py
+++ b/homeassistant/components/tado_v1.py
@@ -1,0 +1,58 @@
+"""
+Support for the (unofficial) tado api.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/tado_v1/
+"""
+
+import logging
+import urllib
+
+from homeassistant.components.discovery import load_platform
+from homeassistant.helpers import config_validation as cv
+
+import voluptuous as vol
+
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'tado_v1'
+
+REQUIREMENTS = ['https://github.com/wmalgadey/PyTado/archive/'
+                '0.1.10.zip#'
+                'PyTado==0.1.10']
+
+TADO_V1_COMPONENTS = [
+    'sensor', 'climate'
+]
+
+CONF_MYTADO_USERNAME = 'mytado_username'
+CONF_MYTADO_PASSWORD = 'mytado_password'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_MYTADO_USERNAME, default=''): cv.string,
+        vol.Required(CONF_MYTADO_PASSWORD, default=''): cv.string
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Your controller/hub specific code."""
+    username = config[DOMAIN][CONF_MYTADO_USERNAME]
+    password = config[DOMAIN][CONF_MYTADO_PASSWORD]
+
+    from PyTado.interface import Tado
+
+    try:
+        tado = Tado(username, password)
+    except (RuntimeError, urllib.error.HTTPError):
+        _LOGGER.error("Unable to connect to mytado with username and password")
+        return False
+
+    hass.data['Mytado'] = tado
+
+    for component in TADO_V1_COMPONENTS:
+        load_platform(hass, component, DOMAIN, {}, config)
+
+    return True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -734,3 +734,8 @@ zengge==0.2
 
 # homeassistant.components.zeroconf
 zeroconf==0.18.0
+
+# homeassistant.components.tado_v1
+# homeassistant.components.sensor.tado_v1
+# homeassistant.components.switch.tado_v1
+https://github.com/wmalgadey/PyTado/archive/0.1.10.zip#PyTado==0.1.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -284,6 +284,9 @@ https://github.com/theolind/pymysensors/archive/0b705119389be58332f17753c53167f5
 # homeassistant.components.alarm_control_panel.simplisafe
 https://github.com/w1ll1am23/simplisafe-python/archive/586fede0e85fd69e56e516aaa8e97eb644ca8866.zip#simplisafe-python==0.0.1
 
+# homeassistant.components.tado_v1
+https://github.com/wmalgadey/PyTado/archive/0.1.10.zip#PyTado==0.1.10
+
 # homeassistant.components.media_player.lg_netcast
 https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 
@@ -734,8 +737,3 @@ zengge==0.2
 
 # homeassistant.components.zeroconf
 zeroconf==0.18.0
-
-# homeassistant.components.tado_v1
-# homeassistant.components.sensor.tado_v1
-# homeassistant.components.switch.tado_v1
-https://github.com/wmalgadey/PyTado/archive/0.1.10.zip#PyTado==0.1.10


### PR DESCRIPTION
**Description:**
Custom home-assistant component for tado (using my fork of PyTado for a py3 compatible module)

It is highly inspired by https://community.home-assistant.io/t/tado-api-json/272/5 and the comments by diplix (https://community.home-assistant.io/users/diplix)

It is called `tado_v1` because it is build upon the unofficial API used by the myTado.com-Webapp.


**Example entry for `configuration.yaml` (if applicable):**
```yaml
tado_v1:
    username: 
    password:
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
