### PR TITLE
Slugify trackr device_id

### DIFF
--- a/homeassistant/components/device_tracker/trackr.py
+++ b/homeassistant/components/device_tracker/trackr.py
@@ -59,7 +59,7 @@ class TrackRDeviceScanner(object):
             trackr_id = trackr.tracker_id()
             trackr_device_id = trackr.id()
             lost = trackr.lost()
-            dev_id = slugify(trackr.name().replace(" ", "_"))
+            dev_id = slugify(trackr.name())
             if dev_id is None:
                 dev_id = trackr_id
             location = trackr.last_known_location()

--- a/homeassistant/components/device_tracker/trackr.py
+++ b/homeassistant/components/device_tracker/trackr.py
@@ -12,6 +12,7 @@ from homeassistant.components.device_tracker import PLATFORM_SCHEMA
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_utc_time_change
+from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ class TrackRDeviceScanner(object):
             trackr_id = trackr.tracker_id()
             trackr_device_id = trackr.id()
             lost = trackr.lost()
-            dev_id = trackr.name().replace(" ", "_")
+            dev_id = slugify(trackr.name().replace(" ", "_"))
             if dev_id is None:
                 dev_id = trackr_id
             location = trackr.last_known_location()


### PR DESCRIPTION
**Description:**
What the title says

**Related issue (if applicable):** fixes #6044 

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
