### PR TITLE
Return None instead of raising ValueException from as_timestamp template function.

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -387,6 +387,14 @@ def timestamp_utc(value):
         return value
 
 
+def forgiving_as_timestamp(value):
+    """Try to convert value to timestamp."""
+    try:
+        return dt_util.as_timestamp(value)
+    except (ValueError, TypeError):
+        return None
+
+
 def strptime(string, fmt):
     """Parse a time string to datetime."""
     try:
@@ -430,6 +438,6 @@ ENV.filters['min'] = min
 ENV.globals['float'] = forgiving_float
 ENV.globals['now'] = dt_util.now
 ENV.globals['utcnow'] = dt_util.utcnow
-ENV.globals['as_timestamp'] = dt_util.as_timestamp
+ENV.globals['as_timestamp'] = forgiving_as_timestamp
 ENV.globals['relative_time'] = dt_util.get_age
 ENV.globals['strptime'] = strptime

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -215,6 +215,21 @@ class TestHelpersTemplate(unittest.TestCase):
                 template.Template('{{ %s | timestamp_utc }}' % inp,
                                   self.hass).render())
 
+    def test_as_timestamp(self):
+        """Test the as_timestamp function."""
+        self.assertEqual("None",
+                         template.Template('{{ as_timestamp("invalid") }}',
+                                           self.hass).render())
+        self.hass.mock = None
+        self.assertEqual("None",
+                         template.Template('{{ as_timestamp(states.mock) }}',
+                                           self.hass).render())
+
+        tpl = '{{ as_timestamp(strptime("2024-02-03T09:10:24+0000", ' \
+            '"%Y-%m-%dT%H:%M:%S%z")) }}'
+        self.assertEqual("1706951424.0",
+                         template.Template(tpl, self.hass).render())
+
     def test_passing_vars_as_keywords(self):
         """Test passing variables as keywords."""
         self.assertEqual(


### PR DESCRIPTION
**Description:** 

Return None instead of raising ValueException from as_timestamp template function. 

Other template extensions, like float, round, and other datetime ones, avoid raising exceptions. I also think the exception should not be raised here.

See https://community.home-assistant.io/t/sanity-check-for-as-timestamp/12358 .

**Related issue (if applicable):** #5076 #3659

**Checklist:**

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

