### PR TITLE
volvooncall bugfixes: fix missing property. see vehicle when discovered.

### DIFF
--- a/homeassistant/components/device_tracker/volvooncall.py
+++ b/homeassistant/components/device_tracker/volvooncall.py
@@ -31,5 +31,6 @@ def setup_scanner(hass, config, see, discovery_info=None):
                  vehicle.position['longitude']))
 
     hass.data[DOMAIN].entities[vin].append(see_vehicle)
+    see_vehicle(vehicle)
 
     return True

--- a/homeassistant/components/switch/volvooncall.py
+++ b/homeassistant/components/switch/volvooncall.py
@@ -42,6 +42,7 @@ class VolvoSwitch(VolvoEntity, ToggleEntity):
         """Return the name of the switch."""
         return 'Heater'
 
+    @property
     def icon(self):
         """Return the icon."""
         return 'mdi:radiator'


### PR DESCRIPTION
**Description:**
- a `@property` was missing
- a vehicle was not seen until the second server update

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
