### PR TITLE
Support xy_color for all light platforms

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -244,11 +244,16 @@ def async_setup(hass, config):
         xy_color = params.get(ATTR_XY_COLOR, None)
 
         for light in target_lights:
-            support_xy = bool(light.supported_features & SUPPORT_XY_COLOR)
-            if xy_color is not None and not support_xy:
-                params[ATTR_RGB_COLOR] = color_util.color_xy_brightness_to_RGB(
-                    *xy_color,
-                    ibrightness=params.get(ATTR_BRIGHTNESS, light.brightness))
+            # Convert xy_color if unsupported
+            if xy_color is not None:
+                support_xy = bool(light.supported_features & SUPPORT_XY_COLOR)
+                brightness = params.get(ATTR_BRIGHTNESS, light.brightness)
+
+                if not support_xy and brightness is not None:
+                    rgb = color_util.color_xy_brightness_to_RGB(
+                        *xy_color,
+                        ibrightness=brightness)
+                    params[ATTR_RGB_COLOR] = rgb
 
             if service.service == SERVICE_TURN_ON:
                 yield from light.async_turn_on(**params)

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -241,7 +241,15 @@ def async_setup(hass, config):
         if color_name is not None:
             params[ATTR_RGB_COLOR] = color_util.color_name_to_rgb(color_name)
 
+        xy_color = params.get(ATTR_XY_COLOR, None)
+
         for light in target_lights:
+            support_xy = bool(light.supported_features & SUPPORT_XY_COLOR)
+            if xy_color is not None and not support_xy:
+                params[ATTR_RGB_COLOR] = color_util.color_xy_brightness_to_RGB(
+                    *xy_color,
+                    ibrightness=params.get(ATTR_BRIGHTNESS, light.brightness))
+
             if service.service == SERVICE_TURN_ON:
                 yield from light.async_turn_on(**params)
             elif service.service == SERVICE_TURN_OFF:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -242,19 +242,16 @@ def async_setup(hass, config):
             params[ATTR_RGB_COLOR] = color_util.color_name_to_rgb(color_name)
 
         xy_color = params.get(ATTR_XY_COLOR, None)
+        brightness = params.get(ATTR_BRIGHTNESS, None)
+
+        # Convert xy_color/brightness for lights that do not support xy
+        if xy_color is not None and brightness is not None:
+            rgb = color_util.color_xy_brightness_to_RGB(
+                *xy_color,
+                ibrightness=brightness)
+            params.setdefault(ATTR_RGB_COLOR, rgb)
 
         for light in target_lights:
-            # Convert xy_color if unsupported
-            if xy_color is not None:
-                support_xy = bool(light.supported_features & SUPPORT_XY_COLOR)
-                brightness = params.get(ATTR_BRIGHTNESS, light.brightness)
-
-                if not support_xy and brightness is not None:
-                    rgb = color_util.color_xy_brightness_to_RGB(
-                        *xy_color,
-                        ibrightness=brightness)
-                    params.setdefault(ATTR_RGB_COLOR, rgb)
-
             if service.service == SERVICE_TURN_ON:
                 yield from light.async_turn_on(**params)
             elif service.service == SERVICE_TURN_OFF:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -245,19 +245,27 @@ def async_setup(hass, config):
         brightness = params.get(ATTR_BRIGHTNESS, None)
 
         # Convert xy_color/brightness for lights that do not support xy
+        params_rgb = params.copy()
         if xy_color is not None and brightness is not None:
             rgb = color_util.color_xy_brightness_to_RGB(
                 *xy_color,
                 ibrightness=brightness)
-            params.setdefault(ATTR_RGB_COLOR, rgb)
+            params_rgb.setdefault(ATTR_RGB_COLOR, rgb)
 
         for light in target_lights:
-            if service.service == SERVICE_TURN_ON:
-                yield from light.async_turn_on(**params)
-            elif service.service == SERVICE_TURN_OFF:
-                yield from light.async_turn_off(**params)
+            support_xy = bool(light.supported_features & SUPPORT_XY_COLOR)
+            support_rgb = bool(light.supported_features & SUPPORT_RGB_COLOR)
+            if not support_xy and support_rgb:
+                lightparams = params_rgb
             else:
-                yield from light.async_toggle(**params)
+                lightparams = params
+
+            if service.service == SERVICE_TURN_ON:
+                yield from light.async_turn_on(**lightparams)
+            elif service.service == SERVICE_TURN_OFF:
+                yield from light.async_turn_off(**lightparams)
+            else:
+                yield from light.async_toggle(**lightparams)
 
         update_tasks = []
 

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -253,7 +253,7 @@ def async_setup(hass, config):
                     rgb = color_util.color_xy_brightness_to_RGB(
                         *xy_color,
                         ibrightness=brightness)
-                    params[ATTR_RGB_COLOR] = rgb
+                    params.setdefault(ATTR_RGB_COLOR, rgb)
 
             if service.service == SERVICE_TURN_ON:
                 yield from light.async_turn_on(**params)

--- a/homeassistant/components/light/demo.py
+++ b/homeassistant/components/light/demo.py
@@ -9,7 +9,7 @@ import random
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT,
-    ATTR_RGB_COLOR, ATTR_WHITE_VALUE, ATTR_XY_COLOR, SUPPORT_BRIGHTNESS,
+    ATTR_RGB_COLOR, ATTR_WHITE_VALUE, SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR_TEMP, SUPPORT_EFFECT, SUPPORT_RGB_COLOR, SUPPORT_WHITE_VALUE,
     Light)
 
@@ -42,7 +42,7 @@ class DemoLight(Light):
     """Representation of a demo light."""
 
     def __init__(self, name, state, available=False, rgb=None, ct=None,
-                 brightness=180, xy_color=(.5, .5), white=200,
+                 brightness=180, white=200,
                  effect_list=None, effect=None):
         """Initialize the light."""
         self._name = name
@@ -50,7 +50,6 @@ class DemoLight(Light):
         self._rgb = rgb
         self._ct = ct or random.choice(LIGHT_TEMPS)
         self._brightness = brightness
-        self._xy_color = xy_color
         self._white = white
         self._effect_list = effect_list
         self._effect = effect
@@ -76,11 +75,6 @@ class DemoLight(Light):
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         return self._brightness
-
-    @property
-    def xy_color(self) -> tuple:
-        """Return the XY color value [float, float]."""
-        return self._xy_color
 
     @property
     def rgb_color(self) -> tuple:
@@ -130,9 +124,6 @@ class DemoLight(Light):
         if ATTR_BRIGHTNESS in kwargs:
             self._brightness = kwargs[ATTR_BRIGHTNESS]
 
-        if ATTR_XY_COLOR in kwargs:
-            self._xy_color = kwargs[ATTR_XY_COLOR]
-
         if ATTR_WHITE_VALUE in kwargs:
             self._white = kwargs[ATTR_WHITE_VALUE]
 
@@ -164,9 +155,6 @@ class DemoLight(Light):
 
         if 'rgb_color' in kwargs:
             self._rgb = kwargs['rgb_color']
-
-        if 'xy_color' in kwargs:
-            self._xy_color = kwargs['xy_color']
 
         if 'white_value' in kwargs:
             self._white = kwargs['white_value']

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -364,7 +364,11 @@ class HueLight(Light):
     @property
     def supported_features(self):
         """Flag supported features."""
-        return SUPPORT_HUE.get(self.info.get('type'), SUPPORT_HUE_EXTENDED)
+        features = SUPPORT_HUE.get(self.info.get('type'), SUPPORT_HUE_EXTENDED)
+        if self.info.get('manufacturername') == "OSRAM":
+            return features & ~SUPPORT_XY_COLOR;
+        else:
+            return features
 
     @property
     def effect_list(self):
@@ -379,15 +383,7 @@ class HueLight(Light):
             command['transitiontime'] = int(kwargs[ATTR_TRANSITION] * 10)
 
         if ATTR_XY_COLOR in kwargs:
-            if self.info.get('manufacturername') == "OSRAM":
-                hsv = color_util.color_xy_brightness_to_hsv(
-                    *kwargs[ATTR_XY_COLOR],
-                    ibrightness=self.info['bri'])
-                command['hue'] = hsv[0]
-                command['sat'] = hsv[1]
-                command['bri'] = hsv[2]
-            else:
-                command['xy'] = kwargs[ATTR_XY_COLOR]
+            command['xy'] = kwargs[ATTR_XY_COLOR]
         elif ATTR_RGB_COLOR in kwargs:
             if self.info.get('manufacturername') == "OSRAM":
                 hsv = color_util.color_RGB_to_hsv(

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -366,7 +366,7 @@ class HueLight(Light):
         """Flag supported features."""
         features = SUPPORT_HUE.get(self.info.get('type'), SUPPORT_HUE_EXTENDED)
         if self.info.get('manufacturername') == "OSRAM":
-            return features & ~SUPPORT_XY_COLOR;
+            return features & ~SUPPORT_XY_COLOR
         else:
             return features
 

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -36,7 +36,6 @@ class TestDemoLight(unittest.TestCase):
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_LIGHT)
         self.assertTrue(light.is_on(self.hass, ENTITY_LIGHT))
-        self.assertEqual((.4, .6), state.attributes.get(light.ATTR_XY_COLOR))
         self.assertEqual(25, state.attributes.get(light.ATTR_BRIGHTNESS))
         self.assertEqual(
             (76, 95, 0), state.attributes.get(light.ATTR_RGB_COLOR))
@@ -75,7 +74,6 @@ def test_restore_state(hass):
             'brightness': 'value-brightness',
             'color_temp': 'value-color_temp',
             'rgb_color': 'value-rgb_color',
-            'xy_color': 'value-xy_color',
             'white_value': 'value-white_value',
             'effect': 'value-effect',
         }),
@@ -93,6 +91,5 @@ def test_restore_state(hass):
     assert state.attributes.get('brightness') == 'value-brightness'
     assert state.attributes.get('color_temp') == 'value-color_temp'
     assert state.attributes.get('rgb_color') == 'value-rgb_color'
-    assert state.attributes.get('xy_color') == 'value-xy_color'
     assert state.attributes.get('white_value') == 'value-white_value'
     assert state.attributes.get('effect') == 'value-effect'

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -216,13 +216,15 @@ class TestLight(unittest.TestCase):
         _, data = dev1.last_call('turn_on')
         self.assertEqual(
             {light.ATTR_BRIGHTNESS: prof_bri,
-             light.ATTR_XY_COLOR: (prof_x, prof_y)},
+             light.ATTR_XY_COLOR: (prof_x, prof_y),
+             light.ATTR_RGB_COLOR: (246, 178, 74)},
             data)
 
         _, data = dev2.last_call('turn_on')
         self.assertEqual(
             {light.ATTR_BRIGHTNESS: 100,
-             light.ATTR_XY_COLOR: (.4, .6)},
+             light.ATTR_XY_COLOR: (.4, .6),
+             light.ATTR_RGB_COLOR: (147, 181, 0)},
             data)
 
         # Test shitty data
@@ -297,5 +299,5 @@ class TestLight(unittest.TestCase):
         _, data = dev1.last_call('turn_on')
 
         self.assertEqual(
-            {light.ATTR_XY_COLOR: (.4, .6), light.ATTR_BRIGHTNESS: 100},
+            {light.ATTR_XY_COLOR: (.4, .6), light.ATTR_BRIGHTNESS: 100, light.ATTR_RGB_COLOR: (147, 181, 0)},
             data)

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -216,15 +216,13 @@ class TestLight(unittest.TestCase):
         _, data = dev1.last_call('turn_on')
         self.assertEqual(
             {light.ATTR_BRIGHTNESS: prof_bri,
-             light.ATTR_XY_COLOR: (prof_x, prof_y),
-             light.ATTR_RGB_COLOR: (246, 178, 74)},
+             light.ATTR_XY_COLOR: (prof_x, prof_y)},
             data)
 
         _, data = dev2.last_call('turn_on')
         self.assertEqual(
             {light.ATTR_BRIGHTNESS: 100,
-             light.ATTR_XY_COLOR: (.4, .6),
-             light.ATTR_RGB_COLOR: (147, 181, 0)},
+             light.ATTR_XY_COLOR: (.4, .6)},
             data)
 
         # Test shitty data
@@ -299,7 +297,5 @@ class TestLight(unittest.TestCase):
         _, data = dev1.last_call('turn_on')
 
         self.assertEqual(
-            {light.ATTR_XY_COLOR: (.4, .6),
-             light.ATTR_BRIGHTNESS: 100,
-             light.ATTR_RGB_COLOR: (147, 181, 0)},
+            {light.ATTR_XY_COLOR: (.4, .6), light.ATTR_BRIGHTNESS: 100},
             data)

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -299,5 +299,7 @@ class TestLight(unittest.TestCase):
         _, data = dev1.last_call('turn_on')
 
         self.assertEqual(
-            {light.ATTR_XY_COLOR: (.4, .6), light.ATTR_BRIGHTNESS: 100, light.ATTR_RGB_COLOR: (147, 181, 0)},
+            {light.ATTR_XY_COLOR: (.4, .6),
+             light.ATTR_BRIGHTNESS: 100,
+             light.ATTR_RGB_COLOR: (147, 181, 0)},
             data)

--- a/tests/testing_config/custom_components/light/test.py
+++ b/tests/testing_config/custom_components/light/test.py
@@ -4,20 +4,33 @@ Provide a mock switch platform.
 Call init before using it in your tests to ensure clean test data.
 """
 from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.components.light import ( SUPPORT_XY_COLOR )
 from tests.common import MockToggleDevice
 
 
 DEVICES = []
 
+class MockLightDevice(MockToggleDevice):
+    """Provide a mock light device."""
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_XY_COLOR
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return None
 
 def init(empty=False):
     """Initalize the platform with devices."""
     global DEVICES
 
     DEVICES = [] if empty else [
-        MockToggleDevice('Ceiling', STATE_ON),
-        MockToggleDevice('Ceiling', STATE_OFF),
-        MockToggleDevice(None, STATE_OFF)
+        MockLightDevice('Ceiling', STATE_ON),
+        MockLightDevice('Ceiling', STATE_OFF),
+        MockLightDevice(None, STATE_OFF)
     ]
 
 

--- a/tests/testing_config/custom_components/light/test.py
+++ b/tests/testing_config/custom_components/light/test.py
@@ -4,11 +4,12 @@ Provide a mock switch platform.
 Call init before using it in your tests to ensure clean test data.
 """
 from homeassistant.const import STATE_ON, STATE_OFF
-from homeassistant.components.light import ( SUPPORT_XY_COLOR )
+from homeassistant.components.light import (SUPPORT_XY_COLOR)
 from tests.common import MockToggleDevice
 
 
 DEVICES = []
+
 
 class MockLightDevice(MockToggleDevice):
     """Provide a mock light device."""
@@ -22,6 +23,7 @@ class MockLightDevice(MockToggleDevice):
     def brightness(self):
         """Return the brightness of this light between 0..255."""
         return None
+
 
 def init(empty=False):
     """Initalize the platform with devices."""


### PR DESCRIPTION
## Description:

I wanted to add ```xy_color``` support for LIFX, but moving the conversion to core seems like a preferable approach?

The ```xy_color``` support is needed for light profiles and the ```flux``` switch and it is also used in several online examples. Thus, it makes sense to have it available globally.

I have tried to update the ```hue.py``` file but I have no way of testing that it still works!

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** The documentation already gives the impression that ```xy_color``` is supported everywhere.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
