### PR TITLE
Better restore_state warnings

### DIFF
--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -52,10 +52,12 @@ def async_get_last_state(hass, entity_id: str):
     if DATA_RESTORE_CACHE in hass.data:
         return hass.data[DATA_RESTORE_CACHE].get(entity_id)
 
-    if (_RECORDER not in hass.config.components or
-            hass.state not in (CoreState.starting, CoreState.not_running)):
-        _LOGGER.error("Cache can only be loaded during startup, not %s",
-                      hass.state)
+    if _RECORDER not in hass.config.components:
+        return None
+
+    if hass.state not in (CoreState.starting, CoreState.not_running):
+        _LOGGER.debug("Cache for %s can only be loaded during startup, not %s",
+                      entity_id, hass.state)
         return None
 
     yield from wait_connection_ready(hass)
@@ -74,9 +76,9 @@ def async_get_last_state(hass, entity_id: str):
 @asyncio.coroutine
 def async_restore_state(entity, extract_info):
     """Helper to call entity.async_restore_state with cached info."""
-    if entity.hass.state != CoreState.starting:
-        _LOGGER.debug("Not restoring state: State is not starting: %s",
-                      entity.hass.state)
+    if entity.hass.state not in (CoreState.starting, CoreState.not_running):
+        _LOGGER.debug("Not restoring state for %s: Hass is not starting: %s",
+                      entity.entity_id, entity.hass.state)
         return
 
     state = yield from async_get_last_state(entity.hass, entity.entity_id)


### PR DESCRIPTION
## Description:
Restore state would give incorrect warnings:
 - It would warn that the HASS state was not correct if recorder was not loaded.
 - It would not always also allow `not_running` as a hass state
 - Don't print an error if an entity gets loaded after startup, it's not an error but a debug message.

## Example entry for `configuration.yaml` (if applicable):
```yaml
recorder:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
