### PR TITLE
Config fix

### DIFF
--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -129,5 +129,8 @@ def _read(path):
 
 def _write(path, data):
     """Write YAML helper."""
+    # Do it before opening file. If dump causes error it will now not
+    # truncate the file.
+    data = dump(data)
     with open(path, 'w', encoding='utf-8') as outfile:
-        outfile.write(dump(data))
+        outfile.write(data)


### PR DESCRIPTION
## Description:
When editing config panel, if YAML.dump would raise an error, the configuration file to be written would be truncated causing original config to be lost.

## Example entry for `configuration.yaml` (if applicable):
```yaml
config:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
