### PR TITLE
Notify ciscospark

### DIFF
--- a/homeassistant/components/notify/ciscospark.py
+++ b/homeassistant/components/notify/ciscospark.py
@@ -4,14 +4,12 @@ Cisco Spark platform for notify component.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.ciscospark/
 """
-
 import logging
 import voluptuous as vol
 from homeassistant.components.notify import (
     PLATFORM_SCHEMA, BaseNotificationService, ATTR_TITLE)
 from homeassistant.const import (CONF_TOKEN)
 import homeassistant.helpers.config_validation as cv
-
 
 CONF_ROOMID = "roomid"
 
@@ -24,6 +22,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ROOMID): cv.string,
 })
 
+
 # pylint: disable=unused-variable
 def get_service(hass, config, discovery_info=None):
     """
@@ -32,7 +31,6 @@ def get_service(hass, config, discovery_info=None):
     return CiscoSparkNotificationService(
         config.get(CONF_TOKEN),
         config.get(CONF_ROOMID))
-
 
 class CiscoSparkNotificationService(BaseNotificationService):
     def __init__(self, token, default_room):
@@ -48,11 +46,10 @@ class CiscoSparkNotificationService(BaseNotificationService):
         self._token = token
         self._spark = CiscoSparkAPI(access_token=self._token)
 
-
     def send_message(self, message="", **kwargs):
         """
         Send a message to a user.
-          
+
         Args:
             message: notificaiton text
             kwargs: attributes used - 'title'
@@ -62,8 +59,8 @@ class CiscoSparkNotificationService(BaseNotificationService):
             title = ""
             if kwargs.get(ATTR_TITLE) is not None:
                 title = kwargs.get(ATTR_TITLE) + ": "
-            self._spark.messages.create(roomId=self._default_room, 
+            self._spark.messages.create(roomId=self._default_room,
                                         text=title + message)
         except SparkApiError as api_error:
-            _LOGGER.error("Could not send CiscoSpark notification. Error: %s", 
+            _LOGGER.error("Could not send CiscoSpark notification. Error: %s",
                           api_error)

--- a/homeassistant/components/notify/ciscospark.py
+++ b/homeassistant/components/notify/ciscospark.py
@@ -1,3 +1,10 @@
+"""
+Cisco Spark platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.ciscospark/
+"""
+
 import logging
 import voluptuous as vol
 from homeassistant.components.notify import (
@@ -5,13 +12,12 @@ from homeassistant.components.notify import (
 from homeassistant.const import (CONF_TOKEN)
 import homeassistant.helpers.config_validation as cv
 
-from ciscosparkapi import CiscoSparkAPI, SparkApiError
 
 CONF_ROOMID = "roomid"
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ["ciscosparkapi==0.4.2"]
+REQUIREMENTS = ['ciscosparkapi==0.4.2']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_TOKEN): cv.string,
@@ -20,24 +26,44 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 # pylint: disable=unused-variable
 def get_service(hass, config, discovery_info=None):
-    """Get the CiscoSpark notification service."""
+    """
+    Get the CiscoSpark notification service.
+    """
     return CiscoSparkNotificationService(
         config.get(CONF_TOKEN),
         config.get(CONF_ROOMID))
 
+
 class CiscoSparkNotificationService(BaseNotificationService):
     def __init__(self, token, default_room):
-        """Initialize the service."""
+        """
+        Initialize the service.
+ 
+        Args:
+            token: Cisco Spark Developer's Token 
+            default_room: Cisco Spark Room ID
+        """
+        from ciscosparkapi import CiscoSparkAPI
         self._default_room = default_room
         self._token = token
         self._spark = CiscoSparkAPI(access_token=self._token)
 
+
     def send_message(self, message="", **kwargs):
-        """Send a message to a user."""
+        """
+        Send a message to a user.
+          
+        Args:
+            message: notificaiton text
+            kwargs: attributes used - 'title'
+        """
+        from ciscosparkapi import SparkApiError
         try:
             title = ""
             if kwargs.get(ATTR_TITLE) is not None:
                 title = kwargs.get(ATTR_TITLE) + ": "
-            self._spark.messages.create(roomId=self._default_room, text=title + message)
+            self._spark.messages.create(roomId=self._default_room, 
+                                        text=title + message)
         except SparkApiError as api_error:
-            _LOGGER.error("Could not send CiscoSpark notification. Error: %s", api_error)
+            _LOGGER.error("Could not send CiscoSpark notification. Error: %s", 
+                          api_error)

--- a/homeassistant/components/notify/ciscospark.py
+++ b/homeassistant/components/notify/ciscospark.py
@@ -25,20 +25,21 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 # pylint: disable=unused-variable
 def get_service(hass, config, discovery_info=None):
-    """
-    Get the CiscoSpark notification service.
-    """
+    """Get the CiscoSpark notification service."""
     return CiscoSparkNotificationService(
         config.get(CONF_TOKEN),
         config.get(CONF_ROOMID))
 
+
 class CiscoSparkNotificationService(BaseNotificationService):
+    """CiscoSparkNotificationService."""
+
     def __init__(self, token, default_room):
         """
         Initialize the service.
- 
+
         Args:
-            token: Cisco Spark Developer's Token 
+            token: Cisco Spark Developer's Token
             default_room: Cisco Spark Room ID
         """
         from ciscosparkapi import CiscoSparkAPI

--- a/homeassistant/components/notify/ciscospark.py
+++ b/homeassistant/components/notify/ciscospark.py
@@ -1,0 +1,43 @@
+import logging
+import voluptuous as vol
+from homeassistant.components.notify import (
+    PLATFORM_SCHEMA, BaseNotificationService, ATTR_TITLE)
+from homeassistant.const import (CONF_TOKEN)
+import homeassistant.helpers.config_validation as cv
+
+from ciscosparkapi import CiscoSparkAPI, SparkApiError
+
+CONF_ROOMID = "roomid"
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ["ciscosparkapi==0.4.2"]
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_TOKEN): cv.string,
+    vol.Required(CONF_ROOMID): cv.string,
+})
+
+# pylint: disable=unused-variable
+def get_service(hass, config, discovery_info=None):
+    """Get the CiscoSpark notification service."""
+    return CiscoSparkNotificationService(
+        config.get(CONF_TOKEN),
+        config.get(CONF_ROOMID))
+
+class CiscoSparkNotificationService(BaseNotificationService):
+    def __init__(self, token, default_room):
+        """Initialize the service."""
+        self._default_room = default_room
+        self._token = token
+        self._spark = CiscoSparkAPI(access_token=self._token)
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to a user."""
+        try:
+            title = ""
+            if kwargs.get(ATTR_TITLE) is not None:
+                title = kwargs.get(ATTR_TITLE) + ": "
+            self._spark.messages.create(roomId=self._default_room, text=title + message)
+        except SparkApiError as api_error:
+            _LOGGER.error("Could not send CiscoSpark notification. Error: %s", api_error)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -80,6 +80,9 @@ boto3==1.4.3
 # homeassistant.components.switch.broadlink
 broadlink==0.3
 
+# homeassistant.components.notify.ciscospark
+ciscosparkapi==0.4.2
+
 # homeassistant.components.sensor.coinmarketcap
 coinmarketcap==2.0.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -80,9 +80,6 @@ boto3==1.4.3
 # homeassistant.components.switch.broadlink
 broadlink==0.3
 
-# homeassistant.components.notify.ciscospark
-ciscosparkapi==0.4.2
-
 # homeassistant.components.sensor.coinmarketcap
 coinmarketcap==2.0.1
 


### PR DESCRIPTION
**Description:**

Add a new notifier for [Cisco Spark](https://ciscospark.com)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2104

I couldn't verify the documentation.

**Example entry for `configuration.yaml` (if applicable):**
```yaml
notify:
  - name: ciscospark
    platform: ciscospark
    token: <CISCO_SPARK_DEVELOPER_TOKEN>
    roomid: <CISCO_SPARK_ROOM_ID>
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

Working on it.

If the code communicates with devices, web services, or third-party tools:
  - [x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
