### PR TITLE
Integration with lockitron

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -235,6 +235,7 @@ omit =
     homeassistant/components/light/zengge.py
     homeassistant/components/lirc.py
     homeassistant/components/lock/nuki.py
+    homeassistant/components/lock/lockitron.py
     homeassistant/components/media_player/anthemav.py
     homeassistant/components/media_player/apple_tv.py
     homeassistant/components/media_player/aquostv.py

--- a/homeassistant/components/lock/lockitron.py
+++ b/homeassistant/components/lock/lockitron.py
@@ -1,0 +1,99 @@
+"""
+Lockitron lock platform.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/lockitron/
+"""
+import logging
+
+import requests
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.lock import LockDevice, PLATFORM_SCHEMA
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_ID
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'lockitron'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ACCESS_TOKEN): cv.string,
+    vol.Required(CONF_ID): cv.string
+})
+BASE_URL = 'https://api.lockitron.com'
+API_STATE_URL = BASE_URL + '/v2/locks/{}?access_token={}'
+API_ACTION_URL = BASE_URL + '/v2/locks/{}?access_token={}&state={}'
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Lockitron platform."""
+    access_token = config.get(CONF_ACCESS_TOKEN)
+    device_id = config.get(CONF_ID)
+    response = requests.get(API_STATE_URL.format(device_id, access_token))
+    if response.status_code == 200:
+        add_devices([Lockitron(response.json()['state'], access_token,
+                               device_id)])
+    else:
+        _LOGGER.error('Error retrieving lock status during init: %s',
+                      response.text)
+
+
+class Lockitron(LockDevice):
+    """Representation of a Lockitron lock."""
+
+    LOCK_STATE = 'lock'
+    UNLOCK_STATE = 'unlock'
+
+    def __init__(self, state, access_token, device_id):
+        """Initialize the lock."""
+        self._state = state
+        self.access_token = access_token
+        self.device_id = device_id
+
+    @property
+    def should_poll(self):
+        """Return True since we need to poll for the lock's new status."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return DOMAIN
+
+    @property
+    def is_locked(self):
+        """Return True if the lock is currently locked, else False."""
+        return self._state == Lockitron.LOCK_STATE
+
+    def lock(self, **kwargs):
+        """Lock the device."""
+        self._state = self.do_change_request(Lockitron.LOCK_STATE)
+        self.update_ha_state()
+
+    def unlock(self, **kwargs):
+        """Unlock the device."""
+        self._state = self.do_change_request(Lockitron.UNLOCK_STATE)
+        self.update_ha_state()
+
+    def update(self):
+        """Update the internal state of the device."""
+        response = requests \
+            .get(API_STATE_URL.format(self.device_id, self.access_token))
+        if response.status_code == 200:
+            self._state = response.json()['state']
+        else:
+            _LOGGER.error('Error retrieving lock status: %s', response.text)
+
+    def do_change_request(self, requested_state):
+        """Execute the change request and pull out the new state."""
+        response = requests.put(
+            API_ACTION_URL.format(self.device_id, self.access_token,
+                                  requested_state))
+        if response.status_code == 200:
+            return response.json()['state']
+        else:
+            _LOGGER.error('Error setting lock state: %s\n%s',
+                          requested_state, response.text)
+            return self._state

--- a/homeassistant/components/lock/lockitron.py
+++ b/homeassistant/components/lock/lockitron.py
@@ -53,11 +53,6 @@ class Lockitron(LockDevice):
         self.device_id = device_id
 
     @property
-    def should_poll(self):
-        """Return True since we need to poll for the lock's new status."""
-        return True
-
-    @property
     def name(self):
         """Return the name of the device."""
         return DOMAIN
@@ -70,12 +65,10 @@ class Lockitron(LockDevice):
     def lock(self, **kwargs):
         """Lock the device."""
         self._state = self.do_change_request(Lockitron.LOCK_STATE)
-        self.update_ha_state()
 
     def unlock(self, **kwargs):
         """Unlock the device."""
         self._state = self.do_change_request(Lockitron.UNLOCK_STATE)
-        self.update_ha_state()
 
     def update(self):
         """Update the internal state of the device."""


### PR DESCRIPTION
## Description:
Add support to lockitrons that have the bridge extension that enables wi-fi support. Currently only supports one lock at a time.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#2339

## Example entry for `configuration.yaml` (if applicable):
```yaml
lock:
  - platform: lockitron
    access_token: asdf
    id: fdsa
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
