### PR TITLE
Rollback netdisco to 0.8.2 to resolve #6165

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.helpers.discovery import load_platform, discover
 
-REQUIREMENTS = ['netdisco==0.8.3']
+REQUIREMENTS = ['netdisco==0.8.2']
 
 DOMAIN = 'discovery'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -365,7 +365,7 @@ mutagen==1.36.2
 myusps==1.0.3
 
 # homeassistant.components.discovery
-netdisco==0.8.3
+netdisco==0.8.2
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1


### PR DESCRIPTION
## Description:
Between 0.38.3 and 0.38.4 cpu and memory consumption shot way up (it consumed over 15GB on my system crashing it in one instance) ...  There are many folks on the #6165 ticket complaining of similar symptoms post update.   Rolling back netdisco appears to eliminate the problem for me.  This is a patch to roll it back the netdisco dependency.

**Related issue (if applicable):** fixes #6165 