### PR TITLE
Recorder async & remove start_recording event

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -239,7 +239,7 @@ class Recorder(threading.Thread):
             async_track_time_interval(
                 self.hass, self._purge_old_data, timedelta(days=2))
 
-        _wait(self.start_recording, "Waiting to start recording")
+        _wait(self.start_recording, "Waiting to start recording", 90)
 
         while True:
             event = self.queue.get()
@@ -499,13 +499,13 @@ class Recorder(threading.Thread):
         return False
 
 
-def _wait(event, message):
+def _wait(event, message, interval=15):
     """Event wait helper."""
-    for retry in (10, 20, 30):
-        event.wait(10)
+    for mult in range(1, 4):
+        event.wait(interval)
         if event.is_set():
             return
-        msg = message + " ({} seconds)".format(retry)
+        msg = "{} ({} seconds)".format(message, interval*mult)
         _LOGGER.warning(msg)
     if not event.is_set():
         raise HomeAssistantError(msg)

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -6,7 +6,8 @@ from datetime import timedelta
 from homeassistant.core import HomeAssistant, CoreState, callback
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.components.history import get_states, last_recorder_run
-from homeassistant.components.recorder import DOMAIN as _RECORDER
+from homeassistant.components.recorder import (
+    async_get_instance, DOMAIN as _RECORDER)
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,6 +57,8 @@ def async_get_last_state(hass, entity_id: str):
         _LOGGER.error("Cache can only be loaded during startup, not %s",
                       hass.state)
         return None
+
+    yield from async_get_instance()  # Ensure recorder ready
 
     if _LOCK not in hass.data:
         hass.data[_LOCK] = asyncio.Lock(loop=hass.loop)

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -11,7 +11,8 @@ from homeassistant.components import input_boolean, recorder
 from homeassistant.helpers.restore_state import (
     async_get_last_state, DATA_RESTORE_CACHE)
 
-from tests.common import get_test_home_assistant, init_recorder_component
+from tests.common import (
+    get_test_home_assistant, mock_coro, init_recorder_component)
 
 
 @asyncio.coroutine
@@ -29,7 +30,9 @@ def test_caching_data(hass):
     with patch('homeassistant.helpers.restore_state.last_recorder_run',
                return_value=MagicMock(end=dt_util.utcnow())), \
             patch('homeassistant.helpers.restore_state.get_states',
-                  return_value=states):
+                  return_value=states), \
+            patch('homeassistant.helpers.restore_state.async_get_instance',
+                  return_value=mock_coro()):
         state = yield from async_get_last_state(hass, 'input_boolean.b1')
 
     assert DATA_RESTORE_CACHE in hass.data


### PR DESCRIPTION
**Description:**
#4614 made the startup timer for recorder 30 seconds - way too short for certain components.

This PR removes the `recording_start` Event that in the past indicated the recorder can start writing. Since the restore cache inspects the run, we can really start writing data in the new run earlier.

In order to check if the recorder connected in an async friendly way (without blocking the executor pool) this PR adds an asyncio.Event `async_db_ready` which is equivalent to the threading.Event `db_event`. 
These events are checked with `get_instance` and `async_get_instance` respectively.


**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
