### PR TITLE
Add configurable timeout option to notify/smtp

### DIFF
--- a/tests/components/notify/test_smtp.py
+++ b/tests/components/notify/test_smtp.py
@@ -21,7 +21,7 @@ class TestNotifySmtp(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.mailer = MockSMTP('localhost', 25, 'test@test.com', 1, 'testuser',
+        self.mailer = MockSMTP('localhost', 25, 5, 'test@test.com', 1, 'testuser',
                                'testpass', 'testrecip@test.com', 0)
 
     def tearDown(self):  # pylint: disable=invalid-name

--- a/tests/components/notify/test_smtp.py
+++ b/tests/components/notify/test_smtp.py
@@ -21,8 +21,8 @@ class TestNotifySmtp(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.mailer = MockSMTP('localhost', 25, 5, 'test@test.com', 1, 'testuser',
-                               'testpass', 'testrecip@test.com', 0)
+        self.mailer = MockSMTP('localhost', 25, 5, 'test@test.com', 1,
+                               'testuser', 'testpass', 'testrecip@test.com', 0)
 
     def tearDown(self):  # pylint: disable=invalid-name
         """"Stop down everything that was started."""


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2258


## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
notify:
  - name: NOTIFIER_NAME
    platform: smtp
    server: smtp.gmail.com
    port: 587
    timeout: 15
    sender: john@gmail.com
    starttls: true
    username: john@gmail.com
    password: thePassword
    recipient: james@gmail.com
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been updated to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54