### PR TITLE
lyft sensor: re-enable Prime Time rate attribute

### DIFF
--- a/homeassistant/components/sensor/lyft.py
+++ b/homeassistant/components/sensor/lyft.py
@@ -137,10 +137,8 @@ class LyftSensor(Entity):
             params['Trip duration (in seconds)'] = estimate.get(
                 'estimated_duration_seconds')
 
-            # Ignore the Prime Time percentage -- the Lyft API always
-            # returns 0 unless a user is logged in.
-            # params['Prime Time percentage'] = estimate.get(
-            #    'primetime_percentage')
+            params['Prime Time percentage'] = estimate.get(
+                'primetime_percentage')
 
         if self._product.get("eta") is not None:
             eta = self._product['eta']


### PR DESCRIPTION
Minor fix -- this was disabled originally because it appeared not to work without using the authenticated user api, but turns out this does work correctly even without a user login
(assuming that sandbox mode is disabled)

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
