### PR TITLE
Platform for Munich public transport departure times

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -360,6 +360,7 @@ omit =
     homeassistant/components/sensor/miflora.py
     homeassistant/components/sensor/modem_callerid.py
     homeassistant/components/sensor/mqtt_room.py
+    homeassistant/components/sensor/mvglive.py
     homeassistant/components/sensor/netdata.py
     homeassistant/components/sensor/neurio_energy.py
     homeassistant/components/sensor/nut.py

--- a/homeassistant/components/sensor/mvglive.py
+++ b/homeassistant/components/sensor/mvglive.py
@@ -13,6 +13,7 @@ import voluptuous as vol
 from homeassistant.util import Throttle
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import STATE_UNKNOWN
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -73,6 +74,7 @@ class MVGLiveSensor(Entity):
         self._line = line
         self.data = MVGLiveData(station, destination, line,
                                 offset, ubahn, tram, bus, sbahn)
+        self._state = STATE_UNKNOWN
 
     @property
     def name(self):
@@ -108,7 +110,7 @@ class MVGLiveSensor(Entity):
         """Get the latest data and update the state."""
         self.data.update()
         if not self.data.departures:
-            self._state = ('-')
+            self._state = '-'
         else:
             self._state = self.data.departures[0].get('time', '-')
 
@@ -136,10 +138,10 @@ class MVGLiveData(object):
         """Update the connection data."""
         try:
             _departures = self.mvg.getlivedata(station=self._station,
-                                                   ubahn=self._ubahn,
-                                                   tram=self._tram,
-                                                   bus=self._bus,
-                                                   sbahn=self._sbahn)
+                                               ubahn=self._ubahn,
+                                               tram=self._tram,
+                                               bus=self._bus,
+                                               sbahn=self._sbahn)
         except ValueError:
             self.departures = [{}]
             _LOGGER.warning("Returned data not understood.")

--- a/homeassistant/components/sensor/mvglive.py
+++ b/homeassistant/components/sensor/mvglive.py
@@ -18,9 +18,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 # A typo in the file name of the PyPI version prevents installation from PyPI
-REQUIREMENTS = ["https://github.com/pc-coholic/PyMVGLive/archive/"
-                "1.1.2.zip#"
-                "PyMVGLive==1.1.2"]
+REQUIREMENTS = ["PyMVGLive==1.1.3"]
 ICON = 'mdi:bus'
 
 # Return cached results if last scan was less then this time ago.

--- a/homeassistant/components/sensor/mvglive.py
+++ b/homeassistant/components/sensor/mvglive.py
@@ -1,0 +1,160 @@
+"""
+Support for real-time departure information for public transport in Munich.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.mvglive/
+"""
+
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.util import Throttle
+from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+# A typo in the file name of the PyPI version prevents installation from PyPI
+REQUIREMENTS = ["https://github.com/pc-coholic/PyMVGLive/archive/"
+                "1.1.2.zip#"
+                "PyMVGLive==1.1.2"]
+ICON = 'mdi:bus'
+
+# Return cached results if last scan was less then this time ago.
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=15)
+
+CONF_STATION = 'station'
+CONF_DEST = 'destination'
+CONF_LINE = 'line'
+CONF_OFFSET = 'offset'
+CONF_UBAHN = 'ubahn'
+CONF_TRAM = 'tram'
+CONF_BUS = 'bus'
+CONF_SBAHN = 'sbahn'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_STATION): cv.string,
+    vol.Optional(CONF_DEST, default=None): cv.string,
+    vol.Optional(CONF_LINE, default=None): cv.string,
+    vol.Optional(CONF_OFFSET, default=0): cv.positive_int,
+    vol.Optional(CONF_UBAHN, default=True): cv.boolean,
+    vol.Optional(CONF_TRAM, default=True): cv.boolean,
+    vol.Optional(CONF_BUS, default=True): cv.boolean,
+    vol.Optional(CONF_SBAHN, default=True): cv.boolean,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the MVG Live Sensor."""
+    station = config.get(CONF_STATION)
+    destination = config.get(CONF_DEST)
+    line = config.get(CONF_LINE)
+    offset = config.get(CONF_OFFSET)
+    ubahn = config.get(CONF_UBAHN)
+    tram = config.get(CONF_TRAM)
+    bus = config.get(CONF_BUS)
+    sbahn = config.get(CONF_SBAHN)
+
+    add_devices([MVGLiveSensor(station, destination, line,
+                               offset, ubahn, tram, bus, sbahn)])
+
+
+# pylint: disable=too-few-public-methods
+class MVGLiveSensor(Entity):
+    """Implementation of an MVG Live sensor."""
+
+    def __init__(self, station, destination, line,
+                 offset, ubahn, tram, bus, sbahn):
+        """Initialize the sensor."""
+        self._station = station
+        self._destination = destination
+        self._line = line
+        self.data = MVGLiveData(station, destination, line,
+                                offset, ubahn, tram, bus, sbahn)
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        # e.g.
+        # 'Hauptbahnhof (S1)'
+        # 'Hauptbahnhof-Marienplatz'
+        # 'Hauptbahnhof-Marienplatz (S1)'
+        namestr = self._station
+        if self._destination:
+            namestr = namestr + '-' + self._destination
+        if self._line:
+            namestr = namestr + ' (' + self._line + ')'
+        return namestr
+
+    @property
+    def icon(self):
+        """Return the icon for the frontend."""
+        return ICON
+
+    @property
+    def state(self):
+        """Return the departure time of the next train."""
+        return self._state
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        if self.data.departures:
+            return self.data.departures[0]
+
+    def update(self):
+        """Get the latest data and update the state."""
+        self.data.update()
+        if not self.data.departures:
+            self._state = ('-')
+        else:
+            self._state = self.data.departures[0].get('time', '-')
+
+
+class MVGLiveData(object):
+    """Pull data from the mvg-live.de web page."""
+
+    def __init__(self, station, destination, line,
+                 offset, ubahn, tram, bus, sbahn):
+        """Initialize the sensor."""
+        import MVGLive
+        self._station = station
+        self._destination = destination
+        self._line = line
+        self._offset = offset
+        self._ubahn = ubahn
+        self._tram = tram
+        self._bus = bus
+        self._sbahn = sbahn
+        self.mvg = MVGLive.MVGLive()
+        self.departures = [{}]
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Update the connection data."""
+        try:
+            self.departures = self.mvg.getlivedata(station=self._station,
+                                                   ubahn=self._ubahn,
+                                                   tram=self._tram,
+                                                   bus=self._bus,
+                                                   sbahn=self._sbahn)
+        except ValueError:
+            self.departures = [{}]
+            _LOGGER.warning("Returned data not understood.")
+            return
+        self.departures = [con for con in self.departures
+                           if con['time'] >= self._offset and
+                           con['destination'].startswith(self._destination)]
+        for con in self.departures:
+            # Details info is not useful.
+            # Having a more consistent interface simplifies
+            # usage of Template sensors later on
+            con.pop('productsymbol')
+            con.pop('productsymbolurl')
+            con.pop('linesymbol')
+            con.pop('linesymbolurl')
+            if 'time' in con and con['time'].is_integer():
+                con['time'] = int(con['time'])

--- a/homeassistant/components/sensor/mvglive.py
+++ b/homeassistant/components/sensor/mvglive.py
@@ -151,7 +151,8 @@ class MVGLiveData(object):
                 continue
             # now select the relevant data
             _nextdep = {}
-            for k in ['destination', 'linename', 'time', 'direction', 'product']:
+            for k in ['destination', 'linename', 'time', 'direction',
+                      'product']:
                 _nextdep[k] = _departure.get(k, '')
             _nextdep['time'] = int(_nextdep['time'])
             self.nextdeparture = _nextdep

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -282,6 +282,9 @@ https://github.com/nkgilley/python-ecobee-api/archive/a4496b293956b2eac285305136
 # homeassistant.components.notify.joaoapps_join
 https://github.com/nkgilley/python-join-api/archive/3e1e849f1af0b4080f551b62270c6d244d5fbcbd.zip#python-join-api==0.0.1
 
+# homeassistant.components.sensor.mvglive
+https://github.com/pc-coholic/PyMVGLive/archive/1.1.2.zip#PyMVGLive==1.1.2
+
 # homeassistant.components.notify.mailgun
 https://github.com/pschmitt/pymailgun/archive/1.3.zip#pymailgun==1.3
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -21,6 +21,9 @@ PyISY==1.0.7
 # homeassistant.components.notify.html5
 PyJWT==1.4.2
 
+# homeassistant.components.sensor.mvglive
+PyMVGLive==1.1.3
+
 # homeassistant.components.arduino
 PyMata==2.13
 
@@ -281,9 +284,6 @@ https://github.com/nkgilley/python-ecobee-api/archive/a4496b293956b2eac285305136
 # homeassistant.components.joaoapps_join
 # homeassistant.components.notify.joaoapps_join
 https://github.com/nkgilley/python-join-api/archive/3e1e849f1af0b4080f551b62270c6d244d5fbcbd.zip#python-join-api==0.0.1
-
-# homeassistant.components.sensor.mvglive
-https://github.com/pc-coholic/PyMVGLive/archive/1.1.2.zip#PyMVGLive==1.1.2
 
 # homeassistant.components.notify.mailgun
 https://github.com/pschmitt/pymailgun/archive/1.3.zip#pymailgun==1.3


### PR DESCRIPTION
I'm not sure if this is too local to become an official component but for me it's very useful so I thought I'd share it anyway.

## Description:

The MVG live service (http://www.mvg-live.de) provides real-time departure information for the Munich public transort system (bus, tram, subway, suburban rail). This platform provides a sensor for the time to the next departure (optionally the next departure after an offset, e.g. the time it takes you to walk to the bus stop) at  a stop or station. The destination and line number are given in the attributes. Optionally, specific lines or destinations can be selected.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/2311

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: mvglive
  station: Marienplatz
```

## Checklist:

  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
