### PR TITLE
Revise power and energy units and property names.

### DIFF
--- a/homeassistant/components/climate/vera.py
+++ b/homeassistant/components/climate/vera.py
@@ -85,11 +85,11 @@ class VeraThermostat(VeraDevice, ClimateDevice):
             return self.vera_device.fan_cycle()
 
     @property
-    def current_power_mwh(self):
-        """Current power usage in mWh."""
+    def current_power_w(self):
+        """Current power usage in W."""
         power = self.vera_device.power
         if power:
-            return convert(power, float, 0.0) * 1000
+            return convert(power, float, 0.0)
 
     def update(self):
         """Called by the vera device callback to update state."""

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -30,14 +30,14 @@ ENTITY_ID_ALL_SWITCHES = group.ENTITY_ID_FORMAT.format('all_switches')
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
-ATTR_TODAY_MWH = "today_mwh"
-ATTR_CURRENT_POWER_MWH = "current_power_mwh"
+ATTR_TODAY_ENERGY_KWH = "today_energy_kwh"
+ATTR_CURRRENT_POWER_W = "current_power_w"
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
 PROP_TO_ATTR = {
-    'current_power_mwh': ATTR_CURRENT_POWER_MWH,
-    'today_power_mw': ATTR_TODAY_MWH,
+    'current_power_w': ATTR_CURRRENT_POWER_W,
+    'today_energy_kwh': ATTR_TODAY_ENERGY_KWH,
 }
 
 SWITCH_SERVICE_SCHEMA = vol.Schema({
@@ -144,13 +144,13 @@ class SwitchDevice(ToggleEntity):
 
     # pylint: disable=no-self-use
     @property
-    def current_power_mwh(self):
-        """Return the current power usage in mWh."""
+    def current_power_w(self):
+        """Return the current power usage in W."""
         return None
 
     @property
-    def today_power_mw(self):
-        """Return the today total power usage in mW."""
+    def today_energy_kwh(self):
+        """Return the today total energy usage in kWh."""
         return None
 
     @property

--- a/homeassistant/components/switch/demo.py
+++ b/homeassistant/components/switch/demo.py
@@ -48,15 +48,15 @@ class DemoSwitch(SwitchDevice):
         return self._assumed
 
     @property
-    def current_power_mwh(self):
-        """Return the current power usage in mWh."""
+    def current_power_w(self):
+        """Return the current power usage in W."""
         if self._state:
             return 100
 
     @property
-    def today_power_mw(self):
-        """Return the today total power usage in mW."""
-        return 1500
+    def today_energy_kwh(self):
+        """Return the today total energy usage in kWh."""
+        return 15
 
     @property
     def is_on(self):

--- a/homeassistant/components/switch/edimax.py
+++ b/homeassistant/components/switch/edimax.py
@@ -59,13 +59,13 @@ class SmartPlugSwitch(SwitchDevice):
         return self._name
 
     @property
-    def current_power_mwh(self):
-        """Return the current power usage in mWh."""
+    def current_power_w(self):
+        """Return the current power usage in W."""
         return self._now_power
 
     @property
-    def today_power_mw(self):
-        """Return the today total power usage in mW."""
+    def today_energy_kwh(self):
+        """Return the today total energy usage in kWh."""
         return self._now_energy_day
 
     @property

--- a/homeassistant/components/switch/homematic.py
+++ b/homeassistant/components/switch/homematic.py
@@ -40,8 +40,8 @@ class HMSwitch(HMDevice, SwitchDevice):
             return False
 
     @property
-    def current_power_mwh(self):
-        """Return the current power usage in mWh."""
+    def today_energy_kwh(self):
+        """Return the current power usage in kWh."""
         if "ENERGY_COUNTER" in self._data:
             try:
                 return self._data["ENERGY_COUNTER"] / 1000

--- a/homeassistant/components/switch/mfi.py
+++ b/homeassistant/components/switch/mfi.py
@@ -111,9 +111,9 @@ class MfiSwitch(SwitchDevice):
         self._target_state = False
 
     @property
-    def current_power_mwh(self):
-        """Return the current power usage in mWh."""
-        return int(self._port.data.get('active_pwr', 0) * 1000)
+    def current_power_w(self):
+        """Return the current power usage in W."""
+        return int(self._port.data.get('active_pwr', 0))
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/switch/mystrom.py
+++ b/homeassistant/components/switch/mystrom.py
@@ -64,8 +64,8 @@ class MyStromSwitch(SwitchDevice):
         return bool(self.data['relay'])
 
     @property
-    def current_power_mwh(self):
-        """Return the current power consumption in mWh."""
+    def current_power_w(self):
+        """Return the current power consumption in W."""
         return round(self.data['power'], 2)
 
     def turn_on(self, **kwargs):

--- a/homeassistant/components/switch/netio.py
+++ b/homeassistant/components/switch/netio.py
@@ -23,10 +23,7 @@ REQUIREMENTS = ['pynetio==0.1.6']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_CURRENT_POWER_MWH = 'current_power_mwh'
-ATTR_CURRENT_POWER_W = 'current_power_w'
 ATTR_START_DATE = 'start_date'
-ATTR_TODAY_MWH = 'today_mwh'
 ATTR_TOTAL_CONSUMPTION_KWH = 'total_energy_kwh'
 
 CONF_OUTLETS = 'outlets'
@@ -172,7 +169,6 @@ class NetioSwitch(SwitchDevice):
     def state_attributes(self):
         """Return optional state attributes."""
         return {
-            ATTR_CURRENT_POWER_W: self.current_power_w,
             ATTR_TOTAL_CONSUMPTION_KWH: self.cumulated_consumption_kwh,
             ATTR_START_DATE: self.start_date.split('|')[0]
         }

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -46,11 +46,11 @@ class VeraSwitch(VeraDevice, SwitchDevice):
         self.schedule_update_ha_state()
 
     @property
-    def current_power_mwh(self):
-        """Current power usage in mWh."""
+    def current_power_w(self):
+        """Current power usage in W."""
         power = self.vera_device.power
         if power:
-            return convert(power, float, 0.0) * 1000
+            return convert(power, float, 0.0)
 
     @property
     def is_on(self):

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -8,6 +8,7 @@ import logging
 from datetime import datetime, timedelta
 
 from homeassistant.components.switch import SwitchDevice
+from homeassistant.util import convert
 from homeassistant.const import (
     STATE_OFF, STATE_ON, STATE_STANDBY, STATE_UNKNOWN)
 from homeassistant.loader import get_component
@@ -136,16 +137,18 @@ class WemoSwitch(SwitchDevice):
                                                             uptime.second)
 
     @property
-    def current_power_mwh(self):
-        """Current power usage in mWh."""
+    def current_power_w(self):
+        """Current power usage in W."""
         if self.insight_params:
-            return self.insight_params['currentpower']
+            return convert(
+                self.insight_params['currentpower'], float, 0.0
+                ) / 1000.0
 
     @property
-    def today_power_mw(self):
-        """Today total power usage in mW."""
+    def today_energy_kwh(self):
+        """Today total energy usage in kWh."""
         if self.insight_params:
-            return self.insight_params['todaymw']
+            return convert(self.insight_params['todaymw'], float, 0.0) / 1000.0
 
     @property
     def detail_state(self):

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -119,8 +119,10 @@ class WemoSwitch(SwitchDevice):
                 WemoSwitch.as_uptime(self.insight_params['ontoday'])
             attr['on_total_time'] = \
                 WemoSwitch.as_uptime(self.insight_params['ontotal'])
-            attr['power_threshold_mw'] = \
-                self.insight_params['powerthreshold']
+            attr['power_threshold_w'] = \
+                convert(
+                    self.insight_params['powerthreshold'], float, 0.0
+                ) / 1000.0
 
         if self.coffeemaker_mode is not None:
             attr[ATTR_COFFEMAKER_MODE] = self.coffeemaker_mode

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -34,7 +34,7 @@ CONF_LIGHTS = 'lights'
 
 VERA_ID_FORMAT = '{}_{}'
 
-ATTR_CURRENT_POWER_MWH = "current_power_mwh"
+ATTR_CURRENT_POWER_W = "current_power_w"
 
 VERA_DEVICES = defaultdict(list)
 
@@ -179,7 +179,7 @@ class VeraDevice(Entity):
 
         power = self.vera_device.power
         if power:
-            attr[ATTR_CURRENT_POWER_MWH] = convert(power, float, 0.0) * 1000
+            attr[ATTR_CURRENT_POWER_W] = convert(power, float, 0.0)
 
         attr['Vera Device Id'] = self.vera_device.vera_device_id
 

--- a/tests/components/switch/test_mfi.py
+++ b/tests/components/switch/test_mfi.py
@@ -94,15 +94,15 @@ class TestMfiSwitch(unittest.TestCase):
         self.assertEqual(self.port.control.call_args, mock.call(False))
         self.assertFalse(self.switch._target_state)
 
-    def test_current_power_mwh(self):
+    def test_current_power_w(self):
         """Test current power."""
-        self.port.data = {'active_pwr': 1}
-        self.assertEqual(1000, self.switch.current_power_mwh)
+        self.port.data = {'active_pwr': 10}
+        self.assertEqual(10, self.switch.current_power_w)
 
-    def test_current_power_mwh_no_data(self):
+    def test_current_power_w_no_data(self):
         """Test current power if there is no data."""
         self.port.data = {'notpower': 123}
-        self.assertEqual(0, self.switch.current_power_mwh)
+        self.assertEqual(0, self.switch.current_power_w)
 
     def test_device_state_attributes(self):
         """Test the state attributes."""


### PR DESCRIPTION
## Description:
Change switch base class power and energy properties and attributes.

They were somewhat confused so I've tried to make them use `W` and `kWh` for power and energy respectively.

This means I've also had to change all the derived classes. 

With some help from Google I've had a guess for the various switch classes that overrode the base class methods, what they intended.

I've be very grateful if the various experts could check / take a look 

**Related issue (if applicable):** fixes #3828 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
