### PR TITLE
Bug fix in history_stats

### DIFF
--- a/homeassistant/components/sensor/history_stats.py
+++ b/homeassistant/components/sensor/history_stats.py
@@ -187,6 +187,12 @@ class HistoryStatsSensor(Entity):
             last_state = current_state
             last_time = current_time
 
+        # Count time elapsed between last history state and end of measure
+        if last_state:
+            measure_end = min(dt_util.as_timestamp(end), dt_util.as_timestamp(
+                datetime.datetime.now()))
+            elapsed += measure_end - last_time
+
         # Save value in hours
         self.value = elapsed / 3600
 

--- a/tests/components/sensor/test_history_stats.py
+++ b/tests/components/sensor/test_history_stats.py
@@ -71,13 +71,19 @@ class TestHistoryStatsSensor(unittest.TestCase):
 
     def test_measure(self):
         """Test the history statistics sensor measure."""
-        later = dt_util.utcnow() - timedelta(seconds=15)
-        earlier = later - timedelta(minutes=30)
+        t0 = dt_util.utcnow() - timedelta(minutes=40)
+        t1 = t0 + timedelta(minutes=20)
+        t2 = dt_util.utcnow() - timedelta(minutes=10)
+
+        # Start     t0        t1        t2        End
+        # |--20min--|--20min--|--10min--|--10min--|
+        # |---off---|---on----|---off---|---on----|
 
         fake_states = {
             'binary_sensor.test_id': [
-                ha.State('binary_sensor.test_id', 'on', last_changed=earlier),
-                ha.State('binary_sensor.test_id', 'off', last_changed=later),
+                ha.State('binary_sensor.test_id', 'on', last_changed=t0),
+                ha.State('binary_sensor.test_id', 'off', last_changed=t1),
+                ha.State('binary_sensor.test_id', 'on', last_changed=t2),
             ]
         }
 
@@ -97,8 +103,8 @@ class TestHistoryStatsSensor(unittest.TestCase):
                 sensor1.update()
                 sensor2.update()
 
-        self.assertEqual(sensor1.value, 0.5)
-        self.assertEqual(sensor2.value, 0)
+        self.assertEqual(round(sensor1.value, 3), 0.5)
+        self.assertEqual(round(sensor2.value, 3), 0)
         self.assertEqual(sensor1.device_state_attributes['ratio'], '50.0%')
 
     def test_wrong_date(self):


### PR DESCRIPTION
## Description:

This is a fix for an annoying bug in the `history_stats` component.

Imagine the following situation
- You want to track how long you lamp have been `'on'` today
- You setup a history_stats component that you call `sensor.lamp_on`
- The sensor value is equal to 0 at first
- You turn on the lamp
- You wait 15 minutes

Result: the value will stay at 0 until you turn off the lamp, then jump to the real computed value. You won't see a slope on the graph but a step.

The history_stats component didn't count the time elapsed between the state of the lamp (which was at t - 15 minutes) and the end of the measure.

-----

- [x]  Bug fixed
- [x] Related tests added
