### PR TITLE
Make PR template cleaner

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,16 @@
-**Description:**
+## Description:
 
 
 **Related issue (if applicable):** fixes #<home-assistant issue number goes here>
 
 **Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
 
-**Example entry for `configuration.yaml` (if applicable):**
+## Example entry for `configuration.yaml` (if applicable):
 ```yaml
 
 ```
 
-**Checklist:**
+## Checklist:
 
 If user exposed functionality or configuration variables are added/changed:
   - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)


### PR DESCRIPTION
Updates the PR template to use H2 headers (`## ` in Markdown).  This formatting makes it easier to visually differentiate between the different sections.

You can see an example of this in #6182