### PR TITLE
Re-add encoding setting for correct parsing of remote data.

### DIFF
--- a/homeassistant/components/sensor/zamg.py
+++ b/homeassistant/components/sensor/zamg.py
@@ -157,6 +157,7 @@ class ZamgData(object):
             response = requests.get(
                 cls.API_URL, headers=cls.API_HEADERS, timeout=15)
             response.raise_for_status()
+            response.encoding = 'UTF8'
             return csv.DictReader(response.text.splitlines(),
                                   delimiter=';', quotechar='"')
         except Exception:  # pylint:disable=broad-except


### PR DESCRIPTION
All columns with unicode characters would not be recognised as the data file
was interpreted as latin-1 and wrongly decoded into gibberish.

## Description:

**Related issue (if applicable):** fixes #6573
