### PR TITLE
Restore flow on device_tracker platform

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -132,18 +132,6 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
     devices = yield from async_load_config(yaml_path, hass, consider_home)
     tracker = DeviceTracker(hass, consider_home, track_new, devices)
 
-    # added_to_hass
-    add_tasks = [device.async_added_to_hass() for device in devices
-                 if device.track]
-    if add_tasks:
-        yield from asyncio.wait(add_tasks, loop=hass.loop)
-
-    # update tracked devices
-    update_tasks = [device.async_update_ha_state() for device in devices
-                    if device.track]
-    if update_tasks:
-        yield from asyncio.wait(update_tasks, loop=hass.loop)
-
     @asyncio.coroutine
     def async_setup_platform(p_type, p_config, disc_info=None):
         """Setup a device tracker platform."""
@@ -226,6 +214,8 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
     hass.services.async_register(
         DOMAIN, SERVICE_SEE, async_see_service, descriptions.get(SERVICE_SEE))
 
+    # restore
+    yield from tracker.async_setup_tracked_device()
     return True
 
 
@@ -355,6 +345,30 @@ class DeviceTracker(object):
             if (device.track and device.last_update_home) and \
                device.stale(now):
                 self.hass.async_add_job(device.async_update_ha_state(True))
+
+    @asyncio.coroutine
+    def async_setup_tracked_device(self):
+        """Setup at the end of device_tracker component all not exists and
+        tracked devices. It restore also his data.
+
+        This method is a coroutine.
+        """
+        @asyncio.coroutine
+        def async_init_single_device(dev):
+            """Init a single device_tracker entity."""
+            yield from dev.async_added_to_hass()
+            yield from dev.async_update_ha_state()
+
+        tasks = []
+        for device in self.devices.values():
+            if not device.track or device.last_seen:
+                continue
+            tasks.append(self.hass.async_add_job(
+                async_init_single_device(device)
+            ))
+
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
 
 
 class Device(Entity):

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -348,8 +348,7 @@ class DeviceTracker(object):
 
     @asyncio.coroutine
     def async_setup_tracked_device(self):
-        """Setup at the end of device_tracker component all not exists and
-        tracked devices. It restore also his data.
+        """Setup all not exists tracked devices.
 
         This method is a coroutine.
         """

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -361,14 +361,12 @@ class DeviceTracker(object):
 
         tasks = []
         for device in self.devices.values():
-            if not device.track or device.last_seen:
-                continue
-            tasks.append(self.hass.async_add_job(
-                async_init_single_device(device)
-            ))
+            if device.track and not device.last_seen:
+                tasks.append(self.hass.async_add_job(
+                    async_init_single_device(device)))
 
         if tasks:
-            yield from asyncio.wait(tasks, loop=hass.loop)
+            yield from asyncio.wait(tasks, loop=self.hass.loop)
 
 
 class Device(Entity):


### PR DESCRIPTION
## Description:

I change the flow of restore a bit.

Actual:
```
[load device] -> (wait for restore) -> [write to statemachine] -> (wait for init platform) -> [Write found to statemachine] -> [setup others]
```
So we wait first until we have data for restore and write all thing to statemachine. After that we wait until all is setup and we have platform they need 15-60 seconds for it. And they also write found device to statemachine.

New:
```
[load device] -> (wait for init platform) -> [Write found to statemachine] -> [Setup others] -> ("Maby Wait" for restore only not seen entities) -> [Write only this to statemachine]
```

So we do not write the same device 2 times to statemachine and after we Setup all device tracker platforms, the db should finish to laod data for restore without waiting.

So we go more faster than now, and do things only once.