### PR TITLE
Fix UMP volume level

### DIFF
--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -425,12 +425,12 @@ class UniversalMediaPlayer(MediaPlayerDevice):
         return self._async_call_service(
             SERVICE_VOLUME_MUTE, data, allow_override=True)
 
-    def async_set_volume_level(self, volume_level):
+    def async_set_volume_level(self, volume):
         """Set volume level, range 0..1.
 
         This method must be run in the event loop and returns a coroutine.
         """
-        data = {ATTR_MEDIA_VOLUME_LEVEL: volume_level}
+        data = {ATTR_MEDIA_VOLUME_LEVEL: volume}
         return self._async_call_service(
             SERVICE_VOLUME_SET, data, allow_override=True)
 


### PR DESCRIPTION
Async needs consistent parameter naming across platforms. This fixes
UMP's volume set method by renaming the parameter.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

Fixes a bug with UMP's volume set functionality. Currently instead of passing the volume set call to a child, the following error is thrown. This is due to a bad parameter name. (`volume_level` vs `volume`)
```
17-04-02 16:34:03 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/lib64/python3.4/asyncio/tasks.py", line 240, in _step
    result = coro.send(None)
  File "/srv/hass/lib/python3.4/site-packages/homeassistant/core.py", line 1010, in _event_to_service_call
    yield from service_handler.func(service_call)
  File "/srv/hass/lib/python3.4/site-packages/homeassistant/components/media_player/__init__.py", line 365, in async_service_handler
    yield from getattr(player, method['method'])(**params)
TypeError: async_set_volume_level() got an unexpected keyword argument 'volume'
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
N/A

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: 