### PR TITLE
Changed coerce applied to light.transition attribute from int to float

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -88,7 +88,7 @@ PROP_TO_ATTR = {
 }
 
 # Service call validation schemas
-VALID_TRANSITION = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=900))
+VALID_TRANSITION = vol.All(vol.Coerce(float), vol.Clamp(min=0, max=900))
 VALID_BRIGHTNESS = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255))
 
 LIGHT_TURN_ON_SCHEMA = vol.Schema({

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -366,7 +366,7 @@ class HueLight(Light):
         command = {'on': True}
 
         if ATTR_TRANSITION in kwargs:
-            command['transitiontime'] = kwargs[ATTR_TRANSITION] * 10
+            command['transitiontime'] = int(kwargs[ATTR_TRANSITION] * 10)
 
         if ATTR_XY_COLOR in kwargs:
             command['xy'] = kwargs[ATTR_XY_COLOR]
@@ -412,7 +412,10 @@ class HueLight(Light):
         if ATTR_TRANSITION in kwargs:
             # Transition time is in 1/10th seconds and cannot exceed
             # 900 seconds.
-            command['transitiontime'] = min(9000, kwargs[ATTR_TRANSITION] * 10)
+            command['transitiontime'] = min(
+                9000,
+                int(kwargs[ATTR_TRANSITION] * 10)
+            )
 
         flash = kwargs.get(ATTR_FLASH)
 

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -202,7 +202,7 @@ class LIFXLight(Light):
     def turn_on(self, **kwargs):
         """Turn the device on."""
         if ATTR_TRANSITION in kwargs:
-            fade = kwargs[ATTR_TRANSITION] * 1000
+            fade = int(kwargs[ATTR_TRANSITION] * 1000)
         else:
             fade = 0
 
@@ -238,7 +238,7 @@ class LIFXLight(Light):
     def turn_off(self, **kwargs):
         """Turn the device off."""
         if ATTR_TRANSITION in kwargs:
-            fade = kwargs[ATTR_TRANSITION] * 1000
+            fade = int(kwargs[ATTR_TRANSITION] * 1000)
         else:
             fade = 0
 

--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -143,7 +143,7 @@ def state(new_state):
                 pipeline.on()
             # Set transition time.
             if ATTR_TRANSITION in kwargs:
-                transition_time = kwargs[ATTR_TRANSITION]
+                transition_time = int(kwargs[ATTR_TRANSITION])
             # Do group type-specific work.
             function(self, transition_time, pipeline, **kwargs)
             # Update state.

--- a/homeassistant/components/light/mqtt_json.py
+++ b/homeassistant/components/light/mqtt_json.py
@@ -215,7 +215,7 @@ class MqttJson(Light):
                 message['flash'] = self._flash_times[CONF_FLASH_TIME_SHORT]
 
         if ATTR_TRANSITION in kwargs:
-            message['transition'] = kwargs[ATTR_TRANSITION]
+            message['transition'] = int(kwargs[ATTR_TRANSITION])
 
         if ATTR_BRIGHTNESS in kwargs:
             message['brightness'] = int(kwargs[ATTR_BRIGHTNESS])
@@ -245,7 +245,7 @@ class MqttJson(Light):
         message = {'state': 'OFF'}
 
         if ATTR_TRANSITION in kwargs:
-            message['transition'] = kwargs[ATTR_TRANSITION]
+            message['transition'] = int(kwargs[ATTR_TRANSITION])
 
         mqtt.async_publish(
             self.hass, self._topic[CONF_COMMAND_TOPIC], json.dumps(message),

--- a/homeassistant/components/light/mqtt_template.py
+++ b/homeassistant/components/light/mqtt_template.py
@@ -269,7 +269,7 @@ class MqttTemplate(Light):
 
         # transition
         if ATTR_TRANSITION in kwargs:
-            values['transition'] = kwargs[ATTR_TRANSITION]
+            values['transition'] = int(kwargs[ATTR_TRANSITION])
 
         mqtt.async_publish(
             self.hass, self._topics[CONF_COMMAND_TOPIC],
@@ -293,7 +293,7 @@ class MqttTemplate(Light):
 
         # transition
         if ATTR_TRANSITION in kwargs:
-            values['transition'] = kwargs[ATTR_TRANSITION]
+            values['transition'] = int(kwargs[ATTR_TRANSITION])
 
         mqtt.async_publish(
             self.hass, self._topics[CONF_COMMAND_TOPIC],

--- a/homeassistant/components/light/osramlightify.py
+++ b/homeassistant/components/light/osramlightify.py
@@ -145,7 +145,7 @@ class OsramLightifyLight(Light):
         self._state = self._light.on()
 
         if ATTR_TRANSITION in kwargs:
-            transition = kwargs[ATTR_TRANSITION] * 10
+            transition = int(kwargs[ATTR_TRANSITION] * 10)
             _LOGGER.debug("turn_on requested transition time for light:"
                           " %s is: %s ",
                           self._name, transition)
@@ -196,7 +196,7 @@ class OsramLightifyLight(Light):
         _LOGGER.debug("turn_off Attempting to turn off light: %s ",
                       self._name)
         if ATTR_TRANSITION in kwargs:
-            transition = kwargs[ATTR_TRANSITION] * 10
+            transition = int(kwargs[ATTR_TRANSITION] * 10)
             _LOGGER.debug("turn_off requested transition time for light:"
                           " %s is: %s ",
                           self._name, transition)

--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -259,7 +259,7 @@ class YeelightLight(Light):
                 _LOGGER.error("Flash supported currently only in RGB mode.")
                 return
 
-            transition = self.config[CONF_TRANSITION]
+            transition = int(self.config[CONF_TRANSITION])
             if flash == FLASH_LONG:
                 count = 1
                 duration = transition * 5
@@ -288,9 +288,9 @@ class YeelightLight(Light):
         rgb = kwargs.get(ATTR_RGB_COLOR)
         flash = kwargs.get(ATTR_FLASH)
 
-        duration = self.config[CONF_TRANSITION]  # in ms
+        duration = int(self.config[CONF_TRANSITION])  # in ms
         if ATTR_TRANSITION in kwargs:  # passed kwarg overrides config
-            duration = kwargs.get(ATTR_TRANSITION) * 1000  # kwarg in s
+            duration = int(kwargs.get(ATTR_TRANSITION) * 1000)  # kwarg in s
 
         self._bulb.turn_on(duration=duration)
 


### PR DESCRIPTION
Nearly all lights that support transitions, allow values between 0 and 1, but the transition attribute got coerced to an int.

Each device containing SUPPORT_TRANSITION has been edited to cope with the altered input.