### PR TITLE
Restore for input_slider

### DIFF
--- a/homeassistant/components/input_slider.py
+++ b/homeassistant/components/input_slider.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.restore_state import async_get_last_state
 
 DOMAIN = 'input_slider'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
@@ -164,6 +165,18 @@ class InputSlider(Entity):
             ATTR_MAX: self._maximum,
             ATTR_STEP: self._step
         }
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Called when entity about to be added to hass."""
+        state = yield from async_get_last_state(self.hass, self.entity_id)
+        if not state:
+            return
+
+        num_value = float(state.state)
+        if num_value < self._minimum or num_value > self._maximum:
+            return
+        self._current_value = num_value
 
     @asyncio.coroutine
     def async_select_value(self, value):

--- a/tests/components/test_input_slider.py
+++ b/tests/components/test_input_slider.py
@@ -1,11 +1,14 @@
 """The tests for the Input slider component."""
 # pylint: disable=protected-access
+import asyncio
 import unittest
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_component
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.core import CoreState, State
+from homeassistant.bootstrap import setup_component, async_setup_component
 from homeassistant.components.input_slider import (DOMAIN, select_value)
+from homeassistant.helpers.restore_state import DATA_RESTORE_CACHE
 
 
 class TestInputSlider(unittest.TestCase):
@@ -67,3 +70,37 @@ class TestInputSlider(unittest.TestCase):
 
         state = self.hass.states.get(entity_id)
         self.assertEqual(70, float(state.state))
+
+
+@asyncio.coroutine
+def test_restore_state(hass):
+    """Ensure states are restored on startup."""
+    hass.data[DATA_RESTORE_CACHE] = {
+        'input_slider.b1': State('input_slider.b1', '70'),
+        'input_slider.b2': State('input_slider.b2', '200'),
+    }
+
+    hass.state = CoreState.starting
+    mock_component(hass, 'recorder')
+
+    yield from async_setup_component(hass, DOMAIN, {
+        DOMAIN: {
+            'b1': {
+                'initial': 50,
+                'min': 0,
+                'max': 100,
+            },
+            'b2': {
+                'initial': 60,
+                'min': 0,
+                'max': 100,
+            },
+        }})
+
+    state = hass.states.get('input_slider.b1')
+    assert state
+    assert float(state.state) == 70
+
+    state = hass.states.get('input_slider.b2')
+    assert state
+    assert float(state.state) == 60


### PR DESCRIPTION
## Description:

Allow input_slider to restore state.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
