### PR TITLE
Add warning for slow platforms/components

### DIFF
--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -4,7 +4,7 @@ import asyncio
 from collections import OrderedDict
 import logging
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, MagicMock
 from datetime import timedelta
 
 import homeassistant.core as ha
@@ -12,7 +12,7 @@ import homeassistant.loader as loader
 from homeassistant.components import group
 from homeassistant.helpers.entity import Entity, generate_entity_id
 from homeassistant.helpers.entity_component import (
-    EntityComponent, DEFAULT_SCAN_INTERVAL)
+    EntityComponent, DEFAULT_SCAN_INTERVAL, SLOW_SETUP_WARNING)
 
 from homeassistant.helpers import discovery
 import homeassistant.util.dt as dt_util
@@ -410,3 +410,31 @@ class TestHelpersEntityComponent(unittest.TestCase):
             return entity
 
         component.add_entities(create_entity(i) for i in range(2))
+
+
+@asyncio.coroutine
+def test_platform_warn_slow_setup(hass):
+    """Warn we log when platform setup takes a long time."""
+    platform = MockPlatform()
+
+    loader.set_component('test_domain.platform', platform)
+
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    mock_call_later = hass.loop.call_later = MagicMock()
+
+    yield from component.async_setup({
+        DOMAIN: {
+            'platform': 'platform',
+        }
+    })
+
+    assert mock_call_later.called
+    assert len(mock_call_later.mock_calls) == 2
+
+    timeout, logger_method = mock_call_later.mock_calls[0][1][:2]
+
+    assert timeout == SLOW_SETUP_WARNING
+    assert logger_method == _LOGGER.warning
+
+    assert mock_call_later().cancel.called

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -407,3 +407,20 @@ def test_component_cannot_depend_config(hass):
     result = yield from setup._async_process_dependencies(
         hass, None, 'test', ['config'])
     assert not result
+
+
+@asyncio.coroutine
+def test_component_warn_slow_setup(hass):
+    """Warn we log when a component setup takes a long time."""
+    loader.set_component('test_component1', MockModule('test_component1'))
+    mock_call_later = hass.loop.call_later = mock.MagicMock()
+    yield from setup.async_setup_component(hass, 'test_component1', {})
+    assert mock_call_later.called
+    assert len(mock_call_later.mock_calls) == 2
+
+    timeout, logger_method = mock_call_later.mock_calls[0][1][:2]
+
+    assert timeout == setup.SLOW_SETUP_WARNING
+    assert logger_method == setup._LOGGER.warning
+
+    assert mock_call_later().cancel.called


### PR DESCRIPTION
## Description:
Warn when a component or platform takes a long time to setup.

Just putting this out there for discussion.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
