### PR TITLE
switch.tplink: catch exceptions coming from pyHS100 to avoid flooding…

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -83,6 +83,7 @@ class SmartPlugSwitch(SwitchDevice):
 
     def update(self):
         """Update the TP-Link switch's state."""
+        from pyHS100 import SmartPlugException
         try:
             self._state = self.smartplug.state == \
                 self.smartplug.SWITCH_STATE_ON
@@ -107,5 +108,5 @@ class SmartPlugSwitch(SwitchDevice):
                     # device returned no daily history
                     pass
 
-        except OSError:
-            _LOGGER.warning('Could not update status for %s', self.name)
+        except (SmartPlugException, OSError) as ex:
+            _LOGGER.warning('Could not read state for %s: %s', self.name, ex)


### PR DESCRIPTION
… the logs when the plug is not available

## Description:
This just adds catching the exception from the backend library to make logs more readable (by avoiding stacktraces).

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
