### PR TITLE
Upgrade aiohttp to 1.3.4

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ pip>=7.0.0
 jinja2>=2.9.5
 voluptuous==0.9.3
 typing>=3,<4
-aiohttp==1.3.3
+aiohttp==1.3.4
 async_timeout==1.2.0
 
 # homeassistant.components.nuimo_controller

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     'jinja2>=2.9.5',
     'voluptuous==0.9.3',
     'typing>=3,<4',
-    'aiohttp==1.3.3',
+    'aiohttp==1.3.4',
     'async_timeout==1.2.0',
 ]
 


### PR DESCRIPTION
## 1.3.4

- Revert timeout handling in client request
- Fix StreamResponse representation after eof
- Fix file_sender to not fall on bad request (range out of file size)
- Fix file_sender to correct stream video to Chromes
- Fix NotImplementedError server exception #1703
- Clearer error message for URL without a host name. #1691
- Silence deprecation warning in __repr__ #1690
- IDN + HTTPS = ssl.CertificateError #1685

Bugfix version.
http://aiohttp.readthedocs.io/en/stable/changes.html
