### PR TITLE
Fix #5979

### DIFF
--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-wink==1.1.1', 'pubnubsub-handler==1.0.0']
+REQUIREMENTS = ['python-wink==1.1.1', 'pubnubsub-handler==1.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -400,7 +400,7 @@ proliphix==0.4.1
 psutil==5.1.3
 
 # homeassistant.components.wink
-pubnubsub-handler==1.0.0
+pubnubsub-handler==1.0.1
 
 # homeassistant.components.notify.pushbullet
 pushbullet.py==0.10.0


### PR DESCRIPTION
**Description:**
Wink/PubNub made a change to their API and it broke a check performed in pubnubsub-handler. pubnubsub-handler has been updated to perform the check that broke a better way. 

This needs included in the next dot build. All Wink users are experiencing issues resulting in no push updates from pubnub. 

**Related issue (if applicable):** fixes #5979 

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
