### PR TITLE
Don't log username and password in camera url

### DIFF
--- a/homeassistant/components/camera/foscam.py
+++ b/homeassistant/components/camera/foscam.py
@@ -47,15 +47,22 @@ class FoscamCamera(Camera):
         port = device_info.get(CONF_PORT)
 
         self._base_url = 'http://{}:{}/'.format(ip_address, port)
+
+        uri_template = self._base_url + \
+                       'cgi-bin/CGIProxy.fcgi?' \
+                       'cmd=snapPicture2&usr={}&pwd={}'
+
         self._username = device_info.get(CONF_USERNAME)
         self._password = device_info.get(CONF_PASSWORD)
-        self._snap_picture_url = self._base_url \
-            + 'cgi-bin/CGIProxy.fcgi?cmd=snapPicture2&usr=' \
-            + self._username + '&pwd=' + self._password
+        self._snap_picture_url = uri_template.format(
+            self._username,
+            self._password
+        )
         self._name = device_info.get(CONF_NAME)
 
         _LOGGER.info('Using the following URL for %s: %s',
-                     self._name, self._snap_picture_url)
+             self._name, uri_template.format('***', '***')
+         )
 
     def camera_image(self):
         """Return a still image reponse from the camera."""

--- a/homeassistant/components/camera/foscam.py
+++ b/homeassistant/components/camera/foscam.py
@@ -61,7 +61,7 @@ class FoscamCamera(Camera):
         self._name = device_info.get(CONF_NAME)
 
         _LOGGER.info('Using the following URL for %s: %s',
-                        self._name, uri_template.format('***', '***'))
+                     self._name, uri_template.format('***', '***'))
 
     def camera_image(self):
         """Return a still image reponse from the camera."""

--- a/homeassistant/components/camera/foscam.py
+++ b/homeassistant/components/camera/foscam.py
@@ -48,9 +48,9 @@ class FoscamCamera(Camera):
 
         self._base_url = 'http://{}:{}/'.format(ip_address, port)
 
-        uri_template = self._base_url + \
-                       'cgi-bin/CGIProxy.fcgi?' \
-                       'cmd=snapPicture2&usr={}&pwd={}'
+        uri_template = self._base_url \
+            + 'cgi-bin/CGIProxy.fcgi?' \
+            + 'cmd=snapPicture2&usr={}&pwd={}'
 
         self._username = device_info.get(CONF_USERNAME)
         self._password = device_info.get(CONF_PASSWORD)
@@ -61,8 +61,7 @@ class FoscamCamera(Camera):
         self._name = device_info.get(CONF_NAME)
 
         _LOGGER.info('Using the following URL for %s: %s',
-             self._name, uri_template.format('***', '***')
-         )
+                        self._name, uri_template.format('***', '***'))
 
     def camera_image(self):
         """Return a still image reponse from the camera."""


### PR DESCRIPTION
## Description:
Don't want to expose the credentials through the log, so mask them.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
