### PR TITLE
Report proper features in mqtt_json light

### DIFF
--- a/homeassistant/components/light/mqtt_json.py
+++ b/homeassistant/components/light/mqtt_json.py
@@ -148,16 +148,12 @@ class MqttJson(Light):
         self._flash_times = flash_times
 
         self._supported_features = (SUPPORT_TRANSITION | SUPPORT_FLASH)
-        self._supported_features |= (rgb is not None and SUPPORT_RGB_COLOR)
-        self._supported_features |= (brightness is not None and
-                                     SUPPORT_BRIGHTNESS)
-        self._supported_features |= (color_temp is not None and
-                                     SUPPORT_COLOR_TEMP)
-        self._supported_features |= (effect is not None and
-                                     SUPPORT_EFFECT)
-        self._supported_features |= (white_value is not None and
-                                     SUPPORT_WHITE_VALUE)
-        self._supported_features |= (xy is not None and SUPPORT_XY_COLOR)
+        self._supported_features |= (rgb and SUPPORT_RGB_COLOR)
+        self._supported_features |= (brightness and SUPPORT_BRIGHTNESS)
+        self._supported_features |= (color_temp and SUPPORT_COLOR_TEMP)
+        self._supported_features |= (effect and SUPPORT_EFFECT)
+        self._supported_features |= (white_value and SUPPORT_WHITE_VALUE)
+        self._supported_features |= (xy and SUPPORT_XY_COLOR)
 
     @asyncio.coroutine
     def async_added_to_hass(self):

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -81,7 +81,8 @@ import json
 import unittest
 
 from homeassistant.setup import setup_component
-from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
+from homeassistant.const import (
+        STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE, ATTR_SUPPORTED_FEATURES)
 import homeassistant.components.light as light
 from tests.common import (
     get_test_home_assistant, mock_mqtt_component, fire_mqtt_message,
@@ -126,6 +127,7 @@ class TestLightMQTTJSON(unittest.TestCase):
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
+        self.assertEqual(40, state.attributes.get(ATTR_SUPPORTED_FEATURES))
         self.assertIsNone(state.attributes.get('rgb_color'))
         self.assertIsNone(state.attributes.get('brightness'))
         self.assertIsNone(state.attributes.get('color_temp'))
@@ -166,6 +168,7 @@ class TestLightMQTTJSON(unittest.TestCase):
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
+        self.assertEqual(255, state.attributes.get(ATTR_SUPPORTED_FEATURES))
         self.assertIsNone(state.attributes.get('rgb_color'))
         self.assertIsNone(state.attributes.get('brightness'))
         self.assertIsNone(state.attributes.get('color_temp'))
@@ -272,6 +275,7 @@ class TestLightMQTTJSON(unittest.TestCase):
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
+        self.assertEqual(191, state.attributes.get(ATTR_SUPPORTED_FEATURES))
         self.assertTrue(state.attributes.get(ATTR_ASSUMED_STATE))
 
         light.turn_on(self.hass, 'light.test')
@@ -335,6 +339,7 @@ class TestLightMQTTJSON(unittest.TestCase):
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
+        self.assertEqual(40, state.attributes.get(ATTR_SUPPORTED_FEATURES))
 
         light.turn_on(self.hass, 'light.test', flash="short")
         self.hass.block_till_done()
@@ -374,6 +379,7 @@ class TestLightMQTTJSON(unittest.TestCase):
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
+        self.assertEqual(40, state.attributes.get(ATTR_SUPPORTED_FEATURES))
 
         light.turn_on(self.hass, 'light.test', transition=10)
         self.hass.block_till_done()
@@ -418,6 +424,7 @@ class TestLightMQTTJSON(unittest.TestCase):
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
+        self.assertEqual(185, state.attributes.get(ATTR_SUPPORTED_FEATURES))
         self.assertIsNone(state.attributes.get('rgb_color'))
         self.assertIsNone(state.attributes.get('brightness'))
         self.assertIsNone(state.attributes.get('white_value'))


### PR DESCRIPTION
## Description:
`mqtt_json` light was always reporting supported features as 255 despite attempting to set them appropriately. I've fixed setting them properly and added tests to ensure they are correct.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**