### PR TITLE
Save the state we send back to HA

### DIFF
--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -98,8 +98,10 @@ class ManualAlarm(alarm.AlarmControlPanel):
             elif (self._state_ts + self._pending_time +
                   self._trigger_time) < dt_util.utcnow():
                 if self._disarm_after_trigger:
+                    self._state = STATE_ALARM_DISARMED
                     return STATE_ALARM_DISARMED
                 else:
+                    self._state = self._pre_trigger_state
                     return self._pre_trigger_state
 
         return self._state


### PR DESCRIPTION
## Description:

State to state that we send back to HA, otherwise it will remain in STATE_ALARM_TRIGGERED and the alarm will not be re-armed. Based on the documentation the alarm would returning to the previous state.

**Related issue (if applicable):** fixes #6386

## Checklist:

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
