### PR TITLE
Split bootstrap into bs + setup

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -7,7 +7,6 @@ import sys
 from time import time
 from collections import OrderedDict
 
-from types import ModuleType
 from typing import Any, Optional, Dict
 
 import voluptuous as vol
@@ -15,261 +14,21 @@ import voluptuous as vol
 import homeassistant.components as core_components
 from homeassistant.components import persistent_notification
 import homeassistant.config as conf_util
-from homeassistant.config import async_notify_setup_error
 import homeassistant.core as core
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE
+from homeassistant.setup import async_setup_component
 import homeassistant.loader as loader
-import homeassistant.util.package as pkg_util
-from homeassistant.util.async import run_coroutine_threadsafe
 from homeassistant.util.logging import AsyncHandler
 from homeassistant.util.yaml import clear_secret_cache
-from homeassistant.const import EVENT_COMPONENT_LOADED, PLATFORM_FORMAT
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import event_decorators, service
 from homeassistant.helpers.signal import async_register_signal_handling
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_COMPONENT = 'component'
-
-DATA_SETUP = 'setup_tasks'
-DATA_PIP_LOCK = 'pip_lock'
-
 ERROR_LOG_FILENAME = 'home-assistant.log'
-
 FIRST_INIT_COMPONENT = set((
     'recorder', 'mqtt', 'mqtt_eventstream', 'logger', 'introduction'))
-
-
-def setup_component(hass: core.HomeAssistant, domain: str,
-                    config: Optional[Dict]=None) -> bool:
-    """Setup a component and all its dependencies."""
-    return run_coroutine_threadsafe(
-        async_setup_component(hass, domain, config), loop=hass.loop).result()
-
-
-@asyncio.coroutine
-def async_setup_component(hass: core.HomeAssistant, domain: str,
-                          config: Optional[Dict]=None) -> bool:
-    """Setup a component and all its dependencies.
-
-    This method is a coroutine.
-    """
-    if domain in hass.config.components:
-        return True
-
-    setup_tasks = hass.data.get(DATA_SETUP)
-
-    if setup_tasks is not None and domain in setup_tasks:
-        return (yield from setup_tasks[domain])
-
-    if config is None:
-        config = {}
-
-    if setup_tasks is None:
-        setup_tasks = hass.data[DATA_SETUP] = {}
-
-    task = setup_tasks[domain] = hass.async_add_job(
-        _async_setup_component(hass, domain, config))
-
-    return (yield from task)
-
-
-@asyncio.coroutine
-def _async_process_requirements(hass: core.HomeAssistant, name: str,
-                                requirements) -> bool:
-    """Install the requirements for a component.
-
-    This method is a coroutine.
-    """
-    if hass.config.skip_pip:
-        return True
-
-    pip_lock = hass.data.get(DATA_PIP_LOCK)
-    if pip_lock is None:
-        pip_lock = hass.data[DATA_PIP_LOCK] = asyncio.Lock(loop=hass.loop)
-
-    def pip_install(mod):
-        """Install packages."""
-        return pkg_util.install_package(mod, target=hass.config.path('deps'))
-
-    with (yield from pip_lock):
-        for req in requirements:
-            ret = yield from hass.loop.run_in_executor(None, pip_install, req)
-            if not ret:
-                _LOGGER.error('Not initializing %s because could not install '
-                              'dependency %s', name, req)
-                async_notify_setup_error(hass, name)
-                return False
-
-    return True
-
-
-@asyncio.coroutine
-def _async_process_dependencies(hass, config, name, dependencies):
-    """Ensure all dependencies are set up."""
-    blacklisted = [dep for dep in dependencies
-                   if dep in loader.DEPENDENCY_BLACKLIST]
-
-    if blacklisted:
-        _LOGGER.error('Unable to setup dependencies of %s: '
-                      'found blacklisted dependencies: %s',
-                      name, ', '.join(blacklisted))
-        return False
-
-    tasks = [async_setup_component(hass, dep, config) for dep
-             in dependencies]
-
-    if not tasks:
-        return True
-
-    results = yield from asyncio.gather(*tasks, loop=hass.loop)
-
-    failed = [dependencies[idx] for idx, res
-              in enumerate(results) if not res]
-
-    if failed:
-        _LOGGER.error('Unable to setup dependencies of %s. '
-                      'Setup failed for dependencies: %s',
-                      name, ', '.join(failed))
-
-        return False
-    return True
-
-
-@asyncio.coroutine
-def _async_setup_component(hass: core.HomeAssistant,
-                           domain: str, config) -> bool:
-    """Setup a component for Home Assistant.
-
-    This method is a coroutine.
-
-    hass: Home Assistant instance.
-    domain: Domain of component to setup.
-    config: The Home Assistant configuration.
-    """
-    def log_error(msg, link=True):
-        """Log helper."""
-        _LOGGER.error('Setup failed for %s: %s', domain, msg)
-        async_notify_setup_error(hass, domain, link)
-
-    component = loader.get_component(domain)
-
-    if not component:
-        log_error('Component not found.', False)
-        return False
-
-    # Validate no circular dependencies
-    components = loader.load_order_component(domain)
-
-    # OrderedSet is empty if component or dependencies could not be resolved
-    if not components:
-        log_error('Unable to resolve component or dependencies.')
-        return False
-
-    processed_config = \
-        conf_util.async_process_component_config(hass, config, domain)
-
-    if processed_config is None:
-        log_error('Invalid config.')
-        return False
-
-    if not hass.config.skip_pip and hasattr(component, 'REQUIREMENTS'):
-        req_success = yield from _async_process_requirements(
-            hass, domain, component.REQUIREMENTS)
-        if not req_success:
-            log_error('Could not install all requirements.')
-            return False
-
-    if hasattr(component, 'DEPENDENCIES'):
-        dep_success = yield from _async_process_dependencies(
-            hass, config, domain, component.DEPENDENCIES)
-
-        if not dep_success:
-            log_error('Could not setup all dependencies.')
-            return False
-
-    async_comp = hasattr(component, 'async_setup')
-
-    try:
-        _LOGGER.info("Setting up %s", domain)
-        if async_comp:
-            result = yield from component.async_setup(hass, processed_config)
-        else:
-            result = yield from hass.loop.run_in_executor(
-                None, component.setup, hass, processed_config)
-    except Exception:  # pylint: disable=broad-except
-        _LOGGER.exception('Error during setup of component %s', domain)
-        async_notify_setup_error(hass, domain, True)
-        return False
-
-    if result is False:
-        log_error('Component failed to initialize.')
-        return False
-    elif result is not True:
-        log_error('Component did not return boolean if setup was successful. '
-                  'Disabling component.')
-        loader.set_component(domain, None)
-        return False
-
-    hass.config.components.add(component.DOMAIN)
-
-    # cleanup
-    if domain in hass.data[DATA_SETUP]:
-        hass.data[DATA_SETUP].pop(domain)
-
-    hass.bus.async_fire(
-        EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: component.DOMAIN}
-    )
-
-    return True
-
-
-@asyncio.coroutine
-def async_prepare_setup_platform(hass: core.HomeAssistant, config, domain: str,
-                                 platform_name: str) \
-                                 -> Optional[ModuleType]:
-    """Load a platform and makes sure dependencies are setup.
-
-    This method is a coroutine.
-    """
-    platform_path = PLATFORM_FORMAT.format(domain, platform_name)
-
-    def log_error(msg):
-        """Log helper."""
-        _LOGGER.error('Unable to prepare setup for platform %s: %s',
-                      platform_path, msg)
-        async_notify_setup_error(hass, platform_path)
-
-    platform = loader.get_platform(domain, platform_name)
-
-    # Not found
-    if platform is None:
-        log_error('Platform not found.')
-        return None
-
-    # Already loaded
-    elif platform_path in hass.config.components:
-        return platform
-
-    # Load dependencies
-    if hasattr(platform, 'DEPENDENCIES'):
-        dep_success = yield from _async_process_dependencies(
-            hass, config, platform_path, platform.DEPENDENCIES)
-
-        if not dep_success:
-            log_error('Could not setup all dependencies.')
-            return False
-
-    if not hass.config.skip_pip and hasattr(platform, 'REQUIREMENTS'):
-        req_success = yield from _async_process_requirements(
-            hass, platform_path, platform.REQUIREMENTS)
-
-        if not req_success:
-            log_error('Could not install all requirements.')
-            return None
-
-    return platform
 
 
 def from_config_dict(config: Dict[str, Any],

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -11,7 +11,7 @@ import os
 
 import voluptuous as vol
 
-from homeassistant.bootstrap import async_prepare_setup_platform
+from homeassistant.setup import async_prepare_setup_platform
 from homeassistant import config as conf_util
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_PLATFORM, STATE_ON, SERVICE_TURN_ON, SERVICE_TURN_OFF,

--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 
 from homeassistant.core import callback
 from homeassistant.const import EVENT_COMPONENT_LOADED
-from homeassistant.bootstrap import (
+from homeassistant.setup import (
     async_prepare_setup_platform, ATTR_COMPONENT)
 from homeassistant.components.frontend import register_built_in_panel
 from homeassistant.components.http import HomeAssistantView

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -14,7 +14,7 @@ import aiohttp
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.bootstrap import async_prepare_setup_platform
+from homeassistant.setup import async_prepare_setup_platform
 from homeassistant.core import callback
 from homeassistant.components import group, zone
 from homeassistant.components.discovery import SERVICE_NETGEAR

--- a/homeassistant/components/google.py
+++ b/homeassistant/components/google.py
@@ -18,7 +18,7 @@ from voluptuous.error import Error as VoluptuousError
 
 import homeassistant.helpers.config_validation as cv
 import homeassistant.loader as loader
-from homeassistant import bootstrap
+from homeassistant import setup
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.event import track_time_change
@@ -223,7 +223,7 @@ def do_setup(hass, config):
     setup_services(hass, track_new_found_calendars, calendar_service)
 
     # Ensure component is loaded
-    bootstrap.setup_component(hass, 'calendar', config)
+    setup.setup_component(hass, 'calendar', config)
 
     for calendar in hass.data[DATA_INDEX].values():
         discovery.load_platform(hass, 'calendar', DOMAIN, calendar)

--- a/homeassistant/components/google.py
+++ b/homeassistant/components/google.py
@@ -18,7 +18,7 @@ from voluptuous.error import Error as VoluptuousError
 
 import homeassistant.helpers.config_validation as cv
 import homeassistant.loader as loader
-from homeassistant import setup
+from homeassistant.setup import setup_component
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.event import track_time_change
@@ -223,7 +223,7 @@ def do_setup(hass, config):
     setup_services(hass, track_new_found_calendars, calendar_service)
 
     # Ensure component is loaded
-    setup.setup_component(hass, 'calendar', config)
+    setup_component(hass, 'calendar', config)
 
     for calendar in hass.data[DATA_INDEX].values():
         discovery.load_platform(hass, 'calendar', DOMAIN, calendar)

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -13,7 +13,7 @@ import time
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import async_prepare_setup_platform
+from homeassistant.setup import async_prepare_setup_platform
 from homeassistant.config import load_yaml_config_file
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import template, config_validation as cv

--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -12,7 +12,7 @@ import sys
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components.mqtt import (valid_publish_topic,
                                            valid_subscribe_topic)
 from homeassistant.const import (ATTR_BATTERY_LEVEL, CONF_NAME,

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -11,7 +11,7 @@ from functools import partial
 
 import voluptuous as vol
 
-from homeassistant.bootstrap import async_prepare_setup_platform
+from homeassistant.setup import async_prepare_setup_platform
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config import load_yaml_config_file

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -18,7 +18,7 @@ from aiohttp import web
 import voluptuous as vol
 
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.bootstrap import async_prepare_setup_platform
+from homeassistant.setup import async_prepare_setup_platform
 from homeassistant.core import callback
 from homeassistant.config import load_yaml_config_file
 from homeassistant.components.http import HomeAssistantView

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -7,7 +7,7 @@ There are two different types of discoveries that can be fired/listened for.
 """
 import asyncio
 
-from homeassistant import bootstrap, core
+from homeassistant import setup, core
 from homeassistant.const import (
     ATTR_DISCOVERED, ATTR_SERVICE, EVENT_PLATFORM_DISCOVERED)
 from homeassistant.exceptions import HomeAssistantError
@@ -63,7 +63,7 @@ def async_discover(hass, service, discovered=None, component=None,
             'Cannot discover the {} component.'.format(component))
 
     if component is not None and component not in hass.config.components:
-        yield from bootstrap.async_setup_component(
+        yield from setup.async_setup_component(
             hass, component, hass_config)
 
     data = {
@@ -151,7 +151,7 @@ def async_load_platform(hass, component, platform, discovered=None,
     setup_success = True
 
     if component not in hass.config.components:
-        setup_success = yield from bootstrap.async_setup_component(
+        setup_success = yield from setup.async_setup_component(
             hass, component, hass_config)
 
     # No need to fire event if we could not setup component

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -3,7 +3,7 @@ import asyncio
 from datetime import timedelta
 
 from homeassistant import config as conf_util
-from homeassistant.bootstrap import async_prepare_setup_platform
+from homeassistant.setup import async_prepare_setup_platform
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_SCAN_INTERVAL, CONF_ENTITY_NAMESPACE,
     DEVICE_DEFAULT_NAME)

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -21,8 +21,7 @@ from typing import Optional
 
 import requests
 
-import homeassistant.bootstrap as bootstrap
-import homeassistant.core as ha
+from homeassistant import setup, core as ha
 from homeassistant.const import (
     HTTP_HEADER_HA_AUTH, SERVER_PORT, URL_API, URL_API_EVENT_FORWARD,
     URL_API_EVENTS, URL_API_EVENTS_EVENT, URL_API_SERVICES, URL_API_CONFIG,
@@ -151,7 +150,7 @@ class HomeAssistant(ha.HomeAssistant):
         """Start the instance."""
         # Ensure a local API exists to connect with remote
         if 'api' not in self.config.components:
-            if not bootstrap.setup_component(self, 'api'):
+            if not setup.setup_component(self, 'api'):
                 raise HomeAssistantError(
                     'Unable to setup local API to receive events')
 

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -28,8 +28,6 @@ MOCKS = {
                config_util.async_log_exception),
     'package_error': ("homeassistant.config._log_pkg_error",
                       config_util._log_pkg_error),
-    'logger_exception': ("homeassistant.bootstrap._LOGGER.error",
-                         bootstrap._LOGGER.error),
     'logger_exception': ("homeassistant.setup._LOGGER.error",
                          setup._LOGGER.error),
 }

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -9,9 +9,7 @@ from unittest.mock import patch
 
 from typing import Dict, List, Sequence
 
-import homeassistant.bootstrap as bootstrap
-import homeassistant.config as config_util
-import homeassistant.loader as loader
+from homeassistant import bootstrap, loader, setup, config as config_util
 import homeassistant.util.yaml as yaml
 from homeassistant.exceptions import HomeAssistantError
 
@@ -32,6 +30,8 @@ MOCKS = {
                       config_util._log_pkg_error),
     'logger_exception': ("homeassistant.bootstrap._LOGGER.error",
                          bootstrap._LOGGER.error),
+    'logger_exception': ("homeassistant.setup._LOGGER.error",
+                         setup._LOGGER.error),
 }
 SILENCE = (
     'homeassistant.bootstrap.clear_secret_cache',

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -1,0 +1,253 @@
+"""Provides methods to bootstrap a home assistant instance."""
+import asyncio
+import logging
+import logging.handlers
+
+from types import ModuleType
+from typing import Optional, Dict
+
+import homeassistant.config as conf_util
+from homeassistant.config import async_notify_setup_error
+import homeassistant.core as core
+import homeassistant.loader as loader
+import homeassistant.util.package as pkg_util
+from homeassistant.util.async import run_coroutine_threadsafe
+from homeassistant.const import EVENT_COMPONENT_LOADED, PLATFORM_FORMAT
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_COMPONENT = 'component'
+
+DATA_SETUP = 'setup_tasks'
+DATA_PIP_LOCK = 'pip_lock'
+
+
+def setup_component(hass: core.HomeAssistant, domain: str,
+                    config: Optional[Dict]=None) -> bool:
+    """Setup a component and all its dependencies."""
+    return run_coroutine_threadsafe(
+        async_setup_component(hass, domain, config), loop=hass.loop).result()
+
+
+@asyncio.coroutine
+def async_setup_component(hass: core.HomeAssistant, domain: str,
+                          config: Optional[Dict]=None) -> bool:
+    """Setup a component and all its dependencies.
+
+    This method is a coroutine.
+    """
+    if domain in hass.config.components:
+        return True
+
+    setup_tasks = hass.data.get(DATA_SETUP)
+
+    if setup_tasks is not None and domain in setup_tasks:
+        return (yield from setup_tasks[domain])
+
+    if config is None:
+        config = {}
+
+    if setup_tasks is None:
+        setup_tasks = hass.data[DATA_SETUP] = {}
+
+    task = setup_tasks[domain] = hass.async_add_job(
+        _async_setup_component(hass, domain, config))
+
+    return (yield from task)
+
+
+@asyncio.coroutine
+def _async_process_requirements(hass: core.HomeAssistant, name: str,
+                                requirements) -> bool:
+    """Install the requirements for a component.
+
+    This method is a coroutine.
+    """
+    if hass.config.skip_pip:
+        return True
+
+    pip_lock = hass.data.get(DATA_PIP_LOCK)
+    if pip_lock is None:
+        pip_lock = hass.data[DATA_PIP_LOCK] = asyncio.Lock(loop=hass.loop)
+
+    def pip_install(mod):
+        """Install packages."""
+        return pkg_util.install_package(mod, target=hass.config.path('deps'))
+
+    with (yield from pip_lock):
+        for req in requirements:
+            ret = yield from hass.loop.run_in_executor(None, pip_install, req)
+            if not ret:
+                _LOGGER.error('Not initializing %s because could not install '
+                              'dependency %s', name, req)
+                async_notify_setup_error(hass, name)
+                return False
+
+    return True
+
+
+@asyncio.coroutine
+def _async_process_dependencies(hass, config, name, dependencies):
+    """Ensure all dependencies are set up."""
+    blacklisted = [dep for dep in dependencies
+                   if dep in loader.DEPENDENCY_BLACKLIST]
+
+    if blacklisted:
+        _LOGGER.error('Unable to setup dependencies of %s: '
+                      'found blacklisted dependencies: %s',
+                      name, ', '.join(blacklisted))
+        return False
+
+    tasks = [async_setup_component(hass, dep, config) for dep
+             in dependencies]
+
+    if not tasks:
+        return True
+
+    results = yield from asyncio.gather(*tasks, loop=hass.loop)
+
+    failed = [dependencies[idx] for idx, res
+              in enumerate(results) if not res]
+
+    if failed:
+        _LOGGER.error('Unable to setup dependencies of %s. '
+                      'Setup failed for dependencies: %s',
+                      name, ', '.join(failed))
+
+        return False
+    return True
+
+
+@asyncio.coroutine
+def _async_setup_component(hass: core.HomeAssistant,
+                           domain: str, config) -> bool:
+    """Setup a component for Home Assistant.
+
+    This method is a coroutine.
+
+    hass: Home Assistant instance.
+    domain: Domain of component to setup.
+    config: The Home Assistant configuration.
+    """
+    def log_error(msg, link=True):
+        """Log helper."""
+        _LOGGER.error('Setup failed for %s: %s', domain, msg)
+        async_notify_setup_error(hass, domain, link)
+
+    component = loader.get_component(domain)
+
+    if not component:
+        log_error('Component not found.', False)
+        return False
+
+    # Validate no circular dependencies
+    components = loader.load_order_component(domain)
+
+    # OrderedSet is empty if component or dependencies could not be resolved
+    if not components:
+        log_error('Unable to resolve component or dependencies.')
+        return False
+
+    processed_config = \
+        conf_util.async_process_component_config(hass, config, domain)
+
+    if processed_config is None:
+        log_error('Invalid config.')
+        return False
+
+    if not hass.config.skip_pip and hasattr(component, 'REQUIREMENTS'):
+        req_success = yield from _async_process_requirements(
+            hass, domain, component.REQUIREMENTS)
+        if not req_success:
+            log_error('Could not install all requirements.')
+            return False
+
+    if hasattr(component, 'DEPENDENCIES'):
+        dep_success = yield from _async_process_dependencies(
+            hass, config, domain, component.DEPENDENCIES)
+
+        if not dep_success:
+            log_error('Could not setup all dependencies.')
+            return False
+
+    async_comp = hasattr(component, 'async_setup')
+
+    try:
+        _LOGGER.info("Setting up %s", domain)
+        if async_comp:
+            result = yield from component.async_setup(hass, processed_config)
+        else:
+            result = yield from hass.loop.run_in_executor(
+                None, component.setup, hass, processed_config)
+    except Exception:  # pylint: disable=broad-except
+        _LOGGER.exception('Error during setup of component %s', domain)
+        async_notify_setup_error(hass, domain, True)
+        return False
+
+    if result is False:
+        log_error('Component failed to initialize.')
+        return False
+    elif result is not True:
+        log_error('Component did not return boolean if setup was successful. '
+                  'Disabling component.')
+        loader.set_component(domain, None)
+        return False
+
+    hass.config.components.add(component.DOMAIN)
+
+    # cleanup
+    if domain in hass.data[DATA_SETUP]:
+        hass.data[DATA_SETUP].pop(domain)
+
+    hass.bus.async_fire(
+        EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: component.DOMAIN}
+    )
+
+    return True
+
+
+@asyncio.coroutine
+def async_prepare_setup_platform(hass: core.HomeAssistant, config, domain: str,
+                                 platform_name: str) \
+                                 -> Optional[ModuleType]:
+    """Load a platform and makes sure dependencies are setup.
+
+    This method is a coroutine.
+    """
+    platform_path = PLATFORM_FORMAT.format(domain, platform_name)
+
+    def log_error(msg):
+        """Log helper."""
+        _LOGGER.error('Unable to prepare setup for platform %s: %s',
+                      platform_path, msg)
+        async_notify_setup_error(hass, platform_path)
+
+    platform = loader.get_platform(domain, platform_name)
+
+    # Not found
+    if platform is None:
+        log_error('Platform not found.')
+        return None
+
+    # Already loaded
+    elif platform_path in hass.config.components:
+        return platform
+
+    # Load dependencies
+    if hasattr(platform, 'DEPENDENCIES'):
+        dep_success = yield from _async_process_dependencies(
+            hass, config, platform_path, platform.DEPENDENCIES)
+
+        if not dep_success:
+            log_error('Could not setup all dependencies.')
+            return False
+
+    if not hass.config.skip_pip and hasattr(platform, 'REQUIREMENTS'):
+        req_success = yield from _async_process_requirements(
+            hass, platform_path, platform.REQUIREMENTS)
+
+        if not req_success:
+            log_error('Could not install all requirements.')
+            return None
+
+    return platform

--- a/tests/common.py
+++ b/tests/common.py
@@ -13,7 +13,7 @@ from aiohttp import web
 from aiohttp.test_utils import unused_port as get_test_instance_port  # noqa
 
 from homeassistant import core as ha, loader
-from homeassistant.bootstrap import setup_component, DATA_SETUP
+from homeassistant.setup import setup_component, DATA_SETUP
 from homeassistant.config import async_process_component_config
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import ToggleEntity
@@ -435,7 +435,7 @@ def assert_setup_component(count, domain=None):
     - domain: The domain to count is optional. It can be automatically
               determined most of the time
 
-    Use as a context manager aroung bootstrap.setup_component
+    Use as a context manager aroung setup.setup_component
         with assert_setup_component(0) as result_config:
             setup_component(hass, domain, start_config)
             # using result_config is optional

--- a/tests/components/alarm_control_panel/test_manual.py
+++ b/tests/components/alarm_control_panel/test_manual.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import unittest
 from unittest.mock import patch
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import (
     STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED)

--- a/tests/components/alarm_control_panel/test_mqtt.py
+++ b/tests/components/alarm_control_panel/test_mqtt.py
@@ -1,7 +1,7 @@
 """The tests the MQTT alarm control panel component."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import (
     STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED, STATE_UNKNOWN)

--- a/tests/components/automation/test_event.py
+++ b/tests/components/automation/test_event.py
@@ -2,7 +2,7 @@
 import unittest
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.automation as automation
 
 from tests.common import get_test_home_assistant, mock_component

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import patch
 
 from homeassistant.core import State
-from homeassistant.bootstrap import setup_component, async_setup_component
+from homeassistant.setup import setup_component, async_setup_component
 import homeassistant.components.automation as automation
 from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, STATE_OFF
 from homeassistant.exceptions import HomeAssistantError

--- a/tests/components/automation/test_litejet.py
+++ b/tests/components/automation/test_litejet.py
@@ -4,7 +4,7 @@ import unittest
 from unittest import mock
 from datetime import timedelta
 
-from homeassistant import bootstrap
+from homeassistant import setup
 import homeassistant.util.dt as dt_util
 from homeassistant.components import litejet
 from tests.common import (fire_time_changed, get_test_home_assistant)
@@ -57,7 +57,7 @@ class TestLiteJetTrigger(unittest.TestCase):
                 'port': '/tmp/this_will_be_mocked'
             }
         }
-        assert bootstrap.setup_component(self.hass, litejet.DOMAIN, config)
+        assert setup.setup_component(self.hass, litejet.DOMAIN, config)
 
         self.hass.services.register('test', 'automation', record_call)
 
@@ -106,7 +106,7 @@ class TestLiteJetTrigger(unittest.TestCase):
 
     def setup_automation(self, trigger):
         """Test setting up the automation."""
-        assert bootstrap.setup_component(self.hass, automation.DOMAIN, {
+        assert setup.setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: [
                 {
                     'alias': 'My Test',

--- a/tests/components/automation/test_mqtt.py
+++ b/tests/components/automation/test_mqtt.py
@@ -2,7 +2,7 @@
 import unittest
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.automation as automation
 from tests.common import (
     mock_mqtt_component, fire_mqtt_message, get_test_home_assistant,

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -2,7 +2,7 @@
 import unittest
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.automation as automation
 
 from tests.common import get_test_home_assistant, mock_component

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import patch
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.util.dt as dt_util
 import homeassistant.components.automation as automation
 

--- a/tests/components/automation/test_sun.py
+++ b/tests/components/automation/test_sun.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import patch
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import sun
 import homeassistant.components.automation as automation
 import homeassistant.util.dt as dt_util

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -2,7 +2,7 @@
 import unittest
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.automation as automation
 
 from tests.common import (

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.util.dt as dt_util
 import homeassistant.components.automation as automation
 

--- a/tests/components/automation/test_zone.py
+++ b/tests/components/automation/test_zone.py
@@ -2,7 +2,7 @@
 import unittest
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import automation, zone
 
 from tests.common import get_test_home_assistant, mock_component

--- a/tests/components/binary_sensor/test_command_line.py
+++ b/tests/components/binary_sensor/test_command_line.py
@@ -3,7 +3,7 @@ import unittest
 
 from homeassistant.const import (STATE_ON, STATE_OFF)
 from homeassistant.components.binary_sensor import command_line
-from homeassistant import bootstrap
+from homeassistant import setup
 from homeassistant.helpers import template
 
 from tests.common import get_test_home_assistant
@@ -47,7 +47,7 @@ class TestCommandSensorBinarySensor(unittest.TestCase):
                   'platform': 'not_command_line',
                   }
 
-        self.assertFalse(bootstrap.setup_component(self.hass, 'test', {
+        self.assertFalse(setup.setup_component(self.hass, 'test', {
             'command_line': config,
         }))
 

--- a/tests/components/binary_sensor/test_ffmpeg.py
+++ b/tests/components/binary_sensor/test_ffmpeg.py
@@ -1,7 +1,7 @@
 """The tests for Home Assistant ffmpeg binary sensor."""
 from unittest.mock import patch
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 from tests.common import (
     get_test_home_assistant, assert_setup_component, mock_coro)

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -1,7 +1,7 @@
 """The tests for the  MQTT binary sensor platform."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.binary_sensor as binary_sensor
 from homeassistant.const import (STATE_OFF, STATE_ON)
 

--- a/tests/components/binary_sensor/test_nx584.py
+++ b/tests/components/binary_sensor/test_nx584.py
@@ -6,7 +6,7 @@ from unittest import mock
 from nx584 import client as nx584_client
 
 from homeassistant.components.binary_sensor import nx584
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/binary_sensor/test_sleepiq.py
+++ b/tests/components/binary_sensor/test_sleepiq.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import requests_mock
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components.binary_sensor import sleepiq
 
 from tests.components.test_sleepiq import mock_responses

--- a/tests/components/binary_sensor/test_tcp.py
+++ b/tests/components/binary_sensor/test_tcp.py
@@ -2,7 +2,7 @@
 import unittest
 from unittest.mock import patch, Mock
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components.binary_sensor import tcp as bin_tcp
 from homeassistant.components.sensor import tcp
 from tests.common import (get_test_home_assistant, assert_setup_component)

--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from homeassistant.core import CoreState, State
 from homeassistant.const import MATCH_ALL
-import homeassistant.bootstrap as bootstrap
+from homeassistant import setup
 from homeassistant.components.binary_sensor import template
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template as template_hlpr
@@ -45,13 +45,13 @@ class TestBinarySensorTemplate(unittest.TestCase):
             },
         }
         with assert_setup_component(1):
-            assert bootstrap.setup_component(
+            assert setup.setup_component(
                 self.hass, 'binary_sensor', config)
 
     def test_setup_no_sensors(self):
         """"Test setup with no sensors."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+            assert setup.setup_component(self.hass, 'binary_sensor', {
                 'binary_sensor': {
                     'platform': 'template'
                 }
@@ -60,7 +60,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
     def test_setup_invalid_device(self):
         """"Test the setup with invalid devices."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+            assert setup.setup_component(self.hass, 'binary_sensor', {
                 'binary_sensor': {
                     'platform': 'template',
                     'sensors': {
@@ -72,7 +72,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
     def test_setup_invalid_device_class(self):
         """"Test setup with invalid sensor class."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+            assert setup.setup_component(self.hass, 'binary_sensor', {
                 'binary_sensor': {
                     'platform': 'template',
                     'sensors': {
@@ -87,7 +87,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
     def test_setup_invalid_missing_template(self):
         """"Test setup with invalid and missing template."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+            assert setup.setup_component(self.hass, 'binary_sensor', {
                 'binary_sensor': {
                     'platform': 'template',
                     'sensors': {
@@ -134,7 +134,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
             },
         }
         with assert_setup_component(1):
-            assert bootstrap.setup_component(
+            assert setup.setup_component(
                 self.hass, 'binary_sensor', config)
 
         self.hass.start()
@@ -187,7 +187,7 @@ def test_restore_state(hass):
             },
         },
     }
-    yield from bootstrap.async_setup_component(hass, 'binary_sensor', config)
+    yield from setup.async_setup_component(hass, 'binary_sensor', config)
 
     state = hass.states.get('binary_sensor.test')
     assert state.state == 'on'

--- a/tests/components/binary_sensor/test_threshold.py
+++ b/tests/components/binary_sensor/test_threshold.py
@@ -1,7 +1,7 @@
 """The test for the threshold sensor platform."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import (ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
 
 from tests.common import get_test_home_assistant

--- a/tests/components/binary_sensor/test_trend.py
+++ b/tests/components/binary_sensor/test_trend.py
@@ -1,5 +1,5 @@
 """The test for the Trend sensor platform."""
-import homeassistant.bootstrap as bootstrap
+from homeassistant import setup
 
 from tests.common import get_test_home_assistant, assert_setup_component
 
@@ -19,7 +19,7 @@ class TestTrendBinarySensor:
 
     def test_up(self):
         """Test up trend."""
-        assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+        assert setup.setup_component(self.hass, 'binary_sensor', {
             'binary_sensor': {
                 'platform': 'trend',
                 'sensors': {
@@ -40,7 +40,7 @@ class TestTrendBinarySensor:
 
     def test_down(self):
         """Test down trend."""
-        assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+        assert setup.setup_component(self.hass, 'binary_sensor', {
             'binary_sensor': {
                 'platform': 'trend',
                 'sensors': {
@@ -61,7 +61,7 @@ class TestTrendBinarySensor:
 
     def test__invert_up(self):
         """Test up trend with custom message."""
-        assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+        assert setup.setup_component(self.hass, 'binary_sensor', {
             'binary_sensor': {
                 'platform': 'trend',
                 'sensors': {
@@ -83,7 +83,7 @@ class TestTrendBinarySensor:
 
     def test_invert_down(self):
         """Test down trend with custom message."""
-        assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+        assert setup.setup_component(self.hass, 'binary_sensor', {
             'binary_sensor': {
                 'platform': 'trend',
                 'sensors': {
@@ -105,7 +105,7 @@ class TestTrendBinarySensor:
 
     def test_attribute_up(self):
         """Test attribute up trend."""
-        assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+        assert setup.setup_component(self.hass, 'binary_sensor', {
             'binary_sensor': {
                 'platform': 'trend',
                 'sensors': {
@@ -126,7 +126,7 @@ class TestTrendBinarySensor:
 
     def test_attribute_down(self):
         """Test attribute down trend."""
-        assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+        assert setup.setup_component(self.hass, 'binary_sensor', {
             'binary_sensor': {
                 'platform': 'trend',
                 'sensors': {
@@ -149,7 +149,7 @@ class TestTrendBinarySensor:
 
     def test_non_numeric(self):
         """Test up trend."""
-        assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+        assert setup.setup_component(self.hass, 'binary_sensor', {
             'binary_sensor': {
                 'platform': 'trend',
                 'sensors': {
@@ -170,7 +170,7 @@ class TestTrendBinarySensor:
 
     def test_missing_attribute(self):
         """Test attribute down trend."""
-        assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+        assert setup.setup_component(self.hass, 'binary_sensor', {
             'binary_sensor': {
                 'platform': 'trend',
                 'sensors': {
@@ -195,7 +195,7 @@ class TestTrendBinarySensor:
             # pylint: disable=invalid-name
         """Test invalid name."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+            assert setup.setup_component(self.hass, 'binary_sensor', {
                 'binary_sensor': {
                     'platform': 'template',
                     'sensors': {
@@ -212,7 +212,7 @@ class TestTrendBinarySensor:
             # pylint: disable=invalid-name
         """Test invalid sensor."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+            assert setup.setup_component(self.hass, 'binary_sensor', {
                 'binary_sensor': {
                     'platform': 'template',
                     'sensors': {
@@ -228,7 +228,7 @@ class TestTrendBinarySensor:
     def test_no_sensors_does_not_create(self):
         """Test no sensors."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'binary_sensor', {
+            assert setup.setup_component(self.hass, 'binary_sensor', {
                 'binary_sensor': {
                     'platform': 'trend'
                 }

--- a/tests/components/camera/test_generic.py
+++ b/tests/components/camera/test_generic.py
@@ -2,7 +2,7 @@
 import asyncio
 from unittest import mock
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 
 @asyncio.coroutine

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import ATTR_ENTITY_PICTURE
 import homeassistant.components.camera as camera
 import homeassistant.components.http as http

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -6,7 +6,7 @@ from unittest import mock
 # https://bugs.python.org/issue23004
 from mock_open import MockOpen
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 from tests.common import mock_http_component
 import logging

--- a/tests/components/camera/test_uvc.py
+++ b/tests/components/camera/test_uvc.py
@@ -7,7 +7,7 @@ import requests
 from uvcclient import camera
 from uvcclient import nvr
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components.camera import uvc
 from tests.common import get_test_home_assistant, mock_http_component
 

--- a/tests/components/climate/test_demo.py
+++ b/tests/components/climate/test_demo.py
@@ -4,7 +4,7 @@ import unittest
 from homeassistant.util.unit_system import (
     METRIC_SYSTEM
 )
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import climate
 
 from tests.common import get_test_home_assistant

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import homeassistant.core as ha
 from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component, async_setup_component
+from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     SERVICE_TURN_OFF,

--- a/tests/components/config/test_init.py
+++ b/tests/components/config/test_init.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.const import EVENT_COMPONENT_LOADED
-from homeassistant.bootstrap import async_setup_component, ATTR_COMPONENT
+from homeassistant.setup import async_setup_component, ATTR_COMPONENT
 from homeassistant.components import config
 
 from tests.common import mock_http_component, mock_coro, mock_component

--- a/tests/components/cover/test_command_line.py
+++ b/tests/components/cover/test_command_line.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from unittest import mock
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.cover as cover
 from homeassistant.components.cover import (
     command_line as cmd_rs)

--- a/tests/components/cover/test_demo.py
+++ b/tests/components/cover/test_demo.py
@@ -3,7 +3,7 @@ import unittest
 from datetime import timedelta
 import homeassistant.util.dt as dt_util
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import cover
 from tests.common import get_test_home_assistant, fire_time_changed
 

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -1,7 +1,7 @@
 """The tests for the MQTT cover platform."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import STATE_OPEN, STATE_CLOSED, STATE_UNKNOWN
 import homeassistant.components.cover as cover
 

--- a/tests/components/cover/test_rfxtrx.py
+++ b/tests/components/cover/test_rfxtrx.py
@@ -3,7 +3,7 @@ import unittest
 
 import pytest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
 
 from tests.common import get_test_home_assistant, mock_component

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import voluptuous as vol
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.components.device_tracker import (
     CONF_CONSIDER_HOME, CONF_TRACK_NEW)

--- a/tests/components/device_tracker/test_ddwrt.py
+++ b/tests/components/device_tracker/test_ddwrt.py
@@ -8,7 +8,7 @@ import requests
 import requests_mock
 
 from homeassistant import config
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.const import (
     CONF_PLATFORM, CONF_HOST, CONF_PASSWORD, CONF_USERNAME)

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -10,7 +10,7 @@ import os
 
 from homeassistant.components import zone
 from homeassistant.core import callback, State
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.helpers import discovery
 from homeassistant.loader import get_component
 from homeassistant.util.async import run_coroutine_threadsafe

--- a/tests/components/device_tracker/test_locative.py
+++ b/tests/components/device_tracker/test_locative.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import requests
 
-from homeassistant import bootstrap, const
+from homeassistant import setup, const
 import homeassistant.components.device_tracker as device_tracker
 import homeassistant.components.http as http
 from homeassistant.const import CONF_PLATFORM
@@ -33,7 +33,7 @@ def setUpModule():
 
     hass = get_test_home_assistant()
     # http is not platform based, assert_setup_component not applicable
-    bootstrap.setup_component(hass, http.DOMAIN, {
+    setup.setup_component(hass, http.DOMAIN, {
         http.DOMAIN: {
             http.CONF_SERVER_PORT: SERVER_PORT
         },
@@ -41,7 +41,7 @@ def setUpModule():
 
     # Set up device tracker
     with assert_setup_component(1, device_tracker.DOMAIN):
-        bootstrap.setup_component(hass, device_tracker.DOMAIN, {
+        setup.setup_component(hass, device_tracker.DOMAIN, {
             device_tracker.DOMAIN: {
                 CONF_PLATFORM: 'locative'
             }

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import logging
 import os
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.const import CONF_PLATFORM
 

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -10,7 +10,7 @@ from tests.common import (assert_setup_component, fire_mqtt_message,
                           get_test_home_assistant, mock_mqtt_component)
 
 import homeassistant.components.device_tracker.owntracks as owntracks
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.const import CONF_PLATFORM, STATE_NOT_HOME
 from homeassistant.util.async import run_coroutine_threadsafe

--- a/tests/components/device_tracker/test_upc_connect.py
+++ b/tests/components/device_tracker/test_upc_connect.py
@@ -4,7 +4,7 @@ import os
 from unittest.mock import patch
 import logging
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.const import (
     CONF_PLATFORM, CONF_HOST, CONF_PASSWORD)

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -5,7 +5,7 @@ import json
 from unittest.mock import patch
 import pytest
 
-from homeassistant import bootstrap, const, core
+from homeassistant import setup, const, core
 import homeassistant.components as core_components
 from homeassistant.components import (
     emulated_hue, http, light, script, media_player, fan
@@ -33,14 +33,14 @@ def hass_hue(loop, hass):
     loop.run_until_complete(
         core_components.async_setup(hass, {core.DOMAIN: {}}))
 
-    loop.run_until_complete(bootstrap.async_setup_component(
+    loop.run_until_complete(setup.async_setup_component(
         hass, http.DOMAIN,
         {http.DOMAIN: {http.CONF_SERVER_PORT: HTTP_SERVER_PORT}}))
 
     with patch('homeassistant.components'
                '.emulated_hue.UPNPResponderThread'):
         loop.run_until_complete(
-            bootstrap.async_setup_component(hass, emulated_hue.DOMAIN, {
+            setup.async_setup_component(hass, emulated_hue.DOMAIN, {
                 emulated_hue.DOMAIN: {
                     emulated_hue.CONF_LISTEN_PORT: BRIDGE_SERVER_PORT,
                     emulated_hue.CONF_EXPOSE_BY_DEFAULT: True
@@ -48,7 +48,7 @@ def hass_hue(loop, hass):
             }))
 
     loop.run_until_complete(
-        bootstrap.async_setup_component(hass, light.DOMAIN, {
+        setup.async_setup_component(hass, light.DOMAIN, {
             'light': [
                 {
                     'platform': 'demo',
@@ -57,7 +57,7 @@ def hass_hue(loop, hass):
         }))
 
     loop.run_until_complete(
-        bootstrap.async_setup_component(hass, script.DOMAIN, {
+        setup.async_setup_component(hass, script.DOMAIN, {
             'script': {
                 'set_kitchen_light': {
                     'sequence': [
@@ -75,7 +75,7 @@ def hass_hue(loop, hass):
         }))
 
     loop.run_until_complete(
-        bootstrap.async_setup_component(hass, media_player.DOMAIN, {
+        setup.async_setup_component(hass, media_player.DOMAIN, {
             'media_player': [
                 {
                     'platform': 'demo',
@@ -84,7 +84,7 @@ def hass_hue(loop, hass):
         }))
 
     loop.run_until_complete(
-        bootstrap.async_setup_component(hass, fan.DOMAIN, {
+        setup.async_setup_component(hass, fan.DOMAIN, {
             'fan': [
                 {
                     'platform': 'demo',

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import patch
 import requests
 
-from homeassistant import bootstrap, const, core
+from homeassistant import setup, const, core
 import homeassistant.components as core_components
 from homeassistant.components import emulated_hue, http
 from homeassistant.util.async import run_coroutine_threadsafe
@@ -28,11 +28,11 @@ def setup_hass_instance(emulated_hue_config):
         core_components.async_setup(hass, {core.DOMAIN: {}}), hass.loop
     ).result()
 
-    bootstrap.setup_component(
+    setup.setup_component(
         hass, http.DOMAIN,
         {http.DOMAIN: {http.CONF_SERVER_PORT: HTTP_SERVER_PORT}})
 
-    bootstrap.setup_component(hass, emulated_hue.DOMAIN, emulated_hue_config)
+    setup.setup_component(hass, emulated_hue.DOMAIN, emulated_hue_config)
 
     return hass
 
@@ -57,13 +57,13 @@ class TestEmulatedHue(unittest.TestCase):
             core_components.async_setup(hass, {core.DOMAIN: {}}), hass.loop
         ).result()
 
-        bootstrap.setup_component(
+        setup.setup_component(
             hass, http.DOMAIN,
             {http.DOMAIN: {http.CONF_SERVER_PORT: HTTP_SERVER_PORT}})
 
         with patch('homeassistant.components'
                    '.emulated_hue.UPNPResponderThread'):
-            bootstrap.setup_component(hass, emulated_hue.DOMAIN, {
+            setup.setup_component(hass, emulated_hue.DOMAIN, {
                 emulated_hue.DOMAIN: {
                     emulated_hue.CONF_LISTEN_PORT: BRIDGE_SERVER_PORT
                 }})

--- a/tests/components/fan/test_demo.py
+++ b/tests/components/fan/test_demo.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import fan
 from homeassistant.components.fan.demo import FAN_ENTITY_ID
 from homeassistant.const import STATE_OFF, STATE_ON

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import requests
 
-from homeassistant import bootstrap, const
+from homeassistant import setup, const
 import homeassistant.components.http as http
 from homeassistant.components.http.const import (
     KEY_TRUSTED_NETWORKS, KEY_USE_X_FORWARDED_FOR, HTTP_HEADER_X_FORWARDED_FOR)
@@ -43,7 +43,7 @@ def setUpModule():
 
     hass = get_test_home_assistant()
 
-    bootstrap.setup_component(
+    setup.setup_component(
         hass, http.DOMAIN, {
             http.DOMAIN: {
                 http.CONF_API_PASSWORD: API_PASSWORD,
@@ -52,7 +52,7 @@ def setUpModule():
         }
     )
 
-    bootstrap.setup_component(hass, 'api')
+    setup.setup_component(hass, 'api')
 
     hass.http.app[KEY_TRUSTED_NETWORKS] = [
         ip_network(trusted_network)

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, mock_open
 
 import requests
 
-from homeassistant import bootstrap, const
+from homeassistant import setup, const
 import homeassistant.components.http as http
 from homeassistant.components.http.const import (
     KEY_BANS_ENABLED, KEY_LOGIN_THRESHOLD, KEY_BANNED_IPS)
@@ -38,7 +38,7 @@ def setUpModule():
 
     hass = get_test_home_assistant()
 
-    bootstrap.setup_component(
+    setup.setup_component(
         hass, http.DOMAIN, {
             http.DOMAIN: {
                 http.CONF_API_PASSWORD: API_PASSWORD,
@@ -47,7 +47,7 @@ def setUpModule():
         }
     )
 
-    bootstrap.setup_component(hass, 'api')
+    setup.setup_component(hass, 'api')
 
     hass.http.app[KEY_BANNED_IPS] = [IpBan(banned_ip) for banned_ip
                                      in BANNED_IPS]

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -2,7 +2,7 @@
 import asyncio
 import requests
 
-from homeassistant import bootstrap, const
+from homeassistant import setup, const
 import homeassistant.components.http as http
 
 from tests.common import get_test_instance_port, get_test_home_assistant
@@ -32,7 +32,7 @@ def setUpModule():
 
     hass = get_test_home_assistant()
 
-    bootstrap.setup_component(
+    setup.setup_component(
         hass, http.DOMAIN, {
             http.DOMAIN: {
                 http.CONF_API_PASSWORD: API_PASSWORD,
@@ -42,7 +42,7 @@ def setUpModule():
         }
     )
 
-    bootstrap.setup_component(hass, 'api')
+    setup.setup_component(hass, 'api')
 
     # Registering static path as it caused CORS to blow up
     hass.http.register_static_path(
@@ -131,7 +131,7 @@ class TestView(http.HomeAssistantView):
 @asyncio.coroutine
 def test_registering_view_while_running(hass, test_client):
     """Test that we can register a view while the server is running."""
-    yield from bootstrap.async_setup_component(
+    yield from setup.async_setup_component(
         hass, http.DOMAIN, {
             http.DOMAIN: {
                 http.CONF_SERVER_PORT: get_test_instance_port(),
@@ -139,7 +139,7 @@ def test_registering_view_while_running(hass, test_client):
         }
     )
 
-    yield from bootstrap.async_setup_component(hass, 'api')
+    yield from setup.async_setup_component(hass, 'api')
 
     yield from hass.async_start()
 
@@ -159,7 +159,7 @@ def test_registering_view_while_running(hass, test_client):
 @asyncio.coroutine
 def test_api_base_url_with_domain(hass):
     """Test setting api url."""
-    result = yield from bootstrap.async_setup_component(hass, 'http', {
+    result = yield from setup.async_setup_component(hass, 'http', {
         'http': {
             'base_url': 'example.com'
         }
@@ -171,7 +171,7 @@ def test_api_base_url_with_domain(hass):
 @asyncio.coroutine
 def test_api_base_url_with_ip(hass):
     """Test setting api url."""
-    result = yield from bootstrap.async_setup_component(hass, 'http', {
+    result = yield from setup.async_setup_component(hass, 'http', {
         'http': {
             'server_host': '1.1.1.1'
         }
@@ -183,7 +183,7 @@ def test_api_base_url_with_ip(hass):
 @asyncio.coroutine
 def test_api_base_url_with_ip_port(hass):
     """Test setting api url."""
-    result = yield from bootstrap.async_setup_component(hass, 'http', {
+    result = yield from setup.async_setup_component(hass, 'http', {
         'http': {
             'base_url': '1.1.1.1:8124'
         }
@@ -195,7 +195,7 @@ def test_api_base_url_with_ip_port(hass):
 @asyncio.coroutine
 def test_api_no_base_url(hass):
     """Test setting api url."""
-    result = yield from bootstrap.async_setup_component(hass, 'http', {
+    result = yield from setup.async_setup_component(hass, 'http', {
         'http': {
         }
     })

--- a/tests/components/image_processing/test_init.py
+++ b/tests/components/image_processing/test_init.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, PropertyMock
 
 from homeassistant.core import callback
 from homeassistant.const import ATTR_ENTITY_PICTURE
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.components.http as http
 import homeassistant.components.image_processing as ip

--- a/tests/components/image_processing/test_microsoft_face_detect.py
+++ b/tests/components/image_processing/test_microsoft_face_detect.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, PropertyMock
 
 from homeassistant.core import callback
 from homeassistant.const import ATTR_ENTITY_PICTURE
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.image_processing as ip
 import homeassistant.components.microsoft_face as mf
 

--- a/tests/components/image_processing/test_microsoft_face_identify.py
+++ b/tests/components/image_processing/test_microsoft_face_identify.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, PropertyMock
 
 from homeassistant.core import callback
 from homeassistant.const import ATTR_ENTITY_PICTURE
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.image_processing as ip
 import homeassistant.components.microsoft_face as mf
 

--- a/tests/components/image_processing/test_openalpr_cloud.py
+++ b/tests/components/image_processing/test_openalpr_cloud.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, PropertyMock
 
 from homeassistant.core import callback
 from homeassistant.const import ATTR_ENTITY_PICTURE
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.image_processing as ip
 from homeassistant.components.image_processing.openalpr_cloud import (
     OPENALPR_API_URL)

--- a/tests/components/image_processing/test_openalpr_local.py
+++ b/tests/components/image_processing/test_openalpr_local.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, PropertyMock, MagicMock
 
 from homeassistant.core import callback
 from homeassistant.const import ATTR_ENTITY_PICTURE
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.image_processing as ip
 
 from tests.common import (

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -4,7 +4,7 @@ import asyncio
 import unittest
 
 from homeassistant.core import State, CoreState
-from homeassistant.bootstrap import setup_component, async_setup_component
+from homeassistant.setup import setup_component, async_setup_component
 import homeassistant.components.light as light
 from homeassistant.helpers.restore_state import DATA_RESTORE_CACHE
 

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -3,7 +3,7 @@
 import unittest
 import os
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.loader as loader
 from homeassistant.const import (
     ATTR_ENTITY_ID, STATE_ON, STATE_OFF, CONF_PLATFORM,

--- a/tests/components/light/test_litejet.py
+++ b/tests/components/light/test_litejet.py
@@ -3,7 +3,7 @@ import logging
 import unittest
 from unittest import mock
 
-from homeassistant import bootstrap
+from homeassistant import setup
 from homeassistant.components import litejet
 from tests.common import get_test_home_assistant
 import homeassistant.components.light as light
@@ -47,7 +47,7 @@ class TestLiteJetLight(unittest.TestCase):
         self.mock_lj.on_load_activated.side_effect = on_load_activated
         self.mock_lj.on_load_deactivated.side_effect = on_load_deactivated
 
-        assert bootstrap.setup_component(
+        assert setup.setup_component(
             self.hass,
             litejet.DOMAIN,
             {

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -76,7 +76,7 @@ light:
 import unittest
 from unittest import mock
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.light as light
 from tests.common import (

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -30,7 +30,7 @@ light:
 import json
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.light as light
 from tests.common import (

--- a/tests/components/light/test_mqtt_template.py
+++ b/tests/components/light/test_mqtt_template.py
@@ -22,7 +22,7 @@ If your light doesn't support rgb feature, omit `(red|green|blue)_template`.
 """
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.light as light
 from tests.common import (

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -3,7 +3,7 @@ import unittest
 
 import pytest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
 
 from tests.common import get_test_home_assistant, mock_component

--- a/tests/components/lock/test_demo.py
+++ b/tests/components/lock/test_demo.py
@@ -1,7 +1,7 @@
 """The tests for the Demo lock platform."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import lock
 
 from tests.common import get_test_home_assistant

--- a/tests/components/lock/test_mqtt.py
+++ b/tests/components/lock/test_mqtt.py
@@ -1,7 +1,7 @@
 """The tests for the MQTT lock platform."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED,
                                  ATTR_ASSUMED_STATE)
 import homeassistant.components.lock as lock

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import patch
 import asyncio
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import HTTP_HEADER_HA_AUTH
 import homeassistant.components.media_player as mp
 import homeassistant.components.http as http

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -5,7 +5,7 @@ import soco.snapshot
 from unittest import mock
 import soco
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components.media_player import sonos, DOMAIN
 from homeassistant.components.media_player.sonos import CONF_INTERFACE_ADDR, \
     CONF_ADVERTISE_ADDR

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -8,7 +8,7 @@ import socket
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component, async_setup_component
+from homeassistant.setup import setup_component, async_setup_component
 import homeassistant.components.mqtt as mqtt
 from homeassistant.const import (
     EVENT_CALL_SERVICE, ATTR_DOMAIN, ATTR_SERVICE, EVENT_HOMEASSISTANT_START,

--- a/tests/components/mqtt/test_server.py
+++ b/tests/components/mqtt/test_server.py
@@ -1,7 +1,7 @@
 """The tests for the MQTT component embedded server."""
 from unittest.mock import Mock, MagicMock, patch
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.mqtt as mqtt
 
 from tests.common import (

--- a/tests/components/notify/test_apns.py
+++ b/tests/components/notify/test_apns.py
@@ -7,7 +7,7 @@ from apns2.errors import Unregistered
 import yaml
 
 import homeassistant.components.notify as notify
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components.notify import apns
 from homeassistant.core import State
 

--- a/tests/components/notify/test_command_line.py
+++ b/tests/components/notify/test_command_line.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.notify as notify
 from tests.common import assert_setup_component, get_test_home_assistant
 

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import patch
 
 import homeassistant.components.notify as notify
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components.notify import demo
 from homeassistant.core import callback
 from homeassistant.helpers import discovery, script

--- a/tests/components/notify/test_file.py
+++ b/tests/components/notify/test_file.py
@@ -3,7 +3,7 @@ import os
 import unittest
 from unittest.mock import call, mock_open, patch
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.notify as notify
 from homeassistant.components.notify import (
     ATTR_TITLE_DEFAULT)

--- a/tests/components/notify/test_group.py
+++ b/tests/components/notify/test_group.py
@@ -2,7 +2,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.notify as notify
 from homeassistant.components.notify import group, demo
 from homeassistant.util.async import run_coroutine_threadsafe

--- a/tests/components/remote/test_demo.py
+++ b/tests/components/remote/test_demo.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.remote as remote
 from homeassistant.const import (
     ATTR_ENTITY_ID, STATE_ON, STATE_OFF, CONF_PLATFORM,

--- a/tests/components/remote/test_init.py
+++ b/tests/components/remote/test_init.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import (
     ATTR_ENTITY_ID, STATE_ON, STATE_OFF, CONF_PLATFORM,
     SERVICE_TURN_ON, SERVICE_TURN_OFF)

--- a/tests/components/scene/test_init.py
+++ b/tests/components/scene/test_init.py
@@ -1,7 +1,7 @@
 """The tests for the Scene component."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant import loader
 from homeassistant.components import light, scene
 

--- a/tests/components/scene/test_litejet.py
+++ b/tests/components/scene/test_litejet.py
@@ -3,7 +3,7 @@ import logging
 import unittest
 from unittest import mock
 
-from homeassistant import bootstrap
+from homeassistant import setup
 from homeassistant.components import litejet
 from tests.common import get_test_home_assistant
 import homeassistant.components.scene as scene
@@ -35,7 +35,7 @@ class TestLiteJetScene(unittest.TestCase):
         self.mock_lj.scenes.return_value = range(1, 3)
         self.mock_lj.get_scene_name.side_effect = get_scene_name
 
-        assert bootstrap.setup_component(
+        assert setup.setup_component(
             self.hass,
             litejet.DOMAIN,
             {

--- a/tests/components/sensor/test_command_line.py
+++ b/tests/components/sensor/test_command_line.py
@@ -3,7 +3,7 @@ import unittest
 
 from homeassistant.helpers.template import Template
 from homeassistant.components.sensor import command_line
-from homeassistant import bootstrap
+from homeassistant import setup
 from tests.common import get_test_home_assistant
 
 
@@ -45,7 +45,7 @@ class TestCommandSensorSensor(unittest.TestCase):
                   'platform': 'not_command_line',
                   }
 
-        self.assertFalse(bootstrap.setup_component(self.hass, 'test', {
+        self.assertFalse(setup.setup_component(self.hass, 'test', {
             'command_line': config,
         }))
 

--- a/tests/components/sensor/test_darksky.py
+++ b/tests/components/sensor/test_darksky.py
@@ -9,7 +9,7 @@ import requests_mock
 from datetime import timedelta
 
 from homeassistant.components.sensor import darksky
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 from tests.common import load_fixture, get_test_home_assistant
 

--- a/tests/components/sensor/test_history_stats.py
+++ b/tests/components/sensor/test_history_stats.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import unittest
 from unittest.mock import patch
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components.sensor.history_stats import HistoryStatsSensor
 import homeassistant.core as ha
 from homeassistant.helpers.template import Template

--- a/tests/components/sensor/test_mfi.py
+++ b/tests/components/sensor/test_mfi.py
@@ -4,7 +4,7 @@ import unittest.mock as mock
 
 import requests
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.sensor as sensor
 import homeassistant.components.sensor.mfi as mfi
 from homeassistant.const import TEMP_CELSIUS

--- a/tests/components/sensor/test_mhz19.py
+++ b/tests/components/sensor/test_mhz19.py
@@ -2,7 +2,7 @@
 import unittest
 from unittest.mock import patch, DEFAULT, Mock
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components.sensor import DOMAIN
 import homeassistant.components.sensor.mhz19 as mhz19
 from homeassistant.const import TEMP_FAHRENHEIT

--- a/tests/components/sensor/test_min_max.py
+++ b/tests/components/sensor/test_min_max.py
@@ -1,7 +1,7 @@
 """The test for the min/max sensor platform."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import (
     STATE_UNKNOWN, ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS, TEMP_FAHRENHEIT)
 from tests.common import get_test_home_assistant

--- a/tests/components/sensor/test_moldindicator.py
+++ b/tests/components/sensor/test_moldindicator.py
@@ -1,7 +1,7 @@
 """The tests for the MoldIndicator sensor."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.sensor as sensor
 from homeassistant.components.sensor.mold_indicator import (ATTR_DEWPOINT,
                                                             ATTR_CRITICAL_TEMP)

--- a/tests/components/sensor/test_moon.py
+++ b/tests/components/sensor/test_moon.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from unittest.mock import patch
 
 import homeassistant.util.dt as dt_util
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -1,7 +1,7 @@
 """The tests for the MQTT sensor platform."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.sensor as sensor
 from tests.common import mock_mqtt_component, fire_mqtt_message
 

--- a/tests/components/sensor/test_mqtt_room.py
+++ b/tests/components/sensor/test_mqtt_room.py
@@ -4,7 +4,7 @@ import datetime
 import unittest
 from unittest.mock import patch
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.sensor as sensor
 from homeassistant.components.mqtt import (CONF_STATE_TOPIC, CONF_QOS,
                                            DEFAULT_QOS)

--- a/tests/components/sensor/test_pilight.py
+++ b/tests/components/sensor/test_pilight.py
@@ -1,7 +1,7 @@
 """The tests for the Pilight sensor platform."""
 import logging
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.sensor as sensor
 from homeassistant.components import pilight
 

--- a/tests/components/sensor/test_random.py
+++ b/tests/components/sensor/test_random.py
@@ -1,7 +1,7 @@
 """The test for the random number sensor platform."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/sensor/test_rest.py
+++ b/tests/components/sensor/test_rest.py
@@ -6,7 +6,7 @@ import requests
 from requests.exceptions import Timeout, MissingSchema, RequestException
 import requests_mock
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.sensor as sensor
 import homeassistant.components.sensor.rest as rest
 from homeassistant.const import STATE_UNKNOWN

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -3,7 +3,7 @@ import unittest
 
 import pytest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.const import TEMP_CELSIUS
 

--- a/tests/components/sensor/test_sleepiq.py
+++ b/tests/components/sensor/test_sleepiq.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import requests_mock
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components.sensor import sleepiq
 
 from tests.components.test_sleepiq import mock_responses

--- a/tests/components/sensor/test_statistics.py
+++ b/tests/components/sensor/test_statistics.py
@@ -2,7 +2,7 @@
 import unittest
 import statistics
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import (ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
 from tests.common import get_test_home_assistant
 

--- a/tests/components/sensor/test_tcp.py
+++ b/tests/components/sensor/test_tcp.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from unittest.mock import patch, Mock
 
 from tests.common import (get_test_home_assistant, assert_setup_component)
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components.sensor import tcp
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.template import Template

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -2,7 +2,7 @@
 import asyncio
 
 from homeassistant.core import CoreState, State
-from homeassistant.bootstrap import setup_component, async_setup_component
+from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.helpers.restore_state import DATA_RESTORE_CACHE
 
 from tests.common import (

--- a/tests/components/sensor/test_worldclock.py
+++ b/tests/components/sensor/test_worldclock.py
@@ -1,7 +1,7 @@
 """The test for the World clock sensor platform."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from tests.common import get_test_home_assistant
 import homeassistant.util.dt as dt_util
 

--- a/tests/components/sensor/test_wsdot.py
+++ b/tests/components/sensor/test_wsdot.py
@@ -10,7 +10,7 @@ from homeassistant.components.sensor.wsdot import (
     WashingtonStateTravelTimeSensor, ATTR_DESCRIPTION,
     ATTR_TIME_UPDATED, CONF_API_KEY, CONF_NAME,
     CONF_ID, CONF_TRAVEL_TIMES, SCAN_INTERVAL)
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from tests.common import load_fixture, get_test_home_assistant
 
 

--- a/tests/components/sensor/test_yahoo_finance.py
+++ b/tests/components/sensor/test_yahoo_finance.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import patch
 
 import homeassistant.components.sensor as sensor
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from tests.common import (
     get_test_home_assistant, load_fixture, assert_setup_component)
 

--- a/tests/components/switch/test_command_line.py
+++ b/tests/components/switch/test_command_line.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import STATE_ON, STATE_OFF
 import homeassistant.components.switch as switch
 import homeassistant.components.switch.command_line as command_line

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import unittest
 from unittest.mock import patch
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import switch, light
 from homeassistant.const import CONF_PLATFORM, STATE_ON, SERVICE_TURN_ON
 import homeassistant.loader as loader

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant import loader
 from homeassistant.components import switch
 from homeassistant.const import STATE_ON, STATE_OFF, CONF_PLATFORM

--- a/tests/components/switch/test_litejet.py
+++ b/tests/components/switch/test_litejet.py
@@ -3,7 +3,7 @@ import logging
 import unittest
 from unittest import mock
 
-from homeassistant import bootstrap
+from homeassistant import setup
 from homeassistant.components import litejet
 from tests.common import get_test_home_assistant
 import homeassistant.components.switch as switch
@@ -56,7 +56,7 @@ class TestLiteJetSwitch(unittest.TestCase):
         elif method != self.test_include_switches_unspecified:
             config['litejet']['include_switches'] = True
 
-        assert bootstrap.setup_component(self.hass, litejet.DOMAIN, config)
+        assert setup.setup_component(self.hass, litejet.DOMAIN, config)
         self.hass.block_till_done()
 
     def teardown_method(self, method):

--- a/tests/components/switch/test_mfi.py
+++ b/tests/components/switch/test_mfi.py
@@ -2,7 +2,7 @@
 import unittest
 import unittest.mock as mock
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.switch as switch
 import homeassistant.components.switch.mfi as mfi
 from tests.components.sensor import test_mfi as test_mfi_sensor

--- a/tests/components/switch/test_mochad.py
+++ b/tests/components/switch/test_mochad.py
@@ -2,7 +2,7 @@
 import unittest
 import unittest.mock as mock
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import switch
 from homeassistant.components.switch import mochad
 

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -1,7 +1,7 @@
 """The tests for the MQTT switch platform."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
 import homeassistant.components.switch as switch
 from tests.common import (

--- a/tests/components/switch/test_rest.py
+++ b/tests/components/switch/test_rest.py
@@ -4,7 +4,7 @@ import asyncio
 import aiohttp
 
 import homeassistant.components.switch.rest as rest
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.util.async import run_coroutine_threadsafe
 from homeassistant.helpers.template import Template
 from tests.common import get_test_home_assistant, assert_setup_component

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -3,7 +3,7 @@ import unittest
 
 import pytest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
 
 from tests.common import get_test_home_assistant, mock_component

--- a/tests/components/switch/test_template.py
+++ b/tests/components/switch/test_template.py
@@ -2,7 +2,7 @@
 import asyncio
 
 from homeassistant.core import callback, State, CoreState
-import homeassistant.bootstrap as bootstrap
+from homeassistant import setup
 import homeassistant.components as core
 from homeassistant.const import STATE_ON, STATE_OFF
 from homeassistant.helpers.restore_state import DATA_RESTORE_CACHE
@@ -37,7 +37,7 @@ class TestTemplateSwitch:
     def test_template_state_text(self):
         """"Test the state text of a template."""
         with assert_setup_component(1):
-            assert bootstrap.setup_component(self.hass, 'switch', {
+            assert setup.setup_component(self.hass, 'switch', {
                 'switch': {
                     'platform': 'template',
                     'switches': {
@@ -75,7 +75,7 @@ class TestTemplateSwitch:
     def test_template_state_boolean_on(self):
         """Test the setting of the state with boolean on."""
         with assert_setup_component(1):
-            assert bootstrap.setup_component(self.hass, 'switch', {
+            assert setup.setup_component(self.hass, 'switch', {
                 'switch': {
                     'platform': 'template',
                     'switches': {
@@ -104,7 +104,7 @@ class TestTemplateSwitch:
     def test_template_state_boolean_off(self):
         """Test the setting of the state with off."""
         with assert_setup_component(1):
-            assert bootstrap.setup_component(self.hass, 'switch', {
+            assert setup.setup_component(self.hass, 'switch', {
                 'switch': {
                     'platform': 'template',
                     'switches': {
@@ -133,7 +133,7 @@ class TestTemplateSwitch:
     def test_template_syntax_error(self):
         """Test templating syntax error."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'switch', {
+            assert setup.setup_component(self.hass, 'switch', {
                 'switch': {
                     'platform': 'template',
                     'switches': {
@@ -161,7 +161,7 @@ class TestTemplateSwitch:
     def test_invalid_name_does_not_create(self):
         """Test invalid name."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'switch', {
+            assert setup.setup_component(self.hass, 'switch', {
                 'switch': {
                     'platform': 'template',
                     'switches': {
@@ -189,7 +189,7 @@ class TestTemplateSwitch:
     def test_invalid_switch_does_not_create(self):
         """Test invalid switch."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'switch', {
+            assert setup.setup_component(self.hass, 'switch', {
                 'switch': {
                     'platform': 'template',
                     'switches': {
@@ -206,7 +206,7 @@ class TestTemplateSwitch:
     def test_no_switches_does_not_create(self):
         """Test if there are no switches no creation."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'switch', {
+            assert setup.setup_component(self.hass, 'switch', {
                 'switch': {
                     'platform': 'template'
                 }
@@ -220,7 +220,7 @@ class TestTemplateSwitch:
     def test_missing_template_does_not_create(self):
         """Test missing template."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'switch', {
+            assert setup.setup_component(self.hass, 'switch', {
                 'switch': {
                     'platform': 'template',
                     'switches': {
@@ -248,7 +248,7 @@ class TestTemplateSwitch:
     def test_missing_on_does_not_create(self):
         """Test missing on."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'switch', {
+            assert setup.setup_component(self.hass, 'switch', {
                 'switch': {
                     'platform': 'template',
                     'switches': {
@@ -276,7 +276,7 @@ class TestTemplateSwitch:
     def test_missing_off_does_not_create(self):
         """Test missing off."""
         with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'switch', {
+            assert setup.setup_component(self.hass, 'switch', {
                 'switch': {
                     'platform': 'template',
                     'switches': {
@@ -303,7 +303,7 @@ class TestTemplateSwitch:
 
     def test_on_action(self):
         """Test on action."""
-        assert bootstrap.setup_component(self.hass, 'switch', {
+        assert setup.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template',
                 'switches': {
@@ -338,7 +338,7 @@ class TestTemplateSwitch:
 
     def test_off_action(self):
         """Test off action."""
-        assert bootstrap.setup_component(self.hass, 'switch', {
+        assert setup.setup_component(self.hass, 'switch', {
             'switch': {
                 'platform': 'template',
                 'switches': {
@@ -384,7 +384,7 @@ def test_restore_state(hass):
     hass.state = CoreState.starting
     mock_component(hass, 'recorder')
 
-    yield from bootstrap.async_setup_component(hass, 'switch', {
+    yield from setup.async_setup_component(hass, 'switch', {
         'switch': {
             'platform': 'template',
             'switches': {

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.core import callback
 import homeassistant.components.alert as alert
 import homeassistant.components.notify as notify

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -7,7 +7,7 @@ import unittest
 import requests
 
 from homeassistant.core import callback
-from homeassistant import bootstrap, const
+from homeassistant import setup, const
 from homeassistant.components import alexa, http
 
 from tests.common import get_test_instance_port, get_test_home_assistant
@@ -43,7 +43,7 @@ def setUpModule():
 
     hass = get_test_home_assistant()
 
-    bootstrap.setup_component(
+    setup.setup_component(
         hass, http.DOMAIN,
         {http.DOMAIN: {http.CONF_API_PASSWORD: API_PASSWORD,
                        http.CONF_SERVER_PORT: SERVER_PORT}})
@@ -54,7 +54,7 @@ def setUpModule():
 
     hass.services.register("test", "alexa", mock_service)
 
-    bootstrap.setup_component(hass, alexa.DOMAIN, {
+    setup.setup_component(hass, alexa.DOMAIN, {
         # Key is here to verify we allow other keys in config too
         "homeassistant": {},
         "alexa": {

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, patch
 from aiohttp import web
 import requests
 
-from homeassistant import bootstrap, const
+from homeassistant import setup, const
 import homeassistant.core as ha
 import homeassistant.components.http as http
 
@@ -41,12 +41,12 @@ def setUpModule():
     hass.bus.listen('test_event', lambda _: _)
     hass.states.set('test.test', 'a_state')
 
-    bootstrap.setup_component(
+    setup.setup_component(
         hass, http.DOMAIN,
         {http.DOMAIN: {http.CONF_API_PASSWORD: API_PASSWORD,
          http.CONF_SERVER_PORT: SERVER_PORT}})
 
-    bootstrap.setup_component(hass, 'api')
+    setup.setup_component(hass, 'api')
 
     hass.start()
 

--- a/tests/components/test_apiai.py
+++ b/tests/components/test_apiai.py
@@ -6,7 +6,7 @@ import unittest
 import requests
 
 from homeassistant.core import callback
-from homeassistant import bootstrap, const
+from homeassistant import setup, const
 from homeassistant.components import apiai, http
 
 from tests.common import get_test_instance_port, get_test_home_assistant
@@ -45,7 +45,7 @@ def setUpModule():
 
     hass = get_test_home_assistant()
 
-    bootstrap.setup_component(
+    setup.setup_component(
         hass, http.DOMAIN,
         {http.DOMAIN: {http.CONF_API_PASSWORD: API_PASSWORD,
                        http.CONF_SERVER_PORT: SERVER_PORT}})
@@ -57,7 +57,7 @@ def setUpModule():
 
     hass.services.register("test", "apiai", mock_service)
 
-    bootstrap.setup_component(hass, apiai.DOMAIN, {
+    setup.setup_component(hass, apiai.DOMAIN, {
         # Key is here to verify we allow other keys in config too
         "homeassistant": {},
         "apiai": {

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components as core_components
 from homeassistant.components import conversation
 from homeassistant.const import ATTR_ENTITY_ID

--- a/tests/components/test_demo.py
+++ b/tests/components/test_demo.py
@@ -3,7 +3,7 @@ import json
 import os
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import demo, device_tracker
 from homeassistant.remote import JSONEncoder
 

--- a/tests/components/test_device_sun_light_trigger.py
+++ b/tests/components/test_device_sun_light_trigger.py
@@ -3,7 +3,7 @@
 import os
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.loader as loader
 from homeassistant.const import CONF_PLATFORM, STATE_HOME, STATE_NOT_HOME
 from homeassistant.components import (

--- a/tests/components/test_ffmpeg.py
+++ b/tests/components/test_ffmpeg.py
@@ -3,7 +3,7 @@ import asyncio
 from unittest.mock import patch, MagicMock
 
 import homeassistant.components.ffmpeg as ffmpeg
-from homeassistant.bootstrap import setup_component, async_setup_component
+from homeassistant.setup import setup_component, async_setup_component
 
 from tests.common import (
     get_test_home_assistant, assert_setup_component, mock_coro)

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -5,7 +5,7 @@ import unittest
 
 import requests
 
-import homeassistant.bootstrap as bootstrap
+from homeassistant import setup
 from homeassistant.components import http
 from homeassistant.const import HTTP_HEADER_HA_AUTH
 
@@ -31,12 +31,12 @@ def setUpModule():
 
     hass = get_test_home_assistant()
 
-    assert bootstrap.setup_component(
+    assert setup.setup_component(
         hass, http.DOMAIN,
         {http.DOMAIN: {http.CONF_API_PASSWORD: API_PASSWORD,
                        http.CONF_SERVER_PORT: SERVER_PORT}})
 
-    assert bootstrap.setup_component(hass, 'frontend')
+    assert setup.setup_component(hass, 'frontend')
 
     hass.start()
 

--- a/tests/components/test_google.py
+++ b/tests/components/test_google.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch
 
 import homeassistant.components.google as google
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from tests.common import get_test_home_assistant
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/test_graphite.py
+++ b/tests/components/test_graphite.py
@@ -4,7 +4,7 @@ import unittest
 from unittest import mock
 from unittest.mock import patch
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.core as ha
 import homeassistant.components.graphite as graphite
 from homeassistant.const import (

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 import unittest
 from unittest.mock import patch
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import (
     STATE_ON, STATE_OFF, STATE_HOME, STATE_UNKNOWN, ATTR_ICON, ATTR_HIDDEN,
     ATTR_ASSUMED_STATE, STATE_NOT_HOME, )

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import unittest
 from unittest.mock import patch, sentinel
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.core as ha
 import homeassistant.util.dt as dt_util
 from homeassistant.components import history, recorder

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import influxdb as influx_client
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.influxdb as influxdb
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
 

--- a/tests/components/test_input_boolean.py
+++ b/tests/components/test_input_boolean.py
@@ -7,7 +7,7 @@ import logging
 from tests.common import get_test_home_assistant, mock_component
 
 from homeassistant.core import CoreState, State
-from homeassistant.bootstrap import setup_component, async_setup_component
+from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.components.input_boolean import (
     DOMAIN, is_on, toggle, turn_off, turn_on)
 from homeassistant.const import (

--- a/tests/components/test_input_select.py
+++ b/tests/components/test_input_select.py
@@ -6,7 +6,7 @@ import unittest
 from tests.common import get_test_home_assistant, mock_restore_cache
 
 from homeassistant.core import State
-from homeassistant.bootstrap import setup_component, async_setup_component
+from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.components.input_select import (
     ATTR_OPTIONS, DOMAIN, SERVICE_SET_OPTIONS,
     select_option, select_next, select_previous)

--- a/tests/components/test_input_slider.py
+++ b/tests/components/test_input_slider.py
@@ -6,7 +6,7 @@ import unittest
 from tests.common import get_test_home_assistant, mock_component
 
 from homeassistant.core import CoreState, State
-from homeassistant.bootstrap import setup_component, async_setup_component
+from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.components.input_slider import (DOMAIN, select_value)
 from homeassistant.helpers.restore_state import DATA_RESTORE_CACHE
 

--- a/tests/components/test_introduction.py
+++ b/tests/components/test_introduction.py
@@ -1,7 +1,7 @@
 """The tests for the Introduction component."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import introduction
 
 from tests.common import get_test_home_assistant

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     ATTR_HIDDEN, STATE_NOT_HOME, STATE_ON, STATE_OFF)
 import homeassistant.util.dt as dt_util
 from homeassistant.components import logbook
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 from tests.common import (
     mock_http_component, init_recorder_component, get_test_home_assistant)

--- a/tests/components/test_logentries.py
+++ b/tests/components/test_logentries.py
@@ -3,7 +3,7 @@
 import unittest
 from unittest import mock
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.logentries as logentries
 from homeassistant.const import STATE_ON, STATE_OFF, EVENT_STATE_CHANGED
 

--- a/tests/components/test_logger.py
+++ b/tests/components/test_logger.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 import logging
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import logger
 
 from tests.common import get_test_home_assistant

--- a/tests/components/test_microsoft_face.py
+++ b/tests/components/test_microsoft_face.py
@@ -3,7 +3,7 @@ import asyncio
 from unittest.mock import patch
 
 import homeassistant.components.microsoft_face as mf
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 from tests.common import (
     get_test_home_assistant, assert_setup_component, mock_coro, load_fixture)

--- a/tests/components/test_mqtt_eventstream.py
+++ b/tests/components/test_mqtt_eventstream.py
@@ -2,7 +2,7 @@
 import json
 from unittest.mock import ANY, patch
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.mqtt_eventstream as eventstream
 from homeassistant.const import EVENT_STATE_CHANGED
 from homeassistant.core import State, callback

--- a/tests/components/test_panel_custom.py
+++ b/tests/components/test_panel_custom.py
@@ -4,7 +4,7 @@ import shutil
 import unittest
 from unittest.mock import Mock, patch
 
-from homeassistant import bootstrap
+from homeassistant import setup
 from homeassistant.components import panel_custom
 
 from tests.common import get_test_home_assistant
@@ -34,15 +34,15 @@ class TestPanelCustom(unittest.TestCase):
             }
         }
 
-        assert not bootstrap.setup_component(self.hass, 'panel_custom', config)
+        assert not setup.setup_component(self.hass, 'panel_custom', config)
         assert not mock_register.called
 
         path = self.hass.config.path(panel_custom.PANEL_DIR)
         os.mkdir(path)
-        self.hass.data.pop(bootstrap.DATA_SETUP)
+        self.hass.data.pop(setup.DATA_SETUP)
 
         with open(os.path.join(path, 'todomvc.html'), 'a'):
-            assert bootstrap.setup_component(self.hass, 'panel_custom', config)
+            assert setup.setup_component(self.hass, 'panel_custom', config)
             assert mock_register.called
 
     @patch('homeassistant.components.panel_custom.register_panel')
@@ -62,16 +62,16 @@ class TestPanelCustom(unittest.TestCase):
         }
 
         with patch('os.path.isfile', Mock(return_value=False)):
-            assert not bootstrap.setup_component(
+            assert not setup.setup_component(
                 self.hass, 'panel_custom', config
             )
             assert not mock_register.called
 
-        self.hass.data.pop(bootstrap.DATA_SETUP)
+        self.hass.data.pop(setup.DATA_SETUP)
 
         with patch('os.path.isfile', Mock(return_value=True)):
             with patch('os.access', Mock(return_value=True)):
-                assert bootstrap.setup_component(
+                assert setup.setup_component(
                     self.hass, 'panel_custom', config
                 )
 

--- a/tests/components/test_panel_iframe.py
+++ b/tests/components/test_panel_iframe.py
@@ -2,7 +2,7 @@
 import unittest
 from unittest.mock import patch
 
-from homeassistant import bootstrap
+from homeassistant import setup
 from homeassistant.components import frontend
 
 from tests.common import get_test_home_assistant
@@ -28,7 +28,7 @@ class TestPanelIframe(unittest.TestCase):
                 'url': 'not-a-url'}}]
 
         for conf in to_try:
-            assert not bootstrap.setup_component(
+            assert not setup.setup_component(
                 self.hass, 'panel_iframe', {
                     'panel_iframe': conf
                 })
@@ -37,7 +37,7 @@ class TestPanelIframe(unittest.TestCase):
         'panels/ha-panel-iframe.html': 'md5md5'})
     def test_correct_config(self):
         """Test correct config."""
-        assert bootstrap.setup_component(
+        assert setup.setup_component(
             self.hass, 'panel_iframe', {
                 'panel_iframe': {
                     'router': {

--- a/tests/components/test_persistent_notification.py
+++ b/tests/components/test_persistent_notification.py
@@ -1,5 +1,5 @@
 """The tests for the persistent notification component."""
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.persistent_notification as pn
 
 from tests.common import get_test_home_assistant

--- a/tests/components/test_pilight.py
+++ b/tests/components/test_pilight.py
@@ -6,7 +6,7 @@ import socket
 from datetime import timedelta
 
 from homeassistant import core as ha
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import pilight
 from homeassistant.util import dt as dt_util
 

--- a/tests/components/test_proximity.py
+++ b/tests/components/test_proximity.py
@@ -4,7 +4,7 @@ import unittest
 from homeassistant.components import proximity
 from homeassistant.components.proximity import DOMAIN
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from tests.common import get_test_home_assistant
 
 

--- a/tests/components/test_rest_command.py
+++ b/tests/components/test_rest_command.py
@@ -4,7 +4,7 @@ import asyncio
 import aiohttp
 
 import homeassistant.components.rest_command as rc
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 from tests.common import (
     get_test_home_assistant, assert_setup_component)

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -5,7 +5,7 @@ import unittest
 import pytest
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import rfxtrx as rfxtrx
 from tests.common import get_test_home_assistant
 

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -3,7 +3,7 @@
 import unittest
 
 from homeassistant.core import callback
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import script
 
 from tests.common import get_test_home_assistant, mock_component

--- a/tests/components/test_shell_command.py
+++ b/tests/components/test_shell_command.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import patch
 from subprocess import SubprocessError
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import shell_command
 
 from tests.common import get_test_home_assistant

--- a/tests/components/test_sleepiq.py
+++ b/tests/components/test_sleepiq.py
@@ -2,7 +2,7 @@
 import unittest
 import requests_mock
 
-from homeassistant import bootstrap
+from homeassistant import setup
 import homeassistant.components.sleepiq as sleepiq
 
 from tests.common import load_fixture, get_test_home_assistant
@@ -66,11 +66,11 @@ class TestSleepIQ(unittest.TestCase):
         """Test the setup when no login is configured."""
         conf = self.config.copy()
         del conf['sleepiq']['username']
-        assert not bootstrap.setup_component(self.hass, sleepiq.DOMAIN, conf)
+        assert not setup.setup_component(self.hass, sleepiq.DOMAIN, conf)
 
     def test_setup_component_no_password(self):
         """Test the setup when no password is configured."""
         conf = self.config.copy()
         del conf['sleepiq']['password']
 
-        assert not bootstrap.setup_component(self.hass, sleepiq.DOMAIN, conf)
+        assert not setup.setup_component(self.hass, sleepiq.DOMAIN, conf)

--- a/tests/components/test_splunk.py
+++ b/tests/components/test_splunk.py
@@ -2,7 +2,7 @@
 import unittest
 from unittest import mock
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.splunk as splunk
 from homeassistant.const import STATE_ON, STATE_OFF, EVENT_STATE_CHANGED
 

--- a/tests/components/test_statsd.py
+++ b/tests/components/test_statsd.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import voluptuous as vol
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.core as ha
 import homeassistant.components.statsd as statsd
 from homeassistant.const import (STATE_ON, STATE_OFF, EVENT_STATE_CHANGED)

--- a/tests/components/test_sun.py
+++ b/tests/components/test_sun.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch
 from datetime import timedelta, datetime
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.core as ha
 import homeassistant.util.dt as dt_util
 import homeassistant.components.sun as sun

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -8,7 +8,7 @@ import requests
 import requests_mock
 import voluptuous as vol
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import updater
 
 from tests.common import (

--- a/tests/components/test_weblink.py
+++ b/tests/components/test_weblink.py
@@ -1,9 +1,8 @@
 """The tests for the weblink component."""
 import unittest
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components import weblink
-from homeassistant import bootstrap
 
 from tests.common import get_test_home_assistant
 
@@ -21,7 +20,7 @@ class TestComponentWeblink(unittest.TestCase):
 
     def test_bad_config(self):
         """Test if new entity is created."""
-        self.assertFalse(bootstrap.setup_component(self.hass, 'weblink', {
+        self.assertFalse(setup_component(self.hass, 'weblink', {
             'weblink': {
                 'entities': [{}],
             }

--- a/tests/components/test_zone.py
+++ b/tests/components/test_zone.py
@@ -1,7 +1,7 @@
 """Test zone component."""
 import unittest
 
-from homeassistant import bootstrap
+from homeassistant import setup
 from homeassistant.components import zone
 
 from tests.common import get_test_home_assistant
@@ -20,7 +20,7 @@ class TestComponentZone(unittest.TestCase):
 
     def test_setup_no_zones_still_adds_home_zone(self):
         """Test if no config is passed in we still get the home zone."""
-        assert bootstrap.setup_component(self.hass, zone.DOMAIN,
+        assert setup.setup_component(self.hass, zone.DOMAIN,
                                          {'zone': None})
 
         assert len(self.hass.states.entity_ids('zone')) == 1
@@ -39,7 +39,7 @@ class TestComponentZone(unittest.TestCase):
             'radius': 250,
             'passive': True
         }
-        assert bootstrap.setup_component(self.hass, zone.DOMAIN, {
+        assert setup.setup_component(self.hass, zone.DOMAIN, {
             'zone': info
         })
 
@@ -52,7 +52,7 @@ class TestComponentZone(unittest.TestCase):
 
     def test_active_zone_skips_passive_zones(self):
         """Test active and passive zones."""
-        assert bootstrap.setup_component(self.hass, zone.DOMAIN, {
+        assert setup.setup_component(self.hass, zone.DOMAIN, {
             'zone': [
                 {
                     'name': 'Passive Zone',
@@ -69,7 +69,7 @@ class TestComponentZone(unittest.TestCase):
 
     def test_active_zone_skips_passive_zones_2(self):
         """Test active and passive zones."""
-        assert bootstrap.setup_component(self.hass, zone.DOMAIN, {
+        assert setup.setup_component(self.hass, zone.DOMAIN, {
             'zone': [
                 {
                     'name': 'Active Zone',
@@ -87,7 +87,7 @@ class TestComponentZone(unittest.TestCase):
         """Test zone size preferences."""
         latitude = 32.880600
         longitude = -117.237561
-        assert bootstrap.setup_component(self.hass, zone.DOMAIN, {
+        assert setup.setup_component(self.hass, zone.DOMAIN, {
             'zone': [
                 {
                     'name': 'Small Zone',
@@ -111,7 +111,7 @@ class TestComponentZone(unittest.TestCase):
         """Test zone size preferences."""
         latitude = 32.880600
         longitude = -117.237561
-        assert bootstrap.setup_component(self.hass, zone.DOMAIN, {
+        assert setup.setup_component(self.hass, zone.DOMAIN, {
             'zone': [
                 {
                     'name': 'Smallest Zone',
@@ -129,7 +129,7 @@ class TestComponentZone(unittest.TestCase):
         """Test working in passive zones."""
         latitude = 32.880600
         longitude = -117.237561
-        assert bootstrap.setup_component(self.hass, zone.DOMAIN, {
+        assert setup.setup_component(self.hass, zone.DOMAIN, {
             'zone': [
                 {
                     'name': 'Passive Zone',

--- a/tests/components/test_zone.py
+++ b/tests/components/test_zone.py
@@ -21,7 +21,7 @@ class TestComponentZone(unittest.TestCase):
     def test_setup_no_zones_still_adds_home_zone(self):
         """Test if no config is passed in we still get the home zone."""
         assert setup.setup_component(self.hass, zone.DOMAIN,
-                                         {'zone': None})
+                                     {'zone': None})
 
         assert len(self.hass.states.entity_ids('zone')) == 1
         state = self.hass.states.get('zone.home')

--- a/tests/components/tts/test_google.py
+++ b/tests/components/tts/test_google.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import homeassistant.components.tts as tts
 from homeassistant.components.media_player import (
     SERVICE_PLAY_MEDIA, ATTR_MEDIA_CONTENT_ID, DOMAIN as DOMAIN_MP)
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 from tests.common import (
     get_test_home_assistant, assert_setup_component, mock_service)

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -12,7 +12,7 @@ from homeassistant.components.tts.demo import DemoProvider
 from homeassistant.components.media_player import (
     SERVICE_PLAY_MEDIA, MEDIA_TYPE_MUSIC, ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE, DOMAIN as DOMAIN_MP)
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 from tests.common import (
     get_test_home_assistant, get_test_instance_port, assert_setup_component,

--- a/tests/components/tts/test_voicerss.py
+++ b/tests/components/tts/test_voicerss.py
@@ -6,7 +6,7 @@ import shutil
 import homeassistant.components.tts as tts
 from homeassistant.components.media_player import (
     SERVICE_PLAY_MEDIA, ATTR_MEDIA_CONTENT_ID, DOMAIN as DOMAIN_MP)
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 from tests.common import (
     get_test_home_assistant, assert_setup_component, mock_service)

--- a/tests/components/tts/test_yandextts.py
+++ b/tests/components/tts/test_yandextts.py
@@ -4,7 +4,7 @@ import os
 import shutil
 
 import homeassistant.components.tts as tts
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components.media_player import (
     SERVICE_PLAY_MEDIA, DOMAIN as DOMAIN_MP)
 from tests.common import (

--- a/tests/components/weather/test_weather.py
+++ b/tests/components/weather/test_weather.py
@@ -7,7 +7,7 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_PRESSURE, ATTR_WEATHER_TEMPERATURE, ATTR_WEATHER_WIND_BEARING,
     ATTR_WEATHER_WIND_SPEED, ATTR_FORECAST, ATTR_FORECAST_TEMP)
 from homeassistant.util.unit_system import METRIC_SYSTEM
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 import requests_mock as _requests_mock
 
-from homeassistant import util, bootstrap
+from homeassistant import util, setup
 from homeassistant.util import location
 from homeassistant.components import mqtt
 
@@ -76,7 +76,7 @@ def mqtt_mock(loop, hass):
     """Fixture to mock MQTT."""
     with patch('homeassistant.components.mqtt.MQTT') as mock_mqtt:
         mock_mqtt().async_connect.return_value = mock_coro(True)
-        assert loop.run_until_complete(bootstrap.async_setup_component(
+        assert loop.run_until_complete(setup.async_setup_component(
             hass, mqtt.DOMAIN, {
                 mqtt.DOMAIN: {
                     mqtt.CONF_BROKER: 'mock-broker',

--- a/tests/helpers/test_aiohttp_client.py
+++ b/tests/helpers/test_aiohttp_client.py
@@ -5,7 +5,7 @@ import unittest
 import aiohttp
 
 from homeassistant.core import EVENT_HOMEASSISTANT_CLOSE
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.helpers.aiohttp_client as client
 from homeassistant.util.async import run_callback_threadsafe
 

--- a/tests/helpers/test_discovery.py
+++ b/tests/helpers/test_discovery.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import loader, bootstrap
+from homeassistant import loader, setup
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import discovery
@@ -24,7 +24,7 @@ class TestHelpersDiscovery:
         """Stop everything that was started."""
         self.hass.stop()
 
-    @patch('homeassistant.bootstrap.async_setup_component')
+    @patch('homeassistant.setup.async_setup_component')
     def test_listen(self, mock_setup_component):
         """Test discovery listen/discover combo."""
         calls_single = []
@@ -63,7 +63,7 @@ class TestHelpersDiscovery:
         assert ['test service', 'another service'] == [info[0] for info
                                                        in calls_multi]
 
-    @patch('homeassistant.bootstrap.async_setup_component',
+    @patch('homeassistant.setup.async_setup_component',
            return_value=mock_coro(True))
     def test_platform(self, mock_setup_component):
         """Test discover platform method."""
@@ -136,7 +136,7 @@ class TestHelpersDiscovery:
             MockPlatform(setup_platform,
                          dependencies=['test_component']))
 
-        bootstrap.setup_component(self.hass, 'test_component', {
+        setup.setup_component(self.hass, 'test_component', {
             'test_component': None,
             'switch': [{
                 'platform': 'test_circular',
@@ -184,14 +184,14 @@ class TestHelpersDiscovery:
             MockModule('test_component2', setup=component2_setup))
 
         @callback
-        def setup():
+        def do_setup():
             """Setup 2 components."""
-            self.hass.async_add_job(bootstrap.async_setup_component(
+            self.hass.async_add_job(setup.async_setup_component(
                 self.hass, 'test_component1', {}))
-            self.hass.async_add_job(bootstrap.async_setup_component(
+            self.hass.async_add_job(setup.async_setup_component(
                 self.hass, 'test_component2', {}))
 
-        self.hass.add_job(setup)
+        self.hass.add_job(do_setup)
         self.hass.block_till_done()
 
         # test_component will only be setup once

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -301,7 +301,7 @@ class TestHelpersEntityComponent(unittest.TestCase):
 
     @patch('homeassistant.helpers.entity_component.EntityComponent'
            '._async_setup_platform', return_value=mock_coro())
-    @patch('homeassistant.bootstrap.async_setup_component',
+    @patch('homeassistant.setup.async_setup_component',
            return_value=mock_coro(True))
     def test_setup_does_discovery(self, mock_setup_component, mock_setup):
         """Test setup for discovery."""

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 from astral import Astral
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 import homeassistant.core as ha
 from homeassistant.const import MATCH_ALL
 from homeassistant.helpers.event import (

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -3,7 +3,7 @@ import asyncio
 from datetime import timedelta
 from unittest.mock import patch, MagicMock
 
-from homeassistant.bootstrap import setup_component
+from homeassistant.setup import setup_component
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.core import CoreState, split_entity_id, State
 import homeassistant.util.dt as dt_util

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -2,23 +2,14 @@
 # pylint: disable=protected-access
 import asyncio
 import os
-from unittest import mock
-import threading
+from unittest.mock import Mock, patch
 import logging
 
-import voluptuous as vol
-
-from homeassistant.core import callback
-from homeassistant.const import EVENT_HOMEASSISTANT_START
 import homeassistant.config as config_util
-from homeassistant import bootstrap, loader
+from homeassistant import bootstrap
 import homeassistant.util.dt as dt_util
-from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
-from homeassistant.helpers import discovery
 
-from tests.common import \
-    get_test_home_assistant, MockModule, MockPlatform, \
-    assert_setup_component, patch_yaml_files, get_test_config_dir
+from tests.common import patch_yaml_files, get_test_config_dir
 
 ORIG_TIMEZONE = dt_util.DEFAULT_TIME_ZONE
 VERSION_PATH = os.path.join(get_test_config_dir(), config_util.VERSION_FILE)
@@ -26,431 +17,38 @@ VERSION_PATH = os.path.join(get_test_config_dir(), config_util.VERSION_FILE)
 _LOGGER = logging.getLogger(__name__)
 
 
-class TestBootstrap:
-    """Test the bootstrap utils."""
-
-    hass = None
-    backup_cache = None
-
-    # pylint: disable=invalid-name, no-self-use
-    def setup_method(self, method):
-        """Setup the test."""
-        self.backup_cache = loader._COMPONENT_CACHE
-
-        if method == self.test_from_config_file:
-            return
-
-        self.hass = get_test_home_assistant()
-
-    def teardown_method(self, method):
-        """Clean up."""
-        if method == self.test_from_config_file:
-            return
-
-        dt_util.DEFAULT_TIME_ZONE = ORIG_TIMEZONE
-        self.hass.stop()
-        loader._COMPONENT_CACHE = self.backup_cache
-        if os.path.isfile(VERSION_PATH):
-            os.remove(VERSION_PATH)
-
-    @mock.patch(
-        # prevent .HA_VERISON file from being written
-        'homeassistant.bootstrap.conf_util.process_ha_config_upgrade',
-        autospec=True)
-    @mock.patch('homeassistant.util.location.detect_location_info',
-                autospec=True, return_value=None)
-    @mock.patch('homeassistant.bootstrap.async_register_signal_handling')
-    def test_from_config_file(self, mock_upgrade, mock_detect, mock_signal):
-        """Test with configuration file."""
-        components = set(['browser', 'conversation', 'script'])
-        files = {
-            'config.yaml': ''.join(
-                '{}:\n'.format(comp)
-                for comp in components
-            )
-        }
-
-        with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
-                mock.patch('os.access', mock.Mock(return_value=True)), \
-                mock.patch('homeassistant.bootstrap.async_enable_logging',
-                           mock.Mock(return_value=True)), \
-                patch_yaml_files(files, True):
-            self.hass = bootstrap.from_config_file('config.yaml')
-
-        assert components == self.hass.config.components
-
-    def test_validate_component_config(self):
-        """Test validating component configuration."""
-        config_schema = vol.Schema({
-            'comp_conf': {
-                'hello': str
-            }
-        }, required=True)
-        loader.set_component(
-            'comp_conf', MockModule('comp_conf', config_schema=config_schema))
-
-        with assert_setup_component(0):
-            assert not bootstrap.setup_component(self.hass, 'comp_conf', {})
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-
-        with assert_setup_component(0):
-            assert not bootstrap.setup_component(self.hass, 'comp_conf', {
-                'comp_conf': None
-            })
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-
-        with assert_setup_component(0):
-            assert not bootstrap.setup_component(self.hass, 'comp_conf', {
-                'comp_conf': {}
-            })
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-
-        with assert_setup_component(0):
-            assert not bootstrap.setup_component(self.hass, 'comp_conf', {
-                'comp_conf': {
-                    'hello': 'world',
-                    'invalid': 'extra',
-                }
-            })
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-
-        with assert_setup_component(1):
-            assert bootstrap.setup_component(self.hass, 'comp_conf', {
-                'comp_conf': {
-                    'hello': 'world',
-                }
-            })
-
-    def test_validate_platform_config(self):
-        """Test validating platform configuration."""
-        platform_schema = PLATFORM_SCHEMA.extend({
-            'hello': str,
-        })
-        loader.set_component(
-            'platform_conf',
-            MockModule('platform_conf', platform_schema=platform_schema))
-
-        loader.set_component(
-            'platform_conf.whatever', MockPlatform('whatever'))
-
-        with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'platform_conf', {
-                'platform_conf': {
-                    'hello': 'world',
-                    'invalid': 'extra',
-                }
-            })
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-        self.hass.config.components.remove('platform_conf')
-
-        with assert_setup_component(1):
-            assert bootstrap.setup_component(self.hass, 'platform_conf', {
-                'platform_conf': {
-                    'platform': 'whatever',
-                    'hello': 'world',
-                },
-                'platform_conf 2': {
-                    'invalid': True
-                }
-            })
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-        self.hass.config.components.remove('platform_conf')
-
-        with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'platform_conf', {
-                'platform_conf': {
-                    'platform': 'not_existing',
-                    'hello': 'world',
-                }
-            })
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-        self.hass.config.components.remove('platform_conf')
-
-        with assert_setup_component(1):
-            assert bootstrap.setup_component(self.hass, 'platform_conf', {
-                'platform_conf': {
-                    'platform': 'whatever',
-                    'hello': 'world',
-                }
-            })
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-        self.hass.config.components.remove('platform_conf')
-
-        with assert_setup_component(1):
-            assert bootstrap.setup_component(self.hass, 'platform_conf', {
-                'platform_conf': [{
-                    'platform': 'whatever',
-                    'hello': 'world',
-                }]
-            })
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-        self.hass.config.components.remove('platform_conf')
-
-        # Any falsey platform config will be ignored (None, {}, etc)
-        with assert_setup_component(0) as config:
-            assert bootstrap.setup_component(self.hass, 'platform_conf', {
-                'platform_conf': None
-            })
-            assert 'platform_conf' in self.hass.config.components
-            assert not config['platform_conf']  # empty
-
-            assert bootstrap.setup_component(self.hass, 'platform_conf', {
-                'platform_conf': {}
-            })
-            assert 'platform_conf' in self.hass.config.components
-            assert not config['platform_conf']  # empty
-
-    def test_component_not_found(self):
-        """setup_component should not crash if component doesn't exist."""
-        assert not bootstrap.setup_component(self.hass, 'non_existing')
-
-    def test_component_not_double_initialized(self):
-        """Test we do not setup a component twice."""
-        mock_setup = mock.MagicMock(return_value=True)
-
-        loader.set_component('comp', MockModule('comp', setup=mock_setup))
-
-        assert bootstrap.setup_component(self.hass, 'comp')
-        assert mock_setup.called
-
-        mock_setup.reset_mock()
-
-        assert bootstrap.setup_component(self.hass, 'comp')
-        assert not mock_setup.called
-
-    @mock.patch('homeassistant.util.package.install_package',
-                return_value=False)
-    def test_component_not_installed_if_requirement_fails(self, mock_install):
-        """Component setup should fail if requirement can't install."""
-        self.hass.config.skip_pip = False
-        loader.set_component(
-            'comp', MockModule('comp', requirements=['package==0.0.1']))
-
-        assert not bootstrap.setup_component(self.hass, 'comp')
-        assert 'comp' not in self.hass.config.components
-
-    def test_component_not_setup_twice_if_loaded_during_other_setup(self):
-        """Test component setup while waiting for lock is not setup twice."""
-        result = []
-
-        @asyncio.coroutine
-        def async_setup(hass, config):
-            """Tracking Setup."""
-            result.append(1)
-
-        loader.set_component(
-            'comp', MockModule('comp', async_setup=async_setup))
-
-        def setup_component():
-            """Setup the component."""
-            bootstrap.setup_component(self.hass, 'comp')
-
-        thread = threading.Thread(target=setup_component)
-        thread.start()
-        bootstrap.setup_component(self.hass, 'comp')
-
-        thread.join()
-
-        assert len(result) == 1
-
-    def test_component_not_setup_missing_dependencies(self):
-        """Test we do not setup a component if not all dependencies loaded."""
-        deps = ['non_existing']
-        loader.set_component('comp', MockModule('comp', dependencies=deps))
-
-        assert not bootstrap.setup_component(self.hass, 'comp', {})
-        assert 'comp' not in self.hass.config.components
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-
-        loader.set_component('non_existing', MockModule('non_existing'))
-        assert bootstrap.setup_component(self.hass, 'comp', {})
-
-    def test_component_failing_setup(self):
-        """Test component that fails setup."""
-        loader.set_component(
-            'comp', MockModule('comp', setup=lambda hass, config: False))
-
-        assert not bootstrap.setup_component(self.hass, 'comp', {})
-        assert 'comp' not in self.hass.config.components
-
-    def test_component_exception_setup(self):
-        """Test component that raises exception during setup."""
-        def exception_setup(hass, config):
-            """Setup that raises exception."""
-            raise Exception('fail!')
-
-        loader.set_component('comp', MockModule('comp', setup=exception_setup))
-
-        assert not bootstrap.setup_component(self.hass, 'comp', {})
-        assert 'comp' not in self.hass.config.components
-
-    @mock.patch('homeassistant.bootstrap.async_enable_logging')
-    @mock.patch('homeassistant.bootstrap.async_register_signal_handling')
-    def test_home_assistant_core_config_validation(self, log_mock, sig_mock):
-        """Test if we pass in wrong information for HA conf."""
-        # Extensive HA conf validation testing is done in test_config.py
-        assert None is bootstrap.from_config_dict({
-            'homeassistant': {
-                'latitude': 'some string'
-            }
-        })
-
-    def test_component_setup_with_validation_and_dependency(self):
-        """Test all config is passed to dependencies."""
-        def config_check_setup(hass, config):
-            """Setup method that tests config is passed in."""
-            if config.get('comp_a', {}).get('valid', False):
-                return True
-            raise Exception('Config not passed in: {}'.format(config))
-
-        loader.set_component('comp_a',
-                             MockModule('comp_a', setup=config_check_setup))
-
-        loader.set_component('switch.platform_a', MockPlatform('comp_b',
-                                                               ['comp_a']))
-
-        bootstrap.setup_component(self.hass, 'switch', {
-            'comp_a': {
-                'valid': True
-            },
-            'switch': {
-                'platform': 'platform_a',
-            }
-        })
-        assert 'comp_a' in self.hass.config.components
-
-    def test_platform_specific_config_validation(self):
-        """Test platform that specifies config."""
-        platform_schema = PLATFORM_SCHEMA.extend({
-            'valid': True,
-        }, extra=vol.PREVENT_EXTRA)
-
-        mock_setup = mock.MagicMock(spec_set=True)
-
-        loader.set_component(
-            'switch.platform_a',
-            MockPlatform(platform_schema=platform_schema,
-                         setup_platform=mock_setup))
-
-        with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'switch', {
-                'switch': {
-                    'platform': 'platform_a',
-                    'invalid': True
-                }
-            })
-            assert mock_setup.call_count == 0
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-        self.hass.config.components.remove('switch')
-
-        with assert_setup_component(0):
-            assert bootstrap.setup_component(self.hass, 'switch', {
-                'switch': {
-                    'platform': 'platform_a',
-                    'valid': True,
-                    'invalid_extra': True,
-                }
-            })
-            assert mock_setup.call_count == 0
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-        self.hass.config.components.remove('switch')
-
-        with assert_setup_component(1):
-            assert bootstrap.setup_component(self.hass, 'switch', {
-                'switch': {
-                    'platform': 'platform_a',
-                    'valid': True
-                }
-            })
-            assert mock_setup.call_count == 1
-
-    def test_disable_component_if_invalid_return(self):
-        """Test disabling component if invalid return."""
-        loader.set_component(
-            'disabled_component',
-            MockModule('disabled_component', setup=lambda hass, config: None))
-
-        assert not bootstrap.setup_component(self.hass, 'disabled_component')
-        assert loader.get_component('disabled_component') is None
-        assert 'disabled_component' not in self.hass.config.components
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-        loader.set_component(
-            'disabled_component',
-            MockModule('disabled_component', setup=lambda hass, config: False))
-
-        assert not bootstrap.setup_component(self.hass, 'disabled_component')
-        assert loader.get_component('disabled_component') is not None
-        assert 'disabled_component' not in self.hass.config.components
-
-        self.hass.data.pop(bootstrap.DATA_SETUP)
-        loader.set_component(
-            'disabled_component',
-            MockModule('disabled_component', setup=lambda hass, config: True))
-
-        assert bootstrap.setup_component(self.hass, 'disabled_component')
-        assert loader.get_component('disabled_component') is not None
-        assert 'disabled_component' in self.hass.config.components
-
-    @mock.patch('homeassistant.bootstrap.async_register_signal_handling')
-    def test_all_work_done_before_start(self, signal_mock):
-        """Test all init work done till start."""
-        call_order = []
-
-        def component1_setup(hass, config):
-            """Setup mock component."""
-            discovery.discover(hass, 'test_component2',
-                               component='test_component2')
-            discovery.discover(hass, 'test_component3',
-                               component='test_component3')
-            return True
-
-        def component_track_setup(hass, config):
-            """Setup mock component."""
-            call_order.append(1)
-            return True
-
-        loader.set_component(
-            'test_component1',
-            MockModule('test_component1', setup=component1_setup))
-
-        loader.set_component(
-            'test_component2',
-            MockModule('test_component2', setup=component_track_setup))
-
-        loader.set_component(
-            'test_component3',
-            MockModule('test_component3', setup=component_track_setup))
-
-        @callback
-        def track_start(event):
-            """Track start event."""
-            call_order.append(2)
-
-        self.hass.bus.listen_once(EVENT_HOMEASSISTANT_START, track_start)
-
-        self.hass.add_job(bootstrap.async_setup_component(
-            self.hass, 'test_component1', {}))
-        self.hass.block_till_done()
-        self.hass.start()
-        assert call_order == [1, 1, 2]
+# prevent .HA_VERISON file from being written
+@patch(
+    'homeassistant.bootstrap.conf_util.process_ha_config_upgrade', Mock())
+@patch('homeassistant.util.location.detect_location_info',
+       Mock(return_value=None))
+@patch('homeassistant.bootstrap.async_register_signal_handling', Mock())
+@patch('os.path.isfile', Mock(return_value=True))
+@patch('os.access', Mock(return_value=True))
+@patch('homeassistant.bootstrap.async_enable_logging',
+       Mock(return_value=True))
+def test_from_config_file(hass):
+    """Test with configuration file."""
+    components = set(['browser', 'conversation', 'script'])
+    files = {
+        'config.yaml': ''.join('{}:\n'.format(comp) for comp in components)
+    }
+
+    with patch_yaml_files(files, True):
+        yield from bootstrap.async_from_config_file('config.yaml')
+
+    assert components == hass.config.components
 
 
 @asyncio.coroutine
-def test_component_cannot_depend_config(hass):
-    """Test config is not allowed to be a dependency."""
-    result = yield from bootstrap._async_process_dependencies(
-        hass, None, 'test', ['config'])
-    assert not result
+@patch('homeassistant.bootstrap.async_enable_logging', Mock())
+@patch('homeassistant.bootstrap.async_register_signal_handling', Mock())
+def test_home_assistant_core_config_validation(hass):
+    """Test if we pass in wrong information for HA conf."""
+    # Extensive HA conf validation testing is done
+    result = yield from bootstrap.async_from_config_dict({
+        'homeassistant': {
+            'latitude': 'some string'
+        }
+    }, hass)
+    assert result is None

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -5,9 +5,7 @@ import threading
 import unittest
 from unittest.mock import patch
 
-import homeassistant.core as ha
-import homeassistant.bootstrap as bootstrap
-import homeassistant.remote as remote
+from homeassistant import remote, setup, core as ha
 import homeassistant.components.http as http
 from homeassistant.const import HTTP_HEADER_HA_AUTH, EVENT_STATE_CHANGED
 import homeassistant.util.dt as dt_util
@@ -42,12 +40,12 @@ def setUpModule():
     hass.bus.listen('test_event', lambda _: _)
     hass.states.set('test.test', 'a_state')
 
-    bootstrap.setup_component(
+    setup.setup_component(
         hass, http.DOMAIN,
         {http.DOMAIN: {http.CONF_API_PASSWORD: API_PASSWORD,
                        http.CONF_SERVER_PORT: MASTER_PORT}})
 
-    bootstrap.setup_component(hass, 'api')
+    setup.setup_component(hass, 'api')
 
     hass.start()
 
@@ -64,7 +62,7 @@ def setUpModule():
     slave.async_track_tasks()
     slave.config.config_dir = get_test_config_dir()
     slave.config.skip_pip = True
-    bootstrap.setup_component(
+    setup.setup_component(
         slave, http.DOMAIN,
         {http.DOMAIN: {http.CONF_API_PASSWORD: API_PASSWORD,
                        http.CONF_SERVER_PORT: SLAVE_PORT}})

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,408 @@
+"""Test component/platform setup."""
+# pylint: disable=protected-access
+import asyncio
+import os
+from unittest import mock
+import threading
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.const import EVENT_HOMEASSISTANT_START
+import homeassistant.config as config_util
+from homeassistant import setup, loader
+import homeassistant.util.dt as dt_util
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
+from homeassistant.helpers import discovery
+
+from tests.common import \
+    get_test_home_assistant, MockModule, MockPlatform, \
+    assert_setup_component, get_test_config_dir
+
+ORIG_TIMEZONE = dt_util.DEFAULT_TIME_ZONE
+VERSION_PATH = os.path.join(get_test_config_dir(), config_util.VERSION_FILE)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TestSetup:
+    """Test the bootstrap utils."""
+
+    hass = None
+    backup_cache = None
+
+    # pylint: disable=invalid-name, no-self-use
+    def setup_method(self, method):
+        """Setup the test."""
+        self.hass = get_test_home_assistant()
+
+    def teardown_method(self, method):
+        """Clean up."""
+        self.hass.stop()
+
+        # if os.path.isfile(VERSION_PATH):
+        #     os.remove(VERSION_PATH)
+
+    def test_validate_component_config(self):
+        """Test validating component configuration."""
+        config_schema = vol.Schema({
+            'comp_conf': {
+                'hello': str
+            }
+        }, required=True)
+        loader.set_component(
+            'comp_conf', MockModule('comp_conf', config_schema=config_schema))
+
+        with assert_setup_component(0):
+            assert not setup.setup_component(self.hass, 'comp_conf', {})
+
+        self.hass.data.pop(setup.DATA_SETUP)
+
+        with assert_setup_component(0):
+            assert not setup.setup_component(self.hass, 'comp_conf', {
+                'comp_conf': None
+            })
+
+        self.hass.data.pop(setup.DATA_SETUP)
+
+        with assert_setup_component(0):
+            assert not setup.setup_component(self.hass, 'comp_conf', {
+                'comp_conf': {}
+            })
+
+        self.hass.data.pop(setup.DATA_SETUP)
+
+        with assert_setup_component(0):
+            assert not setup.setup_component(self.hass, 'comp_conf', {
+                'comp_conf': {
+                    'hello': 'world',
+                    'invalid': 'extra',
+                }
+            })
+
+        self.hass.data.pop(setup.DATA_SETUP)
+
+        with assert_setup_component(1):
+            assert setup.setup_component(self.hass, 'comp_conf', {
+                'comp_conf': {
+                    'hello': 'world',
+                }
+            })
+
+    def test_validate_platform_config(self):
+        """Test validating platform configuration."""
+        platform_schema = PLATFORM_SCHEMA.extend({
+            'hello': str,
+        })
+        loader.set_component(
+            'platform_conf',
+            MockModule('platform_conf', platform_schema=platform_schema))
+
+        loader.set_component(
+            'platform_conf.whatever', MockPlatform('whatever'))
+
+        with assert_setup_component(0):
+            assert setup.setup_component(self.hass, 'platform_conf', {
+                'platform_conf': {
+                    'hello': 'world',
+                    'invalid': 'extra',
+                }
+            })
+
+        self.hass.data.pop(setup.DATA_SETUP)
+        self.hass.config.components.remove('platform_conf')
+
+        with assert_setup_component(1):
+            assert setup.setup_component(self.hass, 'platform_conf', {
+                'platform_conf': {
+                    'platform': 'whatever',
+                    'hello': 'world',
+                },
+                'platform_conf 2': {
+                    'invalid': True
+                }
+            })
+
+        self.hass.data.pop(setup.DATA_SETUP)
+        self.hass.config.components.remove('platform_conf')
+
+        with assert_setup_component(0):
+            assert setup.setup_component(self.hass, 'platform_conf', {
+                'platform_conf': {
+                    'platform': 'not_existing',
+                    'hello': 'world',
+                }
+            })
+
+        self.hass.data.pop(setup.DATA_SETUP)
+        self.hass.config.components.remove('platform_conf')
+
+        with assert_setup_component(1):
+            assert setup.setup_component(self.hass, 'platform_conf', {
+                'platform_conf': {
+                    'platform': 'whatever',
+                    'hello': 'world',
+                }
+            })
+
+        self.hass.data.pop(setup.DATA_SETUP)
+        self.hass.config.components.remove('platform_conf')
+
+        with assert_setup_component(1):
+            assert setup.setup_component(self.hass, 'platform_conf', {
+                'platform_conf': [{
+                    'platform': 'whatever',
+                    'hello': 'world',
+                }]
+            })
+
+        self.hass.data.pop(setup.DATA_SETUP)
+        self.hass.config.components.remove('platform_conf')
+
+        # Any falsey platform config will be ignored (None, {}, etc)
+        with assert_setup_component(0) as config:
+            assert setup.setup_component(self.hass, 'platform_conf', {
+                'platform_conf': None
+            })
+            assert 'platform_conf' in self.hass.config.components
+            assert not config['platform_conf']  # empty
+
+            assert setup.setup_component(self.hass, 'platform_conf', {
+                'platform_conf': {}
+            })
+            assert 'platform_conf' in self.hass.config.components
+            assert not config['platform_conf']  # empty
+
+    def test_component_not_found(self):
+        """setup_component should not crash if component doesn't exist."""
+        assert not setup.setup_component(self.hass, 'non_existing')
+
+    def test_component_not_double_initialized(self):
+        """Test we do not setup a component twice."""
+        mock_setup = mock.MagicMock(return_value=True)
+
+        loader.set_component('comp', MockModule('comp', setup=mock_setup))
+
+        assert setup.setup_component(self.hass, 'comp')
+        assert mock_setup.called
+
+        mock_setup.reset_mock()
+
+        assert setup.setup_component(self.hass, 'comp')
+        assert not mock_setup.called
+
+    @mock.patch('homeassistant.util.package.install_package',
+                return_value=False)
+    def test_component_not_installed_if_requirement_fails(self, mock_install):
+        """Component setup should fail if requirement can't install."""
+        self.hass.config.skip_pip = False
+        loader.set_component(
+            'comp', MockModule('comp', requirements=['package==0.0.1']))
+
+        assert not setup.setup_component(self.hass, 'comp')
+        assert 'comp' not in self.hass.config.components
+
+    def test_component_not_setup_twice_if_loaded_during_other_setup(self):
+        """Test component setup while waiting for lock is not setup twice."""
+        result = []
+
+        @asyncio.coroutine
+        def async_setup(hass, config):
+            """Tracking Setup."""
+            result.append(1)
+
+        loader.set_component(
+            'comp', MockModule('comp', async_setup=async_setup))
+
+        def setup_component():
+            """Setup the component."""
+            setup.setup_component(self.hass, 'comp')
+
+        thread = threading.Thread(target=setup_component)
+        thread.start()
+        setup.setup_component(self.hass, 'comp')
+
+        thread.join()
+
+        assert len(result) == 1
+
+    def test_component_not_setup_missing_dependencies(self):
+        """Test we do not setup a component if not all dependencies loaded."""
+        deps = ['non_existing']
+        loader.set_component('comp', MockModule('comp', dependencies=deps))
+
+        assert not setup.setup_component(self.hass, 'comp', {})
+        assert 'comp' not in self.hass.config.components
+
+        self.hass.data.pop(setup.DATA_SETUP)
+
+        loader.set_component('non_existing', MockModule('non_existing'))
+        assert setup.setup_component(self.hass, 'comp', {})
+
+    def test_component_failing_setup(self):
+        """Test component that fails setup."""
+        loader.set_component(
+            'comp', MockModule('comp', setup=lambda hass, config: False))
+
+        assert not setup.setup_component(self.hass, 'comp', {})
+        assert 'comp' not in self.hass.config.components
+
+    def test_component_exception_setup(self):
+        """Test component that raises exception during setup."""
+        def exception_setup(hass, config):
+            """Setup that raises exception."""
+            raise Exception('fail!')
+
+        loader.set_component('comp', MockModule('comp', setup=exception_setup))
+
+        assert not setup.setup_component(self.hass, 'comp', {})
+        assert 'comp' not in self.hass.config.components
+
+    def test_component_setup_with_validation_and_dependency(self):
+        """Test all config is passed to dependencies."""
+        def config_check_setup(hass, config):
+            """Setup method that tests config is passed in."""
+            if config.get('comp_a', {}).get('valid', False):
+                return True
+            raise Exception('Config not passed in: {}'.format(config))
+
+        loader.set_component('comp_a',
+                             MockModule('comp_a', setup=config_check_setup))
+
+        loader.set_component('switch.platform_a', MockPlatform('comp_b',
+                                                               ['comp_a']))
+
+        setup.setup_component(self.hass, 'switch', {
+            'comp_a': {
+                'valid': True
+            },
+            'switch': {
+                'platform': 'platform_a',
+            }
+        })
+        assert 'comp_a' in self.hass.config.components
+
+    def test_platform_specific_config_validation(self):
+        """Test platform that specifies config."""
+        platform_schema = PLATFORM_SCHEMA.extend({
+            'valid': True,
+        }, extra=vol.PREVENT_EXTRA)
+
+        mock_setup = mock.MagicMock(spec_set=True)
+
+        loader.set_component(
+            'switch.platform_a',
+            MockPlatform(platform_schema=platform_schema,
+                         setup_platform=mock_setup))
+
+        with assert_setup_component(0):
+            assert setup.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'platform_a',
+                    'invalid': True
+                }
+            })
+            assert mock_setup.call_count == 0
+
+        self.hass.data.pop(setup.DATA_SETUP)
+        self.hass.config.components.remove('switch')
+
+        with assert_setup_component(0):
+            assert setup.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'platform_a',
+                    'valid': True,
+                    'invalid_extra': True,
+                }
+            })
+            assert mock_setup.call_count == 0
+
+        self.hass.data.pop(setup.DATA_SETUP)
+        self.hass.config.components.remove('switch')
+
+        with assert_setup_component(1):
+            assert setup.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'platform_a',
+                    'valid': True
+                }
+            })
+            assert mock_setup.call_count == 1
+
+    def test_disable_component_if_invalid_return(self):
+        """Test disabling component if invalid return."""
+        loader.set_component(
+            'disabled_component',
+            MockModule('disabled_component', setup=lambda hass, config: None))
+
+        assert not setup.setup_component(self.hass, 'disabled_component')
+        assert loader.get_component('disabled_component') is None
+        assert 'disabled_component' not in self.hass.config.components
+
+        self.hass.data.pop(setup.DATA_SETUP)
+        loader.set_component(
+            'disabled_component',
+            MockModule('disabled_component', setup=lambda hass, config: False))
+
+        assert not setup.setup_component(self.hass, 'disabled_component')
+        assert loader.get_component('disabled_component') is not None
+        assert 'disabled_component' not in self.hass.config.components
+
+        self.hass.data.pop(setup.DATA_SETUP)
+        loader.set_component(
+            'disabled_component',
+            MockModule('disabled_component', setup=lambda hass, config: True))
+
+        assert setup.setup_component(self.hass, 'disabled_component')
+        assert loader.get_component('disabled_component') is not None
+        assert 'disabled_component' in self.hass.config.components
+
+    def test_all_work_done_before_start(self):
+        """Test all init work done till start."""
+        call_order = []
+
+        def component1_setup(hass, config):
+            """Setup mock component."""
+            discovery.discover(hass, 'test_component2',
+                               component='test_component2')
+            discovery.discover(hass, 'test_component3',
+                               component='test_component3')
+            return True
+
+        def component_track_setup(hass, config):
+            """Setup mock component."""
+            call_order.append(1)
+            return True
+
+        loader.set_component(
+            'test_component1',
+            MockModule('test_component1', setup=component1_setup))
+
+        loader.set_component(
+            'test_component2',
+            MockModule('test_component2', setup=component_track_setup))
+
+        loader.set_component(
+            'test_component3',
+            MockModule('test_component3', setup=component_track_setup))
+
+        @callback
+        def track_start(event):
+            """Track start event."""
+            call_order.append(2)
+
+        self.hass.bus.listen_once(EVENT_HOMEASSISTANT_START, track_start)
+
+        self.hass.add_job(setup.async_setup_component(
+            self.hass, 'test_component1', {}))
+        self.hass.block_till_done()
+        self.hass.start()
+        assert call_order == [1, 1, 2]
+
+@asyncio.coroutine
+def test_component_cannot_depend_config(hass):
+    """Test config is not allowed to be a dependency."""
+    result = yield from setup._async_process_dependencies(
+        hass, None, 'test', ['config'])
+    assert not result

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -400,6 +400,7 @@ class TestSetup:
         self.hass.start()
         assert call_order == [1, 1, 2]
 
+
 @asyncio.coroutine
 def test_component_cannot_depend_config(hass):
     """Test config is not allowed to be a dependency."""


### PR DESCRIPTION
## Description:
This was long overdue - splitting of bootstrap into two files. One about bootstrapping hass from a config file and one for setting up individual components. It also makes it quite clear that we lack some test coverage.

Large number of files changes because `bootstrap.setup_component` -> `setup.setup_component`

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
