### PR TITLE
Rflink: added support for lights with toggle type

### DIFF
--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -269,7 +269,7 @@ class ToggleRflinkLight(SwitchableRflinkDevice, Light):
         if command == 'on':
             # if the state is unknown or false, it gets set as true
             # if the state is true, it gets set as false
-            self._state = self._state is (STATE_UNKNOWN or False)
+            self._state = self._state in [STATE_UNKNOWN, False]
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -24,6 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 TYPE_DIMMABLE = 'dimmable'
 TYPE_SWITCHABLE = 'switchable'
 TYPE_HYBRID = 'hybrid'
+TYPE_TOGGLE = 'toggle'
 
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): DOMAIN,
@@ -35,7 +36,7 @@ PLATFORM_SCHEMA = vol.Schema({
         cv.string: {
             vol.Optional(CONF_NAME): cv.string,
             vol.Optional(CONF_TYPE):
-                vol.Any(TYPE_DIMMABLE, TYPE_SWITCHABLE, TYPE_HYBRID),
+                vol.Any(TYPE_DIMMABLE, TYPE_SWITCHABLE, TYPE_HYBRID, TYPE_TOGGLE),
             vol.Optional(CONF_ALIASSES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
@@ -73,6 +74,9 @@ def entity_class_for_type(entity_type):
         # sends 'dim' and 'on' command to support both dimmers and on/off
         # switches. Not compatible with signal repetition.
         TYPE_HYBRID: HybridRflinkLight,
+        # sends only 'on' commands for switches which turn on and off
+        # using the same 'on' command for both.
+        TYPE_TOGGLE: ToggleRflinkLight,
     }
 
     return entity_device_mapping.get(entity_type, RflinkLight)
@@ -240,3 +244,36 @@ class HybridRflinkLight(SwitchableRflinkDevice, Light):
     def supported_features(self):
         """Flag supported features."""
         return SUPPORT_BRIGHTNESS
+
+
+class ToggleRflinkLight(SwitchableRflinkDevice, Light):
+    """Rflink light device which sends out only 'on' commands.
+    
+    Some switches like for example Livolo light switches use the
+    same 'on' command to switch on and switch off the lights.
+    If the light is on and 'on' gets sent, the light will turn off
+    and if the light is off and 'on' gets sent, the light will turn on.
+    """
+
+    @property
+    def entity_id(self):
+        """Return entity id."""
+        return "light.{}".format(self.name)
+
+    def _handle_event(self, event):
+        """Adjust state if Rflink picks up a remote command for this device."""
+        self.cancel_queued_send_commands()
+
+        command = event['command']
+        if command == 'on':
+            self._state = not self._state
+
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        yield from self._async_handle_command('toggle')
+
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
+        """Turn the device off."""
+        yield from self._async_handle_command('toggle')

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -36,7 +36,8 @@ PLATFORM_SCHEMA = vol.Schema({
         cv.string: {
             vol.Optional(CONF_NAME): cv.string,
             vol.Optional(CONF_TYPE):
-                vol.Any(TYPE_DIMMABLE, TYPE_SWITCHABLE, TYPE_HYBRID, TYPE_TOGGLE),
+                vol.Any(TYPE_DIMMABLE, TYPE_SWITCHABLE,
+                        TYPE_HYBRID, TYPE_TOGGLE),
             vol.Optional(CONF_ALIASSES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
@@ -248,7 +249,7 @@ class HybridRflinkLight(SwitchableRflinkDevice, Light):
 
 class ToggleRflinkLight(SwitchableRflinkDevice, Light):
     """Rflink light device which sends out only 'on' commands.
-    
+
     Some switches like for example Livolo light switches use the
     same 'on' command to switch on and switch off the lights.
     If the light is on and 'on' gets sent, the light will turn off

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -267,10 +267,9 @@ class ToggleRflinkLight(SwitchableRflinkDevice, Light):
 
         command = event['command']
         if command == 'on':
-            if self._state is (STATE_UNKNOWN or False):
-                self._state = True
-            else:
-                self._state = False
+            # if the state is unknown or false, it gets set as true
+            # if the state is true, it gets set as false
+            self._state = self._state is (STATE_UNKNOWN or False)
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -15,8 +15,8 @@ from homeassistant.components.rflink import (
     CONF_IGNORE_DEVICES, CONF_NEW_DEVICES_GROUP, CONF_SIGNAL_REPETITIONS,
     DATA_DEVICE_REGISTER, DATA_ENTITY_LOOKUP, DEVICE_DEFAULTS_SCHEMA, DOMAIN,
     EVENT_KEY_COMMAND, EVENT_KEY_ID, SwitchableRflinkDevice, cv, vol)
-from homeassistant.const import CONF_NAME, CONF_PLATFORM, CONF_TYPE, STATE_UNKNOWN
-
+from homeassistant.const import (
+    CONF_NAME, CONF_PLATFORM, CONF_TYPE, STATE_UNKNOWN)
 DEPENDENCIES = ['rflink']
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -15,7 +15,7 @@ from homeassistant.components.rflink import (
     CONF_IGNORE_DEVICES, CONF_NEW_DEVICES_GROUP, CONF_SIGNAL_REPETITIONS,
     DATA_DEVICE_REGISTER, DATA_ENTITY_LOOKUP, DEVICE_DEFAULTS_SCHEMA, DOMAIN,
     EVENT_KEY_COMMAND, EVENT_KEY_ID, SwitchableRflinkDevice, cv, vol)
-from homeassistant.const import CONF_NAME, CONF_PLATFORM, CONF_TYPE
+from homeassistant.const import CONF_NAME, CONF_PLATFORM, CONF_TYPE, STATE_UNKNOWN
 
 DEPENDENCIES = ['rflink']
 
@@ -267,7 +267,10 @@ class ToggleRflinkLight(SwitchableRflinkDevice, Light):
 
         command = event['command']
         if command == 'on':
-            self._state = not self._state
+            if self._state is (STATE_UNKNOWN or False):
+                self._state = True
+            else:
+                self._state = False
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -317,6 +317,10 @@ class RflinkCommand(RflinkDevice):
             cmd = str(int(args[0] / 17))
             self._state = True
 
+        elif command == 'toggle':
+            cmd = 'on'
+            self._state = not self._state
+
         # Send initial command and queue repetitions.
         # This allows the entity state to be updated quickly and not having to
         # wait for all repetitions to be sent

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -321,7 +321,7 @@ class RflinkCommand(RflinkDevice):
             cmd = 'on'
             # if the state is unknown or false, it gets set as true
             # if the state is true, it gets set as false
-            self._state = self._state is (STATE_UNKNOWN or False)
+            self._state = self._state in [STATE_UNKNOWN, False]
 
         # Send initial command and queue repetitions.
         # This allows the entity state to be updated quickly and not having to

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -319,10 +319,9 @@ class RflinkCommand(RflinkDevice):
 
         elif command == 'toggle':
             cmd = 'on'
-            if self._state is (STATE_UNKNOWN or False):
-                self._state = True
-            else:
-                self._state = False
+            # if the state is unknown or false, it gets set as true
+            # if the state is true, it gets set as false
+            self._state = self._state is (STATE_UNKNOWN or False)
 
         # Send initial command and queue repetitions.
         # This allows the entity state to be updated quickly and not having to

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -319,7 +319,10 @@ class RflinkCommand(RflinkDevice):
 
         elif command == 'toggle':
             cmd = 'on'
-            self._state = not self._state
+            if self._state is (STATE_UNKNOWN or False):
+                self._state = True
+            else:
+                self._state = False
 
         # Send initial command and queue repetitions.
         # This allows the entity state to be updated quickly and not having to

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -371,3 +371,46 @@ def test_signal_repetitions_cancelling(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[1][0][1] == 'on'
     assert protocol.send_command_ack.call_args_list[2][0][1] == 'on'
     assert protocol.send_command_ack.call_args_list[3][0][1] == 'on'
+
+
+@asyncio.coroutine
+def test_type_toggle(hass, monkeypatch):
+    """Test toggle type lights (on/on)."""
+    config = {
+        'rflink': {
+            'port': '/dev/ttyABC0',
+        },
+        DOMAIN: {
+            'platform': 'rflink',
+            'devices': {
+                'toggle_0_0': {
+                    'name': 'toggle_test',
+                    'type': 'toggle',
+                },
+            },
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, _, _, _ = yield from mock_rflink(
+        hass, config, DOMAIN, monkeypatch)
+
+    assert hass.states.get('light.toggle_test').state == 'off'
+
+    # test sending on command to toggle alias
+    event_callback({
+        'id': 'toggle_0_0',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get('light.toggle_test').state == 'on'
+
+    # test sending group command to group alias
+    event_callback({
+        'id': 'toggle_0_0',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get('light.toggle_test').state == 'off'


### PR DESCRIPTION
## Description:
I recently installed a Livolo switch which requires the same command to be sent to turn the switch on and off, by sending the 'on' command for both. Since this isn't possible yet, I decided to implement it.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2284

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  platform: rflink
  devices:
    Livolo_1_8:
      name: Livolo
      type: toggle
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
