### PR TITLE
Bugfix mqtt socket memory error

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -331,18 +331,11 @@ def async_setup(hass, config):
     @asyncio.coroutine
     def async_stop_mqtt(event):
         """Stop MQTT component."""
-        yield from hass.data[DATA_MQTT].async_stop()
+        yield from hass.data[DATA_MQTT].async_disconnect()
 
-    @asyncio.coroutine
-    def async_start_mqtt(event):
-        """Launch MQTT component when Home Assistant starts up."""
-        yield from hass.data[DATA_MQTT].async_start()
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_mqtt)
-
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, async_start_mqtt)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_mqtt)
 
     success = yield from hass.data[DATA_MQTT].async_connect()
-
     if not success:
         return False
 
@@ -442,13 +435,12 @@ class MQTT(object):
         with (yield from self._paho_lock):
             yield from self.hass.loop.run_in_executor(
                 None, self._mqttc.publish, topic, payload, qos, retain)
-            yield from asyncio.sleep(0, loop=self.hass.loop)
 
     @asyncio.coroutine
     def async_connect(self):
-        """Connect to the host. Does not process messages yet.
+        """Connect to the host. Does process messages yet.
 
-        This method must be run in the event loop and returns a coroutine.
+        This method is a coroutine.
         """
         result = yield from self.hass.loop.run_in_executor(
             None, self._mqttc.connect, self.broker, self.port, self.keepalive)
@@ -456,17 +448,12 @@ class MQTT(object):
         if result != 0:
             import paho.mqtt.client as mqtt
             _LOGGER.error('Failed to connect: %s', mqtt.error_string(result))
+        else:
+            self._mqttc.loop_start()
 
         return not result
 
-    def async_start(self):
-        """Run the MQTT client.
-
-        This method must be run in the event loop and returns a coroutine.
-        """
-        return self.hass.loop.run_in_executor(None, self._mqttc.loop_start)
-
-    def async_stop(self):
+    def async_disconnect(self):
         """Stop the MQTT client.
 
         This method must be run in the event loop and returns a coroutine.
@@ -493,7 +480,6 @@ class MQTT(object):
 
             result, mid = yield from self.hass.loop.run_in_executor(
                 None, self._mqttc.subscribe, topic, qos)
-            yield from asyncio.sleep(0, loop=self.hass.loop)
 
             _raise_on_error(result)
             self.progress[mid] = topic

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -23,8 +23,8 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.util.async import (
     run_coroutine_threadsafe, run_callback_threadsafe)
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, CONF_VALUE_TEMPLATE,
-    CONF_USERNAME, CONF_PASSWORD, CONF_PORT, CONF_PROTOCOL, CONF_PAYLOAD)
+    EVENT_HOMEASSISTANT_STOP, CONF_VALUE_TEMPLATE, CONF_USERNAME,
+    CONF_PASSWORD, CONF_PORT, CONF_PROTOCOL, CONF_PAYLOAD)
 from homeassistant.components.mqtt.server import HBMQTT_CONFIG_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -51,7 +51,7 @@ def async_dispatcher_connect(hass, signal, target):
 
 def dispatcher_send(hass, signal, *args):
     """Send signal and data."""
-    hass.add_job(async_dispatcher_send, hass, signal, *args)
+    hass.loop.call_soon_threadsafe(async_dispatcher_send, hass, signal, *args)
 
 
 @callback

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -59,7 +59,7 @@ class TestMQTT(unittest.TestCase):
         """"Test if client start on HA launch."""
         self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
         self.hass.block_till_done()
-        self.assertTrue(self.hass.data['mqtt'].async_start.called)
+        self.assertTrue(self.hass.data['mqtt'].async_connect.called)
 
     def test_client_stops_on_home_assistant_start(self):
         """Test if client stops on HA launch."""

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -11,8 +11,7 @@ from homeassistant.core import callback
 from homeassistant.setup import setup_component, async_setup_component
 import homeassistant.components.mqtt as mqtt
 from homeassistant.const import (
-    EVENT_CALL_SERVICE, ATTR_DOMAIN, ATTR_SERVICE, EVENT_HOMEASSISTANT_START,
-    EVENT_HOMEASSISTANT_STOP)
+    EVENT_CALL_SERVICE, ATTR_DOMAIN, ATTR_SERVICE, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from tests.common import (

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -55,19 +55,15 @@ class TestMQTT(unittest.TestCase):
         """Helper for recording calls."""
         self.calls.append(args)
 
-    def test_client_starts_on_home_assistant_start(self):
-        """"Test if client start on HA launch."""
-        self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
-        self.hass.block_till_done()
-        self.assertTrue(self.hass.data['mqtt'].async_connect.called)
+    def test_client_starts_on_home_assistant_mqtt_setup(self):
+        """Test if client is connect after mqtt init on bootstrap."""
+        assert self.hass.data['mqtt'].async_connect.called
 
     def test_client_stops_on_home_assistant_start(self):
         """Test if client stops on HA launch."""
-        self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
-        self.hass.block_till_done()
         self.hass.bus.fire(EVENT_HOMEASSISTANT_STOP)
         self.hass.block_till_done()
-        self.assertTrue(self.hass.data['mqtt'].async_stop.called)
+        self.assertTrue(self.hass.data['mqtt'].async_disconnect.called)
 
     def test_publish_calls_service(self):
         """Test the publishing of call to services."""


### PR DESCRIPTION
## Description:

```
'Error talking to MQTT: {}'.format(mqtt.error_string(result)))
homeassistant.exceptions.HomeAssistantError: Error talking to MQTT: Out of memory.
```

The problem is OS/hardware network driver depend. I.e. on Raspberry can fix it with `rpi-update` and `apt-get update/upgrade`. But it also depend if we use publish inside bootstrap or try to process data. Also look like that some linux kernel versions are more affected with it. With last Firmware and Linux kernel for rpi, I don't see it anymore. But I think we need fix it on software. 

The only way is to process data from socket cache bevor he going out of memory.

**Thansk** for all tester they help to find out this problem :+1: 

**Related issue (if applicable):** fixes #6247 #6292

Anyone they affected with it, please try this patch and help to make the right fix.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
