### PR TITLE
Rename zwave nodes by node ID instead of entity ID

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -68,7 +68,7 @@ DATA_ZWAVE_DICT = 'zwave_devices'
 NETWORK = None
 
 RENAME_NODE_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+    vol.Required(const.ATTR_NODE_ID): vol.Coerce(int),
     vol.Required(const.ATTR_NAME): cv.string,
 })
 SET_CONFIG_PARAMETER_SCHEMA = vol.Schema({
@@ -393,8 +393,7 @@ def setup(hass, config):
 
     def rename_node(service):
         """Rename a node."""
-        state = hass.states.get(service.data.get(ATTR_ENTITY_ID))
-        node_id = state.attributes.get(const.ATTR_NODE_ID)
+        node_id = service.data.get(const.ATTR_NODE_ID)
         node = NETWORK.nodes[node_id]
         name = service.data.get(const.ATTR_NAME)
         node.name = name

--- a/homeassistant/components/zwave/services.yaml
+++ b/homeassistant/components/zwave/services.yaml
@@ -102,9 +102,9 @@ test_network:
 rename_node:
   description: Set the name(s) of a node.
   fields:
-    entity_id:
-      description: Name(s) of entities to to rename
-      example: 'light.leviton_vrmx11lz_multilevel_scene_switch_level_40'
+    node_id:
+      description: ID of the node to rename.
+      example: 10
     name:
       description: New Name
       example: 'kitchen'


### PR DESCRIPTION
## Description:
This brings the rename node service in line with the other zwave node services. We'll want a solid foundation here for the frontend zwave configuration.

Docs: https://github.com/home-assistant/home-assistant.github.io/pull/2382