### PR TITLE
Bugfix android camera autodiscovery settings

### DIFF
--- a/homeassistant/components/android_ip_webcam.py
+++ b/homeassistant/components/android_ip_webcam.py
@@ -202,11 +202,11 @@ def async_setup(hass, config):
                     "Android webcam %s not found for discovery!", host)
                 return
 
-            sensors = cam.enabled_sensors
-            switches = cam.enabled_settings
-            if 'motion_active' in sensors:
-                sensors.pop('motion_active')
-                motion = True
+            sensors = [sensor for sensor in cam.enabled_sensors
+                       if sensor in SENSORS]
+            switches = [setting for setting in cam.enabled_settings
+                        if setting in SWITCHES]
+            motion = True if 'motion_active' in cam.enabled_sensors else False
 
         # load platforms
         webcams[host] = cam


### PR DESCRIPTION
## Description:

I see that in some case it have settings they we not support on UI with switch.

Fix a bug from #6488 

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
