### PR TITLE
Bump limitlessled dependency to 1.0.5.

### DIFF
--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -17,7 +17,7 @@ from homeassistant.components.light import (
     SUPPORT_RGB_COLOR, SUPPORT_TRANSITION, Light, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['limitlessled==1.0.4']
+REQUIREMENTS = ['limitlessled==1.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -337,7 +337,7 @@ libsoundtouch==0.1.0
 liffylights==0.9.4
 
 # homeassistant.components.light.limitlessled
-limitlessled==1.0.4
+limitlessled==1.0.5
 
 # homeassistant.components.media_player.liveboxplaytv
 liveboxplaytv==1.4.9


### PR DESCRIPTION
## Description:

The bug that causes #6295 is fixed in limitlessled 1.0.5. So we need to bump the dependency to that version.


**Related issue (if applicable):** fixes #6295

