### PR TITLE
Wink scene(shortcut) support

### DIFF
--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -18,6 +18,8 @@ DEPENDENCIES = ['wink']
 
 SUPPORT_WINK = SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_RGB_COLOR
 
+RGB_MODES = ['hsb', 'rgb']
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Wink lights."""
@@ -54,6 +56,8 @@ class WinkLight(WinkDevice, Light):
         """Current bulb color in RGB."""
         if not self.wink.supports_hue_saturation():
             return None
+        elif self.wink.color_model() not in RGB_MODES:
+            return False
         else:
             hue = self.wink.color_hue()
             saturation = self.wink.color_saturation()

--- a/homeassistant/components/scene/wink.py
+++ b/homeassistant/components/scene/wink.py
@@ -1,0 +1,40 @@
+"""
+Support for Wink scenes.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/scene.wink/
+"""
+import logging
+
+from homeassistant.components.scene import Scene
+from homeassistant.components.wink import WinkDevice, DOMAIN
+
+DEPENDENCIES = ['wink']
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Wink platform."""
+    import pywink
+
+    for scene in pywink.get_scenes():
+        _id = scene.object_id() + scene.name()
+        if _id not in hass.data[DOMAIN]['unique_ids']:
+            add_devices([WinkScene(scene, hass)])
+
+
+class WinkScene(WinkDevice, Scene):
+    """Representation of a Wink shortcut/scene."""
+
+    def __init__(self, wink, hass):
+        """Initialize the Wink device."""
+        super().__init__(wink, hass)
+
+    @property
+    def is_on(self):
+        """Python-wink will always return False."""
+        return self.wink.state()
+
+    def activate(self, **kwargs):
+        """Activate the scene."""
+        self.wink.activate()

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -31,10 +31,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _id = sprinkler.object_id() + sprinkler.name()
         if _id not in hass.data[DOMAIN]['unique_ids']:
             add_devices([WinkToggleDevice(sprinkler, hass)])
-    for scene in pywink.get_scenes():
-        _id = scene.object_id() + scene.name()
-        if _id not in hass.data[DOMAIN]['unique_ids']:
-            add_devices([WinkScene(scene, hass)])
 
 
 class WinkToggleDevice(WinkDevice, ToggleEntity):
@@ -67,24 +63,3 @@ class WinkToggleDevice(WinkDevice, ToggleEntity):
         return {
             'last_event': event
         }
-
-
-class WinkScene(WinkDevice, ToggleEntity):
-    """Representation of a Wink shorcut/scene."""
-
-    def __init__(self, wink, hass):
-        """Initialize the Wink device."""
-        super().__init__(wink, hass)
-
-    @property
-    def is_on(self):
-        """Return true if device is on."""
-        return self.wink.state()
-
-    def turn_on(self, **kwargs):
-        """Turn the device on."""
-        self.wink.activate()
-
-    def turn_off(self):
-        """Scene can only be turned on."""
-        return

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -86,5 +86,5 @@ class WinkScene(WinkDevice, ToggleEntity):
         self.wink.activate()
 
     def turn_off(self):
-        """Scenes can only be turned on."""
+        """Scene can only be turned on."""
         return

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -31,6 +31,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _id = sprinkler.object_id() + sprinkler.name()
         if _id not in hass.data[DOMAIN]['unique_ids']:
             add_devices([WinkToggleDevice(sprinkler, hass)])
+    for scene in pywink.get_scenes():
+        _id = scene.object_id() + scene.name()
+        if _id not in hass.data[DOMAIN]['unique_ids']:
+            add_devices([WinkScene(scene, hass)])
 
 
 class WinkToggleDevice(WinkDevice, ToggleEntity):
@@ -63,3 +67,24 @@ class WinkToggleDevice(WinkDevice, ToggleEntity):
         return {
             'last_event': event
         }
+
+
+class WinkScene(WinkDevice, ToggleEntity):
+    """Representation of a Wink shorcut/scene."""
+
+    def __init__(self, wink, hass):
+        """Initialize the Wink device."""
+        super().__init__(wink, hass)
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self.wink.state()
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        self.wink.activate()
+
+    def turn_off(self):
+        """Scenes can only be turned on."""
+        return

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-wink==1.2.0', 'pubnubsub-handler==1.0.1']
+REQUIREMENTS = ['python-wink==1.2.1', 'pubnubsub-handler==1.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -55,7 +55,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 WINK_COMPONENTS = [
     'binary_sensor', 'sensor', 'light', 'switch', 'lock', 'cover', 'climate',
-    'fan', 'alarm_control_panel'
+    'fan', 'alarm_control_panel', 'scene'
 ]
 
 

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-wink==1.1.1', 'pubnubsub-handler==1.0.1']
+REQUIREMENTS = ['python-wink==1.2.0', 'pubnubsub-handler==1.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -615,7 +615,7 @@ python-twitch==1.3.0
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==1.2.0
+python-wink==1.2.1
 
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -615,7 +615,7 @@ python-twitch==1.3.0
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==1.1.1
+python-wink==1.2.0
 
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5


### PR DESCRIPTION
**Description:**
This adds support for Wink shortcuts as a scene.

NOTE: Wink shortcuts are called scenes in the API

This also adds a small fix for RGB wink bulbs displaying a color in the frontend when they are set to temperature only mode.

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running 

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
