### PR TITLE
QNAP update

### DIFF
--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 
 import voluptuous as vol
 
-REQUIREMENTS = ['qnapstats==0.2.2']
+REQUIREMENTS = ['qnapstats==0.2.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
     CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_PORT, CONF_SSL,
-    CONF_VERIFY_SSL, CONF_MONITORED_CONDITIONS, TEMP_CELSIUS)
+    CONF_VERIFY_SSL, CONF_TIMEOUT, CONF_MONITORED_CONDITIONS, TEMP_CELSIUS)
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
@@ -44,6 +44,7 @@ CONF_NICS = 'nics'
 CONF_VOLUMES = 'volumes'
 DEFAULT_NAME = 'QNAP'
 DEFAULT_PORT = 8080
+DEFAULT_TIMEOUT = 5
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
@@ -88,6 +89,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SSL, default=False): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS):
@@ -177,7 +179,8 @@ class QNAPStatsAPI(object):
             config.get(CONF_PORT),
             config.get(CONF_USERNAME),
             config.get(CONF_PASSWORD),
-            verify_ssl=config.get(CONF_VERIFY_SSL)
+            verify_ssl=config.get(CONF_VERIFY_SSL),
+            timeout=config.get(CONF_TIMEOUT),
         )
 
         self.data = {}

--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -48,6 +48,9 @@ DEFAULT_TIMEOUT = 5
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
+NOTIFICATION_ID = 'qnap_notification'
+NOTIFICATION_TITLE = 'QNAP Sensor Setup'
+
 _HEALTH_MON_COND = {
     'status': ['Status', None, 'mdi:checkbox-marked-circle-outline'],
 }
@@ -105,6 +108,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the QNAP NAS sensor."""
     api = QNAPStatsAPI(config)
     api.update()
+
+    if not api.data:
+        import homeassistant.loader as loader
+        loader.get_component('persistent_notification').create(
+            hass, 'Error: Failed to set up QNAP sensor.<br />'
+                  'Check the logs for additional information. '
+                  'You will need to restart hass after fixing.',
+            title=NOTIFICATION_TITLE,
+            notification_id=NOTIFICATION_ID)
+        return False
 
     sensors = []
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -620,7 +620,7 @@ pywemo==0.4.13
 pyzabbix==0.7.4
 
 # homeassistant.components.sensor.qnap
-qnapstats==0.2.2
+qnapstats==0.2.3
 
 # homeassistant.components.climate.radiotherm
 radiotherm==1.2


### PR DESCRIPTION
## Description:

Several small enhancements to the QNAP sensor:

### Library Version Bump

Bumps underlying library version to [0.2.3](https://github.com/colinodell/python-qnapstats/releases/tag/0.2.3), which fixes compatibility issues with some QNAP devices.

### New `timeout` setting

The underlying library now supports a configurable timeout.  This is needed because some lower-end models are slower and therefore need more time to supply their data.  (If the first API data update fails, this setup process of this sensor will fail)

### Persistent notification on sensor setup failure

If the sensor setup fails to obtain the necessary API data (usually due to a timeout or incorrect server settings), it now shows a persistent notification.  This behavior was mirrored from the Amcrest component, which also requires API data during setup.

### New `system_temp` condition

HASS users can now monitor the system temperature of their QNAP device.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2112

## Example entry for `configuration.yaml` (if applicable):

Here's a minimal configuration showing the new `timeout` and `system_temp` options:

```yaml
  - platform: qnap
    host: 192.168.1.10
    ssl: false
    timeout: 15
    username: admin
    password: correcthorsebatterystaple
    monitored_conditions:
      - system_temp
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
