### PR TITLE
Bugfix sonos favorite_source after lost connection

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -365,7 +365,6 @@ class SonosDevice(MediaPlayerDevice):
             self._support_pause = False
             self._is_playing_tv = False
             self._is_playing_line_in = False
-            self._favorite_sources = None
             self._source_name = None
             self._last_avtransport_event = None
             return


### PR DESCRIPTION
**Description:**

-  Aftert lost connection, we should not reset the favorite cache same as other cache

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
