### PR TITLE
Update pwaqi to 3.0 to use public API

### DIFF
--- a/homeassistant/components/sensor/waqi.py
+++ b/homeassistant/components/sensor/waqi.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pwaqi==2.0']
+REQUIREMENTS = ['pwaqi==3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -162,7 +162,7 @@ class WaqiData(object):
         """Get the data from World Air Quality Index and updates the states."""
         import pwaqi
         try:
-            self.data = pwaqi.getStationObservation(
+            self.data = pwaqi.get_station_observation(
                 self._station_id, self._token)
         except AttributeError:
             _LOGGER.exception("Unable to fetch data from WAQI")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -433,7 +433,7 @@ pushbullet.py==0.10.0
 pushetta==1.0.15
 
 # homeassistant.components.sensor.waqi
-pwaqi==2.0
+pwaqi==3.0
 
 # homeassistant.components.sensor.cpuspeed
 py-cpuinfo==0.2.6


### PR DESCRIPTION
## Description:
The underlying PWAQI library version 3.0 is now using public API to access AQICN data.

## Checklist:

If user exposed functionality or configuration variables are added/changed:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.