### PR TITLE
Telegram polling

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -405,6 +405,7 @@ omit =
     homeassistant/components/switch/transmission.py
     homeassistant/components/switch/wake_on_lan.py
     homeassistant/components/telegram_webhooks.py
+    homeassistant/components/telegram_poll.py
     homeassistant/components/thingspeak.py
     homeassistant/components/tts/amazon_polly.py
     homeassistant/components/tts/picotts.py

--- a/homeassistant/components/telegram_poll.py
+++ b/homeassistant/components/telegram_poll.py
@@ -16,7 +16,6 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import EVENT_HOMEASSISTANT_START, \
     EVENT_HOMEASSISTANT_STOP
-from telegram.error import NetworkError, Unauthorized
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,7 +43,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 
 def setup(hass, config):
-    """Setup is called when Home Assistant is loading our component."""
+    """ Setup is called when Home Assistant is loading our component."""
     import telegram
     bot_token = config[DOMAIN].get(BOT_TOKEN)
     bot = telegram.Bot(bot_token)
@@ -52,13 +51,16 @@ def setup(hass, config):
 
 
 def _setup(hass, config, bot):
+    """ The actual setup of the telegram component"""
     allowed_chat_ids = config[DOMAIN].get(ALLOWED_CHAT_IDS)
     checker = IncomingChecker(bot, hass, allowed_chat_ids)
 
     def _start_bot(_event):
+        """ Starts the thread"""
         checker.check_thread.start()
 
     def _stop_bot(_event):
+        """ Stops the thread"""
         checker.checking = False
 
     hass.bus.listen_once(
@@ -119,7 +121,7 @@ class IncomingChecker:
         while self.checking:
             try:
                 self.handle()
-            except NetworkError:
+            except telegram.NetworkError:
                 sleep(1)
-            except Unauthorized:
+            except telegram.Unauthorized:
                 self.update_id += 1

--- a/homeassistant/components/telegram_poll.py
+++ b/homeassistant/components/telegram_poll.py
@@ -114,6 +114,7 @@ class IncomingChecker:
         # get the first pending update_id, this is so
         # we can skip over it in case
         # we get an "Unauthorized" exception.
+        import telegram
         try:
             self.update_id = self.bot.getUpdates()[0].update_id
         except IndexError:
@@ -121,7 +122,7 @@ class IncomingChecker:
         while self.checking:
             try:
                 self.handle()
-            except telegram.NetworkError:
+            except telegram.error.NetworkError:
                 sleep(1)
-            except telegram.Unauthorized:
+            except telegram.error.Unauthorized:
                 self.update_id += 1

--- a/homeassistant/components/telegram_poll.py
+++ b/homeassistant/components/telegram_poll.py
@@ -1,0 +1,124 @@
+"""
+Inspired by : telegram_webhooks.py
+https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/telegram_webhooks.py
+
+Allows utilizing telegram incoming commands.
+
+Once Hass will upgrade to python version >= 3.5 an async library like
+aiotg could be used for this.
+https://github.com/szastupov/aiotg
+"""
+
+import logging
+from threading import Thread
+from time import sleep
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import EVENT_HOMEASSISTANT_START, \
+    EVENT_HOMEASSISTANT_STOP
+from telegram.error import NetworkError, Unauthorized
+
+_LOGGER = logging.getLogger(__name__)
+
+EVENT_TELEGRAM_COMMAND = 'telegram.command'
+
+ATTR_COMMAND = 'command'
+ATTR_USER_ID = 'user_id'
+ATTR_ARGS = 'args'
+ATTR_FROM_FIRST = 'from_first'
+ATTR_FROM_LAST = 'from_last'
+
+# The domain of your component. Should be equal to the name of your component.
+DOMAIN = 'telegram_poll'
+BOT_TOKEN = 'bot_token'
+ALLOWED_CHAT_IDS = 'allowed_chat_ids'
+
+REQUIREMENTS = ['python-telegram-bot==5.3.0']
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(BOT_TOKEN): cv.string,
+        vol.Required(ALLOWED_CHAT_IDS): vol.All(cv.ensure_list, [cv.string]),
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Setup is called when Home Assistant is loading our component."""
+    import telegram
+    bot_token = config[DOMAIN].get(BOT_TOKEN)
+    bot = telegram.Bot(bot_token)
+    return _setup(hass, config, bot)
+
+
+def _setup(hass, config, bot):
+    allowed_chat_ids = config[DOMAIN].get(ALLOWED_CHAT_IDS)
+    checker = IncomingChecker(bot, hass, allowed_chat_ids)
+
+    def _start_bot(_event):
+        checker.check_thread.start()
+
+    def _stop_bot(_event):
+        checker.checking = False
+
+    hass.bus.listen_once(
+        EVENT_HOMEASSISTANT_START,
+        _start_bot
+    )
+    hass.bus.listen_once(
+        EVENT_HOMEASSISTANT_STOP,
+        _stop_bot
+    )
+
+    # Return boolean to indicate that initialization was successfully.
+    return True
+
+
+class IncomingChecker:
+    def __init__(self, bot, hass, allowed_ids):
+        self.update_id = None
+        self.bot = bot
+        self.hass = hass
+        # boolean to check if checking loop should continue running
+        self.checking = True
+        self.allowed_ids = allowed_ids
+        self.check_thread = Thread(target=self.check_incoming)
+
+    def handle(self):
+        """" Receiving and processing incoming messages."""
+        for update in self.bot.getUpdates(offset=self.update_id, timeout=10):
+            self.update_id = update.update_id + 1
+
+            # Updates can also be empty.
+            if update.message:
+                # we only want to process text messages and coming from
+                # allowed ids
+                chat_id = str(update.message.chat_id)
+                if (update.message.text and
+                        chat_id in self.allowed_ids):
+                    command = update.message.text.split(' ')
+                    self.hass.bus.fire(EVENT_TELEGRAM_COMMAND, {
+                        ATTR_COMMAND: command[0],
+                        ATTR_ARGS: ' '.join(command[1:]),
+                        ATTR_FROM_FIRST: update.message.from_user.first_name,
+                        ATTR_FROM_LAST: update.message.from_user.last_name,
+                        ATTR_USER_ID: chat_id
+                    })
+
+    def check_incoming(self):
+        """" Loop which continuously checks for incoming telegram messages"""
+
+        # get the first pending update_id, this is so
+        # we can skip over it in case
+        # we get an "Unauthorized" exception.
+        try:
+            self.update_id = self.bot.getUpdates()[0].update_id
+        except IndexError:
+            self.update_id = None
+        while self.checking:
+            try:
+                self.handle()
+            except NetworkError:
+                sleep(1)
+            except Unauthorized:
+                self.update_id += 1

--- a/homeassistant/components/telegram_poll.py
+++ b/homeassistant/components/telegram_poll.py
@@ -1,8 +1,8 @@
 """
+Allows utilizing telegram incoming commands.
+
 Inspired by : telegram_webhooks.py
 https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/telegram_webhooks.py
-
-Allows utilizing telegram incoming commands.
 
 Once Hass will upgrade to python version >= 3.5 an async library like
 aiotg could be used for this.
@@ -43,7 +43,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 
 def setup(hass, config):
-    """ Setup is called when Home Assistant is loading our component."""
+    """Setup is called when Home Assistant is loading our component."""
     import telegram
     bot_token = config[DOMAIN].get(BOT_TOKEN)
     bot = telegram.Bot(bot_token)
@@ -51,16 +51,16 @@ def setup(hass, config):
 
 
 def _setup(hass, config, bot):
-    """ The actual setup of the telegram component"""
+    """The actual setup of the telegram component."""
     allowed_chat_ids = config[DOMAIN].get(ALLOWED_CHAT_IDS)
     checker = IncomingChecker(bot, hass, allowed_chat_ids)
 
     def _start_bot(_event):
-        """ Starts the thread"""
+        """Start the polling thread."""
         checker.check_thread.start()
 
     def _stop_bot(_event):
-        """ Stops the thread"""
+        """Stop the thread."""
         checker.checking = False
 
     hass.bus.listen_once(
@@ -78,7 +78,9 @@ def _setup(hass, config, bot):
 
 class IncomingChecker:
     """Threaded telegram incoming message handler."""
+
     def __init__(self, bot, hass, allowed_ids):
+        """Initialize the thread."""
         self.update_id = None
         self.bot = bot
         self.hass = hass
@@ -109,8 +111,7 @@ class IncomingChecker:
                     })
 
     def check_incoming(self):
-        """" Loop which continuously checks for incoming telegram messages"""
-
+        """"Loop which continuously checks for incoming telegram messages."""
         # get the first pending update_id, this is so
         # we can skip over it in case
         # we get an "Unauthorized" exception.

--- a/homeassistant/components/telegram_poll.py
+++ b/homeassistant/components/telegram_poll.py
@@ -75,6 +75,7 @@ def _setup(hass, config, bot):
 
 
 class IncomingChecker:
+    """Threaded telegram incoming message handler."""
     def __init__(self, bot, hass, allowed_ids):
         self.update_id = None
         self.bot = bot

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -584,6 +584,7 @@ python-pushsafer==0.2
 # homeassistant.components.sensor.synologydsm
 python-synology==0.1.0
 
+# homeassistant.components.telegram_poll
 # homeassistant.components.telegram_webhooks
 # homeassistant.components.notify.telegram
 python-telegram-bot==5.3.0

--- a/tests/components/test_telegram_poll.py
+++ b/tests/components/test_telegram_poll.py
@@ -1,0 +1,52 @@
+import unittest
+from threading import Event
+
+from homeassistant.bootstrap import setup_component
+from homeassistant.components import telegram_poll
+from homeassistant.components.telegram_poll import IncomingChecker, \
+    EVENT_TELEGRAM_COMMAND
+
+# pylint: disable=invalid-name
+from tests.common import get_test_home_assistant
+
+
+class TestTelegramPoll(unittest.TestCase):
+    """Test the sun module."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.mockbot = MockTelegramBot()
+        self.checker = IncomingChecker(self.mockbot, self.hass,
+                                       [123, 456])
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_1(self):
+        def listener():
+            return "abc"
+
+        self.hass.bus.listen(EVENT_TELEGRAM_COMMAND, listener)
+
+        self.mockbot.send_message({'text'})
+        # setup_component(self.hass, sun.DOMAIN, {
+        #     sun.DOMAIN: {sun.CONF_ELEVATION: 0}})
+
+
+class MockTelegramBot():
+    def __init__(self):
+        self.update_event = Event()
+        self.update_event.clear()
+        self.message = {}
+
+    def getUpdates(self, offset=None, limit=100, timeout=0, network_delay=5.,
+                   **kwargs):
+        self.update_event.wait()
+        self.update_event.clear()
+        return self.message
+
+    def send_message(self, message):
+        self.message = message
+        self.update_event.set()


### PR DESCRIPTION
## Description:
Inspired by `telegram_webhook.py`
But using polling mechanism to listen for incoming telegram messages which doesn't require your hass to be exposed to the internet.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
telegram_poll:
    bot_token : `bot token`
    allowed_chat_ids : 
    - `chat id1`
    - `chat id2`
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
