### PR TITLE
Send a logo with webostv notifications

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -25,8 +25,8 @@ from homeassistant.loader import get_component
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['https://github.com/TheRealLink/pylgtv'
-                '/archive/v0.1.3.zip'
-                '#pylgtv==0.1.3',
+                '/archive/v0.1.4.zip'
+                '#pylgtv==0.1.4',
                 'websockets==3.2',
                 'wakeonlan==0.2.2']
 

--- a/homeassistant/components/notify/webostv.py
+++ b/homeassistant/components/notify/webostv.py
@@ -5,13 +5,14 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.webostv/
 """
 import logging
+import os
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
-    BaseNotificationService, PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_FILENAME, CONF_HOST)
+    ATTR_DATA, BaseNotificationService, PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_FILENAME, CONF_HOST, CONF_ICON)
 
 REQUIREMENTS = ['https://github.com/TheRealLink/pylgtv/archive/v0.1.4.zip'
                 '#pylgtv==0.1.4']
@@ -19,10 +20,14 @@ REQUIREMENTS = ['https://github.com/TheRealLink/pylgtv/archive/v0.1.4.zip'
 _LOGGER = logging.getLogger(__name__)
 
 WEBOSTV_CONFIG_FILE = 'webostv.conf'
+HOME_ASSISTANT_ICON_PATH = os.path.join(os.path.dirname(__file__), '..',
+                                        'frontend', 'www_static', 'icons',
+                                        'favicon-1024x1024.png')
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string
+    vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string,
+    vol.Optional(CONF_ICON, default=HOME_ASSISTANT_ICON_PATH): cv.string
 })
 
 
@@ -44,23 +49,29 @@ def get_service(hass, config, discovery_info=None):
             _LOGGER.error("TV unreachable")
             return None
 
-    return LgWebOSNotificationService(client)
+    return LgWebOSNotificationService(client, config.get(CONF_ICON))
 
 
 class LgWebOSNotificationService(BaseNotificationService):
     """Implement the notification service for LG WebOS TV."""
 
-    def __init__(self, client):
+    def __init__(self, client, icon_path):
         """Initialize the service."""
         self._client = client
+        self._icon_path = icon_path
 
     def send_message(self, message="", **kwargs):
         """Send a message to the tv."""
         from pylgtv import PyLGTVPairException
 
         try:
-            self._client.send_message(message)
+            data = kwargs.get(ATTR_DATA)
+            icon_path = data.get(CONF_ICON, self._icon_path) if data else \
+                self._icon_path
+            self._client.send_message(message, icon_path=icon_path)
         except PyLGTVPairException:
             _LOGGER.error("Pairing with TV failed")
+        except FileNotFoundError:
+            _LOGGER.error("Icon %s not found", icon_path)
         except OSError:
             _LOGGER.error("TV unreachable")

--- a/homeassistant/components/notify/webostv.py
+++ b/homeassistant/components/notify/webostv.py
@@ -13,8 +13,8 @@ from homeassistant.components.notify import (
     BaseNotificationService, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_FILENAME, CONF_HOST)
 
-REQUIREMENTS = ['https://github.com/TheRealLink/pylgtv/archive/v0.1.3.zip'
-                '#pylgtv==0.1.3']
+REQUIREMENTS = ['https://github.com/TheRealLink/pylgtv/archive/v0.1.4.zip'
+                '#pylgtv==0.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -217,7 +217,7 @@ https://github.com/LinuxChristian/pyW215/archive/v0.4.zip#pyW215==0.4
 
 # homeassistant.components.media_player.webostv
 # homeassistant.components.notify.webostv
-https://github.com/TheRealLink/pylgtv/archive/v0.1.3.zip#pylgtv==0.1.3
+https://github.com/TheRealLink/pylgtv/archive/v0.1.4.zip#pylgtv==0.1.4
 
 # homeassistant.components.sensor.thinkingcleaner
 # homeassistant.components.switch.thinkingcleaner


### PR DESCRIPTION
## Description:
Send an icon alongside notifications to the LG WebOS component. By default, use the Home Assistant logo, but allow configuring an alternative logo for the component itself, or individual notifications.

Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation: home-assistant/home-assistant.github.io#2188

## Example entry for `configuration.yaml`:
```yaml
notify:
  - platform: webostv
    host: 192.168.0.112
    name: livingroom_tv
    filename: webostv.conf
    icon: "/home/homeassistant/images/hal.png"
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. 
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.