### PR TITLE
LiteJet: Lights should have the option to dim in the UI.

### DIFF
--- a/homeassistant/components/light/litejet.py
+++ b/homeassistant/components/light/litejet.py
@@ -7,7 +7,8 @@ https://home-assistant.io/components/light.litejet/
 import logging
 
 import homeassistant.components.litejet as litejet
-from homeassistant.components.light import ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
 
 DEPENDENCIES = ['litejet']
 

--- a/homeassistant/components/light/litejet.py
+++ b/homeassistant/components/light/litejet.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/light.litejet/
 import logging
 
 import homeassistant.components.litejet as litejet
-from homeassistant.components.light import ATTR_BRIGHTNESS, Light
+from homeassistant.components.light import ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light
 
 DEPENDENCIES = ['litejet']
 
@@ -48,6 +48,11 @@ class LiteJetLight(Light):
         """Called on a LiteJet thread when a load's state changes."""
         _LOGGER.debug("Updating due to notification for %s", self._name)
         self._hass.async_add_job(self.async_update_ha_state(True))
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_BRIGHTNESS
 
     @property
     def name(self):


### PR DESCRIPTION
**Description:**
Frontend has started looking at the supported features of the device, but the LiteJet light wasn't setting that property for brightness. This property is now set for all LiteJet lights. The LiteJet protocol doesn't expose a method for determining if a load is actually dimmable, so this assumes all loads can be dimmed.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [na] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [na] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [na] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [na] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [na] New files were added to `.coveragerc`.
