### PR TITLE
Remove unit of measurement

### DIFF
--- a/homeassistant/components/sensor/moon.py
+++ b/homeassistant/components/sensor/moon.py
@@ -63,11 +63,6 @@ class MoonSensor(Entity):
             return 'New moon'
 
     @property
-    def unit_of_measurement(self):
-        """Return the unit the value is expressed in."""
-        return 'Phase'
-
-    @property
     def icon(self):
         """Icon to use in the frontend, if any."""
         return ICON


### PR DESCRIPTION
**Description:**
Removal of unit of measurement of the moon phases.

**Related issue (if applicable):** fixes [11798](https://community.home-assistant.io/t/platform-moon-phase-as-unit-of-measurement-necessary/11798)

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: moon
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
