### PR TITLE
Fix wake_on_lan for german version of Windows 10 (#6397)

### DIFF
--- a/homeassistant/components/switch/wake_on_lan.py
+++ b/homeassistant/components/switch/wake_on_lan.py
@@ -91,5 +91,5 @@ class WOLSwitch(SwitchDevice):
             ping_cmd = 'ping -c 1 -W {} {}'.format(
                 DEFAULT_PING_TIMEOUT, self._host)
 
-        status = sp.getstatusoutput(ping_cmd)[0]
+        status = sp.call(ping_cmd, stdout=sp.DEVNULL)
         self._state = not bool(status)


### PR DESCRIPTION
## Description: Fix wake_on_lan for german version of Windows 10 


**Related issue (if applicable):** fixes #6397

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
