### PR TITLE
Fix possibility that have multible topic subscribe mqtt

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -482,17 +482,17 @@ class MQTT(object):
         if not isinstance(topic, str):
             raise HomeAssistantError("topic need to be a string!")
 
-        if topic in self.topics:
-            return
-
         with (yield from self._paho_lock):
+            if topic in self.topics:
+                return
+
             result, mid = yield from self.hass.loop.run_in_executor(
                 None, self._mqttc.subscribe, topic, qos)
             yield from asyncio.sleep(0, loop=self.hass.loop)
 
-        _raise_on_error(result)
-        self.progress[mid] = topic
-        self.topics[topic] = None
+            _raise_on_error(result)
+            self.progress[mid] = topic
+            self.topics[topic] = None
 
     @asyncio.coroutine
     def async_unsubscribe(self, topic):


### PR DESCRIPTION
## Description:

It was possible that same topic can be multible subscribe. I move the async lock above to protect that.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
