### PR TITLE
Additional support for ecobee hold mode

### DIFF
--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -306,7 +306,7 @@ class Thermostat(ClimateDevice):
                 self.data.ecobee.set_climate_hold(self.thermostat_index,
                                                   hold_mode,
                                                   self.hold_preference())
-            self.update_without_throttle = True
+        self.update_without_throttle = True
 
     def set_auto_temp_hold(self, heat_temp, cool_temp):
         """Set temperature hold in auto mode."""

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -237,7 +237,7 @@ class Thermostat(ClimateDevice):
 
     @property
     def mode(self):
-        """Return current mode (as the user-defined name)."""
+        """Return current mode, as the user-visible name."""
         cur = self.thermostat['program']['currentClimateRef']
         climates = self.thermostat['program']['climates']
         current = list(filter(lambda x: x['climateRef'] == cur, climates))

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -237,8 +237,11 @@ class Thermostat(ClimateDevice):
 
     @property
     def mode(self):
-        """Return current mode ie. home, away, sleep."""
-        return self.thermostat['program']['currentClimateRef']
+        """Return current mode (as the user-defined name)."""
+        cur = self.thermostat['program']['currentClimateRef']
+        climates = self.thermostat['program']['climates']
+        current = list(filter(lambda x: x['climateRef'] == cur, climates))
+        return current[0]['name']
 
     @property
     def fan_min_on_time(self):

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -115,6 +115,7 @@ class Thermostat(ClimateDevice):
         self._name = self.thermostat['name']
         self.hold_temp = hold_temp
         self.vacation = None
+        self._climate_list = self.climate_list
         self._operation_list = ['auto', 'auxHeatOnly', 'cool',
                                 'heat', 'off']
         self.update_without_throttle = False
@@ -265,6 +266,7 @@ class Thermostat(ClimateDevice):
             "fan": self.fan,
             "mode": self.mode,
             "operation": operation,
+            "climate_list": self.climate_list,
             "fan_min_on_time": self.fan_min_on_time
         }
 
@@ -380,3 +382,9 @@ class Thermostat(ClimateDevice):
         # as an indefinite away hold is interpreted as away_mode
         else:
             return 'nextTransition'
+
+    @property
+    def climate_list(self):
+        """Return the list of climates currently available."""
+        climates = self.thermostat['program']['climates']
+        return list(map((lambda x: x['name']), climates))

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -25,6 +25,7 @@ ATTR_FAN_MIN_ON_TIME = 'fan_min_on_time'
 ATTR_RESUME_ALL = 'resume_all'
 
 DEFAULT_RESUME_ALL = False
+TEMPERATURE_HOLD = 'temp'
 
 DEPENDENCIES = ['ecobee']
 
@@ -203,7 +204,7 @@ class Thermostat(ClimateDevice):
                         return event['holdClimateRef']
                     else:
                         # any hold not based on a climate is a temp hold
-                        return 'temp'
+                        return TEMPERATURE_HOLD
                 elif event['type'].startswith('auto'):
                     # all auto modes are treated as holds
                     return event['type'][4:].lower()
@@ -294,7 +295,7 @@ class Thermostat(ClimateDevice):
         elif hold_mode == 'None' or hold_mode is None:
             self.data.ecobee.resume_program(self.thermostat_index)
         else:
-            if hold_mode == 'temp':
+            if hold_mode == TEMPERATURE_HOLD:
                 self.set_temp_hold(int(self.current_temperature))
             else:
                 self.data.ecobee.set_climate_hold(self.thermostat_index,

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -276,10 +276,7 @@ class Thermostat(ClimateDevice):
     @property
     def is_away_mode_on(self):
         """Return true if away mode is on."""
-        events = self.thermostat['events']
-        return any(event['holdClimateRef'] == 'away' and
-                   int(event['endDate'][0:4])-int(event['startDate'][0:4]) > 1
-                   for event in events)
+        return self.current_hold_mode == 'away'
 
     def turn_away_mode_on(self):
         """Turn away on."""


### PR DESCRIPTION
## Description:

Additional updates to hold mode are provided in this pull request:

1. In pull request #5590 nordlead2005 had proposed to support arbitrary climate-based holds. This was a good suggestion, but nothing was done on this for over a month. As this suggestion is somewhat behind, I decided to pull it into this update. I don't want to step on nordlead2005's toes, but his suggestion is good and should not be abandoned.
2. Use defined constant for TEMPERATURE_HOLD
3. Integrate handling of vacation into hold mode. Canceling vacation hold requires that the latest version of the external pyecobee library be used (where I made corresponding changes). Creation of vacation is not supported (it would be straightforward in the code, but a complex user interface would be required, similar to what is now done in the ecobee thermostat).
4. Add capability to retrieve list of defined climates from ecobee.
5. The mode() method used to return the system mode in internal representation. However, the user sees a different notation in the ecobee thermostat. Seeing some internal name is particularly weired with user-defined climates, where these are named "smart1", "smart2", etc., instead of the name the user has defined. Return the user-defined name instead. This change might break some user interfaces but is easily remedied (e.g., use "Away" instead of "away").
6. Simplification to is_away_mode_on().


## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
