### PR TITLE
Don't warn if octoprint completion is null

### DIFF
--- a/homeassistant/components/sensor/octoprint.py
+++ b/homeassistant/components/sensor/octoprint.py
@@ -127,6 +127,6 @@ class OctoPrintSensor(Entity):
             # Error calling the api, already logged in api.update()
             return
 
-        if self._state is None:
+        if self._state is None and self.sensor_type != "completion":
             _LOGGER.warning("Unable to locate value for %s", self.sensor_type)
             return


### PR DESCRIPTION
## Description:
The Octoprint API returns `null` for `progress.completion` when there is no current job, don't log a warning in this case.