### PR TITLE
Fix current_temperature is rounded

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -692,9 +692,9 @@ class ClimateDevice(Entity):
 
     def _convert_for_display(self, temp):
         """Convert temperature into preferred units for display purposes."""
-        if (temp is None or not isinstance(temp, Number)):
+        if temp is None or not isinstance(temp, Number):
             return temp
-        if(self.temperature_unit != self.unit_of_measurement):
+        if self.temperature_unit != self.unit_of_measurement:
             temp = convert_temperature(temp, self.temperature_unit,
                                        self.unit_of_measurement)
         # Round in the units appropriate

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -692,18 +692,16 @@ class ClimateDevice(Entity):
 
     def _convert_for_display(self, temp):
         """Convert temperature into preferred units for display purposes."""
-        if (temp is None or not isinstance(temp, Number) or
-                self.temperature_unit == self.unit_of_measurement):
+        if (temp is None or not isinstance(temp, Number)):
             return temp
-
-        value = convert_temperature(temp, self.temperature_unit,
-                                    self.unit_of_measurement)
-
+        if(self.temperature_unit != self.unit_of_measurement):
+            temp = convert_temperature(temp, self.temperature_unit,
+                                       self.unit_of_measurement)
         # Round in the units appropriate
         if self.precision == PRECISION_HALVES:
-            return round(value * 2) / 2.0
+            return round(temp * 2) / 2.0
         elif self.precision == PRECISION_TENTHS:
-            return round(value, 1)
+            return round(temp, 1)
         else:
             # PRECISION_WHOLE as a fall back
-            return round(value)
+            return round(temp)


### PR DESCRIPTION
## Description:
Fix now  when temperature_unit == unit_of_measurement the convert_to_display will round it.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54