### PR TITLE
Warn if start takes a long time.

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -170,7 +170,7 @@ class HomeAssistant(object):
             _LOGGER.warning(
                 'Something is blocking Home Assistant from wrapping up the '
                 'start up phase. We\'re going to continue anyway. Please '
-                'report at http://bit.ly/2ogP58T your components: %s',
+                'report the following info at http://bit.ly/2ogP58T : %s',
                 ', '.join(self.config.components))
             self._track_task = False
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -170,7 +170,7 @@ class HomeAssistant(object):
             _LOGGER.warning(
                 'Something is blocking Home Assistant from wrapping up the '
                 'start up phase. We\'re going to continue anyway. Please '
-                'report at http://bit.ly/2ogP58T: %s'
+                'report at http://bit.ly/2ogP58T your components: %s',
                 ', '.join(self.config.components))
             self._track_task = False
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -168,8 +168,9 @@ class HomeAssistant(object):
                 yield from self.async_stop_track_tasks()
         except asyncio.TimeoutError:
             _LOGGER.warning(
-                'Something is blocking Hass start from finishing, going to '
-                'start anyway. Please report at http://bit.ly/2ogP58T: %s',
+                'Something is blocking Home Assistant from wrapping up the '
+                'start up phase. We\'re going to continue anyway. Please '
+                'report at http://bit.ly/2ogP58T: %s'
                 ', '.join(self.config.components))
             self._track_task = False
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,6 +5,7 @@ import unittest
 from unittest.mock import patch, MagicMock, sentinel
 from datetime import datetime, timedelta
 
+import logging
 import pytz
 import pytest
 
@@ -867,3 +868,45 @@ def test_timer_out_of_sync(mock_monotonic, loop):
     assert slp_seconds == 1
     assert callback is fire_time_event
     assert abs(nxt - 12.3) < 0.001
+
+
+@asyncio.coroutine
+def test_hass_start_starts_the_timer(loop):
+    """Test when hass starts, it starts the timer."""
+    hass = ha.HomeAssistant(loop=loop)
+
+    try:
+        with patch('homeassistant.core._async_create_timer') as mock_timer:
+            yield from hass.async_start()
+
+        assert hass.state == ha.CoreState.running
+        assert not hass._track_task
+        assert len(mock_timer.mock_calls) == 1
+        assert mock_timer.mock_calls[0][1][0] is hass
+
+    finally:
+        yield from hass.async_stop()
+        assert hass.state == ha.CoreState.not_running
+
+
+@asyncio.coroutine
+def test_start_taking_too_long(loop, caplog):
+    """Test when async_start takes too long."""
+    hass = ha.HomeAssistant(loop=loop)
+    caplog.set_level(logging.WARNING)
+
+    try:
+        with patch('homeassistant.core.timeout',
+                   side_effect=asyncio.TimeoutError), \
+             patch('homeassistant.core._async_create_timer') as mock_timer:
+            yield from hass.async_start()
+
+        assert not hass._track_task
+        assert hass.state == ha.CoreState.running
+        assert len(mock_timer.mock_calls) == 1
+        assert mock_timer.mock_calls[0][1][0] is hass
+        assert 'Something is blocking Home Assistant' in caplog.text
+
+    finally:
+        yield from hass.async_stop()
+        assert hass.state == ha.CoreState.not_running


### PR DESCRIPTION
## Description:
We now wait till all tasks that respond to `EVENT_HOMEASSISTANT_START` are done. This warning is there to make sure faulty integrations are getting called out.

Log message asks people to report their components/platforms to https://github.com/home-assistant/home-assistant/issues/6973

## Checklist:

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
