### PR TITLE
Tado device_tracker exception when mobile device location unknown

### DIFF
--- a/homeassistant/components/device_tracker/tado.py
+++ b/homeassistant/components/device_tracker/tado.py
@@ -142,7 +142,7 @@ class TadoDeviceScanner(DeviceScanner):
 
         # Find devices that have geofencing enabled, and are currently at home.
         for mobile_device in tado_json:
-            if 'location' in mobile_device:
+            if mobile_device.get('location'):
                 if mobile_device['location']['atHome']:
                     device_id = mobile_device['id']
                     device_name = mobile_device['name']


### PR DESCRIPTION
## Description:
Tado device_tracker exception when mobile device has geofencing enabled but location is currently unknown. This happens when a mobile phone app hasn't been active for a longer periode of time.

The tracker crashed and all devices where marked as 'away'.

**Related issue (if applicable):** fixes. No issue registered.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
