### PR TITLE
Bugfix[zwave][lock]Wrong info in discovery schema

### DIFF
--- a/homeassistant/components/zwave/discovery_schemas.py
+++ b/homeassistant/components/zwave/discovery_schemas.py
@@ -164,7 +164,6 @@ DISCOVERY_SCHEMAS = [
          'v2btze_advanced': {
              const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_CONFIGURATION],
              const.DISC_INDEX: [12],
-             const.DISC_LABEL: 'Access Control',
              const.DISC_OPTIONAL: True,
          }})},
     {const.DISC_COMPONENT: 'sensor',


### PR DESCRIPTION
## Description:
The config option value to detect what type of report was active for Danalock V2BTZE, had wrong info in discovery schema.