### PR TITLE
Fix #6534

### DIFF
--- a/homeassistant/components/light/osramlightify.py
+++ b/homeassistant/components/light/osramlightify.py
@@ -215,6 +215,6 @@ class OsramLightifyLight(Light):
         self._name = self._light.name()
         self._rgb = self._light.rgb()
         o_temp = self._light.temp()
-        if o_temp is not 0:
+        if o_temp != 0:
             self._temperature = color_temperature_kelvin_to_mired(o_temp)
         self._state = self._light.on()

--- a/homeassistant/components/light/osramlightify.py
+++ b/homeassistant/components/light/osramlightify.py
@@ -215,6 +215,8 @@ class OsramLightifyLight(Light):
         self._name = self._light.name()
         self._rgb = self._light.rgb()
         o_temp = self._light.temp()
-        if o_temp != 0:
+        if o_temp == 0:
+            self._temperature = None
+        else:
             self._temperature = color_temperature_kelvin_to_mired(o_temp)
         self._state = self._light.on()

--- a/homeassistant/components/light/osramlightify.py
+++ b/homeassistant/components/light/osramlightify.py
@@ -215,5 +215,6 @@ class OsramLightifyLight(Light):
         self._name = self._light.name()
         self._rgb = self._light.rgb()
         o_temp = self._light.temp()
-        self._temperature = color_temperature_kelvin_to_mired(o_temp)
+        if o_temp is not 0:
+            self._temperature = color_temperature_kelvin_to_mired(o_temp)
         self._state = self._light.on()


### PR DESCRIPTION
Makes sure 0 is not passes to `color_temperature_kelvin_to_mired`.
I think we should make a hot-fix out of it, because it effects core functionality for quite some people.  

## Description:


**Related issue (if applicable):** fixes #6534

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
