### PR TITLE
Fix hydroquebec

### DIFF
--- a/homeassistant/components/sensor/hydroquebec.py
+++ b/homeassistant/components/sensor/hydroquebec.py
@@ -149,7 +149,8 @@ class HydroQuebecSensor(Entity):
     def update(self):
         """Get the latest data from Hydroquebec and update the state."""
         self.hydroquebec_data.update()
-        self._state = round(self.hydroquebec_data.data[self.type], 2)
+        if self.type in self.hydroquebec_data.data:
+            self._state = round(self.hydroquebec_data.data[self.type], 2)
 
 
 class HydroquebecData(object):


### PR DESCRIPTION
## Description:

Hello, @djfjeff got an error after the 0.40 upgrade. The issue is related to init stage where data had not been already collected (by the hydroquebec client) when they are requested by the component.
So the data attribute is empty.

Here the log from @djfjeff:
```
17-03-13 07:09:40 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
File "/usr/lib/python3.4/asyncio/tasks.py", line 233, in _step
result = coro.throw(exc)
File "/srv/homeassistant/lib/python3.4/site-packages/homeassistant/helpers/entity_component.py", line 359, in async_process_entity
new_entity, self, update_before_add=update_before_add
File "/srv/homeassistant/lib/python3.4/site-packages/homeassistant/helpers/entity_component.py", line 189, in async_add_entity
yield from self.hass.loop.run_in_executor(None, entity.update)
File "/usr/lib/python3.4/asyncio/futures.py", line 388, in iter
yield self # This tells Task to wait for completion.
File "/usr/lib/python3.4/asyncio/tasks.py", line 286, in _wakeup
value = future.result()
File "/usr/lib/python3.4/asyncio/futures.py", line 277, in result
raise self._exception
File "/usr/lib/python3.4/concurrent/futures/thread.py", line 54, in run
result = self.fn(*self.args, **self.kwargs)
File "/srv/homeassistant/lib/python3.4/site-packages/homeassistant/components/sensor/hydroquebec.py", line 152, in update
self._state = round(self.hydroquebec_data.data[self.type], 2)
KeyError: 'period_total_bill'
```

**Related issue (if applicable):** fixes #https://github.com/home-assistant/home-assistant.github.io/pull/2191


## Checklist:

  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
