### PR TITLE
Restore input_select and test helper proposal

### DIFF
--- a/homeassistant/components/input_select.py
+++ b/homeassistant/components/input_select.py
@@ -13,6 +13,7 @@ from homeassistant.const import ATTR_ENTITY_ID, CONF_ICON, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.restore_state import async_get_last_state
 
 
 DOMAIN = 'input_select'
@@ -193,6 +194,16 @@ class InputSelect(Entity):
         self._current_option = state
         self._options = options
         self._icon = icon
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Called when entity about to be added to hass."""
+        state = yield from async_get_last_state(self.hass, self.entity_id)
+        if not state:
+            return
+        if state.state not in self._options:
+            return
+        self._current_option = state.state
 
     @property
     def should_poll(self):

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -297,6 +297,9 @@ class Recorder(threading.Thread):
         """Tell the recorder to shut down."""
         global _INSTANCE  # pylint: disable=global-statement
         self.queue.put(None)
+        if not self.start_recording.is_set():
+            _LOGGER.warning("Recorder never started correctly")
+            self.start_recording.set()
         self.join()
         _INSTANCE = None
 

--- a/tests/components/test_input_select.py
+++ b/tests/components/test_input_select.py
@@ -1,10 +1,12 @@
 """The tests for the Input select component."""
 # pylint: disable=protected-access
+import asyncio
 import unittest
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_restore_cache
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.core import State
+from homeassistant.bootstrap import setup_component, async_setup_component
 from homeassistant.components.input_select import (
     ATTR_OPTIONS, DOMAIN, SERVICE_SET_OPTIONS,
     select_option, select_next, select_previous)
@@ -211,3 +213,35 @@ class TestInputSelect(unittest.TestCase):
         self.hass.block_till_done()
         state = self.hass.states.get(entity_id)
         self.assertEqual('test2', state.state)
+
+
+@asyncio.coroutine
+def test_restore_state(hass):
+    """Ensure states are restored on startup."""
+    mock_restore_cache(hass, (
+        State('input_select.s1', 'last option'),
+        State('input_select.s2', 'bad option'),
+    ))
+
+    options = {
+        'options': [
+            'first option',
+            'middle option',
+            'last option',
+        ],
+        'initial': 'middle option',
+    }
+
+    yield from async_setup_component(hass, DOMAIN, {
+        DOMAIN: {
+            's1': options,
+            's2': options,
+        }})
+
+    state = hass.states.get('input_select.s1')
+    assert state
+    assert state.state == 'last option'
+
+    state = hass.states.get('input_select.s2')
+    assert state
+    assert state.state == 'middle option'

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -1,13 +1,17 @@
 """The tests for the Restore component."""
 import asyncio
+from datetime import timedelta
 from unittest.mock import patch, MagicMock
 
+from homeassistant.bootstrap import setup_component
 from homeassistant.const import EVENT_HOMEASSISTANT_START
-from homeassistant.core import CoreState, State
+from homeassistant.core import CoreState, split_entity_id, State
 import homeassistant.util.dt as dt_util
-
+from homeassistant.components import input_boolean, recorder
 from homeassistant.helpers.restore_state import (
     async_get_last_state, DATA_RESTORE_CACHE)
+
+from tests.common import get_test_home_assistant, init_recorder_component
 
 
 @asyncio.coroutine
@@ -40,3 +44,63 @@ def test_caching_data(hass):
     yield from hass.async_block_till_done()
 
     assert DATA_RESTORE_CACHE not in hass.data
+
+
+def _add_data_in_last_run(entities):
+    """Add test data in the last recorder_run."""
+    # pylint: disable=protected-access
+    t_now = dt_util.utcnow() - timedelta(minutes=10)
+    t_min_1 = t_now - timedelta(minutes=20)
+    t_min_2 = t_now - timedelta(minutes=30)
+
+    recorder_runs = recorder.get_model('RecorderRuns')
+    states = recorder.get_model('States')
+    with recorder.session_scope() as session:
+        run = recorder_runs(
+            start=t_min_2,
+            end=t_now,
+            created=t_min_2
+        )
+        recorder._INSTANCE._commit(session, run)
+
+        for entity_id, state in entities.items():
+            dbstate = states(
+                entity_id=entity_id,
+                domain=split_entity_id(entity_id)[0],
+                state=state,
+                attributes='{}',
+                last_changed=t_min_1,
+                last_updated=t_min_1,
+                created=t_min_1)
+            recorder._INSTANCE._commit(session, dbstate)
+
+
+def test_filling_the_cache(hass):
+    """Test filling the cache from the DB."""
+    test_entity_id1 = 'input_boolean.b1'
+    test_entity_id2 = 'input_boolean.b2'
+
+    hass = get_test_home_assistant()
+    hass.state = CoreState.starting
+
+    init_recorder_component(hass)
+
+    _add_data_in_last_run({
+        test_entity_id1: 'on',
+        test_entity_id2: 'off',
+    })
+
+    hass.block_till_done()
+    setup_component(hass, input_boolean.DOMAIN, {
+        input_boolean.DOMAIN: {
+            'b1': None,
+            'b2': None,
+        }})
+
+    state = hass.states.get('input_boolean.b1')
+    assert state
+    assert state.state == 'on'
+
+    state = hass.states.get('input_boolean.b2')
+    assert state
+    assert state.state == 'off'

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -75,7 +75,7 @@ def _add_data_in_last_run(entities):
             recorder._INSTANCE._commit(session, dbstate)
 
 
-def test_filling_the_cache(hass):
+def test_filling_the_cache():
     """Test filling the cache from the DB."""
     test_entity_id1 = 'input_boolean.b1'
     test_entity_id2 = 'input_boolean.b2'
@@ -97,6 +97,8 @@ def test_filling_the_cache(hass):
             'b2': None,
         }})
 
+    hass.start()
+
     state = hass.states.get('input_boolean.b1')
     assert state
     assert state.state == 'on'
@@ -104,3 +106,5 @@ def test_filling_the_cache(hass):
     state = hass.states.get('input_boolean.b2')
     assert state
     assert state.state == 'off'
+
+    hass.stop()


### PR DESCRIPTION
**Description:**
Restore `input_select` based on #4614 

Also propose a standard test helper to test these `restore` functions that will be added everywhere
```python
def mock_restore_cache(hass, states):
```


**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
