### PR TITLE
self.loop.create_task -> self.add_job

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -113,7 +113,7 @@ def async_setup(hass, config):
             if not alarm.should_poll:
                 continue
 
-            update_coro = hass.loop.create_task(
+            update_coro = hass.async_add_job(
                 alarm.async_update_ha_state(True))
             if hasattr(alarm, 'async_update'):
                 update_tasks.append(update_coro)

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -224,7 +224,7 @@ def async_setup(hass, config):
             if not climate.should_poll:
                 continue
 
-            update_coro = hass.loop.create_task(
+            update_coro = hass.async_add_job(
                 climate.async_update_ha_state(True))
             if hasattr(climate, 'async_update'):
                 update_tasks.append(update_coro)

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -166,7 +166,7 @@ def async_setup(hass, config):
             if not cover.should_poll:
                 continue
 
-            update_coro = hass.loop.create_task(
+            update_coro = hass.async_add_job(
                 cover.async_update_ha_state(True))
             if hasattr(cover, 'async_update'):
                 update_tasks.append(update_coro)

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -218,7 +218,7 @@ def async_setup(hass, config: dict):
             if not fan.should_poll:
                 continue
 
-            update_coro = hass.loop.create_task(
+            update_coro = hass.async_add_job(
                 fan.async_update_ha_state(True))
             if hasattr(fan, 'async_update'):
                 update_tasks.append(update_coro)

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -255,7 +255,7 @@ def async_setup(hass, config):
             if not light.should_poll:
                 continue
 
-            update_coro = hass.loop.create_task(
+            update_coro = hass.async_add_job(
                 light.async_update_ha_state(True))
             if hasattr(light, 'async_update'):
                 update_tasks.append(update_coro)

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -96,7 +96,7 @@ def async_setup(hass, config):
             if not entity.should_poll:
                 continue
 
-            update_coro = hass.loop.create_task(
+            update_coro = hass.async_add_job(
                 entity.async_update_ha_state(True))
             if hasattr(entity, 'async_update'):
                 update_tasks.append(update_coro)

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -268,7 +268,7 @@ class KodiDevice(MediaPlayerDevice):
                 "Unable to connect to Kodi via websocket", exc_info=True)
             # Websocket connection is not required. Just return.
             return
-        self.hass.loop.create_task(self.async_ws_loop())
+        self.hass.async_add_job(self.async_ws_loop())
         self._ws_connected = True
 
     @asyncio.coroutine
@@ -297,7 +297,7 @@ class KodiDevice(MediaPlayerDevice):
             return
 
         if self._enable_websocket and not self._ws_connected:
-            self.hass.loop.create_task(self.async_ws_connect())
+            self.hass.async_add_job(self.async_ws_connect())
 
         self._app_properties = \
             yield from self.server.Application.GetProperties(

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -112,7 +112,7 @@ def async_setup(hass, config):
             if not remote.should_poll:
                 continue
 
-            update_coro = hass.loop.create_task(
+            update_coro = hass.async_add_job(
                 remote.async_update_ha_state(True))
             if hasattr(remote, 'async_update'):
                 update_tasks.append(update_coro)

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -358,7 +358,7 @@ class RflinkCommand(RflinkDevice):
                 self._protocol.send_command, self._device_id, cmd))
 
         if repetitions > 1:
-            self._repetition_task = self.hass.loop.create_task(
+            self._repetition_task = self.hass.async_add_job(
                 self._async_send_command(cmd, repetitions - 1))
 
 

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -111,7 +111,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         # Make all device entities aware of new telegram
         for device in devices:
             device.telegram = telegram
-            hass.async_add_job(device.async_update_ha_state)
+            hass.async_add_job(device.async_update_ha_state())
 
     # Creates a asyncio.Protocol factory for reading DSMR telegrams from serial
     # and calls update_entities_telegram to update entities on arrival
@@ -133,7 +133,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     def connect_and_reconnect():
         """Connect to DSMR and keep reconnecting until HA stops."""
         while hass.state != CoreState.stopping:
-            # Start DSMR asycnio.Protocol reader
+            # Start DSMR asyncio.Protocol reader
             try:
                 transport, protocol = yield from hass.loop.create_task(
                     reader_factory())
@@ -161,6 +161,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                 yield from asyncio.sleep(config[CONF_RECONNECT_INTERVAL],
                                          loop=hass.loop)
 
+    # Cannot be hass.async_add_job because job runs forever
     hass.loop.create_task(connect_and_reconnect())
 
 

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -112,7 +112,7 @@ def async_setup(hass, config):
             if not switch.should_poll:
                 continue
 
-            update_coro = hass.loop.create_task(
+            update_coro = hass.async_add_job(
                 switch.async_update_ha_state(True))
             if hasattr(switch, 'async_update'):
                 update_tasks.append(update_coro)

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -141,7 +141,7 @@ class HomeAssistant(object):
     def start(self) -> None:
         """Start home assistant."""
         # Register the async start
-        self.loop.create_task(self.async_start())
+        self.add_job(self.async_start())
 
         # Run forever and catch keyboard interrupt
         try:
@@ -149,7 +149,7 @@ class HomeAssistant(object):
             _LOGGER.info("Starting Home Assistant core loop")
             self.loop.run_forever()
         except KeyboardInterrupt:
-            self.loop.create_task(self.async_stop())
+            self.add_job(self.async_stop())
             self.loop.run_forever()
         finally:
             self.loop.close()

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -149,7 +149,7 @@ class HomeAssistant(object):
             _LOGGER.info("Starting Home Assistant core loop")
             self.loop.run_forever()
         except KeyboardInterrupt:
-            self.add_job(self.async_stop())
+            self.loop.create_task(self.async_stop())
             self.loop.run_forever()
         finally:
             self.loop.close()

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -419,7 +419,7 @@ class EntityPlatform(object):
                 update_coro = entity.async_update_ha_state(True)
                 if hasattr(entity, 'async_update'):
                     tasks.append(
-                        self.component.hass.loop.create_task(update_coro))
+                        self.component.hass.async_add_job(update_coro))
                 else:
                     to_update.append(update_coro)
 


### PR DESCRIPTION
## Description:
Home Assistant startup will wait till all startup tasks are done. This only works if we make sure that all startup tasks are added to the event loop using `hass.async_add_job`. This was not always the case because only recently did we have that method return a yieldable Task object.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
