### PR TITLE
Support StartTLS mail servers in IMAP sensors

### DIFF
--- a/homeassistant/components/sensor/imap.py
+++ b/homeassistant/components/sensor/imap.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME, CONF_PORT, CONF_USERNAME, CONF_PASSWORD, CONF_SSL)
+    CONF_NAME, CONF_PORT, CONF_USERNAME, CONF_PASSWORD)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,7 +27,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_SERVER): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_SSL): cv.boolean,
 })
 
 
@@ -37,8 +36,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                         config.get(CONF_USERNAME),
                         config.get(CONF_PASSWORD),
                         config.get(CONF_SERVER),
-                        config.get(CONF_PORT),
-                        config.get(CONF_SSL))
+                        config.get(CONF_PORT))
 
     if sensor.connection:
         add_devices([sensor])
@@ -49,14 +47,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class ImapSensor(Entity):
     """Representation of an IMAP sensor."""
 
-    def __init__(self, name, user, password, server, port, ssl):
+    def __init__(self, name, user, password, server, port):
         """Initialize the sensor."""
         self._name = name or user
         self._user = user
         self._password = password
         self._server = server
         self._port = port
-        self._ssl = (port == 993) if ssl is None else ssl
         self._unread_count = 0
         self.connection = self._login()
         self.update()
@@ -65,10 +62,7 @@ class ImapSensor(Entity):
         """Login and return an IMAP connection."""
         import imaplib
         try:
-            if self._ssl:
-                connection = imaplib.IMAP4_SSL(self._server, self._port)
-            else:
-                connection = imaplib.IMAP4(self._server, self._port)
+            connection = imaplib.IMAP4_SSL(self._server, self._port)
             connection.login(self._user, self._password)
             return connection
         except imaplib.IMAP4.error:

--- a/homeassistant/components/sensor/imap.py
+++ b/homeassistant/components/sensor/imap.py
@@ -62,7 +62,11 @@ class ImapSensor(Entity):
         """Login and return an IMAP connection."""
         import imaplib
         try:
-            connection = imaplib.IMAP4_SSL(self._server, self._port)
+            if self._port == DEFAULT_PORT:
+                connection = imaplib.IMAP4_SSL(self._server, self._port)
+            else:
+                connection = imaplib.IMAP4(self._server, self._port)
+                connection.starttls()
             connection.login(self._user, self._password)
             return connection
         except imaplib.IMAP4.error:

--- a/homeassistant/components/sensor/imap.py
+++ b/homeassistant/components/sensor/imap.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME, CONF_PORT, CONF_USERNAME, CONF_PASSWORD)
+    CONF_NAME, CONF_PORT, CONF_USERNAME, CONF_PASSWORD, CONF_SSL)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,6 +27,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_SERVER): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_SSL): cv.boolean,
 })
 
 
@@ -36,7 +37,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                         config.get(CONF_USERNAME),
                         config.get(CONF_PASSWORD),
                         config.get(CONF_SERVER),
-                        config.get(CONF_PORT))
+                        config.get(CONF_PORT),
+                        config.get(CONF_SSL))
 
     if sensor.connection:
         add_devices([sensor])
@@ -47,13 +49,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class ImapSensor(Entity):
     """Representation of an IMAP sensor."""
 
-    def __init__(self, name, user, password, server, port):
+    def __init__(self, name, user, password, server, port, ssl):
         """Initialize the sensor."""
         self._name = name or user
         self._user = user
         self._password = password
         self._server = server
         self._port = port
+        self._ssl = (port == 993) if ssl is None else ssl
         self._unread_count = 0
         self.connection = self._login()
         self.update()
@@ -62,7 +65,10 @@ class ImapSensor(Entity):
         """Login and return an IMAP connection."""
         import imaplib
         try:
-            connection = imaplib.IMAP4_SSL(self._server, self._port)
+            if self._ssl:
+                connection = imaplib.IMAP4_SSL(self._server, self._port)
+            else:
+                connection = imaplib.IMAP4(self._server, self._port)
             connection.login(self._user, self._password)
             return connection
         except imaplib.IMAP4.error:

--- a/homeassistant/components/sensor/imap_email_content.py
+++ b/homeassistant/components/sensor/imap_email_content.py
@@ -79,7 +79,11 @@ class EmailReader:
         """Login and setup the connection."""
         import imaplib
         try:
-            self.connection = imaplib.IMAP4_SSL(self._server, self._port)
+            if self._port == DEFAULT_PORT:
+                self.connection = imaplib.IMAP4_SSL(self._server, self._port)
+            else:
+                self.connection = imaplib.IMAP4(self._server, self._port)
+                self.connection.starttls()
             self.connection.login(self._user, self._password)
             return True
         except imaplib.IMAP4.error:


### PR DESCRIPTION
## Description:

Being able to disable SSL lets the imap sensor work with servers expecting STARTTLS.

If this is acceptable I will update the documentation and the imap_email_content sensor as well.

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: imap
    server: !secret mail_server
    port: 143
    username: !secret mail_username
    password: !secret mail_password
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
