### PR TITLE
Update hassbian component with real output

### DIFF
--- a/homeassistant/components/config/hassbian.py
+++ b/homeassistant/components/config/hassbian.py
@@ -8,42 +8,26 @@ from homeassistant.components.http import HomeAssistantView
 
 _TEST_OUTPUT = """
 {
-  "suites": [
-    {
-      "openzwave": [
-        {
-          "state": "installed"
+    "suites":{
+        "libcec":{
+            "state":"Uninstalled",
+            "description":"Installs the libcec package for controlling CEC devices from this Pi"
         },
-        {
-          "description": "This is the description of the Open Z-Wave suite."
-        }
-      ]
-    },
-    {
-      "openelec": [
-        {
-          "state": "not_installed"
+        "mosquitto":{
+            "state":"failed",
+            "description":"Installs the Mosquitto package for setting up a local MQTT server"
         },
-        {
-          "description":
-          "OpenElec is amazing. It allows you to control the TV."
-        }
-      ]
-    },
-    {
-      "mosquitto": [
-        {
-          "state": "installing"
+        "openzwave":{
+            "state":"Uninstalled",
+            "description":"Installs the Open Z-wave package for setting up your zwave network"
         },
-        {
-          "description":
-          "Mosquitto is an MQTT broker."
+        "samba":{
+            "state":"installing",
+            "description":"Installs the samba package for sharing the hassbian configuration files over the Pi's network."
         }
-      ]
     }
-  ]
 }
-"""
+"""  # noqa
 
 
 @asyncio.coroutine
@@ -87,18 +71,7 @@ class HassbianSuitesView(HomeAssistantView):
         """Request suite status."""
         inp = yield from hassbian_status(request.app['hass'], self._test_mode)
 
-        # Flatten the structure a bit
-        suites = {}
-
-        for suite in inp['suites']:
-            key = next(iter(suite))
-            info = suites[key] = {}
-
-            for item in suite[key]:
-                item_key = next(iter(item))
-                info[item_key] = item[item_key]
-
-        return self.json(suites)
+        return self.json(inp['suites'])
 
 
 class HassbianSuiteInstallView(HomeAssistantView):

--- a/tests/components/config/test_hassbian.py
+++ b/tests/components/config/test_hassbian.py
@@ -51,8 +51,9 @@ def test_get_suites(hass, test_client):
 
     assert 'mosquitto' in result
     info = result['mosquitto']
-    assert info['state'] == 'installing'
-    assert info['description'] == 'Mosquitto is an MQTT broker.'
+    assert info['state'] == 'failed'
+    assert info['description'] == \
+        'Installs the Mosquitto package for setting up a local MQTT server'
 
 
 @asyncio.coroutine


### PR DESCRIPTION
**Description:**
Update the hassbian config panel with real output of the tool. Next step will be to hook it into the real tool.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
