### PR TITLE
device_tracker: Add `source_type` to `see` service

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -99,7 +99,7 @@ def is_on(hass: HomeAssistantType, entity_id: str=None):
 def see(hass: HomeAssistantType, mac: str=None, dev_id: str=None,
         host_name: str=None, location_name: str=None,
         gps: GPSType=None, gps_accuracy=None,
-        battery=None, attributes: dict=None):
+        battery=None, attributes: dict=None, source_type: str=None):
     """Call service to notify you see device."""
     data = {key: value for key, value in
             ((ATTR_MAC, mac),
@@ -108,7 +108,8 @@ def see(hass: HomeAssistantType, mac: str=None, dev_id: str=None,
              (ATTR_LOCATION_NAME, location_name),
              (ATTR_GPS, gps),
              (ATTR_GPS_ACCURACY, gps_accuracy),
-             (ATTR_BATTERY, battery)) if value is not None}
+             (ATTR_BATTERY, battery),
+             (ATTR_SOURCE_TYPE, source_type)) if value is not None}
     if attributes:
         data[ATTR_ATTRIBUTES] = attributes
     hass.services.call(DOMAIN, SERVICE_SEE, data)
@@ -210,7 +211,8 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
         """Service to see a device."""
         args = {key: value for key, value in call.data.items() if key in
                 (ATTR_MAC, ATTR_DEV_ID, ATTR_HOST_NAME, ATTR_LOCATION_NAME,
-                 ATTR_GPS, ATTR_GPS_ACCURACY, ATTR_BATTERY, ATTR_ATTRIBUTES)}
+                 ATTR_GPS, ATTR_GPS_ACCURACY, ATTR_BATTERY, ATTR_ATTRIBUTES,
+                 ATTR_SOURCE_TYPE)}
         yield from tracker.async_see(**args)
 
     descriptions = yield from hass.loop.run_in_executor(

--- a/homeassistant/components/device_tracker/services.yaml
+++ b/homeassistant/components/device_tracker/services.yaml
@@ -32,6 +32,10 @@ see:
       description: Battery level of device
       example: '100'
 
+    source_type:
+      description: Type of data source where the device was seen (Use "gps" with coordinates)
+      example: 'router'
+
 icloud:
   icloud_lost_iphone:
     description: Service to play the lost iphone sound on an iDevice

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -446,7 +446,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
             'gps': [.3, .8],
             'attributes': {
                 'test': 'test'
-            }
+            },
+            'source_type': 'mqtt',
         }
         device_tracker.see(self.hass, **params)
         self.hass.block_till_done()


### PR DESCRIPTION
**Description:** Follow-up to #4852 to support overriding the default "gps" source_type when called via a service.

Perhaps that default should also be fixed but I wasn't sure why the method would default to "gps" in the first place.

**Related issue (if applicable):**  #4852

**Example entry for `configuration.yaml` (if applicable):**
```yaml
automation mqtt:
  trigger:
    platform: mqtt
    topic: /device_tracker/+
  action:
    service: device_tracker.see
    data_template:
      location_name: "{{ trigger.payload }}"
      mac: "{{ trigger.topic.split('/')[-1] }}"
      source_type: "mqtt"
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
- * Documented in services.yaml instead

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully.
  - [x] Tests have been added to verify that the new code works.