### PR TITLE
Added emulated_hue instances

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -53,7 +53,7 @@ DEFAULT_TYPE = TYPE_GOOGLE
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: cv.ordered_dict({
-        cv.slug: cv.string, 
+        cv.slug: cv.string,
         vol.Optional(CONF_HOST_IP): cv.string,
         vol.Optional(CONF_LISTEN_PORT, default=DEFAULT_LISTEN_PORT):
             vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
@@ -80,7 +80,7 @@ def setup(hass, yaml_config):
 
     for hue_name, conf in yaml_config.get(DOMAIN, {}).items():
         _LOGGER.error("hue {}".format(hue_name))
-        config = Config(hass,conf,hue_name)
+        config = Config(hass, conf, hue_name)
 
         server = HomeAssistantWSGI(
             hass,
@@ -108,7 +108,7 @@ def setup(hass, yaml_config):
             config.upnp_bind_multicast, config.advertise_ip,
             config.advertise_port, config.target_ip)
 
-        hue_data = { 'config': config, 'server': server, 'upnp_listener': upnp_listener}
+        hue_data = {'config': config, 'server': server, 'upnp_listener': upnp_listener}
         hue_list.append(hue_data)
 
 
@@ -116,15 +116,15 @@ def setup(hass, yaml_config):
     def stop_emulated_hue_bridge(event):
         """Stop the emulated hue bridge."""
         for hue_data in hue_list:
-           hue_data['upnp_listener'].stop()
-           yield from hue_data['server'].stop()
+            hue_data['upnp_listener'].stop()
+            yield from hue_data['server'].stop()
 
     @asyncio.coroutine
     def start_emulated_hue_bridge(event):
         """Start the emulated hue bridge."""
         for hue_data in hue_list:
-           hue_data['upnp_listener'].start()
-           yield from hue_data['server'].start()
+            hue_data['upnp_listener'].start()
+            yield from hue_data['server'].start()
 
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,
                                    stop_emulated_hue_bridge)
@@ -141,7 +141,7 @@ class Config(object):
         """Initialize the instance."""
         self.hass = hass
         self.type = conf.get(CONF_TYPE)
-        self.target_ip = conf.get(CONF_TARGET_IP,None)
+        self.target_ip = conf.get(CONF_TARGET_IP, None)
         self.numbers = None
         self.cached_states = {}
         self.hue_name = hue_name
@@ -242,14 +242,11 @@ class Config(object):
         domain = entity.domain.lower()
         explicit_expose = entity.attributes.get(ATTR_EMULATED_HUE, None)
 
-        # 
         # entity attribute emulated_hue_instance - e.g. 'emulated_hue_instance: hue1'
-        #
         hue_instance = entity.attributes.get(ATTR_EMULATED_HUE_INSTANCE, None)
         if hue_instance is not None:
             if hue_instance != self.hue_name:
                 return False
-                
         domain_exposed_by_default = \
             self.expose_by_default and domain in self.exposed_domains
 

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -63,14 +63,14 @@ class UPNPResponderThread(threading.Thread):
     _interrupted = False
 
     def __init__(self, host_ip_addr, listen_port, upnp_bind_multicast,
-                 advertise_ip, advertise_port,target_ip):
+                 advertise_ip, advertise_port, target_ip):
         """Initialize the class."""
         threading.Thread.__init__(self)
 
         self.host_ip_addr = host_ip_addr
         self.listen_port = listen_port
         self.upnp_bind_multicast = upnp_bind_multicast
-        self.advertise_ip = advertise_ip 
+        self.advertise_ip = advertise_ip
         self.advertise_port = advertise_port
         self.target_ip = target_ip
 
@@ -104,13 +104,13 @@ USN: uuid:Socket-1_0-221438K0100073::urn:schemas-upnp-org:device:basic:1
                 return
 
         # Randomize the mcast response - otherwise Echo can lose messages
-        r = random.randint(1,8)
+        r = random.randint(1, 8)
         time.sleep(r)
 
         upnp_response = resp_template.format(
             self.advertise_ip, self.advertise_port).replace("\n", "\r\n") \
                                          .encode('utf-8')
-        resp_socket = socket.socket( socket.AF_INET, socket.SOCK_DGRAM)
+        resp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         resp_socket.sendto(upnp_response, addr)
         resp_socket.close()
 
@@ -167,7 +167,7 @@ USN: uuid:Socket-1_0-221438K0100073::urn:schemas-upnp-org:device:basic:1
 
             if "M-SEARCH" in data.decode('utf-8'):
                 # SSDP M-SEARCH method received, respond to it with our info
-                self.send_adv(addr,data)
+                self.send_adv(addr, data)
 
     def stop(self):
         """Stop the server."""

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -115,7 +115,7 @@ def hass_hue(loop, hass):
 def hue_client(loop, hass_hue, test_client):
     """Create web client for emulated hue api."""
     web_app = mock_http_component_app(hass_hue)
-    config = Config(None, {'hue': {'type': 'alexa'}})
+    config = Config(None, {'type': 'alexa'}, 'hue')
 
     HueUsernameView().register(web_app.router)
     HueAllLightsStateView(config).register(web_app.router)

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -115,7 +115,7 @@ def hass_hue(loop, hass):
 def hue_client(loop, hass_hue, test_client):
     """Create web client for emulated hue api."""
     web_app = mock_http_component_app(hass_hue)
-    config = Config(None, {('hue': 'type': 'alexa'}})
+    config = Config(None, {'hue': {'type': 'alexa'}})
 
     HueUsernameView().register(web_app.router)
     HueAllLightsStateView(config).register(web_app.router)

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -115,7 +115,7 @@ def hass_hue(loop, hass):
 def hue_client(loop, hass_hue, test_client):
     """Create web client for emulated hue api."""
     web_app = mock_http_component_app(hass_hue)
-    config = Config(None, {'type': 'alexa'})
+    config = Config(None, {('hue': 'type': 'alexa'}})
 
     HueUsernameView().register(web_app.router)
     HueAllLightsStateView(config).register(web_app.router)

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -38,11 +38,7 @@ def test_config_google_home_entity_id_to_number():
 
 def test_config_alexa_entity_id_to_number():
     """Test config adheres to the type."""
-    conf = Config(None, {
-        'hue': {
-           'type': 'alexa'
-        }
-    })
+    conf = Config(None, {'type': 'alexa'}, 'hue')
 
     number = conf.entity_id_to_number('light.test')
     assert number == 'light.test'

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -8,9 +8,7 @@ from homeassistant.components.emulated_hue import Config, _LOGGER
 
 def test_config_google_home_entity_id_to_number():
     """Test config adheres to the type."""
-    conf = Config(Mock(), {
-        'type': 'google_home'
-    })
+    conf = Config(Mock(), {'type': 'google_home'}, 'hue')
 
     mop = mock_open(read_data=json.dumps({'1': 'light.test2'}))
     handle = mop()
@@ -60,7 +58,7 @@ def test_warning_config_google_home_listen_port():
             'type': 'google_home',
             'host_ip': '123.123.123.123',
             'listen_port': 8300
-        })
+        }, 'hue')
 
         assert mock_warn.called
         assert mock_warn.mock_calls[0][1][0] == \

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -39,7 +39,7 @@ def test_config_google_home_entity_id_to_number():
 def test_config_alexa_entity_id_to_number():
     """Test config adheres to the type."""
     conf = Config(None, {
-        'hue' {
+        'hue': {
            'type': 'alexa'
         }
     })

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -39,7 +39,9 @@ def test_config_google_home_entity_id_to_number():
 def test_config_alexa_entity_id_to_number():
     """Test config adheres to the type."""
     conf = Config(None, {
-        'type': 'alexa'
+        'hue' {
+           'type': 'alexa'
+        }
     })
 
     number = conf.entity_id_to_number('light.test')


### PR DESCRIPTION
**Description:**

Added the ability to support multiple emulated_hue instances. 

This makes HASS look like it is multiple Hue devices. This has a couple of benefits:

1. it allows configurations to go past the 49 device limit
2. it allows configurations where some devices can be discovered by separate Amazon Echo devices and mapped to separate Amazon Alexa accounts.

**Related issue (if applicable):** non that I am aware

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

  customize:
    group.master_bedroom:
      friendly_name: lights
      emulated_hue: true
      emulated_hue_instance: hue1

  emulated_hue:
    hue1:
      type: alexa
      listen_port: 8301
      expose_by_default: false      
```
**and**
```yaml
  emulated_hue:
    hue1:
      type: alexa
      listen_port: 8301
      expose_by_default: true
      exposed_domains:
        - fan
        - group
        - climate
        - script
    hue2:
      type: alexa
      listen_port: 8302
      target_ip: 192.168.1.111
      expose_by_default: true
      exposed_domains:
        - light
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

  Not yet - I wanted to feedback on this PR first. Particular on the configuration changes.

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

How does this work? I've only tested with Amazon Echos.

  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
