### PR TITLE
Add pushsafer.com notification service

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -271,6 +271,7 @@ omit =
     homeassistant/components/notify/pushbullet.py
     homeassistant/components/notify/pushetta.py
     homeassistant/components/notify/pushover.py
+    homeassistant/components/notify/pushsafer.py
     homeassistant/components/notify/rest.py
     homeassistant/components/notify/sendgrid.py
     homeassistant/components/notify/simplepush.py

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,6 @@ Build home automation on top of your devices:
    (NMA) <http://www.notifymyandroid.com/>`__,
    `PushBullet <https://www.pushbullet.com/>`__,
    `PushOver <https://pushover.net/>`__,
-   `Pushsafer <https://www.pushsafer.com/>`__,
    `Slack <https://slack.com/>`__,
    `Telegram <https://telegram.org/>`__, `Join <http://joaoapps.com/join/>`__, and `Jabber
    (XMPP) <http://xmpp.org>`__

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,9 @@ Build home automation on top of your devices:
    `Instapush <https://instapush.im>`__, `Notify My Android
    (NMA) <http://www.notifymyandroid.com/>`__,
    `PushBullet <https://www.pushbullet.com/>`__,
-   `PushOver <https://pushover.net/>`__, `Slack <https://slack.com/>`__,
+   `PushOver <https://pushover.net/>`__,
+   `Pushsafer <https://www.pushsafer.com/>`__,
+   `Slack <https://slack.com/>`__,
    `Telegram <https://telegram.org/>`__, `Join <http://joaoapps.com/join/>`__, and `Jabber
    (XMPP) <http://xmpp.org>`__
 

--- a/homeassistant/components/notify/pushsafer.py
+++ b/homeassistant/components/notify/pushsafer.py
@@ -66,6 +66,6 @@ class PushsaferNotificationService(BaseNotificationService):
             try:
                 self.pushsafer.send_message(message, data['title'], "", "",
                                             "", "", "", "",
-                                            "0", "", "", "" )
+                                            "0", "", "", "")
             except ValueError as val_err:
                 _LOGGER.error(str(val_err))

--- a/homeassistant/components/notify/pushsafer.py
+++ b/homeassistant/components/notify/pushsafer.py
@@ -64,6 +64,8 @@ class PushsaferNotificationService(BaseNotificationService):
                 data['device'] = target
 
             try:
-                self.pushsafer.send_message(message, data['title'], "", "", "", "", "", "", "0", "", "", "" )
+                self.pushsafer.send_message(message, data['title'], "", "",
+                                            "", "", "", "",
+                                            "0", "", "", "" )
             except ValueError as val_err:
                 _LOGGER.error(str(val_err))

--- a/homeassistant/components/notify/pushsafer.py
+++ b/homeassistant/components/notify/pushsafer.py
@@ -48,7 +48,6 @@ class PushsaferNotificationService(BaseNotificationService):
 
     def send_message(self, message='', **kwargs):
         """Send a message to a user."""
-
         # Make a copy and use empty dict if necessary
         data = dict(kwargs.get(ATTR_DATA) or {})
 

--- a/homeassistant/components/notify/pushsafer.py
+++ b/homeassistant/components/notify/pushsafer.py
@@ -1,0 +1,69 @@
+"""
+Pushsafer platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.pushsafer/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.notify import (
+    ATTR_TITLE, ATTR_TITLE_DEFAULT, ATTR_TARGET, ATTR_DATA,
+    BaseNotificationService)
+from homeassistant.const import CONF_API_KEY
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['python-pushsafer==0.2']
+_LOGGER = logging.getLogger(__name__)
+
+
+PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+})
+
+
+# pylint: disable=unused-variable
+def get_service(hass, config, discovery_info=None):
+    """Get the Pushsafer notification service."""
+    from pushsafer import InitError
+
+    try:
+        return PushsaferNotificationService(config[CONF_API_KEY])
+    except InitError:
+        _LOGGER.error(
+            'Wrong private key supplied. Get it at https://www.pushsafer.com')
+        return None
+
+
+class PushsaferNotificationService(BaseNotificationService):
+    """Implement the notification service for Pushsafer."""
+
+    def __init__(self, privatekey):
+        """Initialize the service."""
+        from pushsafer import Client
+        self._privatekey = privatekey
+        self.pushsafer = Client(
+            "", privatekey=self._privatekey)
+
+    def send_message(self, message='', **kwargs):
+        """Send a message to a user."""
+
+        # Make a copy and use empty dict if necessary
+        data = dict(kwargs.get(ATTR_DATA) or {})
+
+        data['title'] = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
+
+        targets = kwargs.get(ATTR_TARGET)
+
+        if not isinstance(targets, list):
+            targets = [targets]
+
+        for target in targets:
+            if target is not None:
+                data['device'] = target
+
+            try:
+                self.pushsafer.send_message(message, data['title'], "", "", "", "", "", "", "0", "", "", "" )
+            except ValueError as val_err:
+                _LOGGER.error(str(val_err))

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -570,6 +570,9 @@ python-nmap==0.6.1
 # homeassistant.components.notify.pushover
 python-pushover==0.2
 
+# homeassistant.components.notify.pushsafer
+python-pushsafer==0.2
+
 # homeassistant.components.sensor.synologydsm
 python-synology==0.1.0
 


### PR DESCRIPTION
**Description:**
Add pushsafer.com notification service

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2071

**Example entry for `configuration.yaml` (if applicable):**
```yaml
notify:
  - name: NOTIFIER_NAME
    platform: pushsafer
    private_key: ABCDEFGHJKLMNOPQRSTUVXYZ
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
