### PR TITLE
Upgrade psutil to 5.2.1

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==5.2.0']
+REQUIREMENTS = ['psutil==5.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -435,7 +435,7 @@ pmsensor==0.4
 proliphix==0.4.1
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.2.0
+psutil==5.2.1
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.1


### PR DESCRIPTION
## 5.2.1

Bug fixes

- [Linux] sensors_temperatures() may not show all temperatures.
- [FreeBSD] virtual_memory() may fail due to missing sysctl parameter on FreeBSD 12.
- [Linux] cpu_freq() may return an empty list.
- [Windows] Process.memory_maps() on Python 3 may raise UnicodeDecodeError.

Tested with the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: load_1m
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
```