### PR TITLE
New component 'insteon_plm' and related platforms

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -40,6 +40,9 @@ omit =
     homeassistant/components/insteon_local.py
     homeassistant/components/*/insteon_local.py
 
+    homeassistant/components/insteon_plm.py
+    homeassistant/components/*/insteon_plm.py
+
     homeassistant/components/ios.py
     homeassistant/components/*/ios.py
 

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -8,6 +8,7 @@ from homeassistant.components.binary_sensor import (SENSOR_CLASSES,
                                                     BinarySensorDevice)
 from homeassistant.loader import get_component
 import homeassistant.util as util
+from homeassistant.components import insteon_plm
 
 DEPENDENCIES = ['insteon_plm']
 
@@ -77,3 +78,7 @@ class InsteonPLMBinarySensorDevice(BinarySensorDevice):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)
         self._hass.async_add_job(self.async_update_ha_state(True))
+
+    @property
+    def device_state_attributes(self):
+        return insteon_plm.common_attributes(self)

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -4,11 +4,8 @@ Support for INSTEON dimmers via PowerLinc Modem.
 import logging
 import asyncio
 
-from homeassistant.components.switch import (
-    ENTITY_ID_FORMAT, SwitchDevice, PLATFORM_SCHEMA)
-from homeassistant.const import (
-    ATTR_FRIENDLY_NAME, CONF_VALUE_TEMPLATE, STATE_OFF, STATE_ON,
-    ATTR_ENTITY_ID, CONF_SWITCHES)
+from homeassistant.components.binary_sensor import (SENSOR_CLASSES,
+                                                    BinarySensorDevice)
 from homeassistant.loader import get_component
 import homeassistant.util as util
 
@@ -19,37 +16,37 @@ _LOGGER = logging.getLogger(__name__)
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Moo."""
-    _LOGGER.info('Provisioning Insteon PLM Switches')
+    _LOGGER.info('Provisioning Insteon PLM Binary Sensors')
 
     plm = hass.data['insteon_plm']
 
-    def async_insteonplm_switch_callback(device):
+    def async_insteonplm_binarysensor_callback(device):
         """New device detected from transport."""
         name = device['address']
         address = device['address_hex']
 
-        _LOGGER.info('New INSTEON PLM switch device: %s (%s)', name, address)
-        hass.async_add_job(async_add_devices([InsteonPLMSwitchDevice(hass, plm, address, name)]))
+        _LOGGER.info('New INSTEON PLM binary sensor device: %s (%s)', name, address)
+        hass.async_add_job(async_add_devices([InsteonPLMBinarySensorDevice(hass, plm, address, name)]))
 
-    criteria = dict(capability='switch')
-    plm.protocol.add_device_callback(async_insteonplm_switch_callback, criteria)
+    criteria = dict(capability='binary_sensor')
+    plm.protocol.add_device_callback(async_insteonplm_binarysensor_callback, criteria)
 
 
-    new_switchs = []
-    yield from async_add_devices(new_switchs)
+    new_binarysensors = []
+    yield from async_add_devices(new_binarysensors)
 
-class InsteonPLMSwitchDevice(SwitchDevice):
+class InsteonPLMBinarySensorDevice(BinarySensorDevice):
     """A Class for an Insteon device."""
 
     def __init__(self, hass, plm, address, name):
-        """Initialize the switch."""
+        """Initialize the binarysensor."""
         self._hass = hass
         self._plm = plm.protocol
         self._address = address
         self._name = name
 
         self._plm.add_update_callback(
-            self.async_insteonplm_switch_update_callback,
+            self.async_insteonplm_binarysensor_update_callback,
             dict(address=self._address))
 
     @property
@@ -76,7 +73,7 @@ class InsteonPLMSwitchDevice(SwitchDevice):
         else:
             return False
 
-    def async_insteonplm_switch_update_callback(self, message):
+    def async_insteonplm_binarysensor_update_callback(self, message):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)
         self._hass.async_add_job(self.async_update_ha_state(True))

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/insteon_plm/
 import logging
 import asyncio
 
-from homeassistant.components.binary_sensor import (BinarySensorDevice)
+from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.loader import get_component
 
 DEPENDENCIES = ['insteon_plm']
@@ -32,7 +32,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         hass.async_add_job(async_add_devices(
             [InsteonPLMBinarySensorDevice(hass, plm, address, name)]))
 
-    criteria = dict(capability='binary_sensor')
+    criteria = {'capability': 'binary_sensor'}
     plm.protocol.devices.add_device_callback(
         async_plm_binarysensor_callback, criteria)
 
@@ -51,7 +51,7 @@ class InsteonPLMBinarySensorDevice(BinarySensorDevice):
         self._name = name
 
         self._plm.add_update_callback(
-            self.async_binarysensor_update, dict(address=self._address))
+            self.async_binarysensor_update, {'address': self._address})
 
     @property
     def should_poll(self):

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -57,6 +57,11 @@ class InsteonPLMBinarySensorDevice(BinarySensorDevice):
         return False
 
     @property
+    def address(self):
+        """Return the the address of the node."""
+        return self._address
+
+    @property
     def name(self):
         """Return the the name of the node."""
         return self._name
@@ -79,6 +84,10 @@ class InsteonPLMBinarySensorDevice(BinarySensorDevice):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)
         self._hass.async_add_job(self.async_update_ha_state(True))
+
+    def get_attr(self, key):
+        """Return specified attribute for this device."""
+        return self._plm.get_device_attr(self.address, key)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -36,9 +36,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     plm.protocol.devices.add_device_callback(
         async_plm_binarysensor_callback, criteria)
 
-    new_binarysensors = []
-    yield from async_add_devices(new_binarysensors)
-
 
 class InsteonPLMBinarySensorDevice(BinarySensorDevice):
     """A Class for an Insteon device."""
@@ -69,11 +66,6 @@ class InsteonPLMBinarySensorDevice(BinarySensorDevice):
         return self._name
 
     @property
-    def sensor_class(self):
-        """Sensor class is unknown."""
-        return
-
-    @property
     def is_on(self):
         """Return the boolean response if the node is on."""
         sensorstate = self._plm.get_device_attr(self._address, 'sensorstate')
@@ -93,4 +85,4 @@ class InsteonPLMBinarySensorDevice(BinarySensorDevice):
     def async_binarysensor_update(self, message):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)
-        self._hass.async_add_job(self.async_update_ha_state(True))
+        self._hass.async_add_job(self.async_update_ha_state())

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -10,8 +10,6 @@ import asyncio
 from homeassistant.components.binary_sensor import (BinarySensorDevice)
 from homeassistant.loader import get_component
 
-insteon_plm = get_component('insteon_plm')
-
 DEPENDENCIES = ['insteon_plm']
 
 _LOGGER = logging.getLogger(__name__)
@@ -85,6 +83,7 @@ class InsteonPLMBinarySensorDevice(BinarySensorDevice):
     @property
     def device_state_attributes(self):
         """Provide attributes for display on device card."""
+        insteon_plm = get_component('insteon_plm')
         return insteon_plm.common_attributes(self)
 
     def get_attr(self, key):

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-    """Moo."""
+    """Set up the INSTEON PLM device class for the hass platform."""
     _LOGGER.info('Provisioning Insteon PLM Binary Sensors')
 
     plm = hass.data['insteon_plm']

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -68,10 +68,10 @@ class InsteonPLMBinarySensorDevice(BinarySensorDevice):
     @property
     def is_on(self):
         """Return the boolean response if the node is on."""
-        onlevel = self._plm.get_device_attr(self._address, 'onlevel')
-        _LOGGER.info('sensor state for %s is %s', self._address, onlevel)
-        if onlevel:
-            return (onlevel > 0)
+        sensorstate = self._plm.get_device_attr(self._address, 'sensorstate')
+        _LOGGER.info('sensor state for %s is %s', self._address, sensorstate)
+        if sensorstate:
+            return (sensorstate > 0)
         else:
             return False
 

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -8,7 +8,8 @@ from homeassistant.components.binary_sensor import (SENSOR_CLASSES,
                                                     BinarySensorDevice)
 from homeassistant.loader import get_component
 import homeassistant.util as util
-from homeassistant.components import insteon_plm
+
+insteon_plm = get_component('insteon_plm')
 
 DEPENDENCIES = ['insteon_plm']
 

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -1,19 +1,21 @@
 """
 Support for INSTEON dimmers via PowerLinc Modem.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/insteon_plm/
 """
 import logging
 import asyncio
 
-from homeassistant.components.binary_sensor import (SENSOR_CLASSES,
-                                                    BinarySensorDevice)
+from homeassistant.components.binary_sensor import (BinarySensorDevice)
 from homeassistant.loader import get_component
-import homeassistant.util as util
 
 insteon_plm = get_component('insteon_plm')
 
 DEPENDENCIES = ['insteon_plm']
 
 _LOGGER = logging.getLogger(__name__)
+
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
@@ -22,20 +24,23 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     plm = hass.data['insteon_plm']
 
-    def async_insteonplm_binarysensor_callback(device):
+    def async_plm_binarysensor_callback(device):
         """New device detected from transport."""
         name = device['address']
         address = device['address_hex']
 
-        _LOGGER.info('New INSTEON PLM binary sensor device: %s (%s)', name, address)
-        hass.async_add_job(async_add_devices([InsteonPLMBinarySensorDevice(hass, plm, address, name)]))
+        _LOGGER.info('New INSTEON PLM binary sensor device: %s (%s)',
+                     name, address)
+        hass.async_add_job(async_add_devices(
+            [InsteonPLMBinarySensorDevice(hass, plm, address, name)]))
 
     criteria = dict(capability='binary_sensor')
-    plm.protocol.devices.add_device_callback(async_insteonplm_binarysensor_callback, criteria)
-
+    plm.protocol.devices.add_device_callback(
+        async_plm_binarysensor_callback, criteria)
 
     new_binarysensors = []
     yield from async_add_devices(new_binarysensors)
+
 
 class InsteonPLMBinarySensorDevice(BinarySensorDevice):
     """A Class for an Insteon device."""
@@ -48,8 +53,7 @@ class InsteonPLMBinarySensorDevice(BinarySensorDevice):
         self._name = name
 
         self._plm.add_update_callback(
-            self.async_insteonplm_binarysensor_update_callback,
-            dict(address=self._address))
+            self.async_binarysensor_update, dict(address=self._address))
 
     @property
     def should_poll(self):
@@ -68,6 +72,7 @@ class InsteonPLMBinarySensorDevice(BinarySensorDevice):
 
     @property
     def sensor_class(self):
+        """Sensor class is unknown."""
         return
 
     @property
@@ -75,20 +80,18 @@ class InsteonPLMBinarySensorDevice(BinarySensorDevice):
         """Return the boolean response if the node is on."""
         sensorstate = self._plm.get_device_attr(self._address, 'sensorstate')
         _LOGGER.info('sensor state for %s is %s', self._address, sensorstate)
-        if sensorstate:
-            return (sensorstate > 0)
-        else:
-            return False
+        return bool(sensorstate)
 
-    def async_insteonplm_binarysensor_update_callback(self, message):
-        """Receive notification from transport that new data exists."""
-        _LOGGER.info('Received update calback from PLM for %s', self._address)
-        self._hass.async_add_job(self.async_update_ha_state(True))
+    @property
+    def device_state_attributes(self):
+        """Provide attributes for display on device card."""
+        return insteon_plm.common_attributes(self)
 
     def get_attr(self, key):
         """Return specified attribute for this device."""
         return self._plm.get_device_attr(self.address, key)
 
-    @property
-    def device_state_attributes(self):
-        return insteon_plm.common_attributes(self)
+    def async_binarysensor_update(self, message):
+        """Receive notification from transport that new data exists."""
+        _LOGGER.info('Received update calback from PLM for %s', self._address)
+        self._hass.async_add_job(self.async_update_ha_state(True))

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -19,24 +19,20 @@ _LOGGER = logging.getLogger(__name__)
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the INSTEON PLM device class for the hass platform."""
-    _LOGGER.info('Provisioning Insteon PLM Binary Sensors')
-
     plm = hass.data['insteon_plm']
 
-    @callback
-    def async_plm_binarysensor_callback(device):
-        """New device detected from transport."""
-        name = device['address']
-        address = device['address_hex']
+    device_list = []
+    for device in discovery_info:
+        name = device.get('address')
+        address = device.get('address_hex')
 
-        _LOGGER.info('New INSTEON PLM binary sensor device: %s (%s)',
-                     name, address)
-        hass.async_add_job(async_add_devices(
-            [InsteonPLMBinarySensorDevice(hass, plm, address, name)]))
+        _LOGGER.info('Registered %s with binary_sensor platform.', name)
 
-    criteria = {'capability': 'binary_sensor'}
-    plm.protocol.devices.add_device_callback(
-        async_plm_binarysensor_callback, criteria)
+        device_list.append(
+            InsteonPLMBinarySensorDevice(hass, plm, address, name)
+        )
+
+    hass.async_add_job(async_add_devices(device_list))
 
 
 class InsteonPLMBinarySensorDevice(BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -67,7 +67,7 @@ class InsteonPLMBinarySensorDevice(BinarySensorDevice):
     def is_on(self):
         """Return the boolean response if the node is on."""
         onlevel = self._plm.get_device_attr(self._address, 'onlevel')
-        _LOGGER.debug('on level for %s is %s', self._address, onlevel)
+        _LOGGER.info('sensor state for %s is %s', self._address, onlevel)
         if onlevel:
             return (onlevel > 0)
         else:

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/insteon_plm/
 import logging
 import asyncio
 
+from homeassistant.core import callback
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.loader import get_component
 
@@ -22,6 +23,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     plm = hass.data['insteon_plm']
 
+    @callback
     def async_plm_binarysensor_callback(device):
         """New device detected from transport."""
         name = device['address']
@@ -82,6 +84,7 @@ class InsteonPLMBinarySensorDevice(BinarySensorDevice):
         """Return specified attribute for this device."""
         return self._plm.get_device_attr(self.address, key)
 
+    @callback
     def async_binarysensor_update(self, message):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)

--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -31,7 +31,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         hass.async_add_job(async_add_devices([InsteonPLMBinarySensorDevice(hass, plm, address, name)]))
 
     criteria = dict(capability='binary_sensor')
-    plm.protocol.add_device_callback(async_insteonplm_binarysensor_callback, criteria)
+    plm.protocol.devices.add_device_callback(async_insteonplm_binarysensor_callback, criteria)
 
 
     new_binarysensors = []

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -1,0 +1,51 @@
+"""
+Support for INSTEON PowerLinc Modem.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/insteon_plm/
+"""
+import logging
+import asyncio
+
+import requests
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_PORT, EVENT_HOMEASSISTANT_STOP)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['insteonplm==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_PORT = '/dev/ttyUSB0'
+DOMAIN = 'insteon_plm'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Set up our connection to the PLM."""
+    import insteonplm
+
+    conf = config[DOMAIN]
+    port = conf.get(CONF_PORT)
+
+    _LOGGER.info('Looking for PLM on %s', port)
+
+    def async_insteonplm_update_callback(message):
+        """Receive notification from transport that new data exists."""
+        _LOGGER.info('Received update calback from PLM: %s', message)
+
+    plm = yield from insteonplm.Connection.create(
+        device=port, loop=hass.loop,
+        update_callback=async_insteonplm_update_callback)
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, plm.close)
+
+    return True

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -46,6 +46,8 @@ def async_setup(hass, config):
         device=port, loop=hass.loop,
         update_callback=async_insteonplm_update_callback)
 
+    hass.data['insteon_plm'] = plm
+
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, plm.close)
 
     return True

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -87,7 +87,7 @@ def common_attributes(entity):
 
     for key in attributekeys:
         name = attributekeys[key]
-        val = entity._plm.get_device_attr(entity._address, key)
+        val = entity.get_attr(key)
         if val is not None:
             if key in hexkeys:
                 attributes[name] = hex(int(val))

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -22,13 +22,11 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_PORT = '/dev/ttyUSB0'
 DOMAIN = 'insteon_plm'
 
-CONF_DEBUG = 'debug'
 CONF_OVERRIDE = 'device_override'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
-        vol.Optional(CONF_DEBUG, default=False): cv.boolean,
         vol.Optional(CONF_OVERRIDE, default=[]): vol.All(
             cv.ensure_list_csv, vol.Length(min=1))
     })

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
 
-REQUIREMENTS = ['insteonplm==0.7.2']
+REQUIREMENTS = ['insteonplm==0.7.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
 
-REQUIREMENTS = ['insteonplm==0.7.3']
+REQUIREMENTS = ['insteonplm==0.7.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     CONF_PORT, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['insteonplm==0.0.1']
+REQUIREMENTS = ['insteonplm==0.7.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -29,7 +29,7 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
         vol.Optional(CONF_DEBUG, default=False): cv.boolean,
-        vol.Optional(CONF_OVERRIDE, default=None): vol.All(
+        vol.Optional(CONF_OVERRIDE, default=[]): vol.All(
             cv.ensure_list_csv, vol.Length(min=1))
     })
 }, extra=vol.ALLOW_EXTRA)
@@ -52,6 +52,8 @@ def async_setup(hass, config):
 
     plm = yield from insteonplm.Connection.create(
         device=port, loop=hass.loop)
+
+    print(overrides)
 
     for device in overrides:
         #

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -13,19 +13,27 @@ import voluptuous as vol
 from homeassistant.const import (
     CONF_PORT, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import discovery
 
-REQUIREMENTS = ['insteonplm==0.7.1']
+REQUIREMENTS = ['insteonplm==0.7.2']
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PORT = '/dev/ttyUSB0'
 DOMAIN = 'insteon_plm'
 
+CONF_DEBUG = 'debug'
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
+        vol.Optional(CONF_DEBUG, default=False): cv.boolean
     })
 }, extra=vol.ALLOW_EXTRA)
+
+PLM_PLATFORMS = [
+    'binary_sensor', 'light', 'switch'
+]
 
 
 @asyncio.coroutine
@@ -45,4 +53,32 @@ def async_setup(hass, config):
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, plm.close)
 
+    for platform in PLM_PLATFORMS:
+        _LOGGER.info('Trying to load platform %s', platform)
+        hass.async_add_job(discovery.async_load_platform(hass, platform, DOMAIN, config))
+
     return True
+
+def common_attributes(entity):
+    """Return the device state attributes."""
+    attributes = {}
+    attributekeys = {}
+    attributekeys['address'] = 'INSTEON Address'
+    attributekeys['description'] = 'Description'
+    attributekeys['model'] = 'Model'
+    attributekeys['cat'] = 'Category'
+    attributekeys['subcat'] = 'Subcategory'
+    attributekeys['firmware'] = 'Firmware'
+    attributekeys['product_key'] = 'Product Key'
+
+    hexkeys = ['cat', 'subcat', 'firmware']
+
+    for key in attributekeys:
+        name = attributekeys[key]
+        val = entity._plm.device_attribute(entity._address, key)
+        if val is not None:
+            if key in hexkeys:
+                attributes[name] = hex(int(val))
+            else:
+                attributes[name] = val
+    return attributes

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -50,8 +50,6 @@ def async_setup(hass, config):
     plm = yield from insteonplm.Connection.create(
         device=port, loop=hass.loop)
 
-    print(overrides)
-
     for device in overrides:
         #
         # Override the device default capabilities for a specific address
@@ -74,14 +72,15 @@ def async_setup(hass, config):
 def common_attributes(entity):
     """Return the device state attributes."""
     attributes = {}
-    attributekeys = {}
-    attributekeys['address'] = 'INSTEON Address'
-    attributekeys['description'] = 'Description'
-    attributekeys['model'] = 'Model'
-    attributekeys['cat'] = 'Category'
-    attributekeys['subcat'] = 'Subcategory'
-    attributekeys['firmware'] = 'Firmware'
-    attributekeys['product_key'] = 'Product Key'
+    attributekeys = {
+        'address': 'INSTEON Address',
+        'description': 'Description',
+        'model': 'Model',
+        'cat': 'Cagegory',
+        'subcat': 'Subcategory',
+        'firmware': 'Firmware',
+        'product_key': 'Product Key'
+    }
 
     hexkeys = ['cat', 'subcat', 'firmware']
 

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -38,13 +38,8 @@ def async_setup(hass, config):
 
     _LOGGER.info('Looking for PLM on %s', port)
 
-    def async_insteonplm_update_callback(message):
-        """Receive notification from transport that new data exists."""
-        _LOGGER.info('Received update calback from PLM: %s', message)
-
     plm = yield from insteonplm.Connection.create(
-        device=port, loop=hass.loop,
-        update_callback=async_insteonplm_update_callback)
+        device=port, loop=hass.loop)
 
     hass.data['insteon_plm'] = plm
 

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -75,7 +75,7 @@ def common_attributes(entity):
 
     for key in attributekeys:
         name = attributekeys[key]
-        val = entity._plm.device_attribute(entity._address, key)
+        val = entity._plm.get_device_attr(entity._address, key)
         if val is not None:
             if key in hexkeys:
                 attributes[name] = hex(int(val))

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -18,14 +18,13 @@ REQUIREMENTS = ['insteonplm==0.7.4']
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_PORT = '/dev/ttyUSB0'
 DOMAIN = 'insteon_plm'
 
 CONF_OVERRIDE = 'device_override'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
+        vol.Required(CONF_PORT): cv.string,
         vol.Optional(CONF_OVERRIDE, default=[]): vol.All(
             cv.ensure_list_csv, vol.Length(min=1))
     })

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     CONF_PORT, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['insteonplm==0.7.0']
+REQUIREMENTS = ['insteonplm==0.7.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/insteon_plm/
 import logging
 import asyncio
 
-import requests
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -57,7 +56,8 @@ def async_setup(hass, config):
         #
         # Override the device default capabilities for a specific address
         #
-        plm.protocol.devices.add_override(device['address'], 'capabilities', [device['platform']])
+        plm.protocol.devices.add_override(
+            device['address'], 'capabilities', [device['platform']])
 
     hass.data['insteon_plm'] = plm
 
@@ -65,9 +65,11 @@ def async_setup(hass, config):
 
     for platform in PLM_PLATFORMS:
         _LOGGER.info('Trying to load platform %s', platform)
-        hass.async_add_job(discovery.async_load_platform(hass, platform, DOMAIN, config))
+        hass.async_add_job(
+            discovery.async_load_platform(hass, platform, DOMAIN, config))
 
     return True
+
 
 def common_attributes(entity):
     """Return the device state attributes."""

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -20,10 +20,54 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     plm = hass.data['insteon_plm']
 
-    def async_insteonplm_light_callback(device):
+    def async_insteonplm_light_callback(address = None, name = None):
         """New device detected from transport."""
-        _LOGGER.info('New INSTEON PLM light device: %s', device)
+        _LOGGER.info('New INSTEON PLM light device: %s (%s)', name, address)
+        hass.async_add_job(async_add_devices([InsteonPLMDimmerDevice(address, name)]))
+
+    plm.protocol.callback_new_light(async_insteonplm_light_callback)
+    plm.protocol.dump_all_link_database()
 
     new_lights = []
-
     yield from async_add_devices(new_lights)
+
+class InsteonPLMDimmerDevice(Light):
+    """A Class for an Insteon device."""
+
+    def __init__(self, address, name):
+        """Initialize the light."""
+        self._value = 0
+        self._address = address
+        self._name = name
+
+    @property
+    def name(self):
+        """Return the the name of the node."""
+        return self._name
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return self._value
+
+    @property
+    def is_on(self):
+        """Return the boolean response if the node is on."""
+        return self._value != 0
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_BRIGHTNESS
+
+    def turn_on(self, **kwargs):
+        """Turn device on."""
+        brightness = 100
+        if ATTR_BRIGHTNESS in kwargs:
+            brightness = int(kwargs[ATTR_BRIGHTNESS]) / 255 * 100
+
+        self.node.on(brightness)
+
+    def turn_off(self, **kwargs):
+        """Turn device off."""
+        self.node.off()

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -18,10 +18,12 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Moo."""
     _LOGGER.info('Provisioning Insteon PLM Lights')
 
+    plm = hass.data['insteon_plm']
+
+    def async_insteonplm_light_callback(device):
+        """New device detected from transport."""
+        _LOGGER.info('New INSTEON PLM light device: %s', device)
+
     new_lights = []
 
     yield from async_add_devices(new_lights)
-
-class InsteonPLMDimmerDevice(Light):
-    """Moo."""
-    def __init__

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -1,0 +1,27 @@
+"""
+Support for INSTEON dimmers via PowerLinc Modem.
+"""
+import logging
+import asyncio
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
+from homeassistant.loader import get_component
+import homeassistant.util as util
+
+DEPENDENCIES = ['insteon_plm']
+
+_LOGGER = logging.getLogger(__name__)
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Moo."""
+    _LOGGER.info('Provisioning Insteon PLM Lights')
+
+    new_lights = []
+
+    yield from async_add_devices(new_lights)
+
+class InsteonPLMDimmerDevice(Light):
+    """Moo."""
+    def __init__

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/insteon_plm/
 import logging
 import asyncio
 
+from homeassistant.core import callback
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
 from homeassistant.loader import get_component
@@ -25,6 +26,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     plm = hass.data['insteon_plm']
 
+    @callback
     def async_plm_light_callback(device):
         """New device detected from transport."""
         name = device['address']
@@ -100,6 +102,7 @@ class InsteonPLMDimmerDevice(Light):
         """Return specified attribute for this device."""
         return self._plm.get_device_attr(self.address, key)
 
+    @callback
     def async_light_update(self, message):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -36,7 +36,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         hass.async_add_job(async_add_devices([InsteonPLMDimmerDevice(hass, plm, address, name, dimmable)]))
 
     criteria = dict(capability='light')
-    plm.protocol.add_device_callback(async_insteonplm_light_callback, criteria)
+    plm.protocol.devices.add_device_callback(async_insteonplm_light_callback, criteria)
 
 
     new_lights = []

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -8,7 +8,8 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
 from homeassistant.loader import get_component
 import homeassistant.util as util
-from homeassistant.components import insteon_plm
+
+insteon_plm = get_component('insteon_plm')
 
 DEPENDENCIES = ['insteon_plm']
 

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -25,7 +25,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         _LOGGER.info('New INSTEON PLM light device: %s (%s)', name, address)
         hass.async_add_job(async_add_devices([InsteonPLMDimmerDevice(hass, plm, address, name)]))
 
-    plm.protocol.new_device_callback(async_insteonplm_light_callback, {})
+    plm.protocol.add_device_callback(async_insteonplm_light_callback, {})
 
 
     new_lights = []
@@ -40,7 +40,7 @@ class InsteonPLMDimmerDevice(Light):
         self._plm = plm.protocol
         self._address = address
         self._name = name
-        self._plm.update_callback(self.async_insteonplm_light_update_callback, dict(address=self._address))
+        self._plm.add_update_callback(self.async_insteonplm_light_update_callback, dict(address=self._address))
 
     @property
     def should_poll(self):

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -33,7 +33,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         _LOGGER.info('New INSTEON PLM light device: %s (%s)', name, address)
         hass.async_add_job(async_add_devices([InsteonPLMDimmerDevice(hass, plm, address, name, dimmable)]))
 
-    criteria = dict(capability='switch')
+    criteria = dict(capability='light')
     plm.protocol.add_device_callback(async_insteonplm_light_callback, criteria)
 
 

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -13,6 +13,8 @@ from homeassistant.loader import get_component
 
 DEPENDENCIES = ['insteon_plm']
 
+MAX_BRIGHTNESS = 255
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -34,7 +36,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         hass.async_add_job(async_add_devices(
             [InsteonPLMDimmerDevice(hass, plm, address, name, dimmable)]))
 
-    criteria = dict(capability='light')
+    criteria = {'capability': 'light'}
     plm.protocol.devices.add_device_callback(
         async_plm_light_callback, criteria)
 
@@ -54,7 +56,7 @@ class InsteonPLMDimmerDevice(Light):
         self._dimmable = dimmable
 
         self._plm.add_update_callback(
-            self.async_light_update, dict(address=self._address))
+            self.async_light_update, {'address': self._address})
 
     @property
     def should_poll(self):
@@ -112,7 +114,7 @@ class InsteonPLMDimmerDevice(Light):
         if ATTR_BRIGHTNESS in kwargs:
             brightness = int(kwargs[ATTR_BRIGHTNESS])
         else:
-            brightness = 255
+            brightness = MAX_BRIGHTNESS
         self._plm.turn_on(self._address, brightness=brightness)
 
     @asyncio.coroutine

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -63,6 +63,11 @@ class InsteonPLMDimmerDevice(Light):
         return False
 
     @property
+    def address(self):
+        """Return the the address of the node."""
+        return self._address
+
+    @property
     def name(self):
         """Return the the name of the node."""
         return self._name
@@ -108,6 +113,10 @@ class InsteonPLMDimmerDevice(Light):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)
         self._hass.async_add_job(self.async_update_ha_state(True))
+
+    def get_attr(self, key):
+        """Return specified attribute for this device."""
+        return self._plm.get_device_attr(self.address, key)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-    """Moo."""
+    """Set up the INSTEON PLM device class for the hass platform."""
     _LOGGER.info('Provisioning Insteon PLM Lights')
 
     plm = hass.data['insteon_plm']

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -8,6 +8,7 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
 from homeassistant.loader import get_component
 import homeassistant.util as util
+from homeassistant.components import insteon_plm
 
 DEPENDENCIES = ['insteon_plm']
 
@@ -106,3 +107,7 @@ class InsteonPLMDimmerDevice(Light):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)
         self._hass.async_add_job(self.async_update_ha_state(True))
+
+    @property
+    def device_state_attributes(self):
+        return insteon_plm.common_attributes(self)

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -88,7 +88,8 @@ class InsteonPLMDimmerDevice(Light):
         if self._dimmable:
             return SUPPORT_BRIGHTNESS
 
-    def turn_on(self, **kwargs):
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
         """Turn device on."""
         if ATTR_BRIGHTNESS in kwargs:
             brightness = int(kwargs[ATTR_BRIGHTNESS])
@@ -96,7 +97,8 @@ class InsteonPLMDimmerDevice(Light):
             brightness = 255
         self._plm.turn_on(self._address, brightness=brightness)
 
-    def turn_off(self, **kwargs):
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
         """Turn device off."""
         self._plm.turn_off(self._address)
 

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -11,8 +11,6 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
 from homeassistant.loader import get_component
 
-insteon_plm = get_component('insteon_plm')
-
 DEPENDENCIES = ['insteon_plm']
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,7 +54,7 @@ class InsteonPLMDimmerDevice(Light):
         self._dimmable = dimmable
 
         self._plm.add_update_callback(
-           self.async_light_update, dict(address=self._address))
+            self.async_light_update, dict(address=self._address))
 
     @property
     def should_poll(self):
@@ -96,6 +94,7 @@ class InsteonPLMDimmerDevice(Light):
     @property
     def device_state_attributes(self):
         """Provide attributes for display on device card."""
+        insteon_plm = get_component('insteon_plm')
         return insteon_plm.common_attributes(self)
 
     def get_attr(self, key):

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -40,9 +40,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     plm.protocol.devices.add_device_callback(
         async_plm_light_callback, criteria)
 
-    new_lights = []
-    yield from async_add_devices(new_lights)
-
 
 class InsteonPLMDimmerDevice(Light):
     """A Class for an Insteon device."""
@@ -106,7 +103,7 @@ class InsteonPLMDimmerDevice(Light):
     def async_light_update(self, message):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)
-        self._hass.async_add_job(self.async_update_ha_state(True))
+        self._hass.async_add_job(self.async_update_ha_state())
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -22,25 +22,21 @@ _LOGGER = logging.getLogger(__name__)
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the INSTEON PLM device class for the hass platform."""
-    _LOGGER.info('Provisioning Insteon PLM Lights')
-
     plm = hass.data['insteon_plm']
 
-    @callback
-    def async_plm_light_callback(device):
-        """New device detected from transport."""
-        name = device['address']
-        address = device['address_hex']
+    device_list = []
+    for device in discovery_info:
+        name = device.get('address')
+        address = device.get('address_hex')
+        dimmable = bool('dimmable' in device.get('capabilities'))
 
-        dimmable = bool('dimmable' in device['capabilities'])
+        _LOGGER.info('Registered %s with light platform.', name)
 
-        _LOGGER.info('New INSTEON PLM light device: %s (%s)', name, address)
-        hass.async_add_job(async_add_devices(
-            [InsteonPLMDimmerDevice(hass, plm, address, name, dimmable)]))
+        device_list.append(
+            InsteonPLMDimmerDevice(hass, plm, address, name, dimmable)
+        )
 
-    criteria = {'capability': 'light'}
-    plm.protocol.devices.add_device_callback(
-        async_plm_light_callback, criteria)
+    hass.async_add_job(async_add_devices(device_list))
 
 
 class InsteonPLMDimmerDevice(Light):

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -57,9 +57,7 @@ class InsteonPLMDimmerDevice(Light):
         """Return the brightness of this light between 0..255."""
         onlevel = self._plm.get_device_attr(self._address, 'onlevel')
         _LOGGER.info('on level for %s is %s', self._address, onlevel)
-        per = int(onlevel / 255 * 100)
-        _LOGGER.info('per for %s is %s', self._address, per)
-        return per
+        return int(onlevel)
 
     @property
     def is_on(self):
@@ -78,14 +76,13 @@ class InsteonPLMDimmerDevice(Light):
 
     def turn_on(self, **kwargs):
         """Turn device on."""
-        print('turn_on',kwargs)
-        brightness = 100
         if ATTR_BRIGHTNESS in kwargs:
-            brightness = int(kwargs[ATTR_BRIGHTNESS]) / 255 * 100
-        self._plm.turn_on(self._address,brightness)
+            brightness = int(kwargs[ATTR_BRIGHTNESS])
+        else:
+            brightness = 255
+        self._plm.turn_on(self._address, brightness=brightness)
 
     def turn_off(self, **kwargs):
-        print('turn_off',kwargs)
         """Turn device off."""
         self._plm.turn_off(self._address)
 

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -1,0 +1,23 @@
+"""
+Support for INSTEON dimmers via PowerLinc Modem.
+"""
+import logging
+import asyncio
+
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.loader import get_component
+import homeassistant.util as util
+
+DEPENDENCIES = ['insteon_plm']
+
+_LOGGER = logging.getLogger(__name__)
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Moo."""
+    _LOGGER.info('Provisioning Insteon PLM Switches')
+
+
+class InsteonPLMDimmerDevice(Light):
+    """Moo."""
+    def __init__

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -82,7 +82,7 @@ class InsteonPLMSwitchDevice(SwitchDevice):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Moo."""
-        self._plm.turn_on(self._address, 1)
+        self._plm.turn_on(self._address)
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -10,9 +10,6 @@ import asyncio
 from homeassistant.components.switch import (SwitchDevice)
 from homeassistant.loader import get_component
 
-insteon_plm = get_component('insteon_plm')
-
-
 DEPENDENCIES = ['insteon_plm']
 
 _LOGGER = logging.getLogger(__name__)
@@ -81,6 +78,7 @@ class InsteonPLMSwitchDevice(SwitchDevice):
     @property
     def device_state_attributes(self):
         """Provide attributes for display on device card."""
+        insteon_plm = get_component('insteon_plm')
         return insteon_plm.common_attributes(self)
 
     def get_attr(self, key):

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -11,7 +11,9 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_SWITCHES)
 from homeassistant.loader import get_component
 import homeassistant.util as util
-from homeassistant.components import insteon_plm
+
+insteon_plm = get_component('insteon_plm')
+
 
 DEPENDENCIES = ['insteon_plm']
 

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -72,7 +72,7 @@ class InsteonPLMSwitchDevice(SwitchDevice):
     @property
     def is_on(self):
         """Return the boolean response if the node is on."""
-        onlevel = self._plm.get_device_attr(self._address, 'switchstate')
+        onlevel = self._plm.get_device_attr(self._address, 'onlevel')
         _LOGGER.debug('on level for %s is %s', self._address, onlevel)
         if onlevel:
             return (onlevel > 0)

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -19,24 +19,20 @@ _LOGGER = logging.getLogger(__name__)
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the INSTEON PLM device class for the hass platform."""
-    _LOGGER.info('Provisioning Insteon PLM Switches')
-
     plm = hass.data['insteon_plm']
 
-    @callback
-    def async_plm_switch_callback(device):
-        """New device detected from transport."""
-        name = device['address']
-        address = device['address_hex']
+    device_list = []
+    for device in discovery_info:
+        name = device.get('address')
+        address = device.get('address_hex')
 
-        _LOGGER.info('New INSTEON PLM switch device: %s (%s)', name, address)
-        hass.async_add_job(
-            async_add_devices(
-                [InsteonPLMSwitchDevice(hass, plm, address, name)]))
+        _LOGGER.info('Registered %s with switch platform.', name)
 
-    criteria = {'capability': 'switch'}
-    plm.protocol.devices.add_device_callback(
-        async_plm_switch_callback, criteria)
+        device_list.append(
+            InsteonPLMSwitchDevice(hass, plm, address, name)
+        )
+
+    hass.async_add_job(async_add_devices(device_list))
 
 
 class InsteonPLMSwitchDevice(SwitchDevice):

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -1,16 +1,14 @@
 """
 Support for INSTEON dimmers via PowerLinc Modem.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/insteon_plm/
 """
 import logging
 import asyncio
 
-from homeassistant.components.switch import (
-    ENTITY_ID_FORMAT, SwitchDevice, PLATFORM_SCHEMA)
-from homeassistant.const import (
-    ATTR_FRIENDLY_NAME, CONF_VALUE_TEMPLATE, STATE_OFF, STATE_ON,
-    ATTR_ENTITY_ID, CONF_SWITCHES)
+from homeassistant.components.switch import (SwitchDevice)
 from homeassistant.loader import get_component
-import homeassistant.util as util
 
 insteon_plm = get_component('insteon_plm')
 
@@ -19,6 +17,7 @@ DEPENDENCIES = ['insteon_plm']
 
 _LOGGER = logging.getLogger(__name__)
 
+
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Moo."""
@@ -26,20 +25,23 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     plm = hass.data['insteon_plm']
 
-    def async_insteonplm_switch_callback(device):
+    def async_plm_switch_callback(device):
         """New device detected from transport."""
         name = device['address']
         address = device['address_hex']
 
         _LOGGER.info('New INSTEON PLM switch device: %s (%s)', name, address)
-        hass.async_add_job(async_add_devices([InsteonPLMSwitchDevice(hass, plm, address, name)]))
+        hass.async_add_job(
+            async_add_devices(
+                [InsteonPLMSwitchDevice(hass, plm, address, name)]))
 
     criteria = dict(capability='switch')
-    plm.protocol.devices.add_device_callback(async_insteonplm_switch_callback, criteria)
+    plm.protocol.devices.add_device_callback(
+        async_plm_switch_callback, criteria)
 
+    new_switches = []
+    yield from async_add_devices(new_switches)
 
-    new_switchs = []
-    yield from async_add_devices(new_switchs)
 
 class InsteonPLMSwitchDevice(SwitchDevice):
     """A Class for an Insteon device."""
@@ -52,8 +54,7 @@ class InsteonPLMSwitchDevice(SwitchDevice):
         self._name = name
 
         self._plm.add_update_callback(
-            self.async_insteonplm_switch_update_callback,
-            dict(address=self._address))
+            self.async_switch_update, dict(address=self._address))
 
     @property
     def should_poll(self):
@@ -71,18 +72,25 @@ class InsteonPLMSwitchDevice(SwitchDevice):
         return self._name
 
     @property
-    def sensor_class(self):
-        return
-
-    @property
     def is_on(self):
         """Return the boolean response if the node is on."""
         onlevel = self._plm.get_device_attr(self._address, 'onlevel')
         _LOGGER.debug('on level for %s is %s', self._address, onlevel)
-        if onlevel:
-            return (onlevel > 0)
-        else:
-            return False
+        return bool(onlevel)
+
+    @property
+    def device_state_attributes(self):
+        """Provide attributes for display on device card."""
+        return insteon_plm.common_attributes(self)
+
+    def get_attr(self, key):
+        """Return specified attribute for this device."""
+        return self._plm.get_device_attr(self.address, key)
+
+    def async_switch_update(self, message):
+        """Receive notification from transport that new data exists."""
+        _LOGGER.info('Received update calback from PLM for %s', self._address)
+        self._hass.async_add_job(self.async_update_ha_state(True))
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
@@ -93,16 +101,3 @@ class InsteonPLMSwitchDevice(SwitchDevice):
     def async_turn_off(self, **kwargs):
         """Moo."""
         self._plm.turn_off(self._address)
-
-    def async_insteonplm_switch_update_callback(self, message):
-        """Receive notification from transport that new data exists."""
-        _LOGGER.info('Received update calback from PLM for %s', self._address)
-        self._hass.async_add_job(self.async_update_ha_state(True))
-
-    def get_attr(self, key):
-        """Return specified attribute for this device."""
-        return self._plm.get_device_attr(self.address, key)
-
-    @property
-    def device_state_attributes(self):
-        return insteon_plm.common_attributes(self)

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_SWITCHES)
 from homeassistant.loader import get_component
 import homeassistant.util as util
+from homeassistant.components import insteon_plm
 
 DEPENDENCIES = ['insteon_plm']
 
@@ -90,3 +91,7 @@ class InsteonPLMSwitchDevice(SwitchDevice):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)
         self._hass.async_add_job(self.async_update_ha_state(True))
+
+    @property
+    def device_state_attributes(self):
+        return insteon_plm.common_attributes(self)

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -61,6 +61,11 @@ class InsteonPLMSwitchDevice(SwitchDevice):
         return False
 
     @property
+    def address(self):
+        """Return the the address of the node."""
+        return self._address
+
+    @property
     def name(self):
         """Return the the name of the node."""
         return self._name
@@ -93,6 +98,10 @@ class InsteonPLMSwitchDevice(SwitchDevice):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)
         self._hass.async_add_job(self.async_update_ha_state(True))
+
+    def get_attr(self, key):
+        """Return specified attribute for this device."""
+        return self._plm.get_device_attr(self.address, key)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -32,7 +32,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             async_add_devices(
                 [InsteonPLMSwitchDevice(hass, plm, address, name)]))
 
-    criteria = dict(capability='switch')
+    criteria = {'capability': 'switch'}
     plm.protocol.devices.add_device_callback(
         async_plm_switch_callback, criteria)
 
@@ -51,7 +51,7 @@ class InsteonPLMSwitchDevice(SwitchDevice):
         self._name = name
 
         self._plm.add_update_callback(
-            self.async_switch_update, dict(address=self._address))
+            self.async_switch_update, {'address': self._address})
 
     @property
     def should_poll(self):

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -36,9 +36,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     plm.protocol.devices.add_device_callback(
         async_plm_switch_callback, criteria)
 
-    new_switches = []
-    yield from async_add_devices(new_switches)
-
 
 class InsteonPLMSwitchDevice(SwitchDevice):
     """A Class for an Insteon device."""
@@ -88,7 +85,7 @@ class InsteonPLMSwitchDevice(SwitchDevice):
     def async_switch_update(self, message):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)
-        self._hass.async_add_job(self.async_update_ha_state(True))
+        self._hass.async_add_job(self.async_update_ha_state())
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -92,10 +92,10 @@ class InsteonPLMSwitchDevice(SwitchDevice):
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
-        """Moo."""
+        """Turn device on."""
         self._plm.turn_on(self._address)
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
-        """Moo."""
+        """Turn device off."""
         self._plm.turn_off(self._address)

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -69,7 +69,7 @@ class InsteonPLMSwitchDevice(SwitchDevice):
     @property
     def is_on(self):
         """Return the boolean response if the node is on."""
-        onlevel = self._plm.get_device_attr(self._address, 'onlevel')
+        onlevel = self._plm.get_device_attr(self._address, 'switchstate')
         _LOGGER.debug('on level for %s is %s', self._address, onlevel)
         if onlevel:
             return (onlevel > 0)
@@ -79,12 +79,12 @@ class InsteonPLMSwitchDevice(SwitchDevice):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Moo."""
-        print(kwargs)
+        self._plm.turn_on(self._address, 1)
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Moo."""
-        print(kwargs)
+        self._plm.turn_off(self._address)
 
     def async_insteonplm_switch_update_callback(self, message):
         """Receive notification from transport that new data exists."""

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -35,7 +35,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         hass.async_add_job(async_add_devices([InsteonPLMSwitchDevice(hass, plm, address, name)]))
 
     criteria = dict(capability='switch')
-    plm.protocol.add_device_callback(async_insteonplm_switch_callback, criteria)
+    plm.protocol.devices.add_device_callback(async_insteonplm_switch_callback, criteria)
 
 
     new_switchs = []

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -76,6 +76,16 @@ class InsteonPLMSwitchDevice(SwitchDevice):
         else:
             return False
 
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
+        """Moo."""
+        print(kwargs)
+
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
+        """Moo."""
+        print(kwargs)
+
     def async_insteonplm_switch_update_callback(self, message):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-    """Moo."""
+    """Set up the INSTEON PLM device class for the hass platform."""
     _LOGGER.info('Provisioning Insteon PLM Switches')
 
     plm = hass.data['insteon_plm']

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/insteon_plm/
 import logging
 import asyncio
 
+from homeassistant.core import callback
 from homeassistant.components.switch import (SwitchDevice)
 from homeassistant.loader import get_component
 
@@ -22,6 +23,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     plm = hass.data['insteon_plm']
 
+    @callback
     def async_plm_switch_callback(device):
         """New device detected from transport."""
         name = device['address']
@@ -82,6 +84,7 @@ class InsteonPLMSwitchDevice(SwitchDevice):
         """Return specified attribute for this device."""
         return self._plm.get_device_attr(self.address, key)
 
+    @callback
     def async_switch_update(self, message):
         """Receive notification from transport that new data exists."""
         _LOGGER.info('Received update calback from PLM for %s', self._address)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -288,6 +288,9 @@ insteon_hub==0.4.5
 # homeassistant.components.insteon_local
 insteonlocal==0.39
 
+# homeassistant.components.insteon_plm
+insteonplm==0.7.4
+
 # homeassistant.components.media_player.kodi
 jsonrpc-async==0.2
 


### PR DESCRIPTION
**Description:**

This PR adds a new component 'insteon_plm' for use with INSTEON PowerLinc USB/serial modems. It includes constituent platforms: light, switch, and binary_sensor.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2092

**Example entry for `configuration.yaml` (if applicable):**
```yaml
insteon_plm:
    port: /dev/ttyUSB0
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51