### PR TITLE
Exposed more attributes, enabled play_media tv show or season episodes

### DIFF
--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -4,26 +4,40 @@ Support to interface with the Plex API.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.plex/
 """
-from datetime import timedelta
 import json
 import logging
 import os
+from datetime import timedelta
 from urllib.parse import urlparse
 
 import requests
-
+import voluptuous as vol
 from homeassistant import util
 from homeassistant.components.media_player import (
-    MEDIA_TYPE_MUSIC, MEDIA_TYPE_TVSHOW, MEDIA_TYPE_VIDEO, PLATFORM_SCHEMA,
-    SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PLAY, SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
-    MediaPlayerDevice)
+    MEDIA_TYPE_MUSIC,
+    MEDIA_TYPE_TVSHOW,
+    MEDIA_TYPE_VIDEO,
+    PLATFORM_SCHEMA,
+    SUPPORT_NEXT_TRACK,
+    SUPPORT_PAUSE,
+    SUPPORT_PLAY,
+    SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_STOP,
+    SUPPORT_TURN_OFF,
+    SUPPORT_VOLUME_MUTE,
+    SUPPORT_VOLUME_SET,
+    MediaPlayerDevice,
+)
 from homeassistant.const import (
-    DEVICE_DEFAULT_NAME, STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING)
+    DEVICE_DEFAULT_NAME,
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_PAUSED,
+    STATE_PLAYING,
+)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import track_utc_time_change
 from homeassistant.loader import get_component
-import voluptuous as vol
 
 REQUIREMENTS = ['plexapi==2.0.2']
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -330,7 +330,8 @@ class PlexClient(MediaPlayerDevice):
                 self._session.viewOffset)
             self._media_content_id = self._convert_na_to_none(
                 self._session.ratingKey)
-            self._media_content_rating = self._session.contentRating
+            self._media_content_rating = self._convert_na_to_none(
+                self._session.contentRating)
         else:
             self._media_position = None
             self._media_content_id = None
@@ -342,7 +343,8 @@ class PlexClient(MediaPlayerDevice):
                 self._session.player.machineIdentifier)
             self._name = self._convert_na_to_none(self._session.player.title)
             self._player_state = self._session.player.state
-            self._session_username = self._session.username
+            self._session_username = self._convert_na_to_none(
+                self._session.username)
             self._make = self._convert_na_to_none(self._session.player.device)
         else:
             self._is_player_available = False

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -330,6 +330,7 @@ class PlexClient(MediaPlayerDevice):
                 self._session.viewOffset)
             self._media_content_id = self._convert_na_to_none(
                 self._session.ratingKey)
+            self._media_content_rating = self._session.contentRating
         else:
             self._media_position = None
             self._media_content_id = None
@@ -341,6 +342,7 @@ class PlexClient(MediaPlayerDevice):
                 self._session.player.machineIdentifier)
             self._name = self._convert_na_to_none(self._session.player.title)
             self._player_state = self._session.player.state
+            self._session_username = self._session.username
             self._make = self._convert_na_to_none(self._session.player.device)
         else:
             self._is_player_available = False

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -250,6 +250,7 @@ class PlexClient(MediaPlayerDevice):
         self._machine_identifier = None
         self._make = ''
         self._media_content_id = None
+        self._media_content_rating = None
         self._media_content_type = None
         self._media_duration = None
         self._media_image_url = None
@@ -259,6 +260,7 @@ class PlexClient(MediaPlayerDevice):
         self._previous_volume_level = 1  # Used in fake muting
         self._session = None
         self._session_type = None
+        self._session_username = None
         self._state = STATE_IDLE
         self._volume_level = 1  # since we can't retrieve remotely
         self._volume_muted = False  # since we can't retrieve remotely


### PR DESCRIPTION
Changes:
- Exposed content rating, library name, and session username attributes
- Enabled play_media to play a TV episodes for a specific show or season in addition to the existing functionality of playing a specific episode.  This allows you to do things like - play Season 2 of Rick and Morty, Play but shuffle all rick and Morty episodes