### PR TITLE
Make icon,picture,device_class,entity_id,... directly configurable in…

### DIFF
--- a/homeassistant/components/binary_sensor/command_line.py
+++ b/homeassistant/components/binary_sensor/command_line.py
@@ -52,15 +52,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     add_devices([CommandBinarySensor(
         hass, data, name, device_class, payload_on, payload_off,
-        value_template)])
+        value_template, config)])
 
 
 class CommandBinarySensor(BinarySensorDevice):
     """Represent a command line binary sensor."""
 
     def __init__(self, hass, data, name, device_class, payload_on,
-                 payload_off, value_template):
+                 payload_off, value_template, config):
         """Initialize the Command line binary sensor."""
+        super(CommandBinarySensor, self).__init__(config)
         self._hass = hass
         self.data = data
         self._name = name

--- a/homeassistant/components/sensor/min_max.py
+++ b/homeassistant/components/sensor/min_max.py
@@ -62,7 +62,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     round_digits = config.get(CONF_ROUND_DIGITS)
 
     async_add_devices(
-        [MinMaxSensor(hass, entity_ids, name, sensor_type, round_digits)],
+        [MinMaxSensor(hass, entity_ids, name, sensor_type, round_digits,
+                      config)],
         True)
     return True
 
@@ -70,8 +71,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class MinMaxSensor(Entity):
     """Representation of a min/max sensor."""
 
-    def __init__(self, hass, entity_ids, name, sensor_type, round_digits):
+    def __init__(self, hass, entity_ids, name, sensor_type, round_digits,
+                 config):
         """Initialize the min/max sensor."""
+        super(MinMaxSensor, self).__init__(config)
         self._hass = hass
         self._entity_ids = entity_ids
         self._sensor_type = sensor_type

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -55,6 +55,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_FORCE_UPDATE),
         config.get(CONF_EXPIRE_AFTER),
         value_template,
+        config
     )])
 
 
@@ -62,8 +63,9 @@ class MqttSensor(Entity):
     """Representation of a sensor that can be updated using MQTT."""
 
     def __init__(self, name, state_topic, qos, unit_of_measurement,
-                 force_update, expire_after, value_template):
+                 force_update, expire_after, value_template, config):
         """Initialize the sensor."""
+        super(MqttSensor, self).__init__(config)
         self._state = STATE_UNKNOWN
         self._name = name
         self._state_topic = state_topic

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -59,6 +59,15 @@ def async_generate_entity_id(entity_id_format: str, name: Optional[str],
 class Entity(object):
     """An abstract class for Home Assistant entities."""
 
+    def __init__(self, config):
+        """Configure basic properties."""
+        if (config):
+            self._unit_of_measurement = config.get('unit_of_measurement')
+            self._icon = config.get('icon')
+            self._entity_picture = config.get('entity_picture')
+            self._hidden = config.get('hidden')
+            self.entity_id = config.get('id')
+
     # pylint: disable=no-self-use
     # SAFE TO OVERWRITE
     # The properties and methods here are safe to overwrite when inheriting
@@ -73,6 +82,21 @@ class Entity(object):
 
     # protect for multible updates
     _update_warn = None
+
+    # The icon to use in the frontend, if any
+    _icon = None
+
+    # The unit of measurement of this entity, if any
+    _unit_of_measurement = None
+
+    # The entity picture to use in the frontend, if any.
+    _entity_picture = None
+
+    # True if the entity should be hidden from UIs
+    _hidden = False
+
+    # The class of this device, from component DEVICE_CLASSES
+    _device_class = None
 
     @property
     def should_poll(self) -> bool:
@@ -116,27 +140,27 @@ class Entity(object):
     @property
     def device_class(self) -> str:
         """Return the class of this device, from component DEVICE_CLASSES."""
-        return None
+        return self._device_class
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        return None
+        return self._unit_of_measurement
 
     @property
     def icon(self):
         """Return the icon to use in the frontend, if any."""
-        return None
+        return self._icon
 
     @property
     def entity_picture(self):
         """Return the entity picture to use in the frontend, if any."""
-        return None
+        return self._entity_picture
 
     @property
     def hidden(self) -> bool:
         """Return True if the entity should be hidden from UIs."""
-        return False
+        return self._hidden
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
… entities

## Description:

This is a proposal for https://community.home-assistant.io/t/allow-customizing-directly-in-component-configuration/14832/2

Please have a look on it and give feedback. If you agree with this approach. If so, I would go through all the entities and add the super-init-call.

Regards,
Michael.