### PR TITLE
[WIP] History stats sensor can not handle entity attributes

### DIFF
--- a/tests/components/sensor/test_history_stats.py
+++ b/tests/components/sensor/test_history_stats.py
@@ -53,9 +53,9 @@ class TestHistoryStatsSensor(unittest.TestCase):
         duration = timedelta(hours=2, minutes=1)
 
         sensor1 = HistoryStatsSensor(
-            self.hass, 'test', 'on', today, None, duration, 'test')
+            self.hass, 'test', None, 'on', today, None, duration, 'test')
         sensor2 = HistoryStatsSensor(
-            self.hass, 'test', 'on', None, today, duration, 'test')
+            self.hass, 'test', None, 'on', None, today, duration, 'test')
 
         sensor1.update_period()
         sensor2.update_period()
@@ -91,10 +91,11 @@ class TestHistoryStatsSensor(unittest.TestCase):
         end = Template('{{ now() }}', self.hass)
 
         sensor1 = HistoryStatsSensor(
-            self.hass, 'binary_sensor.test_id', 'on', start, end, None, 'Test')
+            self.hass, 'binary_sensor.test_id', None, 'on',
+            start, end, None, 'Test')
 
         sensor2 = HistoryStatsSensor(
-            self.hass, 'unknown.id', 'on', start, end, None, 'Test')
+            self.hass, 'unknown.id', None, 'on', start, end, None, 'Test')
 
         with patch('homeassistant.components.history.'
                    'state_changes_during_period', return_value=fake_states):
@@ -113,9 +114,9 @@ class TestHistoryStatsSensor(unittest.TestCase):
         bad = Template('{{ TEST }}', self.hass)
 
         sensor1 = HistoryStatsSensor(
-            self.hass, 'test', 'on', good, bad, None, 'Test')
+            self.hass, 'test', None, 'on', good, bad, None, 'Test')
         sensor2 = HistoryStatsSensor(
-            self.hass, 'test', 'on', bad, good, None, 'Test')
+            self.hass, 'test', None, 'on', bad, good, None, 'Test')
 
         before_update1 = sensor1._period
         before_update2 = sensor2._period
@@ -153,9 +154,9 @@ class TestHistoryStatsSensor(unittest.TestCase):
         duration = '01:00'
 
         sensor1 = HistoryStatsSensor(
-            self.hass, 'test', 'on', bad, None, duration, 'Test')
+            self.hass, 'test', None, 'on', bad, None, duration, 'Test')
         sensor2 = HistoryStatsSensor(
-            self.hass, 'test', 'on', None, bad, duration, 'Test')
+            self.hass, 'test', None, 'on', None, bad, duration, 'Test')
 
         before_update1 = sensor1._period
         before_update2 = sensor2._period


### PR DESCRIPTION
## Description:
History stats sensor can not handle entity attributes

**Related issue (if applicable):** fixes #6347 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: history_stats
    name: Ecobee heating time
    entity_id: climate.ecobee_mainfloor
    attribute: operation
    state: 'heat'
    start: '{{ now().replace(hour=0).replace(minute=0).replace(second=0) }}'
    end: '{{ now() }}'
```

## Checklist:

  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
