### PR TITLE
Fix for errors on missing preview on LG webos TV

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -240,7 +240,7 @@ class LgWebOSDevice(MediaPlayerDevice):
     def media_image_url(self):
         """Image url of current playing media."""
         if self._current_source_id in self._app_list:
-            return self._app_list[self._current_source_id]['largeIcon']
+            return self._app_list[self._current_source_id]['icon']
         return None
 
     @property

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -240,7 +240,10 @@ class LgWebOSDevice(MediaPlayerDevice):
     def media_image_url(self):
         """Image url of current playing media."""
         if self._current_source_id in self._app_list:
-            return self._app_list[self._current_source_id]['icon']
+            icon = self._app_list[self._current_source_id]['largeIcon']
+            if not icon.startswith('http'):
+                icon = self._app_list[self._current_source_id]['icon']
+            return icon
         return None
 
     @property


### PR DESCRIPTION
## Description:
largeIcon property on my TV and I guess other versions is file path. That's why it can not be requested as HTTP URI. I changed it to icon property that is the icon of current playing source.

**Related issue (if applicable):** fixes #5113