### PR TITLE
Append vera device id to entity id - but not name.

### DIFF
--- a/homeassistant/components/binary_sensor/vera.py
+++ b/homeassistant/components/binary_sensor/vera.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/binary_sensor.vera/
 import logging
 
 from homeassistant.components.binary_sensor import (
-    BinarySensorDevice)
+    ENTITY_ID_FORMAT, BinarySensorDevice)
 from homeassistant.components.vera import (
     VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
 
@@ -30,6 +30,8 @@ class VeraBinarySensor(VeraDevice, BinarySensorDevice):
         """Initialize the binary_sensor."""
         self._state = False
         VeraDevice.__init__(self, vera_device, controller)
+        self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
+
 
     @property
     def is_on(self):

--- a/homeassistant/components/binary_sensor/vera.py
+++ b/homeassistant/components/binary_sensor/vera.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, ENTITY_ID_FORMAT)
 from homeassistant.components.vera import (
-    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
+    VERA_CONTROLLER, VERA_DEVICES, VeraDevice)
 
 DEPENDENCIES = ['vera']
 

--- a/homeassistant/components/binary_sensor/vera.py
+++ b/homeassistant/components/binary_sensor/vera.py
@@ -7,9 +7,9 @@ https://home-assistant.io/components/binary_sensor.vera/
 import logging
 
 from homeassistant.components.binary_sensor import (
-    ENTITY_ID_FORMAT, BinarySensorDevice)
+    BinarySensorDevice, ENTITY_ID_FORMAT)
 from homeassistant.components.vera import (
-    VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
+    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
 
 DEPENDENCIES = ['vera']
 

--- a/homeassistant/components/binary_sensor/vera.py
+++ b/homeassistant/components/binary_sensor/vera.py
@@ -32,7 +32,6 @@ class VeraBinarySensor(VeraDevice, BinarySensorDevice):
         VeraDevice.__init__(self, vera_device, controller)
         self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
-
     @property
     def is_on(self):
         """Return true if sensor is on."""

--- a/homeassistant/components/climate/vera.py
+++ b/homeassistant/components/climate/vera.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/switch.vera/
 import logging
 
 from homeassistant.util import convert
-from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate import (ENTITY_ID_FORMAT, ClimateDevice)
 from homeassistant.const import (
     TEMP_FAHRENHEIT,
     TEMP_CELSIUS,
@@ -37,6 +37,7 @@ class VeraThermostat(VeraDevice, ClimateDevice):
     def __init__(self, vera_device, controller):
         """Initialize the Vera device."""
         VeraDevice.__init__(self, vera_device, controller)
+        self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     @property
     def current_operation(self):

--- a/homeassistant/components/climate/vera.py
+++ b/homeassistant/components/climate/vera.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE)
 
 from homeassistant.components.vera import (
-    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
+    VERA_CONTROLLER, VERA_DEVICES, VeraDevice)
 
 DEPENDENCIES = ['vera']
 

--- a/homeassistant/components/climate/vera.py
+++ b/homeassistant/components/climate/vera.py
@@ -7,14 +7,14 @@ https://home-assistant.io/components/switch.vera/
 import logging
 
 from homeassistant.util import convert
-from homeassistant.components.climate import (ENTITY_ID_FORMAT, ClimateDevice)
+from homeassistant.components.climate import ClimateDevice, ENTITY_ID_FORMAT
 from homeassistant.const import (
     TEMP_FAHRENHEIT,
     TEMP_CELSIUS,
     ATTR_TEMPERATURE)
 
 from homeassistant.components.vera import (
-    VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
+    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
 
 DEPENDENCIES = ['vera']
 

--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/cover.vera/
 """
 import logging
 
-from homeassistant.components.cover import CoverDevice
+from homeassistant.components.cover import (ENTITY_ID_FORMAT, CoverDevice)
 from homeassistant.components.vera import (
     VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
 
@@ -28,6 +28,7 @@ class VeraCover(VeraDevice, CoverDevice):
     def __init__(self, vera_device, controller):
         """Initialize the Vera device."""
         VeraDevice.__init__(self, vera_device, controller)
+        self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     @property
     def current_cover_position(self):

--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -6,9 +6,9 @@ https://home-assistant.io/components/cover.vera/
 """
 import logging
 
-from homeassistant.components.cover import (ENTITY_ID_FORMAT, CoverDevice)
+from homeassistant.components.cover import CoverDevice, ENTITY_ID_FORMAT
 from homeassistant.components.vera import (
-    VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
+    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
 
 DEPENDENCIES = ['vera']
 

--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -8,7 +8,7 @@ import logging
 
 from homeassistant.components.cover import CoverDevice, ENTITY_ID_FORMAT
 from homeassistant.components.vera import (
-    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
+    VERA_CONTROLLER, VERA_DEVICES, VeraDevice)
 
 DEPENDENCIES = ['vera']
 

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -10,7 +10,7 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ENTITY_ID_FORMAT, Light, SUPPORT_BRIGHTNESS)
 from homeassistant.const import (STATE_OFF, STATE_ON)
 from homeassistant.components.vera import (
-    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
+    VERA_CONTROLLER, VERA_DEVICES, VeraDevice)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/light.vera/
 import logging
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, ENTITY_ID_FORMAT, Light)
 from homeassistant.const import (STATE_OFF, STATE_ON)
 from homeassistant.components.vera import (
     VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
@@ -33,6 +33,7 @@ class VeraLight(VeraDevice, Light):
         """Initialize the light."""
         self._state = False
         VeraDevice.__init__(self, vera_device, controller)
+        self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     @property
     def brightness(self):

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -7,10 +7,10 @@ https://home-assistant.io/components/light.vera/
 import logging
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, ENTITY_ID_FORMAT, Light)
+    ATTR_BRIGHTNESS, ENTITY_ID_FORMAT, Light, SUPPORT_BRIGHTNESS)
 from homeassistant.const import (STATE_OFF, STATE_ON)
 from homeassistant.components.vera import (
-    VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
+    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/lock/vera.py
+++ b/homeassistant/components/lock/vera.py
@@ -6,10 +6,10 @@ https://home-assistant.io/components/lock.vera/
 """
 import logging
 
-from homeassistant.components.lock import (ENTITY_ID_FORMAT, LockDevice)
+from homeassistant.components.lock import ENTITY_ID_FORMAT, LockDevice
 from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED)
 from homeassistant.components.vera import (
-    VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
+    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/lock/vera.py
+++ b/homeassistant/components/lock/vera.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/lock.vera/
 """
 import logging
 
-from homeassistant.components.lock import LockDevice
+from homeassistant.components.lock import (ENTITY_ID_FORMAT, LockDevice)
 from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED)
 from homeassistant.components.vera import (
     VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
@@ -30,6 +30,7 @@ class VeraLock(VeraDevice, LockDevice):
         """Initialize the Vera device."""
         self._state = None
         VeraDevice.__init__(self, vera_device, controller)
+        self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     def lock(self, **kwargs):
         """Lock the device."""

--- a/homeassistant/components/lock/vera.py
+++ b/homeassistant/components/lock/vera.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.lock import ENTITY_ID_FORMAT, LockDevice
 from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED)
 from homeassistant.components.vera import (
-    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
+    VERA_CONTROLLER, VERA_DEVICES, VeraDevice)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -9,9 +9,9 @@ import logging
 from homeassistant.const import (
     TEMP_CELSIUS, TEMP_FAHRENHEIT)
 from homeassistant.helpers.entity import Entity
-from homeassistant.components.sensor import (ENTITY_ID_FORMAT)
+from homeassistant.components.sensor import ENTITY_ID_FORMAT
 from homeassistant.components.vera import (
-    VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
+    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
 
 DEPENDENCIES = ['vera']
 

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -9,6 +9,7 @@ import logging
 from homeassistant.const import (
     TEMP_CELSIUS, TEMP_FAHRENHEIT)
 from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import (ENTITY_ID_FORMAT)
 from homeassistant.components.vera import (
     VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
 
@@ -32,6 +33,7 @@ class VeraSensor(VeraDevice, Entity):
         self.current_value = None
         self._temperature_units = None
         VeraDevice.__init__(self, vera_device, controller)
+        self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
 from homeassistant.components.vera import (
-    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
+    VERA_CONTROLLER, VERA_DEVICES, VeraDevice)
 
 DEPENDENCIES = ['vera']
 

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -7,10 +7,10 @@ https://home-assistant.io/components/switch.vera/
 import logging
 
 from homeassistant.util import convert
-from homeassistant.components.switch import (SwitchDevice, ENTITY_ID_FORMAT)
+from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchDevice
 from homeassistant.const import (STATE_OFF, STATE_ON)
 from homeassistant.components.vera import (
-    VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
+    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
 
 DEPENDENCIES = ['vera']
 

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/switch.vera/
 import logging
 
 from homeassistant.util import convert
-from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.switch import (SwitchDevice, ENTITY_ID_FORMAT)
 from homeassistant.const import (STATE_OFF, STATE_ON)
 from homeassistant.components.vera import (
     VeraDevice, VERA_DEVICES, VERA_CONTROLLER)
@@ -31,6 +31,7 @@ class VeraSwitch(VeraDevice, SwitchDevice):
         """Initialize the Vera device."""
         self._state = False
         VeraDevice.__init__(self, vera_device, controller)
+        self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     def turn_on(self, **kwargs):
         """Turn device on."""

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -10,7 +10,7 @@ from homeassistant.util import convert
 from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchDevice
 from homeassistant.const import (STATE_OFF, STATE_ON)
 from homeassistant.components.vera import (
-    VERA_CONTROLLER, VeraDevice, VERA_DEVICES)
+    VERA_CONTROLLER, VERA_DEVICES, VeraDevice)
 
 DEPENDENCIES = ['vera']
 

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -134,9 +134,9 @@ class VeraDevice(Entity):
         self.controller = controller
 
         self._name = self.vera_device.name
-
         # Append device id to prevent name clashes in HA.
-        self.vera_id = VERA_ID_FORMAT.format(slugify(vera_device.name), vera_device.device_id)
+        self.vera_id = VERA_ID_FORMAT.format(
+            slugify(vera_device.name), vera_device.device_id)
 
         self.controller.register(vera_device, self._update_callback)
         self.update()

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from requests.exceptions import RequestException
 
 from homeassistant.util.dt import utc_from_timestamp
-from homeassistant.util import convert
+from homeassistant.util import (convert, slugify)
 from homeassistant.helpers import discovery
 from homeassistant.helpers import config_validation as cv
 from homeassistant.const import (
@@ -31,6 +31,8 @@ VERA_CONTROLLER = None
 CONF_CONTROLLER = 'vera_controller_url'
 CONF_EXCLUDE = 'exclude'
 CONF_LIGHTS = 'lights'
+
+VERA_ID_FORMAT = '{}_{}'
 
 ATTR_CURRENT_POWER_MWH = "current_power_mwh"
 
@@ -131,8 +133,10 @@ class VeraDevice(Entity):
         self.vera_device = vera_device
         self.controller = controller
 
+        self._name = self.vera_device.name
+
         # Append device id to prevent name clashes in HA.
-        self._name = self.vera_device.name + ' ' + str(vera_device.device_id)
+        self.vera_id = VERA_ID_FORMAT.format(slugify(vera_device.name), vera_device.device_id)
 
         self.controller.register(vera_device, self._update_callback)
         self.update()


### PR DESCRIPTION
## Description:
Fix problem in https://github.com/home-assistant/home-assistant/pull/6100#discussion_r105529891 that appended the device ids to the name as well as the entity_id.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
