### PR TITLE
snmp: upgrade pysnmp to 4.3.4

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -19,7 +19,7 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pysnmp==4.3.3']
+REQUIREMENTS = ['pysnmp==4.3.4']
 
 CONF_COMMUNITY = 'community'
 CONF_AUTHKEY = 'authkey'

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pysnmp==4.3.3']
+REQUIREMENTS = ['pysnmp==4.3.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -558,7 +558,7 @@ pysma==0.1.3
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
-pysnmp==4.3.3
+pysnmp==4.3.4
 
 # homeassistant.components.media_player.clementine
 python-clementine-remote==1.0.1


### PR DESCRIPTION
## Description:
Upgrade to latest pysnmp version to fix in-module incompatibility with upstream pyasn.
See https://github.com/etingof/pysnmp/issues/40

**Related issue:** fixes regression #6238

Tested with latest `dev[#c32300a]` and `0.39.1`; Full component functionality is restored.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
