### PR TITLE
yeelight: adjust supported features on update()

### DIFF
--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -44,12 +44,13 @@ DEVICE_SCHEMA = vol.Schema({
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA}, })
 
-SUPPORT_YEELIGHT_RGB = (SUPPORT_RGB_COLOR |
-                        SUPPORT_COLOR_TEMP)
-
 SUPPORT_YEELIGHT = (SUPPORT_BRIGHTNESS |
                     SUPPORT_TRANSITION |
                     SUPPORT_FLASH)
+
+SUPPORT_YEELIGHT_RGB = (SUPPORT_YEELIGHT |
+                        SUPPORT_RGB_COLOR |
+                        SUPPORT_COLOR_TEMP)
 
 
 def _cmd(func):
@@ -201,7 +202,7 @@ class YeelightLight(Light):
             self._bulb.get_properties()
 
             if self._bulb_device.bulb_type == yeelight.BulbType.Color:
-                self._supported_features |= SUPPORT_YEELIGHT_RGB
+                self._supported_features = SUPPORT_YEELIGHT_RGB
 
             self._is_on = self._properties.get("power") == "on"
 

--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -179,9 +179,6 @@ class YeelightLight(Light):
                 self._bulb_device = yeelight.Bulb(self._ipaddr)
                 self._bulb_device.get_properties()  # force init for type
 
-                btype = self._bulb_device.bulb_type
-                if btype == yeelight.BulbType.Color:
-                    self._supported_features |= SUPPORT_YEELIGHT_RGB
                 self._available = True
             except yeelight.BulbException as ex:
                 self._available = False
@@ -202,6 +199,9 @@ class YeelightLight(Light):
         import yeelight
         try:
             self._bulb.get_properties()
+
+            if self._bulb_device.bulb_type == yeelight.BulbType.Color:
+                self._supported_features |= SUPPORT_YEELIGHT_RGB
 
             self._is_on = self._properties.get("power") == "on"
 


### PR DESCRIPTION
## Description:
Earlier we checked for the type only during the initialization,
but this won't work when the bulb is disconnected during the init,
causing failures to adjust rgb&color temperature even if those should be supported.

fixes #6692

**Related issue (if applicable):** fixes #6692

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
