### PR TITLE
Add dispatcher camera for internal image.

### DIFF
--- a/homeassistant/components/camera/dispatcher.py
+++ b/homeassistant/components/camera/dispatcher.py
@@ -50,10 +50,11 @@ class DispatcherCamera(Camera):
     def async_added_to_hass(self):
         """Register dispatcher and callbacks."""
         @callback
-        def update_image(image):
+        def async_update_image(image):
+            """Update image from dispatcher call."""
             self._image = image
 
-        async_dispatcher_connect(self.hass, self._signal, update_image)
+        async_dispatcher_connect(self.hass, self._signal, async_update_image)
 
     @asyncio.coroutine
     def async_camera_image(self):

--- a/homeassistant/components/camera/dispatcher.py
+++ b/homeassistant/components/camera/dispatcher.py
@@ -28,7 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-    """Setup a generic IP Camera."""
+    """Setup a dispatcher camera."""
     if discovery_info:
         config = PLATFORM_SCHEMA(discovery_info)
 

--- a/homeassistant/components/camera/dispatcher.py
+++ b/homeassistant/components/camera/dispatcher.py
@@ -21,7 +21,7 @@ CONF_SIGNAL = 'signal'
 DEFAULT_NAME = 'Dispatcher Camera'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_SINGAL): cv.slugify,
+    vol.Required(CONF_SIGNAL): cv.slugify,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
@@ -33,7 +33,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config = PLATFORM_SCHEMA(discovery_info)
 
     async_add_devices(
-        [DispatcherCamera(config[CONF_NAME], config[CONF_SINGAL])])
+        [DispatcherCamera(config[CONF_NAME], config[CONF_SIGNAL])])
 
 
 class DispatcherCamera(Camera):

--- a/homeassistant/components/camera/dispatcher.py
+++ b/homeassistant/components/camera/dispatcher.py
@@ -1,0 +1,66 @@
+"""
+Support for internal dispatcher image push to Camera.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/camera.dispatcher/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.const import CONF_NAME
+from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_SIGNAL = 'signal'
+DEFAULT_NAME = 'Dispatcher Camera'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SINGAL): cv.slugify,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Setup a generic IP Camera."""
+    if discovery_info:
+        config = PLATFORM_SCHEMA(discovery_info)
+
+    async_add_devices(
+        [DispatcherCamera(config[CONF_NAME], config[CONF_SINGAL])])
+
+
+class DispatcherCamera(Camera):
+    """A dispatcher implementation of an camera."""
+
+    def __init__(self, name, signal):
+        """Initialize a dispatcher camera."""
+        super().__init__()
+        self._name = name
+        self._signal = signal
+        self._image = None
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register dispatcher and callbacks."""
+        @callback
+        def update_image(image):
+            self._image = image
+
+        async_dispatcher_connect(self.hass, self._signal, update_image)
+
+    @asyncio.coroutine
+    def async_camera_image(self):
+        """Return a still image response from the camera."""
+        return self._image
+
+    @property
+    def name(self):
+        """Return the name of this device."""
+        return self._name

--- a/tests/components/camera/test_dispatcher.py
+++ b/tests/components/camera/test_dispatcher.py
@@ -1,0 +1,36 @@
+"""The tests for dispatcher camera component."""
+import asyncio
+
+from homeassistant.setup import async_setup_component
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+
+@asyncio.coroutine
+def test_run_camera_setup(hass, test_client):
+    """Test that it fetches the given dispatcher data."""
+    yield from async_setup_component(hass, 'camera', {
+        'camera': {
+            'platform': 'dispatcher',
+            'name': 'dispatcher',
+            'signal': 'test_camera',
+        }})
+
+    client = yield from test_client(hass.http.app)
+
+    async_dispatcher_send(hass, 'test_camera', b'test')
+    yield from hass.async_block_till_done()
+
+    resp = yield from client.get('/api/camera_proxy/camera.dispatcher')
+
+    assert resp.status == 200
+    body = yield from resp.text()
+    assert body == 'test'
+
+    async_dispatcher_send(hass, 'test_camera', b'test2')
+    yield from hass.async_block_till_done()
+
+    resp = yield from client.get('/api/camera_proxy/camera.dispatcher')
+
+    assert resp.status == 200
+    body = yield from resp.text()
+    assert body == 'test2'


### PR DESCRIPTION
## Description:

This is also for #6448 

It's a lightway and small overhead internal camera that is attach to dispatcher. That allow platform/component to make ouput without make here own quirk.

He is able to use with discovery.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
I think that would be only used with discovery.
```yaml
camera:
  platform: Dispatcher
  name: Face
  signal: blabla_bleble_signal
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
