### PR TITLE
Fix wink siren

### DIFF
--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -56,10 +56,10 @@ class WinkToggleDevice(WinkDevice, ToggleEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
+        attributes = super(WinkToggleDevice, self).device_state_attributes
         try:
             event = self.wink.last_event()
+            attributes["last_event"] = event
         except AttributeError:
-            event = None
-        return {
-            'last_event': event
-        }
+            pass
+        return attributes

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-wink==1.2.1', 'pubnubsub-handler==1.0.1']
+REQUIREMENTS = ['python-wink==1.2.3', 'pubnubsub-handler==1.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -626,7 +626,7 @@ python-twitch==1.3.0
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==1.2.1
+python-wink==1.2.3
 
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5


### PR DESCRIPTION
## Description:
Bump python-wink to fix a bug with sirens and Aros AC units. Switches now pull the base wink device attributes before applying and unique attributes.

**Related issue (if applicable):** fixes #6644 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
