### PR TITLE
more moon states

### DIFF
--- a/homeassistant/components/sensor/moon.py
+++ b/homeassistant/components/sensor/moon.py
@@ -53,14 +53,22 @@ class MoonSensor(Entity):
     @property
     def state(self):
         """Return the state of the device."""
-        if self._state >= 21:
-            return 'Last quarter'
-        elif self._state >= 14:
-            return 'Full moon'
-        elif self._state >= 7:
-            return 'First quarter'
-        else:
+        if self._state == 0:
             return 'New moon'
+        elif self._state < 7:
+            return 'Waxing crescent'
+        elif self._state == 7:
+            return 'First quarter'
+        elif self._state < 14:
+            return 'Waxing gibbous'
+        elif self._state == 14:
+            return 'Full moon'
+        elif self._state < 21:
+            return 'Waning gibbous'
+        elif self._state == 21:
+            return 'Last quarter'
+        else:
+            return 'Waning crescent'
 
     @property
     def icon(self):

--- a/tests/components/sensor/test_moon.py
+++ b/tests/components/sensor/test_moon.py
@@ -37,7 +37,7 @@ class TestMoonSensor(unittest.TestCase):
         assert setup_component(self.hass, 'sensor', config)
 
         state = self.hass.states.get('sensor.moon_day1')
-        self.assertEqual(state.state, 'New moon')
+        self.assertEqual(state.state, 'Waxing crescent')
 
     @patch('homeassistant.components.sensor.moon.dt_util.utcnow',
            return_value=DAY2)
@@ -53,4 +53,4 @@ class TestMoonSensor(unittest.TestCase):
         assert setup_component(self.hass, 'sensor', config)
 
         state = self.hass.states.get('sensor.moon_day2')
-        self.assertEqual(state.state, 'Full moon')
+        self.assertEqual(state.state, 'Waning gibbous')


### PR DESCRIPTION
## Description:
Add some moon states. Prior to this change, a technically inaccurate state was reported. This is a breaking change if people were relying on improper states.


## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: moon
```

## Checklist:


If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
