### PR TITLE
Fix colortemp conversion for lifx lights

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -14,6 +14,8 @@ from homeassistant.components.light import (
     SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_RGB_COLOR,
     SUPPORT_TRANSITION, Light, PLATFORM_SCHEMA)
 from homeassistant.helpers.event import track_time_change
+from homeassistant.util.color import (
+    color_temperature_mired_to_kelvin, color_temperature_kelvin_to_mired)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -181,8 +183,7 @@ class LIFXLight(Light):
     @property
     def color_temp(self):
         """Return the color temperature."""
-        temperature = int(TEMP_MIN_HASS + (TEMP_MAX_HASS - TEMP_MIN_HASS) *
-                          (self._kel - TEMP_MIN) / (TEMP_MAX - TEMP_MIN))
+        temperature = color_temperature_kelvin_to_mired(self._kel)
 
         _LOGGER.debug("color_temp: %d", temperature)
         return temperature
@@ -219,11 +220,8 @@ class LIFXLight(Light):
             brightness = self._bri
 
         if ATTR_COLOR_TEMP in kwargs:
-            # pylint: disable=fixme
-            # TODO: Use color_temperature_mired_to_kelvin from util.color
-            kelvin = int(((TEMP_MAX - TEMP_MIN) *
-                          (kwargs[ATTR_COLOR_TEMP] - TEMP_MIN_HASS) /
-                          (TEMP_MAX_HASS - TEMP_MIN_HASS)) + TEMP_MIN)
+            kelvin = int(color_temperature_mired_to_kelvin(
+                kwargs[ATTR_COLOR_TEMP]))
         else:
             kelvin = self._kel
 


### PR DESCRIPTION
**Description:**
This PR changes colortemp conversion in lifx.py so that it uses the utility functions from homeassistant.util.color.  The current code does not correctly convert between mired and kevin.  For example, setting a light to 369 mired with the light.turn_on service sets the bulb to 6539K as reported by the lifx app.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
This bug was discovered by another user in this thread https://community.home-assistant.io/t/automation-to-change-light-temp-brightness-while-it-is-on-how/2717/22, but I couldn't find an existing PR for the change.

**Checklist:**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51