### PR TITLE
Automation: initial state > restore state

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -264,15 +264,13 @@ class AutomationEntity(ToggleEntity):
     @asyncio.coroutine
     def async_added_to_hass(self) -> None:
         """Startup with initial state or previous state."""
-        enable_automation = False
+        enable_automation = DEFAULT_INITIAL_STATE
 
         if self._initial_state is not None:
             enable_automation = self._initial_state
         else:
             state = yield from async_get_last_state(self.hass, self.entity_id)
-            if state is None:
-                enable_automation = DEFAULT_INITIAL_STATE
-            else:
+            if state:
                 enable_automation = state.state == STATE_ON
                 self._last_triggered = state.attributes.get('last_triggered')
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -277,7 +277,10 @@ def _async_setup_discovery(hass, config):
 @asyncio.coroutine
 def async_setup(hass, config):
     """Start the MQTT protocol service."""
-    conf = config.get(DOMAIN, {})
+    conf = config.get(DOMAIN)
+
+    if conf is None:
+        conf = CONFIG_SCHEMA({DOMAIN: {}})[DOMAIN]
 
     client_id = conf.get(CONF_CLIENT_ID)
     keepalive = conf.get(CONF_KEEPALIVE)

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -253,7 +253,7 @@ def async_prepare_setup_platform(hass: core.HomeAssistant, config, domain: str,
 
         if not dep_success:
             log_error('Could not setup all dependencies.')
-            return False
+            return None
 
     if not hass.config.skip_pip and hasattr(platform, 'REQUIREMENTS'):
         req_success = yield from _async_process_requirements(

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -14,7 +14,7 @@ import homeassistant.util.dt as dt_util
 
 from tests.common import (
     assert_setup_component, get_test_home_assistant, fire_time_changed,
-    mock_component, mock_service, mock_restore_cache)
+    mock_service, mock_restore_cache)
 
 
 # pylint: disable=invalid-name
@@ -24,7 +24,6 @@ class TestAutomation(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        mock_component(self.hass, 'group')
         self.calls = mock_service(self.hass, 'test', 'automation')
 
     def tearDown(self):
@@ -155,46 +154,6 @@ class TestAutomation(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
         self.assertEqual(['hello.world'],
                          self.calls[0].data.get(ATTR_ENTITY_ID))
-
-    def test_service_initial_value_off(self):
-        """Test initial value off."""
-        entity_id = 'automation.hello'
-
-        assert setup_component(self.hass, automation.DOMAIN, {
-            automation.DOMAIN: {
-                'alias': 'hello',
-                'initial_state': 'off',
-                'trigger': {
-                    'platform': 'event',
-                    'event_type': 'test_event',
-                },
-                'action': {
-                    'service': 'test.automation',
-                    'entity_id': ['hello.world', 'hello.world2']
-                }
-            }
-        })
-        assert not automation.is_on(self.hass, entity_id)
-
-    def test_service_initial_value_on(self):
-        """Test initial value on."""
-        entity_id = 'automation.hello'
-
-        assert setup_component(self.hass, automation.DOMAIN, {
-            automation.DOMAIN: {
-                'alias': 'hello',
-                'initial_state': 'on',
-                'trigger': {
-                    'platform': 'event',
-                    'event_type': 'test_event',
-                },
-                'action': {
-                    'service': 'test.automation',
-                    'entity_id': ['hello.world', 'hello.world2']
-                }
-            }
-        })
-        assert automation.is_on(self.hass, entity_id)
 
     def test_service_specify_entity_id_list(self):
         """Test service data."""
@@ -652,4 +611,118 @@ def test_automation_restore_state(hass):
     hass.bus.async_fire('test_event_hello')
     yield from hass.async_block_till_done()
 
+    assert len(calls) == 1
+
+
+@asyncio.coroutine
+def test_initial_value_off(hass):
+    """Test initial value off."""
+    calls = mock_service(hass, 'test', 'automation')
+
+    res = yield from async_setup_component(hass, automation.DOMAIN, {
+        automation.DOMAIN: {
+            'alias': 'hello',
+            'initial_state': 'off',
+            'trigger': {
+                'platform': 'event',
+                'event_type': 'test_event',
+            },
+            'action': {
+                'service': 'test.automation',
+                'entity_id': 'hello.world'
+            }
+        }
+    })
+    assert res
+    assert not automation.is_on(hass, 'automation.hello')
+
+    hass.bus.async_fire('test_event')
+    yield from hass.async_block_till_done()
+    assert len(calls) == 0
+
+
+@asyncio.coroutine
+def test_initial_value_on(hass):
+    """Test initial value on."""
+    calls = mock_service(hass, 'test', 'automation')
+
+    res = yield from async_setup_component(hass, automation.DOMAIN, {
+        automation.DOMAIN: {
+            'alias': 'hello',
+            'initial_state': 'on',
+            'trigger': {
+                'platform': 'event',
+                'event_type': 'test_event',
+            },
+            'action': {
+                'service': 'test.automation',
+                'entity_id': ['hello.world', 'hello.world2']
+            }
+        }
+    })
+    assert res
+    assert automation.is_on(hass, 'automation.hello')
+
+    hass.bus.async_fire('test_event')
+    yield from hass.async_block_till_done()
+    assert len(calls) == 1
+
+
+@asyncio.coroutine
+def test_initial_value_off_but_restore_on(hass):
+    """Test initial value off and restored state is turned on."""
+    calls = mock_service(hass, 'test', 'automation')
+    mock_restore_cache(hass, (
+        State('automation.hello', STATE_ON),
+    ))
+
+    res = yield from async_setup_component(hass, automation.DOMAIN, {
+        automation.DOMAIN: {
+            'alias': 'hello',
+            'initial_state': 'off',
+            'trigger': {
+                'platform': 'event',
+                'event_type': 'test_event',
+            },
+            'action': {
+                'service': 'test.automation',
+                'entity_id': 'hello.world'
+            }
+        }
+    })
+    assert res
+    assert not automation.is_on(hass, 'automation.hello')
+
+    hass.bus.async_fire('test_event')
+    yield from hass.async_block_till_done()
+    assert len(calls) == 0
+
+
+@asyncio.coroutine
+def test_initial_value_on_but_restore_off(hass):
+    """Test initial value off and restored state is turned on."""
+    calls = mock_service(hass, 'test', 'automation')
+    mock_restore_cache(hass, (
+        State('automation.hello', STATE_OFF),
+    ))
+
+    res = yield from async_setup_component(hass, automation.DOMAIN, {
+        automation.DOMAIN: {
+            'alias': 'hello',
+            'initial_state': 'on',
+            'trigger': {
+                'platform': 'event',
+                'event_type': 'test_event',
+            },
+            'action': {
+                'service': 'test.automation',
+                'entity_id': 'hello.world'
+            }
+        }
+    })
+    assert res
+    assert automation.is_on(hass, 'automation.hello')
+
+    hass.bus.async_fire('test_event')
+    yield from hass.async_block_till_done()
     assert len(calls) == 1


### PR DESCRIPTION
## Description:
When defining automations, a user supplied initial state should take precedence over a restored state.

**Related issue (if applicable):** fixes #6903

## Breaking change:

 - Because automations are being turned on when Home Assistant starts, you are no longer able to listen for the `HOMEASSISTANT_START` event in your automations.
 - Setting an initial value for your automation overrules the value it would get from a restored state.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
