### PR TITLE
Don't always asume manufacturername is present

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -379,7 +379,7 @@ class HueLight(Light):
             command['transitiontime'] = int(kwargs[ATTR_TRANSITION] * 10)
 
         if ATTR_XY_COLOR in kwargs:
-            if self.info['manufacturername'] == "OSRAM":
+            if self.info.get('manufacturername') == "OSRAM":
                 hsv = color_util.color_xy_brightness_to_hsv(
                     *kwargs[ATTR_XY_COLOR],
                     ibrightness=self.info['bri'])
@@ -389,7 +389,7 @@ class HueLight(Light):
             else:
                 command['xy'] = kwargs[ATTR_XY_COLOR]
         elif ATTR_RGB_COLOR in kwargs:
-            if self.info['manufacturername'] == "OSRAM":
+            if self.info.get('manufacturername') == "OSRAM":
                 hsv = color_util.color_RGB_to_hsv(
                     *(int(val) for val in kwargs[ATTR_RGB_COLOR]))
                 command['hue'] = hsv[0]
@@ -426,7 +426,7 @@ class HueLight(Light):
             command['hue'] = random.randrange(0, 65535)
             command['sat'] = random.randrange(150, 254)
         elif self.bridge_type == 'hue':
-            if self.info['manufacturername'] != "OSRAM":
+            if self.info.get('manufacturername') != "OSRAM":
                 command['effect'] = 'none'
 
         self._command_func(self.light_id, command)


### PR DESCRIPTION
## Description:
@Thundergreen reported the following log in the chat:

```
Mar 08 07:34:26 home-assistant hass[4000]: File "/srv/hass/hass_venv/lib/python3.4/site-packages/homeassistant/components/light/hue.py", line 392, in turn_on
Mar 08 07:34:26 home-assistant hass[4000]: if self.info['manufacturername'] == "OSRAM":
Mar 08 07:34:26 home-assistant hass[4000]: KeyError: 'manufacturername'
```

Not sure when and how manufacturname is available but changing it to a `get` so it won't blow up.
