### PR TITLE
[On hold] Zwave: add get_power_consumption attribute

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -427,12 +427,13 @@ def setup(hass, config):
                 node=node, value=value, node_config=node_config, hass=hass)
             if not device:
                 continue
-                
-            # If CONF_GET_POWER_CONSUMPTION is explicitly false or it is missing and
-            # CONF_POLLING_INTENSITY is set - cancel fetching power consumption attribute.
+
+            # If CONF_GET_POWER_CONSUMPTION is explicitly false or it is
+            # missing and CONF_POLLING_INTENSITY is set - cancel fetching power
+            # consumption attribute.
             get_power_consumption = node_config.get(CONF_GET_POWER_CONSUMPTION)
-            if (get_power_consumption is False) or (get_power_consumption is None and 
-                                                    polling_intensity):
+            if (get_power_consumption is False) or (
+                    get_power_consumption is None and polling_intensity):
                 device.cancel_fetch_power()
 
             dict_id = value.value_id

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -42,6 +42,7 @@ CONF_CONFIG_PATH = 'config_path'
 CONF_IGNORED = 'ignored'
 CONF_REFRESH_VALUE = 'refresh_value'
 CONF_REFRESH_DELAY = 'delay'
+CONF_GET_POWER_CONSUMPTION = 'get_power_consumption'
 CONF_DEVICE_CONFIG = 'device_config'
 CONF_DEVICE_CONFIG_GLOB = 'device_config_glob'
 CONF_DEVICE_CONFIG_DOMAIN = 'device_config_domain'
@@ -182,7 +183,8 @@ DEVICE_CONFIG_SCHEMA_ENTRY = vol.Schema({
     vol.Optional(CONF_REFRESH_VALUE, default=DEFAULT_CONF_REFRESH_VALUE):
         cv.boolean,
     vol.Optional(CONF_REFRESH_DELAY, default=DEFAULT_CONF_REFRESH_DELAY):
-        cv.positive_int
+        cv.positive_int,
+    vol.Optional(CONF_GET_POWER_CONSUMPTION): cv.boolean,
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -425,6 +427,14 @@ def setup(hass, config):
                 node=node, value=value, node_config=node_config, hass=hass)
             if not device:
                 continue
+                
+            # If CONF_GET_POWER_CONSUMPTION is explicitly false or it is missing and
+            # CONF_POLLING_INTENSITY is set - cancel fetching power consumption attribute.
+            get_power_consumption = node_config.get(CONF_GET_POWER_CONSUMPTION)
+            if (get_power_consumption is False) or (get_power_consumption is None and 
+                                                    polling_intensity):
+                device.cancel_fetch_power()
+
             dict_id = value.value_id
 
             @asyncio.coroutine
@@ -738,6 +748,7 @@ class ZWaveDeviceEntity(Entity):
         self._wakeup_value_id = None
         self._battery_value_id = None
         self._power_value_id = None
+        self._fetch_power = True
         self._update_attributes()
 
         dispatcher.connect(
@@ -773,7 +784,7 @@ class ZWaveDeviceEntity(Entity):
         if self._battery_value_id is None:
             self._battery_value_id = self.get_value(
                 class_id=const.COMMAND_CLASS_BATTERY, member='value_id')
-        if self._power_value_id is None:
+        if self._power_value_id is None and self._fetch_power:
             self._power_value_id = self.get_value(
                 class_id=[const.COMMAND_CLASS_SENSOR_MULTILEVEL,
                           const.COMMAND_CLASS_METER],
@@ -846,6 +857,12 @@ class ZWaveDeviceEntity(Entity):
     def name(self):
         """Return the name of the device."""
         return self._name
+
+    def cancel_fetch_power(self):
+        """Cancel fetching power consumption."""
+        self._fetch_power = False
+        self._power_value_id = None
+        self.power_consumption = None
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -750,6 +750,7 @@ class ZWaveDeviceEntity(Entity):
         self._battery_value_id = None
         self._power_value_id = None
         self._fetch_power = True
+        self.power_consumption = None
         self._update_attributes()
 
         dispatcher.connect(


### PR DESCRIPTION

## Description:

Add `get_power_consumption` config attribute to `device_config`.
If is explicitly false or it is missing and `polling_intensity` is set - cancel fetching power consumption attribute.

This is to help with home-assistant/home-assistant#6391 as polled multi-endpoint device with power measuring can cause a large number of state updates.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
zwave:
  device_config:
    sensor.aotec_1:
      get_power_consumption: false
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
