### PR TITLE
Fix gen_requirements_all.py script for Windows.

### DIFF
--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -30,6 +30,10 @@ IGNORE_PACKAGES = (
 
 IGNORE_PIN = ('colorlog>2.1,<3', 'keyring>=9.3,<10.0', 'urllib3')
 
+IGNORE_REQ = (
+    'colorama<=1',  # Windows only requirement in check_config
+)
+
 URL_PIN = ('https://home-assistant.io/developers/code_review_platform/'
            '#1-requirements')
 
@@ -85,6 +89,8 @@ def gather_modules():
             continue
 
         for req in module.REQUIREMENTS:
+            if req in IGNORE_REQ:
+                continue
             if req.partition('==')[1] == '' and req not in IGNORE_PIN:
                 errors.append(
                     "{}[Please pin requirement {}, see {}]".format(
@@ -120,7 +126,7 @@ def gather_modules():
 
 def write_file(data):
     """Write the modules to the requirements_all.txt."""
-    with open('requirements_all.txt', 'w+') as req_file:
+    with open('requirements_all.txt', 'w+', newline="\n") as req_file:
         req_file.write(data)
 
 


### PR DESCRIPTION
## Description:

The gen_requirements_all.py script failed on Windows and also didn't use newlines as line terminators.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
