### PR TITLE
Upgrade to dsmr_parser 0.8, supporting protocol 3 and 5.

### DIFF
--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -40,7 +40,7 @@ import voluptuous as vol
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['dsmr_parser==0.6']
+REQUIREMENTS = ['dsmr_parser==0.8']
 
 CONF_DSMR_VERSION = 'dsmr_version'
 CONF_RECONNECT_INTERVAL = 'reconnect_interval'
@@ -72,7 +72,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     logging.getLogger('dsmr_parser').setLevel(logging.ERROR)
 
     from dsmr_parser import obis_references as obis_ref
-    from dsmr_parser.protocol import create_dsmr_reader, create_tcp_dsmr_reader
+    from dsmr_parser.clients.protocol import (create_dsmr_reader,
+                                              create_tcp_dsmr_reader)
     import serial
 
     dsmr_version = config[CONF_DSMR_VERSION]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -124,7 +124,7 @@ dnspython3==1.15.0
 dovado==0.4.1
 
 # homeassistant.components.sensor.dsmr
-dsmr_parser==0.6
+dsmr_parser==0.8
 
 # homeassistant.components.dweet
 # homeassistant.components.sensor.dweet

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -20,7 +20,7 @@ from tests.common import assert_setup_component
 @pytest.fixture
 def mock_connection_factory(monkeypatch):
     """Mock the create functions for serial and TCP Asyncio connections."""
-    from dsmr_parser.protocol import DSMRProtocol
+    from dsmr_parser.clients.protocol import DSMRProtocol
     transport = asynctest.Mock(spec=asyncio.Transport)
     protocol = asynctest.Mock(spec=DSMRProtocol)
 
@@ -32,10 +32,10 @@ def mock_connection_factory(monkeypatch):
 
     # apply the mock to both connection factories
     monkeypatch.setattr(
-        'dsmr_parser.protocol.create_dsmr_reader',
+        'dsmr_parser.clients.protocol.create_dsmr_reader',
         connection_factory)
     monkeypatch.setattr(
-        'dsmr_parser.protocol.create_tcp_dsmr_reader',
+        'dsmr_parser.clients.protocol.create_tcp_dsmr_reader',
         connection_factory)
 
     return connection_factory, transport, protocol
@@ -161,7 +161,7 @@ def test_connection_errors_retry(hass, monkeypatch, mock_connection_factory):
             TimeoutError])
 
     monkeypatch.setattr(
-        'dsmr_parser.protocol.create_dsmr_reader',
+        'dsmr_parser.clients.protocol.create_dsmr_reader',
         first_fail_connection_factory)
     yield from async_setup_component(hass, 'sensor', {'sensor': config})
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #6218 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
