### PR TITLE
Fix iCloud lost_iphone not working if device_name given

### DIFF
--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -407,7 +407,7 @@ class Icloud(DeviceScanner):
         self.api.authenticate()
 
         for device in self.api.devices:
-            if devicename is None or device == self.devices[devicename]:
+            if devicename is None or str(device) == str(self.devices[devicename]):
                 device.play_sound()
 
     def update_icloud(self, devicename=None):


### PR DESCRIPTION
## Description:

This fixes the icloud_lost_iphone service not triggering when a device_name is given.  

The lost_iphone service would match devices by comparing device dictionaries. This would fail if the device location had changed. Updated to match by the device name only. 
