### PR TITLE
Clean up value_added in zwave light.

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -125,7 +125,6 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
         if self._refresh_value:
             if self._refreshing:
                 self._refreshing = False
-                self.update_properties()
             else:
                 def _refresh_value():
                     """Used timer callback for delayed value refresh."""
@@ -137,10 +136,8 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
 
                 self._timer = Timer(self._delay, _refresh_value)
                 self._timer.start()
-            self.schedule_update_ha_state()
-        else:
-            self.update_properties()
-            self.schedule_update_ha_state()
+                return
+        super().value_changed(value)
 
     @property
     def brightness(self):


### PR DESCRIPTION
**Description:**

Clean up value_added in zwave light.

Now `schedule_update_ha_state` is called if we came after a refresh.
If we are starting a refresh it is not called (was called before).

I think the previous behavior doesn't make sense: we want to update state when think we have good data - i.e. after refresh.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
