### PR TITLE
round output values

### DIFF
--- a/homeassistant/components/sensor/comed_hourly_pricing.py
+++ b/homeassistant/components/sensor/comed_hourly_pricing.py
@@ -99,11 +99,13 @@ class ComedHourlyPricingSensor(Entity):
             if self.type == CONF_FIVE_MINUTE:
                 url_string = _RESOURCE + '?type=5minutefeed'
                 response = get(url_string, timeout=10)
-                self._state = float(response.json()[0]['price']) + self.offset
+                self._state = round(
+                    float(response.json()[0]['price']) + self.offset, 2)
             elif self.type == CONF_CURRENT_HOUR_AVERAGE:
                 url_string = _RESOURCE + '?type=currenthouraverage'
                 response = get(url_string, timeout=10)
-                self._state = float(response.json()[0]['price']) + self.offset
+                self._state = round(
+                    float(response.json()[0]['price']) + self.offset, 2)
             else:
                 self._state = STATE_UNKNOWN
         except (RequestException, ValueError, KeyError):


### PR DESCRIPTION
## Description:

Round output values in ComEd hourly pricing sensor.  This prevents an issue where values were sometimes displayed for example as 12.400000000001 

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: comed_hourly_pricing
    monitored_feeds:
      - type: five_minute
      - type: current_hour_average
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
