### PR TITLE
Update liveboxplaytv and catch connection errors

### DIFF
--- a/homeassistant/components/media_player/liveboxplaytv.py
+++ b/homeassistant/components/media_player/liveboxplaytv.py
@@ -50,11 +50,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     port = config.get(CONF_PORT)
     name = config.get(CONF_NAME)
 
+    livebox_devices =  []
+
     try:
-        add_devices([LiveboxPlayTvDevice(host, port, name)], True)
+        device = LiveboxPlayTvDevice(host, port, name)
+        livebox_devices.append(device)
     except IOError:
         _LOGGER.error('Failed to connect to Livebox Play TV at %s:%s. '
                       'Please check your configuration.', host, port)
+    add_devices(livebox_devices, True)
 
 
 class LiveboxPlayTvDevice(MediaPlayerDevice):

--- a/homeassistant/components/media_player/liveboxplaytv.py
+++ b/homeassistant/components/media_player/liveboxplaytv.py
@@ -50,7 +50,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     port = config.get(CONF_PORT)
     name = config.get(CONF_NAME)
 
-    livebox_devices =  []
+    livebox_devices = []
 
     try:
         device = LiveboxPlayTvDevice(host, port, name)

--- a/homeassistant/components/media_player/liveboxplaytv.py
+++ b/homeassistant/components/media_player/liveboxplaytv.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     STATE_PAUSED, STATE_UNKNOWN, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['liveboxplaytv==1.4.7']
+REQUIREMENTS = ['liveboxplaytv==1.4.8']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +50,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     port = config.get(CONF_PORT)
     name = config.get(CONF_NAME)
 
-    add_devices([LiveboxPlayTvDevice(host, port, name)], True)
+    try:
+        add_devices([LiveboxPlayTvDevice(host, port, name)], True)
+    except IOError:
+        _LOGGER.error('Failed to connect to Livebox Play TV at %s:%s. '
+                      'Please check your configuration.', host, port)
 
 
 class LiveboxPlayTvDevice(MediaPlayerDevice):
@@ -62,7 +66,6 @@ class LiveboxPlayTvDevice(MediaPlayerDevice):
         self._client = LiveboxPlayTv(host, port)
         # Assume that the appliance is not muted
         self._muted = False
-        # Assume that the TV is in Play mode
         self._name = name
         self._current_source = None
         self._state = STATE_UNKNOWN

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -322,7 +322,7 @@ liffylights==0.9.4
 limitlessled==1.0.4
 
 # homeassistant.components.media_player.liveboxplaytv
-liveboxplaytv==1.4.7
+liveboxplaytv==1.4.8
 
 # homeassistant.components.notify.matrix
 matrix-client==0.0.5


### PR DESCRIPTION
**Description:**
 Update the [liveboxplaytv](https://github.com/pschmitt/python-liveboxplaytv) library.
There is now a default 3 second connection timeout, previous versions took up to 2 minutes - which resulted in quite a slow HA start.
Connection (setup) errors are now displayed in the log.

**Example entry for `configuration.yaml` (if applicable):**
```yaml
media_player:
  - platform: liveboxplaytv
    name: Livebox Play
    host: livebox-play.lan
```

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
