### PR TITLE
Bumped openhomedevice version number

### DIFF
--- a/homeassistant/components/media_player/openhome.py
+++ b/homeassistant/components/media_player/openhome.py
@@ -14,7 +14,7 @@ from homeassistant.components.media_player import (
 from homeassistant.const import (
     STATE_IDLE, STATE_PAUSED, STATE_PLAYING, STATE_OFF)
 
-REQUIREMENTS = ['openhomedevice==0.2']
+REQUIREMENTS = ['openhomedevice==0.2.1']
 
 SUPPORT_OPENHOME = SUPPORT_SELECT_SOURCE | \
     SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET | \

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -365,7 +365,7 @@ oemthermostat==1.1
 openevsewifi==0.4
 
 # homeassistant.components.media_player.openhome
-openhomedevice==0.2
+openhomedevice==0.2.1
 
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1


### PR DESCRIPTION
## Description:

A bug in the support library resulted in some devices on older (popular) firmware not being able to control their volume through Home Assistant. The bug has been fixed and this bumps the version number of the `openhome` component to use that newer library. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
fixes #6450

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** Not Applicable

## Example entry for `configuration.yaml` (if applicable):
Not applicable

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.