### PR TITLE
Prevent duplicate names on Vera devices by appending the device id

### DIFF
--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -5,7 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/vera/
 """
 import logging
-from collections import Counter, defaultdict
+from collections import defaultdict
 
 import voluptuous as vol
 
@@ -84,17 +84,13 @@ def setup(hass, base_config):
     devices = [device for device in devices
                if device.device_id not in exclude_ids]
 
-    # Count the different device names.
-    counts = Counter(getattr(device, 'name').lower() for device in devices)
-
     for device in devices:
         device_type = map_vera_device(device, light_ids)
         if device_type is None:
             continue
 
-        if counts[device.name.lower()] > 1:
-            # Non-unique device name, append id to prevent name clashes in HA.
-            device.name += ' ' + str(device.device_id)
+        # Append id to prevent name clashes in HA.
+        device.name += ' ' + str(device.device_id)
 
         VERA_DEVICES[device_type].append(device)
 

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -130,9 +130,9 @@ class VeraDevice(Entity):
         """Initialize the device."""
         self.vera_device = vera_device
         self.controller = controller
-        
+
         # Append device id to prevent name clashes in HA.
-        self._name = self.vera_device.name + ' ' + str(self.vera_device.device_id)
+        self._name = self.vera_device.name + ' ' + str(vera_device.device_id)
 
         self.controller.register(vera_device, self._update_callback)
         self.update()


### PR DESCRIPTION
**Description:**
I have multiple ceiling lights in different rooms and therefor they are named the same (=Plafondlamp) in the Vera controller.

HASS maps the Vera devices to entities, but with each restart the mapping changes. So one time it is mapped like this:

```
light.plafondlamp_5	 - Vera Device Id: 66
friendly_name: Plafondlamp
```

and on the next restart it could be:

```
light.plafondlamp_5	 - Vera Device Id: 29
friendly_name: Plafondlamp
```

So with duplicate names grouping for instance is impossible.

So this pull requests checks if device name is not unique and if that is the case it adds the Vera `device_id` to the name.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
