### PR TITLE
Kodi use websocket loop task created by library

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -327,7 +327,7 @@ insteonplm==0.7.4
 jsonrpc-async==0.4
 
 # homeassistant.components.media_player.kodi
-jsonrpc-websocket==0.2
+jsonrpc-websocket==0.3
 
 # homeassistant.scripts.keyring
 keyring>=9.3,<10.0


### PR DESCRIPTION
## Description:
As @pvizeli suggested, I modified the jsonrpc library to create it's own task on the event loop. (This is definitely cleaner.) Unfortunately, I don't think we can quite escape creating our own task, since we don't want exceptions from websocket errors to fall directly out to stderr. I'm open to other solutions if there's a better way to capture task exceptions with asyncio.

**Related issue (if applicable):** fixes #6674