### PR TITLE
MQTT convert to async

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -412,7 +412,7 @@ def _async_process_trigger(hass, config, trigger_configs, name, action):
         if platform is None:
             return None
 
-        remove = platform.async_trigger(hass, conf, action)
+        remove = yield from platform.async_trigger(hass, conf, action)
 
         if not remove:
             _LOGGER.error("Error setting up trigger %s", name)

--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -4,6 +4,7 @@ Offer event listening automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#event-trigger
 """
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -24,6 +25,7 @@ TRIGGER_SCHEMA = vol.Schema({
 })
 
 
+@asyncio.coroutine
 def async_trigger(hass, config, action):
     """Listen for events based on configuration."""
     event_type = config.get(CONF_EVENT_TYPE)

--- a/homeassistant/components/automation/litejet.py
+++ b/homeassistant/components/automation/litejet.py
@@ -4,6 +4,7 @@ Trigger an automation when a LiteJet switch is released.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/automation.litejet/
 """
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -32,6 +33,7 @@ TRIGGER_SCHEMA = vol.Schema({
 })
 
 
+@asyncio.coroutine
 def async_trigger(hass, config, action):
     """Listen for events based on configuration."""
     number = config.get(CONF_NUMBER)

--- a/homeassistant/components/automation/mqtt.py
+++ b/homeassistant/components/automation/mqtt.py
@@ -4,6 +4,7 @@ Offer MQTT listening automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#mqtt-trigger
 """
+import asyncio
 import json
 
 import voluptuous as vol
@@ -24,6 +25,7 @@ TRIGGER_SCHEMA = vol.Schema({
 })
 
 
+@asyncio.coroutine
 def async_trigger(hass, config, action):
     """Listen for state changes based on configuration."""
     topic = config.get(CONF_TOPIC)
@@ -49,4 +51,6 @@ def async_trigger(hass, config, action):
                 'trigger': data
             })
 
-    return mqtt.async_subscribe(hass, topic, mqtt_automation_listener)
+    remove = yield from mqtt.async_subscribe(
+        hass, topic, mqtt_automation_listener)
+    return remove

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -4,6 +4,7 @@ Offer numeric state listening automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#numeric-state-trigger
 """
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -26,6 +27,7 @@ TRIGGER_SCHEMA = vol.All(vol.Schema({
 _LOGGER = logging.getLogger(__name__)
 
 
+@asyncio.coroutine
 def async_trigger(hass, config, action):
     """Listen for state changes based on configuration."""
     entity_id = config.get(CONF_ENTITY_ID)

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -4,6 +4,7 @@ Offer state listening automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#state-trigger
 """
+import asyncio
 import voluptuous as vol
 
 from homeassistant.core import callback
@@ -34,6 +35,7 @@ TRIGGER_SCHEMA = vol.All(
 )
 
 
+@asyncio.coroutine
 def async_trigger(hass, config, action):
     """Listen for state changes based on configuration."""
     entity_id = config.get(CONF_ENTITY_ID)
@@ -97,6 +99,7 @@ def async_trigger(hass, config, action):
     unsub = async_track_state_change(
         hass, entity_id, state_automation_listener, from_state, to_state)
 
+    @callback
     def async_remove():
         """Remove state listeners async."""
         unsub()

--- a/homeassistant/components/automation/sun.py
+++ b/homeassistant/components/automation/sun.py
@@ -4,6 +4,7 @@ Offer sun based automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#sun-trigger
 """
+import asyncio
 from datetime import timedelta
 import logging
 
@@ -26,6 +27,7 @@ TRIGGER_SCHEMA = vol.Schema({
 })
 
 
+@asyncio.coroutine
 def async_trigger(hass, config, action):
     """Listen for events based on configuration."""
     event = config.get(CONF_EVENT)

--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -4,6 +4,7 @@ Offer template automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#template-trigger
 """
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -22,6 +23,7 @@ TRIGGER_SCHEMA = IF_ACTION_SCHEMA = vol.Schema({
 })
 
 
+@asyncio.coroutine
 def async_trigger(hass, config, action):
     """Listen for state changes based on configuration."""
     value_template = config.get(CONF_VALUE_TEMPLATE)

--- a/homeassistant/components/automation/time.py
+++ b/homeassistant/components/automation/time.py
@@ -4,6 +4,7 @@ Offer time listening automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#time-trigger
 """
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -29,6 +30,7 @@ TRIGGER_SCHEMA = vol.All(vol.Schema({
                             CONF_SECONDS, CONF_AFTER))
 
 
+@asyncio.coroutine
 def async_trigger(hass, config, action):
     """Listen for state changes based on configuration."""
     if CONF_AFTER in config:

--- a/homeassistant/components/automation/zone.py
+++ b/homeassistant/components/automation/zone.py
@@ -4,6 +4,7 @@ Offer zone automation rules.
 For more details about this automation rule, please refer to the documentation
 at https://home-assistant.io/components/automation/#zone-trigger
 """
+import asyncio
 import voluptuous as vol
 
 from homeassistant.core import callback
@@ -26,6 +27,7 @@ TRIGGER_SCHEMA = vol.Schema({
 })
 
 
+@asyncio.coroutine
 def async_trigger(hass, config, action):
     """Listen for state changes based on configuration."""
     entity_id = config.get(CONF_ENTITY_ID)

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -4,6 +4,7 @@ Support for MQTT message handling.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/mqtt/
 """
+import asyncio
 import logging
 import os
 import socket
@@ -12,11 +13,12 @@ import time
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import prepare_setup_platform
+from homeassistant.bootstrap import async_prepare_setup_platform
 from homeassistant.config import load_yaml_config_file
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import template, config_validation as cv
-from homeassistant.helpers.event import threaded_listener_factory
+from homeassistant.util.async import (
+    run_coroutine_threadsafe, run_callback_threadsafe)
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, CONF_VALUE_TEMPLATE,
     CONF_USERNAME, CONF_PASSWORD, CONF_PORT, CONF_PROTOCOL, CONF_PAYLOAD)
@@ -26,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'mqtt'
 
-MQTT_CLIENT = None
+DATA_MQTT = 'mqtt'
 
 SERVICE_PUBLISH = 'publish'
 EVENT_MQTT_MESSAGE_RECEIVED = 'mqtt_message_received'
@@ -183,11 +185,11 @@ def publish_template(hass, topic, payload_template, qos=None, retain=None):
     hass.services.call(DOMAIN, SERVICE_PUBLISH, data)
 
 
-@callback
+@asyncio.coroutine
 def async_subscribe(hass, topic, msg_callback, qos=DEFAULT_QOS):
     """Subscribe to an MQTT topic."""
     @callback
-    def mqtt_topic_subscriber(event):
+    def async_mqtt_topic_subscriber(event):
         """Match subscribed MQTT topic."""
         if not _match_topic(topic, event.data[ATTR_TOPIC]):
             return
@@ -195,61 +197,82 @@ def async_subscribe(hass, topic, msg_callback, qos=DEFAULT_QOS):
         hass.async_run_job(msg_callback, event.data[ATTR_TOPIC],
                            event.data[ATTR_PAYLOAD], event.data[ATTR_QOS])
 
-    async_remove = hass.bus.async_listen(EVENT_MQTT_MESSAGE_RECEIVED,
-                                         mqtt_topic_subscriber)
+    async_remove = hass.bus.async_listen(
+        EVENT_MQTT_MESSAGE_RECEIVED, async_mqtt_topic_subscriber)
 
-    # Future: track subscriber count and unsubscribe in remove
-    MQTT_CLIENT.subscribe(topic, qos)
-
+    yield from hass.data[DATA_MQTT].async_subscribe(topic, qos)
     return async_remove
 
 
-# pylint: disable=invalid-name
-subscribe = threaded_listener_factory(async_subscribe)
+def subscribe(hass, topic, msg_callback, qos=DEFAULT_QOS):
+    """Subscribe to an MQTT topic."""
+    async_remove = run_coroutine_threadsafe(
+        async_subscribe(hass, topic, msg_callback, qos),
+        hass.loop
+    ).result()
+
+    def remove():
+        """Remove listener convert."""
+        run_callback_threadsafe(hass.loop, async_remove).result()
+
+    return remove
 
 
-def _setup_server(hass, config):
-    """Try to start embedded MQTT broker."""
+@asyncio.coroutine
+def _async_setup_server(hass, config):
+    """Try to start embedded MQTT broker.
+
+    This method is a coroutine.
+    """
     conf = config.get(DOMAIN, {})
 
     # Only setup if embedded config passed in or no broker specified
     if CONF_EMBEDDED not in conf and CONF_BROKER in conf:
         return None
 
-    server = prepare_setup_platform(hass, config, DOMAIN, 'server')
+    server = yield from async_prepare_setup_platform(
+        hass, config, DOMAIN, 'server')
 
     if server is None:
         _LOGGER.error("Unable to load embedded server")
         return None
 
-    success, broker_config = server.start(hass, conf.get(CONF_EMBEDDED))
+    success, broker_config = \
+        yield from server.async_start(hass, conf.get(CONF_EMBEDDED))
 
     return success and broker_config
 
 
-def _setup_discovery(hass, config):
-    """Try to start the discovery of MQTT devices."""
+@asyncio.coroutine
+def _async_setup_discovery(hass, config):
+    """Try to start the discovery of MQTT devices.
+
+    This method is a coroutine.
+    """
     conf = config.get(DOMAIN, {})
 
-    discovery = prepare_setup_platform(hass, config, DOMAIN, 'discovery')
+    discovery = yield from async_prepare_setup_platform(
+        hass, config, DOMAIN, 'discovery')
 
     if discovery is None:
         _LOGGER.error("Unable to load MQTT discovery")
         return None
 
-    success = discovery.async_start(hass, conf[CONF_DISCOVERY_PREFIX], config)
+    success = yield from discovery.async_start(
+        hass, conf[CONF_DISCOVERY_PREFIX], config)
 
     return success
 
 
-def setup(hass, config):
+@asyncio.coroutine
+def async_setup(hass, config):
     """Start the MQTT protocol service."""
     conf = config.get(DOMAIN, {})
 
     client_id = conf.get(CONF_CLIENT_ID)
     keepalive = conf.get(CONF_KEEPALIVE)
 
-    broker_config = _setup_server(hass, config)
+    broker_config = yield from _async_setup_server(hass, config)
 
     if CONF_BROKER in conf:
         broker = conf[CONF_BROKER]
@@ -283,27 +306,31 @@ def setup(hass, config):
     will_message = conf.get(CONF_WILL_MESSAGE)
     birth_message = conf.get(CONF_BIRTH_MESSAGE)
 
-    global MQTT_CLIENT
     try:
-        MQTT_CLIENT = MQTT(hass, broker, port, client_id, keepalive,
-                           username, password, certificate, client_key,
-                           client_cert, tls_insecure, protocol, will_message,
-                           birth_message)
+        hass.data[DATA_MQTT] = MQTT(
+            hass, broker, port, client_id, keepalive, username, password,
+            certificate, client_key, client_cert, tls_insecure, protocol,
+            will_message, birth_message)
     except socket.error:
         _LOGGER.exception("Can't connect to the broker. "
                           "Please check your settings and the broker itself")
         return False
 
-    def stop_mqtt(event):
+    @asyncio.coroutine
+    def async_stop_mqtt(event):
         """Stop MQTT component."""
-        MQTT_CLIENT.stop()
+        yield from hass.data[DATA_MQTT].async_stop()
 
-    def start_mqtt(event):
+    @asyncio.coroutine
+    def async_start_mqtt(event):
         """Launch MQTT component when Home Assistant starts up."""
-        MQTT_CLIENT.start()
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_mqtt)
+        yield from hass.data[DATA_MQTT].async_start()
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_mqtt)
 
-    def publish_service(call):
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, async_start_mqtt)
+
+    @asyncio.coroutine
+    def async_publish_service(call):
         """Handle MQTT publish service calls."""
         msg_topic = call.data[ATTR_TOPIC]
         payload = call.data.get(ATTR_PAYLOAD)
@@ -312,26 +339,28 @@ def setup(hass, config):
         retain = call.data[ATTR_RETAIN]
         try:
             if payload_template is not None:
-                payload = template.Template(payload_template, hass).render()
+                payload = \
+                    template.Template(payload_template, hass).async_render()
         except template.jinja2.TemplateError as exc:
             _LOGGER.error(
                 "Unable to publish to '%s': rendering payload template of "
                 "'%s' failed because %s",
                 msg_topic, payload_template, exc)
             return
-        MQTT_CLIENT.publish(msg_topic, payload, qos, retain)
 
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_mqtt)
+        yield from hass.data[DATA_MQTT].async_publish(
+            msg_topic, payload, qos, retain)
 
-    descriptions = load_yaml_config_file(
-        os.path.join(os.path.dirname(__file__), 'services.yaml'))
+    descriptions = yield from hass.loop.run_in_executor(
+        None, load_yaml_config_file, os.path.join(
+            os.path.dirname(__file__), 'services.yaml'))
 
-    hass.services.register(DOMAIN, SERVICE_PUBLISH, publish_service,
-                           descriptions.get(SERVICE_PUBLISH),
-                           schema=MQTT_PUBLISH_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_PUBLISH, async_publish_service,
+        descriptions.get(SERVICE_PUBLISH), schema=MQTT_PUBLISH_SCHEMA)
 
     if conf.get(CONF_DISCOVERY):
-        _setup_discovery(hass, config)
+        yield from _async_setup_discovery(hass, config)
 
     return True
 
@@ -349,6 +378,7 @@ class MQTT(object):
         self.topics = {}
         self.progress = {}
         self.birth_message = birth_message
+        self._mqttc = None
 
         if protocol == PROTOCOL_31:
             proto = mqtt.MQTTv31
@@ -364,8 +394,8 @@ class MQTT(object):
             self._mqttc.username_pw_set(username, password)
 
         if certificate is not None:
-            self._mqttc.tls_set(certificate, certfile=client_cert,
-                                keyfile=client_key)
+            self._mqttc.tls_set(
+                certificate, certfile=client_cert, keyfile=client_key)
 
         if tls_insecure is not None:
             self._mqttc.tls_insecure_set(tls_insecure)
@@ -375,25 +405,49 @@ class MQTT(object):
         self._mqttc.on_connect = self._mqtt_on_connect
         self._mqttc.on_disconnect = self._mqtt_on_disconnect
         self._mqttc.on_message = self._mqtt_on_message
+
         if will_message:
             self._mqttc.will_set(will_message.get(ATTR_TOPIC),
                                  will_message.get(ATTR_PAYLOAD),
                                  will_message.get(ATTR_QOS),
                                  will_message.get(ATTR_RETAIN))
-        self._mqttc.connect(broker, port, keepalive)
+
+        self._mqttc.connect_async(broker, port, keepalive)
 
     def publish(self, topic, payload, qos, retain):
         """Publish a MQTT message."""
         self._mqttc.publish(topic, payload, qos, retain)
 
+    def async_publish(self, topic, payload, qos, retain):
+        """Publish a MQTT message.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        return self.hass.run_in_executor(
+            None, self.publish, topic, payload, qos, retain)
+
     def start(self):
         """Run the MQTT client."""
         self._mqttc.loop_start()
+
+    def async_start(self):
+        """Run the MQTT client.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        return self.hass.run_in_executor(None, self.start)
 
     def stop(self):
         """Stop the MQTT client."""
         self._mqttc.disconnect()
         self._mqttc.loop_stop()
+
+    def async_stop(self):
+        """Stop the MQTT client.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        return self.hass.run_in_executor(None, self.stop)
 
     def subscribe(self, topic, qos):
         """Subscribe to a topic."""
@@ -406,11 +460,25 @@ class MQTT(object):
         self.progress[mid] = topic
         self.topics[topic] = None
 
+    def async_subscribe(self, topic, qos):
+        """Subscribe to a topic.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        return self.hass.run_in_executor(None, self.subscribe, topic, qos)
+
     def unsubscribe(self, topic):
         """Unsubscribe from topic."""
         result, mid = self._mqttc.unsubscribe(topic)
         _raise_on_error(result)
         self.progress[mid] = topic
+
+    def async_unsubscribe(self, topic):
+        """Unsubscribe from topic.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        return self.hass.run_in_executor(None, self.unsubscribe, topic)
 
     def _mqtt_on_connect(self, _mqttc, _userdata, _flags, result_code):
         """On connect callback.

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -9,7 +9,6 @@ import json
 import logging
 import re
 
-from homeassistant.core import callback
 import homeassistant.components.mqtt as mqtt
 from homeassistant.components.mqtt import DOMAIN
 from homeassistant.helpers.discovery import async_load_platform
@@ -24,7 +23,7 @@ TOPIC_MATCHER = re.compile(
 SUPPORTED_COMPONENTS = ['binary_sensor', 'sensor']
 
 
-@callback
+@asyncio.coroutine
 def async_start(hass, discovery_topic, hass_config):
     """Initialization of MQTT Discovery."""
     @asyncio.coroutine
@@ -56,7 +55,7 @@ def async_start(hass, discovery_topic, hass_config):
         yield from async_load_platform(
             hass, component, DOMAIN, payload, hass_config)
 
-    mqtt.async_subscribe(hass, discovery_topic + '/#',
-                         async_device_message_received, 0)
+    yield from mqtt.async_subscribe(
+        hass, discovery_topic + '/#', async_device_message_received, 0)
 
     return True

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -190,8 +190,6 @@ class HomeAssistant(object):
             self.loop.create_task(target)
         elif is_callback(target):
             self.loop.call_soon(target, *args)
-        elif isinstance(target, asyncio.Future):
-            pass
         elif asyncio.iscoroutinefunction(target):
             self.loop.create_task(target(*args))
         else:
@@ -215,8 +213,6 @@ class HomeAssistant(object):
             task = self.loop.create_task(target)
         elif is_callback(target):
             self.loop.call_soon(target, *args)
-        elif isinstance(target, asyncio.Future):
-            task = target
         elif asyncio.iscoroutinefunction(target):
             task = self.loop.create_task(target(*args))
         else:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -190,6 +190,8 @@ class HomeAssistant(object):
             self.loop.create_task(target)
         elif is_callback(target):
             self.loop.call_soon(target, *args)
+        elif isinstance(target, asyncio.Future):
+            pass
         elif asyncio.iscoroutinefunction(target):
             self.loop.create_task(target(*args))
         else:
@@ -213,6 +215,8 @@ class HomeAssistant(object):
             task = self.loop.create_task(target)
         elif is_callback(target):
             self.loop.call_soon(target, *args)
+        elif isinstance(target, asyncio.Future):
+            task = target
         elif asyncio.iscoroutinefunction(target):
             task = self.loop.create_task(target(*args))
         else:

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -34,6 +34,7 @@ def threaded_listener_factory(async_factory):
     return factory
 
 
+@callback
 def async_track_state_change(hass, entity_ids, action, from_state=None,
                              to_state=None):
     """Track specific state changes.
@@ -84,6 +85,7 @@ def async_track_state_change(hass, entity_ids, action, from_state=None,
 track_state_change = threaded_listener_factory(async_track_state_change)
 
 
+@callback
 def async_track_template(hass, template, action, variables=None):
     """Add a listener that track state changes with template condition."""
     from . import condition
@@ -111,6 +113,7 @@ def async_track_template(hass, template, action, variables=None):
 track_template = threaded_listener_factory(async_track_template)
 
 
+@callback
 def async_track_point_in_time(hass, action, point_in_time):
     """Add a listener that fires once after a specific point in time."""
     utc_point_in_time = dt_util.as_utc(point_in_time)
@@ -127,6 +130,7 @@ def async_track_point_in_time(hass, action, point_in_time):
 track_point_in_time = threaded_listener_factory(async_track_point_in_time)
 
 
+@callback
 def async_track_point_in_utc_time(hass, action, point_in_time):
     """Add a listener that fires once after a specific point in UTC time."""
     # Ensure point_in_time is UTC
@@ -160,6 +164,7 @@ track_point_in_utc_time = threaded_listener_factory(
     async_track_point_in_utc_time)
 
 
+@callback
 def async_track_time_interval(hass, action, interval):
     """Add a listener that fires repetitively at every timedelta interval."""
     remove = None
@@ -189,6 +194,7 @@ def async_track_time_interval(hass, action, interval):
 track_time_interval = threaded_listener_factory(async_track_time_interval)
 
 
+@callback
 def async_track_sunrise(hass, action, offset=None):
     """Add a listener that will fire a specified offset from sunrise daily."""
     from homeassistant.components import sun
@@ -225,6 +231,7 @@ def async_track_sunrise(hass, action, offset=None):
 track_sunrise = threaded_listener_factory(async_track_sunrise)
 
 
+@callback
 def async_track_sunset(hass, action, offset=None):
     """Add a listener that will fire a specified offset from sunset daily."""
     from homeassistant.components import sun
@@ -261,6 +268,7 @@ def async_track_sunset(hass, action, offset=None):
 track_sunset = threaded_listener_factory(async_track_sunset)
 
 
+@callback
 def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
                                 hour=None, minute=None, second=None,
                                 local=False):
@@ -305,6 +313,7 @@ def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
 track_utc_time_change = threaded_listener_factory(async_track_utc_time_change)
 
 
+@callback
 def async_track_time_change(hass, action, year=None, month=None, day=None,
                             hour=None, minute=None, second=None):
     """Add a listener that will fire if UTC time matches a pattern."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -86,7 +86,13 @@ def async_test_home_assistant(loop):
     loop._thread_ident = threading.get_ident()
 
     hass = ha.HomeAssistant(loop)
-    hass.async_track_tasks()
+
+    def async_add_job(target, *args):
+        if isinstance(target, MagicMock):
+            return
+        hass._async_add_job_tracking(target, *args)
+
+    hass.async_add_job = async_add_job
 
     hass.config.location_name = 'test home'
     hass.config.config_dir = get_test_config_dir()

--- a/tests/components/alarm_control_panel/test_mqtt.py
+++ b/tests/components/alarm_control_panel/test_mqtt.py
@@ -111,7 +111,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         alarm_control_panel.alarm_arm_home(self.hass)
         self.hass.block_till_done()
         self.assertEqual(('alarm/command', 'ARM_HOME', 0, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
 
     def test_arm_home_not_publishes_mqtt_with_invalid_code(self):
         """Test not publishing of MQTT messages with invalid code."""
@@ -146,7 +146,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         alarm_control_panel.alarm_arm_away(self.hass)
         self.hass.block_till_done()
         self.assertEqual(('alarm/command', 'ARM_AWAY', 0, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
 
     def test_arm_away_not_publishes_mqtt_with_invalid_code(self):
         """Test not publishing of MQTT messages with invalid code."""
@@ -181,7 +181,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         alarm_control_panel.alarm_disarm(self.hass)
         self.hass.block_till_done()
         self.assertEqual(('alarm/command', 'DISARM', 0, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
 
     def test_disarm_not_publishes_mqtt_with_invalid_code(self):
         """Test not publishing of MQTT messages with invalid code."""

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -118,7 +118,7 @@ class TestCoverMQTT(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(('command-topic', 'OPEN', 0, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
         state = self.hass.states.get('cover.test')
         self.assertEqual(STATE_OPEN, state.state)
 
@@ -126,7 +126,7 @@ class TestCoverMQTT(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(('command-topic', 'CLOSE', 0, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
         state = self.hass.states.get('cover.test')
         self.assertEqual(STATE_CLOSED, state.state)
 
@@ -150,7 +150,7 @@ class TestCoverMQTT(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(('command-topic', 'OPEN', 2, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
         state = self.hass.states.get('cover.test')
         self.assertEqual(STATE_UNKNOWN, state.state)
 
@@ -174,7 +174,7 @@ class TestCoverMQTT(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(('command-topic', 'CLOSE', 2, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
         state = self.hass.states.get('cover.test')
         self.assertEqual(STATE_UNKNOWN, state.state)
 
@@ -198,7 +198,7 @@ class TestCoverMQTT(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(('command-topic', 'STOP', 2, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
         state = self.hass.states.get('cover.test')
         self.assertEqual(STATE_UNKNOWN, state.state)
 

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -172,7 +172,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(('test_light_rgb/set', '{"state": "ON"}', 2, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_ON, state.state)
 
@@ -180,7 +180,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(('test_light_rgb/set', '{"state": "OFF"}', 2, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
 
@@ -189,11 +189,11 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual('test_light_rgb/set',
-                         self.mock_publish.mock_calls[-1][1][0])
-        self.assertEqual(2, self.mock_publish.mock_calls[-1][1][2])
-        self.assertEqual(False, self.mock_publish.mock_calls[-1][1][3])
+                         self.mock_publish.mock_calls[-2][1][0])
+        self.assertEqual(2, self.mock_publish.mock_calls[-2][1][2])
+        self.assertEqual(False, self.mock_publish.mock_calls[-2][1][3])
         # Get the sent message
-        message_json = json.loads(self.mock_publish.mock_calls[-1][1][1])
+        message_json = json.loads(self.mock_publish.mock_calls[-2][1][1])
         self.assertEqual(50, message_json["brightness"])
         self.assertEqual(75, message_json["color"]["r"])
         self.assertEqual(75, message_json["color"]["g"])
@@ -228,11 +228,11 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual('test_light_rgb/set',
-                         self.mock_publish.mock_calls[-1][1][0])
-        self.assertEqual(0, self.mock_publish.mock_calls[-1][1][2])
-        self.assertEqual(False, self.mock_publish.mock_calls[-1][1][3])
+                         self.mock_publish.mock_calls[-2][1][0])
+        self.assertEqual(0, self.mock_publish.mock_calls[-2][1][2])
+        self.assertEqual(False, self.mock_publish.mock_calls[-2][1][3])
         # Get the sent message
-        message_json = json.loads(self.mock_publish.mock_calls[-1][1][1])
+        message_json = json.loads(self.mock_publish.mock_calls[-2][1][1])
         self.assertEqual(5, message_json["flash"])
         self.assertEqual("ON", message_json["state"])
 
@@ -240,11 +240,11 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual('test_light_rgb/set',
-                         self.mock_publish.mock_calls[-1][1][0])
-        self.assertEqual(0, self.mock_publish.mock_calls[-1][1][2])
-        self.assertEqual(False, self.mock_publish.mock_calls[-1][1][3])
+                         self.mock_publish.mock_calls[-2][1][0])
+        self.assertEqual(0, self.mock_publish.mock_calls[-2][1][2])
+        self.assertEqual(False, self.mock_publish.mock_calls[-2][1][3])
         # Get the sent message
-        message_json = json.loads(self.mock_publish.mock_calls[-1][1][1])
+        message_json = json.loads(self.mock_publish.mock_calls[-2][1][1])
         self.assertEqual(15, message_json["flash"])
         self.assertEqual("ON", message_json["state"])
 
@@ -268,11 +268,11 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual('test_light_rgb/set',
-                         self.mock_publish.mock_calls[-1][1][0])
-        self.assertEqual(0, self.mock_publish.mock_calls[-1][1][2])
-        self.assertEqual(False, self.mock_publish.mock_calls[-1][1][3])
+                         self.mock_publish.mock_calls[-2][1][0])
+        self.assertEqual(0, self.mock_publish.mock_calls[-2][1][2])
+        self.assertEqual(False, self.mock_publish.mock_calls[-2][1][3])
         # Get the sent message
-        message_json = json.loads(self.mock_publish.mock_calls[-1][1][1])
+        message_json = json.loads(self.mock_publish.mock_calls[-2][1][1])
         self.assertEqual(10, message_json["transition"])
         self.assertEqual("ON", message_json["state"])
 
@@ -281,11 +281,11 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual('test_light_rgb/set',
-                         self.mock_publish.mock_calls[-1][1][0])
-        self.assertEqual(0, self.mock_publish.mock_calls[-1][1][2])
-        self.assertEqual(False, self.mock_publish.mock_calls[-1][1][3])
+                         self.mock_publish.mock_calls[-2][1][0])
+        self.assertEqual(0, self.mock_publish.mock_calls[-2][1][2])
+        self.assertEqual(False, self.mock_publish.mock_calls[-2][1][3])
         # Get the sent message
-        message_json = json.loads(self.mock_publish.mock_calls[-1][1][1])
+        message_json = json.loads(self.mock_publish.mock_calls[-2][1][1])
         self.assertEqual(10, message_json["transition"])
         self.assertEqual("OFF", message_json["state"])
 

--- a/tests/components/light/test_mqtt_template.py
+++ b/tests/components/light/test_mqtt_template.py
@@ -196,7 +196,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(('test_light_rgb/set', 'on,,--', 2, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_ON, state.state)
 
@@ -205,7 +205,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(('test_light_rgb/set', 'off', 2, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
 
@@ -215,12 +215,12 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual('test_light_rgb/set',
-                         self.mock_publish.mock_calls[-1][1][0])
-        self.assertEqual(2, self.mock_publish.mock_calls[-1][1][2])
-        self.assertEqual(False, self.mock_publish.mock_calls[-1][1][3])
+                         self.mock_publish.mock_calls[-2][1][0])
+        self.assertEqual(2, self.mock_publish.mock_calls[-2][1][2])
+        self.assertEqual(False, self.mock_publish.mock_calls[-2][1][3])
 
         # check the payload
-        payload = self.mock_publish.mock_calls[-1][1][1]
+        payload = self.mock_publish.mock_calls[-2][1][1]
         self.assertEqual('on,50,75-75-75', payload)
 
         # check the state
@@ -253,12 +253,12 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual('test_light_rgb/set',
-                         self.mock_publish.mock_calls[-1][1][0])
-        self.assertEqual(0, self.mock_publish.mock_calls[-1][1][2])
-        self.assertEqual(False, self.mock_publish.mock_calls[-1][1][3])
+                         self.mock_publish.mock_calls[-2][1][0])
+        self.assertEqual(0, self.mock_publish.mock_calls[-2][1][2])
+        self.assertEqual(False, self.mock_publish.mock_calls[-2][1][3])
 
         # check the payload
-        payload = self.mock_publish.mock_calls[-1][1][1]
+        payload = self.mock_publish.mock_calls[-2][1][1]
         self.assertEqual('on,short', payload)
 
         # long flash
@@ -266,12 +266,12 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual('test_light_rgb/set',
-                         self.mock_publish.mock_calls[-1][1][0])
-        self.assertEqual(0, self.mock_publish.mock_calls[-1][1][2])
-        self.assertEqual(False, self.mock_publish.mock_calls[-1][1][3])
+                         self.mock_publish.mock_calls[-2][1][0])
+        self.assertEqual(0, self.mock_publish.mock_calls[-2][1][2])
+        self.assertEqual(False, self.mock_publish.mock_calls[-2][1][3])
 
         # check the payload
-        payload = self.mock_publish.mock_calls[-1][1][1]
+        payload = self.mock_publish.mock_calls[-2][1][1]
         self.assertEqual('on,long', payload)
 
     def test_transition(self):
@@ -296,12 +296,12 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual('test_light_rgb/set',
-                         self.mock_publish.mock_calls[-1][1][0])
-        self.assertEqual(0, self.mock_publish.mock_calls[-1][1][2])
-        self.assertEqual(False, self.mock_publish.mock_calls[-1][1][3])
+                         self.mock_publish.mock_calls[-2][1][0])
+        self.assertEqual(0, self.mock_publish.mock_calls[-2][1][2])
+        self.assertEqual(False, self.mock_publish.mock_calls[-2][1][3])
 
         # check the payload
-        payload = self.mock_publish.mock_calls[-1][1][1]
+        payload = self.mock_publish.mock_calls[-2][1][1]
         self.assertEqual('on,10', payload)
 
         # transition off
@@ -309,12 +309,12 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual('test_light_rgb/set',
-                         self.mock_publish.mock_calls[-1][1][0])
-        self.assertEqual(0, self.mock_publish.mock_calls[-1][1][2])
-        self.assertEqual(False, self.mock_publish.mock_calls[-1][1][3])
+                         self.mock_publish.mock_calls[-2][1][0])
+        self.assertEqual(0, self.mock_publish.mock_calls[-2][1][2])
+        self.assertEqual(False, self.mock_publish.mock_calls[-2][1][3])
 
         # check the payload
-        payload = self.mock_publish.mock_calls[-1][1][1]
+        payload = self.mock_publish.mock_calls[-2][1][1]
         self.assertEqual('off,4', payload)
 
     def test_invalid_values(self): \

--- a/tests/components/lock/test_mqtt.py
+++ b/tests/components/lock/test_mqtt.py
@@ -73,7 +73,7 @@ class TestLockMQTT(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(('command-topic', 'LOCK', 2, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
         state = self.hass.states.get('lock.test')
         self.assertEqual(STATE_LOCKED, state.state)
 
@@ -81,7 +81,7 @@ class TestLockMQTT(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(('command-topic', 'UNLOCK', 2, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
         state = self.hass.states.get('lock.test')
         self.assertEqual(STATE_UNLOCKED, state.state)
 

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -12,9 +12,10 @@ def test_subscribing_config_topic(hass, mqtt_mock):
     """Test setting up discovery."""
     hass_config = {}
     discovery_topic = 'homeassistant'
-    async_start(hass, discovery_topic, hass_config)
-    assert mqtt_mock.subscribe.called
-    call_args = mqtt_mock.subscribe.mock_calls[0][1]
+    yield from async_start(hass, discovery_topic, hass_config)
+
+    assert mqtt_mock.async_subscribe.called
+    call_args = mqtt_mock.async_subscribe.mock_calls[0][1]
     assert call_args[0] == discovery_topic + '/#'
     assert call_args[1] == 0
 
@@ -24,7 +25,7 @@ def test_subscribing_config_topic(hass, mqtt_mock):
 def test_invalid_topic(mock_load_platform, hass, mqtt_mock):
     """Test sending in invalid JSON."""
     mock_load_platform.return_value = mock_coro()
-    async_start(hass, 'homeassistant', {})
+    yield from async_start(hass, 'homeassistant', {})
 
     async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/not_config',
                             '{}')
@@ -37,7 +38,7 @@ def test_invalid_topic(mock_load_platform, hass, mqtt_mock):
 def test_invalid_json(mock_load_platform, hass, mqtt_mock, caplog):
     """Test sending in invalid JSON."""
     mock_load_platform.return_value = mock_coro()
-    async_start(hass, 'homeassistant', {})
+    yield from async_start(hass, 'homeassistant', {})
 
     async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
                             'not json')
@@ -51,7 +52,7 @@ def test_invalid_json(mock_load_platform, hass, mqtt_mock, caplog):
 def test_only_valid_components(mock_load_platform, hass, mqtt_mock, caplog):
     """Test sending in invalid JSON."""
     mock_load_platform.return_value = mock_coro()
-    async_start(hass, 'homeassistant', {})
+    yield from async_start(hass, 'homeassistant', {})
 
     async_fire_mqtt_message(hass, 'homeassistant/climate/bla/config', '{}')
     yield from hass.async_block_till_done()
@@ -62,7 +63,7 @@ def test_only_valid_components(mock_load_platform, hass, mqtt_mock, caplog):
 @asyncio.coroutine
 def test_correct_config_discovery(hass, mqtt_mock, caplog):
     """Test sending in invalid JSON."""
-    async_start(hass, 'homeassistant', {})
+    yield from async_start(hass, 'homeassistant', {})
 
     async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
                             '{ "name": "Beer" }')

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -356,6 +356,7 @@ class TestMQTTCallbacks(unittest.TestCase):
 
 @asyncio.coroutine
 def test_birth_message(hass):
+    """Test sending birth message."""
     mqtt_client = yield from mock_mqtt_client(hass, {
         mqtt.CONF_BROKER: 'mock-broker',
         mqtt.CONF_BIRTH_MESSAGE: {mqtt.ATTR_TOPIC: 'birth',

--- a/tests/components/mqtt/test_server.py
+++ b/tests/components/mqtt/test_server.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, MagicMock, patch
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.mqtt as mqtt
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_coro
 
 
 class TestMQTT:
@@ -21,9 +21,8 @@ class TestMQTT:
 
     @patch('passlib.apps.custom_app_context', Mock(return_value=''))
     @patch('tempfile.NamedTemporaryFile', Mock(return_value=MagicMock()))
-    @patch('homeassistant.components.mqtt.server.run_coroutine_threadsafe',
-           Mock(return_value=MagicMock()))
     @patch('hbmqtt.broker.Broker', Mock(return_value=MagicMock()))
+    @patch('hbmqtt.broker.Broker.start', Mock(return_value=mock_coro()))
     @patch('homeassistant.components.mqtt.MQTT')
     def test_creating_config_with_http_pass(self, mock_mqtt):
         """Test if the MQTT server gets started and subscribe/publish msg."""
@@ -46,7 +45,7 @@ class TestMQTT:
         assert mock_mqtt.mock_calls[0][1][6] is None
 
     @patch('tempfile.NamedTemporaryFile', Mock(return_value=MagicMock()))
-    @patch('homeassistant.components.mqtt.server.run_coroutine_threadsafe')
+    @patch('hbmqtt.broker.Broker.start', return_value=mock_coro())
     def test_broker_config_fails(self, mock_run):
         """Test if the MQTT component fails if server fails."""
         from hbmqtt.broker import BrokerException

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -72,7 +72,7 @@ class TestSensorMQTT(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(('command-topic', 'beer on', 2, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
         state = self.hass.states.get('switch.test')
         self.assertEqual(STATE_ON, state.state)
 
@@ -80,7 +80,7 @@ class TestSensorMQTT(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(('command-topic', 'beer off', 2, False),
-                         self.mock_publish.mock_calls[-1][1])
+                         self.mock_publish.mock_calls[-2][1])
         state = self.hass.states.get('switch.test')
         self.assertEqual(STATE_OFF, state.state)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -217,29 +217,6 @@ class TestHomeAssistant(unittest.TestCase):
         assert len(self.hass._pending_tasks) == 0
         assert len(call_count) == 2
 
-    def test_async_add_job_pending_tasks_future(self):
-        """Run a executor/future in pending tasks."""
-        call_count = []
-
-        def test_executor():
-            """Test executor."""
-            call_count.append('call')
-
-        @asyncio.coroutine
-        def task_callback():
-            """Wait until all stuff is scheduled."""
-            fut1 = self.hass.loop.run_in_executor(None, test_executor)
-            fut2 = self.hass.loop.run_in_executor(None, test_executor)
-            self.hass.async_add_job(fut1)
-            self.hass.async_add_job(fut2)
-
-        run_coroutine_threadsafe(
-            task_callback(), self.hass.loop).result()
-
-        assert len(self.hass._pending_tasks) == 2
-        self.hass.block_till_done()
-        assert len(call_count) == 2
-
     def test_add_job_with_none(self):
         """Try to add a job with None as function."""
         with pytest.raises(ValueError):


### PR DESCRIPTION
**Description:**

- Convert mqtt to async
- Remove globs
- Allow core to schedule our Future from new base entity concept
- Unittest / don't schedule MagicMocks

This layout should be compatible to hbmqtt. So we can easy replace our mqtt Client. I think we should cut our support for old 3.1 standard and move Forward to 3.1.1 (this is now 4 years old). But that is in a other PR.

Next step is also, convert all platform mqtt to async.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
