### PR TITLE
Allow scene configs to be merged

### DIFF
--- a/homeassistant/components/scene/__init__.py
+++ b/homeassistant/components/scene/__init__.py
@@ -21,9 +21,15 @@ DOMAIN = 'scene'
 STATE = 'scening'
 
 CONF_ENTITIES = "entities"
+CONF_NAME = "name"
 
 SCENE_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+})
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_ENTITIES): cv.ordered_dict(cv.match_all, cv.entity_id),
 })
 
 SceneConfig = namedtuple('SceneConfig', ['name', 'states'])


### PR DESCRIPTION
## Description:
It is currently not possible to use scenes inside packages. This PR adds a PLATFORM_SCHEMA field to `scene/__init__.py` so that it can be analysed and merged on boot. Existing tests still pass locally.

**Related issue (if applicable):** fixes #6641

## Example entry for `configuration.yaml` (if applicable):
Scenes configuration stays the same as defined in https://home-assistant.io/components/scene/

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
