### PR TITLE
Upgrade paho-mqtt to 1.2.1

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -28,6 +28,8 @@ from homeassistant.const import (
     CONF_PASSWORD, CONF_PORT, CONF_PROTOCOL, CONF_PAYLOAD)
 from homeassistant.components.mqtt.server import HBMQTT_CONFIG_SCHEMA
 
+REQUIREMENTS = ['paho-mqtt==1.2.1']
+
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'mqtt'
@@ -36,8 +38,6 @@ DATA_MQTT = 'mqtt'
 
 SERVICE_PUBLISH = 'publish'
 SIGNAL_MQTT_MESSAGE_RECEIVED = 'mqtt_message_received'
-
-REQUIREMENTS = ['paho-mqtt==1.2']
 
 CONF_EMBEDDED = 'embedded'
 CONF_BROKER = 'broker'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -407,7 +407,7 @@ openhomedevice==0.2.1
 orvibo==1.1.1
 
 # homeassistant.components.mqtt
-paho-mqtt==1.2
+paho-mqtt==1.2.1
 
 # homeassistant.components.media_player.panasonic_viera
 panasonic_viera==0.2


### PR DESCRIPTION
1.2.1
=====

- Handle unicode username and passwords correctly.
- Fix handling of invalid UTF-8 topics on incoming messages - the library now does not attempt to decode the topic - this will happen when the user accesses msg.topic in the on_message callback. If the topic is not valid UTF-8, an exception will be raised.
- Fix issue with WebSocket connection in case of network issue (timeout or connection broken). 
- Fix issue with SSL connection, where latest incoming message may be delayed or never processed.
- Fix possible message lost with publish.single and publish.multiple.

Tested with the following configuration:

``` yaml
mqtt:
  broker: localhost

binary_sensor:
  - platform: mqtt
    name: Bathroom door
    state_topic: "home/bathroom/door"
    payload_on: "1"
    payload_off: "0"
    device_class: opening
```

```bash
$ mosquitto_pub -h localhost -t "home/bathroom/door" -m 1
$ mosquitto_pub -h localhost -t "home/bathroom/door" -m 0

17-04-04 10:05:52 INFO (Thread-9) [homeassistant.components.mqtt] Received message on home/bathroom/door: 1
17-04-04 10:05:52 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=binary_sensor.bathroom_door, new_state=<state binary_sensor.bathroom_door=on; friendly_name=ABCDE, device_class=opening @ 2017-04-04T10:05:52.465251+02:00>, old_state=<state binary_sensor.bathroom_door=off; friendly_name=ABCDE, device_class=opening @ 2017-04-04T10:05:19.030989+02:00>>
17-04-04 10:05:55 INFO (Thread-9) [homeassistant.components.mqtt] Received message on home/bathroom/door: 0
17-04-04 10:05:55 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=binary_sensor.bathroom_door, new_state=<state binary_sensor.bathroom_door=off; friendly_name=ABCDE, device_class=opening @ 2017-04-04T10:05:55.450299+02:00>, old_state=<state binary_sensor.bathroom_door=on; friendly_name=ABCDE, device_class=opening @ 2017-04-04T10:05:52.465251+02:00>>
```