### PR TITLE
Constrain core dependencies to core versions

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,6 +7,7 @@ __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 4, 2)
 REQUIRED_PYTHON_VER_WIN = (3, 5, 2)
+CONSTRAINT_FILE = 'package_constraints.txt'
 
 PROJECT_NAME = 'Home Assistant'
 PROJECT_PACKAGE_NAME = 'homeassistant'

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,0 +1,9 @@
+requests>=2,<3
+pyyaml>=3.11,<4
+pytz>=2016.10
+pip>=7.1.0
+jinja2>=2.9.5
+voluptuous==0.9.3
+typing>=3,<4
+aiohttp==1.3.5
+async_timeout==1.2.0

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 import logging.handlers
+import os
 
 from types import ModuleType
 from typing import Optional, Dict
@@ -12,7 +13,8 @@ import homeassistant.core as core
 import homeassistant.loader as loader
 import homeassistant.util.package as pkg_util
 from homeassistant.util.async import run_coroutine_threadsafe
-from homeassistant.const import EVENT_COMPONENT_LOADED, PLATFORM_FORMAT
+from homeassistant.const import (
+    EVENT_COMPONENT_LOADED, PLATFORM_FORMAT, CONSTRAINT_FILE)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,7 +76,10 @@ def _async_process_requirements(hass: core.HomeAssistant, name: str,
 
     def pip_install(mod):
         """Install packages."""
-        return pkg_util.install_package(mod, target=hass.config.path('deps'))
+        return pkg_util.install_package(
+            mod, target=hass.config.path('deps'),
+            constraints=os.path.join(os.path.dirname(__file__),
+                                     CONSTRAINT_FILE))
 
     with (yield from pip_lock):
         for req in requirements:

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -15,7 +15,8 @@ INSTALL_LOCK = threading.Lock()
 
 
 def install_package(package: str, upgrade: bool=True,
-                    target: Optional[str]=None) -> bool:
+                    target: Optional[str]=None,
+                    constraints: Optional[str]=None) -> bool:
     """Install a package on PyPi. Accepts pip compatible package strings.
 
     Return boolean if install successful.
@@ -31,6 +32,9 @@ def install_package(package: str, upgrade: bool=True,
             args.append('--upgrade')
         if target:
             args += ['--target', os.path.abspath(target)]
+
+        if constraints is not None:
+            args += ['--constraint', constraints]
 
         try:
             return subprocess.call(args) == 0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2,7 +2,7 @@
 requests>=2,<3
 pyyaml>=3.11,<4
 pytz>=2016.10
-pip>=7.0.0
+pip>=7.1.0
 jinja2>=2.9.5
 voluptuous==0.9.3
 typing>=3,<4

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -38,6 +38,10 @@ URL_PIN = ('https://home-assistant.io/developers/code_review_platform/'
            '#1-requirements')
 
 
+CONSTRAINT_PATH = os.path.join(os.path.dirname(__file__),
+                               '../homeassistant/package_constraints.txt')
+
+
 def explore_module(package, explore_children):
     """Explore the modules."""
     module = importlib.import_module(package)
@@ -124,15 +128,32 @@ def gather_modules():
     return ''.join(output)
 
 
-def write_file(data):
+def gather_constraints():
+    """Construct output for constraint file"""
+    return '\n'.join(core_requirements() + [''])
+
+
+def write_requirements_file(data):
     """Write the modules to the requirements_all.txt."""
     with open('requirements_all.txt', 'w+', newline="\n") as req_file:
         req_file.write(data)
 
 
-def validate_file(data):
+def write_constraints_file(data):
+    """Write constraints to a file."""
+    with open(CONSTRAINT_PATH, 'w+', newline="\n") as req_file:
+        req_file.write(data)
+
+
+def validate_requirements_file(data):
     """Validate if requirements_all.txt is up to date."""
     with open('requirements_all.txt', 'r') as req_file:
+        return data == ''.join(req_file)
+
+
+def validate_constraints_file(data):
+    """Validate if constraints is up to date."""
+    with open(CONSTRAINT_PATH, 'r') as req_file:
         return data == ''.join(req_file)
 
 
@@ -147,15 +168,25 @@ def main():
     if data is None:
         sys.exit(1)
 
-    if sys.argv[-1] == 'validate':
-        if validate_file(data):
-            sys.exit(0)
-        print("******* ERROR")
-        print("requirements_all.txt is not up to date")
-        print("Please run script/gen_requirements_all.py")
-        sys.exit(1)
+    constraints = gather_constraints()
 
-    write_file(data)
+    if sys.argv[-1] == 'validate':
+        if not validate_requirements_file(data):
+            print("******* ERROR")
+            print("requirements_all.txt is not up to date")
+            print("Please run script/gen_requirements_all.py")
+            sys.exit(1)
+
+        if not validate_constraints_file(constraints):
+            print("******* ERROR")
+            print("home-assistant/package_constraints.txt is not up to date")
+            print("Please run script/gen_requirements_all.py")
+            sys.exit(1)
+
+        sys.exit(0)
+
+    write_requirements_file(data)
+    write_constraints_file(constraints)
 
 
 if __name__ == '__main__':

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -129,7 +129,7 @@ def gather_modules():
 
 
 def gather_constraints():
-    """Construct output for constraint file"""
+    """Construct output for constraint file."""
     return '\n'.join(core_requirements() + [''])
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ REQUIRES = [
     'requests>=2,<3',
     'pyyaml>=3.11,<4',
     'pytz>=2016.10',
-    'pip>=7.0.0',
+    'pip>=7.1.0',
     'jinja2>=2.9.5',
     'voluptuous==0.9.3',
     'typing>=3,<4',


### PR DESCRIPTION
## Description:
Constrain the dependencies that get installed as part of installing dependencies to the version that HASS uses if they overlap.

Updates `gen_requirements_all.py` to also generate a constraint file and validate that it is up to date.

**Related issue (if applicable):** fixes #5892. Fixes #6728

## Example entry for `configuration.yaml` (if applicable):
Add either one of the following to your config and HASS will crash after 2 reboots before this patch.

```yaml
media_player:
  platform: apple_tv
  host: ''
  login_id: ''

android_ip_webcam:
  host: ''
```
