### PR TITLE
Handle initial event after entity is added.

### DIFF
--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -138,8 +138,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         hass.data[DATA_ENTITY_LOOKUP][
             EVENT_KEY_COMMAND][device_id].append(device)
 
-        # Make sure the event is processed by the new entity
-        device.handle_event(event)
+        # Schedule task to process event after entity is created
+        hass.async_add_job(device.handle_event, event)
 
     hass.data[DATA_DEVICE_REGISTER][EVENT_KEY_COMMAND] = add_new_device
 

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -88,8 +88,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         hass.data[DATA_ENTITY_LOOKUP][
             EVENT_KEY_SENSOR][device_id].append(device)
 
-        # Make sure the event is processed by the new entity
-        device.handle_event(event)
+        # Schedule task to process event after entity is created
+        hass.async_add_job(device.handle_event, event)
 
     hass.data[DATA_DEVICE_REGISTER][EVENT_KEY_SENSOR] = add_new_device
 


### PR DESCRIPTION
## Description: Make sure entity is not used before it can be used.

Recently entity creation has been made asynchronous. The Rflink codebase assumes it to be synchronous. If an event for a unknown entity is received a new entity object is created and added. The event handler is also directly called on the new object to update the new entities state with the incoming event. The subsequent `async_update_ha_state` is called on an 'unadded' entity which causes errors as described in: https://github.com/home-assistant/home-assistant/issues/5965

```
homeassistant.exceptions.NoEntitySpecifiedError: No entity id specified for entity auriolv2_5e01_bat
17-03-23 08:40:42 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/lib/python3.4/asyncio/tasks.py", line 237, in _step
    result = next(coro)
  File "/srv/hass/lib/python3.4/site-packages/homeassistant/helpers/entity.py", line 200, in async_update_ha_state
    "No entity id specified for entity {}".format(self.name))
```

