### PR TITLE
Local file camera now supports yet inexistent files.

### DIFF
--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -8,7 +8,8 @@ from mock_open import MockOpen
 
 from homeassistant.bootstrap import setup_component
 
-from tests.common import assert_setup_component, mock_http_component
+from tests.common import mock_http_component
+import logging
 
 
 @asyncio.coroutine
@@ -42,19 +43,25 @@ def test_loading_file(hass, test_client):
 
 
 @asyncio.coroutine
-def test_file_not_readable(hass):
-    """Test local file will not setup when file is not readable."""
+def test_file_not_readable(hass, caplog):
+    """Test a warning is shown setup when file is not readable."""
     mock_http_component(hass)
 
+    @mock.patch('os.path.isfile', mock.Mock(return_value=True))
+    @mock.patch('os.access', mock.Mock(return_value=False))
     def run_test():
-        with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
-                mock.patch('os.access', return_value=False), \
-                assert_setup_component(0, 'camera'):
-            assert setup_component(hass, 'camera', {
-                'camera': {
-                    'name': 'config_test',
-                    'platform': 'local_file',
-                    'file_path': 'mock.file',
-                }})
+
+        caplog.set_level(
+            logging.WARNING, logger='requests.packages.urllib3.connectionpool')
+
+        assert setup_component(hass, 'camera', {
+            'camera': {
+                'name': 'config_test',
+                'platform': 'local_file',
+                'file_path': 'mock.file',
+            }})
+        assert 'Could not read' in caplog.text
+        assert 'config_test' in caplog.text
+        assert 'mock.file' in caplog.text
 
     yield from hass.loop.run_in_executor(None, run_test)


### PR DESCRIPTION
**Description:** 

Local file camera has an explicit check to ensure the local file exists and can be read. 

In my use case, the file appears in the file system only after a few minutes, as I use a memory fs to store the camera image. However at this time the camera component was already discarded and the image will never show up. 

With this fix, by allowing the component to be set up, the local file is picked up as soon as it is available. This is also more forgiving with situations where network drives or usb drives are not available during HA initialization. 

The initialized component, when the image is not loaded, is harmless as the user receives a correct message in the frontend ("Error loading image."). UI behaves correctly on addition and removal of the image from the filesystem.

This patch also adds a concise logger error (instead of an exception) when the file cannot be read.  

**Checklist:**

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

