### PR TITLE
Clean artifacts after running Ring tests.

### DIFF
--- a/tests/components/binary_sensor/test_ring.py
+++ b/tests/components/binary_sensor/test_ring.py
@@ -1,4 +1,5 @@
 """The tests for the Ring binary sensor platform."""
+import os
 import unittest
 import requests_mock
 
@@ -6,7 +7,8 @@ from homeassistant.components.binary_sensor import ring
 from homeassistant.components import ring as base_ring
 
 from tests.components.test_ring import ATTRIBUTION, VALID_CONFIG
-from tests.common import get_test_home_assistant, load_fixture
+from tests.common import (
+    get_test_config_dir, get_test_home_assistant, load_fixture)
 
 
 class TestRingBinarySensorSetup(unittest.TestCase):
@@ -19,9 +21,15 @@ class TestRingBinarySensorSetup(unittest.TestCase):
         for device in devices:
             self.DEVICES.append(device)
 
+    def cleanup(self):
+        """Cleanup any data created from the tests."""
+        if os.path.isfile(self.cache):
+            os.remove(self.cache)
+
     def setUp(self):
         """Initialize values for this testcase class."""
         self.hass = get_test_home_assistant()
+        self.cache = get_test_config_dir(base_ring.DEFAULT_CACHEDB)
         self.config = {
             'username': 'foo',
             'password': 'bar',
@@ -31,6 +39,7 @@ class TestRingBinarySensorSetup(unittest.TestCase):
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
+        self.cleanup()
 
     @requests_mock.Mocker()
     def test_binary_sensor(self, mock):

--- a/tests/components/sensor/test_ring.py
+++ b/tests/components/sensor/test_ring.py
@@ -1,4 +1,5 @@
 """The tests for the Ring sensor platform."""
+import os
 import unittest
 import requests_mock
 
@@ -6,7 +7,8 @@ from homeassistant.components.sensor import ring
 from homeassistant.components import ring as base_ring
 
 from tests.components.test_ring import ATTRIBUTION, VALID_CONFIG
-from tests.common import get_test_home_assistant, load_fixture
+from tests.common import (
+    get_test_config_dir, get_test_home_assistant, load_fixture)
 
 
 class TestRingSensorSetup(unittest.TestCase):
@@ -19,9 +21,15 @@ class TestRingSensorSetup(unittest.TestCase):
         for device in devices:
             self.DEVICES.append(device)
 
+    def cleanup(self):
+        """Cleanup any data created from the tests."""
+        if os.path.isfile(self.cache):
+            os.remove(self.cache)
+
     def setUp(self):
         """Initialize values for this testcase class."""
         self.hass = get_test_home_assistant()
+        self.cache = get_test_config_dir(base_ring.DEFAULT_CACHEDB)
         self.config = {
             'username': 'foo',
             'password': 'bar',
@@ -36,6 +44,7 @@ class TestRingSensorSetup(unittest.TestCase):
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
+        self.cleanup()
 
     @requests_mock.Mocker()
     def test_sensor(self, mock):

--- a/tests/components/test_ring.py
+++ b/tests/components/test_ring.py
@@ -1,11 +1,13 @@
 """The tests for the Ring component."""
+import os
 import unittest
 import requests_mock
 
 from homeassistant import setup
 import homeassistant.components.ring as ring
 
-from tests.common import get_test_home_assistant, load_fixture
+from tests.common import (
+    get_test_config_dir, get_test_home_assistant, load_fixture)
 
 ATTRIBUTION = 'Data provided by Ring.com'
 
@@ -20,14 +22,21 @@ VALID_CONFIG = {
 class TestRing(unittest.TestCase):
     """Tests the Ring component."""
 
+    def cleanup(self):
+        """Cleanup any data created from the tests."""
+        if os.path.isfile(self.cache):
+            os.remove(self.cache)
+
     def setUp(self):
         """Initialize values for this test case class."""
         self.hass = get_test_home_assistant()
+        self.cache = get_test_config_dir(ring.DEFAULT_CACHEDB)
         self.config = VALID_CONFIG
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""
         self.hass.stop()
+        self.cleanup()
 
     @requests_mock.Mocker()
     def test_setup(self, mock):


### PR DESCRIPTION
## Description:
Clean any artifacts files created Ring after running unittests. 

```bash
	../../tests/testing_config/.ring_cache.pickle
```

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
