### PR TITLE
eliqonline lib upgrade

### DIFF
--- a/homeassistant/components/sensor/eliqonline.py
+++ b/homeassistant/components/sensor/eliqonline.py
@@ -14,7 +14,7 @@ from homeassistant.const import (CONF_ACCESS_TOKEN, CONF_NAME, STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['eliqonline==1.0.12']
+REQUIREMENTS = ['eliqonline==1.0.13']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -94,4 +94,4 @@ class EliqSensor(Entity):
             self._state = int(response.power)
             _LOGGER.debug("Updated power from server %d W", self._state)
         except URLError:
-            _LOGGER.error("Could not connect to the ELIQ Online API")
+            _LOGGER.warning("Could not connect to the ELIQ Online API")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -105,7 +105,7 @@ dsmr_parser==0.4
 dweepy==0.2.0
 
 # homeassistant.components.sensor.eliqonline
-eliqonline==1.0.12
+eliqonline==1.0.13
 
 # homeassistant.components.enocean
 enocean==0.31


### PR DESCRIPTION
**Description:**
Upgrade library version
Downgrade logger message from error to warning when losing contact with server

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
