### PR TITLE
Help test next Python bug-fix releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
+    - python: "3.6-dev"
+      env: TOXENV=py36
   # allow_failures:
   #   - python: "3.5"
   #     env: TOXENV=typing


### PR DESCRIPTION
[Brett Cannon wrote today](https://snarky.ca/how-to-use-your-project-travis-to-help-test-python-itself/) about how projects can help to test upcoming Python releases by running tests against them. I think it's a great idea and so added a test branch to run on Python 3.6-dev.