### PR TITLE
Bump qnapstats requirement to 0.2.3 release

### DIFF
--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 
 import voluptuous as vol
 
-REQUIREMENTS = ['qnapstats==0.2.2']
+REQUIREMENTS = ['qnapstats==0.2.3']
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes compatibility issues with QNAP firmware 4.2.3 with some models (TS-639Pro)
https://github.com/colinodell/python-qnapstats/issues/4
