### PR TITLE
Upgrade py-cpuinfo to 3.0.0

### DIFF
--- a/homeassistant/components/sensor/cpuspeed.py
+++ b/homeassistant/components/sensor/cpuspeed.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['py-cpuinfo==0.2.7']
+REQUIREMENTS = ['py-cpuinfo==3.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -460,7 +460,7 @@ pushetta==1.0.15
 pwaqi==3.0
 
 # homeassistant.components.sensor.cpuspeed
-py-cpuinfo==0.2.7
+py-cpuinfo==3.0.0
 
 # homeassistant.components.hdmi_cec
 pyCEC==0.4.13


### PR DESCRIPTION
3.0.0
----
* Change API to hide low level functions
* Combine data from all sources instead of picking one
* Not working on OS X 10.12 Sierra
* Change version number format
* Not working on ARM64 odroid-c2

Tested with the following configuration:

``` yaml
sensor:
  - platform: cpuspeed
    name: CPU
```