### PR TITLE
[switch.wemo] Fix mW to kW conversion.

### DIFF
--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -148,7 +148,8 @@ class WemoSwitch(SwitchDevice):
     def today_energy_kwh(self):
         """Today total energy usage in kWh."""
         if self.insight_params:
-            return convert(self.insight_params['todaymw'], float, 0.0) / 1000000.0
+            miliwatts = convert(self.insight_params['todaymw'], float, 0.0)
+            return miliwatts / 1000000.0
 
     @property
     def detail_state(self):

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -148,7 +148,7 @@ class WemoSwitch(SwitchDevice):
     def today_energy_kwh(self):
         """Today total energy usage in kWh."""
         if self.insight_params:
-            return convert(self.insight_params['todaymw'], float, 0.0) / 1000.0
+            return convert(self.insight_params['todaymw'], float, 0.0) / 1000000.0
 
     @property
     def detail_state(self):


### PR DESCRIPTION
## Description:

Conversion was wrong.

8954105 mW should convert to 8.954105 kW, not 8954.105 kW.