### PR TITLE
Support zwave glob & domain device settings.

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -55,7 +55,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     node = zwave.NETWORK.nodes[discovery_info[zwave.const.ATTR_NODE_ID]]
     value = node.values[discovery_info[zwave.const.ATTR_VALUE_ID]]
     name = '{}.{}'.format(DOMAIN, zwave.object_id(value))
-    node_config = hass.data[zwave.DATA_DEVICE_CONFIG].get(name) or {}
+    node_config = hass.data[zwave.DATA_DEVICE_CONFIG].get(name)
     refresh = node_config.get(zwave.CONF_REFRESH_VALUE)
     delay = node_config.get(zwave.CONF_REFRESH_DELAY)
     _LOGGER.debug('name=%s node_config=%s CONF_REFRESH_VALUE=%s'

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -43,4 +43,5 @@ def test_device_config(hass):
         for key, value in device_config.items()
     }
 
-    assert hass.data[DATA_DEVICE_CONFIG].get('light.kitchen') == test_data.get('light.kitchen')
+    assert hass.data[DATA_DEVICE_CONFIG].get('light.kitchen') == \
+        test_data.get('light.kitchen')

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -43,4 +43,4 @@ def test_device_config(hass):
         for key, value in device_config.items()
     }
 
-    assert hass.data[DATA_DEVICE_CONFIG] == test_data
+    assert hass.data[DATA_DEVICE_CONFIG].get('light.kitchen') == test_data

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -43,4 +43,4 @@ def test_device_config(hass):
         for key, value in device_config.items()
     }
 
-    assert hass.data[DATA_DEVICE_CONFIG].get('light.kitchen') == test_data
+    assert hass.data[DATA_DEVICE_CONFIG].get('light.kitchen') == test_data.get('light.kitchen')


### PR DESCRIPTION
**Description:**

Support zwave glob & domain device settings.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml
zwave:
  device_settings:
    light.bed:
      ignored: true
  device_settings_domain:
    light:
      ignored: true
  device_settings_glob:
    light.b*:
      ignored: true
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) TODO

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

