### PR TITLE
Add android ip webcam support for aiohttp2

### DIFF
--- a/homeassistant/components/android_ip_webcam.py
+++ b/homeassistant/components/android_ip_webcam.py
@@ -26,7 +26,7 @@ from homeassistant.util.dt import utcnow
 from homeassistant.components.camera.mjpeg import (
     CONF_MJPEG_URL, CONF_STILL_IMAGE_URL)
 
-REQUIREMENTS = ['pydroid-ipcam==0.7']
+REQUIREMENTS = ['pydroid-ipcam==0.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -500,7 +500,7 @@ pycmus==0.1.0
 pydispatcher==2.0.5
 
 # homeassistant.components.android_ip_webcam
-pydroid-ipcam==0.7
+pydroid-ipcam==0.8
 
 # homeassistant.components.sensor.ebox
 pyebox==0.1.0


### PR DESCRIPTION
## Description:

Pump verison of android ip webcam to support aiohttp 2

**Related issue (if applicable):** fixes #6930

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
