### PR TITLE
fix WOL in docker/jail

### DIFF
--- a/homeassistant/components/switch/wake_on_lan.py
+++ b/homeassistant/components/switch/wake_on_lan.py
@@ -75,7 +75,10 @@ class WOLSwitch(SwitchDevice):
 
     def turn_on(self):
         """Turn the device on."""
-        self._wol.send_magic_packet(self._mac_address)
+        if self._host:
+            self._wol.send_magic_packet(self._mac_address, ip_address=self._host)
+        else:
+            self._wol.send_magic_packet(self._mac_address)
 
     def turn_off(self):
         """Turn the device off if an off action is present."""

--- a/homeassistant/components/switch/wake_on_lan.py
+++ b/homeassistant/components/switch/wake_on_lan.py
@@ -76,7 +76,8 @@ class WOLSwitch(SwitchDevice):
     def turn_on(self):
         """Turn the device on."""
         if self._host:
-            self._wol.send_magic_packet(self._mac_address, ip_address=self._host)
+            self._wol.send_magic_packet(self._mac_address,
+                                        ip_address=self._host)
         else:
             self._wol.send_magic_packet(self._mac_address)
 


### PR DESCRIPTION
## Description:

in docker/jail, WOL doesn't works due to subnet multicast issues.

add ip_address parameter to send_magic_packet if host specific.