### PR TITLE
Cleanup component track_point_in_utc_time usage

### DIFF
--- a/homeassistant/components/device_tracker/bluetooth_le_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_le_tracker.py
@@ -110,7 +110,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
                     _LOGGER.info("Discovered Bluetooth LE device %s", address)
                     see_device(address, devs[address], new_device=True)
 
-        track_point_in_utc_time(hass, update_ble, now + interval)
+        track_point_in_utc_time(hass, update_ble, dt_util.utcnow() + interval)
 
     update_ble(dt_util.utcnow())
 

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -82,7 +82,8 @@ def setup_scanner(hass, config, see, discovery_info=None):
                 see_device((mac, result))
         except bluetooth.BluetoothError:
             _LOGGER.exception('Error looking up bluetooth device!')
-        track_point_in_utc_time(hass, update_bluetooth, now + interval)
+        track_point_in_utc_time(
+            hass, update_bluetooth, dt_util.utcnow() + interval)
 
     update_bluetooth(dt_util.utcnow())
 

--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -86,7 +86,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
         """Update all the hosts on every interval time."""
         for host in hosts:
             host.update(see)
-        track_point_in_utc_time(hass, update, now + interval)
+        track_point_in_utc_time(hass, update, util.dt.utcnow() + interval)
         return True
 
     return update(util.dt.utcnow())

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -98,9 +98,8 @@ class TelldusLiveClient(object):
         try:
             self._sync()
         finally:
-            track_point_in_utc_time(self._hass,
-                                    self.update,
-                                    now + self._interval)
+            track_point_in_utc_time(
+                self._hass, self.update, utcnow() + self._interval)
 
     def _sync(self):
         """Update local list of devices."""
@@ -123,11 +122,8 @@ class TelldusLiveClient(object):
 
         def discover(device_id, component):
             """Discover the component."""
-            discovery.load_platform(self._hass,
-                                    component,
-                                    DOMAIN,
-                                    [device_id],
-                                    self._config)
+            discovery.load_platform(
+                self._hass, component, DOMAIN, [device_id], self._config)
 
         known_ids = set([entity.device_id for entity in self.entities])
         for device in self._client.devices:

--- a/homeassistant/components/volvooncall.py
+++ b/homeassistant/components/volvooncall.py
@@ -109,7 +109,7 @@ def setup(hass, config):
 
             return True
         finally:
-            track_point_in_utc_time(hass, update, now + interval)
+            track_point_in_utc_time(hass, update, utcnow() + interval)
 
     _LOGGER.info('Logging in to service')
     return update(utcnow())


### PR DESCRIPTION
## Description:

Fix wrong handling with track_point_in_utc_time on component/platform. Which use `now` it could be schedule in past. Now it do what he should do.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
