### PR TITLE
Fix control+c quitting HASS

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -141,7 +141,8 @@ class HomeAssistant(object):
             self.loop.run_forever()
             return self.exit_code
         except KeyboardInterrupt:
-            fire_coroutine_threadsafe(self.async_stop(), self.loop)
+            self.loop.call_soon_threadsafe(
+                self.loop.create_task, self.async_stop())
             self.loop.run_forever()
         finally:
             self.loop.close()


### PR DESCRIPTION
## Description:
When we hit control+C to exit HASS, we raise KeyboardInterrupted exception on the main thread. If we then use `fire_coroutine_threadsafe`, it will check the thread ID and raise a "Cannot be called from within event loop" error.
