### PR TITLE
Migrate calendar setup to async.

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -3,8 +3,8 @@ Support for Google Calendar event device sensors.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/calendar/
-
 """
+import asyncio
 import logging
 from datetime import timedelta
 
@@ -27,13 +27,13 @@ DOMAIN = 'calendar'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 
-def setup(hass, config):
+@asyncio.coroutine
+def async_setup(hass, config):
     """Track states and offer events for calendars."""
     component = EntityComponent(
         logging.getLogger(__name__), DOMAIN, hass, SCAN_INTERVAL, DOMAIN)
 
-    component.setup(config)
-
+    yield from component.async_setup(config)
     return True
 
 


### PR DESCRIPTION
## Description:

All components entity should be use async inside hass. That is for async bootstrap

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
