### PR TITLE
Add initial group config backend

### DIFF
--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -1,15 +1,20 @@
 """Component to configure Home Assistant via an API."""
 import asyncio
+import os
+
+import voluptuous as vol
 
 from homeassistant.core import callback
 from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.bootstrap import (
     async_prepare_setup_platform, ATTR_COMPONENT)
 from homeassistant.components.frontend import register_built_in_panel
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.util.yaml import load_yaml, dump
 
 DOMAIN = 'config'
 DEPENDENCIES = ['http']
-SECTIONS = ('core', 'hassbian')
+SECTIONS = ('core', 'group', 'hassbian')
 ON_DEMAND = ('zwave', )
 
 
@@ -53,3 +58,76 @@ def async_setup(hass, config):
     hass.bus.async_listen(EVENT_COMPONENT_LOADED, component_loaded)
 
     return True
+
+
+class EditKeyBasedConfigView(HomeAssistantView):
+    """Configure a Group endpoint."""
+
+    def __init__(self, component, config_type, path, key_schema, data_schema,
+                 *, post_write_hook=None):
+        """Initialize a config view."""
+        self.url = '/api/config/%s/%s/{config_key}' % (component, config_type)
+        self.name = 'api:config:%s:%s' % (component, config_type)
+        self.path = path
+        self.key_schema = key_schema
+        self.data_schema = data_schema
+        self.post_write_hook = post_write_hook
+
+    @asyncio.coroutine
+    def get(self, request, config_key):
+        """Fetch device specific config."""
+        hass = request.app['hass']
+        current = yield from hass.loop.run_in_executor(
+            None, _read, hass.config.path(self.path))
+        return self.json(current.get(config_key, {}))
+
+    @asyncio.coroutine
+    def post(self, request, config_key):
+        """Validate config and return results."""
+        try:
+            data = yield from request.json()
+        except ValueError:
+            return self.json_message('Invalid JSON specified', 400)
+
+        try:
+            self.key_schema(config_key)
+        except vol.Invalid as err:
+            return self.json_message('Key malformed: {}'.format(err), 400)
+
+        try:
+            # We just validate, we don't store that data because
+            # we don't want to store the defaults.
+            self.data_schema(data)
+        except vol.Invalid as err:
+            return self.json_message('Message malformed: {}'.format(err), 400)
+
+        hass = request.app['hass']
+        path = hass.config.path(self.path)
+
+        current = yield from hass.loop.run_in_executor(None, _read, path)
+        current.setdefault(config_key, {}).update(data)
+
+        yield from hass.loop.run_in_executor(None, _write, path, current)
+
+        if self.post_write_hook is not None:
+            hass.async_add_job(self.post_write_hook(hass))
+
+        return self.json({
+            'result': 'ok',
+        })
+
+
+def _read(path):
+    """Read YAML helper."""
+    if not os.path.isfile(path):
+        with open(path, 'w'):
+            pass
+        return {}
+
+    return load_yaml(path)
+
+
+def _write(path, data):
+    """Write YAML helper."""
+    with open(path, 'w', encoding='utf-8') as outfile:
+        outfile.write(dump(data))

--- a/homeassistant/components/config/group.py
+++ b/homeassistant/components/config/group.py
@@ -1,0 +1,19 @@
+"""Provide configuration end points for Groups."""
+import asyncio
+
+from homeassistant.components.config import EditKeyBasedConfigView
+from homeassistant.components.group import GROUP_SCHEMA, async_reload
+import homeassistant.helpers.config_validation as cv
+
+
+CONFIG_PATH = 'groups.yaml'
+
+
+@asyncio.coroutine
+def async_setup(hass):
+    """Setup the Group config API."""
+    hass.http.register_view(EditKeyBasedConfigView(
+        'group', 'config', CONFIG_PATH, cv.slug,
+        GROUP_SCHEMA, post_write_hook=async_reload
+    ))
+    return True

--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -1,78 +1,19 @@
 """Provide configuration end points for Z-Wave."""
 import asyncio
-import os
-import voluptuous as vol
 
-from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.config import EditKeyBasedConfigView
 from homeassistant.components.zwave import DEVICE_CONFIG_SCHEMA_ENTRY
-from homeassistant.util.yaml import load_yaml, dump
+import homeassistant.helpers.config_validation as cv
 
 
-DEVICE_CONFIG = 'zwave_device_config.yaml'
+CONFIG_PATH = 'zwave_device_config.yaml'
 
 
 @asyncio.coroutine
 def async_setup(hass):
     """Setup the Z-Wave config API."""
-    hass.http.register_view(DeviceConfigView)
+    hass.http.register_view(EditKeyBasedConfigView(
+        'zwave', 'device_config', CONFIG_PATH, cv.entity_id,
+        DEVICE_CONFIG_SCHEMA_ENTRY
+    ))
     return True
-
-
-class DeviceConfigView(HomeAssistantView):
-    """Configure a Z-Wave device endpoint."""
-
-    url = '/api/config/zwave/device_config/{entity_id}'
-    name = 'api:config:zwave:device_config:update'
-
-    @asyncio.coroutine
-    def get(self, request, entity_id):
-        """Fetch device specific config."""
-        hass = request.app['hass']
-        current = yield from hass.loop.run_in_executor(
-            None, _read, hass.config.path(DEVICE_CONFIG))
-        return self.json(current.get(entity_id, {}))
-
-    @asyncio.coroutine
-    def post(self, request, entity_id):
-        """Validate config and return results."""
-        try:
-            data = yield from request.json()
-        except ValueError:
-            return self.json_message('Invalid JSON specified', 400)
-
-        try:
-            # We just validate, we don't store that data because
-            # we don't want to store the defaults.
-            DEVICE_CONFIG_SCHEMA_ENTRY(data)
-        except vol.Invalid as err:
-            print(data, err)
-            return self.json_message('Message malformed: {}'.format(err), 400)
-
-        hass = request.app['hass']
-        path = hass.config.path(DEVICE_CONFIG)
-        current = yield from hass.loop.run_in_executor(
-            None, _read, hass.config.path(DEVICE_CONFIG))
-        current.setdefault(entity_id, {}).update(data)
-
-        yield from hass.loop.run_in_executor(
-            None, _write, hass.config.path(path), current)
-
-        return self.json({
-            'result': 'ok',
-        })
-
-
-def _read(path):
-    """Read YAML helper."""
-    if not os.path.isfile(path):
-        with open(path, 'w'):
-            pass
-        return {}
-
-    return load_yaml(path)
-
-
-def _write(path, data):
-    """Write YAML helper."""
-    with open(path, 'w', encoding='utf-8') as outfile:
-        outfile.write(dump(data))

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -57,14 +57,16 @@ def _conf_preprocess(value):
     return value
 
 
+GROUP_SCHEMA = vol.Schema({
+    vol.Optional(CONF_ENTITIES): vol.Any(cv.entity_ids, None),
+    CONF_VIEW: cv.boolean,
+    CONF_NAME: cv.string,
+    CONF_ICON: cv.icon,
+    CONF_CONTROL: cv.string,
+})
+
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: cv.ordered_dict(vol.All(_conf_preprocess, {
-        vol.Optional(CONF_ENTITIES): vol.Any(cv.entity_ids, None),
-        CONF_VIEW: cv.boolean,
-        CONF_NAME: cv.string,
-        CONF_ICON: cv.icon,
-        CONF_CONTROL: cv.string,
-    }, cv.match_all))
+    DOMAIN: cv.ordered_dict(vol.All(_conf_preprocess, GROUP_SCHEMA))
 }, extra=vol.ALLOW_EXTRA)
 
 # List of ON/OFF state tuples for groupable states
@@ -97,6 +99,12 @@ def is_on(hass, entity_id):
 def reload(hass):
     """Reload the automation from config."""
     hass.services.call(DOMAIN, SERVICE_RELOAD)
+
+
+@asyncio.coroutine
+def async_reload(hass):
+    """Reload the automation from config."""
+    yield from hass.services.async_call(DOMAIN, SERVICE_RELOAD)
 
 
 def set_visibility(hass, entity_id=None, visible=True):

--- a/tests/components/config/test_group.py
+++ b/tests/components/config/test_group.py
@@ -8,7 +8,7 @@ from homeassistant.components import config
 from tests.common import mock_http_component_app
 
 
-VIEW_NAME = 'api:config:zwave:device_config'
+VIEW_NAME = 'api:config:group:config'
 
 
 @asyncio.coroutine
@@ -16,7 +16,7 @@ def test_get_device_config(hass, test_client):
     """Test getting device config."""
     app = mock_http_component_app(hass)
 
-    with patch.object(config, 'SECTIONS', ['zwave']):
+    with patch.object(config, 'SECTIONS', ['group']):
         yield from async_setup_component(hass, 'config', {})
 
     hass.http.views[VIEW_NAME].register(app.router)
@@ -36,7 +36,7 @@ def test_get_device_config(hass, test_client):
 
     with patch('homeassistant.components.config._read', mock_read):
         resp = yield from client.get(
-            '/api/config/zwave/device_config/hello.beer')
+            '/api/config/group/config/hello.beer')
 
     assert resp.status == 200
     result = yield from resp.json()
@@ -49,7 +49,7 @@ def test_update_device_config(hass, test_client):
     """Test updating device config."""
     app = mock_http_component_app(hass)
 
-    with patch.object(config, 'SECTIONS', ['zwave']):
+    with patch.object(config, 'SECTIONS', ['group']):
         yield from async_setup_component(hass, 'config', {})
 
     hass.http.views[VIEW_NAME].register(app.router)
@@ -78,15 +78,15 @@ def test_update_device_config(hass, test_client):
     with patch('homeassistant.components.config._read', mock_read), \
             patch('homeassistant.components.config._write', mock_write):
         resp = yield from client.post(
-            '/api/config/zwave/device_config/hello.beer', data=json.dumps({
-                'polling_intensity': 2
+            '/api/config/group/config/hello_beer', data=json.dumps({
+                'name': 'Beer',
             }))
 
     assert resp.status == 200
     result = yield from resp.json()
     assert result == {'result': 'ok'}
 
-    orig_data['hello.beer']['polling_intensity'] = 2
+    orig_data['hello_beer']['name'] = 'Beer'
 
     assert written[0] == orig_data
 
@@ -96,7 +96,7 @@ def test_update_device_config_invalid_key(hass, test_client):
     """Test updating device config."""
     app = mock_http_component_app(hass)
 
-    with patch.object(config, 'SECTIONS', ['zwave']):
+    with patch.object(config, 'SECTIONS', ['group']):
         yield from async_setup_component(hass, 'config', {})
 
     hass.http.views[VIEW_NAME].register(app.router)
@@ -104,8 +104,8 @@ def test_update_device_config_invalid_key(hass, test_client):
     client = yield from test_client(app)
 
     resp = yield from client.post(
-        '/api/config/zwave/device_config/invalid_entity', data=json.dumps({
-            'polling_intensity': 2
+        '/api/config/group/config/not a slug', data=json.dumps({
+            'name': 'YO',
         }))
 
     assert resp.status == 400
@@ -116,7 +116,7 @@ def test_update_device_config_invalid_data(hass, test_client):
     """Test updating device config."""
     app = mock_http_component_app(hass)
 
-    with patch.object(config, 'SECTIONS', ['zwave']):
+    with patch.object(config, 'SECTIONS', ['group']):
         yield from async_setup_component(hass, 'config', {})
 
     hass.http.views[VIEW_NAME].register(app.router)
@@ -124,7 +124,7 @@ def test_update_device_config_invalid_data(hass, test_client):
     client = yield from test_client(app)
 
     resp = yield from client.post(
-        '/api/config/zwave/device_config/hello.beer', data=json.dumps({
+        '/api/config/group/config/hello_beer', data=json.dumps({
             'invalid_option': 2
         }))
 
@@ -136,7 +136,7 @@ def test_update_device_config_invalid_json(hass, test_client):
     """Test updating device config."""
     app = mock_http_component_app(hass)
 
-    with patch.object(config, 'SECTIONS', ['zwave']):
+    with patch.object(config, 'SECTIONS', ['group']):
         yield from async_setup_component(hass, 'config', {})
 
     hass.http.views[VIEW_NAME].register(app.router)
@@ -144,6 +144,6 @@ def test_update_device_config_invalid_json(hass, test_client):
     client = yield from test_client(app)
 
     resp = yield from client.post(
-        '/api/config/zwave/device_config/hello.beer', data='not json')
+        '/api/config/group/config/hello_beer', data='not json')
 
     assert resp.status == 400


### PR DESCRIPTION
**Description:**
 - Refactor Z-Wave config web UI into a generic key-based config storage.
 - Add initial group config backend. 

If you want to use this with Home Assistant, make sure your groups are stored in `groups.yaml`:

```yaml
group: !include groups.yaml
```

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
