### PR TITLE
Treat default_view as view by default

### DIFF
--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -215,6 +215,8 @@ def _async_process_config(hass, config, component):
         entity_ids = conf.get(CONF_ENTITIES) or []
         icon = conf.get(CONF_ICON)
         view = conf.get(CONF_VIEW)
+        if view is None and object_id == 'default_view':
+            view = True
         control = conf.get(CONF_CONTROL)
 
         # Don't create tasks and await them all. The order is important as


### PR DESCRIPTION
## Description:

Treat default_view as view by default
Redo of home-assistant/home-assistant-js-websocket/pull/6

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
