### PR TITLE
tellduslive: cache name in entity. updated library dependency

### DIFF
--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -17,7 +17,7 @@ import voluptuous as vol
 
 DOMAIN = 'tellduslive'
 
-REQUIREMENTS = ['tellduslive==0.3.2']
+REQUIREMENTS = ['tellduslive==0.3.4']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -104,7 +104,8 @@ class TelldusLiveClient(object):
 
     def _sync(self):
         """Update local list of devices."""
-        self._client.update()
+        if not self._client.update():
+            _LOGGER.warning('Failed request')
 
         def identify_device(device):
             """Find out what type of HA component to create."""
@@ -160,10 +161,13 @@ class TelldusLiveEntity(Entity):
         self._id = device_id
         self._client = hass.data[DOMAIN]
         self._client.entities.append(self)
+        self._name = self.device.name
         _LOGGER.debug('Created device %s', self)
 
     def changed(self):
         """A property of the device might have changed."""
+        if self.device.name:
+            self._name = self.device.name
         self.schedule_update_ha_state()
 
     @property
@@ -194,7 +198,7 @@ class TelldusLiveEntity(Entity):
     @property
     def name(self):
         """Return name of device."""
-        return self.device.name or DEVICE_DEFAULT_NAME
+        return self._name or DEVICE_DEFAULT_NAME
 
     @property
     def available(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -685,7 +685,7 @@ steamodd==4.21
 tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
-tellduslive==0.3.2
+tellduslive==0.3.4
 
 # homeassistant.components.sensor.temper
 temperusb==1.5.1


### PR DESCRIPTION
- cache name in entity so we can display it even if the connection is lost
- update tellduslive dependency (including increased timeout, which might help connection issues reported by users). also check return value from update

**Description:**


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
