### PR TITLE
Upgrade pysnmp to 4.3.5

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -19,7 +19,7 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pysnmp==4.3.4']
+REQUIREMENTS = ['pysnmp==4.3.5']
 
 CONF_COMMUNITY = 'community'
 CONF_AUTHKEY = 'authkey'

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pysnmp==4.3.4']
+REQUIREMENTS = ['pysnmp==4.3.5']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,9 +42,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the SNMP sensor."""
-    from pysnmp.hlapi import (getCmd, CommunityData, SnmpEngine,
-                              UdpTransportTarget, ContextData, ObjectType,
-                              ObjectIdentity)
+    from pysnmp.hlapi import (
+        getCmd, CommunityData, SnmpEngine, UdpTransportTarget, ContextData,
+        ObjectType, ObjectIdentity)
 
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
@@ -114,9 +114,9 @@ class SnmpData(object):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data from the remote SNMP capable host."""
-        from pysnmp.hlapi import (getCmd, CommunityData, SnmpEngine,
-                                  UdpTransportTarget, ContextData, ObjectType,
-                                  ObjectIdentity)
+        from pysnmp.hlapi import (
+            getCmd, CommunityData, SnmpEngine, UdpTransportTarget, ContextData,
+            ObjectType, ObjectIdentity)
         errindication, errstatus, errindex, restable = next(
             getCmd(SnmpEngine(),
                    CommunityData(self._community, mpModel=0),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -577,7 +577,7 @@ pysma==0.1.3
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
-pysnmp==4.3.4
+pysnmp==4.3.5
 
 # homeassistant.components.media_player.clementine
 python-clementine-remote==1.0.1


### PR DESCRIPTION
## 4.3.5
- The getNext() and getBulk() calls of Twisted interface. Now support ignoreNonIncreasingOid option.
- TextualConvention is now a new-style class.
- Fix to accidentally reset error-status when building confirmed class   SNMPv1 PDU.
- Fix to possible infinite recursion in TextualConvention.prettyIn().
- Fixed crash when attempting to report unsupported request/notification PDU back to sender.

Tested with the following configuration:

``` yaml
sensor:
  - platform: snmp
    name: SNMP TEST String
    host: demo.snmplabs.com
    community: public
    baseoid: 1.3.6.1.4.1.2021.10.1.3.1
    unit_of_measurement: "load"
```
