### PR TITLE
Update operation mode during init

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -109,14 +109,6 @@ class GenericThermostat(ClimateDevice):
         if sensor_state:
             self._async_update_temp(sensor_state)
 
-        def _start_generic_thermostat(_event):
-            self._async_control_heating()
-
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_START,
-            _start_generic_thermostat
-        )
-
     @property
     def should_poll(self):
         """No polling needed."""
@@ -181,6 +173,18 @@ class GenericThermostat(ClimateDevice):
         else:
             # Get default temp from super class
             return ClimateDevice.max_temp.fget(self)
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register EVENT_HOMEASSISTANT_START callback."""
+        @callback
+        def _start_generic_thermostat(_event):
+            self._async_control_heating()
+
+        self.hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_START,
+            _start_generic_thermostat
+        )
 
     @asyncio.coroutine
     def _async_sensor_changed(self, entity_id, old_state, new_state):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -69,19 +69,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     tolerance = config.get(CONF_TOLERANCE)
     keep_alive = config.get(CONF_KEEP_ALIVE)
 
-    thermostat = GenericThermostat(
+    async_add_devices([GenericThermostat(
         hass, name, heater_entity_id, sensor_entity_id, min_temp, max_temp,
-        target_temp, ac_mode, min_cycle_duration, tolerance, keep_alive)
-
-    async_add_devices([thermostat])
-
-    def _start_generic_thermostat(_event):
-        thermostat._async_control_heating()
-
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_START,
-        _start_generic_thermostat
-    )
+        target_temp, ac_mode, min_cycle_duration, tolerance, keep_alive)])
 
 
 class GenericThermostat(ClimateDevice):
@@ -118,6 +108,14 @@ class GenericThermostat(ClimateDevice):
         sensor_state = hass.states.get(sensor_entity_id)
         if sensor_state:
             self._async_update_temp(sensor_state)
+
+        def _start_generic_thermostat(_event):
+            self._async_control_heating()
+
+        hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_START,
+            _start_generic_thermostat
+        )
 
     @property
     def should_poll(self):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -107,6 +107,7 @@ class GenericThermostat(ClimateDevice):
         sensor_state = hass.states.get(sensor_entity_id)
         if sensor_state:
             self._async_update_temp(sensor_state)
+            self._async_control_heating()
 
     @property
     def should_poll(self):
@@ -188,6 +189,7 @@ class GenericThermostat(ClimateDevice):
         """Called when heater switch changes state."""
         if new_state is None:
             return
+
         self.hass.async_add_job(self.async_update_ha_state())
 
     @callback


### PR DESCRIPTION
## Description:

Upon restart, Home Assistant doesn't turn the thermostat on, even if there's a default temperature set in the configuration, and based on the current temperature, the thermostat should be on. This PR fixes the behavior by calling the appropriate method during the thermostat's initialization.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
