### PR TITLE
Bugfix automation fire on bootstrap

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -285,8 +285,8 @@ class AutomationEntity(ToggleEntity):
                 """Start automation on startup."""
                 yield from self.async_enable()
 
-                self.hass.bus.async_listen_once(
-                    EVENT_HOMEASSISTANT_START, async_enable_automation)
+            self.hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_START, async_enable_automation)
 
         # HomeAssistant is running
         elif enable_automation:

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -12,10 +12,11 @@ import os
 import voluptuous as vol
 
 from homeassistant.setup import async_prepare_setup_platform
+from homeassistant.core import CoreState
 from homeassistant import config as conf_util
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_PLATFORM, STATE_ON, SERVICE_TURN_ON, SERVICE_TURN_OFF,
-    SERVICE_TOGGLE, SERVICE_RELOAD)
+    SERVICE_TOGGLE, SERVICE_RELOAD, EVENT_HOMEASSISTANT_START)
 from homeassistant.components import logbook
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import extract_domain_configs, script, condition
@@ -266,14 +267,30 @@ class AutomationEntity(ToggleEntity):
     @asyncio.coroutine
     def async_added_to_hass(self) -> None:
         """Startup with initial state or previous state."""
+        enable_automation = False
+
         state = yield from async_get_last_state(self.hass, self.entity_id)
         if state is None:
             if self._initial_state:
-                yield from self.async_enable()
+                enable_automation = True
         else:
             self._last_triggered = state.attributes.get('last_triggered')
             if state.state == STATE_ON:
+                enable_automation = True
+
+        # HomeAssistant is on bootstrap
+        if enable_automation and self.hass.state == CoreState.not_running:
+            @asyncio.coroutine
+            def async_enable_automation(event):
+                """Start automation on startup."""
                 yield from self.async_enable()
+
+                self.hass.bus.async_listen_once(
+                    EVENT_HOMEASSISTANT_START, async_enable_automation)
+
+        # HomeAssistant is running
+        elif enable_automation:
+            yield from self.async_enable()
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs) -> None:

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -4,10 +4,11 @@ from datetime import timedelta
 import unittest
 from unittest.mock import patch
 
-from homeassistant.core import State
+from homeassistant.core import State, CoreState
 from homeassistant.setup import setup_component, async_setup_component
 import homeassistant.components.automation as automation
-from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, STATE_OFF
+from homeassistant.const import (
+    ATTR_ENTITY_ID, STATE_ON, STATE_OFF, EVENT_HOMEASSISTANT_START)
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util.dt as dt_util
 


### PR DESCRIPTION
## Description:

Enable automation only on startup of home-assistant or running state

- [x] unittest

**Related issue (if applicable):** fixes #6745

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
