### PR TITLE
Support for Pocket Casts

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -323,6 +323,7 @@ omit =
     homeassistant/components/sensor/openweathermap.py
     homeassistant/components/sensor/pi_hole.py
     homeassistant/components/sensor/plex.py
+    homeassistant/components/sensor/pocketcasts.py
     homeassistant/components/sensor/pvoutput.py
     homeassistant/components/sensor/sabnzbd.py
     homeassistant/components/sensor/scrape.py

--- a/homeassistant/components/sensor/pocketcasts.py
+++ b/homeassistant/components/sensor/pocketcasts.py
@@ -1,0 +1,81 @@
+"""
+Support for Pocket Casts.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.pocketcasts/
+"""
+import logging
+
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD)
+from homeassistant.components.sensor import (PLATFORM_SCHEMA)
+
+_LOGGER = logging.getLogger(__name__)
+
+COMMIT = '9f61ff00c77c7c98ffa0af9dd3540df3dce4a836'
+REQUIREMENTS = ['https://github.com/molobrakos/python-pocketcasts/'
+                'archive/%s.zip#python-pocketcasts==0.0.1' % COMMIT]
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+})
+
+ICON = 'mdi:rss'
+SENSOR_NAME = 'Pocketcasts unlistened episodes'
+SCAN_INTERVAL = timedelta(minutes=5)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the pocketcasts platform for sensors."""
+    import pocketcasts
+    try:
+        api = pocketcasts.Api(
+            config.get(CONF_USERNAME),
+            config.get(CONF_PASSWORD))
+        _LOGGER.debug('Found %d podcasts',
+                      len(api.my_podcasts()))
+        add_devices([PocketCastsSensor(api)])
+        return True
+    except OSError as err:
+        _LOGGER.error('Failed to contact server '
+                      '(wrong credentials?): %s', err)
+        return False
+
+
+class PocketCastsSensor(Entity):
+    """Representation of a pocket casts sensor."""
+
+    def __init__(self, api):
+        """Initialize the sensor."""
+        self._api = api
+        self._state = None
+        self.update()
+
+    def update(self):
+        """Update sensor values."""
+        try:
+            self._state = len(self._api.new_episodes_released())
+            _LOGGER.debug('Found %d new episodes', self._state)
+        except OSError as err:
+            _LOGGER.warning('Failed to contact server: %s', err)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return SENSOR_NAME
+
+    @property
+    def state(self):
+        """Return the sensor state."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Return the icon for the sensor."""
+        return ICON

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -234,6 +234,9 @@ https://github.com/joopert/nad_receiver/archive/0.0.3.zip#nad_receiver==0.0.3
 # homeassistant.components.media_player.russound_rnet
 https://github.com/laf/russound/archive/0.1.6.zip#russound==0.1.6
 
+# homeassistant.components.sensor.pocketcasts
+https://github.com/molobrakos/python-pocketcasts/archive/9f61ff00c77c7c98ffa0af9dd3540df3dce4a836.zip#python-pocketcasts==0.0.1
+
 # homeassistant.components.switch.anel_pwrctrl
 https://github.com/mweinelt/anel-pwrctrl/archive/ed26e8830e28a2bfa4260a9002db23ce3e7e63d7.zip#anel_pwrctrl==0.0.1
 


### PR DESCRIPTION
**Description:**
Support for displaying number of new unlistened episodes on pocketcasts.
Requires paid access to the pockecasts web player (play.pocketcasts.com)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
