### PR TITLE
Added support for alternate SSH ports in AsusWRT (#4832)

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -119,9 +119,8 @@ class AsusWrtDeviceScanner(DeviceScanner):
         self.ssh_args = {}
 
         if self.protocol == 'ssh':
-
-            if self.port != DEFAULT_SSH_PORT:
-                self.ssh_args['port'] = self.port
+            
+            self.ssh_args['port'] = self.port
             if self.ssh_key:
                 self.ssh_args['ssh_key'] = self.ssh_key
             elif self.password:

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -16,7 +16,8 @@ import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (
+    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT)
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
@@ -25,6 +26,7 @@ MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 CONF_PROTOCOL = 'protocol'
 CONF_MODE = 'mode'
+DEFAULT_SSH_PORT = 22
 CONF_SSH_KEY = 'ssh_key'
 CONF_PUB_KEY = 'pub_key'
 SECRET_GROUP = 'Password or SSH Key'
@@ -38,6 +40,7 @@ PLATFORM_SCHEMA = vol.All(
             vol.In(['ssh', 'telnet']),
         vol.Optional(CONF_MODE, default='router'):
             vol.In(['router', 'ap']),
+        vol.Optional(CONF_PORT, default=DEFAULT_SSH_PORT): cv.port,
         vol.Exclusive(CONF_PASSWORD, SECRET_GROUP): cv.string,
         vol.Exclusive(CONF_SSH_KEY, SECRET_GROUP): cv.isfile,
         vol.Exclusive(CONF_PUB_KEY, SECRET_GROUP): cv.isfile
@@ -112,12 +115,17 @@ class AsusWrtDeviceScanner(DeviceScanner):
         self.ssh_key = config.get('ssh_key', config.get('pub_key', ''))
         self.protocol = config[CONF_PROTOCOL]
         self.mode = config[CONF_MODE]
+        self.port = config.get(CONF_PORT, 22)
+        self.ssh_args = {}
 
         if self.protocol == 'ssh':
+
+            if self.port != DEFAULT_SSH_PORT:
+                self.ssh_args['port'] = self.port
             if self.ssh_key:
-                self.ssh_secret = {'ssh_key': self.ssh_key}
+                self.ssh_args['ssh_key'] = self.ssh_key
             elif self.password:
-                self.ssh_secret = {'password': self.password}
+                self.ssh_args['password'] = self.password
             else:
                 _LOGGER.error('No password or private key specified')
                 self.success_init = False
@@ -179,7 +187,7 @@ class AsusWrtDeviceScanner(DeviceScanner):
 
         ssh = pxssh.pxssh()
         try:
-            ssh.login(self.host, self.username, **self.ssh_secret)
+            ssh.login(self.host, self.username, **self.ssh_args)
         except exceptions.EOF as err:
             _LOGGER.error('Connection refused. Is SSH enabled?')
             return None

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -115,7 +115,7 @@ class AsusWrtDeviceScanner(DeviceScanner):
         self.ssh_key = config.get('ssh_key', config.get('pub_key', ''))
         self.protocol = config[CONF_PROTOCOL]
         self.mode = config[CONF_MODE]
-        self.port = config.get(CONF_PORT, 22)
+        self.port = config[CONF_PORT]
         self.ssh_args = {}
 
         if self.protocol == 'ssh':

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -119,7 +119,7 @@ class AsusWrtDeviceScanner(DeviceScanner):
         self.ssh_args = {}
 
         if self.protocol == 'ssh':
-            
+
             self.ssh_args['port'] = self.port
             if self.ssh_key:
                 self.ssh_args['ssh_key'] = self.ssh_key

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -12,7 +12,7 @@ from homeassistant.components.device_tracker import (
     CONF_CONSIDER_HOME, CONF_TRACK_NEW)
 from homeassistant.components.device_tracker.asuswrt import (
     CONF_PROTOCOL, CONF_MODE, CONF_PUB_KEY, DOMAIN,
-    PLATFORM_SCHEMA)
+    CONF_PORT, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME,
                                  CONF_HOST)
 
@@ -86,6 +86,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
 
         conf_dict[DOMAIN][CONF_MODE] = 'router'
         conf_dict[DOMAIN][CONF_PROTOCOL] = 'ssh'
+        conf_dict[DOMAIN][CONF_PORT] = 22
         self.assertEqual(asuswrt_mock.call_count, 1)
         self.assertEqual(asuswrt_mock.call_args, mock.call(conf_dict[DOMAIN]))
 
@@ -111,6 +112,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
 
         conf_dict[DOMAIN][CONF_MODE] = 'router'
         conf_dict[DOMAIN][CONF_PROTOCOL] = 'ssh'
+        conf_dict[DOMAIN][CONF_PORT] = 22
         self.assertEqual(asuswrt_mock.call_count, 1)
         self.assertEqual(asuswrt_mock.call_args, mock.call(conf_dict[DOMAIN]))
 

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -138,7 +138,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         self.assertEqual(ssh.login.call_count, 1)
         self.assertEqual(
             ssh.login.call_args,
-            mock.call('fake_host', 'fake_user', ssh_key=FAKEFILE)
+            mock.call('fake_host', 'fake_user', port=22, ssh_key=FAKEFILE)
         )
 
     def test_ssh_login_with_password(self):
@@ -163,7 +163,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         self.assertEqual(ssh.login.call_count, 1)
         self.assertEqual(
             ssh.login.call_args,
-            mock.call('fake_host', 'fake_user', password='fake_pass')
+            mock.call('fake_host', 'fake_user', password='fake_pass', port=22)
         )
 
     def test_ssh_login_without_password_or_pubkey(self):  \


### PR DESCRIPTION
My Asus router doesn't run SSH on port 22. This allows Home Assistant to work now by exposing this the SSH port as a parameter.


**Related issue (if applicable):** fixes #4832

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#1721

**Example entry for `configuration.yaml` (if applicable):**
```
device_tracker:
  - platform: asuswrt
    host: YOUR_ROUTER_IP
    username: YOUR_ADMIN_USERNAME
    password: YOUR_ADMIN_PASSWORD
    protocol: ssh
    port: 22222
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
