### PR TITLE
Add switch to MQTT discovery

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -19,12 +19,13 @@ _LOGGER = logging.getLogger(__name__)
 TOPIC_MATCHER = re.compile(
     r'(?P<prefix_topic>\w+)/(?P<component>\w+)/(?P<object_id>\w+)/config')
 
-SUPPORTED_COMPONENTS = ['binary_sensor', 'light', 'sensor']
+SUPPORTED_COMPONENTS = ['binary_sensor', 'light', 'sensor', 'switch']
 
 ALLOWED_PLATFORMS = {
     'binary_sensor': ['mqtt'],
     'light': ['mqtt', 'mqtt_json', 'mqtt_template'],
-    'sensor': ['mqtt']
+    'sensor': ['mqtt'],
+    'switch': ['mqtt'],
 }
 
 

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -38,7 +38,10 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-    """Setup the MQTT switch."""
+    """Set up the MQTT switch."""
+    if discovery_info is not None:
+        config = PLATFORM_SCHEMA(discovery_info)
+
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
         value_template.hass = hass


### PR DESCRIPTION
## Description:
Enables the discovery of MQTT switches.

Setting up a switch.

```bash
$ mosquitto_pub -h 127.0.0.1 -p 1883 -t "homeassistant/switch/irrigation/config" \
  -m '{"name": "garden", "command_topic": "homeassistant/switch/irrigation/set"}'
```
Set the state.

```bash
$ mosquitto_pub -h 127.0.0.1 -p 1883 -t "homeassistant/switch/irrigation/set" -m ON
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2312

## Example entry for `configuration.yaml` (if applicable):
```yaml
mqtt:
  discovery: true
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
