### PR TITLE
Add support for aliased owfs sensors

### DIFF
--- a/homeassistant/components/sensor/onewire.py
+++ b/homeassistant/components/sensor/onewire.py
@@ -52,7 +52,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 device_files.append(os.path.join(
                     os.path.split(family_file_path)[0], 'temperature'))
 
-
     if device_files == []:
         _LOGGER.error('No onewire sensor found. Check if '
                       'dtoverlay=w1-gpio is in your /boot/config.txt. '

--- a/homeassistant/components/sensor/onewire.py
+++ b/homeassistant/components/sensor/onewire.py
@@ -34,14 +34,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     sensor_ids = []
     device_files = []
     if base_dir == DEFAULT_MOUNT_DIR:
-        """ Use w1_gpio + w1_therm driver """
         for device_family in DEVICE_FAMILIES:
             for device_folder in glob(os.path.join(base_dir, device_family +
                                                    '[.-]*')):
                 sensor_ids.append(os.path.split(device_folder)[1])
                 device_files.append(os.path.join(device_folder, 'w1_slave'))
     else:
-        """ Use OWFS driver. Folder name may be aliased by OWFS """
         for family_file_path in glob(os.path.join(base_dir, '*', 'family')):
             family_file = open(family_file_path, "r")
             family = family_file.read()

--- a/homeassistant/components/sensor/onewire.py
+++ b/homeassistant/components/sensor/onewire.py
@@ -33,14 +33,21 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     base_dir = config.get(CONF_MOUNT_DIR)
     sensor_ids = []
     device_files = []
-    for device_family in DEVICE_FAMILIES:
+    if base_dir == DEFAULT_MOUNT_DIR:
+        """ Use w1_gpio + w1_therm driver """
         for device_folder in glob(os.path.join(base_dir, device_family +
                                                '[.-]*')):
             sensor_ids.append(os.path.split(device_folder)[1])
-            if base_dir == DEFAULT_MOUNT_DIR:
-                device_files.append(os.path.join(device_folder, 'w1_slave'))
-            else:
-                device_files.append(os.path.join(device_folder, 'temperature'))
+            device_files.append(os.path.join(device_folder, 'w1_slave'))
+    else:
+        """ Use OWFS driver. Folder name may be aliased by OWFS """
+        for family_file_path in glob(os.path.join(base_dir, '*', 'family')):
+            family_file = open(family_file_path, "r")
+            family = family_file.read()
+            if family in DEVICE_FAMILIES:
+                sensor_id = os.path.split(os.path.split(family_file_path)[0])[1];
+                sensor_ids.append(sensor_id)
+                device_files.append(os.path.join(os.path.split(family_file_path)[0], 'temperature'))
 
     if device_files == []:
         _LOGGER.error('No onewire sensor found. Check if '

--- a/homeassistant/components/sensor/onewire.py
+++ b/homeassistant/components/sensor/onewire.py
@@ -35,19 +35,23 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     device_files = []
     if base_dir == DEFAULT_MOUNT_DIR:
         """ Use w1_gpio + w1_therm driver """
-        for device_folder in glob(os.path.join(base_dir, device_family +
-                                               '[.-]*')):
-            sensor_ids.append(os.path.split(device_folder)[1])
-            device_files.append(os.path.join(device_folder, 'w1_slave'))
+        for device_family in DEVICE_FAMILIES:
+            for device_folder in glob(os.path.join(base_dir, device_family +
+                                                   '[.-]*')):
+                sensor_ids.append(os.path.split(device_folder)[1])
+                device_files.append(os.path.join(device_folder, 'w1_slave'))
     else:
         """ Use OWFS driver. Folder name may be aliased by OWFS """
         for family_file_path in glob(os.path.join(base_dir, '*', 'family')):
             family_file = open(family_file_path, "r")
             family = family_file.read()
             if family in DEVICE_FAMILIES:
-                sensor_id = os.path.split(os.path.split(family_file_path)[0])[1];
+                sensor_id = os.path.split(
+                    os.path.split(family_file_path)[0])[1]
                 sensor_ids.append(sensor_id)
-                device_files.append(os.path.join(os.path.split(family_file_path)[0], 'temperature'))
+                device_files.append(os.path.join(
+                    os.path.split(family_file_path)[0], 'temperature'))
+
 
     if device_files == []:
         _LOGGER.error('No onewire sensor found. Check if '


### PR DESCRIPTION
**Description:**

 Add support for aliased owfs sensors

Current (dev branch)implementation does not support OneWire OWFS sensors that are aliased by OWFS alias.txt file:
http://owfs.org/index.php?page=aliases
Assumption is that folder name == sensor address

This change reads the families from owfs "family" file and adds both aliased and unaliased supported sensors.
(this approach also skips the "management" folders.. eg simultaenous, bus, alarm, statistics etc. For example when adding "simultaneous" as sensor (it also has "temperature" file) then owfs crashes)
