### PR TITLE
Add fake support for turn on/off for Apple TV

### DIFF
--- a/homeassistant/components/media_player/apple_tv.py
+++ b/homeassistant/components/media_player/apple_tv.py
@@ -13,11 +13,12 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import (
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK, SUPPORT_SEEK,
-    SUPPORT_STOP, SUPPORT_PLAY, SUPPORT_PLAY_MEDIA, MediaPlayerDevice,
-    PLATFORM_SCHEMA, MEDIA_TYPE_MUSIC, MEDIA_TYPE_VIDEO, MEDIA_TYPE_TVSHOW)
+    SUPPORT_STOP, SUPPORT_PLAY, SUPPORT_PLAY_MEDIA, SUPPORT_TURN_ON,
+    SUPPORT_TURN_OFF, MediaPlayerDevice, PLATFORM_SCHEMA, MEDIA_TYPE_MUSIC,
+    MEDIA_TYPE_VIDEO, MEDIA_TYPE_TVSHOW)
 from homeassistant.const import (
     STATE_IDLE, STATE_PAUSED, STATE_PLAYING, STATE_STANDBY, CONF_HOST,
-    CONF_NAME)
+    STATE_OFF, CONF_NAME)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
@@ -28,6 +29,7 @@ REQUIREMENTS = ['pyatv==0.1.4']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_LOGIN_ID = 'login_id'
+CONF_START_OFF = 'start_off'
 
 DEFAULT_NAME = 'Apple TV'
 
@@ -37,6 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_LOGIN_ID): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_START_OFF, default=False): cv.boolean
 })
 
 
@@ -50,10 +53,12 @@ def async_setup_platform(hass, config, async_add_entities,
         name = discovery_info['name']
         host = discovery_info['host']
         login_id = discovery_info['hsgid']
+        start_off = False
     else:
         name = config.get(CONF_NAME)
         host = config.get(CONF_HOST)
         login_id = config.get(CONF_LOGIN_ID)
+        start_off = config.get(CONF_START_OFF)
 
     if DATA_APPLE_TV not in hass.data:
         hass.data[DATA_APPLE_TV] = []
@@ -65,7 +70,7 @@ def async_setup_platform(hass, config, async_add_entities,
     details = pyatv.AppleTVDevice(name, host, login_id)
     session = async_get_clientsession(hass)
     atv = pyatv.connect_to_apple_tv(details, hass.loop, session=session)
-    entity = AppleTvDevice(atv, name)
+    entity = AppleTvDevice(atv, name, start_off)
 
     yield from async_add_entities([entity], update_before_add=True)
 
@@ -73,10 +78,15 @@ def async_setup_platform(hass, config, async_add_entities,
 class AppleTvDevice(MediaPlayerDevice):
     """Representation of an Apple TV device."""
 
-    def __init__(self, atv, name):
+    def __init__(self, atv, name, is_off):
         """Initialize the Apple TV device."""
-        self._name = name
         self._atv = atv
+        self._name = name
+        self._is_off = is_off
+        self._playing = None
+        self._artwork_hash = None
+
+    def _reset(self):
         self._playing = None
         self._artwork_hash = None
 
@@ -88,6 +98,9 @@ class AppleTvDevice(MediaPlayerDevice):
     @property
     def state(self):
         """Return the state of the device."""
+        if self._is_off:
+            return STATE_OFF
+
         if self._playing is not None:
             from pyatv import const
             state = self._playing.play_state
@@ -107,23 +120,24 @@ class AppleTvDevice(MediaPlayerDevice):
     @asyncio.coroutine
     def async_update(self):
         """Retrieve latest state."""
-        from pyatv import exceptions
-        try:
-            playing = yield from self._atv.metadata.playing()
+        if not self._is_off:
+            from pyatv import exceptions
+            try:
+                playing = yield from self._atv.metadata.playing()
 
-            if self._has_playing_media_changed(playing):
-                base = str(playing.title) + str(playing.artist) + \
-                    str(playing.album) + str(playing.total_time)
-                self._artwork_hash = hashlib.md5(
-                    base.encode('utf-8')).hexdigest()
+                if self._has_playing_media_changed(playing):
+                    base = str(playing.title) + str(playing.artist) + \
+                        str(playing.album) + str(playing.total_time)
+                    self._artwork_hash = hashlib.md5(
+                        base.encode('utf-8')).hexdigest()
 
-            self._playing = playing
-        except exceptions.AuthenticationError as ex:
-            _LOGGER.warning('%s (bad login id?)', str(ex))
-        except aiohttp.errors.ClientOSError as ex:
-            _LOGGER.error('failed to connect to Apple TV (%s)', str(ex))
-        except asyncio.TimeoutError:
-            _LOGGER.warning('timed out while connecting to Apple TV')
+                self._playing = playing
+            except exceptions.AuthenticationError as ex:
+                _LOGGER.warning('%s (bad login id?)', str(ex))
+            except aiohttp.errors.ClientOSError as ex:
+                _LOGGER.error('failed to connect to Apple TV (%s)', str(ex))
+            except asyncio.TimeoutError:
+                _LOGGER.warning('timed out while connecting to Apple TV')
 
     def _has_playing_media_changed(self, new_playing):
         if self._playing is None:
@@ -131,6 +145,18 @@ class AppleTvDevice(MediaPlayerDevice):
         old_playing = self._playing
         return new_playing.media_type != old_playing.media_type or \
             new_playing.title != old_playing.title
+
+    def turn_on(self):
+        """Turn the media player on."""
+        self._is_off = False
+        self._reset()
+        self.schedule_update_ha_state()
+
+    def turn_off(self):
+        """Turn the media player off."""
+        self._is_off = True
+        self._reset()
+        self.schedule_update_ha_state()
 
     @property
     def media_content_type(self):
@@ -183,20 +209,24 @@ class AppleTvDevice(MediaPlayerDevice):
     def media_title(self):
         """Title of current playing media."""
         if self._playing is not None:
+            if self.state == STATE_IDLE:
+                return 'Nothing playing'
             title = self._playing.title
             return title if title else "No title"
 
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
+        features = SUPPORT_TURN_ON | SUPPORT_TURN_OFF
         if self._playing is not None:
             if self.state != STATE_IDLE:
-                return SUPPORT_PAUSE | SUPPORT_PLAY | \
+                features |= SUPPORT_PAUSE | SUPPORT_PLAY | \
                     SUPPORT_SEEK | SUPPORT_STOP | \
                     SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK | \
                     SUPPORT_PLAY_MEDIA
             else:
-                return SUPPORT_PLAY_MEDIA
+                features |= SUPPORT_PLAY_MEDIA
+        return features
 
     def async_media_play_pause(self):
         """Pause media on media player.

--- a/homeassistant/components/media_player/apple_tv.py
+++ b/homeassistant/components/media_player/apple_tv.py
@@ -210,15 +210,13 @@ class AppleTvDevice(MediaPlayerDevice):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
-        features = SUPPORT_TURN_ON | SUPPORT_TURN_OFF
-        if self._playing is not None:
-            if self.state != STATE_IDLE:
-                features |= SUPPORT_PAUSE | SUPPORT_PLAY | \
-                    SUPPORT_SEEK | SUPPORT_STOP | \
-                    SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK | \
-                    SUPPORT_PLAY_MEDIA
-            else:
-                features |= SUPPORT_PLAY_MEDIA
+        features = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PLAY_MEDIA
+        if self._playing is None or self.state == STATE_IDLE:
+            return features
+
+        features |= SUPPORT_PAUSE | SUPPORT_PLAY | SUPPORT_SEEK | \
+            SUPPORT_STOP | SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
+
         return features
 
     @asyncio.coroutine


### PR DESCRIPTION
**Description:**
Some users have reported that their Apple TVs automatically start up when Home Assistant start. This is mostly a problem when CEC is enabled since it starts other devices as well. Since I have not yet found a way to know if a device is in standby or not, this cannot easily be fixed. With this PR however, it is possible to "fake" turn off/on a device so that no requests are sent to it. This way the main issue no longer exists, but the user must "turn on" the device again to get updates in Home Assistant. This is probably as good as it gets for now.

There's also a config option so that a device can start in off mode (this must be set to True). Documentation will be written when a user has verified functionality.

**Related issue (if applicable):** fixes #5917 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
media_player:
  - platform: apple_tv
    name: Apple TV
    host: 10.0.10.26
    login_id: 00000000-000-000-0000-00000000000
    start_off: True
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
