### PR TITLE
Fix name in logging message

### DIFF
--- a/homeassistant/components/sensor/ebox.py
+++ b/homeassistant/components/sensor/ebox.py
@@ -150,7 +150,7 @@ class EBoxData(object):
         try:
             self.client.fetch_data()
         except PyEboxError as exp:
-            _LOGGER.error("Error on receive last Fido data: %s", exp)
+            _LOGGER.error("Error on receive last EBox data: %s", exp)
             return
         # Update data
         self.data = self.client.get_data()


### PR DESCRIPTION
**Description:**

Copy-past misstake

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
