### PR TITLE
Move dispatcher out of init.

### DIFF
--- a/homeassistant/components/alarm_control_panel/envisalink.py
+++ b/homeassistant/components/alarm_control_panel/envisalink.py
@@ -94,10 +94,13 @@ class EnvisalinkAlarm(EnvisalinkDevice, alarm.AlarmControlPanel):
         _LOGGER.debug("Setting up alarm: %s", alarm_name)
         super().__init__(alarm_name, info, controller)
 
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
         async_dispatcher_connect(
-            hass, SIGNAL_KEYPAD_UPDATE, self._update_callback)
+            self.hass, SIGNAL_KEYPAD_UPDATE, self._update_callback)
         async_dispatcher_connect(
-            hass, SIGNAL_PARTITION_UPDATE, self._update_callback)
+            self.hass, SIGNAL_PARTITION_UPDATE, self._update_callback)
 
     @callback
     def _update_callback(self, partition):

--- a/homeassistant/components/binary_sensor/envisalink.py
+++ b/homeassistant/components/binary_sensor/envisalink.py
@@ -52,8 +52,11 @@ class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorDevice):
         _LOGGER.debug('Setting up zone: ' + zone_name)
         super().__init__(zone_name, info, controller)
 
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
         async_dispatcher_connect(
-            hass, SIGNAL_ZONE_UPDATE, self._update_callback)
+            self.hass, SIGNAL_ZONE_UPDATE, self._update_callback)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/sensor/envisalink.py
+++ b/homeassistant/components/sensor/envisalink.py
@@ -49,10 +49,13 @@ class EnvisalinkSensor(EnvisalinkDevice, Entity):
         _LOGGER.debug('Setting up sensor for partition: ' + partition_name)
         super().__init__(partition_name + ' Keypad', info, controller)
 
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
         async_dispatcher_connect(
-            hass, SIGNAL_KEYPAD_UPDATE, self._update_callback)
+            self.hass, SIGNAL_KEYPAD_UPDATE, self._update_callback)
         async_dispatcher_connect(
-            hass, SIGNAL_PARTITION_UPDATE, self._update_callback)
+            self.hass, SIGNAL_PARTITION_UPDATE, self._update_callback)
 
     @property
     def icon(self):


### PR DESCRIPTION
## Description:

Only small cleanups to move dispatcher to async_add_to_hass

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
