### PR TITLE
Added tamper detection to Wink devices.

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -92,13 +92,13 @@ class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
     def __init__(self, wink, hass):
         """Initialize the Wink binary sensor."""
         super().__init__(wink, hass)
-        try:
+        if hasattr(self.wink, 'unit'):
             self._unit_of_measurement = self.wink.unit()
-        except AttributeError:
+        else:
             self._unit_of_measurement = None
-        try:
+        if hasattr(self.wink, 'capability'):
             self.capability = self.wink.capability()
-        except AttributeError:
+        else:
             self.capability = None
 
     @property

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -194,6 +194,8 @@ class WinkDevice(Entity):
             attributes["device_manufacturer"] = self._device_manufacturer
         if self._model_name:
             attributes["model_name"] = self._model_name
+        if self._tamper is not None:
+            attributes["tamper_detected"] = self._tamper
         return attributes
 
     @property
@@ -221,3 +223,11 @@ class WinkDevice(Entity):
     def _model_name(self):
         """Return the model name."""
         return self.wink.model_name()
+
+    @property
+    def _tamper(self):
+        """Return the devices tamper status."""
+        try:
+            return self.wink.tamper_detected()
+        except AttributeError:
+            return None

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -139,7 +139,6 @@ class WinkDevice(Entity):
         """Initialize the Wink device."""
         self.hass = hass
         self.wink = wink
-        self._battery = self.wink.battery_level()
         hass.data[DOMAIN]['pubnub'].add_subscription(
             self.wink.pubnub_channel, self._pubnub_update)
         hass.data[DOMAIN]['entities'].append(self)
@@ -183,19 +182,24 @@ class WinkDevice(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         attributes = {}
-        if self._battery:
-            attributes[ATTR_BATTERY_LEVEL] = self._battery_level
-        if self._manufacturer_device_model:
-            _model = self._manufacturer_device_model
-            attributes["manufacturer_device_model"] = _model
-        if self._manufacturer_device_id:
-            attributes["manufacturer_device_id"] = self._manufacturer_device_id
-        if self._device_manufacturer:
-            attributes["device_manufacturer"] = self._device_manufacturer
-        if self._model_name:
-            attributes["model_name"] = self._model_name
-        if self._tamper is not None:
-            attributes["tamper_detected"] = self._tamper
+        battery = self._battery_level
+        if battery:
+            attributes[ATTR_BATTERY_LEVEL] = battery
+        man_dev_model = self._manufacturer_device_model
+        if man_dev_model:
+            attributes["manufacturer_device_model"] = man_dev_model
+        man_dev_id = self._manufacturer_device_id
+        if man_dev_id:
+            attributes["manufacturer_device_id"] = man_dev_id
+        dev_man = self._device_manufacturer
+        if dev_man:
+            attributes["device_manufacturer"] = dev_man
+        model_name = self._model_name
+        if model_name:
+            attributes["model_name"] = model_name
+        tamper = self._tamper
+        if tamper is not None:
+            attributes["tamper_detected"] = tamper
         return attributes
 
     @property

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -227,7 +227,7 @@ class WinkDevice(Entity):
     @property
     def _tamper(self):
         """Return the devices tamper status."""
-        try:
+        if hasattr(self.wink, 'tamper_detected'):
             return self.wink.tamper_detected()
-        except AttributeError:
+        else:
             return None


### PR DESCRIPTION
**Description:**
The Wink API sends back a field on some devices of "tamper_detected." This is set to True when, for example the back door of a door/window sensor is opened.

This should be returned on door windows sensors, motions sensors (and their associated temperature sensors) and on garage_doors as well. There could be others?

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
