### PR TITLE
Upgrade async_timeout to 1.2.0

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -7,7 +7,7 @@ jinja2>=2.9.5
 voluptuous==0.9.3
 typing>=3,<4
 aiohttp==1.3.3
-async_timeout==1.1.0
+async_timeout==1.2.0
 
 # homeassistant.components.nuimo_controller
 --only-binary=all http://github.com/getSenic/nuimo-linux-python/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip#nuimo==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ REQUIRES = [
     'voluptuous==0.9.3',
     'typing>=3,<4',
     'aiohttp==1.3.3',
-    'async_timeout==1.1.0',
+    'async_timeout==1.2.0',
 ]
 
 setup(


### PR DESCRIPTION
## 1.2.0

- Extra check on context manager exit
- 0 is no-op timeout

Tested with the following configuration:

``` yaml
http:
```