### PR TITLE
aiohttp handling in finally to close instead release

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -75,7 +75,7 @@ def async_get_image(hass, entity_id, timeout=10):
 
     finally:
         if response is not None:
-            yield from response.release()
+            response.close()
 
 
 @asyncio.coroutine

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -64,6 +64,7 @@ def async_get_image(hass, entity_id, timeout=10):
             response = yield from websession.get(url)
 
             if response.status != 200:
+                yield from response.release()
                 raise HomeAssistantError("Error {0} on {1}".format(
                     response.status, url))
 

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -116,14 +116,12 @@ class GenericCamera(Camera):
                 self._last_image = yield from response.read()
             except asyncio.TimeoutError:
                 _LOGGER.error('Timeout getting camera image')
-                return self._last_image
             except (aiohttp.errors.ClientError,
                     aiohttp.errors.ClientDisconnectedError) as err:
                 _LOGGER.error('Error getting new camera image: %s', err)
-                return self._last_image
             finally:
                 if response is not None:
-                    self.hass.async_add_job(response.release())
+                    response.close()
 
         self._last_url = url
         return self._last_image

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -109,7 +109,7 @@ class MjpegCamera(Camera):
 
         finally:
             if response is not None:
-                yield from response.release()
+                response.close()
 
     def camera_image(self):
         """Return a still image response from the camera."""

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -133,7 +133,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         _LOGGER.exception("Error on %s", syno_camera_url)
         return False
     finally:
-        camera_req.close()
+        if camera_req is not None:
+            camera_req.close()
 
     cameras = camera_resp['data']['cameras']
 

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -119,19 +119,23 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         'method': 'List',
         'version': '1'
     }
+
+    camera_req = None
     try:
         with async_timeout.timeout(TIMEOUT, loop=hass.loop):
             camera_req = yield from websession.get(
                 syno_camera_url,
                 params=camera_payload
             )
+
+            camera_resp = yield from camera_req.json()
     except (asyncio.TimeoutError, aiohttp.errors.ClientError):
         _LOGGER.exception("Error on %s", syno_camera_url)
         return False
+    finally:
+        camera_req.close()
 
-    camera_resp = yield from camera_req.json()
     cameras = camera_resp['data']['cameras']
-    camera_req.close()
 
     # add cameras
     devices = []

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -92,7 +92,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     finally:
         if query_req is not None:
-            yield from query_req.release()
+            query_req.close()
 
     # Authticate to NAS to get a session id
     syno_auth_url = SYNO_API_URL.format(
@@ -131,7 +131,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     camera_resp = yield from camera_req.json()
     cameras = camera_resp['data']['cameras']
-    yield from camera_req.release()
+    camera_req.close()
 
     # add cameras
     devices = []
@@ -184,7 +184,7 @@ def get_session_id(hass, websession, username, password, login_url):
 
     finally:
         if auth_req is not None:
-            yield from auth_req.release()
+            auth_req.close()
 
 
 class SynologyCamera(Camera):
@@ -235,7 +235,7 @@ class SynologyCamera(Camera):
             return None
 
         image = yield from response.read()
-        yield from response.release()
+        response.close()
 
         return image
 

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -559,7 +559,7 @@ class Device(Entity):
             return 'unknown'
         finally:
             if resp is not None:
-                yield from resp.release()
+                resp.close()
 
 
 class DeviceScanner(object):

--- a/homeassistant/components/device_tracker/tado.py
+++ b/homeassistant/components/device_tracker/tado.py
@@ -133,7 +133,7 @@ class TadoDeviceScanner(DeviceScanner):
 
         finally:
             if response is not None:
-                yield from response.release()
+                response.close()
 
         # Without a home_id, we fetched an URL where the mobile devices can be
         # found under the mobileDevices key.

--- a/homeassistant/components/device_tracker/tado.py
+++ b/homeassistant/components/device_tracker/tado.py
@@ -121,6 +121,7 @@ class TadoDeviceScanner(DeviceScanner):
 
                 # error on Tado webservice
                 if response.status != 200:
+                    yield from response.release()
                     _LOGGER.warning(
                         "Error %d on %s.", response.status, self.tadoapiurl)
                     return

--- a/homeassistant/components/device_tracker/upc_connect.py
+++ b/homeassistant/components/device_tracker/upc_connect.py
@@ -164,6 +164,7 @@ class UPCDeviceScanner(DeviceScanner):
                     _LOGGER.warning(
                         "Error %d on %s.", response.status, function)
                     self.token = None
+                    yield from response.releae()
                     return
 
                 # load data, store token for next request

--- a/homeassistant/components/device_tracker/upc_connect.py
+++ b/homeassistant/components/device_tracker/upc_connect.py
@@ -137,7 +137,7 @@ class UPCDeviceScanner(DeviceScanner):
 
         finally:
             if response is not None:
-                yield from response.release()
+                response.close()
 
     @asyncio.coroutine
     def _async_ws_function(self, function, additional_form=None):
@@ -178,4 +178,4 @@ class UPCDeviceScanner(DeviceScanner):
 
         finally:
             if response is not None:
-                yield from response.release()
+                response.close()

--- a/homeassistant/components/device_tracker/upc_connect.py
+++ b/homeassistant/components/device_tracker/upc_connect.py
@@ -92,8 +92,7 @@ class UPCDeviceScanner(DeviceScanner):
         raw = yield from self._async_ws_function(CMD_DEVICES)
 
         try:
-            xml_root = yield from self.hass.loop.run_in_executor(
-                None, ET.fromstring, raw)
+            xml_root = ET.fromstring(raw)
             return [mac.text for mac in xml_root.iter('MACAddr')]
         except (ET.ParseError, TypeError):
             _LOGGER.warning("Can't read device from %s", self.host)
@@ -156,7 +155,8 @@ class UPCDeviceScanner(DeviceScanner):
                 response = yield from self.websession.post(
                     "http://{}/xml/getter.xml".format(self.host),
                     data=form_data,
-                    headers=self.headers
+                    headers=self.headers,
+                    allow_redirects=False
                 )
 
                 # error on UPC webservice

--- a/homeassistant/components/image_processing/openalpr_cloud.py
+++ b/homeassistant/components/image_processing/openalpr_cloud.py
@@ -133,7 +133,7 @@ class OpenAlprCloudEntity(ImageProcessingAlprEntity):
 
         finally:
             if request is not None:
-                yield from request.release()
+                request.close()
 
         # processing api data
         vehicles = 0

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -883,7 +883,7 @@ def _async_fetch_image(hass, url):
 
     finally:
         if response is not None:
-            yield from response.release()
+            response.close()
 
     if not content:
         return (None, None)

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -877,6 +877,8 @@ def _async_fetch_image(hass, url):
         if response.status == 200:
             content = yield from response.read()
             content_type = response.headers.get(CONTENT_TYPE_HEADER)
+        else:
+            yield from response.release()
 
     except asyncio.TimeoutError:
         pass

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -144,6 +144,7 @@ class LogitechMediaServer(object):
                     _LOGGER.error(
                         "Query failed, response code: %s Full message: %s",
                         response.status, response)
+                    yield from response.release()
                     return False
 
         except (asyncio.TimeoutError,

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -153,7 +153,7 @@ class LogitechMediaServer(object):
             return False
         finally:
             if response is not None:
-                yield from response.release()
+                response.close()
 
         try:
             return data['result']

--- a/homeassistant/components/microsoft_face.py
+++ b/homeassistant/components/microsoft_face.py
@@ -383,6 +383,6 @@ class MicrosoftFace(object):
 
         finally:
             if response is not None:
-                yield from response.release()
+                response.close()
 
         raise HomeAssistantError("Network error on microsoft face api.")

--- a/homeassistant/components/rest_command.py
+++ b/homeassistant/components/rest_command.py
@@ -90,6 +90,8 @@ def async_setup(hass, config):
                         auth=auth
                     )
 
+                    yield from request.release()
+
                     if request.status == 200:
                         _LOGGER.info("Success call %s.", request.url)
                         return

--- a/homeassistant/components/rest_command.py
+++ b/homeassistant/components/rest_command.py
@@ -104,7 +104,7 @@ def async_setup(hass, config):
 
             finally:
                 if request is not None:
-                    yield from request.release()
+                    request.close()
 
         # register services
         hass.services.async_register(DOMAIN, name, async_service_handler)

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -179,7 +179,7 @@ class YrData(object):
 
             finally:
                 if resp is not None:
-                    self.hass.async_add_job(resp.release())
+                    resp.close()
 
             try:
                 import xmltodict

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -169,6 +169,7 @@ class YrData(object):
                                                      params=self._urlparams)
                 if resp.status != 200:
                     try_again('{} returned {}'.format(resp.url, resp.status))
+                    yield from resp.release()
                     return
                 text = yield from resp.text()
 

--- a/homeassistant/components/switch/hook.py
+++ b/homeassistant/components/switch/hook.py
@@ -50,7 +50,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         return False
     finally:
         if response is not None:
-            yield from response.release()
+            response.close()
 
     try:
         token = data['data']['token']
@@ -72,7 +72,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         return False
     finally:
         if response is not None:
-            yield from response.release()
+            response.close()
 
     yield from async_add_devices(
         HookSmartHome(
@@ -127,7 +127,7 @@ class HookSmartHome(SwitchDevice):
 
         finally:
             if response is not None:
-                yield from response.release()
+                response.close()
 
         _LOGGER.debug("Got: %s", data)
         return data['return_value'] == '1'

--- a/homeassistant/components/switch/rest.py
+++ b/homeassistant/components/switch/rest.py
@@ -70,7 +70,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         return False
     finally:
         if req is not None:
-            yield from req.release()
+            req.close()
 
     yield from async_add_devices(
         [RestSwitch(hass, name, resource, body_on, body_off,
@@ -118,7 +118,7 @@ class RestSwitch(SwitchDevice):
             return
         finally:
             if request is not None:
-                yield from request.release()
+                request.close()
 
         if request.status == 200:
             self._state = True
@@ -142,7 +142,7 @@ class RestSwitch(SwitchDevice):
             return
         finally:
             if request is not None:
-                yield from request.release()
+                request.close()
 
         if request.status == 200:
             self._state = False
@@ -165,7 +165,7 @@ class RestSwitch(SwitchDevice):
             return
         finally:
             if request is not None:
-                yield from request.release()
+                request.close()
 
         if self._is_on_template is not None:
             text = self._is_on_template.async_render_with_possible_json_value(

--- a/homeassistant/components/tts/google.py
+++ b/homeassistant/components/tts/google.py
@@ -115,7 +115,7 @@ class GoogleProvider(Provider):
 
             finally:
                 if request is not None:
-                    yield from request.release()
+                    request.close()
 
         return ("mp3", data)
 

--- a/homeassistant/components/tts/voicerss.py
+++ b/homeassistant/components/tts/voicerss.py
@@ -147,6 +147,6 @@ class VoiceRSSProvider(Provider):
 
         finally:
             if request is not None:
-                yield from request.release()
+                request.close()
 
         return (self._extension, data)

--- a/homeassistant/components/tts/yandextts.py
+++ b/homeassistant/components/tts/yandextts.py
@@ -129,6 +129,6 @@ class YandexSpeechKitProvider(Provider):
 
         finally:
             if request is not None:
-                yield from request.release()
+                request.close()
 
         return (self._codec, data)

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -278,6 +278,9 @@ class TestMediaPlayerWeb(unittest.TestCase):
             def release(self):
                 pass
 
+            def close(self):
+                pass
+
         class MockWebsession():
 
             @asyncio.coroutine

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -27,7 +27,8 @@ class AiohttpClientMocker:
                 params=None,
                 headers={},
                 exc=None,
-                cookies=None):
+                cookies=None,
+                allow_redirects=None):
         """Mock a request."""
         if json:
             text = _json.dumps(json)
@@ -73,8 +74,9 @@ class AiohttpClientMocker:
         self.mock_calls.clear()
 
     @asyncio.coroutine
+    # pylint: disable=unused-variable
     def match_request(self, method, url, *, data=None, auth=None, params=None,
-                      headers=None):  # pylint: disable=unused-variable
+                      headers=None, allow_redirects=None):
         """Match a request against pre-registered requests."""
         for response in self._mocks:
             if response.match_request(method, url, params):


### PR DESCRIPTION
**Description:**

We should not call response in finally. In normal case we had call it before we go outsite context. In a error case or stream it is a bad idea to call release twice, so we close the connection only.

I see some sort of lags inside async loop if the connection going broken if we do that.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
