### PR TITLE
Tweak recorder/restore_state

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -29,8 +29,7 @@ from homeassistant.components import sun, mqtt, recorder
 from homeassistant.components.http.auth import auth_middleware
 from homeassistant.components.http.const import (
     KEY_USE_X_FORWARDED_FOR, KEY_BANS_ENABLED, KEY_TRUSTED_NETWORKS)
-from homeassistant.util.async import (
-    run_callback_threadsafe, run_coroutine_threadsafe)
+from homeassistant.util.async import run_callback_threadsafe
 
 _LOGGER = logging.getLogger(__name__)
 INST_COUNT = 0

--- a/tests/common.py
+++ b/tests/common.py
@@ -477,8 +477,6 @@ def init_recorder_component(hass, add_config=None):
         assert setup_component(hass, recorder.DOMAIN,
                                {recorder.DOMAIN: config})
         assert recorder.DOMAIN in hass.config.components
-        run_coroutine_threadsafe(
-            recorder.wait_connection_ready(hass), hass.loop).result()
     _LOGGER.info("In-memory recorder successfully started")
 
 

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -34,7 +34,7 @@ def test_caching_data(hass):
             patch('homeassistant.helpers.restore_state.get_states',
                   return_value=states), \
             patch('homeassistant.helpers.restore_state.wait_connection_ready',
-                  return_value=mock_coro()):
+                  return_value=mock_coro(True)):
         state = yield from async_get_last_state(hass, 'input_boolean.b1')
 
     assert DATA_RESTORE_CACHE in hass.data


### PR DESCRIPTION
## Description:
So this started out as an attempt to fix the flaky `helpers.restore_state.test_filling_the_cache` test.

While looking into the details, I made the following changes:

**Add timeout to restore state**
By adding a timeout we will not block all of startup because we're trying to connect to the recorder.

**Recorder will now be connected when setup is done.**
I want to bring this one up again… Specifying a dependency in Home Assistant means that Home Assistant will guarantee that the dependency is ready to use before your component is set up. Following that logic I think that it makes sense to wait till it is connected.

**Clean up connect code**
It was a bit messy with using `locals`.

**wait_connection_ready will now return if connection was established**
I realized that we would never return from `wait_connection_ready` if the connection failed. That seems like a weird approach and thus I decided to have it return the result. Updated `restore_state` to not query if the connection failed.

## Example entry for `configuration.yaml` (if applicable):
```yaml
recorder:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
