### PR TITLE
Stop duplicate MQTT discovery

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -27,6 +27,8 @@ ALLOWED_PLATFORMS = {
     'sensor': ['mqtt']
 }
 
+DISCOVERED_TOPICS = []
+
 
 @asyncio.coroutine
 def async_start(hass, discovery_topic, hass_config):
@@ -39,6 +41,11 @@ def async_start(hass, discovery_topic, hass_config):
 
         if not match:
             return
+
+        if topic in DISCOVERED_TOPICS:
+            return
+
+        DISCOVERED_TOPICS.append(topic)
 
         prefix_topic, component, object_id = match.groups()
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -45,8 +45,6 @@ def async_start(hass, discovery_topic, hass_config):
         if topic in DISCOVERED_TOPICS:
             return
 
-        DISCOVERED_TOPICS.append(topic)
-
         prefix_topic, component, object_id = match.groups()
 
         try:
@@ -70,6 +68,8 @@ def async_start(hass, discovery_topic, hass_config):
         if CONF_STATE_TOPIC not in payload:
             payload[CONF_STATE_TOPIC] = '{}/{}/{}/state'.format(
                 discovery_topic, component, object_id)
+
+        DISCOVERED_TOPICS.append(topic)
 
         yield from async_load_platform(
             hass, component, platform, payload, hass_config)


### PR DESCRIPTION
## Description:
This stops entities being discovered multiple times if they are turned on/off. I considered checking to see if the payload was the same and if not re-discovering the device but there's no way to un-discover entities that I could find.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
