### PR TITLE
Fix automations listening to HOMEASSISTANT_START

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -20,6 +20,17 @@ from homeassistant.const import (
 from homeassistant.util.async import run_callback_threadsafe
 
 
+def attempt_use_uvloop():
+    """Attempt to use uvloop."""
+    import asyncio
+
+    try:
+        import uvloop
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    except ImportError:
+        pass
+
+
 def monkey_patch_asyncio():
     """Replace weakref.WeakSet to address Python 3 bug.
 
@@ -311,8 +322,7 @@ def setup_and_run_hass(config_dir: str,
             EVENT_HOMEASSISTANT_START, open_browser
         )
 
-    hass.start()
-    return hass.exit_code
+    return hass.start()
 
 
 def try_to_restart() -> None:
@@ -359,10 +369,12 @@ def try_to_restart() -> None:
 
 def main() -> int:
     """Start Home Assistant."""
+    validate_python()
+
+    attempt_use_uvloop()
+
     if sys.version_info[:3] < (3, 5, 3):
         monkey_patch_asyncio()
-
-    validate_python()
 
     args = get_arguments()
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -74,8 +74,6 @@ def async_from_config_dict(config: Dict[str, Any],
     This method is a coroutine.
     """
     start = time()
-    hass.async_track_tasks()
-
     core_config = config.get(core.DOMAIN, {})
 
     try:
@@ -140,10 +138,10 @@ def async_from_config_dict(config: Dict[str, Any],
             continue
         hass.async_add_job(async_setup_component(hass, component, config))
 
-    yield from hass.async_stop_track_tasks()
+    yield from hass.async_block_till_done()
 
     stop = time()
-    _LOGGER.info('Home Assistant initialized in %ss', round(stop-start, 2))
+    _LOGGER.info('Home Assistant initialized in %.2fs', stop-start)
 
     async_register_signal_handling(hass)
     return hass

--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -9,8 +9,8 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
-from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import callback, CoreState
+from homeassistant.const import CONF_PLATFORM, EVENT_HOMEASSISTANT_START
 from homeassistant.helpers import config_validation as cv
 
 CONF_EVENT_TYPE = "event_type"
@@ -30,6 +30,16 @@ def async_trigger(hass, config, action):
     """Listen for events based on configuration."""
     event_type = config.get(CONF_EVENT_TYPE)
     event_data = config.get(CONF_EVENT_DATA)
+
+    if (event_type == EVENT_HOMEASSISTANT_START and
+            hass.state == CoreState.starting):
+        hass.async_run_job(action, {
+            'trigger': {
+                'platform': 'event',
+                'event': None,
+            },
+        })
+        return lambda: None
 
     @callback
     def handle_event(event):

--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -33,6 +33,9 @@ def async_trigger(hass, config, action):
 
     if (event_type == EVENT_HOMEASSISTANT_START and
             hass.state == CoreState.starting):
+        _LOGGER.warning('Deprecation: Automations should not listen to event '
+                        "'homeassistant_start'. Use platform 'homeassistant' "
+                        'instead. Feature will be removed in 0.45')
         hass.async_run_job(action, {
             'trigger': {
                 'platform': 'event',

--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -2,7 +2,7 @@
 Offer event listening automation rules.
 
 For more details about this automation rule, please refer to the documentation
-at https://home-assistant.io/components/automation/#event-trigger
+at https://home-assistant.io/docs/automation/trigger/#event-trigger
 """
 import asyncio
 import logging

--- a/homeassistant/components/automation/homeassistant.py
+++ b/homeassistant/components/automation/homeassistant.py
@@ -1,0 +1,55 @@
+"""
+Offer Home Assistant core automation rules.
+
+For more details about this automation rule, please refer to the documentation
+at https://home-assistant.io/components/automation/#homeassistant-trigger
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import callback, CoreState
+from homeassistant.const import (
+    CONF_PLATFORM, CONF_EVENT, EVENT_HOMEASSISTANT_STOP)
+
+EVENT_START = 'start'
+EVENT_SHUTDOWN = 'shutdown'
+_LOGGER = logging.getLogger(__name__)
+
+TRIGGER_SCHEMA = vol.Schema({
+    vol.Required(CONF_PLATFORM): 'homeassistant',
+    vol.Required(CONF_EVENT): vol.Any(EVENT_START, EVENT_SHUTDOWN),
+})
+
+
+@asyncio.coroutine
+def async_trigger(hass, config, action):
+    """Listen for events based on configuration."""
+    event = config.get(CONF_EVENT)
+
+    if event == EVENT_SHUTDOWN:
+        @callback
+        def hass_shutdown(event):
+            """Called when Home Assistant is shutting down."""
+            hass.async_run_job(action, {
+                'trigger': {
+                    'platform': 'homeassistant',
+                    'event': event,
+                },
+            })
+
+        return hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,
+                                          hass_shutdown)
+
+    # Automation are enabled while hass is starting up, fire right away
+    # Check state because a config reload shouldn't trigger it.
+    elif hass.state == CoreState.starting:
+        hass.async_run_job(action, {
+            'trigger': {
+                'platform': 'homeassistant',
+                'event': event,
+            },
+        })
+
+    return lambda: None

--- a/homeassistant/components/automation/litejet.py
+++ b/homeassistant/components/automation/litejet.py
@@ -70,7 +70,7 @@ def async_trigger(hass, config, action):
         nonlocal held_less_than, held_more_than
         pressed_time = dt_util.utcnow()
         if held_more_than is None and held_less_than is None:
-            call_action()
+            hass.add_job(call_action)
         if held_more_than is not None and held_less_than is None:
             cancel_pressed_more_than = track_point_in_utc_time(
                 hass,
@@ -88,7 +88,7 @@ def async_trigger(hass, config, action):
         held_time = dt_util.utcnow() - pressed_time
         if held_less_than is not None and held_time < held_less_than:
             if held_more_than is None or held_time > held_more_than:
-                call_action()
+                hass.add_job(call_action)
 
     hass.data['litejet_system'].on_switch_pressed(number, pressed)
     hass.data['litejet_system'].on_switch_released(number, released)

--- a/homeassistant/components/automation/mqtt.py
+++ b/homeassistant/components/automation/mqtt.py
@@ -2,7 +2,7 @@
 Offer MQTT listening automation rules.
 
 For more details about this automation rule, please refer to the documentation
-at https://home-assistant.io/components/automation/#mqtt-trigger
+at https://home-assistant.io/docs/automation/trigger/#mqtt-trigger
 """
 import asyncio
 import json

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -2,7 +2,7 @@
 Offer numeric state listening automation rules.
 
 For more details about this automation rule, please refer to the documentation
-at https://home-assistant.io/components/automation/#numeric-state-trigger
+at https://home-assistant.io/docs/automation/trigger/#numeric-state-trigger
 """
 import asyncio
 import logging

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -2,7 +2,7 @@
 Offer state listening automation rules.
 
 For more details about this automation rule, please refer to the documentation
-at https://home-assistant.io/components/automation/#state-trigger
+at https://home-assistant.io/docs/automation/trigger/#state-trigger
 """
 import asyncio
 import voluptuous as vol

--- a/homeassistant/components/automation/sun.py
+++ b/homeassistant/components/automation/sun.py
@@ -2,7 +2,7 @@
 Offer sun based automation rules.
 
 For more details about this automation rule, please refer to the documentation
-at https://home-assistant.io/components/automation/#sun-trigger
+at https://home-assistant.io/docs/automation/trigger/#sun-trigger
 """
 import asyncio
 from datetime import timedelta

--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -2,7 +2,7 @@
 Offer template automation rules.
 
 For more details about this automation rule, please refer to the documentation
-at https://home-assistant.io/components/automation/#template-trigger
+at https://home-assistant.io/docs/automation/trigger/#template-trigger
 """
 import asyncio
 import logging

--- a/homeassistant/components/automation/time.py
+++ b/homeassistant/components/automation/time.py
@@ -2,7 +2,7 @@
 Offer time listening automation rules.
 
 For more details about this automation rule, please refer to the documentation
-at https://home-assistant.io/components/automation/#time-trigger
+at https://home-assistant.io/docs/automation/trigger/#time-trigger
 """
 import asyncio
 import logging

--- a/homeassistant/components/automation/zone.py
+++ b/homeassistant/components/automation/zone.py
@@ -2,7 +2,7 @@
 Offer zone automation rules.
 
 For more details about this automation rule, please refer to the documentation
-at https://home-assistant.io/components/automation/#zone-trigger
+at https://home-assistant.io/docs/automation/trigger/#zone-trigger
 """
 import asyncio
 import voluptuous as vol

--- a/homeassistant/components/light/litejet.py
+++ b/homeassistant/components/light/litejet.py
@@ -48,7 +48,7 @@ class LiteJetLight(Light):
     def _on_load_changed(self):
         """Called on a LiteJet thread when a load's state changes."""
         _LOGGER.debug("Updating due to notification for %s", self._name)
-        self._hass.async_add_job(self.async_update_ha_state(True))
+        self.schedule_update_ha_state(True)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/sensor/mqtt_room.py
+++ b/homeassistant/components/sensor/mqtt_room.py
@@ -98,6 +98,7 @@ class MQTTRoomSensor(Entity):
 
             self.hass.async_add_job(self.async_update_ha_state())
 
+        @callback
         def message_received(topic, payload, qos):
             """A new MQTT message has been received."""
             try:

--- a/homeassistant/components/switch/litejet.py
+++ b/homeassistant/components/switch/litejet.py
@@ -47,12 +47,12 @@ class LiteJetSwitch(SwitchDevice):
     def _on_switch_pressed(self):
         _LOGGER.debug("Updating pressed for %s", self._name)
         self._state = True
-        self._hass.async_add_job(self.async_update_ha_state())
+        self.schedule_update_ha_state()
 
     def _on_switch_released(self):
         _LOGGER.debug("Updating released for %s", self._name)
         self._state = False
-        self._hass.async_add_job(self.async_update_ha_state())
+        self.schedule_update_ha_state()
 
     @property
     def name(self):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -165,10 +165,10 @@ class HomeAssistant(object):
 
         # pylint: disable=protected-access
         self.loop._thread_ident = threading.get_ident()
-        _async_create_timer(self)
         self.bus.async_fire(EVENT_HOMEASSISTANT_START)
         yield from self.async_stop_track_tasks()
         self.state = CoreState.running
+        _async_create_timer(self)
 
     def add_job(self, target: Callable[..., None], *args: Any) -> None:
         """Add job to the executor pool.
@@ -239,7 +239,7 @@ class HomeAssistant(object):
     @asyncio.coroutine
     def async_block_till_done(self):
         """Block till all pending work is done."""
-        assert self._track_task, 'We are not tracking tasks'
+        assert self._track_task, 'Not tracking tasks'
 
         # To flush out any call_soon_threadsafe
         yield from asyncio.sleep(0, loop=self.loop)

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -37,12 +37,6 @@ import homeassistant.util.dt as dt_util
 import homeassistant.util.location as location
 from homeassistant.util.unit_system import UnitSystem, METRIC_SYSTEM  # NOQA
 
-try:
-    import uvloop
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-except ImportError:
-    pass
-
 DOMAIN = 'homeassistant'
 
 # How long we wait for the result of a service call
@@ -144,6 +138,7 @@ class HomeAssistant(object):
             # Block until stopped
             _LOGGER.info("Starting Home Assistant core loop")
             self.loop.run_forever()
+            return self.exit_code
         except KeyboardInterrupt:
             self.loop.create_task(self.async_stop())
             self.loop.run_forever()

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -246,7 +246,8 @@ class HomeAssistant(object):
 
     def stop(self) -> None:
         """Stop Home Assistant and shuts down all threads."""
-        run_coroutine_threadsafe(self.async_stop(), self.loop).result()
+        self.loop.call_soon_threadsafe(
+            self.loop.create_task, self.async_stop())
 
     @asyncio.coroutine
     def async_stop(self, exit_code=0) -> None:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -251,7 +251,7 @@ class HomeAssistant(object):
 
     def stop(self) -> None:
         """Stop Home Assistant and shuts down all threads."""
-        run_coroutine_threadsafe(self.async_stop(), self.loop)
+        run_coroutine_threadsafe(self.async_stop(), self.loop).result()
 
     @asyncio.coroutine
     def async_stop(self, exit_code=0) -> None:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     EVENT_TIME_CHANGED, MATCH_ALL, EVENT_HOMEASSISTANT_CLOSE,
     EVENT_SERVICE_REMOVED, __version__)
 from homeassistant.exceptions import (
-    HomeAssistantError, InvalidEntityFormatError, ShuttingDown)
+    HomeAssistantError, InvalidEntityFormatError)
 from homeassistant.util.async import (
     run_coroutine_threadsafe, run_callback_threadsafe)
 import homeassistant.util as util
@@ -86,10 +86,6 @@ def async_loop_exception_handler(loop, context):
     kwargs = {}
     exception = context.get('exception')
     if exception:
-        # Do not report on shutting down exceptions.
-        if isinstance(exception, ShuttingDown):
-            return
-
         kwargs['exc_info'] = (type(exception), exception,
                               exception.__traceback__)
 
@@ -371,10 +367,6 @@ class EventBus(object):
 
         This method must be run in the event loop.
         """
-        if event_type != EVENT_HOMEASSISTANT_STOP and \
-                self._hass.state == CoreState.stopping:
-            raise ShuttingDown("Home Assistant is shutting down")
-
         listeners = self._listeners.get(event_type, [])
 
         # EVENT_HOMEASSISTANT_CLOSE should go only to his listeners

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -7,12 +7,6 @@ class HomeAssistantError(Exception):
     pass
 
 
-class ShuttingDown(HomeAssistantError):
-    """When trying to change something during shutdown."""
-
-    pass
-
-
 class InvalidEntityFormatError(HomeAssistantError):
     """When an invalid formatted entity is encountered."""
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -23,7 +23,7 @@ import homeassistant.util.yaml as yaml
 from homeassistant.const import (
     STATE_ON, STATE_OFF, DEVICE_DEFAULT_NAME, EVENT_TIME_CHANGED,
     EVENT_STATE_CHANGED, EVENT_PLATFORM_DISCOVERED, ATTR_SERVICE,
-    ATTR_DISCOVERED, SERVER_PORT, EVENT_HOMEASSISTANT_STOP)
+    ATTR_DISCOVERED, SERVER_PORT, EVENT_HOMEASSISTANT_CLOSE)
 from homeassistant.components import sun, mqtt, recorder
 from homeassistant.components.http.auth import auth_middleware
 from homeassistant.components.http.const import (
@@ -137,7 +137,7 @@ def async_test_home_assistant(loop):
         global INST_COUNT
         INST_COUNT -= 1
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, clear_instance)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, clear_instance)
 
     return hass
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -101,7 +101,6 @@ def async_test_home_assistant(loop):
         return orig_async_add_job(target, *args)
 
     hass.async_add_job = async_add_job
-    hass.async_track_tasks()
 
     hass.config.location_name = 'test home'
     hass.config.config_dir = get_test_config_dir()
@@ -123,7 +122,8 @@ def async_test_home_assistant(loop):
     @asyncio.coroutine
     def mock_async_start():
         """Start the mocking."""
-        with patch('homeassistant.core._async_create_timer'):
+        with patch('homeassistant.core._async_create_timer'), \
+                patch.object(hass, 'async_stop_track_tasks', mock_coro):
             yield from orig_start()
 
     hass.async_start = mock_async_start

--- a/tests/common.py
+++ b/tests/common.py
@@ -122,8 +122,11 @@ def async_test_home_assistant(loop):
     @asyncio.coroutine
     def mock_async_start():
         """Start the mocking."""
+        # 1. We only mock time during tests
+        # 2. We want block_till_done that is called inside stop_track_tasks
         with patch('homeassistant.core._async_create_timer'), \
-                patch.object(hass, 'async_stop_track_tasks', mock_coro):
+                patch.object(hass, 'async_stop_track_tasks',
+                             hass.async_block_till_done):
             yield from orig_start()
 
     hass.async_start = mock_async_start

--- a/tests/common.py
+++ b/tests/common.py
@@ -68,7 +68,6 @@ def get_test_home_assistant():
     def stop_hass():
         """Stop hass."""
         orig_stop()
-        loop.stop()
         stop_event.wait()
         loop.close()
 

--- a/tests/components/automation/test_homeassistant.py
+++ b/tests/components/automation/test_homeassistant.py
@@ -1,0 +1,84 @@
+"""The tests for the Event automation."""
+import asyncio
+from unittest.mock import patch, Mock
+
+from homeassistant.core import CoreState
+from homeassistant.setup import async_setup_component
+import homeassistant.components.automation as automation
+
+from tests.common import mock_service, mock_coro
+
+
+@asyncio.coroutine
+def test_if_fires_on_hass_start(hass):
+    """Test the firing when HASS starts."""
+    calls = mock_service(hass, 'test', 'automation')
+    hass.state = CoreState.not_running
+    config = {
+        automation.DOMAIN: {
+            'alias': 'hello',
+            'trigger': {
+                'platform': 'homeassistant',
+                'event': 'start',
+            },
+            'action': {
+                'service': 'test.automation',
+            }
+        }
+    }
+
+    res = yield from async_setup_component(hass, automation.DOMAIN, config)
+    assert res
+    assert not automation.is_on(hass, 'automation.hello')
+    assert len(calls) == 0
+
+    yield from hass.async_start()
+    assert automation.is_on(hass, 'automation.hello')
+    assert len(calls) == 1
+
+    with patch('homeassistant.config.async_hass_config_yaml',
+               Mock(return_value=mock_coro(config))):
+        yield from hass.services.async_call(
+            automation.DOMAIN, automation.SERVICE_RELOAD, blocking=True)
+
+    assert automation.is_on(hass, 'automation.hello')
+    assert len(calls) == 1
+
+
+@asyncio.coroutine
+def test_if_fires_on_hass_shutdown(hass):
+    """Test the firing when HASS starts."""
+    calls = mock_service(hass, 'test', 'automation')
+    hass.state = CoreState.not_running
+
+    res = yield from async_setup_component(hass, automation.DOMAIN, {
+        automation.DOMAIN: {
+            'alias': 'hello',
+            'trigger': {
+                'platform': 'homeassistant',
+                'event': 'shutdown',
+            },
+            'action': {
+                'service': 'test.automation',
+            }
+        }
+    })
+    assert res
+    assert not automation.is_on(hass, 'automation.hello')
+    assert len(calls) == 0
+
+    yield from hass.async_start()
+    assert automation.is_on(hass, 'automation.hello')
+    assert len(calls) == 0
+
+    with patch.object(hass.loop, 'stop'), patch.object(hass.executor, 'shutdown'):
+        yield from hass.async_stop()
+    assert len(calls) == 1
+
+    # with patch('homeassistant.config.async_hass_config_yaml',
+    #            Mock(return_value=mock_coro(config))):
+    #     yield from hass.services.async_call(
+    #         automation.DOMAIN, automation.SERVICE_RELOAD, blocking=True)
+
+    # assert automation.is_on(hass, 'automation.hello')
+    # assert len(calls) == 1

--- a/tests/components/automation/test_homeassistant.py
+++ b/tests/components/automation/test_homeassistant.py
@@ -71,7 +71,7 @@ def test_if_fires_on_hass_shutdown(hass):
     assert automation.is_on(hass, 'automation.hello')
     assert len(calls) == 0
 
-    with patch.object(hass.loop, 'stop'), patch.object(hass.executor, 'shutdown'):
+    with patch.object(hass.loop, 'stop'):
         yield from hass.async_stop()
     assert len(calls) == 1
 

--- a/tests/components/binary_sensor/test_ffmpeg.py
+++ b/tests/components/binary_sensor/test_ffmpeg.py
@@ -65,7 +65,7 @@ class TestFFmpegNoiseSetup(object):
         entity = self.hass.states.get('binary_sensor.ffmpeg_noise')
         assert entity.state == 'off'
 
-        mock_ffmpeg.call_args[0][2](True)
+        self.hass.add_job(mock_ffmpeg.call_args[0][2], True)
         self.hass.block_till_done()
 
         entity = self.hass.states.get('binary_sensor.ffmpeg_noise')
@@ -130,7 +130,7 @@ class TestFFmpegMotionSetup(object):
         entity = self.hass.states.get('binary_sensor.ffmpeg_motion')
         assert entity.state == 'off'
 
-        mock_ffmpeg.call_args[0][2](True)
+        self.hass.add_job(mock_ffmpeg.call_args[0][2], True)
         self.hass.block_till_done()
 
         entity = self.hass.states.get('binary_sensor.ffmpeg_motion')

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -166,7 +166,7 @@ class TestAlert(unittest.TestCase):
     def test_noack(self):
         """Test no ack feature."""
         entity = alert.Alert(self.hass, *TEST_NOACK)
-        self.hass.async_add_job(entity.begin_alerting)
+        self.hass.add_job(entity.begin_alerting)
         self.hass.block_till_done()
 
         self.assertEqual(True, entity.hidden)


### PR DESCRIPTION
## Description:
To prevent false triggers, we only enable automations after all components are setup. This however introduced a breaking change: we no longer allow people to listen to HOMEASSISTANT_START.

This PR is just to start discussion, the included fix is actually a bad one.

I still want people to be able to run something on startup.

 - Make it backwards compatible by checking if listening for `HOMEASSISTANT_START` event and `hass.state == CoreState.starting`. This is a hack.
 - Add a new special automation platform that runs things on startup (and also checks against `hass.state`)

This PR forced me to fix how CoreState is set and ensures we wait till all tasks done before we start firing the timer. This caused some changes to how we mock HASS in tests.

## Breaking changes

 - Deprecation: using automation event platform to listen for `homeassistant_start` on startup is deprecated and will be removed in Home Assistant 0.45. Use the new automation homeassistant platform instead.
 - Devs: during startup, `hass.state` is set to `CoreState.starting`. All tasks will be awaited during startup and the timer will only start when that is done. At that point in time `hass.state` is `CoreState.running`.

## Configuration

```yaml
automation:
  trigger:
    platform: homeassistant
    event: start
  action:
    service: light.turn_on

automation 2:
  trigger:
    platform: homeassistant
    event: shutdown
  action:
    service: light.turn_on

# Will work but raises a warning.
automation deprecated:
  trigger:
    platform: event
    event: homeassistant_start
  action:
    service: light.turn_on
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
