### PR TITLE
Bump pyHik library version to support more cameras

### DIFF
--- a/homeassistant/components/binary_sensor/hikvision.py
+++ b/homeassistant/components/binary_sensor/hikvision.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_SSL, EVENT_HOMEASSISTANT_STOP, EVENT_HOMEASSISTANT_START,
     ATTR_LAST_TRIP_TIME, CONF_CUSTOMIZE)
 
-REQUIREMENTS = ['pyhik==0.1.1']
+REQUIREMENTS = ['pyhik==0.1.2']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_IGNORED = 'ignored'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -524,7 +524,7 @@ pygatt==3.0.0
 pyharmony==1.0.12
 
 # homeassistant.components.binary_sensor.hikvision
-pyhik==0.1.1
+pyhik==0.1.2
 
 # homeassistant.components.homematic
 pyhomematic==0.1.24


### PR DESCRIPTION
## Description:
Bump pyHik to latest version to support more re-badged hikvision cameras and nvr devices.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
 
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
