### PR TITLE
Don't start the push updater if the Apple TV is 'off'

### DIFF
--- a/homeassistant/components/media_player/apple_tv.py
+++ b/homeassistant/components/media_player/apple_tv.py
@@ -96,7 +96,8 @@ class AppleTvDevice(MediaPlayerDevice):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Called when entity is about to be added to HASS."""
-        self._atv.push_updater.start()
+        if not self._is_off:
+            self._atv.push_updater.start()
 
     @callback
     def _set_power_off(self, is_off):


### PR DESCRIPTION
Ensures that Apple TVs that are 'off' (using the fake on/off support in https://github.com/home-assistant/home-assistant/pull/5962) aren't woken up at startup when the poller starts.

/cc @postlund https://github.com/home-assistant/home-assistant/pull/6323