### PR TITLE
Simplify recorder connection

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -162,6 +162,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     try:
         _INSTANCE.initialize()
     except SQLAlchemyError as err:
+        _INSTANCE = None
         _LOGGER.error('Error connecting to the database: %s', err)
         return False
 

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -30,8 +30,6 @@ class BaseTestRecorder(unittest.TestCase):
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""
         self.hass.stop()
-        with self.assertRaises(RuntimeError):
-            recorder.get_instance()
 
     def _add_test_states(self):
         """Add multiple states to the db for testing."""

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the Recorder component."""
 # pylint: disable=protected-access
+import asyncio
 import json
 from datetime import datetime, timedelta
 import unittest
@@ -9,6 +10,7 @@ import pytest
 from sqlalchemy import create_engine
 
 from homeassistant.core import callback
+from homeassistant.bootstrap import async_setup_component
 from homeassistant.const import MATCH_ALL
 from homeassistant.components import recorder
 from tests.common import get_test_home_assistant, init_recorder_component
@@ -174,25 +176,6 @@ class TestRecorder(BaseTestRecorder):
 
         # now we should only have 3 events left
         self.assertEqual(events.count(), 3)
-
-    def test_purge_disabled(self):
-        """Test leaving purge_days disabled."""
-        self._add_test_states()
-        self._add_test_events()
-        # make sure we start with 5 states and events
-        states = recorder.query('States')
-        events = recorder.query('Events').filter(
-            recorder.get_model('Events').event_type.like("EVENT_TEST%"))
-        self.assertEqual(states.count(), 5)
-        self.assertEqual(events.count(), 5)
-
-        # run purge_old_data()
-        recorder._INSTANCE.purge_days = None
-        recorder._INSTANCE._purge_old_data()
-
-        # we should have all of our states still
-        self.assertEqual(states.count(), 5)
-        self.assertEqual(events.count(), 5)
 
     def test_schema_no_recheck(self):
         """Test that schema is not double-checked when up-to-date."""
@@ -392,3 +375,13 @@ def test_recorder_bad_execute(hass_recorder):
         res = recorder.execute((mck1,))
     assert res == []
     assert e_mock.call_count == 3
+
+
+@asyncio.coroutine
+def test_recorder_fails_setup_when_connection_fails(hass):
+    """Test recorder fails to setup when SQLAlchemy fails."""
+    from sqlalchemy.exc import SQLAlchemyError
+    with patch('homeassistant.components.recorder.Recorder.initialize',
+               side_effect=SQLAlchemyError('Bad auth, yo')):
+        result = yield from async_setup_component(hass, 'recorder', {})
+        assert not result

--- a/tests/components/sensor/test_history_stats.py
+++ b/tests/components/sensor/test_history_stats.py
@@ -207,6 +207,5 @@ class TestHistoryStatsSensor(unittest.TestCase):
         """Initialize the recorder."""
         init_recorder_component(self.hass)
         self.hass.start()
-        recorder.get_instance().block_till_db_ready()
         self.hass.block_till_done()
         recorder.get_instance().block_till_done()

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -29,7 +29,6 @@ class TestComponentHistory(unittest.TestCase):
         """Initialize the recorder."""
         init_recorder_component(self.hass)
         self.hass.start()
-        recorder.get_instance().block_till_db_ready()
         self.wait_recording_done()
 
     def wait_recording_done(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,7 @@ def mqtt_mock(loop, hass):
 
 @pytest.fixture(autouse=True)
 def verify_cleanup():
+    """Verify that the test has cleaned up resources correctly."""
     yield
 
     from homeassistant.components import recorder

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,3 +76,11 @@ def mqtt_mock(loop, hass):
         client = mock_mqtt()
         client.reset_mock()
         return client
+
+
+@pytest.fixture(autouse=True)
+def verify_cleanup():
+    yield
+
+    from homeassistant.components import recorder
+    assert recorder._INSTANCE is None


### PR DESCRIPTION
## Description:
The Recorder has become a dependency for setting up certain platforms and components. Yet, it would still try to setup the connection async, causing weird race conditions and blocking threads.

This is all simplified by making sure we synchronously try to connect to the database before we set up any other component. That way we can also correctly report that the database has failed to setup.

**Related issue (if applicable):** fixes #6167 #6192 

## Example entry for `configuration.yaml` (if applicable):
```yaml
recorder:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
