### PR TITLE
Ignore deleted mails in IMAP unread count (#6394)

### DIFF
--- a/homeassistant/components/sensor/imap.py
+++ b/homeassistant/components/sensor/imap.py
@@ -85,7 +85,7 @@ class ImapSensor(Entity):
         try:
             self.connection.select()
             self._unread_count = len(self.connection.search(
-                None, 'UnSeen')[1][0].split())
+                None, 'UnSeen UnDeleted')[1][0].split())
         except imaplib.IMAP4.error:
             _LOGGER.info("Connection to %s lost, attempting to reconnect",
                          self._server)


### PR DESCRIPTION
Message deletion in IMAP is a two step process: first delete, then expunge.
Deleting a message just sets a flag that usually makes the mail client hide
the message. It is the expunge that actually removes the message.

Thus, exclude the deleted messages so that the unread count matches up with
that of most mail clients.

(I am a new contributor, so please inform me of any process failings and I will try to adapt.)

## Description:

**Related issue (if applicable):** fixes #6394

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)**

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
