### PR TITLE
Bugfix mqtt socket error

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -393,8 +393,7 @@ class MQTT(object):
         self.progress = {}
         self.birth_message = birth_message
         self._mqttc = None
-        self._subscribe_lock = asyncio.Lock(loop=hass.loop)
-        self._publish_lock = asyncio.Lock(loop=hass.loop)
+        self._paho_lock = asyncio.Lock(loop=hass.loop)
 
         if protocol == PROTOCOL_31:
             proto = mqtt.MQTTv31
@@ -434,7 +433,7 @@ class MQTT(object):
 
         This method must be run in the event loop and returns a coroutine.
         """
-        with (yield from self._publish_lock):
+        with (yield from self._paho_lock):
             yield from self.hass.loop.run_in_executor(
                 None, self._mqttc.publish, topic, payload, qos, retain)
 
@@ -484,7 +483,7 @@ class MQTT(object):
         if topic in self.topics:
             return
 
-        with (yield from self._subscribe_lock):
+        with (yield from self._paho_lock):
             result, mid = yield from self.hass.loop.run_in_executor(
                 None, self._mqttc.subscribe, topic, qos)
 


### PR DESCRIPTION
## Description:

Use now one lock for protect paho-mqtt for multible access.

**Related issue (if applicable):** fixes #6247

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
