### PR TITLE
Fixes round filter in templating environment

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -335,10 +335,10 @@ class LocationMethods(object):
         return None
 
 
-def forgiving_round(value, precision=0):
+def forgiving_round(value, precision=0, method='common'):
     """Rounding filter that accepts strings."""
     try:
-        value = round(float(value), precision)
+        value = round(float(value), precision, method)
         return int(value) if precision == 0 else value
     except (ValueError, TypeError):
         # If value can't be converted to float

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -112,23 +112,23 @@ class TestHelpersTemplate(unittest.TestCase):
     def test_roudning_value_using_ceil_method(self):
         """Test rounding value using ceil method"""
         self.hass.states.set('sensor.device_battery', 56.65)
-        
+
         self.assertEqual(
             'mdi:battery-60',
             template.Template(
                 "mdi:battery-{{ states.sensor.device_battery|round(0,'ceil') }}", 
                 self.hass).render())
-        
+
     def test_rounding_value_using_floor_method(self):
         """Test rounding value using floor method"""
         self.hass.states.set('sensor.device_battery', 56.65)
-        
+
         self.assertEqual(
-            'mdi:battery-50'
+            'mdi:battery-50',
             template.Template(
             "mdi:battery-{{ states.sensor.device_battery|round(0,'floor') }}",
             self.hass).render())
-        
+
     def test_multiply(self):
         """Test multiply."""
         tests = {

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -109,6 +109,26 @@ class TestHelpersTemplate(unittest.TestCase):
             template.Template(
                 '{{ "no_number" | round }}', self.hass).render())
 
+    def test_roudning_value_using_ceil_method(self):
+        """Test rounding value using ceil method"""
+        self.hass.states.set('sensor.device_battery', 56.65)
+        
+        self.assertEqual(
+            'mdi:battery-60',
+            template.Template(
+                "mdi:battery-{{ states.sensor.device_battery|round(0,'ceil') }}", 
+                self.hass).render())
+        
+    def test_rounding_value_using_floor_method(self):
+        """Test rounding value using floor method"""
+        self.hass.states.set('sensor.device_battery', 56.65)
+        
+        self.assertEqual(
+            'mdi:battery-50'
+            template.Template(
+            "mdi:battery-{{ states.sensor.device_battery|round(0,'floor') }}",
+            self.hass).render())
+        
     def test_multiply(self):
         """Test multiply."""
         tests = {


### PR DESCRIPTION
## Description:
The `round` filter was replaced with `forgiving_round` however, `forgiving_round` 
did not define the `method` argument so you can choose what rounding method
you would like to use. i.e common, ceil, or floor.

Without this change a `Task exception` gets thrown when somebody tries to change
the rounding method from the default.

See http://jinja.pocoo.org/docs/dev/templates/#round

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2159

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
