### PR TITLE
automatically use bundled certificate it set to auto

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -318,7 +318,7 @@ def async_setup(hass, config):
                                    'addtrustexternalcaroot.crt')
 
     # When the certificate is set to auto, use bundled certs from requests
-    if certificate is not None and certificate.lower() == 'auto':
+    if certificate == 'auto':
         certificate = requests.certs.where()
 
     will_message = conf.get(CONF_WILL_MESSAGE)

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -119,7 +119,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_USERNAME): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_CERTIFICATE): vol.Any('auto',cv.isfile),
+        vol.Optional(CONF_CERTIFICATE): vol.Any('auto', cv.isfile),
         vol.Inclusive(CONF_CLIENT_KEY, 'client_key_auth',
                       msg=CLIENT_KEY_AUTH_MSG): cv.isfile,
         vol.Inclusive(CONF_CLIENT_CERT, 'client_key_auth',
@@ -317,7 +317,7 @@ def async_setup(hass, config):
         certificate = os.path.join(os.path.dirname(__file__),
                                    'addtrustexternalcaroot.crt')
 
-    # When the certificate is set to auto, use bundled certificates from requests
+    # When the certificate is set to auto, use bundled certs from requests
     if certificate is not None and certificate.lower() == 'auto':
         certificate = requests.certs.where()
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -119,7 +119,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_USERNAME): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_CERTIFICATE): cv.isfile,
+        vol.Optional(CONF_CERTIFICATE): vol.Any('auto',cv.isfile),
         vol.Inclusive(CONF_CLIENT_KEY, 'client_key_auth',
                       msg=CLIENT_KEY_AUTH_MSG): cv.isfile,
         vol.Inclusive(CONF_CLIENT_CERT, 'client_key_auth',
@@ -317,8 +317,8 @@ def async_setup(hass, config):
         certificate = os.path.join(os.path.dirname(__file__),
                                    'addtrustexternalcaroot.crt')
 
-    # When the port indicates mqtts, use bundled certificates from requests
-    if certificate is None and port == 8883:
+    # When the certificate is set to auto, use bundled certificates from requests
+    if certificate is not None and certificate.lower() == 'auto':
         certificate = requests.certs.where()
 
     will_message = conf.get(CONF_WILL_MESSAGE)

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -377,8 +377,24 @@ def test_setup_fails_if_no_connect_broker(hass):
 
 
 @asyncio.coroutine
-def test_setup_uses_certificate_on_mqtts_port(hass):
-    """Test setup uses bundled certificates when mqtts port is requested."""
+def test_setup_uses_certificate_on_certificate_set_to_auto(hass):
+    """Test setup uses bundled certificates when certificate is set to auto."""
+    test_broker_cfg = {mqtt.DOMAIN: {mqtt.CONF_BROKER: 'test-broker',
+                                     'certificate': 'auto'}}
+
+    with mock.patch('homeassistant.components.mqtt.MQTT') as mock_MQTT:
+        yield from async_setup_component(hass, mqtt.DOMAIN, test_broker_cfg)
+
+    assert mock_MQTT.called
+
+    import requests.certs
+    expectedCertificate = requests.certs.where()
+    assert mock_MQTT.mock_calls[0][1][7] == expectedCertificate
+
+
+@asyncio.coroutine
+def test_setup_does_not_use_certificate_on_mqtts_port(hass):
+    """Test setup doesn't use bundled certificates when certificate is not set."""
     test_broker_cfg = {mqtt.DOMAIN: {mqtt.CONF_BROKER: 'test-broker',
                                      'port': 8883}}
 
@@ -387,23 +403,6 @@ def test_setup_uses_certificate_on_mqtts_port(hass):
 
     assert mock_MQTT.called
     assert mock_MQTT.mock_calls[0][1][2] == 8883
-
-    import requests.certs
-    expectedCertificate = requests.certs.where()
-    assert mock_MQTT.mock_calls[0][1][7] == expectedCertificate
-
-
-@asyncio.coroutine
-def test_setup_uses_certificate_not_on_mqtts_port(hass):
-    """Test setup doesn't use bundled certificates when not mqtts port."""
-    test_broker_cfg = {mqtt.DOMAIN: {mqtt.CONF_BROKER: 'test-broker',
-                                     'port': 1883}}
-
-    with mock.patch('homeassistant.components.mqtt.MQTT') as mock_MQTT:
-        yield from async_setup_component(hass, mqtt.DOMAIN, test_broker_cfg)
-
-    assert mock_MQTT.called
-    assert mock_MQTT.mock_calls[0][1][2] == 1883
 
     import requests.certs
     mqttsCertificateBundle = requests.certs.where()

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -378,7 +378,7 @@ def test_setup_fails_if_no_connect_broker(hass):
 
 @asyncio.coroutine
 def test_setup_uses_certificate_on_certificate_set_to_auto(hass):
-    """Test setup uses bundled certificates when certificate is set to auto."""
+    """Test setup uses bundled certs when certificate is set to auto."""
     test_broker_cfg = {mqtt.DOMAIN: {mqtt.CONF_BROKER: 'test-broker',
                                      'certificate': 'auto'}}
 
@@ -394,7 +394,7 @@ def test_setup_uses_certificate_on_certificate_set_to_auto(hass):
 
 @asyncio.coroutine
 def test_setup_does_not_use_certificate_on_mqtts_port(hass):
-    """Test setup doesn't use bundled certificates when certificate is not set."""
+    """Test setup doesn't use bundled certs when certificate is not set."""
     test_broker_cfg = {mqtt.DOMAIN: {mqtt.CONF_BROKER: 'test-broker',
                                      'port': 8883}}
 


### PR DESCRIPTION
## Description:
Change the way that bundled certificates is automatically used.
From now on it will be specified by setting certificate to 'auto'.
The previous method of using the port set to 8883, will no longer effect the certificate.


**Related issue (if applicable):** fixes #6596

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2295

## Example entry for `configuration.yaml` (if applicable):
```
mqtt:
  broker: <ip>
  port: <port>
  client_id: home-assistant-1
  username: <username>
  password: <password>
  certificate: auto


```

## Checklist:

  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
