### PR TITLE
Support scan_interval for LIFX lights

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -95,7 +95,7 @@ class LIFX(object):
             _LOGGER.debug("new bulb %s %s %d %d %d %d %d",
                           ipaddr, name, power, hue, sat, bri, kel)
             bulb = LIFXLight(self._liffylights, self.probe,
-                ipaddr, name, power, hue, sat, bri, kel)
+                             ipaddr, name, power, hue, sat, bri, kel)
             self._devices.append(bulb)
             self._add_devices_callback([bulb])
         else:
@@ -132,6 +132,7 @@ class LIFX(object):
         """Probe all lights."""
         self._liffylights.probe()
 
+
 def convert_rgb_to_hsv(rgb):
     """Convert Home Assistant RGB values to HSV values."""
     red, green, blue = [_ / BYTE_MAX for _ in rgb]
@@ -146,8 +147,8 @@ def convert_rgb_to_hsv(rgb):
 class LIFXLight(Light):
     """Representation of a LIFX light."""
 
-    def __init__(self, liffy, probe, ipaddr, name, power, hue, saturation, brightness,
-                 kelvin):
+    def __init__(self, liffy, probe, ipaddr, name, power,
+                 hue, saturation, brightness, kelvin):
         """Initialize the light."""
         _LOGGER.debug("LIFXLight: %s %s", ipaddr, name)
 

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/light.lifx/
 """
 import colorsys
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 
@@ -14,6 +15,7 @@ from homeassistant.components.light import (
     SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_RGB_COLOR,
     SUPPORT_TRANSITION, Light, PLATFORM_SCHEMA)
 from homeassistant.helpers.event import track_time_change
+import homeassistant.util as util
 from homeassistant.util.color import (
     color_temperature_mired_to_kelvin, color_temperature_kelvin_to_mired)
 import homeassistant.helpers.config_validation as cv
@@ -26,6 +28,9 @@ BYTE_MAX = 255
 
 CONF_BROADCAST = 'broadcast'
 CONF_SERVER = 'server'
+
+# liffylight packet timeout is 5s
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=6)
 
 SHORT_MAX = 65535
 
@@ -52,7 +57,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     lifx_library = LIFX(add_devices, server_addr, broadcast_addr)
 
     # Register our poll service
-    track_time_change(hass, lifx_library.poll, second=[10, 40])
+    track_time_change(hass, lifx_library.poll, second=[10])
 
     lifx_library.probe()
 
@@ -89,8 +94,8 @@ class LIFX(object):
         if bulb is None:
             _LOGGER.debug("new bulb %s %s %d %d %d %d %d",
                           ipaddr, name, power, hue, sat, bri, kel)
-            bulb = LIFXLight(
-                self._liffylights, ipaddr, name, power, hue, sat, bri, kel)
+            bulb = LIFXLight(self._liffylights, self.probe,
+                ipaddr, name, power, hue, sat, bri, kel)
             self._devices.append(bulb)
             self._add_devices_callback([bulb])
         else:
@@ -118,13 +123,14 @@ class LIFX(object):
 
     # pylint: disable=unused-argument
     def poll(self, now):
-        """Polling for the light."""
-        self.probe()
+        """Probe for the first light."""
+        if not self._devices:
+            self.probe()
 
-    def probe(self, address=None):
-        """Probe the light."""
-        self._liffylights.probe(address)
-
+    @util.Throttle(MIN_TIME_BETWEEN_SCANS)
+    def probe(self):
+        """Probe all lights."""
+        self._liffylights.probe()
 
 def convert_rgb_to_hsv(rgb):
     """Convert Home Assistant RGB values to HSV values."""
@@ -140,21 +146,17 @@ def convert_rgb_to_hsv(rgb):
 class LIFXLight(Light):
     """Representation of a LIFX light."""
 
-    def __init__(self, liffy, ipaddr, name, power, hue, saturation, brightness,
+    def __init__(self, liffy, probe, ipaddr, name, power, hue, saturation, brightness,
                  kelvin):
         """Initialize the light."""
         _LOGGER.debug("LIFXLight: %s %s", ipaddr, name)
 
         self._liffylights = liffy
+        self._probe = probe
         self._ip = ipaddr
         self.set_name(name)
         self.set_power(power)
         self.set_color(hue, saturation, brightness, kelvin)
-
-    @property
-    def should_poll(self):
-        """No polling needed for LIFX light."""
-        return False
 
     @property
     def name(self):
@@ -198,6 +200,10 @@ class LIFXLight(Light):
     def supported_features(self):
         """Flag supported features."""
         return SUPPORT_LIFX
+
+    def update(self):
+        """Update status by triggering a global probe."""
+        self._probe()
 
     def turn_on(self, **kwargs):
         """Turn the device on."""


### PR DESCRIPTION
## Description:

Several public configuration examples indicate that people expect scan_interval to work for LIFX, but it didn't.

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: lifx
    scan_interval: 10
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

This is already documented as working: https://home-assistant.io/docs/configuration/platform_options/


If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
