### PR TITLE
Blink region support

### DIFF
--- a/homeassistant/components/blink.py
+++ b/homeassistant/components/blink.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import discovery
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'blink'
-REQUIREMENTS = ['blinkpy==0.4.4']
+REQUIREMENTS = ['blinkpy==0.5.2']
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/camera/blink.py
+++ b/homeassistant/components/camera/blink.py
@@ -15,7 +15,7 @@ from homeassistant.util import Throttle
 
 DEPENDENCIES = ['blink']
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=90)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -68,7 +68,7 @@ batinfo==0.4.2
 beautifulsoup4==4.5.3
 
 # homeassistant.components.blink
-blinkpy==0.4.4
+blinkpy==0.5.2
 
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.8


### PR DESCRIPTION
## Description: 
Update blinkpy module requirement for Blink component (now properly supports regions other than the US).  Also increased Throttle time on image updates for the camera from 60 seconds to 90 seconds to prevent Blink server-side timeouts.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.