### PR TITLE
Update to pyfido 0.1.4

### DIFF
--- a/homeassistant/components/sensor/fido.py
+++ b/homeassistant/components/sensor/fido.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ["pyfido==0.1.3"]
+REQUIREMENTS = ["pyfido==0.1.4"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -461,7 +461,7 @@ pyemby==0.2
 pyenvisalink==2.0
 
 # homeassistant.components.sensor.fido
-pyfido==0.1.3
+pyfido==0.1.4
 
 # homeassistant.components.ifttt
 pyfttt==0.3


### PR DESCRIPTION
**Description:**
Update to pyfido 0.1.4 to get other_talk data fixed

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
