### PR TITLE
Bugfix restore loading cache with startup state

### DIFF
--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -36,6 +36,7 @@ IGNORE_DOMAINS = ('zone', 'scene',)
 
 def last_recorder_run():
     """Retireve the last closed recorder run from the DB."""
+    recorder.get_instance()
     rec_runs = recorder.get_model('RecorderRuns')
     with recorder.session_scope() as session:
         res = recorder.query(rec_runs).order_by(rec_runs.end.desc()).first()

--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -146,7 +146,7 @@ class InputBoolean(ToggleEntity):
         state = yield from async_get_last_state(self.hass, self.entity_id)
         if not state:
             return
-        self._state = state.state == 'on'
+        self._state = state.state == STATE_ON
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):


### PR DESCRIPTION
**Description:**
Fix #4614.

I always test with hass.restart and have got "commented" out invalid config items, so never really tested this because of no restart on validation failures :-( 

**Related issue (if applicable):** fixes #6172

**Checklist:**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
