### PR TITLE
Update vera cover refresh logic

### DIFF
--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -47,6 +47,7 @@ class VeraCover(VeraDevice, CoverDevice):
     def set_cover_position(self, position, **kwargs):
         """Move the cover to a specific position."""
         self.vera_device.set_level(position)
+        self.schedule_update_ha_state()
 
     @property
     def is_closed(self):
@@ -60,11 +61,15 @@ class VeraCover(VeraDevice, CoverDevice):
     def open_cover(self, **kwargs):
         """Open the cover."""
         self.vera_device.open()
+        self.schedule_update_ha_state()
+
 
     def close_cover(self, **kwargs):
         """Close the cover."""
         self.vera_device.close()
+        self.schedule_update_ha_state()
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
         self.vera_device.stop()
+        self.schedule_update_ha_state()

--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -63,7 +63,6 @@ class VeraCover(VeraDevice, CoverDevice):
         self.vera_device.open()
         self.schedule_update_ha_state()
 
-
     def close_cover(self, **kwargs):
         """Close the cover."""
         self.vera_device.close()

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyvera==0.2.24']
+REQUIREMENTS = ['pyvera==0.2.25']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -638,7 +638,7 @@ pyunifi==2.0
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.2.24
+pyvera==0.2.25
 
 # homeassistant.components.notify.html5
 pywebpush==0.6.1


### PR DESCRIPTION
## Description:
This PR mainly bumps the vera version (which has an update that changes how thermostats are set - plus a change to how covers work - which fixes a bug where `open` and `set_position` didn't play well together.

I added some extra calls to `self.schedule_update_ha_state()` because I think some of the vera devices might not send async position updates correctly.

I'm not 100% these are needed (does the base cover code already schedule an update after a command).?

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
