### PR TITLE
Fix reporting on bad login

### DIFF
--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -18,6 +18,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.auth import validate_password
 from homeassistant.components.http.const import KEY_AUTHENTICATED
+from homeassistant.components.http.ban import process_wrong_login
 
 DOMAIN = 'websocket_api'
 
@@ -256,9 +257,9 @@ class ActiveConnection:
                 else:
                     self.debug('Invalid password')
                     self.send_message(auth_invalid_message('Invalid password'))
-                    return wsock
 
             if not authenticated:
+                yield from process_wrong_login(self.request)
                 return wsock
 
             self.send_message(auth_ok_message())

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -97,7 +97,6 @@ class TestHttp:
             with patch('homeassistant.components.http.'
                        'ban.get_real_ip',
                        return_value=ip_address("200.201.202.204")):
-                print("GETTING API")
                 return requests.get(
                     _url(const.URL_API),
                     headers={const.HTTP_HEADER_HA_AUTH: 'Wrong password'})

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant.core import callback
 from homeassistant.components import websocket_api as wapi, frontend
 
-from tests.common import mock_http_component_app
+from tests.common import mock_http_component_app, mock_coro
 
 API_PASSWORD = 'test1234'
 
@@ -66,13 +66,16 @@ def test_auth_via_msg(no_auth_websocket_client):
 @asyncio.coroutine
 def test_auth_via_msg_incorrect_pass(no_auth_websocket_client):
     """Test authenticating."""
-    no_auth_websocket_client.send_json({
-        'type': wapi.TYPE_AUTH,
-        'api_password': API_PASSWORD + 'wrong'
-    })
+    with patch('homeassistant.components.websocket_api.process_wrong_login',
+               return_value=mock_coro()) as mock_process_wrong_login:
+        no_auth_websocket_client.send_json({
+            'type': wapi.TYPE_AUTH,
+            'api_password': API_PASSWORD + 'wrong'
+        })
 
-    msg = yield from no_auth_websocket_client.receive_json()
+        msg = yield from no_auth_websocket_client.receive_json()
 
+    assert mock_process_wrong_login.called
     assert msg['type'] == wapi.TYPE_AUTH_INVALID
     assert msg['message'] == 'Invalid password'
 


### PR DESCRIPTION
## Description:
Wrong authentication at websocket connections will now trigger the same flow as wrong auth for HTTP endpoints.

**Related issue (if applicable):** fixes #6093

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
