### PR TITLE
camera.zoneminder: Show recording state

### DIFF
--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -19,6 +19,9 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['zoneminder']
 DOMAIN = 'zoneminder'
 
+# From ZoneMinder's web/includes/config.php.in
+ZM_STATE_ALARM = "2"
+
 
 def _get_image_url(hass, monitor, mode):
     zm_data = hass.data[DOMAIN]
@@ -69,10 +72,43 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             CONF_MJPEG_URL: _get_image_url(hass, monitor, 'jpeg'),
             CONF_STILL_IMAGE_URL: _get_image_url(hass, monitor, 'single')
         }
-        cameras.append(MjpegCamera(hass, device_info))
+        cameras.append(ZoneMinderCamera(hass, device_info, monitor))
 
     if not cameras:
         _LOGGER.warning('No active cameras found')
         return
 
     async_add_devices(cameras)
+
+
+class ZoneMinderCamera(MjpegCamera):
+    """Representation of a ZoneMinder Monitor Stream."""
+
+    def __init__(self, hass, device_info, monitor):
+        """Initialize as a subclass of MjpegCamera."""
+        super().__init__(hass, device_info)
+        self._monitor_id = int(monitor['Id'])
+        self._is_recording = None
+
+    @property
+    def should_poll(self):
+        """Update the recording state periodically."""
+        return True
+
+    def update(self):
+        """Update our recording state from the ZM API."""
+        _LOGGER.debug('Updating camera state for monitor %i', self._monitor_id)
+        status_response = zoneminder.get_state(
+            'api/monitors/alarm/id:%i/command:status.json' % self._monitor_id
+        )
+        if not status_response:
+            _LOGGER.warning('Could not get status for monitor %i',
+                            self._monitor_id)
+            return
+
+        self._is_recording = status_response['status'] == ZM_STATE_ALARM
+
+    @property
+    def is_recording(self):
+        """Return whether the monitor is in alarm mode."""
+        return self._is_recording


### PR DESCRIPTION
## Description:
Now that we have camera.zoneminder we can implement #4905 by using the state of the camera itself. For now I only consider STATE_ALARM for is_recording but if HA devs are fine with it I would prefer to expose [all 5 states of ZoneMinder](https://github.com/ZoneMinder/ZoneMinder/blob/254fcbcef790c0db11cd845548cd0383b7660e90/web/includes/config.php.in#L77-L81) instead (which I could do in a separate pull request).

**Related issue (if applicable):** fixes #4905

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A since this is only changing the state, nothing really user visible

## Example entry for `configuration.yaml` (if applicable): 
```yaml
camera:
  platform: zoneminder
```
(nothing new)

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully.
  - * I get a failure in test_workday.py on py35 but it doesn't look related to my changes