### PR TITLE
Shorten recorder connection init

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -159,6 +159,8 @@ class Recorder(threading.Thread):
         connected = False
 
         while not connected and tries < 9:
+            if tries != 1:
+                time.sleep(CONNECT_RETRY_WAIT)
             try:
                 self._setup_connection()
                 migration.migrate_schema(self)
@@ -167,7 +169,6 @@ class Recorder(threading.Thread):
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.error("Error during connection setup: %s (retrying "
                               "in %s seconds)", err, CONNECT_RETRY_WAIT)
-                time.sleep(CONNECT_RETRY_WAIT)
                 tries += 1
 
         if not connected:

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -303,6 +303,9 @@ class Recorder(threading.Thread):
         else:
             kwargs['echo'] = False
 
+        if self.engine is not None:
+            self.engine.dispose()
+
         self.engine = create_engine(self.db_url, **kwargs)
         models.Base.metadata.create_all(self.engine)
         self.get_session = scoped_session(sessionmaker(bind=self.engine))

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -158,7 +158,7 @@ class Recorder(threading.Thread):
         tries = 1
         connected = False
 
-        while not connected and tries < 4:
+        while not connected and tries < 9:
             try:
                 self._setup_connection()
                 migration.migrate_schema(self)

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -43,8 +43,7 @@ DEFAULT_DB_FILE = 'home-assistant_v2.db'
 CONF_DB_URL = 'db_url'
 CONF_PURGE_DAYS = 'purge_days'
 
-CONNECT_RETRY_WAIT = 10
-ERROR_QUERY = "Error during query: %s"
+CONNECT_RETRY_WAIT = 3
 
 FILTER_SCHEMA = vol.Schema({
     vol.Optional(CONF_EXCLUDE, default={}): vol.Schema({
@@ -159,7 +158,7 @@ class Recorder(threading.Thread):
         tries = 1
         connected = False
 
-        while not connected and tries < 5:
+        while not connected and tries < 4:
             try:
                 self._setup_connection()
                 migration.migrate_schema(self)

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -158,7 +158,7 @@ class Recorder(threading.Thread):
         tries = 1
         connected = False
 
-        while not connected and tries < 9:
+        while not connected and tries <= 10:
             if tries != 1:
                 time.sleep(CONNECT_RETRY_WAIT)
             try:


### PR DESCRIPTION
## Description:
The old approach would wait up to 50 seconds for the recorder to come online… that is pretty intense. This new approach will try 3 times and wait 3 seconds between connections.

Which brings me to the next question, why even wait 3 seconds?

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
