### PR TITLE
KWB Easyfire support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -342,6 +342,7 @@ omit =
     homeassistant/components/sensor/imap.py
     homeassistant/components/sensor/imap_email_content.py
     homeassistant/components/sensor/influxdb.py
+    homeassistant/components/sensor/kwb.py
     homeassistant/components/sensor/lastfm.py
     homeassistant/components/sensor/linux_battery.py
     homeassistant/components/sensor/loopenergy.py

--- a/homeassistant/components/sensor/kwb.py
+++ b/homeassistant/components/sensor/kwb.py
@@ -1,0 +1,126 @@
+"""
+Support for KWB Easyfire.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.kwb/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_DEVICE,
+                                 EVENT_HOMEASSISTANT_STOP)
+from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
+
+
+REQUIREMENTS = ['pykwb==0.0.6']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_HOST = 'localhost'
+DEFAULT_PORT = 23
+DEFAULT_TYPE = 'tcp'
+DEFAULT_RAW = False
+DEFAULT_DEVICE = '/dev/ttyUSB0'
+
+MODE_SERIAL = 0
+MODE_TCP = 1
+
+CONF_TYPE = 'type'
+CONF_RAW = 'raw'
+
+SERIAL_SCHEMA = {
+    vol.Required(CONF_DEVICE, default=DEFAULT_DEVICE): cv.string,
+    vol.Required(CONF_TYPE, default=DEFAULT_TYPE): 'serial',
+    vol.Optional(CONF_RAW, default=DEFAULT_RAW): cv.boolean,
+}
+
+ETHERNET_SCHEMA = {
+    vol.Required(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Required(CONF_TYPE, default=DEFAULT_TYPE): 'tcp',
+    vol.Optional(CONF_RAW, default=DEFAULT_RAW): cv.boolean,
+}
+
+"""
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    DOMAIN: vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)
+})
+"""
+
+"""
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)
+}, extra=vol.ALLOW_EXTRA)
+"""
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the KWB component."""
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    device = config.get(CONF_DEVICE)
+    connection_type = config.get(CONF_TYPE)
+    raw = config.get(CONF_RAW)
+
+    if raw == 'on':
+        raw = True
+
+    from pykwb import kwb
+
+    _LOGGER.info('initializing')
+
+    if connection_type == 'serial':
+        easyfire = kwb.KWBEasyfire(MODE_SERIAL, "", 0, device)
+    elif connection_type == 'tcp':
+        easyfire = kwb.KWBEasyfire(MODE_TCP, host, port)
+    else:
+        return False
+
+    sensors = []
+    for sensor in easyfire.get_sensors():
+        if ((sensor.sensor_type != kwb.PROP_SENSOR_RAW)
+                or (sensor.sensor_type == kwb.PROP_SENSOR_RAW and raw)):
+            sensors.append(KWBSensor(easyfire, sensor))
+
+    add_devices(sensors)
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP,
+                         lambda event: easyfire.stop_thread())
+
+    _LOGGER.info('starting thread')
+    easyfire.run_thread()
+    _LOGGER.info('thread started')
+
+
+class KWBSensor(Entity):
+    """Representation of a KWB Easyfire sensor."""
+
+    def __init__(self, easyfire, sensor):
+        """Initialize the KWB sensor."""
+        self._easyfire = easyfire
+        self._sensor = sensor
+        self._client_name = "KWB"
+        self._name = self._sensor.name
+
+    @property
+    def name(self):
+        """Return the name."""
+        return '{} {}'.format(self._client_name, self._name)
+
+    @property
+    def available(self) -> bool:
+        """Return if thermostat is available."""
+        return self._sensor is not None and self._sensor.value is not None
+
+    @property
+    def state(self):
+        """Return the state of value."""
+        return self._sensor.value
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._sensor.unit_of_measurement

--- a/homeassistant/components/sensor/kwb.py
+++ b/homeassistant/components/sensor/kwb.py
@@ -66,9 +66,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     connection_type = config.get(CONF_TYPE)
     raw = config.get(CONF_RAW)
 
-    if raw == 'on':
-        raw = True
-
     from pykwb import kwb
 
     _LOGGER.info('initializing')
@@ -119,7 +116,7 @@ class KWBSensor(Entity):
     @property
     def state(self):
         """Return the state of value."""
-        if (self._sensor.value is not None and self._sensor.available):
+        if self._sensor.value is not None and self._sensor.available:
             return self._sensor.value
         else:
             return STATE_UNKNOWN

--- a/homeassistant/components/sensor/kwb.py
+++ b/homeassistant/components/sensor/kwb.py
@@ -32,6 +32,7 @@ MODE_TCP = 1
 CONF_TYPE = 'type'
 CONF_RAW = 'raw'
 
+"""
 SERIAL_SCHEMA = {
     vol.Required(CONF_DEVICE, default=DEFAULT_DEVICE): cv.string,
     vol.Required(CONF_TYPE, default=DEFAULT_TYPE): 'serial',
@@ -45,17 +46,18 @@ ETHERNET_SCHEMA = {
     vol.Optional(CONF_RAW, default=DEFAULT_RAW): cv.boolean,
 }
 
-"""
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     DOMAIN: vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)
 })
 """
 
-"""
-CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)
-}, extra=vol.ALLOW_EXTRA)
-"""
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_TYPE, default=DEFAULT_TYPE): cv.string,
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_DEVICE, default=DEFAULT_DEVICE): cv.string,
+    vol.Optional(CONF_RAW, default=DEFAULT_RAW): cv.boolean,
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/sensor/kwb.py
+++ b/homeassistant/components/sensor/kwb.py
@@ -96,7 +96,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(sensors)
 
 
-
 class KWBSensor(Entity):
     """Representation of a KWB Easyfire sensor."""
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -517,6 +517,9 @@ pyiss==1.0.1
 # homeassistant.components.remote.itach
 pyitachip2ir==0.0.6
 
+# homeassistant.components.sensor.kwb
+pykwb==0.0.6
+
 # homeassistant.components.sensor.lastfm
 pylast==1.8.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -518,7 +518,7 @@ pyiss==1.0.1
 pyitachip2ir==0.0.6
 
 # homeassistant.components.sensor.kwb
-pykwb==0.0.6
+pykwb==0.0.8
 
 # homeassistant.components.sensor.lastfm
 pylast==1.8.0


### PR DESCRIPTION
**Description:**

KWB Easyfire pellet central heating units with the Comfort3 controller (http://www.kwbheizung.de/de/produkte/kwb-comfort-3.html) have a RS485 port over which sensor and state information is relayed.
This component supports direct connection via serial or via telnet terminal server. The serial cable has to be attached to the control unit port 25 (which is normally used for detached control terminals).
Since this serial protocol is proprietary and closed, only most temperature sensors and a few control relais are supported, the rest is still WIP (see https://www.mikrocontroller.net/topic/274137).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
  - platform: kwb
    name: kwb
    host: <ip>
    port: 23
    type: tcp
    raw: False
```
or
```yaml
  - platform: kwb
    name: kwb
    device: "/dev/ttyUSB0"
    type: serial
    raw: False
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
