### PR TITLE
Don't initialize components which have already been discovered

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -7,6 +7,7 @@ Knows which components handle certain types, will make sure they are
 loaded before the EVENT_PLATFORM_DISCOVERED is fired.
 """
 import asyncio
+import json
 from datetime import timedelta
 import logging
 
@@ -86,10 +87,11 @@ def async_setup(hass, config):
         if not comp_plat:
             return
 
-        if (service, info) in already_discovered:
+        discovery_hash = json.dumps([service, info], sort_keys=True)
+        if discovery_hash in already_discovered:
             return
 
-        already_discovered.add((service, info))
+        already_discovered.add(discovery_hash)
 
         logger.info("Found new service: %s %s", service, info)
 

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -80,8 +80,6 @@ def async_setup(hass, config):
             logger.info("Ignoring service: %s %s", service, info)
             return
 
-        logger.info("Found new service: %s %s", service, info)
-
         comp_plat = SERVICE_HANDLERS.get(service)
 
         # We do not know how to handle this service.
@@ -92,6 +90,8 @@ def async_setup(hass, config):
             return
 
         already_discovered.add((service, info))
+
+        logger.info("Found new service: %s %s", service, info)
 
         component, platform = comp_plat
 

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -65,6 +65,7 @@ def async_setup(hass, config):
 
     logger = logging.getLogger(__name__)
     netdisco = NetworkDiscovery()
+    already_discovered = set()
 
     # Disable zeroconf logging, it spams
     logging.getLogger('zeroconf').setLevel(logging.CRITICAL)
@@ -86,6 +87,11 @@ def async_setup(hass, config):
         # We do not know how to handle this service.
         if not comp_plat:
             return
+
+        if (service, info) in already_discovered:
+            return
+
+        already_discovered.add((service, info))
 
         component, platform = comp_plat
 


### PR DESCRIPTION
## Description:

This change prevents re-discovered devices from creating duplicate components.  It accomplishes this by recording the discovery data and skipping initialization if that device was already discovered.

See discussion thread here: https://github.com/home-assistant/home-assistant/issues/5588#issuecomment-283975166

**Related issue (if applicable):** fixes #5588 

**Target release:** 0.39.3