### PR TITLE
Log errors when loading yaml

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -504,7 +504,8 @@ def async_from_config_file(config_path: str,
     try:
         config_dict = yield from hass.loop.run_in_executor(
             None, conf_util.load_yaml_config_file, config_path)
-    except HomeAssistantError:
+    except HomeAssistantError as err:
+        _LOGGER.exception(err)
         return None
     finally:
         clear_secret_cache()

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -505,7 +505,7 @@ def async_from_config_file(config_path: str,
         config_dict = yield from hass.loop.run_in_executor(
             None, conf_util.load_yaml_config_file, config_path)
     except HomeAssistantError as err:
-        _LOGGER.exception(err)
+        _LOGGER.error('Error loading %s: %s', config_path, err)
         return None
     finally:
         clear_secret_cache()

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -235,7 +235,11 @@ def load_yaml_config_file(config_path):
 
     This method needs to run in an executor.
     """
-    conf_dict = load_yaml(config_path)
+    try:
+        conf_dict = load_yaml(config_path)
+    except FileNotFoundError as err:
+        raise HomeAssistantError("Config file not found: {}".format(
+            getattr(err, 'filename', err)))
 
     if not isinstance(conf_dict, dict):
         msg = 'The configuration file {} does not contain a dictionary'.format(

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -30,6 +30,8 @@ MOCKS = {
                bootstrap.async_log_exception),
     'package_error': ("homeassistant.config._log_pkg_error",
                       config_util._log_pkg_error),
+    'logger_exception': ("homeassistant.bootstrap._LOGGER.exception",
+                         bootstrap._LOGGER.exception),
 }
 SILENCE = (
     'homeassistant.bootstrap.clear_secret_cache',
@@ -180,9 +182,9 @@ def check(config_path):
 
         if module is None:
             # Ensure list
-            res['except'][ERROR_STR] = res['except'].get(ERROR_STR, [])
-            res['except'][ERROR_STR].append('{} not found: {}'.format(
-                'Platform' if '.' in comp_name else 'Component', comp_name))
+            msg = '{} not found: {}'.format(
+                'Platform' if '.' in comp_name else 'Component', comp_name)
+            res['except'].setdefault(ERROR_STR, []).append(msg)
             return None
 
         # Test if platform/component and overwrite setup
@@ -223,6 +225,10 @@ def check(config_path):
         pkg_key = 'homeassistant.packages.{}'.format(package)
         res['except'][pkg_key] = config.get('homeassistant', {}) \
             .get('packages', {}).get(package)
+
+    def mock_logger_exception(msg):
+        """Log logger.exceptions."""
+        res['except'].setdefault(ERROR_STR, []).append(msg)
 
     # Patches to skip functions
     for sil in SILENCE:

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -30,8 +30,8 @@ MOCKS = {
                bootstrap.async_log_exception),
     'package_error': ("homeassistant.config._log_pkg_error",
                       config_util._log_pkg_error),
-    'logger_exception': ("homeassistant.bootstrap._LOGGER.exception",
-                         bootstrap._LOGGER.exception),
+    'logger_exception': ("homeassistant.bootstrap._LOGGER.error",
+                         bootstrap._LOGGER.error),
 }
 SILENCE = (
     'homeassistant.bootstrap.clear_secret_cache',
@@ -226,9 +226,10 @@ def check(config_path):
         res['except'][pkg_key] = config.get('homeassistant', {}) \
             .get('packages', {}).get(package)
 
-    def mock_logger_exception(msg):
+    def mock_logger_exception(msg, *params):
         """Log logger.exceptions."""
-        res['except'].setdefault(ERROR_STR, []).append(msg)
+        res['except'].setdefault(ERROR_STR, []).append(msg % params)
+        MOCKS['logger_exception'][1](msg, *params)
 
     # Patches to skip functions
     for sil in SILENCE:

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -85,6 +85,7 @@ class TestCheckConfig(unittest.TestCase):
             change_yaml_files(res)
 
             self.assertDictEqual({}, res['components'])
+            res['except'].pop(check_config.ERROR_STR)
             self.assertDictEqual(
                 {'http': {'password': 'err123'}},
                 res['except']
@@ -111,6 +112,7 @@ class TestCheckConfig(unittest.TestCase):
                  'light': []},
                 res['components']
             )
+            res['except'].pop(check_config.ERROR_STR)
             self.assertDictEqual(
                 {'light.mqtt_json': {'platform': 'mqtt_json'}},
                 res['except']
@@ -138,10 +140,12 @@ class TestCheckConfig(unittest.TestCase):
 
             res = check_config.check(get_test_config_dir('badplatform.yaml'))
             change_yaml_files(res)
-            self.assertDictEqual({'light': []}, res['components'])
-            self.assertDictEqual({check_config.ERROR_STR:
-                                  ['Platform not found: light.beer']},
-                                 res['except'])
+            assert res['components'] == {'light': []}
+            assert res['except'] == {
+                check_config.ERROR_STR: [
+                    'Platform not found: light.beer',
+                    'Unable to find platform light.beer'
+                ]}
             self.assertDictEqual({}, res['secret_cache'])
             self.assertDictEqual({}, res['secrets'])
             self.assertListEqual(['.../badplatform.yaml'], res['yaml_files'])


### PR DESCRIPTION
## Description:
Log errors far bad yaml in bootstrap & catch in `check_config`

**Related issue (if applicable):** fixes #6200

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation: !include dontexist
```

## Checklist:


If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
