### PR TITLE
Allow to monitor Windows hosts

### DIFF
--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -133,7 +133,11 @@ class GlancesSensor(Entity):
             elif self.type == 'swap_free':
                 return round(value['memswap']['free'] / 1024**3, 1)
             elif self.type == 'processor_load':
-                return value['load']['min15']
+                # Windows systems don't provide load details
+                try:
+                    return value['load']['min15']
+                except KeyError:
+                    return value['cpu']['total']
             elif self.type == 'process_running':
                 return value['processcount']['running']
             elif self.type == 'process_total':


### PR DESCRIPTION
## Description:
Catch the exception of Windows hosts as they don't provide `load` details.

**Related issue (if applicable):** fixes #6482

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: glances
    host: IP_ADDRESS_WINDOWS_MACHINE
    resources:
    - 'processor_load'
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

