### PR TITLE
Upgrade netdisco to 0.9.2

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==0.9.1']
+REQUIREMENTS = ['netdisco==0.9.2']
 
 DOMAIN = 'discovery'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -368,7 +368,7 @@ mutagen==1.36.2
 myusps==1.0.3
 
 # homeassistant.components.discovery
-netdisco==0.9.1
+netdisco==0.9.2
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1


### PR DESCRIPTION
## Description:
Fixes discovery of Google Home/Cast and other mdns devices.
