### PR TITLE
Allow configurable conditions for Pi-Hole sensor

### DIFF
--- a/homeassistant/components/sensor/pi_hole.py
+++ b/homeassistant/components/sensor/pi_hole.py
@@ -43,7 +43,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
-    vol.Optional(CONF_MONITORED_CONDITIONS):
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=MONITORED_CONDITIONS):
         vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)]),
 })
 


### PR DESCRIPTION
## Description:

Currently, the Pi-Hole sensor only exposes the number of blocked ads as a sensor.  Other data like percentage of ads blocked is only available as an attribute.  I'd rather see the percentage and track that over time, and with these changes I can do just that.

![image](https://cloud.githubusercontent.com/assets/202034/23639929/55129b4a-02b8-11e7-91dd-6cc4152a4f67.png)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2211

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: pi_hole
    host: 192.168.1.13
    monitored_conditions:
      - dns_queries_today
      - ads_blocked_today
      - ads_percentage_today
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
