### PR TITLE
Added calendar default offset

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 import re
 
 from homeassistant.components.google import (CONF_OFFSET,
+                                             CONF_DEFAULT_OFFSET,
                                              CONF_DEVICE_ID,
                                              CONF_NAME)
 from homeassistant.const import STATE_OFF, STATE_ON
@@ -55,6 +56,7 @@ class CalendarEventDevice(Entity):
         self._name = data.get(CONF_NAME)
         self.dev_id = data.get(CONF_DEVICE_ID)
         self._offset = data.get(CONF_OFFSET, DEFAULT_CONF_OFFSET)
+        self._default_offset = time_period_str(data.get(CONF_DEFAULT_OFFSET, "00:00"))
         self.entity_id = generate_entity_id(ENTITY_ID_FORMAT,
                                             self.dev_id,
                                             hass=hass)
@@ -173,7 +175,7 @@ class CalendarEventDevice(Entity):
             summary = (summary[:search.start()] + summary[search.end():]) \
                 .strip()
         else:
-            offset_time = dt.dt.timedelta()  # default it
+            offset_time = self._default_offset
 
         # cleanup the string so we don't have a bunch of double+ spaces
         self._cal_data['message'] = re.sub('  +', '', summary).strip()

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -56,7 +56,8 @@ class CalendarEventDevice(Entity):
         self._name = data.get(CONF_NAME)
         self.dev_id = data.get(CONF_DEVICE_ID)
         self._offset = data.get(CONF_OFFSET, DEFAULT_CONF_OFFSET)
-        self._default_offset = time_period_str(data.get(CONF_DEFAULT_OFFSET, "00:00"))
+        self._default_offset = time_period_str(
+            data.get(CONF_DEFAULT_OFFSET, "00:00"))
         self.entity_id = generate_entity_id(ENTITY_ID_FORMAT,
                                             self.dev_id,
                                             hass=hass)

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -11,7 +11,7 @@ from datetime import timedelta
 import re
 
 from homeassistant.components.google import (CONF_OFFSET,
-                                             CONF_DEFAULT_OFFSET,
+                                             CONF_DEFAULT_OFFSET_TIME,
                                              CONF_DEVICE_ID,
                                              CONF_NAME)
 from homeassistant.const import STATE_OFF, STATE_ON
@@ -57,7 +57,7 @@ class CalendarEventDevice(Entity):
         self.dev_id = data.get(CONF_DEVICE_ID)
         self._offset = data.get(CONF_OFFSET, DEFAULT_CONF_OFFSET)
         self._default_offset = time_period_str(
-            data.get(CONF_DEFAULT_OFFSET, "00:00"))
+            data.get(CONF_DEFAULT_OFFSET_TIME, "00:00"))
         self.entity_id = generate_entity_id(ENTITY_ID_FORMAT,
                                             self.dev_id,
                                             hass=hass)

--- a/homeassistant/components/google.py
+++ b/homeassistant/components/google.py
@@ -45,6 +45,7 @@ CONF_ENTITIES = 'entities'
 CONF_TRACK = 'track'
 CONF_SEARCH = 'search'
 CONF_OFFSET = 'offset'
+CONF_DEFAULT_OFFSET = 'default_offset'
 
 DEFAULT_CONF_TRACK_NEW = True
 DEFAULT_CONF_OFFSET = '!!'
@@ -77,6 +78,7 @@ _SINGLE_CALSEARCH_CONFIG = vol.Schema({
     vol.Optional(CONF_TRACK): cv.boolean,
     vol.Optional(CONF_SEARCH): vol.Any(cv.string, None),
     vol.Optional(CONF_OFFSET): cv.string,
+    vol.Optional(CONF_DEFAULT_OFFSET): cv.string,
 })
 
 DEVICE_SCHEMA = vol.Schema({

--- a/homeassistant/components/google.py
+++ b/homeassistant/components/google.py
@@ -45,7 +45,7 @@ CONF_ENTITIES = 'entities'
 CONF_TRACK = 'track'
 CONF_SEARCH = 'search'
 CONF_OFFSET = 'offset'
-CONF_DEFAULT_OFFSET = 'default_offset'
+CONF_DEFAULT_OFFSET_TIME = 'default_offset_time'
 
 DEFAULT_CONF_TRACK_NEW = True
 DEFAULT_CONF_OFFSET = '!!'
@@ -78,7 +78,7 @@ _SINGLE_CALSEARCH_CONFIG = vol.Schema({
     vol.Optional(CONF_TRACK): cv.boolean,
     vol.Optional(CONF_SEARCH): vol.Any(cv.string, None),
     vol.Optional(CONF_OFFSET): cv.string,
-    vol.Optional(CONF_DEFAULT_OFFSET): cv.string,
+    vol.Optional(CONF_DEFAULT_OFFSET_TIME): cv.string,
 })
 
 DEVICE_SCHEMA = vol.Schema({


### PR DESCRIPTION
## Description:
Adds an optional default offset time to all events in the calendar.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `google_calendar.yaml`:
```yaml
- cal_id: "***************************@group.calendar.google.com"
  entities:
  - device_id: calendar
    name: My Calendar
    track: true
    default_offset_time: "-00:15" # Trigger events 15 minutes early
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

