### PR TITLE
Fix wake_on_lan ping for Linux.

### DIFF
--- a/homeassistant/components/switch/wake_on_lan.py
+++ b/homeassistant/components/switch/wake_on_lan.py
@@ -85,11 +85,11 @@ class WOLSwitch(SwitchDevice):
     def update(self):
         """Check if device is on and update the state."""
         if platform.system().lower() == 'windows':
-            ping_cmd = 'ping -n 1 -w {} {}'.format(
-                DEFAULT_PING_TIMEOUT * 1000, self._host)
+            ping_cmd = ['ping', '-n', '1', '-w',
+                        str(DEFAULT_PING_TIMEOUT * 1000), self._host]
         else:
-            ping_cmd = 'ping -c 1 -W {} {}'.format(
-                DEFAULT_PING_TIMEOUT, self._host)
+            ping_cmd = ['ping', '-c', '1', '-W',
+                        str(DEFAULT_PING_TIMEOUT), self._host]
 
         status = sp.call(ping_cmd, stdout=sp.DEVNULL)
         self._state = not bool(status)


### PR DESCRIPTION
## Description:
This time the ping command should work both on Windows and Linux.

**Related issue (if applicable):** fixes #6397  

