### PR TITLE
media_player.kodi extra attributes for tvshow and music media

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -412,7 +412,7 @@ class KodiDevice(MediaPlayerDevice):
     @property
     def media_album_artist(self):
         """Album artist of current playing media, music track only."""
-        return self._item.get('artist', [None])[0]
+        return self._item.get('albumartist', [None])[0]
 
     @property
     def supported_features(self):

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -300,7 +300,8 @@ class KodiDevice(MediaPlayerDevice):
 
             self._item = (yield from self.server.Player.GetItem(
                 player_id,
-                ['title', 'file', 'uniqueid', 'thumbnail', 'artist']
+                ['title', 'file', 'uniqueid', 'thumbnail', 'artist',
+                    'album', 'artist', 'season', 'episode' ]
             ))['item']
         else:
             self._properties = {}
@@ -382,6 +383,32 @@ class KodiDevice(MediaPlayerDevice):
         # find a string we can use as a title
         return self._item.get(
             'title', self._item.get('label', self._item.get('file')))
+
+    @property
+    def media_series_title(self):
+        """Title of series of current playing media, TV show only."""
+        return self._item.get('showtitle')
+
+    @property
+    def media_season(self):
+        """Season of current playing media, TV show only."""
+        return self._item.get('season')
+
+    @property
+    def media_episode(self):
+        """Episode of current playing media, TV show only."""
+        return self._item.get('episode')
+
+    @property
+    def media_album_name(self):
+        """Album name of current playing media, music track only."""
+        return self._item.get('album')
+
+    @property
+    def media_album_artist(self):
+        """Album artist of current playing media, music track only."""
+        return self._item.get('artist')
+
 
     @property
     def supported_features(self):

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -301,7 +301,7 @@ class KodiDevice(MediaPlayerDevice):
             self._item = (yield from self.server.Player.GetItem(
                 player_id,
                 ['title', 'file', 'uniqueid', 'thumbnail', 'artist',
-                    'showtitle', 'season', 'episode']
+                    'showtitle', 'album', 'season', 'episode']
             ))['item']
         else:
             self._properties = {}
@@ -387,17 +387,27 @@ class KodiDevice(MediaPlayerDevice):
     @property
     def media_series_title(self):
         """Title of series of current playing media, TV show only."""
-        return self._item.get('showtitle', None)
+        return self._item.get('showtitle')
 
     @property
     def media_season(self):
         """Season of current playing media, TV show only."""
-        return self._item.get('season', None)
+        return self._item.get('season')
 
     @property
     def media_episode(self):
         """Episode of current playing media, TV show only."""
-        return self._item.get('episode', None)
+        return self._item.get('episode')
+
+    @property
+    def media_album_name(self):
+        """Album name of current playing media, music track only."""
+        return self._item.get('album')
+
+    @property
+    def media_album_artist(self):
+        """Album artist of current playing media, music track only."""
+        return self._item.get('artist')
 
     @property
     def supported_features(self):

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -301,7 +301,7 @@ class KodiDevice(MediaPlayerDevice):
             self._item = (yield from self.server.Player.GetItem(
                 player_id,
                 ['title', 'file', 'uniqueid', 'thumbnail', 'artist',
-                 'showtitle', 'album', 'season', 'episode']
+                 'albumartist', 'showtitle', 'album', 'season', 'episode']
             ))['item']
         else:
             self._properties = {}
@@ -405,9 +405,14 @@ class KodiDevice(MediaPlayerDevice):
         return self._item.get('album')
 
     @property
+    def media_artist(self):
+        """Artist of current playing media, music track only."""
+        return self._item.get('artist', [None])[0]
+
+    @property
     def media_album_artist(self):
         """Album artist of current playing media, music track only."""
-        return self._item.get('artist')
+        return self._item.get('artist', [None])[0]
 
     @property
     def supported_features(self):

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -301,7 +301,7 @@ class KodiDevice(MediaPlayerDevice):
             self._item = (yield from self.server.Player.GetItem(
                 player_id,
                 ['title', 'file', 'uniqueid', 'thumbnail', 'artist',
-                    'album', 'artist', 'season', 'episode' ]
+                    'album', 'artist', 'season', 'episode']
             ))['item']
         else:
             self._properties = {}
@@ -408,7 +408,6 @@ class KodiDevice(MediaPlayerDevice):
     def media_album_artist(self):
         """Album artist of current playing media, music track only."""
         return self._item.get('artist')
-
 
     @property
     def supported_features(self):

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -301,7 +301,7 @@ class KodiDevice(MediaPlayerDevice):
             self._item = (yield from self.server.Player.GetItem(
                 player_id,
                 ['title', 'file', 'uniqueid', 'thumbnail', 'artist',
-                    'showtitle', 'album', 'season', 'episode']
+                 'showtitle', 'album', 'season', 'episode']
             ))['item']
         else:
             self._properties = {}

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -301,7 +301,7 @@ class KodiDevice(MediaPlayerDevice):
             self._item = (yield from self.server.Player.GetItem(
                 player_id,
                 ['title', 'file', 'uniqueid', 'thumbnail', 'artist',
-                    'album', 'artist', 'season', 'episode']
+                    'showtitle', 'season', 'episode']
             ))['item']
         else:
             self._properties = {}
@@ -387,27 +387,17 @@ class KodiDevice(MediaPlayerDevice):
     @property
     def media_series_title(self):
         """Title of series of current playing media, TV show only."""
-        return self._item.get('showtitle')
+        return self._item.get('showtitle', None)
 
     @property
     def media_season(self):
         """Season of current playing media, TV show only."""
-        return self._item.get('season')
+        return self._item.get('season', None)
 
     @property
     def media_episode(self):
         """Episode of current playing media, TV show only."""
-        return self._item.get('episode')
-
-    @property
-    def media_album_name(self):
-        """Album name of current playing media, music track only."""
-        return self._item.get('album')
-
-    @property
-    def media_album_artist(self):
-        """Album artist of current playing media, music track only."""
-        return self._item.get('artist')
+        return self._item.get('episode', None)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -407,12 +407,20 @@ class KodiDevice(MediaPlayerDevice):
     @property
     def media_artist(self):
         """Artist of current playing media, music track only."""
-        return self._item.get('artist', [None])[0]
+        artists = self._item.get('artist', [])
+        if len(artists) > 0:
+            return artists[0]
+        else:
+            return None
 
     @property
     def media_album_artist(self):
         """Album artist of current playing media, music track only."""
-        return self._item.get('albumartist', [None])[0]
+        artists = self._item.get('albumartist', [])
+        if len(artists) > 0:
+            return artists[0]
+        else:
+            return None
 
     @property
     def supported_features(self):


### PR DESCRIPTION
## Description:
New media attributes for kodi media players. 
(First pull request btw)

**Related issue (if applicable):** fixes #6250 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  # https://home-assistant.io/components/media_player.kodi/
  - platform: kodi
    host: osmc-01
    port: 8080
    name: kodi_living_room
    timeout: 10
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
