### PR TITLE
Minimize configuration.yaml

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -85,12 +85,7 @@ sun:
 sensor:
   platform: yr
 
-# Text to speech
-tts:
-  platform: google
-
 """
-
 
 PACKAGES_CONFIG_SCHEMA = vol.Schema({
     cv.slug: vol.Schema(  # Package names are slugs


### PR DESCRIPTION
**Description:**
It doesn't make sense to add Google TTS to the default `configuration.yaml` file without a `media_player:` entry. Also this pull in `gTTS-token`. 

Keeping the default configuration minimal reduces the time for newbies to get started. 

**Checklist:**
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
