### PR TITLE
Bootstrap / Component setup async

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -37,8 +37,8 @@ DATA_PIP_LOCK = 'pip_lock'
 
 ERROR_LOG_FILENAME = 'home-assistant.log'
 
-FIRST_INIT_COMPONENT = set(
-    'recorder', 'mqtt', 'mqtt_eventstream', 'logger', 'introduction')
+FIRST_INIT_COMPONENT = set((
+    'recorder', 'mqtt', 'mqtt_eventstream', 'logger', 'introduction'))
 
 
 def setup_component(hass: core.HomeAssistant, domain: str,

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -165,6 +165,7 @@ def _async_setup_component(hass: core.HomeAssistant,
         conf_util.async_process_component_config(hass, config, domain)
 
     if processed_config is None:
+        log_error('Invalid config')
         return False
 
     requirements = yield from _async_handle_requirements(hass, component,

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -110,13 +110,13 @@ def _async_handle_requirements(hass: core.HomeAssistant, component,
     if pip_lock is None:
         pip_lock = hass.data[DATA_PIP_LOCK] = asyncio.Lock(loop=hass.loop)
 
-    def pip_install():
+    def pip_install(mod):
         """Install packages."""
-        return pkg_util.install_package(req, target=hass.config.path('deps')
+        return pkg_util.install_package(mod, target=hass.config.path('deps'))
 
     with (yield from pip_lock):
         for req in component.REQUIREMENTS:
-            ret = yield from hass.loop.run_in_executor(None, pip_install)
+            ret = yield from hass.loop.run_in_executor(None, pip_install, req)
             if not ret:
                 _LOGGER.error('Not initializing %s because could not install '
                               'dependency %s', name, req)

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -59,9 +59,6 @@ def async_setup_component(hass: core.HomeAssistant, domain: str,
         result = yield from setup_tasks[domain]
         return result
 
-    if not loader.PREPARED:
-        yield from hass.loop.run_in_executor(None, loader.prepare, hass)
-
     if config is None:
         config = {}
 
@@ -228,9 +225,6 @@ def async_prepare_setup_platform(hass: core.HomeAssistant, config, domain: str,
 
     This method is a coroutine.
     """
-    if not loader.PREPARED:
-        yield from hass.loop.run_in_executor(None, loader.prepare, hass)
-
     platform_path = PLATFORM_FORMAT.format(domain, platform_name)
 
     platform = loader.get_platform(domain, platform_name)

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -144,6 +144,10 @@ def _async_setup_component(hass: core.HomeAssistant,
     """Setup a component for Home Assistant.
 
     This method is a coroutine.
+
+    hass: Home Assistant instance.
+    domain: Domain of component to setup.
+    config: The Home Assistant configuration.
     """
     def log_error(msg):
         """Log helper."""
@@ -164,6 +168,12 @@ def _async_setup_component(hass: core.HomeAssistant,
         conf_util.async_process_component_config(hass, config, domain)
 
     if processed_config is None:
+        return False
+
+    requirements = yield from _async_handle_requirements(hass, component,
+                                                         domain)
+    if not requirements:
+        log_error('Could not install all requirements.')
         return False
 
     if hasattr(component, 'DEPENDENCIES'):

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -38,7 +38,7 @@ DATA_PIP_LOCK = 'pip_lock'
 ERROR_LOG_FILENAME = 'home-assistant.log'
 
 FIRST_INIT_COMPONENT = set(
-    'recorder', 'mqtt', 'mqtt_eventstream', 'logger', 'instroduction')
+    'recorder', 'mqtt', 'mqtt_eventstream', 'logger', 'introduction')
 
 
 def setup_component(hass: core.HomeAssistant, domain: str,

--- a/homeassistant/components/alarm_control_panel/envisalink.py
+++ b/homeassistant/components/alarm_control_panel/envisalink.py
@@ -55,7 +55,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         )
         devices.append(device)
 
-    yield from async_add_devices(devices)
+    async_add_devices(devices)
 
     @callback
     def alarm_keypress_handler(service):

--- a/homeassistant/components/alarm_control_panel/mqtt.py
+++ b/homeassistant/components/alarm_control_panel/mqtt.py
@@ -46,7 +46,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup the MQTT platform."""
-    yield from async_add_devices([MqttAlarm(
+    async_add_devices([MqttAlarm(
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_COMMAND_TOPIC),

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -28,8 +28,6 @@ import homeassistant.helpers.config_validation as cv
 DOMAIN = 'automation'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
-DEPENDENCIES = ['group']
-
 GROUP_NAME_ALL_AUTOMATIONS = 'all automations'
 
 CONF_ALIAS = 'alias'

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -346,17 +346,19 @@ def _async_process_config(hass, config, component):
 
             async_attach_triggers = partial(
                 _async_process_trigger, hass, config,
-                config_block.get(CONF_TRIGGER, []), name)
-            entity = AutomationEntity(name, async_attach_triggers, cond_func,
-                                      action, hidden)
+                config_block.get(CONF_TRIGGER, []), name
+            )
+            entity = AutomationEntity(
+                name, async_attach_triggers, cond_func, action, hidden)
+
             if config_block[CONF_INITIAL_STATE]:
                 tasks.append(entity.async_enable())
             entities.append(entity)
 
-    if tasks:
-        yield from asyncio.wait(tasks, loop=hass.loop)
     if entities:
         yield from component.async_add_entities(entities)
+    if tasks:
+        yield from asyncio.wait(tasks, loop=hass.loop)
 
     return len(entities) > 0
 

--- a/homeassistant/components/binary_sensor/envisalink.py
+++ b/homeassistant/components/binary_sensor/envisalink.py
@@ -37,7 +37,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         )
         devices.append(device)
 
-    yield from async_add_devices(devices)
+    async_add_devices(devices)
 
 
 class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/ffmpeg_motion.py
+++ b/homeassistant/components/binary_sensor/ffmpeg_motion.py
@@ -57,7 +57,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     # generate sensor object
     entity = FFmpegMotion(hass, manager, config)
-    yield from async_add_devices([entity])
+    async_add_devices([entity])
 
 
 class FFmpegBinarySensor(FFmpegBase, BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/ffmpeg_noise.py
+++ b/homeassistant/components/binary_sensor/ffmpeg_noise.py
@@ -54,7 +54,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     # generate sensor object
     entity = FFmpegNoise(hass, manager, config)
-    yield from async_add_devices([entity])
+    async_add_devices([entity])
 
 
 class FFmpegNoise(FFmpegBinarySensor):

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -46,7 +46,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if value_template is not None:
         value_template.hass = hass
 
-    yield from async_add_devices([MqttBinarySensor(
+    async_add_devices([MqttBinarySensor(
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
         get_deprecated(config, CONF_DEVICE_CLASS, CONF_SENSOR_CLASS),

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -66,7 +66,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         _LOGGER.error('No sensors added')
         return False
 
-    yield from async_add_devices(sensors, True)
+    async_add_devices(sensors, True)
     return True
 
 

--- a/homeassistant/components/binary_sensor/threshold.py
+++ b/homeassistant/components/binary_sensor/threshold.py
@@ -52,7 +52,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     limit_type = config.get(CONF_TYPE)
     device_class = get_deprecated(config, CONF_DEVICE_CLASS, CONF_SENSOR_CLASS)
 
-    yield from async_add_devices(
+    async_add_devices(
         [ThresholdSensor(hass, entity_id, name, threshold, limit_type,
                          device_class)], True)
     return True

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -34,7 +34,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup a FFmpeg Camera."""
     if not hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_INPUT)):
         return
-    yield from async_add_devices([FFmpegCamera(hass, config)])
+    async_add_devices([FFmpegCamera(hass, config)])
 
 
 class FFmpegCamera(Camera):

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -44,7 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 # pylint: disable=unused-argument
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup a generic IP Camera."""
-    yield from async_add_devices([GenericCamera(hass, config)])
+    async_add_devices([GenericCamera(hass, config)])
 
 
 class GenericCamera(Camera):

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -45,7 +45,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 # pylint: disable=unused-argument
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup a MJPEG IP Camera."""
-    yield from async_add_devices([MjpegCamera(hass, config)])
+    async_add_devices([MjpegCamera(hass, config)])
 
 
 def extract_image_from_mjpeg(stream):

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -153,7 +153,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             )
             devices.append(device)
 
-    yield from async_add_devices(devices)
+    async_add_devices(devices)
 
 
 @asyncio.coroutine

--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -75,4 +75,4 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         _LOGGER.warning('No active cameras found')
         return
 
-    yield from async_add_devices(cameras)
+    async_add_devices(cameras)

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -63,7 +63,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     min_cycle_duration = config.get(CONF_MIN_DUR)
     tolerance = config.get(CONF_TOLERANCE)
 
-    yield from async_add_devices([GenericThermostat(
+    async_add_devices([GenericThermostat(
         hass, name, heater_entity_id, sensor_entity_id, min_temp, max_temp,
         target_temp, ac_mode, min_cycle_duration, tolerance)])
 

--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -54,7 +54,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if value_template is not None:
         value_template.hass = hass
 
-    yield from async_add_devices([MqttCover(
+    async_add_devices([MqttCover(
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_COMMAND_TOPIC),

--- a/homeassistant/components/demo.py
+++ b/homeassistant/components/demo.py
@@ -80,10 +80,10 @@ def async_setup(hass, config):
     # Set up input boolean
     tasks.append(bootstrap.async_setup_component(
         hass, 'input_boolean',
-        {'input_boolean': {'notify': {'icon': 'mdi:car',
-                                      'initial': False,
-                                      'name': 'Notify Anne Therese is home'}}})
-    )
+        {'input_boolean': {'notify': {
+            'icon': 'mdi:car',
+            'initial': False,
+            'name': 'Notify Anne Therese is home'}}}))
 
     # Set up input boolean
     tasks.append(bootstrap.async_setup_component(

--- a/homeassistant/components/demo.py
+++ b/homeassistant/components/demo.py
@@ -4,6 +4,7 @@ Sets up a demo environment that mimics interaction with devices.
 For more details about this component, please refer to the documentation
 https://home-assistant.io/components/demo/
 """
+import asyncio
 import time
 
 import homeassistant.bootstrap as bootstrap
@@ -34,7 +35,8 @@ COMPONENTS_WITH_DEMO_PLATFORM = [
 ]
 
 
-def setup(hass, config):
+@asyncio.coroutine
+def async_setup(hass, config):
     """Setup a demo environment."""
     group = loader.get_component('group')
     configurator = loader.get_component('configurator')
@@ -44,7 +46,7 @@ def setup(hass, config):
     config.setdefault(DOMAIN, {})
 
     if config[DOMAIN].get('hide_demo_state') != 1:
-        hass.states.set('a.Demo_Mode', 'Enabled')
+        hass.states.async_set('a.Demo_Mode', 'Enabled')
 
     # Setup sun
     if not hass.config.latitude:
@@ -53,50 +55,71 @@ def setup(hass, config):
     if not hass.config.longitude:
         hass.config.longitude = 117.22743
 
-    bootstrap.setup_component(hass, 'sun')
+    tasks = [
+        bootstrap.async_setup_component(hass, 'sun')
+    ]
 
     # Setup demo platforms
     demo_config = config.copy()
     for component in COMPONENTS_WITH_DEMO_PLATFORM:
         demo_config[component] = {CONF_PLATFORM: 'demo'}
-        bootstrap.setup_component(hass, component, demo_config)
+        tasks.append(
+            bootstrap.async_setup_component(hass, component, demo_config))
+
+    # Set up input select
+    tasks.append(bootstrap.async_setup_component(
+        hass, 'input_select',
+        {'input_select':
+         {'living_room_preset': {'options': ['Visitors',
+                                             'Visitors with kids',
+                                             'Home Alone']},
+          'who_cooks': {'icon': 'mdi:panda',
+                        'initial': 'Anne Therese',
+                        'name': 'Cook today',
+                        'options': ['Paulus', 'Anne Therese']}}}))
+    # Set up input boolean
+    tasks.append(bootstrap.async_setup_component(
+        hass, 'input_boolean',
+        {'input_boolean': {'notify': {'icon': 'mdi:car',
+                                      'initial': False,
+                                      'name': 'Notify Anne Therese is home'}}})
+    )
+
+    # Set up input boolean
+    tasks.append(bootstrap.async_setup_component(
+        hass, 'input_slider',
+        {'input_slider': {
+            'noise_allowance': {'icon': 'mdi:bell-ring',
+                                'min': 0,
+                                'max': 10,
+                                'name': 'Allowed Noise',
+                                'unit_of_measurement': 'dB'}}}))
+
+    # Set up weblink
+    tasks.append(bootstrap.async_setup_component(
+        hass, 'weblink',
+        {'weblink': {'entities': [{'name': 'Router',
+                                   'url': 'http://192.168.1.1'}]}}))
+
+    results = yield from asyncio.gather(*tasks, loop=hass.loop)
+
+    if any(not result for result in results):
+        return False
 
     # Setup example persistent notification
-    persistent_notification.create(
+    persistent_notification.async_create(
         hass, 'This is an example of a persistent notification.',
         title='Example Notification')
 
     # Setup room groups
-    lights = sorted(hass.states.entity_ids('light'))
-    switches = sorted(hass.states.entity_ids('switch'))
-    media_players = sorted(hass.states.entity_ids('media_player'))
+    lights = sorted(hass.states.async_entity_ids('light'))
+    switches = sorted(hass.states.async_entity_ids('switch'))
+    media_players = sorted(hass.states.async_entity_ids('media_player'))
 
-    group.Group.create_group(hass, 'living room', [
-        lights[1], switches[0], 'input_select.living_room_preset',
-        'rollershutter.living_room_window', media_players[1],
-        'scene.romantic_lights'])
-    group.Group.create_group(hass, 'bedroom', [
-        lights[0], switches[1], media_players[0],
-        'input_slider.noise_allowance'])
-    group.Group.create_group(hass, 'kitchen', [
-        lights[2], 'rollershutter.kitchen_window', 'lock.kitchen_door'])
-    group.Group.create_group(hass, 'doors', [
-        'lock.front_door', 'lock.kitchen_door',
-        'garage_door.right_garage_door', 'garage_door.left_garage_door'])
-    group.Group.create_group(hass, 'automations', [
-        'input_select.who_cooks', 'input_boolean.notify', ])
-    group.Group.create_group(hass, 'people', [
-        'device_tracker.demo_anne_therese', 'device_tracker.demo_home_boy',
-        'device_tracker.demo_paulus'])
-    group.Group.create_group(hass, 'downstairs', [
-        'group.living_room', 'group.kitchen',
-        'scene.romantic_lights', 'rollershutter.kitchen_window',
-        'rollershutter.living_room_window', 'group.doors',
-        'thermostat.ecobee',
-    ], view=True)
+    tasks2 = []
 
     # Setup scripts
-    bootstrap.setup_component(
+    tasks2.append(bootstrap.async_setup_component(
         hass, 'script',
         {'script': {
             'demo': {
@@ -115,10 +138,10 @@ def setup(hass, config):
                     'service': 'light.turn_off',
                     'data': {ATTR_ENTITY_ID: lights[0]}
                 }]
-            }}})
+            }}}))
 
     # Setup scenes
-    bootstrap.setup_component(
+    tasks2.append(bootstrap.async_setup_component(
         hass, 'scene',
         {'scene': [
             {'name': 'Romantic lights',
@@ -132,41 +155,37 @@ def setup(hass, config):
                  switches[0]: True,
                  switches[1]: False,
              }},
-            ]})
+            ]}))
 
-    # Set up input select
-    bootstrap.setup_component(
-        hass, 'input_select',
-        {'input_select':
-         {'living_room_preset': {'options': ['Visitors',
-                                             'Visitors with kids',
-                                             'Home Alone']},
-          'who_cooks': {'icon': 'mdi:panda',
-                        'initial': 'Anne Therese',
-                        'name': 'Cook today',
-                        'options': ['Paulus', 'Anne Therese']}}})
-    # Set up input boolean
-    bootstrap.setup_component(
-        hass, 'input_boolean',
-        {'input_boolean': {'notify': {'icon': 'mdi:car',
-                                      'initial': False,
-                                      'name': 'Notify Anne Therese is home'}}})
+    tasks2.append(group.Group.async_create_group(hass, 'living room', [
+        lights[1], switches[0], 'input_select.living_room_preset',
+        'rollershutter.living_room_window', media_players[1],
+        'scene.romantic_lights']))
+    tasks2.append(group.Group.async_create_group(hass, 'bedroom', [
+        lights[0], switches[1], media_players[0],
+        'input_slider.noise_allowance']))
+    tasks2.append(group.Group.async_create_group(hass, 'kitchen', [
+        lights[2], 'rollershutter.kitchen_window', 'lock.kitchen_door']))
+    tasks2.append(group.Group.async_create_group(hass, 'doors', [
+        'lock.front_door', 'lock.kitchen_door',
+        'garage_door.right_garage_door', 'garage_door.left_garage_door']))
+    tasks2.append(group.Group.async_create_group(hass, 'automations', [
+        'input_select.who_cooks', 'input_boolean.notify', ]))
+    tasks2.append(group.Group.async_create_group(hass, 'people', [
+        'device_tracker.demo_anne_therese', 'device_tracker.demo_home_boy',
+        'device_tracker.demo_paulus']))
+    tasks2.append(group.Group.async_create_group(hass, 'downstairs', [
+        'group.living_room', 'group.kitchen',
+        'scene.romantic_lights', 'rollershutter.kitchen_window',
+        'rollershutter.living_room_window', 'group.doors',
+        'thermostat.ecobee',
+    ], view=True))
 
-    # Set up input boolean
-    bootstrap.setup_component(
-        hass, 'input_slider',
-        {'input_slider': {
-            'noise_allowance': {'icon': 'mdi:bell-ring',
-                                'min': 0,
-                                'max': 10,
-                                'name': 'Allowed Noise',
-                                'unit_of_measurement': 'dB'}}})
+    results = yield from asyncio.gather(*tasks2, loop=hass.loop)
 
-    # Set up weblink
-    bootstrap.setup_component(
-        hass, 'weblink',
-        {'weblink': {'entities': [{'name': 'Router',
-                                   'url': 'http://192.168.1.1'}]}})
+    if any(not result for result in results):
+        return False
+
     # Setup configurator
     configurator_ids = []
 
@@ -184,14 +203,17 @@ def setup(hass, config):
         else:
             configurator.request_done(configurator_ids[0])
 
-    request_id = configurator.request_config(
-        hass, "Philips Hue", hue_configuration_callback,
-        description=("Press the button on the bridge to register Philips Hue "
-                     "with Home Assistant."),
-        description_image="/static/images/config_philips_hue.jpg",
-        submit_caption="I have pressed the button"
-    )
+    def setup_configurator():
+        """Setup configurator."""
+        request_id = configurator.request_config(
+            hass, "Philips Hue", hue_configuration_callback,
+            description=("Press the button on the bridge to register Philips "
+                         "Hue with Home Assistant."),
+            description_image="/static/images/config_philips_hue.jpg",
+            submit_caption="I have pressed the button"
+        )
+        configurator_ids.append(request_id)
 
-    configurator_ids.append(request_id)
+    hass.async_add_job(setup_configurator)
 
     return True

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -14,12 +14,11 @@ import aiohttp
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.bootstrap import (
-    async_prepare_setup_platform, async_log_exception)
+from homeassistant.bootstrap import async_prepare_setup_platform
 from homeassistant.core import callback
 from homeassistant.components import group, zone
 from homeassistant.components.discovery import SERVICE_NETGEAR
-from homeassistant.config import load_yaml_config_file
+from homeassistant.config import load_yaml_config_file, async_log_exception
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_per_platform, discovery

--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -78,7 +78,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup MQTT fan platform."""
-    yield from async_add_devices([MqttFan(
+    async_add_devices([MqttFan(
         config.get(CONF_NAME),
         {
             key: config.get(key) for key in (

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -204,6 +204,7 @@ def async_setup(hass, config):
         DOMAIN, SERVICE_RELOAD, reload_service_handler,
         descriptions[DOMAIN][SERVICE_RELOAD], schema=RELOAD_SERVICE_SCHEMA)
 
+    component.async_set_ready()
     return True
 
 

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -204,7 +204,6 @@ def async_setup(hass, config):
         DOMAIN, SERVICE_RELOAD, reload_service_handler,
         descriptions[DOMAIN][SERVICE_RELOAD], schema=RELOAD_SERVICE_SCHEMA)
 
-    component.async_set_ready()
     return True
 
 

--- a/homeassistant/components/image_processing/microsoft_face_detect.py
+++ b/homeassistant/components/image_processing/microsoft_face_detect.py
@@ -60,7 +60,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             camera[CONF_ENTITY_ID], api, attributes, camera.get(CONF_NAME)
         ))
 
-    yield from async_add_devices(entities)
+    async_add_devices(entities)
 
 
 class MicrosoftFaceDetectEntity(ImageProcessingFaceEntity):

--- a/homeassistant/components/image_processing/microsoft_face_identify.py
+++ b/homeassistant/components/image_processing/microsoft_face_identify.py
@@ -54,7 +54,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             camera.get(CONF_NAME)
         ))
 
-    yield from async_add_devices(entities)
+    async_add_devices(entities)
 
 
 class ImageProcessingFaceEntity(ImageProcessingEntity):

--- a/homeassistant/components/image_processing/openalpr_cloud.py
+++ b/homeassistant/components/image_processing/openalpr_cloud.py
@@ -66,7 +66,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             camera[CONF_ENTITY_ID], params, confidence, camera.get(CONF_NAME)
         ))
 
-    yield from async_add_devices(entities)
+    async_add_devices(entities)
 
 
 class OpenAlprCloudEntity(ImageProcessingAlprEntity):

--- a/homeassistant/components/image_processing/openalpr_local.py
+++ b/homeassistant/components/image_processing/openalpr_local.py
@@ -70,7 +70,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             camera[CONF_ENTITY_ID], command, confidence, camera.get(CONF_NAME)
         ))
 
-    yield from async_add_devices(entities)
+    async_add_devices(entities)
 
 
 class ImageProcessingAlprEntity(ImageProcessingEntity):

--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -107,7 +107,6 @@ def async_setup(hass, config):
         DOMAIN, SERVICE_TOGGLE, async_handler_service, schema=SERVICE_SCHEMA)
 
     yield from component.async_add_entities(entities)
-    component.async_set_ready()
     return True
 
 

--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -107,6 +107,7 @@ def async_setup(hass, config):
         DOMAIN, SERVICE_TOGGLE, async_handler_service, schema=SERVICE_SCHEMA)
 
     yield from component.async_add_entities(entities)
+    component.async_set_ready()
     return True
 
 

--- a/homeassistant/components/input_select.py
+++ b/homeassistant/components/input_select.py
@@ -181,7 +181,6 @@ def async_setup(hass, config):
         schema=SERVICE_SET_OPTIONS_SCHEMA)
 
     yield from component.async_add_entities(entities)
-    component.async_set_ready()
     return True
 
 

--- a/homeassistant/components/input_select.py
+++ b/homeassistant/components/input_select.py
@@ -181,6 +181,7 @@ def async_setup(hass, config):
         schema=SERVICE_SET_OPTIONS_SCHEMA)
 
     yield from component.async_add_entities(entities)
+    component.async_set_ready()
     return True
 
 

--- a/homeassistant/components/input_slider.py
+++ b/homeassistant/components/input_slider.py
@@ -113,6 +113,7 @@ def async_setup(hass, config):
         schema=SERVICE_SELECT_VALUE_SCHEMA)
 
     yield from component.async_add_entities(entities)
+    component.async_set_ready()
     return True
 
 

--- a/homeassistant/components/input_slider.py
+++ b/homeassistant/components/input_slider.py
@@ -113,7 +113,6 @@ def async_setup(hass, config):
         schema=SERVICE_SELECT_VALUE_SCHEMA)
 
     yield from component.async_add_entities(entities)
-    component.async_set_ready()
     return True
 
 

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -70,7 +70,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     config.setdefault(
         CONF_STATE_VALUE_TEMPLATE, config.get(CONF_VALUE_TEMPLATE))
 
-    yield from async_add_devices([MqttLight(
+    async_add_devices([MqttLight(
         config.get(CONF_NAME),
         {
             key: config.get(key) for key in (

--- a/homeassistant/components/light/mqtt_json.py
+++ b/homeassistant/components/light/mqtt_json.py
@@ -61,7 +61,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup a MQTT JSON Light."""
-    yield from async_add_devices([MqttJson(
+    async_add_devices([MqttJson(
         config.get(CONF_NAME),
         {
             key: config.get(key) for key in (

--- a/homeassistant/components/light/mqtt_template.py
+++ b/homeassistant/components/light/mqtt_template.py
@@ -64,7 +64,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup a MQTT Template light."""
-    yield from async_add_devices([MqttTemplate(
+    async_add_devices([MqttTemplate(
         hass,
         config.get(CONF_NAME),
         config.get(CONF_EFFECT_LIST),

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -117,7 +117,7 @@ def devices_from_config(domain_config, hass=None):
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Rflink light platform."""
-    yield from async_add_devices(devices_from_config(config, hass))
+    async_add_devices(devices_from_config(config, hass))
 
     # Add new (unconfigured) devices to user desired group
     if config[CONF_NEW_DEVICES_GROUP]:
@@ -136,7 +136,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
         device_config = config[CONF_DEVICE_DEFAULTS]
         device = entity_class(device_id, hass, **device_config)
-        yield from async_add_devices([device])
+        async_add_devices([device])
 
         # Register entity to listen to incoming Rflink events
         hass.data[DATA_ENTITY_LOOKUP][
@@ -156,13 +156,21 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class RflinkLight(SwitchableRflinkDevice, Light):
     """Representation of a Rflink light."""
 
-    pass
+    @property
+    def entity_id(self):
+        """Return entity id."""
+        return "light.{}".format(self.name)
 
 
 class DimmableRflinkLight(SwitchableRflinkDevice, Light):
     """Rflink light device that support dimming."""
 
     _brightness = 255
+
+    @property
+    def entity_id(self):
+        """Return entity id."""
+        return "light.{}".format(self.name)
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
@@ -201,6 +209,11 @@ class HybridRflinkLight(SwitchableRflinkDevice, Light):
     """
 
     _brightness = 255
+
+    @property
+    def entity_id(self):
+        """Return entity id."""
+        return "light.{}".format(self.name)
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):

--- a/homeassistant/components/lock/mqtt.py
+++ b/homeassistant/components/lock/mqtt.py
@@ -47,7 +47,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if value_template is not None:
         value_template.hass = hass
 
-    yield from async_add_devices([MqttLock(
+    async_add_devices([MqttLock(
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_COMMAND_TOPIC),

--- a/homeassistant/components/media_player/anthemav.py
+++ b/homeassistant/components/media_player/anthemav.py
@@ -63,7 +63,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     _LOGGER.debug('dump_rawdata: '+avr.protocol.dump_rawdata)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, device.avr.close)
-    yield from async_add_devices([device])
+    async_add_devices([device])
 
 
 class AnthemAVR(MediaPlayerDevice):

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -85,7 +85,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         return False
 
     players = yield from lms.create_players()
-    yield from async_add_devices(players)
+    async_add_devices(players)
 
     return True
 

--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -63,7 +63,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config[CONF_ATTRS]
     )
 
-    yield from async_add_devices([player])
+    async_add_devices([player])
 
 
 def validate_config(config):

--- a/homeassistant/components/scene/__init__.py
+++ b/homeassistant/components/scene/__init__.py
@@ -18,7 +18,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 
 DOMAIN = 'scene'
-DEPENDENCIES = ['group']
 STATE = 'scening'
 
 CONF_ENTITIES = "entities"

--- a/homeassistant/components/scene/homeassistant.py
+++ b/homeassistant/components/scene/homeassistant.py
@@ -28,7 +28,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if not isinstance(scene_config, list):
         scene_config = [scene_config]
 
-    yield from async_add_devices(HomeAssistantScene(
+    async_add_devices(HomeAssistantScene(
         hass, _process_config(scene)) for scene in scene_config)
     return True
 

--- a/homeassistant/components/scene/homeassistant.py
+++ b/homeassistant/components/scene/homeassistant.py
@@ -13,7 +13,6 @@ from homeassistant.const import (
 from homeassistant.core import State
 from homeassistant.helpers.state import async_reproduce_state
 
-DEPENDENCIES = ['group']
 STATE = 'scening'
 
 CONF_ENTITIES = "entities"

--- a/homeassistant/components/script.py
+++ b/homeassistant/components/script.py
@@ -25,7 +25,6 @@ from homeassistant.helpers.script import Script
 DOMAIN = "script"
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 GROUP_NAME_ALL_SCRIPTS = 'all scripts'
-DEPENDENCIES = ["group"]
 
 CONF_SEQUENCE = "sequence"
 

--- a/homeassistant/components/script.py
+++ b/homeassistant/components/script.py
@@ -130,7 +130,6 @@ def async_setup(hass, config):
     hass.services.async_register(DOMAIN, SERVICE_TOGGLE, toggle_service,
                                  schema=SCRIPT_TURN_ONOFF_SCHEMA)
 
-    component.async_set_ready()
     return True
 
 

--- a/homeassistant/components/script.py
+++ b/homeassistant/components/script.py
@@ -130,6 +130,8 @@ def async_setup(hass, config):
                                  schema=SCRIPT_TURN_ONOFF_SCHEMA)
     hass.services.async_register(DOMAIN, SERVICE_TOGGLE, toggle_service,
                                  schema=SCRIPT_TURN_ONOFF_SCHEMA)
+
+    component.async_set_ready()
     return True
 
 

--- a/homeassistant/components/sensor/api_streams.py
+++ b/homeassistant/components/sensor/api_streams.py
@@ -61,7 +61,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, remove_logger)
 
-    yield from async_add_devices([entity])
+    async_add_devices([entity])
 
 
 class APICount(Entity):

--- a/homeassistant/components/sensor/dnsip.py
+++ b/homeassistant/components/sensor/dnsip.py
@@ -49,7 +49,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     else:
         resolver = config.get(CONF_RESOLVER)
 
-    yield from async_add_devices([WanIpSensor(
+    async_add_devices([WanIpSensor(
         hass, hostname, resolver, ipv6)], True)
 
 

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -103,7 +103,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         DerivativeDSMREntity('Hourly Gas Consumption', gas_obis),
     ]
 
-    yield from async_add_devices(devices)
+    async_add_devices(devices)
 
     def update_entities_telegram(telegram):
         """Update entities with latests telegram & trigger state update."""

--- a/homeassistant/components/sensor/envisalink.py
+++ b/homeassistant/components/sensor/envisalink.py
@@ -34,7 +34,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             hass.data[DATA_EVL])
         devices.append(device)
 
-    yield from async_add_devices(devices)
+    async_add_devices(devices)
 
 
 class EnvisalinkSensor(EnvisalinkDevice, Entity):

--- a/homeassistant/components/sensor/min_max.py
+++ b/homeassistant/components/sensor/min_max.py
@@ -61,7 +61,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     sensor_type = config.get(CONF_TYPE)
     round_digits = config.get(CONF_ROUND_DIGITS)
 
-    yield from async_add_devices(
+    async_add_devices(
         [MinMaxSensor(hass, entity_ids, name, sensor_type, round_digits)],
         True)
     return True

--- a/homeassistant/components/sensor/moon.py
+++ b/homeassistant/components/sensor/moon.py
@@ -33,7 +33,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Moon sensor."""
     name = config.get(CONF_NAME)
 
-    yield from async_add_devices([MoonSensor(name)], True)
+    async_add_devices([MoonSensor(name)], True)
     return True
 
 

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -38,7 +38,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if value_template is not None:
         value_template.hass = hass
 
-    yield from async_add_devices([MqttSensor(
+    async_add_devices([MqttSensor(
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_QOS),

--- a/homeassistant/components/sensor/mqtt_room.py
+++ b/homeassistant/components/sensor/mqtt_room.py
@@ -59,7 +59,7 @@ MQTT_PAYLOAD = vol.Schema(vol.All(json.loads, vol.Schema({
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup MQTT Sensor."""
-    yield from async_add_devices([MQTTRoomSensor(
+    async_add_devices([MQTTRoomSensor(
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_DEVICE_ID),

--- a/homeassistant/components/sensor/random.py
+++ b/homeassistant/components/sensor/random.py
@@ -36,7 +36,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     minimum = config.get(CONF_MINIMUM)
     maximum = config.get(CONF_MAXIMUM)
 
-    yield from async_add_devices([RandomSensor(name, minimum, maximum)], True)
+    async_add_devices([RandomSensor(name, minimum, maximum)], True)
     return True
 
 

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -74,7 +74,7 @@ def devices_from_config(domain_config, hass=None):
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Rflink platform."""
-    yield from async_add_devices(devices_from_config(config, hass))
+    async_add_devices(devices_from_config(config, hass))
 
     # Add new (unconfigured) devices to user desired group
     if config[CONF_NEW_DEVICES_GROUP]:
@@ -91,7 +91,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         rflinksensor = partial(RflinkSensor, device_id, hass)
         device = rflinksensor(event[EVENT_KEY_SENSOR], event[EVENT_KEY_UNIT])
         # Add device entity
-        yield from async_add_devices([device])
+        async_add_devices([device])
 
         # Register entity to listen to incoming rflink events
         hass.data[DATA_ENTITY_LOOKUP][
@@ -121,6 +121,11 @@ class RflinkSensor(RflinkDevice):
     def _handle_event(self, event):
         """Domain specific event handler."""
         self._state = event['value']
+
+    @property
+    def entity_id(self):
+        """Return entity id."""
+        return "sensor.{}".format(self.name)
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -50,7 +50,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     sampling_size = config.get(CONF_SAMPLING_SIZE)
 
-    yield from async_add_devices(
+    async_add_devices(
         [StatisticsSensor(hass, entity_id, name, sampling_size)], True)
     return True
 

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -69,7 +69,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         _LOGGER.error("No sensors added")
         return False
 
-    yield from async_add_devices(sensors, True)
+    async_add_devices(sensors, True)
     return True
 
 

--- a/homeassistant/components/sensor/time_date.py
+++ b/homeassistant/components/sensor/time_date.py
@@ -46,7 +46,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     for variable in config[CONF_DISPLAY_OPTIONS]:
         devices.append(TimeDateSensor(variable))
 
-    yield from async_add_devices(devices, True)
+    async_add_devices(devices, True)
     return True
 
 

--- a/homeassistant/components/sensor/worldclock.py
+++ b/homeassistant/components/sensor/worldclock.py
@@ -35,7 +35,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     time_zone = dt_util.get_time_zone(config.get(CONF_TIME_ZONE))
 
-    yield from async_add_devices([WorldClockSensor(time_zone, name)], True)
+    async_add_devices([WorldClockSensor(time_zone, name)], True)
     return True
 
 

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -78,7 +78,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     dev = []
     for sensor_type in config[CONF_MONITORED_CONDITIONS]:
         dev.append(YrSensor(sensor_type))
-    yield from async_add_devices(dev)
+    async_add_devices(dev)
 
     weather = YrData(hass, coordinates, dev)
     # Update weather on the hour, spread seconds

--- a/homeassistant/components/switch/hook.py
+++ b/homeassistant/components/switch/hook.py
@@ -74,7 +74,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         if response is not None:
             yield from response.release()
 
-    yield from async_add_devices(
+    async_add_devices(
         HookSmartHome(
             hass,
             token,

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -43,7 +43,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if value_template is not None:
         value_template.hass = hass
 
-    yield from async_add_devices([MqttSwitch(
+    async_add_devices([MqttSwitch(
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_COMMAND_TOPIC),

--- a/homeassistant/components/switch/rest.py
+++ b/homeassistant/components/switch/rest.py
@@ -72,7 +72,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         if req is not None:
             yield from req.release()
 
-    yield from async_add_devices(
+    async_add_devices(
         [RestSwitch(hass, name, resource, body_on, body_off,
                     is_on_template, timeout)])
 

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -52,7 +52,7 @@ def devices_from_config(domain_config, hass=None):
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Rflink platform."""
-    yield from async_add_devices(devices_from_config(config, hass))
+    async_add_devices(devices_from_config(config, hass))
 
 
 class RflinkSwitch(SwitchableRflinkDevice, SwitchDevice):

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -70,7 +70,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         _LOGGER.error("No switches added")
         return False
 
-    yield from async_add_devices(switches, True)
+    async_add_devices(switches, True)
     return True
 
 

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -276,7 +276,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     device = hass.data[DATA_ZWAVE_DICT].pop(
         discovery_info[const.DISCOVERY_DEVICE])
     if device:
-        yield from async_add_devices([device])
+        async_add_devices([device])
         return True
     else:
         return False

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -63,20 +63,9 @@ def async_discover(hass, service, discovered=None, component=None,
             'Cannot discover the {} component.'.format(component))
 
     if component is not None and component not in hass.config.components:
-        did_lock = False
-        setup_lock = hass.data.get('setup_lock')
-        if setup_lock and setup_lock.locked():
-            did_lock = True
-            yield from setup_lock.acquire()
-
-        try:
-            # Could have been loaded while waiting for lock.
-            if component not in hass.config.components:
-                yield from bootstrap.async_setup_component(hass, component,
-                                                           hass_config)
-        finally:
-            if did_lock:
-                setup_lock.release()
+        if component not in hass.config.components:
+            yield from bootstrap.async_setup_component(
+                hass, component, hass_config)
 
     data = {
         ATTR_SERVICE: service
@@ -160,22 +149,11 @@ def async_load_platform(hass, component, platform, discovered=None,
         raise HomeAssistantError(
             'Cannot discover the {} component.'.format(component))
 
-    did_lock = False
-    setup_lock = hass.data.get('setup_lock')
-    if setup_lock and setup_lock.locked():
-        did_lock = True
-        yield from setup_lock.acquire()
-
     setup_success = True
 
-    try:
-        # Could have been loaded while waiting for lock.
-        if component not in hass.config.components:
-            setup_success = yield from bootstrap.async_setup_component(
-                hass, component, hass_config)
-    finally:
-        if did_lock:
-            setup_lock.release()
+    if component not in hass.config.components:
+        setup_success = yield from bootstrap.async_setup_component(
+            hass, component, hass_config)
 
     # No need to fire event if we could not setup component
     if not setup_success:

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -63,9 +63,8 @@ def async_discover(hass, service, discovered=None, component=None,
             'Cannot discover the {} component.'.format(component))
 
     if component is not None and component not in hass.config.components:
-        if component not in hass.config.components:
-            yield from bootstrap.async_setup_component(
-                hass, component, hass_config)
+        yield from bootstrap.async_setup_component(
+            hass, component, hass_config)
 
     data = {
         ATTR_SERVICE: service

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from homeassistant import config as conf_util
 from homeassistant.bootstrap import (
     async_prepare_setup_platform, async_prepare_setup_component,
-    DATA_SETUP_EVENTS, EV_PLATFORM)
+    DATA_PLATFORM)
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_SCAN_INTERVAL, CONF_ENTITY_NAMESPACE,
     DEVICE_DEFAULT_NAME)
@@ -48,8 +48,8 @@ class EntityComponent(object):
         self.add_entities = self._platforms['core'].add_entities
 
         self._ready = asyncio.Event(loop=hass.loop)
-        if domain in hass.data.get(DATA_SETUP_EVENTS, {}):
-            hass.data[DATA_SETUP_EVENTS][domain][EV_PLATFORM] = self._ready
+        if domain in hass.data.get(DATA_PLATFORM, {}):
+            hass.data[DATA_PLATFORM][domain] = self._ready
 
     def setup(self, config):
         """Set up a full entity component.

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -3,9 +3,7 @@ import asyncio
 from datetime import timedelta
 
 from homeassistant import config as conf_util
-from homeassistant.bootstrap import (
-    async_prepare_setup_platform, async_prepare_setup_component,
-    DATA_PLATFORM)
+from homeassistant.bootstrap import async_prepare_setup_platform, DATA_PLATFORM
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_SCAN_INTERVAL, CONF_ENTITY_NAMESPACE,
     DEVICE_DEFAULT_NAME)
@@ -287,7 +285,7 @@ class EntityComponent(object):
             self.logger.error(err)
             return None
 
-        conf = yield from async_prepare_setup_component(
+        conf = conf_util.async_extract_component_config(
             self.hass, conf, self.domain)
 
         if conf is None:

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -52,7 +52,7 @@ class EntityComponent(object):
     def setup(self, config):
         """Set up a full entity component.
 
-        This don't block the executor for protect deadlocks.
+        This doesn't block the executor to protect from deadlocks.
         """
         self.hass.add_job(self.async_setup(config))
 
@@ -75,7 +75,7 @@ class EntityComponent(object):
         if tasks:
             yield from asyncio.wait(tasks, loop=self.hass.loop)
 
-        # set event ready for know that component is setup
+        # set event ready to indicate that component is setup
         self._ready.set()
 
         # Generic discovery listener for loading platform dynamically
@@ -90,9 +90,9 @@ class EntityComponent(object):
             self.hass, self.domain, component_platform_discovered)
 
     def async_set_ready(self):
-        """Set the EntityComponent ready for setup all things done.
+        """Mark the EntityComponent as ready.
 
-        Need to be call if async_setup will not call.
+        Need to be called if component does not call async_setup.
         """
         self._ready.set()
 

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -3,7 +3,7 @@ import asyncio
 from datetime import timedelta
 
 from homeassistant import config as conf_util
-from homeassistant.bootstrap import async_prepare_setup_platform, DATA_PLATFORM
+from homeassistant.bootstrap import async_prepare_setup_platform
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_SCAN_INTERVAL, CONF_ENTITY_NAMESPACE,
     DEVICE_DEFAULT_NAME)
@@ -45,10 +45,6 @@ class EntityComponent(object):
         self.async_add_entities = self._platforms['core'].async_add_entities
         self.add_entities = self._platforms['core'].add_entities
 
-        self._ready = asyncio.Event(loop=hass.loop)
-        if domain in hass.data.get(DATA_PLATFORM, {}):
-            hass.data[DATA_PLATFORM][domain] = self._ready
-
     def setup(self, config):
         """Set up a full entity component.
 
@@ -75,9 +71,6 @@ class EntityComponent(object):
         if tasks:
             yield from asyncio.wait(tasks, loop=self.hass.loop)
 
-        # set event ready to indicate that component is setup
-        self._ready.set()
-
         # Generic discovery listener for loading platform dynamically
         # Refer to: homeassistant.components.discovery.load_platform()
         @callback
@@ -88,13 +81,6 @@ class EntityComponent(object):
 
         discovery.async_listen_platform(
             self.hass, self.domain, component_platform_discovered)
-
-    def async_set_ready(self):
-        """Mark the EntityComponent as ready.
-
-        Need to be called if component does not call async_setup.
-        """
-        self._ready.set()
 
     def extract_from_service(self, service, expand_group=True):
         """Extract all known entities from a service call.

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -139,13 +139,15 @@ class EntityComponent(object):
             if getattr(platform, 'async_setup_platform', None):
                 yield from platform.async_setup_platform(
                     self.hass, platform_config,
-                    entity_platform.async_add_entities, discovery_info
+                    entity_platform.async_add_platform_entities, discovery_info
                 )
             else:
                 yield from self.hass.loop.run_in_executor(
                     None, platform.setup_platform, self.hass, platform_config,
-                    entity_platform.add_entities, discovery_info
+                    entity_platform.add_platform_entities, discovery_info
                 )
+
+            yield from entity_platform.async_block_entities_done()
 
             self.hass.config.components.add(
                 '{}.{}'.format(self.domain, platform_type))
@@ -291,8 +293,39 @@ class EntityPlatform(object):
         self.scan_interval = scan_interval
         self.entity_namespace = entity_namespace
         self.platform_entities = []
+        self._tasks = []
         self._async_unsub_polling = None
         self._process_updates = asyncio.Lock(loop=component.hass.loop)
+
+    @asyncio.coroutine
+    def async_block_entities_done(self):
+        """Wait until all entities add to hass."""
+        if self._tasks:
+            pending = [task for task in self._tasks if not task.done()]
+            self._tasks.clear()
+
+            if pending:
+                yield from asyncio.wait(pending, loop=self.component.hass.loop)
+
+    def add_platform_entities(self, new_entities, update_before_add=False):
+        """Add entities for a single platform."""
+        if update_before_add:
+            for entity in new_entities:
+                entity.update()
+
+        run_callback_threadsafe(
+            self.component.hass.loop,
+            self.async_add_platform_entities, list(new_entities), False
+        ).result()
+
+    @callback
+    def async_add_platform_entities(self, new_entities,
+                                    update_before_add=False):
+        """Add entities for a single platform async."""
+        self._tasks.append(self.component.hass.async_add_job(
+            self.async_add_entities(
+                new_entities, update_before_add=update_before_add)
+        ))
 
     def add_entities(self, new_entities, update_before_add=False):
         """Add entities for a single platform."""
@@ -302,8 +335,7 @@ class EntityPlatform(object):
 
         run_coroutine_threadsafe(
             self.async_add_entities(list(new_entities), False),
-            self.component.hass.loop
-        ).result()
+            self.component.hass.loop).result()
 
     @asyncio.coroutine
     def async_add_entities(self, new_entities, update_before_add=False):
@@ -315,8 +347,16 @@ class EntityPlatform(object):
         if not new_entities:
             return
 
-        tasks = [self._async_process_entity(entity, update_before_add)
-                 for entity in new_entities]
+        @asyncio.coroutine
+        def async_process_entity(new_entity):
+            """Add entities to StateMachine."""
+            ret = yield from self.component.async_add_entity(
+                new_entity, self, update_before_add=update_before_add
+            )
+            if ret:
+                self.platform_entities.append(new_entity)
+
+        tasks = [async_process_entity(entity) for entity in new_entities]
 
         yield from asyncio.wait(tasks, loop=self.component.hass.loop)
         yield from self.component.async_update_group()
@@ -329,15 +369,6 @@ class EntityPlatform(object):
         self._async_unsub_polling = async_track_time_interval(
             self.component.hass, self._update_entity_states, self.scan_interval
         )
-
-    @asyncio.coroutine
-    def _async_process_entity(self, new_entity, update_before_add):
-        """Add entities to StateMachine."""
-        ret = yield from self.component.async_add_entity(
-            new_entity, self, update_before_add=update_before_add
-        )
-        if ret:
-            self.platform_entities.append(new_entity)
 
     @asyncio.coroutine
     def async_reset(self):

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -285,7 +285,7 @@ class EntityComponent(object):
             self.logger.error(err)
             return None
 
-        conf = conf_util.async_extract_component_config(
+        conf = conf_util.async_process_component_config(
             self.hass, conf, self.domain)
 
         if conf is None:

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -139,12 +139,12 @@ class EntityComponent(object):
             if getattr(platform, 'async_setup_platform', None):
                 yield from platform.async_setup_platform(
                     self.hass, platform_config,
-                    entity_platform.async_add_platform_entities, discovery_info
+                    entity_platform.async_schedule_add_entities, discovery_info
                 )
             else:
                 yield from self.hass.loop.run_in_executor(
                     None, platform.setup_platform, self.hass, platform_config,
-                    entity_platform.add_platform_entities, discovery_info
+                    entity_platform.schedule_add_entities, discovery_info
                 )
 
             yield from entity_platform.async_block_entities_done()
@@ -307,7 +307,7 @@ class EntityPlatform(object):
             if pending:
                 yield from asyncio.wait(pending, loop=self.component.hass.loop)
 
-    def add_platform_entities(self, new_entities, update_before_add=False):
+    def schedule_add_entities(self, new_entities, update_before_add=False):
         """Add entities for a single platform."""
         if update_before_add:
             for entity in new_entities:
@@ -315,11 +315,11 @@ class EntityPlatform(object):
 
         run_callback_threadsafe(
             self.component.hass.loop,
-            self.async_add_platform_entities, list(new_entities), False
+            self.async_schedule_add_entities, list(new_entities), False
         ).result()
 
     @callback
-    def async_add_platform_entities(self, new_entities,
+    def async_schedule_add_entities(self, new_entities,
                                     update_before_add=False):
         """Add entities for a single platform async."""
         self._tasks.append(self.component.hass.async_add_job(

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -170,41 +170,6 @@ def get_component(comp_name) -> Optional[ModuleType]:
     return None
 
 
-def load_order_components(components: Sequence[str]) -> OrderedSet:
-    """Take in a list of components we want to load.
-
-    - filters out components we cannot load
-    - filters out components that have invalid/circular dependencies
-    - Will make sure the recorder component is loaded first
-    - Will ensure that all components that do not directly depend on
-      the group component will be loaded before the group component.
-    - returns an OrderedSet load order.
-    - Makes sure MQTT eventstream is available for publish before
-      components start updating states.
-
-    Async friendly.
-    """
-    _check_prepared()
-
-    load_order = OrderedSet()
-
-    # Sort the list of modules on if they depend on group component or not.
-    # Components that do not depend on the group usually set up states.
-    # Components that depend on group usually use states in their setup.
-    for comp_load_order in sorted((load_order_component(component)
-                                   for component in components),
-                                  key=lambda order: 'group' in order):
-        load_order.update(comp_load_order)
-
-    # Push some to first place in load order
-    for comp in ('mqtt_eventstream', 'mqtt', 'recorder',
-                 'introduction', 'logger'):
-        if comp in load_order:
-            load_order.promote(comp)
-
-    return load_order
-
-
 def load_order_component(comp_name: str) -> OrderedSet:
     """Return an OrderedSet of components in the correct order of loading.
 

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -26,8 +26,8 @@ MOCKS = {
     'load*': ("homeassistant.config.load_yaml", yaml.load_yaml),
     'get': ("homeassistant.loader.get_component", loader.get_component),
     'secrets': ("homeassistant.util.yaml._secret_yaml", yaml._secret_yaml),
-    'except': ("homeassistant.bootstrap.async_log_exception",
-               bootstrap.async_log_exception),
+    'except': ("homeassistant.config.async_log_exception",
+               config_util.async_log_exception),
     'package_error': ("homeassistant.config._log_pkg_error",
                       config_util._log_pkg_error),
 }
@@ -211,7 +211,7 @@ def check(config_path):
 
     def mock_except(ex, domain, config,  # pylint: disable=unused-variable
                     hass=None):
-        """Mock bootstrap.log_exception."""
+        """Mock config.log_exception."""
         MOCKS['except'][1](ex, domain, config, hass)
         res['except'][domain] = config.get(domain, config)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -277,9 +277,8 @@ def mock_component(hass, component):
     if setup_tasks is None:
         setup_tasks = hass.data[DATA_SETUP] = {}
 
-    # assert will not work!
     if component not in setup_tasks:
-        RuntimeError("Component {} is allready setup".format(component))
+        AssertionError("Component {} is allready setup".format(component))
 
     hass.config.components.add(component)
     setup_tasks[component] = asyncio.Task(mock_coro(True), loop=hass.loop)

--- a/tests/common.py
+++ b/tests/common.py
@@ -277,7 +277,9 @@ def mock_component(hass, component):
     if setup_tasks is None:
         setup_tasks = hass.data[DATA_SETUP] = {}
 
-    assert component in setup_tasks
+    # assert will not work!
+    if component not in setup_tasks:
+        RuntimeError("Component {} is allready setup".format(component))
 
     hass.config.components.add(component)
     setup_tasks[component] = asyncio.Task(mock_coro(True), loop=hass.loop)

--- a/tests/common.py
+++ b/tests/common.py
@@ -93,13 +93,15 @@ def async_test_home_assistant(loop):
 
     hass = ha.HomeAssistant(loop)
 
+    orig_async_add_job = hass.async_add_job
     def async_add_job(target, *args):
         """Add a magic mock."""
         if isinstance(target, MagicMock):
             return
-        hass._async_add_job_tracking(target, *args)
+        orig_async_add_job(target, *args)
 
     hass.async_add_job = async_add_job
+    hass.async_track_tasks()
 
     hass.config.location_name = 'test home'
     hass.config.config_dir = get_test_config_dir()

--- a/tests/common.py
+++ b/tests/common.py
@@ -12,8 +12,8 @@ from contextlib import contextmanager
 from aiohttp import web
 
 from homeassistant import core as ha, loader
-from homeassistant.bootstrap import (
-    setup_component, async_prepare_setup_component)
+from homeassistant.bootstrap import setup_component, DATA_SETUP, DATA_PLATFORM
+from homeassistant.config import async_process_component_config
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.restore_state import DATA_RESTORE_CACHE
@@ -99,7 +99,7 @@ def async_test_home_assistant(loop):
         """Add a magic mock."""
         if isinstance(target, MagicMock):
             return
-        orig_async_add_job(target, *args)
+        return orig_async_add_job(target, *args)
 
     hass.async_add_job = async_add_job
     hass.async_track_tasks()
@@ -233,7 +233,7 @@ def mock_state_change_event(hass, new_state, old_state=None):
 def mock_http_component(hass, api_password=None):
     """Mock the HTTP component."""
     hass.http = MagicMock(api_password=api_password)
-    hass.config.components.add('http')
+    mock_component(hass, 'http')
     hass.http.views = {}
 
     def mock_register_view(view):
@@ -269,6 +269,19 @@ def mock_mqtt_component(hass):
             }
         })
         return mock_mqtt
+
+
+def mock_component(hass, component):
+    """Mock a component is setup."""
+    # TODO Raise if component already loaded
+    hass.config.components.add(component)
+    setup_tasks = hass.data.get(DATA_SETUP)
+
+    if setup_tasks is None:
+        setup_tasks = hass.data[DATA_SETUP] = {}
+        hass.data[DATA_PLATFORM] = {}
+
+    setup_tasks[component] = asyncio.Task(mock_coro(True), loop=hass.loop)
 
 
 class MockModule(object):
@@ -442,10 +455,10 @@ def assert_setup_component(count, domain=None):
     """
     config = {}
 
-    @asyncio.coroutine
+    @ha.callback
     def mock_psc(hass, config_input, domain):
         """Mock the prepare_setup_component to capture config."""
-        res = yield from async_prepare_setup_component(
+        res = async_process_component_config(
             hass, config_input, domain)
         config[domain] = None if res is None else res.get(domain)
         _LOGGER.debug('Configuration for %s, Validated: %s, Original %s',
@@ -453,7 +466,7 @@ def assert_setup_component(count, domain=None):
         return res
 
     assert isinstance(config, dict)
-    with patch('homeassistant.bootstrap.async_prepare_setup_component',
+    with patch('homeassistant.config.async_process_component_config',
                mock_psc):
         yield config
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from aiohttp import web
 
 from homeassistant import core as ha, loader
-from homeassistant.bootstrap import setup_component, DATA_SETUP, DATA_PLATFORM
+from homeassistant.bootstrap import setup_component, DATA_SETUP
 from homeassistant.config import async_process_component_config
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import ToggleEntity
@@ -279,7 +279,6 @@ def mock_component(hass, component):
 
     if setup_tasks is None:
         setup_tasks = hass.data[DATA_SETUP] = {}
-        hass.data[DATA_PLATFORM] = {}
 
     setup_tasks[component] = asyncio.Task(mock_coro(True), loop=hass.loop)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -277,10 +277,9 @@ def mock_component(hass, component):
     if setup_tasks is None:
         setup_tasks = hass.data[DATA_SETUP] = {}
 
-    if component in setup_tasks:
-        raise RuntimeError("{} allready loaded".format(component))
-    hass.config.components.add(component)
+    assert component in setup_tasks
 
+    hass.config.components.add(component)
     setup_tasks[component] = asyncio.Task(mock_coro(True), loop=hass.loop)
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -273,12 +273,13 @@ def mock_mqtt_component(hass):
 
 def mock_component(hass, component):
     """Mock a component is setup."""
-    # TODO Raise if component already loaded
-    hass.config.components.add(component)
     setup_tasks = hass.data.get(DATA_SETUP)
-
     if setup_tasks is None:
         setup_tasks = hass.data[DATA_SETUP] = {}
+
+    if component in setup_tasks:
+        raise RuntimeError("{} allready loaded".format(component))
+    hass.config.components.add(component)
 
     setup_tasks[component] = asyncio.Task(mock_coro(True), loop=hass.loop)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -278,7 +278,7 @@ def mock_component(hass, component):
         setup_tasks = hass.data[DATA_SETUP] = {}
 
     if component not in setup_tasks:
-        AssertionError("Component {} is allready setup".format(component))
+        AssertionError("Component {} is already setup".format(component))
 
     hass.config.components.add(component)
     setup_tasks[component] = asyncio.Task(mock_coro(True), loop=hass.loop)

--- a/tests/common.py
+++ b/tests/common.py
@@ -94,6 +94,7 @@ def async_test_home_assistant(loop):
     hass = ha.HomeAssistant(loop)
 
     orig_async_add_job = hass.async_add_job
+
     def async_add_job(target, *args):
         """Add a magic mock."""
         if isinstance(target, MagicMock):

--- a/tests/components/alarm_control_panel/test_mqtt.py
+++ b/tests/components/alarm_control_panel/test_mqtt.py
@@ -9,7 +9,7 @@ from homeassistant.components import alarm_control_panel
 
 from tests.common import (
     mock_mqtt_component, fire_mqtt_message, get_test_home_assistant,
-    assert_setup_component)
+    assert_setup_component, mock_component)
 
 CODE = 'HELLO_CODE'
 
@@ -30,7 +30,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_fail_setup_without_state_topic(self):
         """Test for failing with no state topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(0) as config:
             assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
                 alarm_control_panel.DOMAIN: {
@@ -42,7 +42,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_fail_setup_without_command_topic(self):
         """Test failing with no command topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(0):
             assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
                 alarm_control_panel.DOMAIN: {
@@ -53,7 +53,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_update_state_via_state_topic(self):
         """Test updating with via state topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -77,7 +77,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_ignore_update_state_if_unknown_via_state_topic(self):
         """Test ignoring updates via state topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -98,7 +98,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_arm_home_publishes_mqtt(self):
         """Test publishing of MQTT messages while armed."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -115,7 +115,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_arm_home_not_publishes_mqtt_with_invalid_code(self):
         """Test not publishing of MQTT messages with invalid code."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -133,7 +133,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_arm_away_publishes_mqtt(self):
         """Test publishing of MQTT messages while armed."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -150,7 +150,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_arm_away_not_publishes_mqtt_with_invalid_code(self):
         """Test not publishing of MQTT messages with invalid code."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -168,7 +168,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_disarm_publishes_mqtt(self):
         """Test publishing of MQTT messages while disarmed."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -185,7 +185,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_disarm_not_publishes_mqtt_with_invalid_code(self):
         """Test not publishing of MQTT messages with invalid code."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',

--- a/tests/components/alarm_control_panel/test_mqtt.py
+++ b/tests/components/alarm_control_panel/test_mqtt.py
@@ -9,7 +9,7 @@ from homeassistant.components import alarm_control_panel
 
 from tests.common import (
     mock_mqtt_component, fire_mqtt_message, get_test_home_assistant,
-    assert_setup_component, mock_component)
+    assert_setup_component)
 
 CODE = 'HELLO_CODE'
 
@@ -30,7 +30,6 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_fail_setup_without_state_topic(self):
         """Test for failing with no state topic."""
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(0) as config:
             assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
                 alarm_control_panel.DOMAIN: {
@@ -42,7 +41,6 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_fail_setup_without_command_topic(self):
         """Test failing with no command topic."""
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(0):
             assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
                 alarm_control_panel.DOMAIN: {
@@ -53,7 +51,6 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_update_state_via_state_topic(self):
         """Test updating with via state topic."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -77,7 +74,6 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_ignore_update_state_if_unknown_via_state_topic(self):
         """Test ignoring updates via state topic."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -98,7 +94,6 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_arm_home_publishes_mqtt(self):
         """Test publishing of MQTT messages while armed."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -115,7 +110,6 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_arm_home_not_publishes_mqtt_with_invalid_code(self):
         """Test not publishing of MQTT messages with invalid code."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -133,7 +127,6 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_arm_away_publishes_mqtt(self):
         """Test publishing of MQTT messages while armed."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -150,7 +143,6 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_arm_away_not_publishes_mqtt_with_invalid_code(self):
         """Test not publishing of MQTT messages with invalid code."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -168,7 +160,6 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_disarm_publishes_mqtt(self):
         """Test publishing of MQTT messages while disarmed."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
@@ -185,7 +176,6 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
     def test_disarm_not_publishes_mqtt_with_invalid_code(self):
         """Test not publishing of MQTT messages with invalid code."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',

--- a/tests/components/automation/test_event.py
+++ b/tests/components/automation/test_event.py
@@ -5,7 +5,7 @@ from homeassistant.core import callback
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.automation as automation
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
 
 # pylint: disable=invalid-name
@@ -15,7 +15,7 @@ class TestAutomationEvent(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components.add('group')
+        mock_component(self.hass, 'group')
         self.calls = []
 
         @callback

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -11,7 +11,7 @@ from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util.dt as dt_util
 
 from tests.common import get_test_home_assistant, assert_setup_component, \
-    fire_time_changed
+    fire_time_changed, mock_component
 
 
 # pylint: disable=invalid-name
@@ -21,7 +21,7 @@ class TestAutomation(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components.add('group')
+        mock_component(self.hass, 'group')
         self.calls = []
 
         @callback

--- a/tests/components/automation/test_mqtt.py
+++ b/tests/components/automation/test_mqtt.py
@@ -5,7 +5,8 @@ from homeassistant.core import callback
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.automation as automation
 from tests.common import (
-    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant)
+    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant,
+    mock_component)
 
 
 # pylint: disable=invalid-name
@@ -15,7 +16,7 @@ class TestAutomationMQTT(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components.add('group')
+        mock_component(self.hass, 'group')
         mock_mqtt_component(self.hass)
         self.calls = []
 

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -5,7 +5,7 @@ from homeassistant.core import callback
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.automation as automation
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
 
 # pylint: disable=invalid-name
@@ -15,7 +15,7 @@ class TestAutomationNumericState(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components.add('group')
+        mock_component(self.hass, 'group')
         self.calls = []
 
         @callback

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -10,7 +10,8 @@ import homeassistant.util.dt as dt_util
 import homeassistant.components.automation as automation
 
 from tests.common import (
-    fire_time_changed, get_test_home_assistant, assert_setup_component)
+    fire_time_changed, get_test_home_assistant, assert_setup_component,
+    mock_component)
 
 
 # pylint: disable=invalid-name
@@ -20,7 +21,7 @@ class TestAutomationState(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components.add('group')
+        mock_component(self.hass, 'group')
         self.hass.states.set('test.entity', 'hello')
         self.calls = []
 

--- a/tests/components/automation/test_sun.py
+++ b/tests/components/automation/test_sun.py
@@ -10,7 +10,8 @@ from homeassistant.components import sun
 import homeassistant.components.automation as automation
 import homeassistant.util.dt as dt_util
 
-from tests.common import fire_time_changed, get_test_home_assistant
+from tests.common import (
+    fire_time_changed, get_test_home_assistant, mock_component)
 
 
 # pylint: disable=invalid-name
@@ -20,8 +21,8 @@ class TestAutomationSun(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components.add('group')
-        self.hass.config.components.add('sun')
+        mock_component(self.hass, 'group')
+        mock_component(self.hass, 'sun')
 
         self.calls = []
 

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -5,7 +5,8 @@ from homeassistant.core import callback
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.automation as automation
 
-from tests.common import get_test_home_assistant, assert_setup_component
+from tests.common import (
+    get_test_home_assistant, assert_setup_component, mock_component)
 
 
 # pylint: disable=invalid-name
@@ -15,7 +16,7 @@ class TestAutomationTemplate(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components.add('group')
+        mock_component(self.hass, 'group')
         self.hass.states.set('test.entity', 'hello')
         self.calls = []
 

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -9,7 +9,8 @@ import homeassistant.util.dt as dt_util
 import homeassistant.components.automation as automation
 
 from tests.common import (
-    fire_time_changed, get_test_home_assistant, assert_setup_component)
+    fire_time_changed, get_test_home_assistant, assert_setup_component,
+    mock_component)
 
 
 # pylint: disable=invalid-name
@@ -19,7 +20,7 @@ class TestAutomationTime(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components.add('group')
+        mock_component(self.hass, 'group')
         self.calls = []
 
         @callback

--- a/tests/components/automation/test_zone.py
+++ b/tests/components/automation/test_zone.py
@@ -5,7 +5,7 @@ from homeassistant.core import callback
 from homeassistant.bootstrap import setup_component
 from homeassistant.components import automation, zone
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
 
 # pylint: disable=invalid-name
@@ -15,7 +15,7 @@ class TestAutomationZone(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components.add('group')
+        mock_component(self.hass, 'group')
         assert setup_component(self.hass, zone.DOMAIN, {
             'zone': {
                 'name': 'test',

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -6,7 +6,7 @@ import homeassistant.components.binary_sensor as binary_sensor
 from tests.common import mock_mqtt_component, fire_mqtt_message
 from homeassistant.const import (STATE_OFF, STATE_ON)
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
 
 class TestSensorMQTT(unittest.TestCase):
@@ -23,7 +23,7 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_setting_sensor_value_via_mqtt_message(self):
         """Test the setting of the value via MQTT."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, binary_sensor.DOMAIN, {
             binary_sensor.DOMAIN: {
                 'platform': 'mqtt',
@@ -49,7 +49,7 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_valid_device_class(self):
         """Test the setting of a valid sensor class."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, binary_sensor.DOMAIN, {
             binary_sensor.DOMAIN: {
                 'platform': 'mqtt',
@@ -64,7 +64,7 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_invalid_device_class(self):
         """Test the setting of an invalid sensor class."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, binary_sensor.DOMAIN, {
             binary_sensor.DOMAIN: {
                 'platform': 'mqtt',

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -3,10 +3,10 @@ import unittest
 
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.binary_sensor as binary_sensor
-from tests.common import mock_mqtt_component, fire_mqtt_message
 from homeassistant.const import (STATE_OFF, STATE_ON)
 
-from tests.common import get_test_home_assistant, mock_component
+from tests.common import (
+    get_test_home_assistant, mock_mqtt_component, fire_mqtt_message)
 
 
 class TestSensorMQTT(unittest.TestCase):
@@ -23,7 +23,6 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_setting_sensor_value_via_mqtt_message(self):
         """Test the setting of the value via MQTT."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, binary_sensor.DOMAIN, {
             binary_sensor.DOMAIN: {
                 'platform': 'mqtt',
@@ -49,7 +48,6 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_valid_device_class(self):
         """Test the setting of a valid sensor class."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, binary_sensor.DOMAIN, {
             binary_sensor.DOMAIN: {
                 'platform': 'mqtt',
@@ -64,7 +62,6 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_invalid_device_class(self):
         """Test the setting of an invalid sensor class."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, binary_sensor.DOMAIN, {
             binary_sensor.DOMAIN: {
                 'platform': 'mqtt',

--- a/tests/components/camera/test_uvc.py
+++ b/tests/components/camera/test_uvc.py
@@ -9,7 +9,7 @@ from uvcclient import nvr
 
 from homeassistant.bootstrap import setup_component
 from homeassistant.components.camera import uvc
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_http_component
 
 
 class TestUVCSetup(unittest.TestCase):
@@ -18,8 +18,7 @@ class TestUVCSetup(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.http = mock.MagicMock()
-        self.hass.config.components = set(['http'])
+        mock_http_component(self.hass)
 
     def tearDown(self):
         """Stop everything that was started."""

--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -15,6 +15,9 @@ def test_validate_config_ok(hass, test_client):
     with patch.object(config, 'SECTIONS', ['core']):
         yield from async_setup_component(hass, 'config', {})
 
+    # yield from hass.async_block_till_done()
+    yield from asyncio.sleep(0.1, loop=hass.loop)
+
     hass.http.views[CheckConfigView.name].register(app.router)
     client = yield from test_client(app)
 

--- a/tests/components/config/test_init.py
+++ b/tests/components/config/test_init.py
@@ -8,7 +8,7 @@ from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.bootstrap import async_setup_component, ATTR_COMPONENT
 from homeassistant.components import config
 
-from tests.common import mock_http_component, mock_coro
+from tests.common import mock_http_component, mock_coro, mock_component
 
 
 @pytest.fixture(autouse=True)
@@ -27,7 +27,7 @@ def test_config_setup(hass, loop):
 @asyncio.coroutine
 def test_load_on_demand_already_loaded(hass, test_client):
     """Test getting suites."""
-    hass.config.components.add('zwave')
+    mock_component(hass, 'zwave')
 
     with patch.object(config, 'SECTIONS', []), \
             patch.object(config, 'ON_DEMAND', ['zwave']), \

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -6,7 +6,7 @@ from homeassistant.const import STATE_OPEN, STATE_CLOSED, STATE_UNKNOWN
 import homeassistant.components.cover as cover
 from tests.common import mock_mqtt_component, fire_mqtt_message
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
 
 class TestCoverMQTT(unittest.TestCase):
@@ -23,7 +23,7 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_state_via_state_topic(self):
         """Test the controlling state via topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',
@@ -72,7 +72,7 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_state_via_template(self):
         """Test the controlling state via topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',
@@ -101,7 +101,7 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_optimistic_state_change(self):
         """Test changing state optimistically."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',
@@ -132,7 +132,7 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_send_open_cover_command(self):
         """Test the sending of open_cover."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',
@@ -156,7 +156,7 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_send_close_cover_command(self):
         """Test the sending of close_cover."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',
@@ -180,7 +180,7 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_send_stop__cover_command(self):
         """Test the sending of stop_cover."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',
@@ -204,7 +204,7 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_current_cover_position(self):
         """Test the current cover position."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -4,9 +4,9 @@ import unittest
 from homeassistant.bootstrap import setup_component
 from homeassistant.const import STATE_OPEN, STATE_CLOSED, STATE_UNKNOWN
 import homeassistant.components.cover as cover
-from tests.common import mock_mqtt_component, fire_mqtt_message
 
-from tests.common import get_test_home_assistant, mock_component
+from tests.common import (
+    get_test_home_assistant, mock_mqtt_component, fire_mqtt_message)
 
 
 class TestCoverMQTT(unittest.TestCase):
@@ -23,7 +23,6 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_state_via_state_topic(self):
         """Test the controlling state via topic."""
-        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',
@@ -72,7 +71,6 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_state_via_template(self):
         """Test the controlling state via topic."""
-        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',
@@ -101,7 +99,6 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_optimistic_state_change(self):
         """Test changing state optimistically."""
-        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',
@@ -132,7 +129,6 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_send_open_cover_command(self):
         """Test the sending of open_cover."""
-        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',
@@ -156,7 +152,6 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_send_close_cover_command(self):
         """Test the sending of close_cover."""
-        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',
@@ -180,7 +175,6 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_send_stop__cover_command(self):
         """Test the sending of stop_cover."""
-        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',
@@ -204,7 +198,6 @@ class TestCoverMQTT(unittest.TestCase):
 
     def test_current_cover_position(self):
         """Test the current cover position."""
-        mock_component(self.hass, 'mqtt')
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
             cover.DOMAIN: {
                 'platform': 'mqtt',

--- a/tests/components/cover/test_rfxtrx.py
+++ b/tests/components/cover/test_rfxtrx.py
@@ -6,7 +6,7 @@ import pytest
 from homeassistant.bootstrap import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
 
 @pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
@@ -16,7 +16,7 @@ class TestCoverRfxtrx(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components = set(['rfxtrx'])
+        mock_component('rfxtrx')
 
     def tearDown(self):
         """Stop everything that was started."""

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -17,7 +17,8 @@ from homeassistant.const import (CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME,
                                  CONF_HOST)
 
 from tests.common import (
-    get_test_home_assistant, get_test_config_dir, assert_setup_component)
+    get_test_home_assistant, get_test_config_dir, assert_setup_component,
+    mock_component)
 
 FAKEFILE = None
 
@@ -43,7 +44,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
     def setup_method(self, _):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components = set(['zone'])
+        mock_component(self.hass, 'zone')
 
     def teardown_method(self, _):
         """Stop everything that was started."""

--- a/tests/components/device_tracker/test_ddwrt.py
+++ b/tests/components/device_tracker/test_ddwrt.py
@@ -16,7 +16,8 @@ from homeassistant.components.device_tracker import DOMAIN
 from homeassistant.util import slugify
 
 from tests.common import (
-    get_test_home_assistant, assert_setup_component, load_fixture)
+    get_test_home_assistant, assert_setup_component, load_fixture,
+    mock_component)
 
 from ...test_util.aiohttp import mock_aiohttp_client
 
@@ -39,7 +40,7 @@ class TestDdwrt(unittest.TestCase):
     def setup_method(self, _):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components = set(['zone'])
+        mock_component(self.hass, 'zone')
 
     def teardown_method(self, _):
         """Stop everything that was started."""

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -9,7 +9,8 @@ from homeassistant.components import device_tracker
 from homeassistant.const import CONF_PLATFORM
 
 from tests.common import (
-    get_test_home_assistant, mock_mqtt_component, fire_mqtt_message)
+    get_test_home_assistant, mock_mqtt_component, fire_mqtt_message,
+    mock_component)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,6 +22,7 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         mock_mqtt_component(self.hass)
+        mock_component(self.hass, 'mqtt')
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""
@@ -43,7 +45,6 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
 
             dev_id = 'paulus'
             topic = '/location/paulus'
-            self.hass.config.components = set(['mqtt', 'zone'])
             assert setup_component(self.hass, device_tracker.DOMAIN, {
                 device_tracker.DOMAIN: {
                     CONF_PLATFORM: 'mqtt',

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -9,8 +9,7 @@ from homeassistant.components import device_tracker
 from homeassistant.const import CONF_PLATFORM
 
 from tests.common import (
-    get_test_home_assistant, mock_mqtt_component, fire_mqtt_message,
-    mock_component)
+    get_test_home_assistant, mock_mqtt_component, fire_mqtt_message)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +21,6 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         mock_mqtt_component(self.hass)
-        mock_component(self.hass, 'mqtt')
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""

--- a/tests/components/device_tracker/test_upc_connect.py
+++ b/tests/components/device_tracker/test_upc_connect.py
@@ -13,7 +13,8 @@ import homeassistant.components.device_tracker.upc_connect as platform
 from homeassistant.util.async import run_coroutine_threadsafe
 
 from tests.common import (
-    get_test_home_assistant, assert_setup_component, load_fixture)
+    get_test_home_assistant, assert_setup_component, load_fixture,
+    mock_component)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ class TestUPCConnect(object):
     def setup_method(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components = set(['zone'])
+        mock_component(self.hass, 'zone')
 
         self.host = "127.0.0.1"
 

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -1,7 +1,6 @@
 """The tests for the Home Assistant HTTP component."""
 import asyncio
 import requests
-from unittest.mock import MagicMock
 
 from homeassistant import bootstrap, const
 import homeassistant.components.http as http
@@ -157,46 +156,48 @@ def test_registering_view_while_running(hass, test_client):
     assert text == 'hello'
 
 
-def test_api_base_url(loop):
+@asyncio.coroutine
+def test_api_base_url_with_domain(hass):
     """Test setting api url."""
-    hass = MagicMock()
-    hass.loop = loop
-
-    assert loop.run_until_complete(
-        bootstrap.async_setup_component(hass, 'http', {
-            'http': {
-                'base_url': 'example.com'
-            }
-        })
-    )
-
+    result = yield from bootstrap.async_setup_component(hass, 'http', {
+        'http': {
+            'base_url': 'example.com'
+        }
+    })
+    assert result
     assert hass.config.api.base_url == 'http://example.com'
 
-    assert loop.run_until_complete(
-        bootstrap.async_setup_component(hass, 'http', {
-            'http': {
-                'server_host': '1.1.1.1'
-            }
-        })
-    )
 
+@asyncio.coroutine
+def test_api_base_url_with_ip(hass):
+    """Test setting api url."""
+    result = yield from bootstrap.async_setup_component(hass, 'http', {
+        'http': {
+            'server_host': '1.1.1.1'
+        }
+    })
+    assert result
     assert hass.config.api.base_url == 'http://1.1.1.1:8123'
 
-    assert loop.run_until_complete(
-        bootstrap.async_setup_component(hass, 'http', {
-            'http': {
-                'server_host': '1.1.1.1'
-            }
-        })
-    )
 
-    assert hass.config.api.base_url == 'http://1.1.1.1:8123'
+@asyncio.coroutine
+def test_api_base_url_with_ip_port(hass):
+    """Test setting api url."""
+    result = yield from bootstrap.async_setup_component(hass, 'http', {
+        'http': {
+            'base_url': '1.1.1.1:8124'
+        }
+    })
+    assert result
+    assert hass.config.api.base_url == 'http://1.1.1.1:8124'
 
-    assert loop.run_until_complete(
-        bootstrap.async_setup_component(hass, 'http', {
-            'http': {
-            }
-        })
-    )
 
+@asyncio.coroutine
+def test_api_no_base_url(hass):
+    """Test setting api url."""
+    result = yield from bootstrap.async_setup_component(hass, 'http', {
+        'http': {
+        }
+    })
+    assert result
     assert hass.config.api.base_url == 'http://127.0.0.1:8123'

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -8,7 +8,7 @@ from homeassistant.bootstrap import setup_component, async_setup_component
 import homeassistant.components.light as light
 from homeassistant.helpers.restore_state import DATA_RESTORE_CACHE
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
 ENTITY_LIGHT = 'light.bed_light'
 
@@ -68,7 +68,7 @@ class TestDemoLight(unittest.TestCase):
 @asyncio.coroutine
 def test_restore_state(hass):
     """Test state gets restored."""
-    hass.config.components.add('recorder')
+    mock_component(hass, 'recorder')
     hass.state = CoreState.starting
     hass.data[DATA_RESTORE_CACHE] = {
         'light.bed_light': State('light.bed_light', 'on', {

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -81,7 +81,7 @@ from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.light as light
 from tests.common import (
     assert_setup_component, get_test_home_assistant, mock_mqtt_component,
-    fire_mqtt_message, mock_component)
+    fire_mqtt_message)
 
 
 class TestLightMQTT(unittest.TestCase):
@@ -100,7 +100,6 @@ class TestLightMQTT(unittest.TestCase):
 
     def test_fail_setup_if_no_command_topic(self):
         """Test if command fails with command topic."""
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(0):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -113,7 +112,6 @@ class TestLightMQTT(unittest.TestCase):
     def test_no_color_or_brightness_or_color_temp_if_no_topics(self): \
             # pylint: disable=invalid-name
         """Test if there is no color and brightness if no topic."""
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -158,7 +156,6 @@ class TestLightMQTT(unittest.TestCase):
             'payload_off': 0
         }}
 
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, config)
 
@@ -214,7 +211,6 @@ class TestLightMQTT(unittest.TestCase):
 
     def test_controlling_scale(self):
         """Test the controlling scale."""
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -277,7 +273,6 @@ class TestLightMQTT(unittest.TestCase):
             'rgb_value_template': '{{ value_json.hello | join(",") }}',
         }}
 
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, config)
 
@@ -317,7 +312,6 @@ class TestLightMQTT(unittest.TestCase):
             'payload_off': 'off'
         }}
 
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, config)
 
@@ -367,7 +361,6 @@ class TestLightMQTT(unittest.TestCase):
             'state_topic': 'test_light_rgb/status',
         }}
 
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, config)
 
@@ -392,7 +385,6 @@ class TestLightMQTT(unittest.TestCase):
             'state_topic': 'test_light_rgb/status'
         }}
 
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, config)
 

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -81,7 +81,7 @@ from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.light as light
 from tests.common import (
     assert_setup_component, get_test_home_assistant, mock_mqtt_component,
-    fire_mqtt_message)
+    fire_mqtt_message, mock_component)
 
 
 class TestLightMQTT(unittest.TestCase):
@@ -100,7 +100,7 @@ class TestLightMQTT(unittest.TestCase):
 
     def test_fail_setup_if_no_command_topic(self):
         """Test if command fails with command topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(0):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -113,7 +113,7 @@ class TestLightMQTT(unittest.TestCase):
     def test_no_color_or_brightness_or_color_temp_if_no_topics(self): \
             # pylint: disable=invalid-name
         """Test if there is no color and brightness if no topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -158,7 +158,7 @@ class TestLightMQTT(unittest.TestCase):
             'payload_off': 0
         }}
 
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, config)
 
@@ -214,7 +214,7 @@ class TestLightMQTT(unittest.TestCase):
 
     def test_controlling_scale(self):
         """Test the controlling scale."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -277,7 +277,7 @@ class TestLightMQTT(unittest.TestCase):
             'rgb_value_template': '{{ value_json.hello | join(",") }}',
         }}
 
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, config)
 
@@ -317,7 +317,7 @@ class TestLightMQTT(unittest.TestCase):
             'payload_off': 'off'
         }}
 
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, config)
 
@@ -367,7 +367,7 @@ class TestLightMQTT(unittest.TestCase):
             'state_topic': 'test_light_rgb/status',
         }}
 
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, config)
 
@@ -392,7 +392,7 @@ class TestLightMQTT(unittest.TestCase):
             'state_topic': 'test_light_rgb/status'
         }}
 
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, config)
 

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -35,7 +35,7 @@ from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.light as light
 from tests.common import (
     get_test_home_assistant, mock_mqtt_component, fire_mqtt_message,
-    assert_setup_component, mock_component)
+    assert_setup_component)
 
 
 class TestLightMQTTJSON(unittest.TestCase):
@@ -53,7 +53,6 @@ class TestLightMQTTJSON(unittest.TestCase):
     def test_fail_setup_if_no_command_topic(self): \
             # pylint: disable=invalid-name
         """Test if setup fails with no command topic."""
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(0):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -66,7 +65,6 @@ class TestLightMQTTJSON(unittest.TestCase):
     def test_no_color_or_brightness_if_no_config(self): \
             # pylint: disable=invalid-name
         """Test if there is no color and brightness if they aren't defined."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
@@ -92,7 +90,6 @@ class TestLightMQTTJSON(unittest.TestCase):
     def test_controlling_state_via_topic(self): \
             # pylint: disable=invalid-name
         """Test the controlling of the state via topic."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
@@ -152,7 +149,6 @@ class TestLightMQTTJSON(unittest.TestCase):
     def test_sending_mqtt_commands_and_optimistic(self): \
             # pylint: disable=invalid-name
         """Test the sending of command in optimistic mode."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
@@ -208,7 +204,6 @@ class TestLightMQTTJSON(unittest.TestCase):
     def test_flash_short_and_long(self): \
             # pylint: disable=invalid-name
         """Test for flash length being sent when included."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
@@ -250,7 +245,6 @@ class TestLightMQTTJSON(unittest.TestCase):
 
     def test_transition(self):
         """Test for transition time being sent when included."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
@@ -292,7 +286,6 @@ class TestLightMQTTJSON(unittest.TestCase):
     def test_invalid_color_and_brightness_values(self): \
             # pylint: disable=invalid-name
         """Test that invalid color/brightness values are ignored."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -35,7 +35,7 @@ from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.light as light
 from tests.common import (
     get_test_home_assistant, mock_mqtt_component, fire_mqtt_message,
-    assert_setup_component)
+    assert_setup_component, mock_component)
 
 
 class TestLightMQTTJSON(unittest.TestCase):
@@ -53,7 +53,7 @@ class TestLightMQTTJSON(unittest.TestCase):
     def test_fail_setup_if_no_command_topic(self): \
             # pylint: disable=invalid-name
         """Test if setup fails with no command topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(0):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -66,7 +66,7 @@ class TestLightMQTTJSON(unittest.TestCase):
     def test_no_color_or_brightness_if_no_config(self): \
             # pylint: disable=invalid-name
         """Test if there is no color and brightness if they aren't defined."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
@@ -92,7 +92,7 @@ class TestLightMQTTJSON(unittest.TestCase):
     def test_controlling_state_via_topic(self): \
             # pylint: disable=invalid-name
         """Test the controlling of the state via topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
@@ -152,7 +152,7 @@ class TestLightMQTTJSON(unittest.TestCase):
     def test_sending_mqtt_commands_and_optimistic(self): \
             # pylint: disable=invalid-name
         """Test the sending of command in optimistic mode."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
@@ -208,7 +208,7 @@ class TestLightMQTTJSON(unittest.TestCase):
     def test_flash_short_and_long(self): \
             # pylint: disable=invalid-name
         """Test for flash length being sent when included."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
@@ -250,7 +250,7 @@ class TestLightMQTTJSON(unittest.TestCase):
 
     def test_transition(self):
         """Test for transition time being sent when included."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',
@@ -292,7 +292,7 @@ class TestLightMQTTJSON(unittest.TestCase):
     def test_invalid_color_and_brightness_values(self): \
             # pylint: disable=invalid-name
         """Test that invalid color/brightness values are ignored."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
                 'platform': 'mqtt_json',

--- a/tests/components/light/test_mqtt_template.py
+++ b/tests/components/light/test_mqtt_template.py
@@ -27,7 +27,7 @@ from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.light as light
 from tests.common import (
     get_test_home_assistant, mock_mqtt_component, fire_mqtt_message,
-    assert_setup_component, mock_component)
+    assert_setup_component)
 
 
 class TestLightMQTTTemplate(unittest.TestCase):
@@ -45,7 +45,6 @@ class TestLightMQTTTemplate(unittest.TestCase):
     def test_setup_fails(self): \
             # pylint: disable=invalid-name
         """Test that setup fails with missing required configuration items."""
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(0):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -58,7 +57,6 @@ class TestLightMQTTTemplate(unittest.TestCase):
     def test_state_change_via_topic(self): \
             # pylint: disable=invalid-name
         """Test state change via topic."""
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -93,7 +91,6 @@ class TestLightMQTTTemplate(unittest.TestCase):
     def test_state_brightness_color_effect_change_via_topic(self): \
             # pylint: disable=invalid-name
         """Test state, brightness, color and effect change via topic."""
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -170,7 +167,6 @@ class TestLightMQTTTemplate(unittest.TestCase):
     def test_optimistic(self): \
             # pylint: disable=invalid-name
         """Test optimistic mode."""
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -232,7 +228,6 @@ class TestLightMQTTTemplate(unittest.TestCase):
     def test_flash(self): \
             # pylint: disable=invalid-name
         """Test flash."""
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -276,7 +271,6 @@ class TestLightMQTTTemplate(unittest.TestCase):
 
     def test_transition(self):
         """Test for transition time being sent when included."""
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -320,7 +314,6 @@ class TestLightMQTTTemplate(unittest.TestCase):
     def test_invalid_values(self): \
             # pylint: disable=invalid-name
         """Test that invalid values are ignored."""
-        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {

--- a/tests/components/light/test_mqtt_template.py
+++ b/tests/components/light/test_mqtt_template.py
@@ -27,7 +27,7 @@ from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.light as light
 from tests.common import (
     get_test_home_assistant, mock_mqtt_component, fire_mqtt_message,
-    assert_setup_component)
+    assert_setup_component, mock_component)
 
 
 class TestLightMQTTTemplate(unittest.TestCase):
@@ -45,7 +45,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
     def test_setup_fails(self): \
             # pylint: disable=invalid-name
         """Test that setup fails with missing required configuration items."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(0):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -58,7 +58,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
     def test_state_change_via_topic(self): \
             # pylint: disable=invalid-name
         """Test state change via topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -93,7 +93,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
     def test_state_brightness_color_effect_change_via_topic(self): \
             # pylint: disable=invalid-name
         """Test state, brightness, color and effect change via topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -170,7 +170,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
     def test_optimistic(self): \
             # pylint: disable=invalid-name
         """Test optimistic mode."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -232,7 +232,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
     def test_flash(self): \
             # pylint: disable=invalid-name
         """Test flash."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -276,7 +276,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
 
     def test_transition(self):
         """Test for transition time being sent when included."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {
@@ -320,7 +320,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
     def test_invalid_values(self): \
             # pylint: disable=invalid-name
         """Test that invalid values are ignored."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         with assert_setup_component(1):
             assert setup_component(self.hass, light.DOMAIN, {
                 light.DOMAIN: {

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -6,7 +6,7 @@ import pytest
 from homeassistant.bootstrap import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
 
 @pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
@@ -16,7 +16,7 @@ class TestLightRfxtrx(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components = set(['rfxtrx'])
+        mock_component(self.hass, 'rfxtrx')
 
     def tearDown(self):
         """Stop everything that was started."""

--- a/tests/components/lock/test_mqtt.py
+++ b/tests/components/lock/test_mqtt.py
@@ -6,8 +6,7 @@ from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED,
                                  ATTR_ASSUMED_STATE)
 import homeassistant.components.lock as lock
 from tests.common import (
-    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant,
-    mock_component)
+    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant)
 
 
 class TestLockMQTT(unittest.TestCase):
@@ -24,7 +23,6 @@ class TestLockMQTT(unittest.TestCase):
 
     def test_controlling_state_via_topic(self):
         """Test the controlling state via topic."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, lock.DOMAIN, {
             lock.DOMAIN: {
                 'platform': 'mqtt',
@@ -54,7 +52,6 @@ class TestLockMQTT(unittest.TestCase):
 
     def test_sending_mqtt_commands_and_optimistic(self):
         """Test the sending MQTT commands in optimistic mode."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, lock.DOMAIN, {
             lock.DOMAIN: {
                 'platform': 'mqtt',
@@ -88,7 +85,6 @@ class TestLockMQTT(unittest.TestCase):
 
     def test_controlling_state_via_topic_and_json_message(self):
         """Test the controlling state via topic and JSON message."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, lock.DOMAIN, {
             lock.DOMAIN: {
                 'platform': 'mqtt',

--- a/tests/components/lock/test_mqtt.py
+++ b/tests/components/lock/test_mqtt.py
@@ -6,7 +6,8 @@ from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED,
                                  ATTR_ASSUMED_STATE)
 import homeassistant.components.lock as lock
 from tests.common import (
-    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant)
+    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant,
+    mock_component)
 
 
 class TestLockMQTT(unittest.TestCase):
@@ -23,7 +24,7 @@ class TestLockMQTT(unittest.TestCase):
 
     def test_controlling_state_via_topic(self):
         """Test the controlling state via topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, lock.DOMAIN, {
             lock.DOMAIN: {
                 'platform': 'mqtt',
@@ -53,7 +54,7 @@ class TestLockMQTT(unittest.TestCase):
 
     def test_sending_mqtt_commands_and_optimistic(self):
         """Test the sending MQTT commands in optimistic mode."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, lock.DOMAIN, {
             lock.DOMAIN: {
                 'platform': 'mqtt',
@@ -87,7 +88,7 @@ class TestLockMQTT(unittest.TestCase):
 
     def test_controlling_state_via_topic_and_json_message(self):
         """Test the controlling state via topic and JSON message."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, lock.DOMAIN, {
             lock.DOMAIN: {
                 'platform': 'mqtt',

--- a/tests/components/media_player/test_universal.py
+++ b/tests/components/media_player/test_universal.py
@@ -1,5 +1,4 @@
 """The tests for the Universal Media player platform."""
-import asyncio
 from copy import copy
 import unittest
 
@@ -258,7 +257,6 @@ class TestMediaPlayer(unittest.TestCase):
         bad_config = {'platform': 'universal'}
         entities = []
 
-        @asyncio.coroutine
         def add_devices(new_entities):
             """Add devices to list."""
             for dev in new_entities:

--- a/tests/components/mqtt/test_server.py
+++ b/tests/components/mqtt/test_server.py
@@ -4,7 +4,8 @@ from unittest.mock import Mock, MagicMock, patch
 from homeassistant.bootstrap import setup_component
 import homeassistant.components.mqtt as mqtt
 
-from tests.common import get_test_home_assistant, mock_coro
+from tests.common import (
+    get_test_home_assistant, mock_coro, mock_http_component)
 
 
 class TestMQTT:
@@ -13,7 +14,7 @@ class TestMQTT:
     def setup_method(self, method):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components.add('http')
+        mock_http_component(self.hass, 'super_secret')
 
     def teardown_method(self, method):
         """Stop everything that was started."""
@@ -33,13 +34,21 @@ class TestMQTT:
         self.hass.config.api = MagicMock(api_password=password)
         assert setup_component(self.hass, mqtt.DOMAIN, {})
         assert mock_mqtt.called
+        from pprint import pprint
+        pprint(mock_mqtt.mock_calls)
         assert mock_mqtt.mock_calls[1][1][5] == 'homeassistant'
         assert mock_mqtt.mock_calls[1][1][6] == password
 
-        mock_mqtt.reset_mock()
+    @patch('passlib.apps.custom_app_context', Mock(return_value=''))
+    @patch('tempfile.NamedTemporaryFile', Mock(return_value=MagicMock()))
+    @patch('hbmqtt.broker.Broker', Mock(return_value=MagicMock()))
+    @patch('hbmqtt.broker.Broker.start', Mock(return_value=mock_coro()))
+    @patch('homeassistant.components.mqtt.MQTT')
+    def test_creating_config_with_http_no_pass(self, mock_mqtt):
+        """Test if the MQTT server gets started and subscribe/publish msg."""
         mock_mqtt().async_connect.return_value = mock_coro(True)
+        self.hass.bus.listen_once = MagicMock()
 
-        self.hass.config.components = set(['http'])
         self.hass.config.api = MagicMock(api_password=None)
         assert setup_component(self.hass, mqtt.DOMAIN, {})
         assert mock_mqtt.called

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -1,5 +1,4 @@
 """The tests for the notify demo platform."""
-import asyncio
 import unittest
 from unittest.mock import patch
 
@@ -8,8 +7,7 @@ from homeassistant.bootstrap import setup_component
 from homeassistant.components.notify import demo
 from homeassistant.core import callback
 from homeassistant.helpers import discovery, script
-from tests.common import (
-    assert_setup_component, get_test_home_assistant, mock_coro)
+from tests.common import assert_setup_component, get_test_home_assistant
 
 CONFIG = {
     notify.DOMAIN: {
@@ -46,15 +44,6 @@ class TestNotifyDemo(unittest.TestCase):
     def test_setup(self):
         """Test setup."""
         self._setup_notify()
-
-    @patch('homeassistant.bootstrap.async_prepare_setup_platform',
-           return_value=mock_coro())
-    def test_no_prepare_setup_platform(self, mock_prep_setup_platform):
-        """Test missing notify platform."""
-        with assert_setup_component(0):
-            setup_component(self.hass, notify.DOMAIN, CONFIG)
-
-        assert mock_prep_setup_platform.called
 
     @patch('homeassistant.components.notify.demo.get_service', autospec=True)
     def test_no_notify_service(self, mock_demo_get_service):

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -8,19 +8,14 @@ from homeassistant.bootstrap import setup_component
 from homeassistant.components.notify import demo
 from homeassistant.core import callback
 from homeassistant.helpers import discovery, script
-from tests.common import assert_setup_component, get_test_home_assistant
+from tests.common import (
+    assert_setup_component, get_test_home_assistant, mock_coro)
 
 CONFIG = {
     notify.DOMAIN: {
         'platform': 'demo'
     }
 }
-
-
-@asyncio.coroutine
-def mock_setup_platform():
-    """Mock prepare_setup_platform."""
-    return None
 
 
 class TestNotifyDemo(unittest.TestCase):
@@ -53,7 +48,7 @@ class TestNotifyDemo(unittest.TestCase):
         self._setup_notify()
 
     @patch('homeassistant.bootstrap.async_prepare_setup_platform',
-           return_value=mock_setup_platform())
+           return_value=mock_coro())
     def test_no_prepare_setup_platform(self, mock_prep_setup_platform):
         """Test missing notify platform."""
         with assert_setup_component(0):

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -5,7 +5,7 @@ from homeassistant.bootstrap import setup_component
 import homeassistant.components.sensor as sensor
 from tests.common import mock_mqtt_component, fire_mqtt_message
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
 
 class TestSensorMQTT(unittest.TestCase):
@@ -22,7 +22,7 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_setting_sensor_value_via_mqtt_message(self):
         """Test the setting of the value via MQTT."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, sensor.DOMAIN, {
             sensor.DOMAIN: {
                 'platform': 'mqtt',
@@ -42,7 +42,7 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_setting_sensor_value_via_mqtt_json_message(self):
         """Test the setting of the value via MQTT with JSON playload."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, sensor.DOMAIN, {
             sensor.DOMAIN: {
                 'platform': 'mqtt',

--- a/tests/components/sensor/test_pilight.py
+++ b/tests/components/sensor/test_pilight.py
@@ -5,7 +5,8 @@ from homeassistant.bootstrap import setup_component
 import homeassistant.components.sensor as sensor
 from homeassistant.components import pilight
 
-from tests.common import get_test_home_assistant, assert_setup_component
+from tests.common import (
+    get_test_home_assistant, assert_setup_component, mock_component)
 
 HASS = None
 
@@ -23,7 +24,7 @@ def setup_function():
     global HASS
 
     HASS = get_test_home_assistant()
-    HASS.config.components = set(['pilight'])
+    mock_component(HASS, 'pilight')
 
 
 # pylint: disable=invalid-name

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -7,7 +7,7 @@ from homeassistant.bootstrap import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.const import TEMP_CELSIUS
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
 
 @pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
@@ -17,7 +17,7 @@ class TestSensorRfxtrx(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components = set(['rfxtrx'])
+        mock_component(self.hass, 'rfxtrx')
 
     def tearDown(self):
         """Stop everything that was started."""

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -5,7 +5,8 @@ from homeassistant.bootstrap import setup_component
 from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.switch as switch
 from tests.common import (
-    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant)
+    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant,
+    mock_component)
 
 
 class TestSensorMQTT(unittest.TestCase):
@@ -22,7 +23,7 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_controlling_state_via_topic(self):
         """Test the controlling state via topic."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, switch.DOMAIN, {
             switch.DOMAIN: {
                 'platform': 'mqtt',
@@ -52,7 +53,7 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_sending_mqtt_commands_and_optimistic(self):
         """Test the sending MQTT commands in optimistic mode."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, switch.DOMAIN, {
             switch.DOMAIN: {
                 'platform': 'mqtt',
@@ -86,7 +87,7 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_controlling_state_via_topic_and_json_message(self):
         """Test the controlling state via topic and JSON message."""
-        self.hass.config.components = set(['mqtt'])
+        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, switch.DOMAIN, {
             switch.DOMAIN: {
                 'platform': 'mqtt',

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -5,8 +5,7 @@ from homeassistant.bootstrap import setup_component
 from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.switch as switch
 from tests.common import (
-    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant,
-    mock_component)
+    mock_mqtt_component, fire_mqtt_message, get_test_home_assistant)
 
 
 class TestSensorMQTT(unittest.TestCase):
@@ -23,7 +22,6 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_controlling_state_via_topic(self):
         """Test the controlling state via topic."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, switch.DOMAIN, {
             switch.DOMAIN: {
                 'platform': 'mqtt',
@@ -53,7 +51,6 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_sending_mqtt_commands_and_optimistic(self):
         """Test the sending MQTT commands in optimistic mode."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, switch.DOMAIN, {
             switch.DOMAIN: {
                 'platform': 'mqtt',
@@ -87,7 +84,6 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_controlling_state_via_topic_and_json_message(self):
         """Test the controlling state via topic and JSON message."""
-        mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, switch.DOMAIN, {
             switch.DOMAIN: {
                 'platform': 'mqtt',

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -6,7 +6,7 @@ import pytest
 from homeassistant.bootstrap import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
 
 @pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
@@ -16,7 +16,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components = set(['rfxtrx'])
+        mock_component(self.hass, 'rfxtrx')
 
     def tearDown(self):
         """Stop everything that was started."""

--- a/tests/components/test_input_boolean.py
+++ b/tests/components/test_input_boolean.py
@@ -4,7 +4,7 @@ import asyncio
 import unittest
 import logging
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
 from homeassistant.core import CoreState, State
 from homeassistant.bootstrap import setup_component, async_setup_component
@@ -118,7 +118,7 @@ def test_restore_state(hass):
     }
 
     hass.state = CoreState.starting
-    hass.config.components.add('recorder')
+    mock_component(hass, 'recorder')
 
     yield from async_setup_component(hass, DOMAIN, {
         DOMAIN: {

--- a/tests/components/test_panel_custom.py
+++ b/tests/components/test_panel_custom.py
@@ -39,6 +39,7 @@ class TestPanelCustom(unittest.TestCase):
 
         path = self.hass.config.path(panel_custom.PANEL_DIR)
         os.mkdir(path)
+        self.hass.data.pop(bootstrap.DATA_SETUP)
 
         with open(os.path.join(path, 'todomvc.html'), 'a'):
             assert bootstrap.setup_component(self.hass, 'panel_custom', config)
@@ -65,6 +66,8 @@ class TestPanelCustom(unittest.TestCase):
                 self.hass, 'panel_custom', config
             )
             assert not mock_register.called
+
+        self.hass.data.pop(bootstrap.DATA_SETUP)
 
         with patch('os.path.isfile', Mock(return_value=True)):
             with patch('os.access', Mock(return_value=True)):

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -50,8 +50,8 @@ class TestRFXTRX(unittest.TestCase):
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
                 'dummy': True}}))
 
-        self.hass.config.components.remove('rfxtrx')
-
+    def test_valid_config2(self):
+        """Test configuration."""
         self.assertTrue(setup_component(self.hass, 'rfxtrx', {
             'rfxtrx': {
                 'device': '/dev/serial/by-id/usb' +

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -6,7 +6,7 @@ from homeassistant.core import callback
 from homeassistant.bootstrap import setup_component
 from homeassistant.components import script
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
 
 ENTITY_ID = 'script.test'
@@ -19,7 +19,7 @@ class TestScriptComponent(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.hass.config.components.add('group')
+        mock_component(self.hass, 'group')
 
     # pylint: disable=invalid-name
     def tearDown(self):

--- a/tests/components/test_zone.py
+++ b/tests/components/test_zone.py
@@ -63,11 +63,12 @@ class TestComponentZone(unittest.TestCase):
                 },
             ]
         })
-
+        self.hass.block_till_done()
         active = zone.active_zone(self.hass, 32.880600, -117.237561)
         assert active is None
 
-        self.hass.config.components.remove('zone')
+    def test_active_zone_skips_passive_zones_2(self):
+        """Test active and passive zones."""
         assert bootstrap.setup_component(self.hass, zone.DOMAIN, {
             'zone': [
                 {
@@ -78,7 +79,7 @@ class TestComponentZone(unittest.TestCase):
                 },
             ]
         })
-
+        self.hass.block_till_done()
         active = zone.active_zone(self.hass, 32.880700, -117.237561)
         assert 'zone.active_zone' == active.entity_id
 
@@ -106,7 +107,10 @@ class TestComponentZone(unittest.TestCase):
         active = zone.active_zone(self.hass, latitude, longitude)
         assert 'zone.small_zone' == active.entity_id
 
-        self.hass.config.components.remove('zone')
+    def test_active_zone_prefers_smaller_zone_if_same_distance_2(self):
+        """Test zone size preferences."""
+        latitude = 32.880600
+        longitude = -117.237561
         assert bootstrap.setup_component(self.hass, zone.DOMAIN, {
             'zone': [
                 {

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -272,6 +272,7 @@ class TestHelpersEntityComponent(unittest.TestCase):
             }
         })
 
+        self.hass.block_till_done()
         assert component_setup.called
         assert platform_setup.called
 
@@ -294,6 +295,7 @@ class TestHelpersEntityComponent(unittest.TestCase):
             ("{} 3".format(DOMAIN), {'platform': 'mod2'}),
         ]))
 
+        self.hass.block_till_done()
         assert platform1_setup.called
         assert platform2_setup.called
 
@@ -336,6 +338,7 @@ class TestHelpersEntityComponent(unittest.TestCase):
             }
         })
 
+        self.hass.block_till_done()
         assert mock_track.called
         assert timedelta(seconds=30) == mock_track.call_args[0][2]
 
@@ -360,6 +363,7 @@ class TestHelpersEntityComponent(unittest.TestCase):
             }
         })
 
+        self.hass.block_till_done()
         assert mock_track.called
         assert timedelta(seconds=30) == mock_track.call_args[0][2]
 
@@ -384,6 +388,8 @@ class TestHelpersEntityComponent(unittest.TestCase):
                 'entity_namespace': 'yummy'
             }
         })
+
+        self.hass.block_till_done()
 
         assert sorted(self.hass.states.entity_ids()) == \
             ['test_domain.yummy_beer', 'test_domain.yummy_unnamed_device']

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -13,13 +13,14 @@ from homeassistant.helpers.restore_state import (
 from homeassistant.components.recorder.models import RecorderRuns, States
 
 from tests.common import (
-    get_test_home_assistant, mock_coro, init_recorder_component)
+    get_test_home_assistant, mock_coro, init_recorder_component,
+    mock_component)
 
 
 @asyncio.coroutine
 def test_caching_data(hass):
     """Test that we cache data."""
-    hass.config.components.add('recorder')
+    mock_component(hass, 'recorder')
     hass.state = CoreState.starting
 
     states = [

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -77,23 +77,7 @@ class TestBootstrap:
                 patch_yaml_files(files, True):
             self.hass = bootstrap.from_config_file('config.yaml')
 
-        components.add('group')
         assert components == self.hass.config.components
-
-    # We no longer know what is in progress and who depends on what.
-    # def test_handle_setup_circular_dependency(self):
-    #     """Test the setup of circular dependencies."""
-    #     loader.set_component('comp_b', MockModule('comp_b', ['comp_a']))
-
-    #     def setup_a(hass, config):
-    #         """Setup the another component."""
-    #         bootstrap.setup_component(hass, 'comp_b')
-    #         return True
-
-    #     loader.set_component('comp_a', MockModule('comp_a', setup=setup_a))
-
-    #     bootstrap.setup_component(self.hass, 'comp_a')
-    #     assert set(['comp_a']) == self.hass.config.components
 
     def test_validate_component_config(self):
         """Test validating component configuration."""

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -7,12 +7,10 @@ import threading
 import logging
 
 import voluptuous as vol
-import pytest
 
 from homeassistant.core import callback
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 import homeassistant.config as config_util
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant import bootstrap, loader
 import homeassistant.util.dt as dt_util
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
@@ -20,7 +18,8 @@ from homeassistant.helpers import discovery
 
 from tests.common import \
     get_test_home_assistant, MockModule, MockPlatform, \
-    assert_setup_component, patch_yaml_files, get_test_config_dir
+    assert_setup_component, patch_yaml_files, get_test_config_dir, \
+    mock_component
 
 ORIG_TIMEZONE = dt_util.DEFAULT_TIME_ZONE
 VERSION_PATH = os.path.join(get_test_config_dir(), config_util.VERSION_FILE)
@@ -82,19 +81,20 @@ class TestBootstrap:
         components.add('group')
         assert components == self.hass.config.components
 
-    def test_handle_setup_circular_dependency(self):
-        """Test the setup of circular dependencies."""
-        loader.set_component('comp_b', MockModule('comp_b', ['comp_a']))
+    # We no longer know what is in progress and who depends on what.
+    # def test_handle_setup_circular_dependency(self):
+    #     """Test the setup of circular dependencies."""
+    #     loader.set_component('comp_b', MockModule('comp_b', ['comp_a']))
 
-        def setup_a(hass, config):
-            """Setup the another component."""
-            bootstrap.setup_component(hass, 'comp_b')
-            return True
+    #     def setup_a(hass, config):
+    #         """Setup the another component."""
+    #         bootstrap.setup_component(hass, 'comp_b')
+    #         return True
 
-        loader.set_component('comp_a', MockModule('comp_a', setup=setup_a))
+    #     loader.set_component('comp_a', MockModule('comp_a', setup=setup_a))
 
-        bootstrap.setup_component(self.hass, 'comp_a')
-        assert set(['comp_a']) == self.hass.config.components
+    #     bootstrap.setup_component(self.hass, 'comp_a')
+    #     assert set(['comp_a']) == self.hass.config.components
 
     def test_validate_component_config(self):
         """Test validating component configuration."""
@@ -109,15 +109,21 @@ class TestBootstrap:
         with assert_setup_component(0):
             assert not bootstrap.setup_component(self.hass, 'comp_conf', {})
 
+        self.hass.data.pop(bootstrap.DATA_SETUP)
+
         with assert_setup_component(0):
             assert not bootstrap.setup_component(self.hass, 'comp_conf', {
                 'comp_conf': None
             })
 
+        self.hass.data.pop(bootstrap.DATA_SETUP)
+
         with assert_setup_component(0):
             assert not bootstrap.setup_component(self.hass, 'comp_conf', {
                 'comp_conf': {}
             })
+
+        self.hass.data.pop(bootstrap.DATA_SETUP)
 
         with assert_setup_component(0):
             assert not bootstrap.setup_component(self.hass, 'comp_conf', {
@@ -126,6 +132,8 @@ class TestBootstrap:
                     'invalid': 'extra',
                 }
             })
+
+        self.hass.data.pop(bootstrap.DATA_SETUP)
 
         with assert_setup_component(1):
             assert bootstrap.setup_component(self.hass, 'comp_conf', {
@@ -154,6 +162,7 @@ class TestBootstrap:
                 }
             })
 
+        self.hass.data.pop(bootstrap.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')
 
         with assert_setup_component(1):
@@ -167,6 +176,7 @@ class TestBootstrap:
                 }
             })
 
+        self.hass.data.pop(bootstrap.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')
 
         with assert_setup_component(0):
@@ -177,6 +187,7 @@ class TestBootstrap:
                 }
             })
 
+        self.hass.data.pop(bootstrap.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')
 
         with assert_setup_component(1):
@@ -187,6 +198,7 @@ class TestBootstrap:
                 }
             })
 
+        self.hass.data.pop(bootstrap.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')
 
         with assert_setup_component(1):
@@ -197,6 +209,7 @@ class TestBootstrap:
                 }]
             })
 
+        self.hass.data.pop(bootstrap.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')
 
         # Any falsey platform config will be ignored (None, {}, etc)
@@ -254,12 +267,11 @@ class TestBootstrap:
 
         thread = threading.Thread(target=setup_component)
         thread.start()
-        self.hass.config.components.add('comp')
+        mock_component(self.hass, 'comp')
 
         thread.join()
 
-        assert len(result) == 1
-        assert result[0]
+        assert len(result) == 0
 
     def test_component_not_setup_missing_dependencies(self):
         """Test we do not setup a component if not all dependencies loaded."""
@@ -269,8 +281,9 @@ class TestBootstrap:
         assert not bootstrap.setup_component(self.hass, 'comp', {})
         assert 'comp' not in self.hass.config.components
 
-        loader.set_component('non_existing', MockModule('non_existing'))
+        self.hass.data.pop(bootstrap.DATA_SETUP)
 
+        loader.set_component('non_existing', MockModule('non_existing'))
         assert bootstrap.setup_component(self.hass, 'comp', {})
 
     def test_component_failing_setup(self):
@@ -349,6 +362,7 @@ class TestBootstrap:
             })
             assert mock_setup.call_count == 0
 
+        self.hass.data.pop(bootstrap.DATA_SETUP)
         self.hass.config.components.remove('switch')
 
         with assert_setup_component(0):
@@ -361,6 +375,7 @@ class TestBootstrap:
             })
             assert mock_setup.call_count == 0
 
+        self.hass.data.pop(bootstrap.DATA_SETUP)
         self.hass.config.components.remove('switch')
 
         with assert_setup_component(1):
@@ -382,6 +397,7 @@ class TestBootstrap:
         assert loader.get_component('disabled_component') is None
         assert 'disabled_component' not in self.hass.config.components
 
+        self.hass.data.pop(bootstrap.DATA_SETUP)
         loader.set_component(
             'disabled_component',
             MockModule('disabled_component', setup=lambda hass, config: False))
@@ -390,6 +406,7 @@ class TestBootstrap:
         assert loader.get_component('disabled_component') is not None
         assert 'disabled_component' not in self.hass.config.components
 
+        self.hass.data.pop(bootstrap.DATA_SETUP)
         loader.set_component(
             'disabled_component',
             MockModule('disabled_component', setup=lambda hass, config: True))
@@ -441,29 +458,12 @@ class TestBootstrap:
         bootstrap.from_config_dict({'test_component1': None}, self.hass)
 
         self.hass.start()
-
         assert call_order == [1, 1, 2]
 
 
 @asyncio.coroutine
 def test_component_cannot_depend_config(hass):
     """Test config is not allowed to be a dependency."""
-    loader.set_component(
-        'test_component1',
-        MockModule('test_component1', dependencies=['config']))
-
-    with pytest.raises(HomeAssistantError):
-        yield from bootstrap.async_from_config_dict(
-            {'test_component1': None}, hass)
-
-
-@asyncio.coroutine
-def test_platform_cannot_depend_config():
-    """Test config is not allowed to be a dependency."""
-    loader.set_component(
-        'test_component1.test',
-        MockPlatform('whatever', dependencies=['config']))
-
-    with pytest.raises(HomeAssistantError):
-        yield from bootstrap.async_prepare_setup_platform(
-            mock.MagicMock(), {}, 'test_component1', 'test')
+    result = yield from bootstrap._process_dependencies(
+        hass, None, 'test', ['config'])
+    assert not result

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -451,6 +451,6 @@ class TestBootstrap:
 @asyncio.coroutine
 def test_component_cannot_depend_config(hass):
     """Test config is not allowed to be a dependency."""
-    result = yield from bootstrap._process_dependencies(
+    result = yield from bootstrap._async_process_dependencies(
         hass, None, 'test', ['config'])
     assert not result

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -54,33 +54,3 @@ class TestLoader(unittest.TestCase):
 
         # Try to get load order for non-existing component
         self.assertEqual([], loader.load_order_component('mod1'))
-
-    def test_load_order_components(self):
-        """Setup loading order of components."""
-        loader.set_component('mod1', MockModule('mod1', ['group']))
-        loader.set_component('mod2', MockModule('mod2', ['mod1', 'sun']))
-        loader.set_component('mod3', MockModule('mod3', ['mod2']))
-        loader.set_component('mod4', MockModule('mod4', ['group']))
-
-        self.assertEqual(
-            ['group', 'mod4', 'mod1', 'sun', 'mod2', 'mod3'],
-            loader.load_order_components(['mod4', 'mod3', 'mod2']))
-
-        loader.set_component('mod1', MockModule('mod1'))
-        loader.set_component('mod2', MockModule('mod2', ['group']))
-
-        self.assertEqual(
-            ['mod1', 'group', 'mod2'],
-            loader.load_order_components(['mod2', 'mod1']))
-
-        # Add a non existing one
-        self.assertEqual(
-            ['mod1', 'group', 'mod2'],
-            loader.load_order_components(['mod2', 'nonexisting', 'mod1']))
-
-        # Depend on a non existing one
-        loader.set_component('mod1', MockModule('mod1', ['nonexisting']))
-
-        self.assertEqual(
-            ['group', 'mod2'],
-            loader.load_order_components(['mod2', 'mod1']))


### PR DESCRIPTION
## Description:

This make the hole start of hass 50% - 75% faster.

- We don't lost the setup order but It should it make correct on magic of async
- All dependencies are considered
- After setup_component it is all present like before
- We do not lock anythings
- We support now discovery in setup too

### Todo
- [x] Fix some test
- [x] Protect for circular dependencies

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
