### PR TITLE
Default config to setup group editor

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -89,6 +89,7 @@ sensor:
 tts:
   platform: google
 
+group: !include groups.yaml
 """
 
 
@@ -147,8 +148,12 @@ def create_default_config(config_dir, detect_location=True):
     Return path to new config file if success, None if failed.
     This method needs to run in an executor.
     """
+    from homeassistant.components.config.group import (
+        CONFIG_PATH as GROUP_CONFIG_PATH)
+
     config_path = os.path.join(config_dir, YAML_CONFIG_FILE)
     version_path = os.path.join(config_dir, VERSION_FILE)
+    group_yaml_path = os.path.join(config_dir, GROUP_CONFIG_PATH)
 
     info = {attr: default for attr, default, _, _ in DEFAULT_CORE_CONFIG}
 
@@ -186,6 +191,9 @@ def create_default_config(config_dir, detect_location=True):
 
         with open(version_path, 'wt') as version_file:
             version_file.write(__version__)
+
+        with open(group_yaml_path, 'w'):
+            pass
 
         return config_path
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,8 @@ from homeassistant.const import (
 from homeassistant.util import location as location_util, dt as dt_util
 from homeassistant.util.async import run_coroutine_threadsafe
 from homeassistant.helpers.entity import Entity
+from homeassistant.components.config.group import (
+    CONFIG_PATH as GROUP_CONFIG_PATH)
 
 from tests.common import (
     get_test_config_dir, get_test_home_assistant, mock_coro)
@@ -23,6 +25,7 @@ from tests.common import (
 CONFIG_DIR = get_test_config_dir()
 YAML_PATH = os.path.join(CONFIG_DIR, config_util.YAML_CONFIG_FILE)
 VERSION_PATH = os.path.join(CONFIG_DIR, config_util.VERSION_FILE)
+GROUP_PATH = os.path.join(CONFIG_DIR, GROUP_CONFIG_PATH)
 ORIG_TIMEZONE = dt_util.DEFAULT_TIME_ZONE
 
 
@@ -51,13 +54,18 @@ class TestConfig(unittest.TestCase):
         if os.path.isfile(VERSION_PATH):
             os.remove(VERSION_PATH)
 
+        if os.path.isfile(GROUP_PATH):
+            os.remove(GROUP_PATH)
+
         self.hass.stop()
 
     def test_create_default_config(self):
         """Test creation of default config."""
         config_util.create_default_config(CONFIG_DIR, False)
 
-        self.assertTrue(os.path.isfile(YAML_PATH))
+        assert os.path.isfile(YAML_PATH)
+        assert os.path.isfile(VERSION_PATH)
+        assert os.path.isfile(GROUP_PATH)
 
     def test_find_config_file_yaml(self):
         """Test if it finds a YAML config file."""


### PR DESCRIPTION
## Description:
This adds the group component to the default config and sets up the connection using `!include`.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
