### PR TITLE
Add platform for Yeelight Sunflower lights

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -209,6 +209,7 @@ omit =
     homeassistant/components/light/tikteck.py
     homeassistant/components/light/x10.py
     homeassistant/components/light/yeelight.py
+    homeassistant/components/light/yeelightsunflower.py
     homeassistant/components/light/piglow.py
     homeassistant/components/light/zengge.py
     homeassistant/components/lirc.py

--- a/homeassistant/components/light/yeelightsunflower.py
+++ b/homeassistant/components/light/yeelightsunflower.py
@@ -1,0 +1,119 @@
+"""
+Support for Yeelight Sunflower color bulbs (not Yeelight Blue or WiFi).
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.yeelight-sunflower
+Uses the yeelightsunflower library:
+https://github.com/lindsaymarkward/python-yeelight-sunflower
+"""
+import logging
+import voluptuous as vol
+
+from homeassistant.components.light import (Light,
+                                            ATTR_RGB_COLOR, SUPPORT_RGB_COLOR,
+                                            ATTR_BRIGHTNESS,
+                                            SUPPORT_BRIGHTNESS,
+                                            PLATFORM_SCHEMA)
+from homeassistant.const import CONF_HOST
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['yeelightsunflower==0.0.5']
+SUPPORT_YEELIGHT_SUNFLOWER = (SUPPORT_BRIGHTNESS | SUPPORT_RGB_COLOR)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Validate the user's configuration
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Yeelight Sunflower Light platform."""
+    import yeelightsunflower
+
+    # Assign configuration variables.
+    # The configuration check takes care they are present.
+    host = config.get(CONF_HOST)
+
+    # Setup connection with Yeelight Sunflower hub
+    hub = yeelightsunflower.Hub(host)
+
+    # Verify that hub is responsive
+    if not hub.available:
+        _LOGGER.error('Could not connect to Yeelight Sunflower hub')
+        return False
+
+    # Add devices
+    add_devices(SunflowerBulb(light) for light in hub.get_lights())
+
+
+class SunflowerBulb(Light):
+    """Representation of a Yeelight Sunflower Light."""
+
+    def __init__(self, light):
+        """Initialize a Yeelight Sunflower bulb."""
+        self._light = light
+        self._available = light.available
+        self._brightness = light.brightness
+        self._is_on = light.is_on
+        self._rgb_color = light.rgb_color
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return "sunflower_{}".format(self._light.zid)
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._is_on
+
+    @property
+    def brightness(self):
+        """HA brightness is 0-255; Yeelight Sunflower's brightness is 0-100."""
+        return int(self._brightness / 100 * 255)
+
+    @property
+    def rgb_color(self):
+        """Return the color property."""
+        return self._rgb_color
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_YEELIGHT_SUNFLOWER
+
+    def turn_on(self, **kwargs):
+        """Instruct the light to turn on, optionally set colour/brightness."""
+        # when no arguments, just turn light on (full brightness)
+        if not kwargs:
+            self._light.turn_on()
+        else:
+            if ATTR_RGB_COLOR in kwargs and ATTR_BRIGHTNESS in kwargs:
+                rgb = kwargs[ATTR_RGB_COLOR]
+                bright = int(kwargs[ATTR_BRIGHTNESS] / 255 * 100)
+                self._light.set_all(rgb[0], rgb[1], rgb[2], bright)
+            elif ATTR_RGB_COLOR in kwargs:
+                rgb = kwargs[ATTR_RGB_COLOR]
+                self._light.set_rgb_color(rgb[0], rgb[1], rgb[2])
+            elif ATTR_BRIGHTNESS in kwargs:
+                bright = int(kwargs[ATTR_BRIGHTNESS] / 255 * 100)
+                self._light.set_brightness(bright)
+
+    def turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
+        self._light.turn_off()
+
+    def update(self):
+        """Fetch new state data for this light and update local values."""
+        self._light.update()
+        self._available = self._light.available
+        self._brightness = self._light.brightness
+        self._is_on = self._light.is_on
+        self._rgb_color = self._light.rgb_color

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -744,6 +744,9 @@ yahooweather==0.8
 # homeassistant.components.light.yeelight
 yeelight==0.2.2
 
+# homeassistant.components.light.yeelightsunflower
+yeelightsunflower==0.0.5
+
 # homeassistant.components.light.zengge
 zengge==0.2
 


### PR DESCRIPTION
**Description:**
Add new platform for the light component for Yeelight Sunflower bulbs (https://www.yeelight.com/en_US/product/yeelight-sunflower).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2006

**Example entry for `configuration.yaml`:**
```yaml
light:
  - platform: yeelightsunflower
    host: 192.168.1.59
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
