### PR TITLE
history_stats: Fix schema check for state, as it can be arbitrary string

### DIFF
--- a/homeassistant/components/sensor/history_stats.py
+++ b/homeassistant/components/sensor/history_stats.py
@@ -58,7 +58,7 @@ def exactly_two_period_keys(conf):
 
 PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
-    vol.Required(CONF_STATE): cv.slug,
+    vol.Required(CONF_STATE): cv.string,
     vol.Optional(CONF_START, default=None): cv.template,
     vol.Optional(CONF_END, default=None): cv.template,
     vol.Optional(CONF_DURATION, default=None): cv.time_period,


### PR DESCRIPTION
Some components may have states that are arbitrary strings (e.g., "Scattered Showers" in `sensor.yweather_current`). Currently it's impossible to track such components with `history_stats` sensor.