### PR TITLE
Blink auth token recovery and improved responsiveness

### DIFF
--- a/homeassistant/components/binary_sensor/blink.py
+++ b/homeassistant/components/binary_sensor/blink.py
@@ -15,9 +15,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    data = hass.data[DOMAIN].blink
+    data = hass.data[DOMAIN]
     devs = list()
-    for name in data.cameras:
+    for name in data.blink.cameras:
         devs.append(BlinkCameraMotionSensor(name, data))
     devs.append(BlinkSystemSensor(data))
     add_devices(devs, True)
@@ -31,7 +31,7 @@ class BlinkCameraMotionSensor(BinarySensorDevice):
         self._name = 'blink_' + name + '_motion_enabled'
         self._camera_name = name
         self.data = data
-        self._state = self.data.cameras[self._camera_name].armed
+        self._state = self.data.blink.cameras[self._camera_name].armed
 
     @property
     def name(self):
@@ -45,8 +45,8 @@ class BlinkCameraMotionSensor(BinarySensorDevice):
 
     def update(self):
         """Update sensor state."""
-        self.data.refresh()
-        self._state = self.data.cameras[self._camera_name].armed
+        self.data.update()
+        self._state = self.data.blink.cameras[self._camera_name].armed
 
 
 class BlinkSystemSensor(BinarySensorDevice):
@@ -56,7 +56,7 @@ class BlinkSystemSensor(BinarySensorDevice):
         """Initialize the sensor."""
         self._name = 'blink armed status'
         self.data = data
-        self._state = self.data.arm
+        self._state = self.data.blink.arm
 
     @property
     def name(self):
@@ -70,5 +70,4 @@ class BlinkSystemSensor(BinarySensorDevice):
 
     def update(self):
         """Update sensor state."""
-        self.data.refresh()
-        self._state = self.data.arm
+        self._state = self.data.blink.arm

--- a/homeassistant/components/blink.py
+++ b/homeassistant/components/blink.py
@@ -5,6 +5,8 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/blink/
 """
 import logging
+from datetime import timedelta
+import requests
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (CONF_USERNAME,
@@ -12,10 +14,15 @@ from homeassistant.const import (CONF_USERNAME,
                                  ATTR_FRIENDLY_NAME,
                                  ATTR_ARMED)
 from homeassistant.helpers import discovery
+from homeassistant.util import Throttle
+
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'blink'
 REQUIREMENTS = ['blinkpy==0.5.2']
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=180)
+MIN_TIME_BETWEEN_FORCED_UPDATES = timedelta(seconds=5)
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -47,6 +54,42 @@ class BlinkSystem(object):
         self.blink = blinkpy.Blink(username=config_info[DOMAIN][CONF_USERNAME],
                                    password=config_info[DOMAIN][CONF_PASSWORD])
         self.blink.setup_system()
+        self._header = {}
+        self.ignore_throttle = False
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES, MIN_TIME_BETWEEN_FORCED_UPDATES)
+    def image_request(self, image_url, **kwargs):
+        """Request an image from Blink servers."""
+        _LOGGER.info("Requesting image from Blink servers.")
+        response = requests.get(image_url, headers=self._header, stream=True)
+        if self.ignore_throttle:
+            self.ignore_throttle = False
+        return response
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES, MIN_TIME_BETWEEN_FORCED_UPDATES)
+    def update(self, **kwargs):
+        """Check auth token and update system."""
+        # Grab random camera header, doesn't matter which one
+        if not self._header:
+            camera_name = list(self.blink.cameras.keys())[0]
+            self._header = self.blink.cameras[camera_name].header
+            _LOGGER.info("Retrieving header from %s.", camera_name)
+
+        resp = requests.get(self.blink.urls.networks_url,
+                            headers=self._header)
+        if resp.status_code is not 200:
+            # Can't get device data, need to get new auth token
+            _LOGGER.info("Received status code %d, getting new token.",
+                         resp.status_code)
+            self.blink.get_auth_token()
+            self.blink.set_links()
+
+        self.blink.refresh()
+
+    def force_update(self):
+        """Force a system update."""
+        self.ignore_throttle = True
+        self.update(no_throttle=True)
 
 
 def setup(hass, config):
@@ -75,7 +118,11 @@ def setup(hass, config):
         """Arm the system."""
         value = call.data.get(ATTR_ARMED, True)
         hass.data[DOMAIN].blink.arm = value
-        hass.data[DOMAIN].blink.refresh()
+        hass.data[DOMAIN].update()
+
+    def force_update(call):
+        """Force an update."""
+        hass.data[DOMAIN].force_update()
 
     hass.services.register(DOMAIN, 'snap_picture', snap_picture,
                            schema=SNAP_PICTURE_SCHEMA)
@@ -83,5 +130,6 @@ def setup(hass, config):
                            schema=ARM_CAMERA_SCHEMA)
     hass.services.register(DOMAIN, 'arm_system', arm_system,
                            schema=ARM_SYSTEM_SCHEMA)
+    hass.services.register(DOMAIN, 'force_update', force_update)
 
     return True

--- a/homeassistant/components/sensor/blink.py
+++ b/homeassistant/components/sensor/blink.py
@@ -25,10 +25,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    data = hass.data[DOMAIN].blink
+    data = hass.data[DOMAIN]
     devs = list()
     index = 0
-    for name in data.cameras:
+    for name in data.blink.cameras:
         devs.append(BlinkSensor(name, 'temperature', index, data))
         devs.append(BlinkSensor(name, 'battery', index, data))
         devs.append(BlinkSensor(name, 'notifications', index, data))
@@ -72,7 +72,7 @@ class BlinkSensor(Entity):
 
     def update(self):
         """A method to retrieve sensor data from the camera."""
-        camera = self.data.cameras[self._camera_name]
+        camera = self.data.blink.cameras[self._camera_name]
         if self._type == 'temperature':
             self._state = camera.temperature
         elif self._type == 'battery':


### PR DESCRIPTION
## Description:
Current Blink implementation has two limitations:
* Can only talk to the server every 90 seconds
* Cannot recover session if the auth token expires (bug)

This PR fixes both of those by doing the following:
* Automatically update every 180 seconds, but allow for a forced update (for example, if you have called the ``snap_picture`` service, you know new info is on the server, so you can force an update to grab the image)
    - This should alleviate any potential load on Blink's servers while actually improving the responsiveness of the component within HA
* Any time ``BlinkSystem.update()`` is called, check if we can get a summary from the Blink servers.  If the request fails, login again to get a new token.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io# TODO

## Checklist:

  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**