### PR TITLE
Check if droplet exists

### DIFF
--- a/homeassistant/components/binary_sensor/digital_ocean.py
+++ b/homeassistant/components/binary_sensor/digital_ocean.py
@@ -36,8 +36,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     dev = []
     for droplet in droplets:
         droplet_id = digital_ocean.DIGITAL_OCEAN.get_droplet_id(droplet)
-        dev.append(DigitalOceanBinarySensor(
-            digital_ocean.DIGITAL_OCEAN, droplet_id))
+        if droplet_id is None:
+            _LOGGER.error("Droplet is not available")
+            return False
+        else:
+            dev.append(DigitalOceanBinarySensor(
+                digital_ocean.DIGITAL_OCEAN, droplet_id))
 
     add_devices(dev)
 

--- a/homeassistant/components/binary_sensor/digital_ocean.py
+++ b/homeassistant/components/binary_sensor/digital_ocean.py
@@ -37,11 +37,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for droplet in droplets:
         droplet_id = digital_ocean.DIGITAL_OCEAN.get_droplet_id(droplet)
         if droplet_id is None:
-            _LOGGER.error("Droplet is not available")
+            _LOGGER.error("Droplet %s is not available", droplet)
             return False
-        else:
-            dev.append(DigitalOceanBinarySensor(
-                digital_ocean.DIGITAL_OCEAN, droplet_id))
+        dev.append(DigitalOceanBinarySensor(
+            digital_ocean.DIGITAL_OCEAN, droplet_id))
 
     add_devices(dev)
 

--- a/homeassistant/components/switch/digital_ocean.py
+++ b/homeassistant/components/switch/digital_ocean.py
@@ -35,8 +35,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     dev = []
     for droplet in droplets:
         droplet_id = digital_ocean.DIGITAL_OCEAN.get_droplet_id(droplet)
-        dev.append(DigitalOceanSwitch(
-            digital_ocean.DIGITAL_OCEAN, droplet_id))
+        if droplet_id is None:
+            _LOGGER.error("Droplet is not available")
+            return False
+        else:
+            dev.append(DigitalOceanSwitch(
+                digital_ocean.DIGITAL_OCEAN, droplet_id))
 
     add_devices(dev)
 

--- a/homeassistant/components/switch/digital_ocean.py
+++ b/homeassistant/components/switch/digital_ocean.py
@@ -36,11 +36,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for droplet in droplets:
         droplet_id = digital_ocean.DIGITAL_OCEAN.get_droplet_id(droplet)
         if droplet_id is None:
-            _LOGGER.error("Droplet is not available")
+            _LOGGER.error("Droplet %s is not available", droplet)
             return False
-        else:
-            dev.append(DigitalOceanSwitch(
-                digital_ocean.DIGITAL_OCEAN, droplet_id))
+        dev.append(DigitalOceanSwitch(
+            digital_ocean.DIGITAL_OCEAN, droplet_id))
 
     add_devices(dev)
 


### PR DESCRIPTION
## Description:
Running the Digital Ocean integration with no droplets has led to a traceback. No setup is only successful if the given droplets are present.

## Example entry for `configuration.yaml` (if applicable):
```yaml
digital_ocean:
  access_token: !secret do_api
binary_sensor:
  - platform: digital_ocean
    droplets:
      - 'fedora-512mb-nyc3-01'
```

```yaml
digital_ocean:
  access_token: !secret do_api
switch:
  - platform: digital_ocean
    droplets:
      - 'fedora-512mb-nyc3-01'
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
