### PR TITLE
Bump netdisco to 0.9.1

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==0.9.0']
+REQUIREMENTS = ['netdisco==0.9.1']
 
 DOMAIN = 'discovery'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -365,7 +365,7 @@ mutagen==1.36.2
 myusps==1.0.3
 
 # homeassistant.components.discovery
-netdisco==0.9.0
+netdisco==0.9.1
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1


### PR DESCRIPTION
## Description:
Bump netdisco dependency to 0.9.1. Changes:

- Add timeouts to Hue and SSDP requests to make sure that we don't block indefinitely.
