### PR TITLE
Random test fixes

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -34,7 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_COMPONENT = 'component'
 
 ERROR_LOG_FILENAME = 'home-assistant.log'
-_PERSISTENT_ERRORS = {}
+DATA_PERSISTENT_ERRORS = 'bootstrap_persistent_errors'
 HA_COMPONENT_URL = '[{}](https://home-assistant.io/components/{}/)'
 
 
@@ -601,9 +601,14 @@ def _async_persistent_notification(hass: core.HomeAssistant, component: str,
 
     This method must be run in the event loop.
     """
-    _PERSISTENT_ERRORS[component] = _PERSISTENT_ERRORS.get(component) or link
+    errors = hass.data.get(DATA_PERSISTENT_ERRORS)
+
+    if errors is None:
+        errors = hass.data[DATA_PERSISTENT_ERRORS] = {}
+
+    errors[component] = errors.get(component) or link
     _lst = [HA_COMPONENT_URL.format(name.replace('_', '-'), name)
-            if link else name for name, link in _PERSISTENT_ERRORS.items()]
+            if link else name for name, link in errors.items()]
     message = ('The following components and platforms could not be set up:\n'
                '* ' + '\n* '.join(list(_lst)) + '\nPlease check your config')
     persistent_notification.async_create(

--- a/homeassistant/components/sleepiq.py
+++ b/homeassistant/components/sleepiq.py
@@ -39,7 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 DATA = None
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
+    vol.Required(DOMAIN): vol.Schema({
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
     }),

--- a/tests/components/sensor/test_sleepiq.py
+++ b/tests/components/sensor/test_sleepiq.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import requests_mock
 
+from homeassistant.bootstrap import setup_component
 from homeassistant.components.sensor import sleepiq
 
 from tests.components.test_sleepiq import mock_responses
@@ -38,6 +39,13 @@ class TestSleepIQSensorSetup(unittest.TestCase):
     def test_setup(self, mock):
         """Test for successfully setting up the SleepIQ platform."""
         mock_responses(mock)
+
+        assert setup_component(self.hass, 'sleepiq', {
+            'sleepiq': {
+                'username': '',
+                'password': '',
+            }
+        })
 
         sleepiq.setup_platform(self.hass,
                                self.config,


### PR DESCRIPTION
## Description:

While fixing some recorder stuff ran into these issues

 - SleepIQ sensor test no longer requires the sleepiq component test to run first
 - SleepIQ config validation now requires the domain correctly
 - Persistent config errors are stored in hass.data instead of global var (reduces test spam)
