### PR TITLE
Use sqlite's WAL mode to avoid `database is locked` errors

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -299,12 +299,13 @@ class Recorder(threading.Thread):
 
         @event.listens_for(Engine, "connect")
         def set_sqlite_pragma(dbapi_connection, connection_record):
-            old_isolation = dbapi_connection.isolation_level
-            dbapi_connection.isolation_level = None
-            cursor = dbapi_connection.cursor()
-            cursor.execute("PRAGMA journal_mode=WAL")
-            cursor.close()
-            dbapi_connection.isolation_level = old_isolation
+            if self.db_url.startswith("sqlite://"):
+                old_isolation = dbapi_connection.isolation_level
+                dbapi_connection.isolation_level = None
+                cursor = dbapi_connection.cursor()
+                cursor.execute("PRAGMA journal_mode=WAL")
+                cursor.close()
+                dbapi_connection.isolation_level = old_isolation
 
         if self.db_url == 'sqlite://' or ':memory:' in self.db_url:
             from sqlalchemy.pool import StaticPool

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -296,8 +296,10 @@ class Recorder(threading.Thread):
 
         kwargs = {}
 
+        # pylint: disable=unused-variable
         @event.listens_for(Engine, "connect")
         def set_sqlite_pragma(dbapi_connection, connection_record):
+            """Set sqlite's WAL mode."""
             if self.db_url.startswith("sqlite://"):
                 old_isolation = dbapi_connection.isolation_level
                 dbapi_connection.isolation_level = None

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -287,15 +287,14 @@ class Recorder(threading.Thread):
 
     def _setup_connection(self):
         """Ensure database is ready to fly."""
-        from sqlalchemy import create_engine
+        from sqlalchemy import create_engine, event
+        from sqlalchemy.engine import Engine
         from sqlalchemy.orm import scoped_session
         from sqlalchemy.orm import sessionmaker
+
         from . import models
 
         kwargs = {}
-
-        from sqlalchemy.engine import Engine
-        from sqlalchemy import event
 
         @event.listens_for(Engine, "connect")
         def set_sqlite_pragma(dbapi_connection, connection_record):

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -294,6 +294,18 @@ class Recorder(threading.Thread):
 
         kwargs = {}
 
+        from sqlalchemy.engine import Engine
+        from sqlalchemy import event
+
+        @event.listens_for(Engine, "connect")
+        def set_sqlite_pragma(dbapi_connection, connection_record):
+            old_isolation = dbapi_connection.isolation_level
+            dbapi_connection.isolation_level = None
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.close()
+            dbapi_connection.isolation_level = old_isolation
+
         if self.db_url == 'sqlite://' or ':memory:' in self.db_url:
             from sqlalchemy.pool import StaticPool
 


### PR DESCRIPTION
Sending PR to help prompt discussion hopefully, likely still a WIP (due to my lack of in-depth knowledge in the area).

- Relevant issue: https://github.com/home-assistant/home-assistant/issues/4780

Code:

- http://stackoverflow.com/a/23661501/1588795
- http://docs.sqlalchemy.org/en/rel_0_9/dialects/sqlite.html#foreign-key-support
- https://github.com/g2p/bedup/pull/86/files

## Description:

Try using sqlite `WAL` mode to fix "database is locked" errors. Please see: https://github.com/home-assistant/home-assistant/issues/4780#issuecomment-282592963

`(sqlite3.OperationalError) database is locked` is [a common error](https://github.com/home-assistant/home-assistant/issues?utf8=✓&q=is%3Aissue%20database%20is%20locked encountered by HomeAssistant newbies using devices like Raspberry Pi. 

`WAL` mode [helps facilitate simultaneous read and write](https://www.sqlite.org/wal.html) for simple sqlite databases which seems to help alleviate this error. The major drawback to this mode seems to be its requirement for a relatively recent version of sqlite, which seems to be satisfied on a standard Raspbian Jessie / Python 3.4 setup:

```shell_session
$ python3.4 -c 'import sqlite3; print(sqlite3.sqlite_version)'
3.8.7.1
```

**Related issue (if applicable):** fixes #4780

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.