### PR TITLE
Use bundled certificates if port matches mqtts

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -9,6 +9,7 @@ import logging
 import os
 import socket
 import time
+import requests.certs
 
 import voluptuous as vol
 
@@ -312,7 +313,6 @@ def async_setup(hass, config):
 
     # When the port indicates mqtts, use bundled certificates from requests
     if certificate is None and port == 8883:
-        import requests.certs
         certificate = requests.certs.where()
 
     will_message = conf.get(CONF_WILL_MESSAGE)

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -310,6 +310,11 @@ def async_setup(hass, config):
         certificate = os.path.join(os.path.dirname(__file__),
                                    'addtrustexternalcaroot.crt')
 
+    # When the port indicates mqtts, use bundled certificates from requests
+    if certificate is None and port == 8883:
+        import requests.certs
+        certificate = requests.certs.where()
+
     will_message = conf.get(CONF_WILL_MESSAGE)
     birth_message = conf.get(CONF_BIRTH_MESSAGE)
 


### PR DESCRIPTION
## Description:

Whenever a certificate is not specified, but the port specified matches that of mqtts, use the bundled certificates from the requests library.

I have written (some) tests before, but I am fairly new to the python ecosystem in general. Any hints on how to add proper tests (especially since this project seems to be async) are welcome.

Configuration is not changed perse, rather accepts a default when the port hints a secure layer is desired.

**Related issue (if applicable):** fixes none

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
