### PR TITLE
Fix for OSRAM lights connected to hue bridge

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -369,12 +369,27 @@ class HueLight(Light):
             command['transitiontime'] = kwargs[ATTR_TRANSITION] * 10
 
         if ATTR_XY_COLOR in kwargs:
-            command['xy'] = kwargs[ATTR_XY_COLOR]
+            if self.info['manufacturername'] == "OSRAM":
+                hsv = color_util.color_xy_brightness_to_hsv(
+                    *kwargs[ATTR_XY_COLOR],
+                    ibrightness=self.info['bri'])
+                command['hue'] = hsv[0]
+                command['sat'] = hsv[1]
+                command['bri'] = hsv[2]
+            else:
+                command['xy'] = kwargs[ATTR_XY_COLOR]
         elif ATTR_RGB_COLOR in kwargs:
-            xyb = color_util.color_RGB_to_xy(
-                *(int(val) for val in kwargs[ATTR_RGB_COLOR]))
-            command['xy'] = xyb[0], xyb[1]
-            command['bri'] = xyb[2]
+            if self.info['manufacturername'] == "OSRAM":
+                hsv = color_util.color_RGB_to_hsv(
+                    *(int(val) for val in kwargs[ATTR_RGB_COLOR]))
+                command['hue'] = hsv[0]
+                command['sat'] = hsv[1]
+                command['bri'] = hsv[2]
+            else:
+                xyb = color_util.color_RGB_to_xy(
+                    *(int(val) for val in kwargs[ATTR_RGB_COLOR]))
+                command['xy'] = xyb[0], xyb[1]
+                command['bri'] = xyb[2]
 
         if ATTR_BRIGHTNESS in kwargs:
             command['bri'] = kwargs[ATTR_BRIGHTNESS]
@@ -401,7 +416,8 @@ class HueLight(Light):
             command['hue'] = random.randrange(0, 65535)
             command['sat'] = random.randrange(150, 254)
         elif self.bridge_type == 'hue':
-            command['effect'] = 'none'
+            if self.info['manufacturername'] != "OSRAM":
+                command['effect'] = 'none'
 
         self._command_func(self.light_id, command)
 

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -1,6 +1,7 @@
 """Color util methods."""
 import logging
 import math
+import colorsys
 
 from typing import Tuple
 
@@ -257,6 +258,18 @@ def color_xy_brightness_to_RGB(vX: float, vY: float,
     ir, ig, ib = map(lambda x: int(x * 255), [r, g, b])
 
     return (ir, ig, ib)
+
+
+def color_RGB_to_hsv(iR: int, iG: int, iB: int) -> Tuple[int, int, int]:
+    """Convert an rgb color to its hsv representation."""
+    fHSV = colorsys.rgb_to_hsv(iR/255.0, iG/255.0, iB/255.0)
+    return (int(fHSV[0]*65536), int(fHSV[1]*255), int(fHSV[2]*255))
+
+
+def color_xy_brightness_to_hsv(vX: float, vY: float,
+                               ibrightness: int) -> Tuple[int, int, int]:
+    """Convert an xy brightness color to its hsv representation."""
+    return color_RGB_to_hsv(*color_xy_brightness_to_RGB(vX, vY, ibrightness))
 
 
 def _match_max_scale(input_colors: Tuple[int, ...],

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -39,6 +39,40 @@ class TestColorUtil(unittest.TestCase):
         self.assertEqual((0, 83, 255),
                          color_util.color_xy_brightness_to_RGB(0, 0, 255))
 
+    def test_color_RGB_to_hsv(self):
+        """Test color_RGB_to_hsv."""
+        self.assertEqual((0, 0, 0),
+                         color_util.color_RGB_to_hsv(0, 0, 0))
+
+        self.assertEqual((0, 0, 255),
+                         color_util.color_RGB_to_hsv(255, 255, 255))
+
+        self.assertEqual((43690, 255, 255),
+                         color_util.color_RGB_to_hsv(0, 0, 255))
+
+        self.assertEqual((21845, 255, 255),
+                         color_util.color_RGB_to_hsv(0, 255, 0))
+
+        self.assertEqual((0, 255, 255),
+                         color_util.color_RGB_to_hsv(255, 0, 0))
+
+    def test_color_xy_brightness_to_hsv(self):
+        """Test color_RGB_to_xy."""
+        self.assertEqual(color_util.color_RGB_to_hsv(0, 0, 0),
+                         color_util.color_xy_brightness_to_hsv(1, 1, 0))
+
+        self.assertEqual(color_util.color_RGB_to_hsv(255, 235, 214),
+                         color_util.color_xy_brightness_to_hsv(.35, .35, 255))
+
+        self.assertEqual(color_util.color_RGB_to_hsv(255, 0, 45),
+                         color_util.color_xy_brightness_to_hsv(1, 0, 255))
+
+        self.assertEqual(color_util.color_RGB_to_hsv(0, 255, 0),
+                         color_util.color_xy_brightness_to_hsv(0, 1, 255))
+
+        self.assertEqual(color_util.color_RGB_to_hsv(0, 83, 255),
+                         color_util.color_xy_brightness_to_hsv(0, 0, 255))
+
     def test_rgb_hex_to_rgb_list(self):
         """Test rgb_hex_to_rgb_list."""
         self.assertEqual([255, 255, 255],


### PR DESCRIPTION
Do not send command "effect = none" to OSRAM lights
Osram lights connected to a hue bridge do not seem to handle "effect =
none" very well. Most of the times they jump to the selected color and
then change to red within a second.

Osram lights connected to a hue bridge do not handle xy values outside
of their gamut. Since they just stay at their old color value, handling
the UI is very unpredictable. Sending HSV values to the lights fixes this.
