### PR TITLE
bugfix [zwave][climate]current temp could be none at init

### DIFF
--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -112,8 +112,9 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
             _LOGGER.debug("Setpoint is 0, setting default to "
                           "current_temperature=%s",
                           self._current_temperature)
-            self._target_temperature = (
-                round((float(self._current_temperature)), 1))
+            if self._current_temperature is not None:
+                self._target_temperature = (
+                    round((float(self._current_temperature)), 1))
         else:
             self._target_temperature = round(
                 (float(self.values.primary.data)), 1)


### PR DESCRIPTION
## Description:
Fixes the following issue in dev branch:

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
```
[31m17-03-23 18:12:14 ERROR (Dummy-14) [openzwave] Error in manager callback[0m
Traceback (most recent call last):
  File "/srv/hass/lib/python3.4/site-packages/openzwave-0.3.2-py3.4.egg/openzwave/network.py", line 948, in zwcallback
    self._handle_value_added(args)
  File "/srv/hass/lib/python3.4/site-packages/openzwave-0.3.2-py3.4.egg/openzwave/network.py", line 1478, in _handle_value_added
    'value' : self.nodes[args['nodeId']].values[args['valueId']['id']]})
  File "/srv/hass/lib/python3.4/site-packages/PyDispatcher-2.0.5-py3.4.egg/pydispatch/dispatcher.py", line 338, in send
    **named
  File "/srv/hass/lib/python3.4/site-packages/PyDispatcher-2.0.5-py3.4.egg/pydispatch/robustapply.py", line 55, in robustApply
    return receiver(*arguments, **named)
  File "/srv/hass/src/home-assistant/homeassistant/components/zwave/__init__.py", line 291, in value_added
    hass, schema, value, config, device_config)
  File "/srv/hass/src/home-assistant/homeassistant/components/zwave/__init__.py", line 641, in __init__
    self.check_value(value)
  File "/srv/hass/src/home-assistant/homeassistant/components/zwave/__init__.py", line 670, in check_value
    self._check_entity_ready()
  File "/srv/hass/src/home-assistant/homeassistant/components/zwave/__init__.py", line 730, in _check_entity_ready
    node_config=node_config, hass=self._hass)
  File "/srv/hass/src/home-assistant/homeassistant/components/climate/zwave.py", line 38, in get_device
    return ZWaveClimate(values, temp_unit)
  File "/srv/hass/src/home-assistant/homeassistant/components/climate/zwave.py", line 71, in __init__
    self.update_properties()
  File "/srv/hass/src/home-assistant/homeassistant/components/climate/zwave.py", line 116, in update_properties
    round((float(self._current_temperature)), 1))
TypeError: float() argument must be a string or a number, not 'NoneType'[0m
```