### PR TITLE
Fix livebox-play interactions for Python < 3.6

### DIFF
--- a/homeassistant/components/media_player/liveboxplaytv.py
+++ b/homeassistant/components/media_player/liveboxplaytv.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     STATE_PAUSED, STATE_UNKNOWN, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['liveboxplaytv==1.4.8']
+REQUIREMENTS = ['liveboxplaytv==1.4.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -328,7 +328,7 @@ liffylights==0.9.4
 limitlessled==1.0.4
 
 # homeassistant.components.media_player.liveboxplaytv
-liveboxplaytv==1.4.8
+liveboxplaytv==1.4.9
 
 # homeassistant.components.notify.matrix
 matrix-client==0.0.5


### PR DESCRIPTION
## Description:
Update `liveboxplaytv` to 1.4.9.
Previous versions had a weird bug where keys were randomly not sent to the appliance when using Python < 3.6.0.
It all boiled down to the fact that Livebox Play appliances require GET parameters to be passed in a certain order. Who knew dicts are sorted by default in Python 3.6?

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: liveboxplaytv
    host: 192.168.1.2
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.