### PR TITLE
Don't allow sending to invalid iOS targets

### DIFF
--- a/homeassistant/components/notify/ios.py
+++ b/homeassistant/components/notify/ios.py
@@ -77,11 +77,6 @@ class iOSNotificationService(BaseNotificationService):
 
         targets = kwargs.get(ATTR_TARGET)
 
-        if targets not in ios.enabled_push_ids():
-            _LOGGER.error("The target (%s) does not exist in ios.conf.",
-                          targets)
-            return
-
         if not targets:
             targets = ios.enabled_push_ids()
 
@@ -89,6 +84,11 @@ class iOSNotificationService(BaseNotificationService):
             data[ATTR_DATA] = kwargs.get(ATTR_DATA)
 
         for target in targets:
+            if target not in ios.enabled_push_ids():
+                _LOGGER.error("The target (%s) does not exist in ios.conf.",
+                              targets)
+                return
+
             data[ATTR_TARGET] = target
 
             req = requests.post(PUSH_URL, json=data, timeout=10)

--- a/homeassistant/components/notify/ios.py
+++ b/homeassistant/components/notify/ios.py
@@ -77,6 +77,11 @@ class iOSNotificationService(BaseNotificationService):
 
         targets = kwargs.get(ATTR_TARGET)
 
+        if targets not in ios.enabled_push_ids():
+            _LOGGER.error("The target (%s) does not exist in ios.conf.",
+                          targets)
+            return
+
         if not targets:
             targets = ios.enabled_push_ids()
 


### PR DESCRIPTION
**Description:** This fixes a minor edge case discovered by @rrubin0 that causes the iOS target to be overwritten with an invalid target. It can happen when you have an automation like this:

```yaml
- service: notify.notify
  data:
    title: "Door Unlocked"
    target: "device/Chrome"
    message: "Door is unlocked"
```


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
