### PR TITLE
Upgrade astral to 1.4

### DIFF
--- a/homeassistant/components/sensor/moon.py
+++ b/homeassistant/components/sensor/moon.py
@@ -15,7 +15,7 @@ import homeassistant.util.dt as dt_util
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['astral==1.3.4']
+REQUIREMENTS = ['astral==1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -17,7 +17,7 @@ from homeassistant.util import dt as dt_util
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util as util
 
-REQUIREMENTS = ['astral==1.3.4']
+REQUIREMENTS = ['astral==1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -58,7 +58,7 @@ apns2==0.1.1
 
 # homeassistant.components.sun
 # homeassistant.components.sensor.moon
-astral==1.3.4
+astral==1.4
 
 # homeassistant.components.light.avion
 # avion==0.5

--- a/tests/components/test_sun.py
+++ b/tests/components/test_sun.py
@@ -109,6 +109,6 @@ class TestSun(unittest.TestCase):
 
         assert state is not None
         assert sun.next_rising_utc(self.hass) == \
-            datetime(2016, 7, 25, 23, 38, 21, tzinfo=dt_util.UTC)
+            datetime(2016, 7, 25, 23, 23, 39, tzinfo=dt_util.UTC)
         assert sun.next_setting_utc(self.hass) == \
-            datetime(2016, 7, 26, 22, 4, 18, tzinfo=dt_util.UTC)
+            datetime(2016, 7, 26, 22, 19, 1, tzinfo=dt_util.UTC)


### PR DESCRIPTION
1.4
----
- Changed to use calculations from NOAA spreadsheets
- Changed some exception error messages for when sun does not reach a requested elevation.
- Added more tests

Tested with the following configuration:

``` yaml
sun:
sensor:
  - platform: moon
```