### PR TITLE
Avoid bad colors when turning on LIFX lights

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -230,10 +230,12 @@ class LIFXLight(Light):
                       hue, saturation, brightness, kelvin, fade)
 
         if self._power == 0:
+            self._liffylights.set_color(self._ip, hue, saturation,
+                                        brightness, kelvin, 0)
             self._liffylights.set_power(self._ip, 65535, fade)
-
-        self._liffylights.set_color(self._ip, hue, saturation,
-                                    brightness, kelvin, fade)
+        else:
+            self._liffylights.set_color(self._ip, hue, saturation,
+                                        brightness, kelvin, fade)
 
     def turn_off(self, **kwargs):
         """Turn the device off."""


### PR DESCRIPTION
This fixes an issue where the state stored inside LIFX bulbs spills into the "turn on" transition.

## Description:

**Related issue (if applicable):** fixes #2472

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54