### PR TITLE
Added Openhome Support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -243,6 +243,7 @@ omit =
     homeassistant/components/media_player/mpd.py
     homeassistant/components/media_player/nad.py
     homeassistant/components/media_player/onkyo.py
+    homeassistant/components/media_player/openhome.py
     homeassistant/components/media_player/panasonic_viera.py
     homeassistant/components/media_player/pandora.py
     homeassistant/components/media_player/philips_js.py

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -41,6 +41,7 @@ SERVICE_HANDLERS = {
     'yeelight': ('light', 'yeelight'),
     'flux_led': ('light', 'flux_led'),
     'apple_tv': ('media_player', 'apple_tv'),
+    'openhome': ('media_player', 'openhome'),
 }
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/media_player/openhome.py
+++ b/homeassistant/components/media_player/openhome.py
@@ -54,7 +54,7 @@ class OpenhomeDevice(MediaPlayerDevice):
 
     def __init__(self, hass, device):
         """Initialise the Openhome device."""
-      lf.hass = hass
+        self.hass = hass
         self._device = device
         self._track_information = {}
         self._in_standby = None

--- a/homeassistant/components/media_player/openhome.py
+++ b/homeassistant/components/media_player/openhome.py
@@ -86,8 +86,8 @@ class OpenhomeDevice(MediaPlayerDevice):
             source_names.append(source["name"])
             source_index[source["name"]] = source["index"]
 
-        self._source_index = source_index;
-        self._source_names = source_names;
+        self._source_index = source_index
+        self._source_names = source_names
 
         if self._source["type"] == "Radio":
             self._supported_features |= SUPPORT_STOP | SUPPORT_PLAY

--- a/homeassistant/components/media_player/openhome.py
+++ b/homeassistant/components/media_player/openhome.py
@@ -1,0 +1,223 @@
+"""
+Support for Openhome Devices.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.openhome/
+"""
+import logging
+
+from homeassistant.components.media_player import (
+    SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK, SUPPORT_TURN_ON,
+    SUPPORT_TURN_OFF, SUPPORT_VOLUME_SET, SUPPORT_VOLUME_MUTE,
+    SUPPORT_VOLUME_STEP, SUPPORT_STOP, SUPPORT_PLAY, SUPPORT_SELECT_SOURCE,
+    MediaPlayerDevice)
+from homeassistant.const import (
+    STATE_IDLE, STATE_PAUSED, STATE_PLAYING, STATE_OFF)
+
+REQUIREMENTS = ['openhomedevice==0.2']
+
+SUPPORT_OPENHOME = SUPPORT_SELECT_SOURCE | \
+    SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET | \
+    SUPPORT_TURN_OFF | SUPPORT_TURN_ON
+
+_LOGGER = logging.getLogger(__name__)
+
+# List of devices that have been registered
+DEVICES = []
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup Openhome Platform."""
+    from openhomedevice.Device import Device
+
+    if discovery_info:
+        _LOGGER.info('Openhome device found, (%s)', discovery_info[0])
+        device = Device(discovery_info[1])
+
+        # if device already exists by config
+        if device.Uuid() in [x.unique_id for x in DEVICES]:
+            return True
+
+        device = HassOpenhomeDevice(hass, device)
+
+        add_devices([device], True)
+        DEVICES.append(device)
+
+        return True
+
+    return True
+
+
+class HassOpenhomeDevice(MediaPlayerDevice):
+    """Representation of an Openhome device."""
+
+    def __init__(self, hass, device):
+        """Initialise the Openhome device."""
+        self.hass = hass
+        self._device = device
+        self._track_information = {}
+        self._in_standby = None
+        self._transport_state = None
+        self._track_information = None
+        self._volume_level = None
+        self._volume_muted = None
+        self._supported_features = SUPPORT_OPENHOME
+        self._source_names = list()
+        self._name = device.Uuid()
+        self._state = STATE_PLAYING
+
+        self.update()
+
+    def update(self):
+        """Update state of device."""
+        self._in_standby = self._device.IsInStandby()
+        self._transport_state = self._device.TransportState()
+        self._track_information = self._device.TrackInfo()
+        self._volume_level = self._device.VolumeLevel()
+        self._volume_muted = self._device.IsMuted()
+        self._source = self._device.Source()
+        self._source_index = {}
+        self._name = self._device.Room().decode('utf-8')
+        self._supported_features = SUPPORT_OPENHOME
+
+        for source in self._device.Sources():
+            self._source_names.append(source["name"])
+            self._source_index[source["name"]] = source["index"]
+
+        if self._source["type"] == "Radio":
+            if self._transport_state in ('Playing', 'Buffering'):
+                self._supported_features |= SUPPORT_STOP
+            else:
+                self._supported_features |= SUPPORT_PLAY
+        if self._source["type"] == "Playlist":
+            self._supported_features |= SUPPORT_PREVIOUS_TRACK |\
+                SUPPORT_NEXT_TRACK
+            if self._transport_state in ('Playing', 'Buffering'):
+                self._supported_features |= SUPPORT_PAUSE
+            else:
+                self._supported_features |= SUPPORT_PLAY
+
+        if self._in_standby:
+            self._state = STATE_OFF
+        elif self._transport_state == 'Paused':
+            self._state = STATE_PAUSED
+        elif self._transport_state in ('Playing', 'Buffering'):
+            self._state = STATE_PLAYING
+        elif self._transport_state == 'Stopped':
+            self._state = STATE_IDLE
+        else:
+            self._state = STATE_PLAYING
+
+    def turn_on(self):
+        """Bring device out of standby."""
+        self._device.SetStandby(False)
+
+    def turn_off(self):
+        """Put device in standby."""
+        self._device.SetStandby(True)
+
+    def media_pause(self):
+        """Send pause command."""
+        self._device.Pause()
+
+    def media_stop(self):
+        """Send stop command."""
+        self._device.Stop()
+
+    def media_play(self):
+        """Send play commmand."""
+        self._device.Play()
+
+    def media_next_track(self):
+        """Send next track command."""
+        self._device.Skip(1)
+
+    def media_previous_track(self):
+        """Send previous track command."""
+        self._device.Skip(-1)
+
+    def select_source(self, source):
+        """Select input source."""
+        self._device.SetSource(self._source_index[source])
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def supported_features(self):
+        """Flag of features commands that are supported."""
+        return self._supported_features
+
+    @property
+    def should_poll(self):
+        """Polling needed."""
+        return True
+
+    @property
+    def unique_id(self):
+        """Return an unique ID."""
+        return self._device.Uuid()
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def source_list(self):
+        """List of available input sources."""
+        return self._source_names
+
+    @property
+    def media_image_url(self):
+        """Image url of current playing media."""
+        return self._track_information["albumArt"]
+
+    @property
+    def media_artist(self):
+        """Artist of current playing media, music track only."""
+        return self._track_information["artist"]
+
+    @property
+    def media_album_name(self):
+        """Album name of current playing media, music track only."""
+        return self._track_information["album"]
+
+    @property
+    def media_title(self):
+        """Title of current playing media."""
+        return self._track_information["title"]
+
+    @property
+    def source(self):
+        """Name of the current input source."""
+        return self._source["name"]
+
+    @property
+    def volume_level(self):
+        """Volume level of the media player (0..1)."""
+        return self._volume_level / 100.0
+
+    @property
+    def is_volume_muted(self):
+        """Return true if volume is muted."""
+        return self._volume_muted
+
+    def volume_up(self):
+        """Volume up media player."""
+        self._device.IncreaseVolume()
+
+    def volume_down(self):
+        """Volume down media player."""
+        self._device.DecreaseVolume()
+
+    def set_volume_level(self, volume):
+        """Set volume level, range 0..1."""
+        self._device.SetVolumeLevel(int(volume * 100))
+
+    def mute_volume(self, mute):
+        """Mute (true) or unmute (false) media player."""
+        self._device.SetMute(mute)

--- a/homeassistant/components/media_player/openhome.py
+++ b/homeassistant/components/media_player/openhome.py
@@ -35,11 +35,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.info('Openhome device found, (%s)', discovery_info[0])
         device = Device(discovery_info[1])
 
-        # if device already exists by config
+        # if device has already been discovered
         if device.Uuid() in [x.unique_id for x in DEVICES]:
             return True
 
-        device = HassOpenhomeDevice(hass, device)
+        device = OpenhomeDevice(hass, device)
 
         add_devices([device], True)
         DEVICES.append(device)
@@ -49,12 +49,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     return True
 
 
-class HassOpenhomeDevice(MediaPlayerDevice):
+class OpenhomeDevice(MediaPlayerDevice):
     """Representation of an Openhome device."""
 
     def __init__(self, hass, device):
         """Initialise the Openhome device."""
-        self.hass = hass
+      lf.hass = hass
         self._device = device
         self._track_information = {}
         self._in_standby = None
@@ -64,10 +64,8 @@ class HassOpenhomeDevice(MediaPlayerDevice):
         self._volume_muted = None
         self._supported_features = SUPPORT_OPENHOME
         self._source_names = list()
-        self._name = device.Uuid()
+        self._name = None
         self._state = STATE_PLAYING
-
-        self.update()
 
     def update(self):
         """Update state of device."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -364,6 +364,9 @@ oemthermostat==1.1
 # homeassistant.components.sensor.openevse
 openevsewifi==0.4
 
+# homeassistant.components.media_player.openhome
+openhomedevice==0.2
+
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1
 


### PR DESCRIPTION
**Description:**
This introduces support for Openhome devices such as the HiFi streamers made by [Linn Products Ltd.](https://www.linn.co.uk)

There are freely available software players which are openhome compliant available at:
http://openhome.org/
https://petemanchester.github.io/MediaPlayer/

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#2107

**Example entry for `configuration.yaml`**
```yaml
discovery:
media_player:
  - platform: openhome
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.