### PR TITLE
Protect device_tracker scan interval / TTS logging

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -250,7 +250,6 @@ class SpeechManager(object):
                 except OSError as err:
                     _LOGGER.warning(
                         "Can't remove cache file '%s': %s", filename, err)
-                    pass
 
         yield from self.hass.loop.run_in_executor(None, remove_files)
         self.file_cache = {}

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -247,7 +247,9 @@ class SpeechManager(object):
             for _, filename in self.file_cache.items():
                 try:
                     os.remove(os.path.join(self.cache_dir, filename))
-                except OSError:
+                except OSError as err:
+                    _LOGGER.warning(
+                        "Can't remove cache file '%s': %s", filename, err)
                     pass
 
         yield from self.hass.loop.run_in_executor(None, remove_files)


### PR DESCRIPTION
**Description:**

- Add log message to tts clear file on error
- After multible issue with device_tracker platform and device they take to Long for grap data, I protect to don't run device_tracker multible times.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
