### PR TITLE
Add supported_features to cover component

### DIFF
--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -38,6 +38,15 @@ DEVICE_CLASSES = [
     'garage',        # Garage door control
 ]
 
+SUPPORT_OPEN = 1
+SUPPORT_CLOSE = 2
+SUPPORT_SET_POSITION = 4
+SUPPORT_STOP = 8
+SUPPORT_OPEN_TILT = 16
+SUPPORT_CLOSE_TILT = 32
+SUPPORT_STOP_TILT = 64
+SUPPORT_SET_TILT_POSITION = 128
+
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_CURRENT_POSITION = 'current_position'
@@ -225,6 +234,21 @@ class CoverDevice(Entity):
             data[ATTR_CURRENT_TILT_POSITION] = self.current_cover_tilt_position
 
         return data
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        supported_features = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP
+
+        if self.current_cover_position is not None:
+            supported_features |= SUPPORT_SET_POSITION
+
+        if self.current_cover_tilt_position is not None:
+            supported_features |= (
+                SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT | SUPPORT_STOP_TILT |
+                SUPPORT_SET_TILT_POSITION)
+
+        return supported_features
 
     @property
     def is_closed(self):

--- a/homeassistant/components/cover/demo.py
+++ b/homeassistant/components/cover/demo.py
@@ -4,7 +4,8 @@ Demo platform for the cover component.
 For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/demo/
 """
-from homeassistant.components.cover import CoverDevice
+from homeassistant.components.cover import (
+    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE)
 from homeassistant.helpers.event import track_utc_time_change
 
 
@@ -14,7 +15,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         DemoCover(hass, 'Kitchen Window'),
         DemoCover(hass, 'Hall Window', 10),
         DemoCover(hass, 'Living Room Window', 70, 50),
-        DemoCover(hass, 'Garage Door', device_class='garage'),
+        DemoCover(hass, 'Garage Door', device_class='garage',
+                  supported_features=(SUPPORT_OPEN | SUPPORT_CLOSE)),
     ])
 
 
@@ -23,12 +25,13 @@ class DemoCover(CoverDevice):
 
     # pylint: disable=no-self-use
     def __init__(self, hass, name, position=None, tilt_position=None,
-                 device_class=None):
+                 device_class=None, supported_features=None):
         """Initialize the cover."""
         self.hass = hass
         self._name = name
         self._position = position
         self._device_class = device_class
+        self._supported_features = supported_features
         self._set_position = None
         self._set_tilt_position = None
         self._tilt_position = tilt_position
@@ -70,6 +73,14 @@ class DemoCover(CoverDevice):
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""
         return self._device_class
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        if self._supported_features is not None:
+            return self._supported_features
+        else:
+            return super().supported_features
 
     def close_cover(self, **kwargs):
         """Close the cover."""

--- a/homeassistant/components/cover/zwave.py
+++ b/homeassistant/components/cover/zwave.py
@@ -7,13 +7,16 @@ https://home-assistant.io/components/cover.zwave/
 # Because we do not compile openzwave on CI
 # pylint: disable=import-error
 import logging
-from homeassistant.components.cover import DOMAIN
+from homeassistant.components.cover import (
+    DOMAIN, SUPPORT_OPEN, SUPPORT_CLOSE)
 from homeassistant.components.zwave import ZWaveDeviceEntity
 from homeassistant.components import zwave
 from homeassistant.components.zwave import workaround
 from homeassistant.components.cover import CoverDevice
 
 _LOGGER = logging.getLogger(__name__)
+
+SUPPORT_GARAGE = SUPPORT_OPEN | SUPPORT_CLOSE
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -133,3 +136,8 @@ class ZwaveGarageDoor(zwave.ZWaveDeviceEntity, CoverDevice):
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""
         return 'garage'
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_GARAGE

--- a/tests/components/cover/test_demo.py
+++ b/tests/components/cover/test_demo.py
@@ -24,6 +24,17 @@ class TestCoverDemo(unittest.TestCase):
         """Stop down everything that was started."""
         self.hass.stop()
 
+    def test_supported_features(self):
+        """Test cover supported features."""
+        state = self.hass.states.get('cover.garage_door')
+        self.assertEqual(3, state.attributes.get('supported_features'))
+        state = self.hass.states.get('cover.kitchen_window')
+        self.assertEqual(11, state.attributes.get('supported_features'))
+        state = self.hass.states.get('cover.hall_window')
+        self.assertEqual(15, state.attributes.get('supported_features'))
+        state = self.hass.states.get('cover.living_room_window')
+        self.assertEqual(255, state.attributes.get('supported_features'))
+
     def test_close_cover(self):
         """Test closing the cover."""
         state = self.hass.states.get(ENTITY_COVER)


### PR DESCRIPTION
**Description:**
This PR adds supported_features to the cover component. Currently the use case is for zwave garage doors, which don't support the cover_stop service. This allows entities to declare their supported features so the frontend can display the appropriate controls.

**See also:**
https://github.com/home-assistant/home-assistant-polymer/pull/215

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
