### PR TITLE
Added workday sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -156,6 +156,7 @@ omit =
     homeassistant/components/binary_sensor/hikvision.py
     homeassistant/components/binary_sensor/iss.py
     homeassistant/components/binary_sensor/rest.py
+    homeassistant/components/binary_sensor/workday.py
     homeassistant/components/browser.py
     homeassistant/components/camera/amcrest.py
     homeassistant/components/camera/bloomsky.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -156,7 +156,6 @@ omit =
     homeassistant/components/binary_sensor/hikvision.py
     homeassistant/components/binary_sensor/iss.py
     homeassistant/components/binary_sensor/rest.py
-    homeassistant/components/binary_sensor/workday.py
     homeassistant/components/browser.py
     homeassistant/components/camera/amcrest.py
     homeassistant/components/camera/bloomsky.py

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -212,6 +212,9 @@ heatmiserV3==0.9.1
 # homeassistant.components.switch.hikvisioncam
 hikvision==0.4
 
+# homeassistant.components.binary_sensor.workday
+holidays==0.8.1
+
 # homeassistant.components.sensor.dht
 # http://github.com/adafruit/Adafruit_Python_DHT/archive/da8cddf7fb629c1ef4f046ca44f42523c9cf2d11.zip#Adafruit_DHT==1.3.0
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -17,3 +17,4 @@ requests_mock>=1.0
 mock-open>=1.3.1
 flake8-docstrings==1.0.2
 asynctest>=0.8.0
+freezegun>=0.3.8

--- a/tests/components/binary_sensor/test_workday.py
+++ b/tests/components/binary_sensor/test_workday.py
@@ -1,0 +1,153 @@
+"""Tests the HASS workday binary sensor."""
+from freezegun import freeze_time
+from homeassistant.components.binary_sensor.workday import day_to_string
+from homeassistant.setup import setup_component
+
+from tests.common import (
+    get_test_home_assistant, assert_setup_component)
+
+
+class TestWorkdaySetup(object):
+    """Test class for workday sensor."""
+
+    def setup_method(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+        # Set valid default config for test
+        self.config_province = {
+            'binary_sensor': {
+                'platform': 'workday',
+                'country': 'DE',
+                'province': 'BW'
+            },
+        }
+
+        self.config_noprovince = {
+            'binary_sensor': {
+                'platform': 'workday',
+                'country': 'DE',
+            },
+        }
+
+        self.config_invalidprovince = {
+            'binary_sensor': {
+                'platform': 'workday',
+                'country': 'DE',
+                'province': 'invalid'
+            },
+        }
+
+        self.config_includeholiday = {
+            'binary_sensor': {
+                'platform': 'workday',
+                'country': 'DE',
+                'province': 'BW',
+                'workdays': ['holiday', 'mon', 'tue', 'wed', 'thu', 'fri'],
+                'excludes': ['sat', 'sun']
+            },
+        }
+
+    def teardown_method(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_setup_component_province(self):
+        """Setup workday component."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_province)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+    # Freeze time to a workday
+    @freeze_time("Mar 15th, 2017")
+    def test_workday_province(self):
+        """Test if workdays are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_province)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'on'
+
+    # Freeze time to a weekend
+    @freeze_time("Mar 12th, 2017")
+    def test_weekend_province(self):
+        """Test if weekends are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_province)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'off'
+
+    # Freeze time to a public holiday in province BW
+    @freeze_time("Jan 6th, 2017")
+    def test_public_holiday_province(self):
+        """Test if public holidays are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_province)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'off'
+
+    def test_setup_component_noprovince(self):
+        """Setup workday component."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_noprovince)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+    # Freeze time to a public holiday in province BW
+    @freeze_time("Jan 6th, 2017")
+    def test_public_holiday_noprovince(self):
+        """Test if public holidays are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_noprovince)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'on'
+
+    def test_setup_component_invalidprovince(self):
+        """Setup workday component."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor',
+                            self.config_invalidprovince)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is None
+
+    # Freeze time to a public holiday in province BW
+    @freeze_time("Jan 6th, 2017")
+    def test_public_holiday_includeholiday(self):
+        """Test if public holidays are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor',
+                            self.config_includeholiday)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'on'
+
+    def test_day_to_string(self):
+        """Test if day_to_string is behaving correctly."""
+        assert day_to_string(0) == 'mon'
+        assert day_to_string(1) == 'tue'
+        assert day_to_string(7) == 'holiday'
+        assert day_to_string(8) is None


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2254

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: workday
    country: DE
    province: BW
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54