### PR TITLE
[chore] Add uvloop test run to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
+    - python: "3.6"
+      env: TOXENV=uvloop
     - python: "3.6-dev"
       env: TOXENV=py36
   # allow_failures:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, lint, requirements, typing
+envlist = py34, py35, py36, lint, requirements, typing, uvloop
 skip_missing_interpreters = True
 
 [testenv]
@@ -37,3 +37,13 @@ deps =
      -r{toxinidir}/requirements_test.txt
 commands =
          mypy --silent-imports homeassistant
+
+[testenv:uvloop]
+basepython = python3
+deps =
+     uvloop
+     -r{toxinidir}/requirements_all.txt
+     -r{toxinidir}/requirements_test.txt
+setenv =
+     PYTHONPATH = {toxinidir}:{toxinidir}/homeassistant
+     UVLOOP=1


### PR DESCRIPTION
## Description:

uvloop support was recently added to the test suite, this runs it as part of the travis build and also includes an option to run it with tox.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
