### PR TITLE
Fix slow status updates from the knx bus

### DIFF
--- a/homeassistant/components/knx.py
+++ b/homeassistant/components/knx.py
@@ -137,7 +137,7 @@ class KNXGroupAddress(Entity):
             """
             if (addr == self.state_address) or (addr == self.address):
                 self._state = data[0]
-                self.update_ha_state()
+                self.schedule_update_ha_state()
 
         KNXTUNNEL.register_listener(self.address, handle_knx_message)
         if self.state_address:

--- a/homeassistant/components/knx.py
+++ b/homeassistant/components/knx.py
@@ -136,7 +136,7 @@ class KNXGroupAddress(Entity):
             information relating to this device.
             """
             if (addr == self.state_address) or (addr == self.address):
-                self._state = data
+                self._state = data[0]
                 self.update_ha_state()
 
         KNXTUNNEL.register_listener(self.address, handle_knx_message)


### PR DESCRIPTION
**Description:**

The data set in the entity was an array, not the value. This resulted in a truthy value all the time. The actual 'slow' update was triggered by the periodic status update.

**Related issue (if applicable):** fixes #4407