### PR TITLE
Add NVR support to Hikvision Binary Sensors

### DIFF
--- a/homeassistant/components/binary_sensor/hikvision.py
+++ b/homeassistant/components/binary_sensor/hikvision.py
@@ -114,7 +114,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 class HikvisionData(object):
-    """Hikvision camera event stream object."""
+    """Hikvision device event stream object."""
 
     def __init__(self, hass, url, port, name, username, password):
         """Initialize the data oject."""

--- a/homeassistant/components/binary_sensor/hikvision.py
+++ b/homeassistant/components/binary_sensor/hikvision.py
@@ -94,7 +94,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     for sensor, channel_list in data.sensors.items():
         for channel in channel_list:
             # Build sensor name, then parse customize config.
-            sensor_name = '{}_{}'.format(sensor.replace(' ', '_'), channel[1])
+            if data.type == 'NVR':
+                sensor_name = '{}_{}'.format(
+                    sensor.replace(' ', '_'), channel[1])
+            else:
+                sensor_name = sensor.replace(' ', '_')
 
             custom = customize.get(sensor_name.lower(), {})
             ignore = custom.get(CONF_IGNORED)
@@ -146,13 +150,18 @@ class HikvisionData(object):
 
     @property
     def cam_id(self):
-        """Return camera id."""
+        """Return device id."""
         return self.camdata.get_id
 
     @property
     def name(self):
-        """Return camera name."""
+        """Return device name."""
         return self._name
+
+    @property
+    def type(self):
+        """Return device type."""
+        return self.camdata.get_type
 
     def get_attributes(self, sensor, channel):
         """Return attribute list for sensor/channel."""
@@ -166,10 +175,15 @@ class HikvisionBinarySensor(BinarySensorDevice):
         """Initialize the binary_sensor."""
         self._hass = hass
         self._cam = cam
-        self._name = '{} {} {}'.format(self._cam.name, sensor, channel)
-        self._id = '{}.{}.{}'.format(self._cam.cam_id, sensor, channel)
         self._sensor = sensor
         self._channel = channel
+
+        if self._cam.type == 'NVR':
+            self._name = '{} {} {}'.format(self._cam.name, sensor, channel)
+        else:
+            self._name = '{} {}'.format(self._cam.name, sensor)
+
+        self._id = '{}.{}.{}'.format(self._cam.cam_id, sensor, channel)
 
         if delay is None:
             self._delay = 0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -514,7 +514,7 @@ pygatt==3.0.0
 pyharmony==1.0.12
 
 # homeassistant.components.binary_sensor.hikvision
-pyhik==0.1.0
+pyhik==0.1.1
 
 # homeassistant.components.homematic
 pyhomematic==0.1.24


### PR DESCRIPTION
## Description:
Update hikvision binary sensor platform to support Hikvision NVR devices in addition to individual cameras.

This PR also removes the "IO Sensor" type, but it does so because it was not reliable in previous builds and is difficult to make it so over the large range of hikvision models.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2340

## Example entry for `configuration.yaml` (if applicable):
Unchanged.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
