### PR TITLE
sensor.rest: add update_interval setting

### DIFF
--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -83,7 +83,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RestSensor(Entity):
     """Implementation of a REST sensor."""
 
-    def __init__(self, hass, rest, name, unit_of_measurement, value_template, 
+    def __init__(self, hass, rest, name, unit_of_measurement, value_template,
                  interval):
         """Initialize the REST sensor."""
         self._hass = hass

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -123,6 +123,7 @@ class RestSensor(Entity):
 
         self._state = value
 
+
 class RestData(object):
     """Class for handling the data retrieval."""
 

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -83,7 +83,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RestSensor(Entity):
     """Implementation of a REST sensor."""
 
-    def __init__(self, hass, rest, name, unit_of_measurement, value_template, interval):
+    def __init__(self, hass, rest, name, unit_of_measurement, value_template, 
+                 interval):
         """Initialize the REST sensor."""
         self._hass = hass
         self.rest = rest

--- a/tests/components/sensor/test_rest.py
+++ b/tests/components/sensor/test_rest.py
@@ -135,7 +135,8 @@ class TestRestSensor(unittest.TestCase):
 
         self.sensor = rest.RestSensor(self.hass, self.rest, self.name,
                                       self.unit_of_measurement,
-                                      self.value_template)
+                                      self.value_template, self.interval)
+
 
     def tearDown(self):
         """Stop everything that was started."""
@@ -162,7 +163,7 @@ class TestRestSensor(unittest.TestCase):
         """Test state gets updated to unknown when sensor returns no data."""
         self.rest.update = Mock('rest.RestData.update',
                                 side_effect=self.update_side_effect(None))
-        self.sensor.update()
+        self.sensor._update()
         self.assertEqual(STATE_UNKNOWN, self.sensor.state)
 
     def test_update_when_value_changed(self):
@@ -170,7 +171,7 @@ class TestRestSensor(unittest.TestCase):
         self.rest.update = Mock('rest.RestData.update',
                                 side_effect=self.update_side_effect(
                                     '{ "key": "updated_state" }'))
-        self.sensor.update()
+        self.sensor._update()
         self.assertEqual('updated_state', self.sensor.state)
 
     def test_update_with_no_template(self):
@@ -180,7 +181,7 @@ class TestRestSensor(unittest.TestCase):
                                     'plain_state'))
         self.sensor = rest.RestSensor(self.hass, self.rest, self.name,
                                       self.unit_of_measurement, None)
-        self.sensor.update()
+        self.sensor._update()
         self.assertEqual('plain_state', self.sensor.state)
 
 


### PR DESCRIPTION
## Description:
I'm trying to add `update_interval` to the `sensor.rest` but... for some reason it does not seem to work. I've used 'fedex' sensor as an example but... can not make it poll with the frequency set... can someone give me a hand witht it? Thanks.

**Related issue (if applicable):** #6647

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: rest
    resource: http://ip.jsontest.com
    name: rest Public IP
    value_template: '{{ value_json.ip }}'
    update_inverval:
      seconds: 10
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
(not yet)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
