### PR TITLE
Remove automatically reloading group config

### DIFF
--- a/homeassistant/components/config/group.py
+++ b/homeassistant/components/config/group.py
@@ -2,7 +2,7 @@
 import asyncio
 
 from homeassistant.components.config import EditKeyBasedConfigView
-from homeassistant.components.group import GROUP_SCHEMA, async_reload
+from homeassistant.components.group import GROUP_SCHEMA
 import homeassistant.helpers.config_validation as cv
 
 
@@ -14,6 +14,6 @@ def async_setup(hass):
     """Setup the Group config API."""
     hass.http.register_view(EditKeyBasedConfigView(
         'group', 'config', CONFIG_PATH, cv.slug,
-        GROUP_SCHEMA, post_write_hook=async_reload
+        GROUP_SCHEMA
     ))
     return True


### PR DESCRIPTION
This feature is currently causing some issues with the frontend. Disabling it for 0.39, will add it back later. (famous last words)
