### PR TITLE
Remove CoreState.starting

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -99,7 +99,6 @@ class CoreState(enum.Enum):
     """Represent the current state of Home Assistant."""
 
     not_running = 'NOT_RUNNING'
-    starting = 'STARTING'
     running = 'RUNNING'
     stopping = 'STOPPING'
 
@@ -134,7 +133,7 @@ class HomeAssistant(object):
     @property
     def is_running(self) -> bool:
         """Return if Home Assistant is running."""
-        return self.state in (CoreState.starting, CoreState.running)
+        return self.state == CoreState.running
 
     def start(self) -> None:
         """Start home assistant."""
@@ -159,13 +158,11 @@ class HomeAssistant(object):
         This method is a coroutine.
         """
         _LOGGER.info("Starting Home Assistant")
-        self.state = CoreState.starting
-
         # pylint: disable=protected-access
+        self.state = CoreState.running
         self.loop._thread_ident = threading.get_ident()
         _async_create_timer(self)
         self.bus.async_fire(EVENT_HOMEASSISTANT_START)
-        self.state = CoreState.running
 
     def add_job(self, target: Callable[..., None], *args: Any) -> None:
         """Add job to the executor pool.

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from homeassistant.core import HomeAssistant, CoreState, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.components.history import get_states, last_recorder_run
 from homeassistant.components.recorder import DOMAIN as _RECORDER
@@ -21,7 +21,6 @@ def _load_restore_cache(hass: HomeAssistant):
     def remove_cache(event):
         """Remove the states cache."""
         hass.data.pop(DATA_RESTORE_CACHE, None)
-
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, remove_cache)
 
     last_run = last_recorder_run()
@@ -48,14 +47,14 @@ def _load_restore_cache(hass: HomeAssistant):
 @asyncio.coroutine
 def async_get_last_state(hass, entity_id: str):
     """Helper to restore state."""
-    if DATA_RESTORE_CACHE in hass.data:
-        return hass.data[DATA_RESTORE_CACHE].get(entity_id)
-
-    if (_RECORDER not in hass.config.components or
-            hass.state not in (CoreState.starting, CoreState.not_running)):
-        _LOGGER.error("Cache can only be loaded during startup, not %s",
+    if _RECORDER not in hass.config.components:
+        return None
+    elif hass.is_running:
+        _LOGGER.debug("Cache can only be loaded during startup, not %s",
                       hass.state)
         return None
+    elif DATA_RESTORE_CACHE in hass.data:
+        return hass.data[DATA_RESTORE_CACHE].get(entity_id)
 
     if _LOCK not in hass.data:
         hass.data[_LOCK] = asyncio.Lock(loop=hass.loop)
@@ -65,14 +64,16 @@ def async_get_last_state(hass, entity_id: str):
             yield from hass.loop.run_in_executor(
                 None, _load_restore_cache, hass)
 
-    return hass.data.get(DATA_RESTORE_CACHE, {}).get(entity_id)
+    return hass.data[DATA_RESTORE_CACHE].get(entity_id)
 
 
 @asyncio.coroutine
 def async_restore_state(entity, extract_info):
     """Helper to call entity.async_restore_state with cached info."""
-    if entity.hass.state != CoreState.starting:
-        _LOGGER.debug("Not restoring state: State is not starting: %s",
+    if _RECORDER not in entity.hass.config.components:
+        return
+    elif entity.hass.is_running:
+        _LOGGER.debug("Not restoring state: hass is already running: %s",
                       entity.hass.state)
         return
 

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -155,7 +155,6 @@ class HomeAssistant(ha.HomeAssistant):
                 raise HomeAssistantError(
                     'Unable to setup local API to receive events')
 
-        self.state = ha.CoreState.starting
         # pylint: disable=protected-access
         ha._async_create_timer(self)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -108,8 +108,6 @@ def async_test_home_assistant(loop):
     if 'custom_components.test' not in loader.AVAILABLE_COMPONENTS:
         yield from loop.run_in_executor(None, loader.prepare, hass)
 
-    hass.state = ha.CoreState.running
-
     # Mock async_start
     orig_start = hass.async_start
 
@@ -237,6 +235,7 @@ def mock_http_component(hass, api_password=None):
 
 def mock_http_component_app(hass, api_password=None):
     """Create an aiohttp.web.Application instance for testing."""
+    hass.state = ha.CoreState.running
     if 'http' not in hass.config.components:
         mock_http_component(hass, api_password)
     app = web.Application(middlewares=[auth_middleware], loop=hass.loop)
@@ -475,5 +474,4 @@ def mock_restore_cache(hass, states):
     _LOGGER.debug('Restore cache: %s', hass.data[DATA_RESTORE_CACHE])
     assert len(hass.data[DATA_RESTORE_CACHE]) == len(states), \
         "Duplicate entity_id? {}".format(states)
-    hass.state = ha.CoreState.starting
     hass.config.components.add(recorder.DOMAIN)

--- a/tests/components/camera/test_generic.py
+++ b/tests/components/camera/test_generic.py
@@ -2,12 +2,14 @@
 import asyncio
 from unittest import mock
 
+from homeassistant.core import CoreState
 from homeassistant.bootstrap import setup_component
 
 
 @asyncio.coroutine
 def test_fetching_url(aioclient_mock, hass, test_client):
     """Test that it fetches the given url."""
+    hass.state = CoreState.running
     aioclient_mock.get('http://example.com', text='hello world')
 
     def setup_platform():
@@ -39,6 +41,7 @@ def test_fetching_url(aioclient_mock, hass, test_client):
 @asyncio.coroutine
 def test_limit_refetch(aioclient_mock, hass, test_client):
     """Test that it fetches the given url."""
+    hass.state = CoreState.running
     aioclient_mock.get('http://example.com/5a', text='hello world')
     aioclient_mock.get('http://example.com/10a', text='hello world')
     aioclient_mock.get('http://example.com/15a', text='hello planet')

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -6,6 +6,7 @@ from unittest import mock
 # https://bugs.python.org/issue23004
 from mock_open import MockOpen
 
+from homeassistant.core import CoreState
 from homeassistant.bootstrap import setup_component
 
 from tests.common import assert_setup_component, mock_http_component
@@ -14,6 +15,8 @@ from tests.common import assert_setup_component, mock_http_component
 @asyncio.coroutine
 def test_loading_file(hass, test_client):
     """Test that it loads image from disk."""
+    hass.state = CoreState.running
+
     @mock.patch('os.path.isfile', mock.Mock(return_value=True))
     @mock.patch('os.access', mock.Mock(return_value=True))
     def setup_platform():

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -3,7 +3,7 @@
 import asyncio
 import unittest
 
-from homeassistant.core import State, CoreState
+from homeassistant.core import State
 from homeassistant.bootstrap import setup_component, async_setup_component
 import homeassistant.components.light as light
 from homeassistant.helpers.restore_state import DATA_RESTORE_CACHE
@@ -69,7 +69,6 @@ class TestDemoLight(unittest.TestCase):
 def test_restore_state(hass):
     """Test state gets restored."""
     hass.config.components.add('recorder')
-    hass.state = CoreState.starting
     hass.data[DATA_RESTORE_CACHE] = {
         'light.bed_light': State('light.bed_light', 'on', {
             'brightness': 'value-brightness',

--- a/tests/components/test_input_boolean.py
+++ b/tests/components/test_input_boolean.py
@@ -6,7 +6,7 @@ import logging
 
 from tests.common import get_test_home_assistant
 
-from homeassistant.core import CoreState, State
+from homeassistant.core import State
 from homeassistant.bootstrap import setup_component, async_setup_component
 from homeassistant.components.input_boolean import (
     DOMAIN, is_on, toggle, turn_off, turn_on)
@@ -117,7 +117,6 @@ def test_restore_state(hass):
         'input_boolean.b3': State('input_boolean.b3', 'on'),
     }
 
-    hass.state = CoreState.starting
     hass.config.components.add('recorder')
 
     yield from async_setup_component(hass, DOMAIN, {

--- a/tests/helpers/test_aiohttp_client.py
+++ b/tests/helpers/test_aiohttp_client.py
@@ -4,7 +4,7 @@ import unittest
 
 import aiohttp
 
-from homeassistant.core import EVENT_HOMEASSISTANT_CLOSE
+from homeassistant.core import EVENT_HOMEASSISTANT_CLOSE, CoreState
 from homeassistant.bootstrap import setup_component
 import homeassistant.helpers.aiohttp_client as client
 from homeassistant.util.async import run_callback_threadsafe
@@ -121,6 +121,7 @@ class TestHelpersAiohttpClient(unittest.TestCase):
 @asyncio.coroutine
 def test_fetching_url(aioclient_mock, hass, test_client):
     """Test that it fetches the given url."""
+    hass.state = CoreState.running
     aioclient_mock.get('http://example.com/mjpeg_stream', content=[
         b'Frame1', b'Frame2', b'Frame3'
     ])

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 
 from homeassistant.bootstrap import setup_component
 from homeassistant.const import EVENT_HOMEASSISTANT_START
-from homeassistant.core import CoreState, split_entity_id, State
+from homeassistant.core import split_entity_id, State
 import homeassistant.util.dt as dt_util
 from homeassistant.components import input_boolean, recorder
 from homeassistant.helpers.restore_state import (
@@ -18,7 +18,6 @@ from tests.common import get_test_home_assistant, init_recorder_component
 def test_caching_data(hass):
     """Test that we cache data."""
     hass.config.components.add('recorder')
-    hass.state = CoreState.starting
 
     states = [
         State('input_boolean.b0', 'on'),
@@ -81,7 +80,6 @@ def test_filling_the_cache():
     test_entity_id2 = 'input_boolean.b2'
 
     hass = get_test_home_assistant()
-    hass.state = CoreState.starting
 
     init_recorder_component(hass)
 


### PR DESCRIPTION
Followup to #6189. Should not go into 0.39.

Hass has an enum for states. One of them is CoreState.starting. However, due to the way the system is setup, we will never be in this state and neither do we have any code that depends on it.