### PR TITLE
Upgrade zeroconf to 0.19.0

### DIFF
--- a/homeassistant/components/zeroconf.py
+++ b/homeassistant/components/zeroconf.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['api']
 DOMAIN = 'zeroconf'
 
-REQUIREMENTS = ['zeroconf==0.18.0']
+REQUIREMENTS = ['zeroconf==0.19.0']
 
 ZEROCONF_TYPE = '_home-assistant._tcp.local.'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -796,4 +796,4 @@ yeelightsunflower==0.0.8
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.18.0
+zeroconf==0.19.0


### PR DESCRIPTION
## 0.19.0
- Windows netmask bug was fixed
- Comments and examples updated

Tested with the following configuration:

``` yaml
zeroconf:
```

Discovery is working as expected.

``` bash
$ avahi-browse -alr
+ eth0 IPv4 Home                              _home-assistant._tcp local
= eth0 IPv4 Home                              _home-assistant._tcp local
   hostname = [Home._home-assistant._tcp.local]
   address = [192.168.0.70]
   port = [8123]
   txt = ["base_url=http://192.168.0.70:8123" "requires_api_password=true" "version=0.41.0"]
```
