### PR TITLE
New Sensor: DNS IP

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -309,6 +309,7 @@ omit =
     homeassistant/components/sensor/darksky.py
     homeassistant/components/sensor/deutsche_bahn.py
     homeassistant/components/sensor/dht.py
+    homeassistant/components/sensor/dnsip.py
     homeassistant/components/sensor/dovado.py
     homeassistant/components/sensor/dte_energy_bridge.py
     homeassistant/components/sensor/ebox.py

--- a/homeassistant/components/sensor/dnsip.py
+++ b/homeassistant/components/sensor/dnsip.py
@@ -49,7 +49,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     else:
         resolver = config.get(CONF_RESOLVER)
 
-    yield from async_add_devices([WanIpSensor(hass, hostname, resolver, ipv6)], True)
+    yield from async_add_devices([WanIpSensor(
+        hass, hostname, resolver, ipv6)], True)
 
 
 class WanIpSensor(Entity):

--- a/homeassistant/components/sensor/dnsip.py
+++ b/homeassistant/components/sensor/dnsip.py
@@ -49,7 +49,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     else:
         resolver = config.get(CONF_RESOLVER)
 
-    yield from async_add_devices([WanIpSensor(hass, hostname, resolver, ipv6)])
+    yield from async_add_devices([WanIpSensor(hass, hostname, resolver, ipv6)], True)
 
 
 class WanIpSensor(Entity):

--- a/homeassistant/components/sensor/dnsip.py
+++ b/homeassistant/components/sensor/dnsip.py
@@ -29,7 +29,7 @@ DEFAULT_RESOLVER = '208.67.222.222'
 DEFAULT_RESOLVER_IPV6 = '2620:0:ccc::2'
 DEFAULT_IPV6 = False
 
-SCAN_INTERVAL = timedelta(seconds=10)
+SCAN_INTERVAL = timedelta(seconds=120)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOSTNAME, default=DEFAULT_HOSTNAME): cv.string,

--- a/homeassistant/components/sensor/dnsip.py
+++ b/homeassistant/components/sensor/dnsip.py
@@ -14,7 +14,6 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 from homeassistant.helpers.entity import Entity
-import homeassistant.util.dt as dt_util
 
 REQUIREMENTS = ['dnspython==1.15.0']
 

--- a/homeassistant/components/sensor/dnsip.py
+++ b/homeassistant/components/sensor/dnsip.py
@@ -74,7 +74,6 @@ class WanIpSensor(Entity):
 
     def update(self):
         """Get the current DNS IP address for hostname."""
-        _LOGGER.error("Updating IP")
         response = self.resolver.query(self._name, self.querytype)
         if response:
             self._state = \

--- a/homeassistant/components/sensor/dnsip.py
+++ b/homeassistant/components/sensor/dnsip.py
@@ -1,0 +1,100 @@
+"""
+Get your own public IP address or that of any host.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.dnsip/
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
+from homeassistant.helpers.entity import Entity
+import homeassistant.util.dt as dt_util
+
+REQUIREMENTS = ['dnspython==1.15.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_HOSTNAME = 'hostname'
+CONF_RESOLVER = 'resolver'
+CONF_RESOLVER_IPV6 = 'resolver_ipv6'
+CONF_IPV6 = 'ipv6'
+
+DEFAULT_HOSTNAME = 'myip.opendns.com'
+DEFAULT_RESOLVER = '208.67.222.222'
+DEFAULT_RESOLVER_IPV6 = '2620:0:ccc::2'
+DEFAULT_IPV6 = False
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=120)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOSTNAME, default=DEFAULT_HOSTNAME): cv.string,
+    vol.Optional(CONF_RESOLVER, default=DEFAULT_RESOLVER): cv.string,
+    vol.Optional(CONF_RESOLVER_IPV6, default=DEFAULT_RESOLVER_IPV6): cv.string,
+    vol.Optional(CONF_IPV6, default=DEFAULT_IPV6): cv.boolean,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the DNS IP sensor."""
+    hostname = config.get(CONF_HOSTNAME)
+    ipv6 = config.get(CONF_IPV6)
+    if ipv6:
+        resolver = config.get(CONF_RESOLVER_IPV6)
+    else:
+        resolver = config.get(CONF_RESOLVER)
+
+    add_devices([WanIpSensor(hostname, resolver, ipv6)])
+
+
+class WanIpSensor(Entity):
+    """Implementation of a DNS IP sensor."""
+
+    def __init__(self, hostname, resolver, ipv6):
+        """Initialize the sensor."""
+        self._name = hostname
+        self.resolver = Resolver(hostname, resolver, ipv6)
+        self._state = STATE_UNKNOWN
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the current DNS IP address for hostname."""
+        return self._state
+
+    def update(self):
+        """Get the current DNS IP address for hostname."""
+        self.resolver.update()
+        self._state = self.resolver.currentip
+
+
+class Resolver(object):
+    """Resolve the provided hostname to an IP address."""
+
+    def __init__(self, hostname, resolver, ipv6):
+        """Initialize the sensor."""
+        import dns.resolver
+
+        self.hostname = hostname
+        self.resolver = dns.resolver.Resolver()
+        self.resolver.nameservers = [resolver]
+        self.currentip = STATE_UNKNOWN
+        self.querytype = 'aaaa' if ipv6 else 'a'
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Update the IP address."""
+        response = self.resolver.query(self.hostname, self.querytype)
+        if response:
+            self.currentip = response.response.answer[0].to_rdataset().items[0].address
+        else:
+            self.currentip = STATE_UNKNOWN

--- a/homeassistant/components/sensor/dnsip.py
+++ b/homeassistant/components/sensor/dnsip.py
@@ -94,6 +94,7 @@ class Resolver(object):
         """Update the IP address."""
         response = self.resolver.query(self.hostname, self.querytype)
         if response:
-            self.currentip = response.response.answer[0].to_rdataset().items[0].address
+            self.currentip = \
+                response.response.answer[0].to_rdataset().items[0].address
         else:
             self.currentip = STATE_UNKNOWN

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -112,7 +112,7 @@ dlipower==0.7.165
 dnspython3==1.15.0
 
 # homeassistant.components.sensor.dnsip
-dnspython==1.15.0
+aiodns==1.1.1
 
 # homeassistant.components.sensor.dovado
 dovado==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -111,6 +111,9 @@ dlipower==0.7.165
 # homeassistant.components.notify.xmpp
 dnspython3==1.15.0
 
+# homeassistant.components.sensor.dnsip
+dnspython==1.15.0
+
 # homeassistant.components.sensor.dovado
 dovado==0.4.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -33,6 +33,9 @@ SoCo==0.12
 # homeassistant.components.notify.twitter
 TwitterAPI==2.4.4
 
+# homeassistant.components.sensor.dnsip
+aiodns==1.1.1
+
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.5.0
@@ -110,9 +113,6 @@ dlipower==0.7.165
 
 # homeassistant.components.notify.xmpp
 dnspython3==1.15.0
-
-# homeassistant.components.sensor.dnsip
-aiodns==1.1.1
 
 # homeassistant.components.sensor.dovado
 dovado==0.4.0


### PR DESCRIPTION
## Description:
This sensor, without fancy configuration, provides the current external IPv4 address, obtained by asking an OpenDNS server (like `dig +short myip.opendns.com @resolver1.opendns.com`). This has less overhead than parsing some of the HTTP solutions one could get using a REST sensor.
Additionally it's possible to customize the hostname and DNS server, which allows to ask for IP addresses of pretty much any host. Could be useful to be notified if some remote location (with some dynamic DNS) had connection issues and got a new IP because of that.
There also is IPv6 support, but getting the own external address doesn't work that well, since this actually resolves to the IPv6 address of the machine running HASS, not the modem.

I'm not sure how useful this is to others and if this should end up in here. But if there are no "naaah, nobody needs that"'s within the next couple days I'll take care of the documentation. :)

One thing one might stumble upon: I don't do the update directly when loading the platform. The reason is, that DNS-queries can timeout, and in that case the entity wouldn't be added. So I decided to just create the entity and let it update later. Given the nature of this sensor I think it's ok to maybe have some delay.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2135

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: dnsip
    hostname: home-assistant.io
    resolver: 8.8.8.8
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
