### PR TITLE
Mqtt fixes

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -226,10 +226,6 @@ def _async_setup_server(hass, config):
     """
     conf = config.get(DOMAIN, {})
 
-    # Only setup if embedded config passed in or no broker specified
-    if CONF_EMBEDDED not in conf and CONF_BROKER in conf:
-        return None
-
     server = yield from async_prepare_setup_platform(
         hass, config, DOMAIN, 'server')
 
@@ -272,7 +268,11 @@ def async_setup(hass, config):
     client_id = conf.get(CONF_CLIENT_ID)
     keepalive = conf.get(CONF_KEEPALIVE)
 
-    broker_config = yield from _async_setup_server(hass, config)
+    # Only setup if embedded config passed in or no broker specified
+    if CONF_EMBEDDED not in conf and CONF_BROKER in conf:
+        broker_config = None
+    else:
+        broker_config = yield from _async_setup_server(hass, config)
 
     if CONF_BROKER in conf:
         broker = conf[CONF_BROKER]
@@ -329,7 +329,10 @@ def async_setup(hass, config):
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, async_start_mqtt)
 
-    yield from hass.data[DATA_MQTT].async_connect()
+    success = yield from hass.data[DATA_MQTT].async_connect()
+
+    if not success:
+        return False
 
     @asyncio.coroutine
     def async_publish_service(call):
@@ -425,13 +428,20 @@ class MQTT(object):
         return self.hass.loop.run_in_executor(
             None, self._mqttc.publish, topic, payload, qos, retain)
 
+    @asyncio.coroutine
     def async_connect(self):
         """Connect to the host. Does not process messages yet.
 
         This method must be run in the event loop and returns a coroutine.
         """
-        return self.hass.loop.run_in_executor(
+        result = yield from self.hass.loop.run_in_executor(
             None, self._mqttc.connect, self.broker, self.port, self.keepalive)
+
+        if result != 0:
+            import paho.mqtt.client as mqtt
+            _LOGGER.error('Failed to connect: %s', mqtt.error_string(result))
+
+        return not result
 
     def async_start(self):
         """Run the MQTT client.
@@ -488,14 +498,11 @@ class MQTT(object):
         Resubscribe to all topics we were subscribed to and publish birth
         message.
         """
-        if result_code != 0:
-            _LOGGER.error('Unable to connect to the MQTT broker: %s', {
-                1: 'Incorrect protocol version',
-                2: 'Invalid client identifier',
-                3: 'Server unavailable',
-                4: 'Bad username or password',
-                5: 'Not authorised'
-            }.get(result_code, 'Unknown reason'))
+        import paho.mqtt.client as mqtt
+
+        if result_code != mqtt.CONNACK_ACCEPTED:
+            _LOGGER.error('Unable to connect to the MQTT broker: %s',
+                          mqtt.connack_string(result_code))
             self._mqttc.disconnect()
             return
 
@@ -585,7 +592,10 @@ class MQTT(object):
 def _raise_on_error(result):
     """Raise error if error result."""
     if result != 0:
-        raise HomeAssistantError('Error talking to MQTT: {}'.format(result))
+        import paho.mqtt.client as mqtt
+
+        raise HomeAssistantError(
+            'Error talking to MQTT: {}'.format(mqtt.error_string(result)))
 
 
 def _match_topic(subscription, topic):

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -434,7 +434,7 @@ class MQTT(object):
 
         This method must be run in the event loop and returns a coroutine.
         """
-        def stop(self):
+        def stop():
             """Stop the MQTT client."""
             self._mqttc.disconnect()
             self._mqttc.loop_stop()

--- a/tests/common.py
+++ b/tests/common.py
@@ -248,6 +248,7 @@ def mock_http_component_app(hass, api_password=None):
 def mock_mqtt_component(hass):
     """Mock the MQTT component."""
     with patch('homeassistant.components.mqtt.MQTT') as mock_mqtt:
+        mock_mqtt().async_connect.return_value = mock_coro(True)
         setup_component(hass, mqtt.DOMAIN, {
             mqtt.DOMAIN: {
                 mqtt.CONF_BROKER: 'mock-broker',

--- a/tests/components/mqtt/test_server.py
+++ b/tests/components/mqtt/test_server.py
@@ -26,23 +26,25 @@ class TestMQTT:
     @patch('homeassistant.components.mqtt.MQTT')
     def test_creating_config_with_http_pass(self, mock_mqtt):
         """Test if the MQTT server gets started and subscribe/publish msg."""
+        mock_mqtt().async_connect.return_value = mock_coro(True)
         self.hass.bus.listen_once = MagicMock()
         password = 'super_secret'
 
         self.hass.config.api = MagicMock(api_password=password)
         assert setup_component(self.hass, mqtt.DOMAIN, {})
         assert mock_mqtt.called
-        assert mock_mqtt.mock_calls[0][1][5] == 'homeassistant'
-        assert mock_mqtt.mock_calls[0][1][6] == password
+        assert mock_mqtt.mock_calls[1][1][5] == 'homeassistant'
+        assert mock_mqtt.mock_calls[1][1][6] == password
 
         mock_mqtt.reset_mock()
+        mock_mqtt().async_connect.return_value = mock_coro(True)
 
         self.hass.config.components = set(['http'])
         self.hass.config.api = MagicMock(api_password=None)
         assert setup_component(self.hass, mqtt.DOMAIN, {})
         assert mock_mqtt.called
-        assert mock_mqtt.mock_calls[0][1][5] is None
-        assert mock_mqtt.mock_calls[0][1][6] is None
+        assert mock_mqtt.mock_calls[1][1][5] is None
+        assert mock_mqtt.mock_calls[1][1][6] is None
 
     @patch('tempfile.NamedTemporaryFile', Mock(return_value=MagicMock()))
     @patch('hbmqtt.broker.Broker.start', return_value=mock_coro())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from homeassistant import util, bootstrap
 from homeassistant.util import location
 from homeassistant.components import mqtt
 
-from .common import async_test_home_assistant
+from .common import async_test_home_assistant, mock_coro
 from .test_util.aiohttp import mock_aiohttp_client
 
 logging.basicConfig()
@@ -66,7 +66,8 @@ def aioclient_mock():
 def mqtt_mock(loop, hass):
     """Fixture to mock MQTT."""
     with patch('homeassistant.components.mqtt.MQTT') as mock_mqtt:
-        loop.run_until_complete(bootstrap.async_setup_component(
+        mock_mqtt().async_connect.return_value = mock_coro(True)
+        assert loop.run_until_complete(bootstrap.async_setup_component(
             hass, mqtt.DOMAIN, {
                 mqtt.DOMAIN: {
                     mqtt.CONF_BROKER: 'mock-broker',


### PR DESCRIPTION
By calling `connect_async` we could not guarantee that the connection to the broker was made at the end of the MQTT component setup. This lead to the issue that subscribing to topics would error out.

This is fixed with this PR and also improved error reporting is included!

Fixes #6094