### PR TITLE
Implemented basic async volume transition for media_player

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -664,7 +664,7 @@ class MediaPlayerDevice(Entity):
 
         step = (volume - current_volume) / transition * transition_interval
         _LOGGER.debug("Changing volume from %d%% to %d%%"
-                      "in steps of %.1f%% every %.1fs.",
+                      " in steps of %.1f%% every %.1fs.",
                       current_volume*100, volume*100, step*100,
                       transition_interval)
 

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -62,6 +62,20 @@ volume_set:
       description: Volume level to set as float
       example: 0.6
 
+volume_transition:
+  description: Transition media player's volume to given level
+
+  fields:
+    entity_id:
+      description: Name(s) of entities to transition the volume level on
+      example: 'media_player.living_room_sonos'
+    volume_level:
+      description: Volume level to set as float
+      example: 0.6
+    transition:
+      description: Transition time in seconds
+      example: 30
+
 media_play_pause:
   description: Toggle media player play/pause state
 


### PR DESCRIPTION
## Description:
This PR implements a simple `volume_transition service` for the media_player platform. The service calls `async_volume_transition` which starts a coroutine `_async_transition_helper`. 

Since I'm new with `asyncio`, I'd appreciate feedback on my implementation. One problem I see is that when the service gets called while another transition is already running, they'd interfere. Is there a way to cancel an already running coroutine? Another solution would be to have a class-owned `threading.Timer` which calls itself after the interval, but this would require `__init__` for the platform and `super`-calls from all platform components.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2319