### PR TITLE
Upgrade aiohttp to 1.3.2

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ pip>=7.0.0
 jinja2>=2.8
 voluptuous==0.9.3
 typing>=3,<4
-aiohttp==1.3.1
+aiohttp==1.3.2
 async_timeout==1.1.0
 
 # homeassistant.components.nuimo_controller

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     'jinja2>=2.8',
     'voluptuous==0.9.3',
     'typing>=3,<4',
-    'aiohttp==1.3.1',
+    'aiohttp==1.3.2',
     'async_timeout==1.1.0',
 ]
 


### PR DESCRIPTION
# 1.3.2
- yarl release is now pinned.

Change log: http://aiohttp.readthedocs.io/en/stable/changes.html

Tested with: 
```yaml
http:
```