### PR TITLE
Add support for waking up Samsung TVs over the network

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -163,6 +163,8 @@ class SamsungTVDevice(MediaPlayerDevice):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
+        if self._mac:
+            return SUPPORT_SAMSUNGTV | SUPPORT_TURN_ON
         return SUPPORT_SAMSUNGTV
 
     def turn_off(self):

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -12,12 +12,13 @@ import voluptuous as vol
 from homeassistant.components.media_player import (
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
     SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP,
-    SUPPORT_PLAY, MediaPlayerDevice, PLATFORM_SCHEMA)
+    SUPPORT_PLAY, MediaPlayerDevice, PLATFORM_SCHEMA, SUPPORT_TURN_ON)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN, CONF_PORT)
+    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN, CONF_PORT,
+    CONF_MAC)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['samsungctl==0.6.0']
+REQUIREMENTS = ['samsungctl==0.6.0', 'wakeonlan==0.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,6 +55,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         host = config.get(CONF_HOST)
         port = config.get(CONF_PORT)
         name = config.get(CONF_NAME)
+        mac = config.get(CONF_MAC)
         timeout = config.get(CONF_TIMEOUT)
     elif discovery_info is not None:
         tv_name, model, host = discovery_info
@@ -70,7 +72,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     ip_addr = socket.gethostbyname(host)
     if ip_addr not in known_devices:
         known_devices.add(ip_addr)
-        add_devices([SamsungTVDevice(host, port, name, timeout)])
+        add_devices([SamsungTVDevice(host, port, name, timeout, mac)])
         _LOGGER.info("Samsung TV %s:%d added as '%s'", host, port, name)
     else:
         _LOGGER.info("Ignoring duplicate Samsung TV %s:%d", host, port)
@@ -79,14 +81,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class SamsungTVDevice(MediaPlayerDevice):
     """Representation of a Samsung TV."""
 
-    def __init__(self, host, port, name, timeout):
+    def __init__(self, host, port, name, timeout, mac):
         """Initialize the Samsung device."""
         from samsungctl import exceptions
         from samsungctl import Remote
+        from wakeonlan import wol
         # Save a reference to the imported classes
         self._exceptions_class = exceptions
         self._remote_class = Remote
         self._name = name
+        self._mac = mac
+        self._wol = wol
         # Assume that the TV is not muted
         self._muted = False
         # Assume that the TV is in Play mode
@@ -208,4 +213,7 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     def turn_on(self):
         """Turn the media player on."""
-        self.send_key('KEY_POWERON')
+        if self._mac:
+            self._wol.send_magic_packet(self._mac)
+        else:
+            self.send_key('KEY_POWERON')

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -723,6 +723,7 @@ vsure==0.11.1
 vtjp==0.1.14
 
 # homeassistant.components.media_player.panasonic_viera
+# homeassistant.components.media_player.samsungtv
 # homeassistant.components.media_player.webostv
 # homeassistant.components.switch.wake_on_lan
 wakeonlan==0.2.2


### PR DESCRIPTION
**Description:**
Adds support for using WoL via the MAC address of the TV. Tested on a UA55KU6000W

**Related issue (if applicable):** None

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2096

**Example entry for `configuration.yaml` (if applicable):**
```yaml
media_player:
  - platform: samsungtv
    host: 192.168.1.223
    mac: 5c:49:7d:9a:6f:5d
    port: 8001
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io): home-assistant/home-assistant.github.io#2096

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass** (passed on python 3.5)
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
