### PR TITLE
Added Met Office weather and sensor components

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -147,7 +147,7 @@ omit =
 
     homeassistant/components/tado.py
     homeassistant/components/*/tado.py
-    
+
     homeassistant/components/alarm_control_panel/alarmdotcom.py
     homeassistant/components/alarm_control_panel/concord232.py
     homeassistant/components/alarm_control_panel/nx584.py
@@ -357,6 +357,7 @@ omit =
     homeassistant/components/sensor/linux_battery.py
     homeassistant/components/sensor/loopenergy.py
     homeassistant/components/sensor/lyft.py
+    homeassistant/components/sensor/metoffice.py
     homeassistant/components/sensor/miflora.py
     homeassistant/components/sensor/modem_callerid.py
     homeassistant/components/sensor/mqtt_room.py
@@ -431,6 +432,7 @@ omit =
     homeassistant/components/tts/picotts.py
     homeassistant/components/upnp.py
     homeassistant/components/weather/bom.py
+    homeassistant/components/weather/metoffice.py
     homeassistant/components/weather/openweathermap.py
     homeassistant/components/weather/zamg.py
     homeassistant/components/zeroconf.py

--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -1,0 +1,159 @@
+"""
+Support for UK Met Office weather service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.metoffice/
+"""
+
+import logging
+import datetime
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_MONITORED_CONDITIONS, TEMP_CELSIUS, STATE_UNKNOWN, CONF_NAME,
+    ATTR_ATTRIBUTION)
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['datapoint==0.4.3']
+
+CONF_ATTRIBUTION = "Data provided by the Met Office"
+CONF_MO_API_KEY = 'api_key'
+
+SCAN_INTERVAL = 35
+LAST_UPDATE = 0
+
+# Sensor types are defined like: Name, units
+SENSOR_TYPES = {
+    'name': ['Station Name', None],
+    'weather': ['Weather', None],
+    'temperature': ['Temperature', TEMP_CELSIUS],
+    'feels_like_temperature': ['Feels Like Temperature', TEMP_CELSIUS],
+    'wind_speed': ['Wind Speed', 'mps'],
+    'wind_direction': ['Wind Direction', None],
+    'wind_gust': ['Wind Gust', 'mps'],
+    'visibility': ['Visibility', 'km'],
+    'uv': ['UV', None],
+    'precipitation': ['Probability of Precipitation', '%'],
+    'humidity': ['Humidity', '%']
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=None): cv.string,
+    vol.Required(CONF_MO_API_KEY): cv.string,
+    vol.Required(CONF_MONITORED_CONDITIONS, default=[]):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the sensor platform."""
+    import datapoint as dp
+    datapoint = dp.connection(api_key=config.get(CONF_MO_API_KEY))
+
+    if None in (hass.config.latitude, hass.config.longitude):
+        _LOGGER.error("Latitude or longitude not set in Home Assistant config")
+        return False
+
+    try:
+        site = datapoint.get_nearest_site(longitude=hass.config.longitude,
+                                          latitude=hass.config.latitude)
+    except dp.exceptions.APIException as err:
+        _LOGGER.error("Received error from Met Office Datapoint: %s", err)
+        return False
+
+    if not site:
+        _LOGGER.error("Unable to get nearest Met Office forecast site")
+        return False
+    else:
+
+        # Get data
+        data = MetOfficeCurrentData(hass, datapoint, site)
+        try:
+            data.update()
+        except (ValueError, dp.exceptions.APIException) as err:
+            _LOGGER.error("Received error from Met Office Datapoint: %s", err)
+            return False
+
+        # Add
+        add_devices([MetOfficeCurrentSensor(site, data, variable)
+                     for variable in config[CONF_MONITORED_CONDITIONS]])
+        return True
+
+
+class MetOfficeCurrentSensor(Entity):
+    """Implementation of a Met Office current sensor."""
+
+    def __init__(self, site, data, condition):
+        """Initialize the sensor."""
+        self.site = site
+        self.data = data
+        self._condition = condition
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return 'Met Office {}'.format(SENSOR_TYPES[self._condition][0])
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        if self._condition in self.data.data.__dict__.keys():
+            variable = getattr(self.data.data, self._condition)
+            if self._condition == "weather":
+                return variable.text
+            else:
+                return variable.value
+        else:
+            return STATE_UNKNOWN
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return SENSOR_TYPES[self._condition][1]
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the device."""
+        attr = {}
+        attr['Sensor Id'] = self._condition
+        attr['Site Id'] = self.site.id
+        attr['Site Name'] = self.site.name
+        attr['Last Update'] = self.data.lastupdate
+        attr[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+        return attr
+
+    def update(self):
+        """Update current conditions."""
+        self.data.update()
+
+
+class MetOfficeCurrentData(object):
+    """Get data from Datapoint."""
+
+    def __init__(self, hass, datapoint, site):
+        """Initialize the data object."""
+        self._hass = hass
+        self._datapoint = datapoint
+        self._site = site
+        self.data = None
+        self.lastupdate = LAST_UPDATE
+
+    @Throttle(SCAN_INTERVAL)
+    def update(self):
+        """Get the latest data from Datapoint."""
+        import datapoint as dp
+
+        try:
+            forecast = self._datapoint.get_forecast_for_site(self._site.id,
+                                                             "3hourly")
+            self.data = forecast.now()
+        except (ValueError, dp.exceptions.APIException) as err:
+            _LOGGER.error("Check Met Office %s", err.args)
+            self.data = None
+            raise

--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -34,7 +34,7 @@ SENSOR_TYPES = {
     'feels_like_temperature': ['Feels Like Temperature', TEMP_CELSIUS],
     'wind_speed': ['Wind Speed', 'm/s'],
     'wind_direction': ['Wind Direction', None],
-    'wind_gust': ['Wind Gust', 'mps'],
+    'wind_gust': ['Wind Gust', 'm/s'],
     'visibility': ['Visibility', 'km'],
     'uv': ['UV', None],
     'precipitation': ['Probability of Precipitation', '%'],

--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS, TEMP_CELSIUS, STATE_UNKNOWN, CONF_NAME,
-    ATTR_ATTRIBUTION)
+    ATTR_ATTRIBUTION, CONF_API_KEY)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
@@ -23,10 +23,8 @@ _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = ['datapoint==0.4.3']
 
 CONF_ATTRIBUTION = "Data provided by the Met Office"
-CONF_MO_API_KEY = 'api_key'
 
 SCAN_INTERVAL = timedelta(minutes=35)
-LAST_UPDATE = 0
 
 # Sensor types are defined like: Name, units
 SENSOR_TYPES = {
@@ -34,7 +32,7 @@ SENSOR_TYPES = {
     'weather': ['Weather', None],
     'temperature': ['Temperature', TEMP_CELSIUS],
     'feels_like_temperature': ['Feels Like Temperature', TEMP_CELSIUS],
-    'wind_speed': ['Wind Speed', 'mps'],
+    'wind_speed': ['Wind Speed', 'm/s'],
     'wind_direction': ['Wind Direction', None],
     'wind_gust': ['Wind Gust', 'mps'],
     'visibility': ['Visibility', 'km'],
@@ -45,7 +43,7 @@ SENSOR_TYPES = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=None): cv.string,
-    vol.Required(CONF_MO_API_KEY): cv.string,
+    vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_MONITORED_CONDITIONS, default=[]):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
@@ -54,7 +52,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the sensor platform."""
     import datapoint as dp
-    datapoint = dp.connection(api_key=config.get(CONF_MO_API_KEY))
+    datapoint = dp.connection(api_key=config.get(CONF_API_KEY))
 
     if None in (hass.config.latitude, hass.config.longitude):
         _LOGGER.error("Latitude or longitude not set in Home Assistant config")
@@ -70,20 +68,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if not site:
         _LOGGER.error("Unable to get nearest Met Office forecast site")
         return False
-    else:
 
-        # Get data
-        data = MetOfficeCurrentData(hass, datapoint, site)
-        try:
-            data.update()
-        except (ValueError, dp.exceptions.APIException) as err:
-            _LOGGER.error("Received error from Met Office Datapoint: %s", err)
-            return False
+    # Get data
+    data = MetOfficeCurrentData(hass, datapoint, site)
+    try:
+        data.update()
+    except (ValueError, dp.exceptions.APIException) as err:
+        _LOGGER.error("Received error from Met Office Datapoint: %s", err)
+        return False
 
-        # Add
-        add_devices([MetOfficeCurrentSensor(site, data, variable)
-                     for variable in config[CONF_MONITORED_CONDITIONS]])
-        return True
+    # Add
+    add_devices([MetOfficeCurrentSensor(site, data, variable)
+                 for variable in config[CONF_MONITORED_CONDITIONS]])
+    return True
 
 
 class MetOfficeCurrentSensor(Entity):
@@ -142,7 +139,6 @@ class MetOfficeCurrentData(object):
         self._datapoint = datapoint
         self._site = site
         self.data = None
-        self.lastupdate = LAST_UPDATE
 
     @Throttle(SCAN_INTERVAL)
     def update(self):

--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS, TEMP_CELSIUS, STATE_UNKNOWN, CONF_NAME,
-    ATTR_ATTRIBUTION, CONF_API_KEY)
+    ATTR_ATTRIBUTION, CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/sensor.metoffice/
 """
 
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 
@@ -24,7 +25,7 @@ REQUIREMENTS = ['datapoint==0.4.3']
 CONF_ATTRIBUTION = "Data provided by the Met Office"
 CONF_MO_API_KEY = 'api_key'
 
-SCAN_INTERVAL = 35
+SCAN_INTERVAL = timedelta(minutes=35)
 LAST_UPDATE = 0
 
 # Sensor types are defined like: Name, units

--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -24,6 +24,23 @@ REQUIREMENTS = ['datapoint==0.4.3']
 
 CONF_ATTRIBUTION = "Data provided by the Met Office"
 
+CONDITION_CLASSES = {
+    'cloudy': ["7", "8"],
+    'fog': ["5", "6"],
+    'hail': ["19", "20", "21"],
+    'lightning': ["30"],
+    'lightning-rainy': ["28", "29"],
+    'partlycloudy': ["2", "3"],
+    'pouring': ["13", "14", "15"],
+    'rainy': ["9", "10", "11", "12"],
+    'snowy': ["22", "23", "24", "25", "26", "27"],
+    'snowy-rainy': ["16", "17", "18"],
+    'sunny': ["0", "1"],
+    'windy': [],
+    'windy-variant': [],
+    'exceptional': [],
+}
+
 SCAN_INTERVAL = timedelta(minutes=35)
 
 # Sensor types are defined like: Name, units
@@ -106,7 +123,8 @@ class MetOfficeCurrentSensor(Entity):
         if self._condition in self.data.data.__dict__.keys():
             variable = getattr(self.data.data, self._condition)
             if self._condition == "weather":
-                return variable.text
+                return [k for k, v in CONDITION_CLASSES.items() if
+                        self.data.data.weather.value in v][0]
             else:
                 return variable.value
         else:

--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/sensor.metoffice/
 """
 
 import logging
-import datetime
 
 import voluptuous as vol
 

--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -54,13 +54,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import datapoint as dp
     datapoint = dp.connection(api_key=config.get(CONF_API_KEY))
 
-    if None in (hass.config.latitude, hass.config.longitude):
+    latitude = config.get(CONF_LATITUDE, hass.config.latitude)
+    longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
+
+    if None in (latitude, longitude):
         _LOGGER.error("Latitude or longitude not set in Home Assistant config")
         return False
 
     try:
-        site = datapoint.get_nearest_site(longitude=hass.config.longitude,
-                                          latitude=hass.config.latitude)
+        site = datapoint.get_nearest_site(latitude=latitude,
+                                          longitude=longitude)
     except dp.exceptions.APIException as err:
         _LOGGER.error("Received error from Met Office Datapoint: %s", err)
         return False

--- a/homeassistant/components/weather/metoffice.py
+++ b/homeassistant/components/weather/metoffice.py
@@ -1,0 +1,117 @@
+"""
+Support for UK Met Office weather service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.metoffice/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.weather import WeatherEntity, PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME, TEMP_CELSIUS
+from homeassistant.helpers import config_validation as cv
+# Reuse data and API logic from the sensor implementation
+from homeassistant.components.sensor.metoffice import \
+    MetOfficeCurrentData, CONF_MO_API_KEY, CONF_ATTRIBUTION
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['datapoint==0.4.3']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Required(CONF_MO_API_KEY): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Met Office weather platform."""
+    import datapoint as dp
+    datapoint = dp.connection(api_key=config.get(CONF_MO_API_KEY))
+
+    if None in (hass.config.latitude, hass.config.longitude):
+        _LOGGER.error("Latitude or longitude not set in Home Assistant config")
+        return False
+
+    try:
+        site = datapoint.get_nearest_site(longitude=hass.config.longitude,
+                                          latitude=hass.config.latitude)
+    except dp.exceptions.APIException as err:
+        _LOGGER.error("Received error from Met Office Datapoint: %s", err)
+        return False
+
+    if not site:
+        _LOGGER.error("Unable to get nearest Met Office forecast site")
+        return False
+    else:
+        # Get data
+        data = MetOfficeCurrentData(hass, datapoint, site)
+        try:
+            data.update()
+        except (ValueError, dp.exceptions.APIException) as err:
+            _LOGGER.error("Received error from Met Office Datapoint: %s", err)
+            return False
+        add_devices([MetOfficeWeather(site, data, config.get(CONF_NAME))],
+                    True)
+        return True
+
+
+class MetOfficeWeather(WeatherEntity):
+    """Implementation of a Met Office weather condition."""
+
+    def __init__(self, site, data, config):
+        """Initialise the platform with a data instance and site."""
+        self.data = data
+        self.site = site
+
+    def update(self):
+        """Update current conditions."""
+        self.data.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return 'Met Office ({})'.format(self.site.name)
+
+    @property
+    def condition(self):
+        """Return the current condition."""
+        return self.data.data.weather.text
+
+    # Now implement the WeatherEntity interface
+
+    @property
+    def temperature(self):
+        """Return the platform temperature."""
+        return self.data.data.temperature.value
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return TEMP_CELSIUS
+
+    @property
+    def pressure(self):
+        """Return the mean sea-level pressure."""
+        return None
+
+    @property
+    def humidity(self):
+        """Return the relative humidity."""
+        return self.data.data.humidity.value
+
+    @property
+    def wind_speed(self):
+        """Return the wind speed."""
+        return self.data.data.wind_speed.value
+
+    @property
+    def wind_bearing(self):
+        """Return the wind bearing."""
+        return self.data.data.wind_direction.value
+
+    @property
+    def attribution(self):
+        """Return the attribution."""
+        return CONF_ATTRIBUTION

--- a/homeassistant/components/weather/metoffice.py
+++ b/homeassistant/components/weather/metoffice.py
@@ -2,18 +2,18 @@
 Support for UK Met Office weather service.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/sensor.metoffice/
+https://home-assistant.io/components/weather.metoffice/
 """
 import logging
 
 import voluptuous as vol
 
 from homeassistant.components.weather import WeatherEntity, PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, TEMP_CELSIUS
+from homeassistant.const import CONF_NAME, TEMP_CELSIUS, CONF_API_KEY
 from homeassistant.helpers import config_validation as cv
 # Reuse data and API logic from the sensor implementation
 from homeassistant.components.sensor.metoffice import \
-    MetOfficeCurrentData, CONF_MO_API_KEY, CONF_ATTRIBUTION
+    MetOfficeCurrentData, CONF_ATTRIBUTION
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,14 +21,14 @@ REQUIREMENTS = ['datapoint==0.4.3']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME): cv.string,
-    vol.Required(CONF_MO_API_KEY): cv.string,
+    vol.Required(CONF_API_KEY): cv.string,
 })
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Met Office weather platform."""
     import datapoint as dp
-    datapoint = dp.connection(api_key=config.get(CONF_MO_API_KEY))
+    datapoint = dp.connection(api_key=config.get(CONF_API_KEY))
 
     if None in (hass.config.latitude, hass.config.longitude):
         _LOGGER.error("Latitude or longitude not set in Home Assistant config")

--- a/homeassistant/components/weather/metoffice.py
+++ b/homeassistant/components/weather/metoffice.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 # Reuse data and API logic from the sensor implementation
 from homeassistant.components.sensor.metoffice import \
-    MetOfficeCurrentData, CONF_ATTRIBUTION
+    MetOfficeCurrentData, CONF_ATTRIBUTION, CONDITION_CLASSES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,7 +81,8 @@ class MetOfficeWeather(WeatherEntity):
     @property
     def condition(self):
         """Return the current condition."""
-        return self.data.data.weather.text
+        return [k for k, v in CONDITION_CLASSES.items() if
+                self.data.data.weather.value in v][0]
 
     # Now implement the WeatherEntity interface
 

--- a/homeassistant/components/weather/metoffice.py
+++ b/homeassistant/components/weather/metoffice.py
@@ -9,8 +9,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.weather import WeatherEntity, PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, TEMP_CELSIUS, CONF_API_KEY,
-    CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.const import (
+    CONF_NAME, TEMP_CELSIUS, CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE)
 from homeassistant.helpers import config_validation as cv
 # Reuse data and API logic from the sensor implementation
 from homeassistant.components.sensor.metoffice import \

--- a/homeassistant/components/weather/metoffice.py
+++ b/homeassistant/components/weather/metoffice.py
@@ -9,7 +9,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.weather import WeatherEntity, PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, TEMP_CELSIUS, CONF_API_KEY
+from homeassistant.const import CONF_NAME, TEMP_CELSIUS, CONF_API_KEY,
+    CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.helpers import config_validation as cv
 # Reuse data and API logic from the sensor implementation
 from homeassistant.components.sensor.metoffice import \
@@ -30,13 +31,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import datapoint as dp
     datapoint = dp.connection(api_key=config.get(CONF_API_KEY))
 
-    if None in (hass.config.latitude, hass.config.longitude):
+    latitude = config.get(CONF_LATITUDE, hass.config.latitude)
+    longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
+
+    if None in (latitude, longitude):
         _LOGGER.error("Latitude or longitude not set in Home Assistant config")
         return False
 
     try:
-        site = datapoint.get_nearest_site(longitude=hass.config.longitude,
-                                          latitude=hass.config.latitude)
+        site = datapoint.get_nearest_site(latitude=latitude,
+                                          longitude=longitude)
     except dp.exceptions.APIException as err:
         _LOGGER.error("Received error from Met Office Datapoint: %s", err)
         return False
@@ -44,17 +48,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if not site:
         _LOGGER.error("Unable to get nearest Met Office forecast site")
         return False
-    else:
-        # Get data
-        data = MetOfficeCurrentData(hass, datapoint, site)
-        try:
-            data.update()
-        except (ValueError, dp.exceptions.APIException) as err:
-            _LOGGER.error("Received error from Met Office Datapoint: %s", err)
-            return False
-        add_devices([MetOfficeWeather(site, data, config.get(CONF_NAME))],
-                    True)
-        return True
+
+    # Get data
+    data = MetOfficeCurrentData(hass, datapoint, site)
+    try:
+        data.update()
+    except (ValueError, dp.exceptions.APIException) as err:
+        _LOGGER.error("Received error from Met Office Datapoint: %s", err)
+        return False
+    add_devices([MetOfficeWeather(site, data, config.get(CONF_NAME))],
+                True)
+    return True
 
 
 class MetOfficeWeather(WeatherEntity):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -102,6 +102,10 @@ colorlog>2.1,<3
 # homeassistant.components.binary_sensor.concord232
 concord232==0.14
 
+# homeassistant.components.sensor.metoffice
+# homeassistant.components.weather.metoffice
+datapoint==0.4.3
+
 # homeassistant.components.light.decora
 # decora==0.3
 


### PR DESCRIPTION
**Description:**
Get weather data from the Met Office's [DataPoint API](http://www.metoffice.gov.uk/datapoint).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2318

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: metoffice
    api_key: "myapikey"
    monitored_conditions:
      - temperature
      - weather

weather:
  - platform: metoffice
    api_key: "myapikey"
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
