### PR TITLE
Fix LIFX unregister races

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -25,7 +25,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['aiolifx==0.4.1.post1']
+REQUIREMENTS = ['aiolifx==0.4.2']
 
 UDP_BROADCAST_PORT = 56700
 
@@ -95,11 +95,12 @@ class LIFXManager(object):
     @callback
     def unregister(self, device):
         """Callback for disappearing bulb."""
-        entity = self.entities[device.mac_addr]
-        _LOGGER.debug("%s unregister", entity.ipaddr)
-        entity.available = False
-        entity.updated_event.set()
-        self.hass.async_add_job(entity.async_update_ha_state())
+        if device.mac_addr in self.entities:
+            entity = self.entities[device.mac_addr]
+            _LOGGER.debug("%s unregister", entity.ipaddr)
+            entity.available = False
+            entity.updated_event.set()
+            self.hass.async_add_job(entity.async_update_ha_state())
 
 
 def convert_rgb_to_hsv(rgb):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -41,7 +41,7 @@ aiodns==1.1.1
 aiohttp_cors==0.5.0
 
 # homeassistant.components.light.lifx
-aiolifx==0.4.1.post1
+aiolifx==0.4.2
 
 # homeassistant.components.camera.amcrest
 # homeassistant.components.sensor.amcrest


### PR DESCRIPTION
## Description:

If the initial state request never got a response, we tried to unregister
a device that was not yet registered.

Also, aiolifx 0.4.2 has an "unregister" race fix.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable.
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.