### PR TITLE
Add optional unit of measurement

### DIFF
--- a/homeassistant/components/sensor/random.py
+++ b/homeassistant/components/sensor/random.py
@@ -11,7 +11,8 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_NAME, CONF_MINIMUM, CONF_MAXIMUM)
+from homeassistant.const import (
+    CONF_NAME, CONF_MINIMUM, CONF_MAXIMUM, CONF_UNIT_OF_MEASUREMENT)
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,6 +27,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MAXIMUM, default=DEFAULT_MAX): cv.positive_int,
     vol.Optional(CONF_MINIMUM, default=DEFAULT_MIN): cv.positive_int,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
 })
 
 
@@ -35,19 +37,21 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     minimum = config.get(CONF_MINIMUM)
     maximum = config.get(CONF_MAXIMUM)
+    unit = config.get(CONF_UNIT_OF_MEASUREMENT)
 
-    async_add_devices([RandomSensor(name, minimum, maximum)], True)
+    async_add_devices([RandomSensor(name, minimum, maximum, unit)], True)
     return True
 
 
 class RandomSensor(Entity):
     """Representation of a Random number sensor."""
 
-    def __init__(self, name, minimum, maximum):
+    def __init__(self, name, minimum, maximum, unit_of_measurement):
         """Initialize the sensor."""
         self._name = name
         self._minimum = minimum
         self._maximum = maximum
+        self._unit_of_measurement = unit_of_measurement
         self._state = None
 
     @property
@@ -64,6 +68,11 @@ class RandomSensor(Entity):
     def icon(self):
         """Icon to use in the frontend, if any."""
         return ICON
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit this state is expressed in."""
+        return self._unit_of_measurement
 
     @asyncio.coroutine
     def async_update(self):


### PR DESCRIPTION
## Description:
With the new optional configuration variable `unit_of_measurement` the sensor can be used to simulate a real sensor.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2337

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: random
    name: Temperature
    min: 20
    max: 25
    unit_of_measurement: '°C'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
