### PR TITLE
Adds CPU temp monitoring, and allow startup when endpoint is not yet available.

### DIFF
--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -40,7 +40,8 @@ SENSOR_TYPES = {
     'process_running': ['Running', 'Count'],
     'process_total': ['Total', 'Count'],
     'process_thread': ['Thread', 'Count'],
-    'process_sleeping': ['Sleeping', 'Count']
+    'process_sleeping': ['Sleeping', 'Count'],
+    'cpu_temp': ['CPU Temp', '°'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -64,11 +65,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         response = requests.get(url, timeout=10)
         if not response.ok:
-            _LOGGER.error("Response status is '%s'", response.status_code)
-            return False
+            _LOGGER.warning("Response status is '%s'", response.status_code)
     except requests.exceptions.ConnectionError:
-        _LOGGER.error("No route to resource/endpoint: %s", url)
-        return False
+        _LOGGER.warning("No route to resource/endpoint: %s", url)
 
     rest = GlancesData(url)
 
@@ -142,6 +141,11 @@ class GlancesSensor(Entity):
                 return value['processcount']['thread']
             elif self.type == 'process_sleeping':
                 return value['processcount']['sleeping']
+            elif self.type == 'cpu_temp':
+                for sensor in value['sensors']:
+                    if sensor['label'] == 'CPU':
+                        return sensor['value']
+                return None
 
     def update(self):
         """Get the latest data from REST API."""
@@ -163,5 +167,5 @@ class GlancesData(object):
             response = requests.get(self._resource, timeout=10)
             self.data = response.json()
         except requests.exceptions.ConnectionError:
-            _LOGGER.error("No route to host/endpoint: %s", self._resource)
+            _LOGGER.warning("Error connecting to resource: %s", self._resource)
             self.data = None


### PR DESCRIPTION
## Description:

Added CPU temperature monitoring to glances sensor.

Removed the requirement that Glances is running when HA boots up. This kind of check is suitable for sensors, but maybe not so much for systems that can be turned on or off when HA starts. Replaced with a warning instead.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** 

https://github.com/home-assistant/home-assistant.github.io/pull/2205

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: glances
    name: Laptop Monitoring
    host: !secret laptop_ip
    resources:
      - 'cpu_temp'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

