### PR TITLE
Upgrade TwitterAPI to 2.4.5

### DIFF
--- a/homeassistant/components/notify/twitter.py
+++ b/homeassistant/components/notify/twitter.py
@@ -13,7 +13,7 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA, BaseNotificationService)
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_USERNAME
 
-REQUIREMENTS = ['TwitterAPI==2.4.4']
+REQUIREMENTS = ['TwitterAPI==2.4.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -31,7 +31,7 @@ PyMata==2.13
 SoCo==0.12
 
 # homeassistant.components.notify.twitter
-TwitterAPI==2.4.4
+TwitterAPI==2.4.5
 
 # homeassistant.components.sensor.dnsip
 aiodns==1.1.1


### PR DESCRIPTION
## 2.4.5
- Added statuses/unretweet API endpoint

Tested with the following configuration:

``` yaml
notify:
  - platform: twitter
    name: twitter
    consumer_key: !secret twitter_consumer_key
    consumer_secret: !secret twitter_consumer_secret
    access_token: !secret twitter_access_token
    access_token_secret: !secret twitter_token_secret
```

Message sent with "Call Service"

``` json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}! Update of TwitterAPI for @home_assistant at #nullcon"
}
```

:smile: -> [:m:](https://twitter.com/fabaff/status/837156593783316480)
