### PR TITLE
Makes amcrest.sensor to handle properly the scan_interval option.

### DIFF
--- a/homeassistant/components/sensor/amcrest.py
+++ b/homeassistant/components/sensor/amcrest.py
@@ -13,8 +13,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_MONITORED_CONDITIONS,
-    CONF_SCAN_INTERVAL, CONF_USERNAME, CONF_PASSWORD,
-    CONF_PORT, STATE_UNKNOWN)
+    CONF_USERNAME, CONF_PASSWORD, CONF_PORT, STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
 import homeassistant.loader as loader
 

--- a/homeassistant/components/sensor/amcrest.py
+++ b/homeassistant/components/sensor/amcrest.py
@@ -29,7 +29,7 @@ NOTIFICATION_TITLE = 'Amcrest Sensor Setup'
 
 DEFAULT_NAME = 'Amcrest'
 DEFAULT_PORT = 80
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=10)
+SCAN_INTERVAL = timedelta(seconds=10)
 
 # Sensor types are defined like: Name, units, icon
 SENSOR_TYPES = {
@@ -44,8 +44,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
-        vol.All(vol.Coerce(int), vol.Range(min=1)),
     vol.Required(CONF_MONITORED_CONDITIONS, default=[]):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })

--- a/homeassistant/components/sensor/amcrest.py
+++ b/homeassistant/components/sensor/amcrest.py
@@ -120,6 +120,8 @@ class AmcrestSensor(Entity):
 
     def update(self):
         """Get the latest data and updates the state."""
+        _LOGGER.debug("Pulling data from %s sensor.", self._name)
+
         try:
             version, build_date = self._camera.software_information
             self._attrs['Build Date'] = build_date.split('=')[-1]


### PR DESCRIPTION
## Description:
Makes `amcrest.sensor` to handle properly the `scan_interval` option.
This patch also adds a debug statement for troubleshooting purposes. 

```python
17-03-18 02:11:31 ERROR (MainThread) [homeassistant.bootstrap] Invalid config for [sensor.amcrest]: 
expected int for dictionary value @ data['scan_interval']. Got datetime.timedelta(0, 10). (See ?, line ?). 
Please check the docs at https://home-assistant.io/components/sensor.amcrest/
```

With this patch now is possible to assign a value to scan_interval as expected.

**Related issue (if applicable):** 
Issue reported at: https://community.home-assistant.io/t/amcrest-sensor-scan-interval/13986/4

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: amcrest
    host: !secret cam_ip 
    username: !secret cam_user
    password: !secret cam_pass
    scan_interval: 5
    monitored_conditions:
      - motion_detector
```

## Checklist:


If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

I tested with different 1`scan_interval` values and worked as expected.