### PR TITLE
Fix for the case of zwave value used in several devices.

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -434,7 +434,7 @@ def setup(hass, config):
                 node=node, value=value, node_config=node_config, hass=hass)
             if not device:
                 continue
-            dict_id = value.value_id
+            dict_id = "{}.{}".format(component, value.value_id)
 
             @asyncio.coroutine
             def discover_device(component, device, dict_id):


### PR DESCRIPTION
## Description:

Fix for the case of zwave value used in several devices.

**Related issue (if applicable):** fixes #6548

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
