### PR TITLE
Enable sensor for discovery

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -27,7 +27,6 @@ SUPPORTED_COMPONENTS = ['binary_sensor', 'sensor']
 @callback
 def async_start(hass, discovery_topic, hass_config):
     """Initialization of MQTT Discovery."""
-
     @asyncio.coroutine
     def async_device_message_received(topic, payload, qos):
         """Process the received message."""

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -20,12 +20,14 @@ _LOGGER = logging.getLogger(__name__)
 
 TOPIC_MATCHER = re.compile(
     r'homeassistant/(?P<component>\w+)/(?P<object_id>\w+)/config')
-SUPPORTED_COMPONENTS = ['binary_sensor']
+
+SUPPORTED_COMPONENTS = ['binary_sensor', 'sensor']
 
 
 @callback
 def async_start(hass, discovery_topic, hass_config):
     """Initialization of MQTT Discovery."""
+
     @asyncio.coroutine
     def async_device_message_received(topic, payload, qos):
         """Process the received message."""
@@ -39,8 +41,7 @@ def async_start(hass, discovery_topic, hass_config):
         try:
             payload = json.loads(payload)
         except ValueError:
-            _LOGGER.warning(
-                "Unable to parse JSON %s: %s", object_id, payload)
+            _LOGGER.warning("Unable to parse JSON %s: %s", object_id, payload)
             return
 
         if component not in SUPPORTED_COMPONENTS:

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -29,7 +29,10 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup MQTT Sensor."""
+    """Set up MQTT Sensor."""
+    if discovery_info is not None:
+        config = PLATFORM_SCHEMA(discovery_info)
+
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
         value_template.hass = hass


### PR DESCRIPTION
**Description:**
Sensors are now enabled.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2019

**Example entry for `configuration.yaml` (if applicable):**
```yaml
mqtt:
  broker: localhost
  discovery: true
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
