### PR TITLE
Fix command sudo not found error in dev Dockerfile

### DIFF
--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -30,7 +30,7 @@ RUN pip3 install --no-cache-dir -r requirements_all.txt && \
 # BEGIN: Development additions
 
 # Install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - && \
     apt-get install -y nodejs
 
 # Install tox


### PR DESCRIPTION
## Description:
I use docker to run all my HASS stuff (including tests and linting). The included dev Dockerfile doesn't build correctly because `sudo` doesn't exist. It's not needed.