### PR TITLE
Only try to pair notify.webostv when not already paired

### DIFF
--- a/homeassistant/components/notify/webostv.py
+++ b/homeassistant/components/notify/webostv.py
@@ -34,14 +34,15 @@ def get_service(hass, config, discovery_info=None):
     path = hass.config.path(config.get(CONF_FILENAME))
     client = WebOsClient(config.get(CONF_HOST), key_file_path=path)
 
-    try:
-        client.register()
-    except PyLGTVPairException:
-        _LOGGER.error("Pairing with TV failed")
-        return None
-    except OSError:
-        _LOGGER.error("TV unreachable")
-        return None
+    if not client.is_registered():
+        try:
+            client.register()
+        except PyLGTVPairException:
+            _LOGGER.error("Pairing with TV failed")
+            return None
+        except OSError:
+            _LOGGER.error("TV unreachable")
+            return None
 
     return LgWebOSNotificationService(client)
 


### PR DESCRIPTION
**Description:**
At present, if home-assistant starts up when a paired WebOS TV is not powered on, the component fails to register successfully because the component always tries to pair with the TV when setting up.
If the TV has already been paired, this is not necessary, and this alteration to only attempt pairing when not already-paired allows the component to successfully register with paired TVs even when they are off. 

To me, this seems significantly better, as you don't have to ensure a paired TV is powered on when restarting home-assistant.