### PR TITLE
Adding AlarmDecoder platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,9 @@ omit =
     homeassistant/helpers/signal.py
 
     # omit pieces of code that rely on external devices being present
+    homeassistant/components/alarmdecoder.py
+    homeassistant/components/*/alarmdecoder.py
+
     homeassistant/components/apcupsd.py
     homeassistant/components/*/apcupsd.py
 

--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -28,9 +28,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Perform the setup for AlarmDecoder alarm panels."""
     _LOGGER.debug("AlarmDecoderAlarmPanel: setup")
 
-    _device = AlarmDecoderAlarmPanel("Alarm Panel", hass)
+    device = AlarmDecoderAlarmPanel("Alarm Panel", hass)
 
-    async_add_devices([_device])
+    async_add_devices([device])
 
     return True
 
@@ -42,7 +42,6 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
         """Initialize the alarm panel."""
         self._display = ""
         self._name = name
-        self._hass = hass
         self._state = STATE_UNKNOWN
 
         _LOGGER.debug("AlarmDecoderAlarm: Setting up panel")
@@ -58,19 +57,19 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
         if message.alarm_sounding or message.fire_alarm:
             if self._state != STATE_ALARM_TRIGGERED:
                 self._state = STATE_ALARM_TRIGGERED
-                self._hass.async_add_job(self.async_update_ha_state())
+                self.hass.async_add_job(self.async_update_ha_state())
         elif message.armed_away:
             if self._state != STATE_ALARM_ARMED_AWAY:
                 self._state = STATE_ALARM_ARMED_AWAY
-                self._hass.async_add_job(self.async_update_ha_state())
+                self.hass.async_add_job(self.async_update_ha_state())
         elif message.armed_home:
             if self._state != STATE_ALARM_ARMED_HOME:
                 self._state = STATE_ALARM_ARMED_HOME
-                self._hass.async_add_job(self.async_update_ha_state())
+                self.hass.async_add_job(self.async_update_ha_state())
         else:
             if self._state != STATE_ALARM_DISARMED:
                 self._state = STATE_ALARM_DISARMED
-                self._hass.async_add_job(self.async_update_ha_state())
+                self.hass.async_add_job(self.async_update_ha_state())
 
     @property
     def name(self):

--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -1,0 +1,120 @@
+"""
+Support for AlarmDecoder-based alarm control panels (Honeywell/DSC).
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/alarm_control_panel.alarmdecoder/
+"""
+import asyncio
+import logging
+
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+import homeassistant.components.alarm_control_panel as alarm
+
+from homeassistant.components.alarmdecoder import (DATA_AD,
+                                                   SIGNAL_PANEL_MESSAGE)
+
+from homeassistant.const import (
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED,
+    STATE_UNKNOWN, STATE_ALARM_TRIGGERED)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['alarmdecoder']
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Perform the setup for AlarmDecoder alarm panels."""
+    _LOGGER.debug("AlarmDecoderAlarmPanel: setup")
+
+    _device = AlarmDecoderAlarmPanel("Alarm Panel", hass)
+
+    async_add_devices([_device])
+
+    return True
+
+
+class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
+    """Representation of an AlarmDecoder-based alarm panel."""
+
+    def __init__(self, name, hass):
+        """Initialize the alarm panel."""
+        self._display = ""
+        self._name = name
+        self._hass = hass
+        self._state = STATE_UNKNOWN
+
+        _LOGGER.debug("AlarmDecoderAlarm: Setting up panel")
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
+        async_dispatcher_connect(
+            self.hass, SIGNAL_PANEL_MESSAGE, self._message_callback)
+
+    @callback
+    def _message_callback(self, message):
+        if message.alarm_sounding or message.fire_alarm:
+            if self._state != STATE_ALARM_TRIGGERED:
+                self._state = STATE_ALARM_TRIGGERED
+                self._hass.async_add_job(self.async_update_ha_state())
+        elif message.armed_away:
+            if self._state != STATE_ALARM_ARMED_AWAY:
+                self._state = STATE_ALARM_ARMED_AWAY
+                self._hass.async_add_job(self.async_update_ha_state())
+        elif message.armed_home:
+            if self._state != STATE_ALARM_ARMED_HOME:
+                self._state = STATE_ALARM_ARMED_HOME
+                self._hass.async_add_job(self.async_update_ha_state())
+        else:
+            if self._state != STATE_ALARM_DISARMED:
+                self._state = STATE_ALARM_DISARMED
+                self._hass.async_add_job(self.async_update_ha_state())
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def code_format(self):
+        """Regex for code format or None if no code is required."""
+        return '^\\d{4,6}$'
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @asyncio.coroutine
+    def async_alarm_disarm(self, code=None):
+        """Send disarm command."""
+        _LOGGER.debug("AlarmDecoderAlarm::alarm_disarm: %s", code)
+        if code:
+            _LOGGER.debug("AlarmDecoderAlarm::alarm_disarm: sending %s1",
+                          str(code))
+            self.hass.data[DATA_AD].send(str(code) + "1")
+
+    @asyncio.coroutine
+    def async_alarm_arm_away(self, code=None):
+        """Send arm away command."""
+        _LOGGER.debug("AlarmDecoderAlarm::alarm_arm_away: %s", code)
+        if code:
+            _LOGGER.debug("AlarmDecoderAlarm::alarm_arm_away: sending %s2",
+                          str(code))
+            self.hass.data[DATA_AD].send(str(code) + "2")
+
+    @asyncio.coroutine
+    def async_alarm_arm_home(self, code=None):
+        """Send arm home command."""
+        _LOGGER.debug("AlarmDecoderAlarm::alarm_arm_home: %s", code)
+        if code:
+            _LOGGER.debug("AlarmDecoderAlarm::alarm_arm_home: sending %s3",
+                          str(code))
+            self.hass.data[DATA_AD].send(str(code) + "3")

--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -98,7 +98,7 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
         if code:
             _LOGGER.debug("AlarmDecoderAlarm::alarm_disarm: sending %s1",
                           str(code))
-            self.hass.data[DATA_AD].send(str(code) + "1")
+            self.hass.data[DATA_AD].send("{!s}1".format(code))
 
     @asyncio.coroutine
     def async_alarm_arm_away(self, code=None):
@@ -107,7 +107,7 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
         if code:
             _LOGGER.debug("AlarmDecoderAlarm::alarm_arm_away: sending %s2",
                           str(code))
-            self.hass.data[DATA_AD].send(str(code) + "2")
+            self.hass.data[DATA_AD].send("{!s}2".format(code))
 
     @asyncio.coroutine
     def async_alarm_arm_home(self, code=None):
@@ -116,4 +116,4 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
         if code:
             _LOGGER.debug("AlarmDecoderAlarm::alarm_arm_home: sending %s3",
                           str(code))
-            self.hass.data[DATA_AD].send(str(code) + "3")
+            self.hass.data[DATA_AD].send("{!s}3".format(code))

--- a/homeassistant/components/alarmdecoder.py
+++ b/homeassistant/components/alarmdecoder.py
@@ -122,33 +122,27 @@ def async_setup(hass, config):
         """Callback to handle zone restore from alarmdecoder."""
         async_dispatcher_send(hass, SIGNAL_ZONE_RESTORE, zone)
 
-    try:
-        controller = False
-        if _type == 'socket':
-            controller = AlarmDecoder(SocketDevice(interface=(_host, _port)))
-        elif _type == 'serial':
-            controller = AlarmDecoder(SerialDevice(interface=_path))
-        elif _type == 'usb':
-            _LOGGER.debug("AlarmDecoder USB Device not implemented yet.")
-            return False
+    controller = False
+    if _type == 'socket':
+        controller = AlarmDecoder(SocketDevice(interface=(_host, _port)))
+    elif _type == 'serial':
+        controller = AlarmDecoder(SerialDevice(interface=_path))
+    elif _type == 'usb':
+        _LOGGER.debug("AlarmDecoder USB Device not implemented yet.")
+        return False
 
-        controller.on_open += handle_open
-        controller.on_message += handle_message
-        controller.on_zone_fault += zone_fault_callback
-        controller.on_zone_restore += zone_restore_callback
+    controller.on_open += handle_open
+    controller.on_message += handle_message
+    controller.on_zone_fault += zone_fault_callback
+    controller.on_zone_restore += zone_restore_callback
 
-        hass.data[DATA_AD] = controller
+    hass.data[DATA_AD] = controller
 
-        controller.open(_baud)
+    controller.open(_baud)
 
-        result = yield from sync_connect
+    result = yield from sync_connect
 
-        if not result:
-            return False
-
-    except Exception as ex:
-        print('AlarmDecoder Exception:', ex)
-        sync_connect.set_result(False)
+    if not result:
         return False
 
     hass.async_add_job(async_load_platform(hass, 'alarm_control_panel', DOMAIN,

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -28,25 +28,19 @@ _LOGGER = logging.getLogger(__name__)
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup AlarmDecoder binary sensor devices."""
-    _configured_zones = discovery_info[CONF_ZONES]
+    configured_zones = discovery_info[CONF_ZONES]
 
-    components = {}
     devices = []
 
-    for zone_num in _configured_zones:
-        _device_config_data = ZONE_SCHEMA(_configured_zones[zone_num])
-        _type = _device_config_data[CONF_ZONE_TYPE]
-        _name = _device_config_data[CONF_ZONE_NAME]
-        _device = AlarmDecoderBinarySensor(hass,
-                                           zone_num,
-                                           _name,
-                                           _type)
-        devices.append(_device)
-
-        if _type not in components:
-            components[_type] = []
-
-        components[_type].append(_device)
+    for zone_num in configured_zones:
+        device_config_data = ZONE_SCHEMA(configured_zones[zone_num])
+        zone_type = device_config_data[CONF_ZONE_TYPE]
+        zone_name = device_config_data[CONF_ZONE_NAME]
+        device = AlarmDecoderBinarySensor(hass,
+                                          zone_num,
+                                          zone_name,
+                                          zone_type)
+        devices.append(device)
 
     async_add_devices(devices)
 
@@ -61,7 +55,6 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
         self._zone_number = zone_number
         self._zone_type = zone_type
         self._state = 0
-        self._hass = hass
         self._name = zone_name
         self._type = zone_type
 
@@ -120,11 +113,11 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
         """Update the zone's state, if needed."""
         if zone is None or int(zone) == self._zone_number:
             self._state = 1
-            self._hass.async_add_job(self.async_update_ha_state())
+            self.hass.async_add_job(self.async_update_ha_state())
 
     @callback
     def _restore_callback(self, zone):
         """Update the zone's state, if needed."""
         if zone is None or int(zone) == self._zone_number:
             self._state = 0
-            self._hass.async_add_job(self.async_update_ha_state())
+            self.hass.async_add_job(self.async_update_ha_state())

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -1,0 +1,130 @@
+"""
+Support for AlarmDecoder zone states- represented as binary sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.alarmdecoder/
+"""
+import asyncio
+import logging
+
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.components.binary_sensor import BinarySensorDevice
+
+from homeassistant.const import (STATE_ON, STATE_OFF, STATE_OPEN, STATE_CLOSED)
+from homeassistant.components.alarmdecoder import (ZONE_SCHEMA,
+                                                   CONF_ZONES,
+                                                   CONF_ZONE_NAME,
+                                                   CONF_ZONE_TYPE,
+                                                   SIGNAL_ZONE_FAULT,
+                                                   SIGNAL_ZONE_RESTORE)
+
+
+DEPENDENCIES = ['alarmdecoder']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Setup AlarmDecoder binary sensor devices."""
+    _configured_zones = discovery_info[CONF_ZONES]
+
+    components = {}
+    devices = []
+
+    for zone_num in _configured_zones:
+        _device_config_data = ZONE_SCHEMA(_configured_zones[zone_num])
+        _type = _device_config_data[CONF_ZONE_TYPE]
+        _name = _device_config_data[CONF_ZONE_NAME]
+        _device = AlarmDecoderBinarySensor(hass,
+                                           zone_num,
+                                           _name,
+                                           _type)
+        devices.append(_device)
+
+        if _type not in components:
+            components[_type] = []
+
+        components[_type].append(_device)
+
+    async_add_devices(devices)
+
+    return True
+
+
+class AlarmDecoderBinarySensor(BinarySensorDevice):
+    """Representation of an AlarmDecoder binary sensor."""
+
+    def __init__(self, hass, zone_number, zone_name, zone_type):
+        """Initialize the binary_sensor."""
+        self._zone_number = zone_number
+        self._zone_type = zone_type
+        self._state = 0
+        self._hass = hass
+        self._name = zone_name
+        self._type = zone_type
+
+        _LOGGER.debug('AlarmDecoderBinarySensor: Setup up zone: ' + zone_name)
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
+        async_dispatcher_connect(
+            self.hass, SIGNAL_ZONE_FAULT, self._fault_callback)
+
+        async_dispatcher_connect(
+            self.hass, SIGNAL_ZONE_RESTORE, self._restore_callback)
+
+    @property
+    def state(self):
+        """Return the state of the binary sensor."""
+        if self._type == 'opening':
+            return STATE_OPEN if self.is_on else STATE_CLOSED
+
+        return STATE_ON if self.is_on else STATE_OFF
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Icon for device by its type."""
+        if "window" in self._name.lower():
+            return "mdi:window-open" if self.is_on else "mdi:window-closed"
+
+        if self._type == 'smoke':
+            return "mdi:fire"
+
+        return None
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return true if sensor is on."""
+        return self._state == 1
+
+    @property
+    def device_class(self):
+        """Return the class of this sensor, from DEVICE_CLASSES."""
+        return self._zone_type
+
+    @callback
+    def _fault_callback(self, zone):
+        """Update the zone's state, if needed."""
+        if zone is None or int(zone) == self._zone_number:
+            self._state = 1
+            self._hass.async_add_job(self.async_update_ha_state())
+
+    @callback
+    def _restore_callback(self, zone):
+        """Update the zone's state, if needed."""
+        if zone is None or int(zone) == self._zone_number:
+            self._state = 0
+            self._hass.async_add_job(self.async_update_ha_state())

--- a/homeassistant/components/sensor/alarmdecoder.py
+++ b/homeassistant/components/sensor/alarmdecoder.py
@@ -25,9 +25,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Perform the setup for AlarmDecoder sensor devices."""
     _LOGGER.debug("AlarmDecoderSensor: async_setup_platform")
 
-    _device = AlarmDecoderSensor(hass)
+    device = AlarmDecoderSensor(hass)
 
-    async_add_devices([_device])
+    async_add_devices([device])
 
 
 class AlarmDecoderSensor(Entity):
@@ -36,7 +36,6 @@ class AlarmDecoderSensor(Entity):
     def __init__(self, hass):
         """Initialize the alarm panel."""
         self._display = ""
-        self._hass = hass
         self._state = STATE_UNKNOWN
         self._icon = 'mdi:alarm-check'
         self._name = 'Alarm Panel Display'

--- a/homeassistant/components/sensor/alarmdecoder.py
+++ b/homeassistant/components/sensor/alarmdecoder.py
@@ -1,0 +1,76 @@
+"""
+Support for AlarmDecoder Sensors (Shows Panel Display).
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.alarmdecoder/
+"""
+import asyncio
+import logging
+
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
+
+from homeassistant.components.alarmdecoder import (SIGNAL_PANEL_MESSAGE)
+
+from homeassistant.const import (STATE_UNKNOWN)
+
+DEPENDENCIES = ['alarmdecoder']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Perform the setup for AlarmDecoder sensor devices."""
+    _LOGGER.debug("AlarmDecoderSensor: async_setup_platform")
+
+    _device = AlarmDecoderSensor(hass)
+
+    async_add_devices([_device])
+
+
+class AlarmDecoderSensor(Entity):
+    """Representation of an AlarmDecoder keypad."""
+
+    def __init__(self, hass):
+        """Initialize the alarm panel."""
+        self._display = ""
+        self._hass = hass
+        self._state = STATE_UNKNOWN
+        self._icon = 'mdi:alarm-check'
+        self._name = 'Alarm Panel Display'
+
+        _LOGGER.debug("AlarmDecoderSensor: Setting up panel")
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
+        async_dispatcher_connect(
+            self.hass, SIGNAL_PANEL_MESSAGE, self._message_callback)
+
+    @callback
+    def _message_callback(self, message):
+        if self._display != message.text:
+            self._display = message.text
+            self.hass.async_add_job(self.async_update_ha_state())
+
+    @property
+    def icon(self):
+        """Return the icon if any."""
+        return self._icon
+
+    @property
+    def state(self):
+        """Return the overall state."""
+        return self._display
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -46,6 +46,9 @@ aiohttp_cors==0.5.2
 # homeassistant.components.light.lifx
 aiolifx==0.4.2
 
+# homeassistant.components.alarmdecoder
+alarmdecoder==0.12.1.0
+
 # homeassistant.components.camera.amcrest
 # homeassistant.components.sensor.amcrest
 amcrest==1.1.5


### PR DESCRIPTION
## Description:

Adding AlarmDecoder devices support.

AlarmDecoder is a USB or Raspberry PI connected device to control and monitor DSC and Ademco / Honeywell Vista alarm systems.

https://www.alarmdecoder.com

I based this off the envisalink code, big thank you to @pvizeli for that.

This has support for both SocketDevice and SerialDevice, but I don’t have access to a USB version for testing.  I left a spot for it to be added.

This adds:

alarmdevice component
alarm_control_panel shows status and allows arm/disarm
binary_sensor for all zones configured
sensor for a panel display, shows the text from the keypad display. This is off by default, enabled via the config

It requires alarmdecoder 0.12.1.0 to talk to the device.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#2373

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarmdecoder:
  device:
    type: socket
    host: 10.0.0.2
    port: 10000
  panel_display: On
  zones:
    01:
      name: 'Smoke Detector'
      type: 'smoke'
    02:
      name: 'Front Door'
      type: 'opening'
    03:
      name: 'Family Room Motion'
      type: 'motion'

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
