### PR TITLE
Upgrade sphinx-autodoc-typehints to 1.2.0

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
 Sphinx==1.5.3
-sphinx-autodoc-typehints==1.1.0
+sphinx-autodoc-typehints==1.2.0
 sphinx-autodoc-annotation==1.0.post1


### PR DESCRIPTION
1.2.0
=====

* Fixed compatibility with Python 3.6 and 3.5.3
* Fixed ``NameError`` when processing signatures of wrapped functions with type hints
* Fixed handling of slotted classes with no ``__init__()`` method
* Fixed Sphinx warning about parallel reads
* Fixed return type being added to class docstring from its ``__init__()`` method
  (thanks to Manuel Krebber for the patch)
* Fixed return type hints of ``@property`` methods being omitted (thanks to pknight for the patch)
* Added a test suite (thanks Manuel Krebber)