### PR TITLE
Upgrade aiohttp_cors to 0.5.2

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -34,8 +34,9 @@ from .static import (
     staticresource_middleware, CachingFileResponse, CachingStaticResource)
 from .util import get_real_ip
 
+REQUIREMENTS = ['aiohttp_cors==0.5.2']
+
 DOMAIN = 'http'
-REQUIREMENTS = ('aiohttp_cors==0.5.0',)
 
 CONF_API_PASSWORD = 'api_password'
 CONF_SERVER_HOST = 'server_host'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -41,7 +41,7 @@ aiodns==1.1.1
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
-aiohttp_cors==0.5.0
+aiohttp_cors==0.5.2
 
 # homeassistant.components.light.lifx
 aiolifx==0.4.2


### PR DESCRIPTION
## 0.5.2

- Fix tests compatibility with aiohttp 2.0. This release and release v0.5.0 should work on aiohttp 2.0.

## 0.5.1

- Enforce aiohttp version to be less than 2.0. Newer aiohttp releases will be supported in the next release.

Tested with: 
```yaml
http:
```