### PR TITLE
Allow testing against uvloop

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -56,7 +56,6 @@ def get_test_home_assistant():
         # pylint: disable=protected-access
         loop._thread_ident = threading.get_ident()
         loop.run_forever()
-        loop.close()
         stop_event.set()
 
     orig_start = hass.start
@@ -73,6 +72,7 @@ def get_test_home_assistant():
         """Stop hass."""
         orig_stop()
         stop_event.wait()
+        loop.close()
 
     hass.start = start_hass
     hass.stop = stop_hass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Setup some common test helper things."""
+import asyncio
 import functools
 import logging
+import os
 from unittest.mock import patch
 
 import pytest
@@ -12,6 +14,10 @@ from homeassistant.components import mqtt
 
 from .common import async_test_home_assistant, mock_coro
 from .test_util.aiohttp import mock_aiohttp_client
+
+if os.environ.get('UVLOOP') == '1':
+    import uvloop
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 logging.basicConfig()
 logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)


### PR DESCRIPTION
## Description:
Allow testing against uvloop. ([uvloop is an asyncio event loop that's FAST](https://github.com/MagicStack/uvloop))

```
UVLOOP=1 py.test
```

On my Mac running Python 3.5.2:
 - Without UV loop: 72.54s
 - WIth UV loop: 70.76s

It might not be a big difference but it is good to ensure that we also run correctly under uvloop, as it's what we have running as the loop in our Docker.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
