### PR TITLE
Upgrade psutil to 5.2.0

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==5.1.3']
+REQUIREMENTS = ['psutil==5.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -422,7 +422,7 @@ pmsensor==0.4
 proliphix==0.4.1
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.1.3
+psutil==5.2.0
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.1


### PR DESCRIPTION
## 5.2.0

Enhancements

- [Linux] Add psutil.sensors_fans() function. (patch by Nicolas Hennion)
- [Windows] Process.io_counters() has 2 new fields: other_count and other_bytes.
- [Linux] Process.io_counters() has 2 new fields: read_chars and write_chars.

Bug fixes

- [Linux] can now compile on Linux by using MUSL C library.
- [Windows] Fix a crash in Process.open_files when the worker thread for NtQueryObject times out.
- [Linux] Process.cwd() may raise NoSuchProcess instead of ZombieProcess.

Tested with the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: load_1m
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
```