### PR TITLE
Upgrade matrix-client to 0.0.6

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -360,7 +360,7 @@ liveboxplaytv==1.4.9
 lyft_rides==0.1.0b0
 
 # homeassistant.components.notify.matrix
-matrix-client==0.0.5
+matrix-client==0.0.6
 
 # homeassistant.components.maxcube
 maxcube-api==0.1.0


### PR DESCRIPTION
## 0.0.6
#### MatrixClient:

- Add get/add/delete endpoints for tags
- Add account_data global and room specific endpoints
- Add methods for setting the room name and topic
- Add methods for getting and setting room aliases
- Add logout functionality
- Send audio/video methods
- Add support for sending location events
- Add support for ephemeral events
- Add support for sending html formatted messages
- Allow setting a displayname & avatar for a user per-room.

#### API:

- Retry requests on ratelimit.
- Get room id from alias
- Get membership event of a user from a room.
- Add get_filter, create_filter methods to api

Tested with the following configuration:

``` yaml
notify:
  - platform: matrix
    name: matrix
    homeserver: https://matrix.org
    username: !secret matrix_user
    password: !secret matrix_password
    default_room: "#the-room:matrix.org"
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```
