### PR TITLE
WIP - Fix bug in state handling in Vera Switch and Light

### DIFF
--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -8,7 +8,6 @@ import logging
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ENTITY_ID_FORMAT, Light, SUPPORT_BRIGHTNESS)
-from homeassistant.const import (STATE_OFF, STATE_ON)
 from homeassistant.components.vera import (
     VERA_CONTROLLER, VERA_DEVICES, VeraDevice)
 

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -53,13 +53,13 @@ class VeraLight(VeraDevice, Light):
         else:
             self.vera_device.switch_on()
 
-        self._state = STATE_ON
+        self._state = True
         self.schedule_update_ha_state(True)
 
     def turn_off(self, **kwargs):
         """Turn the light off."""
         self.vera_device.switch_off()
-        self._state = STATE_OFF
+        self._state = False
         self.schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -8,7 +8,6 @@ import logging
 
 from homeassistant.util import convert
 from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchDevice
-from homeassistant.const import (STATE_OFF, STATE_ON)
 from homeassistant.components.vera import (
     VERA_CONTROLLER, VERA_DEVICES, VeraDevice)
 

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -36,13 +36,13 @@ class VeraSwitch(VeraDevice, SwitchDevice):
     def turn_on(self, **kwargs):
         """Turn device on."""
         self.vera_device.switch_on()
-        self._state = STATE_ON
+        self._state = True
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn device off."""
         self.vera_device.switch_off()
-        self._state = STATE_OFF
+        self._state = False
         self.schedule_update_ha_state()
 
     @property


### PR DESCRIPTION
## Description:
Fixes a long standing bug in Vera switch and Light state handling.

@bwmcin could you check this fixes your bug.

@dpembo this may also be the solution to the weird bug you and I failed to track down in January. Could you try?

I'm not in the same place as my Vera - so need to do some more testing before this is merged (hence WIP).

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/6650

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
