### PR TITLE
Eliminate needless async_add_job invocation of async_add_devices

### DIFF
--- a/homeassistant/components/binary_sensor/insteon_plm.py
+++ b/homeassistant/components/binary_sensor/insteon_plm.py
@@ -32,7 +32,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             InsteonPLMBinarySensorDevice(hass, plm, address, name)
         )
 
-    hass.async_add_job(async_add_devices(device_list))
+    async_add_devices(device_list)
 
 
 class InsteonPLMBinarySensorDevice(BinarySensorDevice):

--- a/homeassistant/components/light/insteon_plm.py
+++ b/homeassistant/components/light/insteon_plm.py
@@ -36,7 +36,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             InsteonPLMDimmerDevice(hass, plm, address, name, dimmable)
         )
 
-    hass.async_add_job(async_add_devices(device_list))
+    async_add_devices(device_list)
 
 
 class InsteonPLMDimmerDevice(Light):

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -95,7 +95,7 @@ class LIFXManager(object):
         entity = LIFXLight(device)
         _LOGGER.debug("%s register READY", entity.ipaddr)
         self.entities[device.mac_addr] = entity
-        self.hass.async_add_job(self.async_add_devices, [entity])
+        self.async_add_devices([entity])
 
     @callback
     def unregister(self, device):

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -32,7 +32,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             InsteonPLMSwitchDevice(hass, plm, address, name)
         )
 
-    hass.async_add_job(async_add_devices(device_list))
+    async_add_devices(device_list)
 
 
 class InsteonPLMSwitchDevice(SwitchDevice):


### PR DESCRIPTION
## Description:

When we changed to async bootstrapping of HASS it changed `async_add_devices` from a coroutine to a callback.  The `yield from` invocations in the codebase were found and amended, but there were a few async platforms that were wrapping `async_add_devices` inside of `async_add_job` instead of doing a yield from.

This PR corrects those instances to simply call the async_add_devices callback directly.  Doing so prevents a traceback in `async_add_job` when it is invoked with an empty/None target.
## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
 
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54