### PR TITLE
Preserve customize glob order.

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -124,7 +124,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_DEVICE_CONFIG, default={}):
             vol.Schema({cv.entity_id: DEVICE_CONFIG_SCHEMA_ENTRY}),
         vol.Optional(CONF_DEVICE_CONFIG_GLOB, default={}):
-            vol.Schema({cv.string: DEVICE_CONFIG_SCHEMA_ENTRY}),
+            cv.ordered_dict(DEVICE_CONFIG_SCHEMA_ENTRY, cv.string),
         vol.Optional(CONF_DEVICE_CONFIG_DOMAIN, default={}):
             vol.Schema({cv.string: DEVICE_CONFIG_SCHEMA_ENTRY}),
         vol.Optional(CONF_DEBUG, default=DEFAULT_DEBUG): cv.boolean,

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -108,7 +108,7 @@ CUSTOMIZE_CONFIG_SCHEMA = vol.Schema({
     vol.Optional(CONF_CUSTOMIZE_DOMAIN, default={}):
         vol.Schema({cv.string: dict}),
     vol.Optional(CONF_CUSTOMIZE_GLOB, default={}):
-        vol.Schema({cv.string: dict}),
+        cv.ordered_dict(OrderedDict, cv.string),
 })
 
 CORE_CONFIG_SCHEMA = CUSTOMIZE_CONFIG_SCHEMA.extend({

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1,7 +1,11 @@
 """Tests for the Z-Wave init."""
 import asyncio
+import unittest
+from collections import OrderedDict
 
 from homeassistant.bootstrap import async_setup_component
+from homeassistant.components.zwave import (
+    CONFIG_SCHEMA, CONF_DEVICE_CONFIG_GLOB)
 
 
 @asyncio.coroutine
@@ -34,3 +38,14 @@ def test_invalid_device_config(hass, mock_openzwave):
         }})
 
     assert not result
+
+
+class TestZwave(unittest.TestCase):
+    """Test zwave init."""
+
+    def test_device_config_glob_is_ordered(self):
+        """Test that device_config_glob preserves order."""
+        conf = CONFIG_SCHEMA(
+            {'zwave': {CONF_DEVICE_CONFIG_GLOB: OrderedDict()}})
+        self.assertIsInstance(
+            conf['zwave'][CONF_DEVICE_CONFIG_GLOB], OrderedDict)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@
 import os
 import unittest
 import unittest.mock as mock
+from collections import OrderedDict
 
 import pytest
 from voluptuous import MultipleInvalid
@@ -204,6 +205,12 @@ class TestConfig(unittest.TestCase):
                 },
             },
         })
+
+    def test_customize_glob_is_ordered(self):
+        """Test that customize_glob preserves order."""
+        conf = config_util.CORE_CONFIG_SCHEMA(
+            {'customize_glob': OrderedDict()})
+        self.assertIsInstance(conf['customize_glob'], OrderedDict)
 
     def _compute_state(self, config):
         run_coroutine_threadsafe(


### PR DESCRIPTION
## Description:

Preserve customize glob order.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
