### PR TITLE
Http ban find yaml

### DIFF
--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from datetime import datetime
 from ipaddress import ip_address
 import logging
+import os
 
 from aiohttp.web_exceptions import HTTPForbidden, HTTPUnauthorized
 import voluptuous as vol
@@ -115,13 +116,14 @@ def load_ip_bans_config(path: str):
     """Loading list of banned IPs from config file."""
     ip_list = []
 
+    if not os.path.isfile(path):
+        return ip_list
+
     try:
         list_ = load_yaml_config_file(path)
-    except FileNotFoundError:
-        return []
     except HomeAssistantError as err:
         _LOGGER.error('Unable to load %s: %s', path, str(err))
-        return []
+        return ip_list
 
     for ip_ban, ip_info in list_.items():
         try:


### PR DESCRIPTION
## Description:
Instead of printing an error, we should silently ignore it when we get an IP ban. The code was already setup to handle the case but the exception was never raised by `load_yaml_config_file`

## Example entry for `configuration.yaml` (if applicable):
```yaml
frontend:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
