### PR TITLE
Update Insight parameters using the subscription data.

### DIFF
--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -61,13 +61,13 @@ class WemoSwitch(SwitchDevice):
         wemo.SUBSCRIPTION_REGISTRY.register(self.wemo)
         wemo.SUBSCRIPTION_REGISTRY.on(self.wemo, None, self._update_callback)
 
-    def _update_callback(self, _device, _params):
+    def _update_callback(self, _device, _type, _params):
         """Called by the Wemo device callback to update state."""
         _LOGGER.info(
             'Subscription update for  %s',
             _device)
-        if self._model_name == 'CoffeeMaker':
-            self.wemo.subscription_callback(_params)
+        if self._model_name in ['CoffeeMaker', 'Insight']:
+            self.wemo.subscription_update(_type, _params)
             self._update(force_update=False)
         else:
             self.update()
@@ -219,5 +219,5 @@ class WemoSwitch(SwitchDevice):
                 self.maker_params = self.wemo.maker_params
             elif self._model_name == 'CoffeeMaker':
                 self.coffeemaker_mode = self.wemo.mode
-        except AttributeError:
-            _LOGGER.warning('Could not update status for %s', self.name)
+        except AttributeError as err:
+            _LOGGER.warning('Could not update status for %s (%s)', self.name, err)

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -219,4 +219,4 @@ class WemoSwitch(SwitchDevice):
                 self.coffeemaker_mode = self.wemo.mode
         except AttributeError as err:
             _LOGGER.warning('Could not update status for %s (%s)',
-                self.name, err)
+                            self.name, err)

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -66,11 +66,9 @@ class WemoSwitch(SwitchDevice):
         _LOGGER.info(
             'Subscription update for  %s',
             _device)
-        if self._model_name in ['CoffeeMaker', 'Insight']:
-            self.wemo.subscription_update(_type, _params)
-            self._update(force_update=False)
-        else:
-            self.update()
+        updated = self.wemo.subscription_update(_type, _params)
+        self._update(force_update=(not updated))
+
         if not hasattr(self, 'hass'):
             return
         self.schedule_update_ha_state()
@@ -220,4 +218,5 @@ class WemoSwitch(SwitchDevice):
             elif self._model_name == 'CoffeeMaker':
                 self.coffeemaker_mode = self.wemo.mode
         except AttributeError as err:
-            _LOGGER.warning('Could not update status for %s (%s)', self.name, err)
+            _LOGGER.warning('Could not update status for %s (%s)',
+                self.name, err)

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import config_validation as cv
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.4.13']
+REQUIREMENTS = ['pywemo==0.4.14']
 
 DOMAIN = 'wemo'
 

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import config_validation as cv
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.4.14']
+REQUIREMENTS = ['pywemo==0.4.15']
 
 DOMAIN = 'wemo'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -644,7 +644,7 @@ pyvera==0.2.24
 pywebpush==0.6.1
 
 # homeassistant.components.wemo
-pywemo==0.4.14
+pywemo==0.4.15
 
 # homeassistant.components.zabbix
 pyzabbix==0.7.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -644,7 +644,7 @@ pyvera==0.2.24
 pywebpush==0.6.1
 
 # homeassistant.components.wemo
-pywemo==0.4.13
+pywemo==0.4.14
 
 # homeassistant.components.zabbix
 pyzabbix==0.7.4


### PR DESCRIPTION
## Description:
The subscription model of the wemo insight switch worked by receiving an alert when the state changed - HA then went to fetch the updated data.

The recent change to update power useage every second caused a lot more traffic - which on my unreliable network can lead to lost subscriptions.

This PR updates the pywemo library and the HA device so that the data in the wemo updates is used to directly update the device state - avoiding a round trip to the device.

Would be grateful for some help testing.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
