### PR TITLE
rest_command: Do not log status as an error if response code is <400

### DIFF
--- a/homeassistant/components/rest_command.py
+++ b/homeassistant/components/rest_command.py
@@ -90,7 +90,7 @@ def async_setup(hass, config):
                         auth=auth
                     )
 
-                    if request.status == 200:
+                    if request.status < 400:
                         _LOGGER.info("Success call %s.", request.url)
                         return
 


### PR DESCRIPTION
## Description:
Do not log status as an error if response code is <400

**Related issue (if applicable):** fixes #6673

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
