### PR TITLE
Upgrade distro to 1.0.3

### DIFF
--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -22,7 +22,7 @@ from homeassistant.const import __version__ as CURRENT_VERSION
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.helpers import event
 
-REQUIREMENTS = ['distro==1.0.2']
+REQUIREMENTS = ['distro==1.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,8 +71,7 @@ def setup(hass, config):
     """Set up the updater component."""
     if 'dev' in CURRENT_VERSION:
         # This component only makes sense in release versions
-        _LOGGER.warning("Updater component enabled in 'dev'. "
-                        "No notifications but analytics will be submitted")
+        _LOGGER.warning("Running on 'dev', only analytics will be submitted")
 
     config = config.get(DOMAIN, {})
     huuid = _load_uuid(hass) if config.get(CONF_REPORTING) else None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -115,7 +115,7 @@ directpy==0.1
 discord.py==0.16.0
 
 # homeassistant.components.updater
-distro==1.0.2
+distro==1.0.3
 
 # homeassistant.components.switch.digitalloggers
 dlipower==0.7.165


### PR DESCRIPTION
1.0.3
-------

* Add manual mapping for redhatenterpriseserver (previously only redhatenterpriseworkstation was mapped)
* Return empty information when failing to read a seemingly version related file due to IO or OS errors.
* When using the CLI without providing the -j flag, printout keys even if their values are empty.
* Replace nose with pytest
* Add RHEL5 test case
* Add OpenELEC test case
* Update supported Python versions (with py36)
* Update classifiers

Also, shorter warning on `dev`.

Tested with the following configuration:

``` yaml
updater:
```