### PR TITLE
Make sensor.ring to handle scan_interval option as expected.

### DIFF
--- a/homeassistant/components/ring.py
+++ b/homeassistant/components/ring.py
@@ -26,7 +26,7 @@ NOTIFICATION_TITLE = 'Ring Sensor Setup'
 DOMAIN = 'ring'
 DEFAULT_CACHEDB = '.ring_cache.pickle'
 DEFAULT_ENTITY_NAMESPACE = 'ring'
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
+SCAN_INTERVAL = timedelta(seconds=30)
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/ring.py
+++ b/homeassistant/components/ring.py
@@ -4,7 +4,6 @@ Support for Ring Doorbell/Chimes.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/ring/
 """
-from datetime import timedelta
 import logging
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
@@ -26,7 +25,6 @@ NOTIFICATION_TITLE = 'Ring Sensor Setup'
 DOMAIN = 'ring'
 DEFAULT_CACHEDB = '.ring_cache.pickle'
 DEFAULT_ENTITY_NAMESPACE = 'ring'
-SCAN_INTERVAL = timedelta(seconds=30)
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/sensor/ring.py
+++ b/homeassistant/components/sensor/ring.py
@@ -4,6 +4,7 @@ This component provides HA sensor support for Ring Door Bell/Chimes.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.ring/
 """
+from datetime import timedelta
 import logging
 
 import voluptuous as vol

--- a/homeassistant/components/sensor/ring.py
+++ b/homeassistant/components/sensor/ring.py
@@ -33,8 +33,6 @@ SENSOR_TYPES = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ENTITY_NAMESPACE, default=DEFAULT_ENTITY_NAMESPACE):
         cv.string,
-    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
-        vol.All(vol.Coerce(int), vol.Range(min=1)),
     vol.Required(CONF_MONITORED_CONDITIONS, default=[]):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
@@ -120,6 +118,8 @@ class RingSensor(Entity):
 
     def update(self):
         """Get the latest data and updates the state."""
+        _LOGGER.debug("Pulling data from %s sensor.", self._name)
+
         self._data.update()
 
         if self._sensor_type == 'volume':

--- a/homeassistant/components/sensor/ring.py
+++ b/homeassistant/components/sensor/ring.py
@@ -10,16 +10,18 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.ring import (
-    CONF_ATTRIBUTION, DEFAULT_ENTITY_NAMESPACE, DEFAULT_SCAN_INTERVAL)
+    CONF_ATTRIBUTION, DEFAULT_ENTITY_NAMESPACE)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_ENTITY_NAMESPACE, CONF_MONITORED_CONDITIONS, CONF_SCAN_INTERVAL,
+    CONF_ENTITY_NAMESPACE, CONF_MONITORED_CONDITIONS,
     STATE_UNKNOWN, ATTR_ATTRIBUTION)
 from homeassistant.helpers.entity import Entity
 
 DEPENDENCIES = ['ring']
 
 _LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=30)
 
 # Sensor types: Name, category, units, icon, kind
 SENSOR_TYPES = {


### PR DESCRIPTION
## Description:
Makes `ring.sensor` to handle properly the `scan_interval` option.
This patch also adds a debug statement for troubleshooting purposes. 

```python
17-03-18 02:11:31 ERROR (MainThread) [homeassistant.bootstrap] Invalid config for [sensor.ring]: 
expected int for dictionary value @ data['scan_interval']. Got datetime.timedelta(0, 10). (See ?, line ?). 
Please check the docs at https://home-assistant.io/components/sensor.ring/
```

With this patch now is possible to assign a value to scan_interval as expected.

## Checklist:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

I tested with different 1`scan_interval` values and worked as expected.

