### PR TITLE
myq-cover update requirement

### DIFF
--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -14,8 +14,8 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = [
-    'https://github.com/arraylabs/pymyq/archive/v0.0.2.zip'
-    '#pymyq==0.0.2']
+    'https://github.com/arraylabs/pymyq/archive/v0.0.5.zip'
+    '#pymyq==0.0.5']
 
 COVER_SCHEMA = vol.Schema({
     vol.Required(CONF_TYPE): cv.string,
@@ -39,7 +39,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     myq = pymyq(username, password, brand)
 
     if not myq.is_supported_brand():
-        logger.error('MyQ Cover - Unsupported Brand')
+        logger.error('MyQ Cover - Unsupported Type. See documentation')
         return
 
     if not myq.is_login_valid():

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -222,7 +222,7 @@ https://github.com/Xorso/pyalarmdotcom/archive/0.1.1.zip#pyalarmdotcom==0.1.1
 https://github.com/aparraga/braviarc/archive/0.3.6.zip#braviarc==0.3.6
 
 # homeassistant.components.cover.myq
-https://github.com/arraylabs/pymyq/archive/v0.0.2.zip#pymyq==0.0.2
+https://github.com/arraylabs/pymyq/archive/v0.0.5.zip#pymyq==0.0.5
 
 # homeassistant.components.media_player.roku
 https://github.com/bah2830/python-roku/archive/3.1.3.zip#roku==3.1.3


### PR DESCRIPTION
**Description:**
Update requirement file version. Changed error response to be more correct.

**Related issue (if applicable):**
No submitted issues but this addresses the external library change needed after chamberlain changed endpoints again.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2046

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
