### PR TITLE
Update FLUX_LED by adding Effects

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -12,8 +12,9 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_PROTOCOL
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATTR_EFFECT, EFFECT_RANDOM,
-    SUPPORT_BRIGHTNESS, SUPPORT_EFFECT, SUPPORT_RGB_COLOR, Light,
+    ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATTR_EFFECT, EFFECT_COLORLOOP,
+    EFFECT_RANDOM, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT,
+    SUPPORT_RGB_COLOR, Light,
     PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
@@ -32,23 +33,20 @@ SUPPORT_FLUX_LED = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT |
 MODE_RGB = 'rgb'
 MODE_RGBW = 'rgbw'
 
-#List of Supported Effects which aren't already declared in LIGHT
-EFFECT_COLORLOOP = "colorloop"
-EFFECT_RANDOM = "random"
-EFFECT_WHITE = "white"
-EFFECT_RED_FADE = "red_fade"    
-EFFECT_GREEN_FADE = "green_fade"  
+# List of Supported Effects which aren't already declared in LIGHT
+EFFECT_RED_FADE = "red_fade"
+EFFECT_GREEN_FADE = "green_fade"
 EFFECT_BLUE_FADE = "blue_fade"
-EFFECT_YELLOW_FADE = "yellow_fade"  
+EFFECT_YELLOW_FADE = "yellow_fade"
 EFFECT_CYAN_FADE = "cyan_fade"
-EFFECT_PURPLE_FADE = "purple_fade" 
-EFFECT_WHITE_FADE = "white_fade"  
-EFFECT_RED_GREEN_CROSS_FADE = "rg_cross_fade"  
-EFFECT_RED_BLUE_CROSS_FADE = "rb_cross_fade"   
-EFFECT_GREEN_BLUE_CROSS_FADE = "gb_cross_fade"  
-EFFECT_COLORSTROBE = "colorstrobe"  
+EFFECT_PURPLE_FADE = "purple_fade"
+EFFECT_WHITE_FADE = "white_fade"
+EFFECT_RED_GREEN_CROSS_FADE = "rg_cross_fade"
+EFFECT_RED_BLUE_CROSS_FADE = "rb_cross_fade"
+EFFECT_GREEN_BLUE_CROSS_FADE = "gb_cross_fade"
+EFFECT_COLORSTROBE = "colorstrobe"
 EFFECT_RED_STROBE = "red_strobe"
-EFFECT_GREEN_STROBE =  "green_strobe"
+EFFECT_GREEN_STROBE = "green_strobe"
 EFFECT_BLUE_STOBE = "blue_strobe"
 EFFECT_YELLOW_STROBE = "yellow_strobe"
 EFFECT_CYAN_STROBE = "cyan_strobe"
@@ -59,7 +57,6 @@ EFFECT_COLORJUMP = "colorjump"
 FLUX_EFFECT_LIST = [
     EFFECT_COLORLOOP,
     EFFECT_RANDOM,
-    EFFECT_WHITE,
     EFFECT_RED_FADE,
     EFFECT_GREEN_FADE,
     EFFECT_BLUE_FADE,
@@ -209,7 +206,7 @@ class FluxLight(Light):
         """Flag supported features."""
         return SUPPORT_FLUX_LED
 
-@property
+    @property
     def effect_list(self):
         """Return the list of supported effects."""
         return FLUX_EFFECT_LIST
@@ -276,7 +273,6 @@ class FluxLight(Light):
             self._bulb.setPresetPattern(0x37, 50)
         elif effect == EFFECT_COLORJUMP:
             self._bulb.setPresetPattern(0x38, 50)
-
 
     def turn_off(self, **kwargs):
         """Turn the specified or all lights off."""

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -33,6 +33,9 @@ MODE_RGB = 'rgb'
 MODE_RGBW = 'rgbw'
 
 #List of Supported Effects which aren't already declared in LIGHT
+EFFECT_COLORLOOP = "colorloop"
+EFFECT_RANDOM = "random"
+EFFECT_WHITE = "white"
 EFFECT_RED_FADE = "red_fade"    
 EFFECT_GREEN_FADE = "green_fade"  
 EFFECT_BLUE_FADE = "blue_fade"
@@ -206,6 +209,11 @@ class FluxLight(Light):
         """Flag supported features."""
         return SUPPORT_FLUX_LED
 
+@property
+    def effect_list(self):
+        """Return the list of supported effects."""
+        return FLUX_EFFECT_LIST
+
     def turn_on(self, **kwargs):
         """Turn the specified or all lights on."""
         if not self.is_on:
@@ -229,45 +237,45 @@ class FluxLight(Light):
                               random.randrange(0, 255),
                               random.randrange(0, 255))
         elif effect == EFFECT_COLORLOOP:
-            self._bulb.setPresetPattern(0x25)
+            self._bulb.setPresetPattern(0x25, 50)
         elif effect == EFFECT_RED_FADE:
-            self._bulb.setPresetPattern(0x26)
+            self._bulb.setPresetPattern(0x26, 50)
         elif effect == EFFECT_GREEN_FADE:
-            self._bulb.setPresetPattern(0x27)
+            self._bulb.setPresetPattern(0x27, 50)
         elif effect == EFFECT_BLUE_FADE:
-            self._bulb.setPresetPattern(0x28)
+            self._bulb.setPresetPattern(0x28, 50)
         elif effect == EFFECT_YELLOW_FADE:
-            self._bulb.setPresetPattern(0x29)
+            self._bulb.setPresetPattern(0x29, 50)
         elif effect == EFFECT_CYAN_FADE:
-            self._bulb.setPresetPattern(0x2a)
+            self._bulb.setPresetPattern(0x2a, 50)
         elif effect == EFFECT_PURPLE_FADE:
-            self._bulb.setPresetPattern(0x2b)
+            self._bulb.setPresetPattern(0x2b, 50)
         elif effect == EFFECT_WHITE_FADE:
-            self._bulb.setPresetPattern(0x2c)
+            self._bulb.setPresetPattern(0x2c, 50)
         elif effect == EFFECT_RED_GREEN_CROSS_FADE:
-            self._bulb.setPresetPattern(0x2d)
+            self._bulb.setPresetPattern(0x2d, 50)
         elif effect == EFFECT_RED_BLUE_CROSS_FADE:
-            self._bulb.setPresetPattern(0x2e)
+            self._bulb.setPresetPattern(0x2e, 50)
         elif effect == EFFECT_GREEN_BLUE_CROSS_FADE:
-            self._bulb.setPresetPattern(0x2f)
+            self._bulb.setPresetPattern(0x2f, 50)
         elif effect == EFFECT_COLORSTROBE:
-            self._bulb.setPresetPattern(0x30)
+            self._bulb.setPresetPattern(0x30, 50)
         elif effect == EFFECT_RED_STROBE:
-            self._bulb.setPresetPattern(0x31)
+            self._bulb.setPresetPattern(0x31, 50)
         elif effect == EFFECT_GREEN_STROBE:
-            self._bulb.setPresetPattern(0x32)
+            self._bulb.setPresetPattern(0x32, 50)
         elif effect == EFFECT_BLUE_STOBE:
-            self._bulb.setPresetPattern(0x33)
+            self._bulb.setPresetPattern(0x33, 50)
         elif effect == EFFECT_YELLOW_STROBE:
-            self._bulb.setPresetPattern(0x34)
+            self._bulb.setPresetPattern(0x34, 50)
         elif effect == EFFECT_CYAN_STROBE:
-            self._bulb.setPresetPattern(0x35)
+            self._bulb.setPresetPattern(0x35, 50)
         elif effect == EFFECT_PURPLE_STROBE:
-            self._bulb.setPresetPattern(0x36)
+            self._bulb.setPresetPattern(0x36, 50)
         elif effect == EFFECT_WHITE_STROBE:
-            self._bulb.setPresetPattern(0x37)
+            self._bulb.setPresetPattern(0x37, 50)
         elif effect == EFFECT_COLORJUMP:
-            self._bulb.setPresetPattern(0x38)
+            self._bulb.setPresetPattern(0x38, 50)
 
 
     def turn_off(self, **kwargs):

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -281,3 +281,4 @@ class FluxLight(Light):
     def update(self):
         """Synchronize state with bulb."""
         self._bulb.refreshState()
+        

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -281,4 +281,3 @@ class FluxLight(Light):
     def update(self):
         """Synchronize state with bulb."""
         self._bulb.refreshState()
-        

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -32,6 +32,51 @@ SUPPORT_FLUX_LED = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT |
 MODE_RGB = 'rgb'
 MODE_RGBW = 'rgbw'
 
+#List of Supported Effects which aren't already declared in LIGHT
+EFFECT_RED_FADE = "red_fade"    
+EFFECT_GREEN_FADE = "green_fade"  
+EFFECT_BLUE_FADE = "blue_fade"
+EFFECT_YELLOW_FADE = "yellow_fade"  
+EFFECT_CYAN_FADE = "cyan_fade"
+EFFECT_PURPLE_FADE = "purple_fade" 
+EFFECT_WHITE_FADE = "white_fade"  
+EFFECT_RED_GREEN_CROSS_FADE = "rg_cross_fade"  
+EFFECT_RED_BLUE_CROSS_FADE = "rb_cross_fade"   
+EFFECT_GREEN_BLUE_CROSS_FADE = "gb_cross_fade"  
+EFFECT_COLORSTROBE = "colorstrobe"  
+EFFECT_RED_STROBE = "red_strobe"
+EFFECT_GREEN_STROBE =  "green_strobe"
+EFFECT_BLUE_STOBE = "blue_strobe"
+EFFECT_YELLOW_STROBE = "yellow_strobe"
+EFFECT_CYAN_STROBE = "cyan_strobe"
+EFFECT_PURPLE_STROBE = "purple_strobe"
+EFFECT_WHITE_STROBE = "white_strobe"
+EFFECT_COLORJUMP = "colorjump"
+
+FLUX_EFFECT_LIST = [
+    EFFECT_COLORLOOP,
+    EFFECT_RANDOM,
+    EFFECT_WHITE,
+    EFFECT_RED_FADE,
+    EFFECT_GREEN_FADE,
+    EFFECT_BLUE_FADE,
+    EFFECT_YELLOW_FADE,
+    EFFECT_CYAN_FADE,
+    EFFECT_PURPLE_FADE,
+    EFFECT_WHITE_FADE,
+    EFFECT_RED_GREEN_CROSS_FADE,
+    EFFECT_RED_BLUE_CROSS_FADE,
+    EFFECT_GREEN_BLUE_CROSS_FADE,
+    EFFECT_COLORSTROBE,
+    EFFECT_RED_STROBE,
+    EFFECT_GREEN_STROBE,
+    EFFECT_BLUE_STOBE,
+    EFFECT_YELLOW_STROBE,
+    EFFECT_CYAN_STROBE,
+    EFFECT_PURPLE_STROBE,
+    EFFECT_WHITE_STROBE,
+    EFFECT_COLORJUMP]
+
 DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(ATTR_MODE, default=MODE_RGBW):
@@ -183,6 +228,47 @@ class FluxLight(Light):
             self._bulb.setRgb(random.randrange(0, 255),
                               random.randrange(0, 255),
                               random.randrange(0, 255))
+        elif effect == EFFECT_COLORLOOP:
+            self._bulb.setPresetPattern(0x25)
+        elif effect == EFFECT_RED_FADE:
+            self._bulb.setPresetPattern(0x26)
+        elif effect == EFFECT_GREEN_FADE:
+            self._bulb.setPresetPattern(0x27)
+        elif effect == EFFECT_BLUE_FADE:
+            self._bulb.setPresetPattern(0x28)
+        elif effect == EFFECT_YELLOW_FADE:
+            self._bulb.setPresetPattern(0x29)
+        elif effect == EFFECT_CYAN_FADE:
+            self._bulb.setPresetPattern(0x2a)
+        elif effect == EFFECT_PURPLE_FADE:
+            self._bulb.setPresetPattern(0x2b)
+        elif effect == EFFECT_WHITE_FADE:
+            self._bulb.setPresetPattern(0x2c)
+        elif effect == EFFECT_RED_GREEN_CROSS_FADE:
+            self._bulb.setPresetPattern(0x2d)
+        elif effect == EFFECT_RED_BLUE_CROSS_FADE:
+            self._bulb.setPresetPattern(0x2e)
+        elif effect == EFFECT_GREEN_BLUE_CROSS_FADE:
+            self._bulb.setPresetPattern(0x2f)
+        elif effect == EFFECT_COLORSTROBE:
+            self._bulb.setPresetPattern(0x30)
+        elif effect == EFFECT_RED_STROBE:
+            self._bulb.setPresetPattern(0x31)
+        elif effect == EFFECT_GREEN_STROBE:
+            self._bulb.setPresetPattern(0x32)
+        elif effect == EFFECT_BLUE_STOBE:
+            self._bulb.setPresetPattern(0x33)
+        elif effect == EFFECT_YELLOW_STROBE:
+            self._bulb.setPresetPattern(0x34)
+        elif effect == EFFECT_CYAN_STROBE:
+            self._bulb.setPresetPattern(0x35)
+        elif effect == EFFECT_PURPLE_STROBE:
+            self._bulb.setPresetPattern(0x36)
+        elif effect == EFFECT_WHITE_STROBE:
+            self._bulb.setPresetPattern(0x37)
+        elif effect == EFFECT_COLORJUMP:
+            self._bulb.setPresetPattern(0x38)
+
 
     def turn_off(self, **kwargs):
         """Turn the specified or all lights off."""


### PR DESCRIPTION
**Description:**
A redo of my previous attempt, the changes are now all entirely within FLUX_LED. In order to do this, I took out the speed variable; I will add this in a future pull for now it defaults to 50, which is the direct middle value. We can now access all of the effects which FLUX_LED offers. If this looks good I will draft and pull request the additional documentation tomorrow.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2081

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [N/A] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [N/A] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [N/A] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [N/A] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
