### PR TITLE
Fix hass script execution on Windows (#4977).

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -258,7 +258,8 @@ def cmdline() -> List[str]:
     if sys.argv[0].endswith(os.path.sep + '__main__.py'):
         modulepath = os.path.dirname(sys.argv[0])
         os.environ['PYTHONPATH'] = os.path.dirname(modulepath)
-        return [sys.executable] + [arg for arg in sys.argv if arg != '--daemon']
+        return [sys.executable] + [arg for arg in sys.argv if
+                                   arg != '--daemon']
     else:
         return [arg for arg in sys.argv if arg != '--daemon']
 

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -255,10 +255,12 @@ def closefds_osx(min_fd: int, max_fd: int) -> None:
 
 def cmdline() -> List[str]:
     """Collect path and arguments to re-execute the current hass instance."""
-    if sys.argv[0].endswith('/__main__.py'):
+    if sys.argv[0].endswith(os.path.sep + '__main__.py'):
         modulepath = os.path.dirname(sys.argv[0])
         os.environ['PYTHONPATH'] = os.path.dirname(modulepath)
-    return [sys.executable] + [arg for arg in sys.argv if arg != '--daemon']
+        return [sys.executable] + [arg for arg in sys.argv if arg != '--daemon']
+    else:
+        return [arg for arg in sys.argv if arg != '--daemon']
 
 
 def setup_and_run_hass(config_dir: str,


### PR DESCRIPTION
hass.exe returned ERRNO2 on a windows machine and must be started using
package loading. This fix adapts the command line options for
`setup_and_run_hass()` to start
either a script with `python homeassistant/__main__.py` or with
`Scripts/hass.exe`

For example:
The `nt_args` will be `['C:\\Miniconda3\\envs\\homeassistantenv\\python.exe', 'C:\\Miniconda3\\envs\\homeassistantenv\\lib\\site-packages\\homeassistant\\__main__.py', '--runner']` if home assistant is started using `python -m homeassistant`
If home assistant is started using `hass.exe` the `nt_args` will be `['C:\\Miniconda3\\envs\\homeassistantenv\\Scripts\\hass', '--runner']` 

## Description:


**Related issue (if applicable):** fixes #4977 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
