### PR TITLE
Remove connection status state.

### DIFF
--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -152,9 +152,6 @@ def async_setup(hass, config):
     def connect():
         """Set up connection and hook it into HA for reconnect/shutdown."""
         _LOGGER.info('Initiating Rflink connection')
-        hass.states.async_set(
-            '{domain}.connection_status'.format(
-                domain=DOMAIN), 'connecting')
 
         # Rflink create_rflink_connection decides based on the value of host
         # (string or None) if serial or tcp mode should be used
@@ -180,9 +177,6 @@ def async_setup(hass, config):
             _LOGGER.exception(
                 "Error connecting to Rflink, reconnecting in %s",
                 reconnect_interval)
-            hass.states.async_set(
-                '{domain}.connection_status'.format(
-                    domain=DOMAIN), 'error')
             hass.loop.call_later(reconnect_interval, reconnect, exc)
             return
 
@@ -195,9 +189,6 @@ def async_setup(hass, config):
                                    lambda x: transport.close())
 
         _LOGGER.info('Connected to Rflink')
-        hass.states.async_set(
-            '{domain}.connection_status'.format(
-                domain=DOMAIN), 'connected')
 
     hass.async_add_job(connect)
     return True

--- a/tests/components/test_rflink.py
+++ b/tests/components/test_rflink.py
@@ -205,14 +205,10 @@ def test_error_when_not_connected(hass, monkeypatch):
     _, mock_create, _, disconnect_callback = yield from mock_rflink(
         hass, config, domain, monkeypatch, failures=failures)
 
-    assert hass.states.get('rflink.connection_status').state == 'connected'
-
     # rflink initiated disconnect
     disconnect_callback(None)
 
     yield from asyncio.sleep(0, loop=hass.loop)
-
-    assert hass.states.get('rflink.connection_status').state == 'error'
 
     success = yield from hass.services.async_call(
         domain, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: 'switch.test'})


### PR DESCRIPTION
Current implementation of connection status doesn't follow convention and is not properly configurable. Might be added again in the future as a full fledged entity or some other way.

For now users can rely on error logging to determine connection status.

