### PR TITLE
MQTT: Managing binary payloads

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -569,7 +569,7 @@ class MQTT(object):
         except (AttributeError, UnicodeDecodeError):
             payload = msg.payload
             _LOGGER.info("Illegal utf-8 unicode payload from "
-                          "MQTT topic: %s", msg.topic)
+                         "MQTT topic: %s", msg.topic)
         else:
             _LOGGER.info("Received message on %s: %s", msg.topic, payload)
         dispatcher_send(

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -217,8 +217,8 @@ def async_subscribe(hass, topic, msg_callback, qos=DEFAULT_QOS,
                              dp_topic, payload)
             except (AttributeError, UnicodeDecodeError):
                 _LOGGER.error("Illegal payload encoding %s from "
-                              "MQTT topic: %s, Payload: %s", encoding,
-                              dp_topic, dp_payload)
+                              "MQTT topic: %s, Payload: %s",
+                              encoding, dp_topic, dp_payload)
                 return
         else:
             _LOGGER.info("Received binary message on %s", dp_topic)

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -567,15 +567,15 @@ class MQTT(object):
         try:
             payload = msg.payload.decode('utf-8')
         except (AttributeError, UnicodeDecodeError):
-            _LOGGER.error("Illegal utf-8 unicode payload from "
-                          "MQTT topic: %s, Payload: %s", msg.topic,
-                          msg.payload)
+            payload = msg.payload
+            _LOGGER.info("Illegal utf-8 unicode payload from "
+                          "MQTT topic: %s", msg.topic)
         else:
             _LOGGER.info("Received message on %s: %s", msg.topic, payload)
-            dispatcher_send(
-                self.hass, SIGNAL_MQTT_MESSAGE_RECEIVED, msg.topic, payload,
-                msg.qos
-            )
+        dispatcher_send(
+            self.hass, SIGNAL_MQTT_MESSAGE_RECEIVED, msg.topic, payload,
+            msg.qos
+        )
 
     def _mqtt_on_unsubscribe(self, _mqttc, _userdata, mid, granted_qos):
         """Unsubscribe successful callback."""

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -216,7 +216,7 @@ def async_subscribe(hass, topic, msg_callback, qos=DEFAULT_QOS,
             try:
                 payload = dp_payload.decode(encoding)
                 _LOGGER.debug("Received message on %s: %s",
-                             dp_topic, payload)
+                              dp_topic, payload)
             except (AttributeError, UnicodeDecodeError):
                 _LOGGER.error("Illegal payload encoding %s from "
                               "MQTT topic: %s, Payload: %s",

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -215,7 +215,7 @@ def async_subscribe(hass, topic, msg_callback, qos=DEFAULT_QOS,
         if encoding is not None:
             try:
                 payload = dp_payload.decode(encoding)
-                _LOGGER.info("Received message on %s: %s",
+                _LOGGER.debug("Received message on %s: %s",
                              dp_topic, payload)
             except (AttributeError, UnicodeDecodeError):
                 _LOGGER.error("Illegal payload encoding %s from "
@@ -223,7 +223,7 @@ def async_subscribe(hass, topic, msg_callback, qos=DEFAULT_QOS,
                               encoding, dp_topic, dp_payload)
                 return
         else:
-            _LOGGER.info("Received binary message on %s", dp_topic)
+            _LOGGER.debug("Received binary message on %s", dp_topic)
             payload = dp_payload
 
         hass.async_run_job(msg_callback, dp_topic, payload, dp_qos)

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -201,7 +201,7 @@ def publish_template(hass, topic, payload_template, qos=None, retain=None):
 
 
 @asyncio.coroutine
-def async_subscribe(hass, topic, msg_callback, qos=DEFAULT_QOS
+def async_subscribe(hass, topic, msg_callback, qos=DEFAULT_QOS,
                     encoding='utf-8'):
     """Subscribe to an MQTT topic."""
     @callback

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -235,10 +235,12 @@ def async_subscribe(hass, topic, msg_callback, qos=DEFAULT_QOS,
     return async_remove
 
 
-def subscribe(hass, topic, msg_callback, qos=DEFAULT_QOS):
+def subscribe(hass, topic, msg_callback, qos=DEFAULT_QOS,
+              encoding='utf-8'):
     """Subscribe to an MQTT topic."""
     async_remove = run_coroutine_threadsafe(
-        async_subscribe(hass, topic, msg_callback, qos),
+        async_subscribe(hass, topic, msg_callback,
+                        qos, encoding),
         hass.loop
     ).result()
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -74,6 +74,7 @@ DEFAULT_TLS_PROTOCOL = 'auto'
 ATTR_TOPIC = 'topic'
 ATTR_PAYLOAD = 'payload'
 ATTR_PAYLOAD_TEMPLATE = 'payload_template'
+ATTR_PAYLOAD_FILE_PATH = 'payload_file_path'
 ATTR_QOS = CONF_QOS
 ATTR_RETAIN = CONF_RETAIN
 
@@ -165,6 +166,7 @@ MQTT_PUBLISH_SCHEMA = vol.Schema({
     vol.Required(ATTR_TOPIC): valid_publish_topic,
     vol.Exclusive(ATTR_PAYLOAD, CONF_PAYLOAD): object,
     vol.Exclusive(ATTR_PAYLOAD_TEMPLATE, CONF_PAYLOAD): cv.string,
+    vol.Exclusive(ATTR_PAYLOAD_FILE_PATH, CONF_PAYLOAD): cv.string,
     vol.Optional(ATTR_QOS, default=DEFAULT_QOS): _VALID_QOS_SCHEMA,
     vol.Optional(ATTR_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
 }, required=True)
@@ -385,18 +387,30 @@ def async_setup(hass, config):
         msg_topic = call.data[ATTR_TOPIC]
         payload = call.data.get(ATTR_PAYLOAD)
         payload_template = call.data.get(ATTR_PAYLOAD_TEMPLATE)
+        payload_file_path = call.data.get(ATTR_PAYLOAD_FILE_PATH)
         qos = call.data[ATTR_QOS]
         retain = call.data[ATTR_RETAIN]
-        try:
-            if payload_template is not None:
+        if payload_template is not None:
+            try:
                 payload = \
                     template.Template(payload_template, hass).async_render()
-        except template.jinja2.TemplateError as exc:
-            _LOGGER.error(
-                "Unable to publish to '%s': rendering payload template of "
-                "'%s' failed because %s",
-                msg_topic, payload_template, exc)
-            return
+            except template.jinja2.TemplateError as exc:
+                _LOGGER.error(
+                    "Unable to publish to '%s': rendering payload template of "
+                    "'%s' failed because %s",
+                    msg_topic, payload_template, exc)
+                return
+        elif payload_file_path is not None:
+            # check filepath given is readable
+            if not os.access(payload_file_path, os.R_OK):
+                _LOGGER.error("Could not read file: %s",
+                              payload_file_path)
+                return
+            else:
+                # Reads the file
+                with open(payload_file_path, "rb") as payload_file:
+                    file_content = payload_file.read()
+                    payload = bytearray(file_content)
 
         yield from hass.data[DATA_MQTT].async_publish(
             msg_topic, payload, qos, retain)

--- a/homeassistant/components/mqtt/services.yaml
+++ b/homeassistant/components/mqtt/services.yaml
@@ -14,6 +14,10 @@ publish:
       description: Template to render as payload value. Ignored if payload given.
       example: "{{ states('sensor.temperature') }}"
 
+    payload_file_path:
+      description: Path to a file to be published as binary payload.
+      example: "/home/user/snapshot.jpg"
+
     qos:
       description: Quality of Service
       example: 2

--- a/homeassistant/components/mqtt/services.yaml
+++ b/homeassistant/components/mqtt/services.yaml
@@ -14,10 +14,6 @@ publish:
       description: Template to render as payload value. Ignored if payload given.
       example: "{{ states('sensor.temperature') }}"
 
-    payload_file_path:
-      description: Path to a file within the local www directory to be published as binary payload.
-      example: "snapshot.jpg"
-
     qos:
       description: Quality of Service
       example: 2

--- a/homeassistant/components/mqtt/services.yaml
+++ b/homeassistant/components/mqtt/services.yaml
@@ -15,8 +15,8 @@ publish:
       example: "{{ states('sensor.temperature') }}"
 
     payload_file_path:
-      description: Path to a file to be published as binary payload.
-      example: "/home/user/snapshot.jpg"
+      description: Path to a file within the local www directory to be published as binary payload.
+      example: "snapshot.jpg"
 
     qos:
       description: Quality of Service

--- a/tests/common.py
+++ b/tests/common.py
@@ -171,9 +171,11 @@ def mock_service(hass, domain, service):
 @ha.callback
 def async_fire_mqtt_message(hass, topic, payload, qos=0):
     """Fire the MQTT message."""
+    if isinstance(payload, str):
+        payload = bytearray(payload, 'utf-8')
     async_dispatcher_send(
         hass, mqtt.SIGNAL_MQTT_MESSAGE_RECEIVED, topic,
-        bytearray(payload, 'utf-8'), qos)
+        payload, qos)
 
 
 def fire_mqtt_message(hass, topic, payload, qos=0):

--- a/tests/common.py
+++ b/tests/common.py
@@ -172,7 +172,8 @@ def mock_service(hass, domain, service):
 def async_fire_mqtt_message(hass, topic, payload, qos=0):
     """Fire the MQTT message."""
     async_dispatcher_send(
-        hass, mqtt.SIGNAL_MQTT_MESSAGE_RECEIVED, topic, bytearray(payload, 'utf-8'), qos)
+        hass, mqtt.SIGNAL_MQTT_MESSAGE_RECEIVED, topic,
+        bytearray(payload, 'utf-8'), qos)
 
 
 def fire_mqtt_message(hass, topic, payload, qos=0):

--- a/tests/common.py
+++ b/tests/common.py
@@ -172,7 +172,7 @@ def mock_service(hass, domain, service):
 def async_fire_mqtt_message(hass, topic, payload, qos=0):
     """Fire the MQTT message."""
     async_dispatcher_send(
-        hass, mqtt.SIGNAL_MQTT_MESSAGE_RECEIVED, topic, payload, qos)
+        hass, mqtt.SIGNAL_MQTT_MESSAGE_RECEIVED, topic, bytearray(payload, 'utf-8'), qos)
 
 
 def fire_mqtt_message(hass, topic, payload, qos=0):

--- a/tests/common.py
+++ b/tests/common.py
@@ -172,7 +172,7 @@ def mock_service(hass, domain, service):
 def async_fire_mqtt_message(hass, topic, payload, qos=0):
     """Fire the MQTT message."""
     if isinstance(payload, str):
-        payload = bytearray(payload, 'utf-8')
+        payload = payload.encode('utf-8')
     async_dispatcher_send(
         hass, mqtt.SIGNAL_MQTT_MESSAGE_RECEIVED, topic,
         payload, qos)

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -255,7 +255,7 @@ class TestMQTTCallbacks(unittest.TestCase):
 
         self.assertEqual(1, len(calls))
         last_event = calls[0]
-        self.assertEqual('Hello World!', last_event['payload'])
+        self.assertEqual(bytearray('Hello World!', 'utf-8'), last_event['payload'])
         self.assertEqual(message.topic, last_event['topic'])
         self.assertEqual(message.qos, last_event['qos'])
 
@@ -298,8 +298,8 @@ class TestMQTTCallbacks(unittest.TestCase):
         self.assertRaises(vol.Invalid, mqtt.valid_publish_topic, 'bad+topic')
         self.assertRaises(vol.Invalid, mqtt.valid_subscribe_topic, 'bad\0one')
 
-    def test_receiving_non_utf8_message_gets_logged(self):
-        """Test receiving a non utf8 encoded message."""
+    def test_receiving_binary_payload(self):
+        """Test receiving a binary message."""
         calls = []
 
         @callback
@@ -319,16 +319,14 @@ class TestMQTTCallbacks(unittest.TestCase):
         topic = 'test_topic'
         MQTTMessage = namedtuple('MQTTMessage', ['topic', 'qos', 'payload'])
         message = MQTTMessage(topic, 1, payload)
-        with self.assertLogs(level='ERROR') as test_handle:
-            self.hass.data['mqtt']._mqtt_on_message(
-                None,
-                {'hass': self.hass},
-                message)
-            self.hass.block_till_done()
-            self.assertIn(
-                "ERROR:homeassistant.components.mqtt:Illegal utf-8 unicode "
-                "payload from MQTT topic: %s, Payload: " % topic,
-                test_handle.output[0])
+
+        self.hass.data['mqtt']._mqtt_on_message(
+            None, {'hass': self.hass}, message)
+        self.hass.block_till_done()
+
+        self.assertEqual(1, len(calls))
+        last_event = calls[0]
+        self.assertEqual(0x9a, last_event['payload'])
 
 
 @asyncio.coroutine
@@ -339,7 +337,7 @@ def test_setup_embedded_starts_with_no_config(hass):
     with mock.patch('homeassistant.components.mqtt.server.async_start',
                     return_value=mock_coro(
                         return_value=(True, client_config))
-                    ) as _start:
+                   ) as _start:
         yield from mock_mqtt_client(hass, {})
         assert _start.call_count == 1
 
@@ -352,7 +350,7 @@ def test_setup_embedded_with_embedded(hass):
     with mock.patch('homeassistant.components.mqtt.server.async_start',
                     return_value=mock_coro(
                         return_value=(True, client_config))
-                    ) as _start:
+                   ) as _start:
         _start.return_value = mock_coro(return_value=(True, client_config))
         yield from mock_mqtt_client(hass, {'embedded': None})
         assert _start.call_count == 1

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -115,6 +115,22 @@ class TestMQTT(unittest.TestCase):
         }, blocking=True)
         self.assertFalse(self.hass.data['mqtt'].async_publish.called)
 
+    def test_service_call_with_ascii_qos_retain_flags(self):
+        """Test the service call with args that can be misinterpreted.
+
+        Empty payload message and ascii formatted qos and retain flags.
+        """
+        self.hass.services.call(mqtt.DOMAIN, mqtt.SERVICE_PUBLISH, {
+            mqtt.ATTR_TOPIC: "test/topic",
+            mqtt.ATTR_PAYLOAD: "",
+            mqtt.ATTR_QOS: '2',
+            mqtt.ATTR_RETAIN: 'no'
+        }, blocking=True)
+        self.assertTrue(self.hass.data['mqtt'].async_publish.called)
+        self.assertEqual(
+            self.hass.data['mqtt'].async_publish.call_args[0][2], 2)
+        self.assertFalse(self.hass.data['mqtt'].async_publish.call_args[0][3])
+
     def test_subscribe_topic(self):
         """Test the subscription of a topic."""
         unsub = mqtt.subscribe(self.hass, 'test-topic', self.record_calls)

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -255,7 +255,8 @@ class TestMQTTCallbacks(unittest.TestCase):
 
         self.assertEqual(1, len(calls))
         last_event = calls[0]
-        self.assertEqual(bytearray('Hello World!', 'utf-8'), last_event['payload'])
+        self.assertEqual(bytearray('Hello World!', 'utf-8'),
+                         last_event['payload'])
         self.assertEqual(message.topic, last_event['topic'])
         self.assertEqual(message.qos, last_event['qos'])
 
@@ -337,7 +338,7 @@ def test_setup_embedded_starts_with_no_config(hass):
     with mock.patch('homeassistant.components.mqtt.server.async_start',
                     return_value=mock_coro(
                         return_value=(True, client_config))
-                   ) as _start:
+                    ) as _start:
         yield from mock_mqtt_client(hass, {})
         assert _start.call_count == 1
 
@@ -350,7 +351,7 @@ def test_setup_embedded_with_embedded(hass):
     with mock.patch('homeassistant.components.mqtt.server.async_start',
                     return_value=mock_coro(
                         return_value=(True, client_config))
-                   ) as _start:
+                    ) as _start:
         _start.return_value = mock_coro(return_value=(True, client_config))
         yield from mock_mqtt_client(hass, {'embedded': None})
         assert _start.call_count == 1

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -115,6 +115,18 @@ class TestMQTT(unittest.TestCase):
         }, blocking=True)
         self.assertFalse(self.hass.data['mqtt'].async_publish.called)
 
+    def test_service_call_with_path_traversal_doesnt_publish(self):
+        """Test the service call with path traversal.
+
+        If 'payload_file_path' is not in 'www' then fail.
+        """
+        payload_file_path = "../configuration.yaml"
+        self.hass.services.call(mqtt.DOMAIN, mqtt.SERVICE_PUBLISH, {
+            mqtt.ATTR_TOPIC: "test/topic",
+            mqtt.ATTR_PAYLOAD_FILE_PATH: payload_file_path
+        }, blocking=True)
+        self.assertFalse(self.hass.data['mqtt'].async_publish.called)
+
     def test_service_call_with_ascii_qos_retain_flags(self):
         """Test the service call with args that can be misinterpreted.
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -115,34 +115,6 @@ class TestMQTT(unittest.TestCase):
         }, blocking=True)
         self.assertFalse(self.hass.data['mqtt'].async_publish.called)
 
-    def test_service_call_with_path_traversal_doesnt_publish(self):
-        """Test the service call with path traversal.
-
-        If 'payload_file_path' is not in 'www' then fail.
-        """
-        payload_file_path = "../configuration.yaml"
-        self.hass.services.call(mqtt.DOMAIN, mqtt.SERVICE_PUBLISH, {
-            mqtt.ATTR_TOPIC: "test/topic",
-            mqtt.ATTR_PAYLOAD_FILE_PATH: payload_file_path
-        }, blocking=True)
-        self.assertFalse(self.hass.data['mqtt'].async_publish.called)
-
-    def test_service_call_with_ascii_qos_retain_flags(self):
-        """Test the service call with args that can be misinterpreted.
-
-        Empty payload message and ascii formatted qos and retain flags.
-        """
-        self.hass.services.call(mqtt.DOMAIN, mqtt.SERVICE_PUBLISH, {
-            mqtt.ATTR_TOPIC: "test/topic",
-            mqtt.ATTR_PAYLOAD: "",
-            mqtt.ATTR_QOS: '2',
-            mqtt.ATTR_RETAIN: 'no'
-        }, blocking=True)
-        self.assertTrue(self.hass.data['mqtt'].async_publish.called)
-        self.assertEqual(
-            self.hass.data['mqtt'].async_publish.call_args[0][2], 2)
-        self.assertFalse(self.hass.data['mqtt'].async_publish.call_args[0][3])
-
     def test_subscribe_topic(self):
         """Test the subscription of a topic."""
         unsub = mqtt.subscribe(self.hass, 'test-topic', self.record_calls)

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -209,6 +209,31 @@ class TestMQTT(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
 
+    def test_subscribe_binary_topic(self):
+        """Test the subscription to a binary topic."""
+        mqtt.subscribe(self.hass, 'test-topic', self.record_calls,
+                       0, None)
+
+        fire_mqtt_message(self.hass, 'test-topic', 0x9a)
+
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        self.assertEqual('test-topic', self.calls[0][0])
+        self.assertEqual(0x9a, self.calls[0][1])
+
+    def test_receiving_non_utf8_message_gets_logged(self):
+        """Test receiving a non utf8 encoded message."""
+        mqtt.subscribe(self.hass, 'test-topic', self.record_calls)
+
+        with self.assertLogs(level='ERROR') as test_handle:
+            fire_mqtt_message(self.hass, 'test-topic', 0x9a)
+            self.hass.block_till_done()
+            self.assertIn(
+                "ERROR:homeassistant.components.mqtt:Illegal payload "
+                "encoding utf-8 from MQTT "
+                "topic: test-topic, Payload: 154",
+                test_handle.output[0])
+
 
 class TestMQTTCallbacks(unittest.TestCase):
     """Test the MQTT callbacks."""
@@ -298,36 +323,6 @@ class TestMQTTCallbacks(unittest.TestCase):
         """Test invalid topics."""
         self.assertRaises(vol.Invalid, mqtt.valid_publish_topic, 'bad+topic')
         self.assertRaises(vol.Invalid, mqtt.valid_subscribe_topic, 'bad\0one')
-
-    def test_receiving_binary_payload(self):
-        """Test receiving a binary message."""
-        calls = []
-
-        @callback
-        def record(topic, payload, qos):
-            """Helper to record calls."""
-            data = {
-                'topic': topic,
-                'payload': payload,
-                'qos': qos,
-            }
-            calls.append(data)
-
-        async_dispatcher_connect(
-            self.hass, mqtt.SIGNAL_MQTT_MESSAGE_RECEIVED, record)
-
-        payload = 0x9a
-        topic = 'test_topic'
-        MQTTMessage = namedtuple('MQTTMessage', ['topic', 'qos', 'payload'])
-        message = MQTTMessage(topic, 1, payload)
-
-        self.hass.data['mqtt']._mqtt_on_message(
-            None, {'hass': self.hass}, message)
-        self.hass.block_till_done()
-
-        self.assertEqual(1, len(calls))
-        last_event = calls[0]
-        self.assertEqual(0x9a, last_event['payload'])
 
 
 @asyncio.coroutine


### PR DESCRIPTION
Hello,
background: I wrote a HA camera component that gets the image from a binary payload. I'm testing it with Zanzito (https://play.google.com/store/apps/details?id=it.barbaro.zanzito) and it works apparently well: it gets the image and correctly displays it in the front-end.
But I had to make the changes I'm proposing here: the message was being blocked because the utf-8 decoding failed.
As far as I know, the utf-8 encoding is required for the topic, not for the payload. What I did here was try the utf-8 decoding, but even if unsuccessful, it dispatches the message anyway.
Is there anything else I'm missing?
thanks
Gianluca

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
