### PR TITLE
Phone book lookup support for Fritz!Box call monitor

### DIFF
--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -15,7 +15,7 @@ from homeassistant.components.device_tracker import (
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['fritzconnection==0.6']
+REQUIREMENTS = ['fritzconnection==0.6.3']
 
 # Return cached results if last scan was less then this time ago.
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)

--- a/homeassistant/components/sensor/fritzbox_callmonitor.py
+++ b/homeassistant/components/sensor/fritzbox_callmonitor.py
@@ -9,13 +9,18 @@ import socket
 import threading
 import datetime
 import time
+import re
 
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_NAME)
+from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_NAME,
+                                 CONF_PASSWORD, CONF_USERNAME)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
+
+REQUIREMENTS = ['fritzconnection==0.6.3']
 
 _LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME = 'Phone'
@@ -30,10 +35,18 @@ VALUE_DISCONNECT = 'idle'
 
 INTERVAL_RECONNECT = 60
 
+# Return cached results if phonebook was downloaded less then this time ago.
+MIN_TIME_PHONEBOOK_UPDATE = datetime.timedelta(hours=6)
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_PASSWORD, default='admin'): cv.string,
+    vol.Optional(CONF_USERNAME, default=''): cv.string,
+    vol.Optional('phonebook', default=0): cv.positive_int,
+    vol.Optional('prefixes', default=[]): vol.All(cv.ensure_list,
+                                                  [cv.string])
 })
 
 
@@ -42,8 +55,24 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    phonebook_id = config.get('phonebook')
+    prefixes = config.get('prefixes')
 
-    sensor = FritzBoxCallSensor(name=name)
+    try:
+        phonebook = FritzBoxPhonebook(host=host, port=port,
+                                      username=username, password=password,
+                                      phonebook_id=phonebook_id,
+                                      prefixes=prefixes)
+    # pylint: disable=bare-except
+    except:
+        phonebook = None
+        _LOGGER.warning('Phonebook with ID '
+                        + str(phonebook_id)
+                        + ' not found on Fritz!Box')
+
+    sensor = FritzBoxCallSensor(name=name, phonebook=phonebook)
 
     add_devices([sensor])
 
@@ -59,11 +88,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class FritzBoxCallSensor(Entity):
     """Implementation of a Fritz!Box call monitor."""
 
-    def __init__(self, name):
+    def __init__(self, name, phonebook):
         """Initialize the sensor."""
         self._state = VALUE_DEFAULT
         self._attributes = {}
         self._name = name
+        self.phonebook = phonebook
 
     def set_state(self, state):
         """Set the state."""
@@ -75,8 +105,11 @@ class FritzBoxCallSensor(Entity):
 
     @property
     def should_poll(self):
-        """No polling needed."""
-        return False
+        """Polling needed only to update phonebook, if defined."""
+        if self.phonebook is None:
+            return False
+        else:
+            return True
 
     @property
     def state(self):
@@ -92,6 +125,18 @@ class FritzBoxCallSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         return self._attributes
+
+    def number_to_name(self, number):
+        """Return a name for a given phone number."""
+        if self.phonebook is None:
+            return 'unknown'
+        else:
+            return self.phonebook.get_name(number)
+
+    def update(self):
+        """Update the phonebook if it is defined."""
+        if self.phonebook is not None:
+            self.phonebook.update_phonebook()
 
 
 class FritzBoxCallMonitor(object):
@@ -152,6 +197,7 @@ class FritzBoxCallMonitor(object):
                    "to": line[4],
                    "device": line[5],
                    "initiated": isotime}
+            att["from_name"] = self._sensor.number_to_name(att["from"])
             self._sensor.set_attributes(att)
         elif line[1] == "CALL":
             self._sensor.set_state(VALUE_CALL)
@@ -160,13 +206,76 @@ class FritzBoxCallMonitor(object):
                    "to": line[5],
                    "device": line[6],
                    "initiated": isotime}
+            att["to_name"] = self._sensor.number_to_name(att["to"])
             self._sensor.set_attributes(att)
         elif line[1] == "CONNECT":
             self._sensor.set_state(VALUE_CONNECT)
             att = {"with": line[4], "device": [3], "accepted": isotime}
+            att["with_name"] = self._sensor.number_to_name(att["with"])
             self._sensor.set_attributes(att)
         elif line[1] == "DISCONNECT":
             self._sensor.set_state(VALUE_DISCONNECT)
             att = {"duration": line[3], "closed": isotime}
             self._sensor.set_attributes(att)
-        self._sensor.schedule_update_ha_state()
+        self._sensor.update_ha_state()
+
+
+class FritzBoxPhonebook(object):
+    """This connects to a FritzBox router and downloads its phone book."""
+
+    def __init__(self, host, port, username, password,
+                 phonebook_id=0, prefixes=None):
+        """Initialize the class."""
+        self.host = host
+        self.username = username
+        self.password = password
+        self.port = port
+        self.phonebook_id = phonebook_id
+        self.phonebook_dict = None
+        self.number_dict = None
+        if prefixes is not None:
+            self.prefixes = prefixes
+        else:
+            self.prefixes = []
+
+        # pylint: disable=import-error
+        import fritzconnection as fc
+        # Establish a connection to the FRITZ!Box.
+        self.fph = fc.FritzPhonebook(address=self.host,
+                                     user=self.username,
+                                     password=self.password)
+
+        if self.phonebook_id not in self.fph.list_phonebooks:
+            raise ValueError("Phonebook with this ID not found.")
+
+        self.update_phonebook()
+
+    @Throttle(MIN_TIME_PHONEBOOK_UPDATE)
+    def update_phonebook(self):
+        """Update the phone book dictionary."""
+        self.phonebook_dict = self.fph.get_all_names(self.phonebook_id)
+        self.number_dict = {re.sub(r'[^\d\+]', '', nr): name
+                            for name, nrs in self.phonebook_dict.items()
+                            for nr in nrs}
+        _LOGGER.info('Fritz!Box phone book successfully updated.')
+
+    def get_name(self, number):
+        """Return a name for a given phone number."""
+        number = re.sub(r'[^\d\+]', '', str(number))
+        if self.number_dict is None:
+            return 'unknown'
+        try:
+            return self.number_dict[number]
+        except KeyError:
+            pass
+        if self.prefixes:
+            for prefix in self.prefixes:
+                try:
+                    return self.number_dict[prefix + number]
+                except KeyError:
+                    pass
+                try:
+                    return self.number_dict[prefix + number.lstrip('0')]
+                except KeyError:
+                    pass
+        return 'unknown'

--- a/homeassistant/components/sensor/fritzbox_callmonitor.py
+++ b/homeassistant/components/sensor/fritzbox_callmonitor.py
@@ -40,6 +40,7 @@ INTERVAL_RECONNECT = 60
 
 # Return cached results if phonebook was downloaded less then this time ago.
 MIN_TIME_PHONEBOOK_UPDATE = datetime.timedelta(hours=6)
+SCAN_INTERVAL = datetime.timedelta(hours=3)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/homeassistant/components/sensor/fritzbox_callmonitor.py
+++ b/homeassistant/components/sensor/fritzbox_callmonitor.py
@@ -32,6 +32,8 @@ VALUE_RING = 'ringing'
 VALUE_CALL = 'dialing'
 VALUE_CONNECT = 'talking'
 VALUE_DISCONNECT = 'idle'
+CONF_PHONEBOOK = 'phonebook'
+CONF_PREFIXES = 'prefixes'
 
 INTERVAL_RECONNECT = 60
 
@@ -44,9 +46,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_PASSWORD, default='admin'): cv.string,
     vol.Optional(CONF_USERNAME, default=''): cv.string,
-    vol.Optional('phonebook', default=0): cv.positive_int,
-    vol.Optional('prefixes', default=[]): vol.All(cv.ensure_list,
-                                                  [cv.string])
+    vol.Optional(CONF_PHONEBOOK, default=0): cv.positive_int,
+    vol.Optional(CONF_PREFIXES, default=[]): vol.All(cv.ensure_list,
+                                                     [cv.string])
 })
 
 
@@ -68,9 +70,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     # pylint: disable=bare-except
     except:
         phonebook = None
-        _LOGGER.warning('Phonebook with ID '
-                        + str(phonebook_id)
-                        + ' not found on Fritz!Box')
+        _LOGGER.warning('Phonebook with ID %s not found on Fritz!Box',
+                        phonebook_id)
 
     sensor = FritzBoxCallSensor(name=name, phonebook=phonebook)
 
@@ -233,10 +234,7 @@ class FritzBoxPhonebook(object):
         self.phonebook_id = phonebook_id
         self.phonebook_dict = None
         self.number_dict = None
-        if prefixes is not None:
-            self.prefixes = prefixes
-        else:
-            self.prefixes = []
+        self.prefixes = prefixes or []
 
         # pylint: disable=import-error
         import fritzconnection as fc

--- a/homeassistant/components/sensor/fritzbox_netmonitor.py
+++ b/homeassistant/components/sensor/fritzbox_netmonitor.py
@@ -17,7 +17,7 @@ from homeassistant.util import Throttle
 
 from requests.exceptions import RequestException
 
-REQUIREMENTS = ['fritzconnection==0.6']
+REQUIREMENTS = ['fritzconnection==0.6.3']
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -164,8 +164,9 @@ flux_led==0.15
 freesms==0.1.1
 
 # homeassistant.components.device_tracker.fritz
+# homeassistant.components.sensor.fritzbox_callmonitor
 # homeassistant.components.sensor.fritzbox_netmonitor
-# fritzconnection==0.6
+# fritzconnection==0.6.3
 
 # homeassistant.components.switch.fritzdect
 fritzhome==1.0.2


### PR DESCRIPTION
## Description:

So far the call monitor only had the phone number of the caller/callee in the attributes. Having their name is great for all kinds of automations, e.g. notifications, TTS announcement ("John Doe is calling"), etc.
Unfortunately the call monitor itself doesn't expose the name. But the router's internal phone book can be accessed as XML document. Parsing this XML on state change is too slow if one wants to use it for fast notifications, so instead the new code downloads the phonebook every six hours and keeps it in a dictionary of the form `{number: name, ...}` in memory.

This feature adds `fritzconnection` version  0.6.3 as a dependency. It is based on a feature I contributed myself to this library; this is why I also had  to increment the `fritzconnection` dependency of the `fritz` and `fritzbox_netmonitor` components from 0.6 to 0.6.3 as well.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation: [#2216](https://github.com/home-assistant/home-assistant.github.io/pull/2216)

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
- platform: my_fritzbox_callmonitor
  username: my_user
  password: my_pw
  phonebook: 0
  prefixes:
    - '+49'
    - '+4989'
    - '089'
```

## Checklist:

  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
