### PR TITLE
Prevent more I/O in apns

### DIFF
--- a/homeassistant/components/notify/apns.py
+++ b/homeassistant/components/notify/apns.py
@@ -190,7 +190,6 @@ class ApnsNotificationService(BaseNotificationService):
         has a tracking id specified.
         """
         self.device_states[entity_id] = str(to_s.state)
-        return
 
     def write_devices(self):
         """Write all known devices to file."""


### PR DESCRIPTION
## Description:
Missed a spot where APNS is doing I/O

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
