### PR TITLE
Do not allow config dependency

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -299,6 +299,10 @@ def async_prepare_setup_platform(hass: core.HomeAssistant, config, domain: str,
 
     # Load dependencies
     for component in getattr(platform, 'DEPENDENCIES', []):
+        if component == 'config':
+            raise HomeAssistantError(
+                'Config is not allowed to be a dependency.')
+
         res = yield from async_setup_component(hass, component, config)
         if not res:
             _LOGGER.error(
@@ -430,7 +434,13 @@ def async_from_config_dict(config: Dict[str, Any],
     service.HASS = hass
 
     # Setup the components
+    no_load_config = 'config' not in components
+
     for domain in loader.load_order_components(components):
+        if no_load_config and domain == 'config':
+            raise HomeAssistantError(
+                'Config is not allowed to be a dependency')
+
         yield from _async_setup_component(hass, domain, config)
 
     setup_lock.release()

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -299,9 +299,9 @@ def async_prepare_setup_platform(hass: core.HomeAssistant, config, domain: str,
 
     # Load dependencies
     for component in getattr(platform, 'DEPENDENCIES', []):
-        if component == 'config':
+        if component in loader.DEPENDENCY_BLACKLIST:
             raise HomeAssistantError(
-                'Config is not allowed to be a dependency.')
+                '{} is not allowed to be a dependency.'.format(component))
 
         res = yield from async_setup_component(hass, component, config)
         if not res:
@@ -434,12 +434,12 @@ def async_from_config_dict(config: Dict[str, Any],
     service.HASS = hass
 
     # Setup the components
-    no_load_config = 'config' not in components
+    dependency_blacklist = loader.DEPENDENCY_BLACKLIST - set(components)
 
     for domain in loader.load_order_components(components):
-        if no_load_config and domain == 'config':
+        if domain in dependency_blacklist:
             raise HomeAssistantError(
-                'Config is not allowed to be a dependency')
+                '{} is not allowed to be a dependency'.format(domain))
 
         yield from _async_setup_component(hass, domain, config)
 

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -10,6 +10,7 @@ import asyncio
 from homeassistant import bootstrap, core
 from homeassistant.const import (
     ATTR_DISCOVERED, ATTR_SERVICE, EVENT_PLATFORM_DISCOVERED)
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.async import run_callback_threadsafe
 
 EVENT_LOAD_PLATFORM = 'load_platform.{}'
@@ -56,6 +57,9 @@ def discover(hass, service, discovered=None, component=None, hass_config=None):
 def async_discover(hass, service, discovered=None, component=None,
                    hass_config=None):
     """Fire discovery event. Can ensure a component is loaded."""
+    if component == 'config':
+        raise HomeAssistantError('Cannot discover the config component.')
+
     if component is not None and component not in hass.config.components:
         did_lock = False
         setup_lock = hass.data.get('setup_lock')
@@ -150,6 +154,9 @@ def async_load_platform(hass, component, platform, discovered=None,
 
     This method is a coroutine.
     """
+    if component == 'config':
+        raise HomeAssistantError('Cannot discover the config component.')
+
     did_lock = False
     setup_lock = hass.data.get('setup_lock')
     if setup_lock and setup_lock.locked():

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -11,6 +11,7 @@ from homeassistant import bootstrap, core
 from homeassistant.const import (
     ATTR_DISCOVERED, ATTR_SERVICE, EVENT_PLATFORM_DISCOVERED)
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.loader import DEPENDENCY_BLACKLIST
 from homeassistant.util.async import run_callback_threadsafe
 
 EVENT_LOAD_PLATFORM = 'load_platform.{}'
@@ -57,8 +58,9 @@ def discover(hass, service, discovered=None, component=None, hass_config=None):
 def async_discover(hass, service, discovered=None, component=None,
                    hass_config=None):
     """Fire discovery event. Can ensure a component is loaded."""
-    if component == 'config':
-        raise HomeAssistantError('Cannot discover the config component.')
+    if component in DEPENDENCY_BLACKLIST:
+        raise HomeAssistantError(
+            'Cannot discover the {} component.'.format(component))
 
     if component is not None and component not in hass.config.components:
         did_lock = False
@@ -154,8 +156,9 @@ def async_load_platform(hass, component, platform, discovered=None,
 
     This method is a coroutine.
     """
-    if component == 'config':
-        raise HomeAssistantError('Cannot discover the config component.')
+    if component in DEPENDENCY_BLACKLIST:
+        raise HomeAssistantError(
+            'Cannot discover the {} component.'.format(component))
 
     did_lock = False
     setup_lock = hass.data.get('setup_lock')

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -30,6 +30,8 @@ if False:
 
 PREPARED = False
 
+DEPENDENCY_BLACKLIST = set(('config',))
+
 # List of available components
 AVAILABLE_COMPONENTS = []  # type: List[str]
 

--- a/tests/helpers/test_discovery.py
+++ b/tests/helpers/test_discovery.py
@@ -1,9 +1,13 @@
 """Test discovery helpers."""
+import asyncio
 from collections import OrderedDict
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant import loader, bootstrap
 from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import discovery
 from homeassistant.util.async import run_coroutine_threadsafe
 
@@ -197,3 +201,17 @@ class TestHelpersDiscovery:
 
         # test_component will only be setup once
         assert len(component_calls) == 1
+
+
+@asyncio.coroutine
+def test_load_platform_forbids_config():
+    """Test you cannot setup config component with load_platform."""
+    with pytest.raises(HomeAssistantError):
+        yield from discovery.async_load_platform(None, 'config', 'zwave')
+
+
+@asyncio.coroutine
+def test_discover_forbids_config():
+    """Test you cannot setup config component with load_platform."""
+    with pytest.raises(HomeAssistantError):
+        yield from discovery.async_discover(None, None, None, 'config')


### PR DESCRIPTION
**Description:**
The config platform will allow the user to configure Home Assistant via an API. We should only set up this component if the user wants this.

This PR will protect components and platforms from loading the config component automatically.

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
