### PR TITLE
Telegram webhooks new text event

### DIFF
--- a/homeassistant/components/telegram_webhooks.py
+++ b/homeassistant/components/telegram_webhooks.py
@@ -24,7 +24,7 @@ REQUIREMENTS = ['python-telegram-bot==5.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-EVENT_TELEGRAM_COMMAND = 'telegram.command'
+EVENT_TELEGRAM_COMMAND = 'telegram_command'
 EVENT_TELEGRAM_TEXT = 'telegram_text'
 
 TELEGRAM_HANDLER_URL = '/api/telegram_webhooks'

--- a/homeassistant/components/telegram_webhooks.py
+++ b/homeassistant/components/telegram_webhooks.py
@@ -133,11 +133,11 @@ class BotPushReceiver(HomeAssistantView):
                 ATTR_ARGS: " ".join(pieces[1:]),
                 ATTR_USER_ID: data['from']['id'],
                 })
-        else:
-            # telegram text "bla bla"
-            request.app['hass'].bus.async_fire(EVENT_TELEGRAM_TEXT, {
-                ATTR_TEXT: data['text'],
-                ATTR_USER_ID: data['from']['id'],
-                })
+
+        # telegram text "bla bla"
+        request.app['hass'].bus.async_fire(EVENT_TELEGRAM_TEXT, {
+            ATTR_TEXT: data['text'],
+            ATTR_USER_ID: data['from']['id'],
+            })
 
         return self.json({})

--- a/homeassistant/components/telegram_webhooks.py
+++ b/homeassistant/components/telegram_webhooks.py
@@ -25,6 +25,7 @@ REQUIREMENTS = ['python-telegram-bot==5.3.0']
 _LOGGER = logging.getLogger(__name__)
 
 EVENT_TELEGRAM_COMMAND = 'telegram.command'
+EVENT_TELEGRAM_TEXT = 'telegram_text'
 
 TELEGRAM_HANDLER_URL = '/api/telegram_webhooks'
 
@@ -40,6 +41,7 @@ DEFAULT_TRUSTED_NETWORKS = [
 ]
 
 ATTR_COMMAND = 'command'
+ATTR_TEXT = 'text'
 ATTR_USER_ID = 'user_id'
 ATTR_ARGS = 'args'
 
@@ -118,15 +120,24 @@ class BotPushReceiver(HomeAssistantView):
             return self.json_message('Invalid user', HTTP_BAD_REQUEST)
 
         _LOGGER.debug("Received telegram data: %s", data)
-        if not data['text'] or data['text'][:1] != '/':
-            _LOGGER.warning('no command')
+        if not data['text']:
+            _LOGGER.warning('no text')
             return self.json({})
 
-        pieces = data['text'].split(' ')
+        if data['text'][:1] == '/':
+            # telegram command "/blabla arg1 arg2 ..."
+            pieces = data['text'].split(' ')
 
-        request.app['hass'].bus.async_fire(EVENT_TELEGRAM_COMMAND, {
-            ATTR_COMMAND: pieces[0],
-            ATTR_ARGS: " ".join(pieces[1:]),
-            ATTR_USER_ID: data['from']['id'],
-            })
+            request.app['hass'].bus.async_fire(EVENT_TELEGRAM_COMMAND, {
+                ATTR_COMMAND: pieces[0],
+                ATTR_ARGS: " ".join(pieces[1:]),
+                ATTR_USER_ID: data['from']['id'],
+                })
+        else:
+            # telegram text "bla bla"
+            request.app['hass'].bus.async_fire(EVENT_TELEGRAM_TEXT, {
+                ATTR_TEXT: data['text'],
+                ATTR_USER_ID: data['from']['id'],
+                })
+
         return self.json({})


### PR DESCRIPTION
New text event and telegram command event renamed.

Current telegram_webhooks component require all commands to start with /. It is an opportunity
to pass complete text in new event `telegram_text` event. If chat contains a command both events are fired: `telegram_text` and `telegram_command` with specific args.

Also, the name of the event telegram.command is not consistent with other event names: none of them has a dot (.), they all use underscores.

## Example automation for new event
```yaml
trigger:
  platform: event
  event_type: telegram_text
action:
  - service:
      tts.google_say
    data_template:
      entity_id: media_player.gstreamer
      message: "{{ trigger.event.data.text }}"
```
