### PR TITLE
Fix bridge-led support in limitlessled.py

### DIFF
--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -25,14 +25,13 @@ CONF_BRIDGES = 'bridges'
 CONF_GROUPS = 'groups'
 CONF_NUMBER = 'number'
 CONF_VERSION = 'version'
-CONF_BRIDGE_LED = 'bridge_led'
 
 DEFAULT_LED_TYPE = 'rgbw'
 DEFAULT_PORT = 5987
 DEFAULT_TRANSITION = 0
 DEFAULT_VERSION = 6
 
-LED_TYPE = ['rgbw', 'rgbww', 'white']
+LED_TYPE = ['rgbw', 'rgbww', 'white', 'bridge-led']
 
 RGB_BOUNDARY = 40
 
@@ -54,7 +53,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
             vol.Optional(CONF_VERSION,
                          default=DEFAULT_VERSION): cv.positive_int,
             vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-            vol.Optional(CONF_BRIDGE_LED, default=False): cv.boolean,
             vol.Required(CONF_GROUPS):  vol.All(cv.ensure_list, [
                 {
                     vol.Required(CONF_NAME): cv.string,
@@ -116,8 +114,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 group_conf.get(CONF_NAME),
                 group_conf.get(CONF_TYPE, DEFAULT_LED_TYPE))
             lights.append(LimitlessLEDGroup.factory(group))
-        if bridge_conf.get(CONF_BRIDGE_LED) and bridge.bridge_led is not None:
-            lights.append(LimitlessLEDGroup.factory(bridge.bridge_led))
     add_devices(lights)
 
 


### PR DESCRIPTION
Addressing #6382 . Feedback from github & forums is the bridge_led feature never worked and defining the bridge LED as another group+bulb type is the right way to do this in the limitlessled component.

## Description:
Removes bridge_led configuration and adds bridge-led as a type parameter

**Related issue (if applicable):** fixes #6382

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2329

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

N/A:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
