### PR TITLE
Make get_snmp_data more robust

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -125,7 +125,10 @@ class SnmpScanner(DeviceScanner):
 
         for resrow in restable:
             for _, val in resrow:
-                mac = binascii.hexlify(val.asOctets()).decode('utf-8')
+                try:
+                    mac = binascii.hexlify(val.asOctets()).decode('utf-8')
+                except AttributeError:
+                    continue
                 _LOGGER.debug("Found MAC %s", mac)
                 mac = ':'.join([mac[i:i+2] for i in range(0, len(mac), 2)])
                 devices.append({'mac': mac})


### PR DESCRIPTION
#### Description: 
Handle cases when non-binary data are encounter in a SNMP response. 

E.g. the following command: `
snmpwalk -v1 -c public myrouter 1.3.6.1.2.1.9999` returns a list of currently assigned MAC addresses from Mikrotik router:
```
SNMPv2-SMI::mib-2.9999.1.1.6.4.1.7.192.168.3.4 = INTEGER: 3
SNMPv2-SMI::mib-2.9999.1.1.6.4.1.7.192.168.3.2 = INTEGER: 3
SNMPv2-SMI::mib-2.9999.1.1.6.4.1.8.192.168.3.4 = Hex-STRING: 01 06 BC 5F F4 FF 03 27 
SNMPv2-SMI::mib-2.9999.1.1.6.4.1.8.192.168.3.2 = Hex-STRING: 01 06 BC 5F F4 FF 02 9C
```
which throws an `AttributeError`, because `Integer` does not have `asOctets()` method.