### PR TITLE
Upgraded amcrest to 1.1.8

### DIFF
--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import (
     async_get_clientsession, async_aiohttp_proxy_web)
 
-REQUIREMENTS = ['amcrest==1.1.5']
+REQUIREMENTS = ['amcrest==1.1.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/amcrest.py
+++ b/homeassistant/components/sensor/amcrest.py
@@ -19,7 +19,7 @@ import homeassistant.loader as loader
 
 from requests.exceptions import HTTPError, ConnectTimeout
 
-REQUIREMENTS = ['amcrest==1.1.5']
+REQUIREMENTS = ['amcrest==1.1.8']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -146,4 +146,4 @@ class AmcrestSensor(Entity):
             sd_total = self._camera.storage_total
             self._attrs['Total'] = '{0} {1}'.format(*sd_total)
             self._attrs['Used'] = '{0} {1}'.format(*sd_used)
-            self._state = self._camera.percent(sd_used[0], sd_total[0])
+            self._state = self._camera.storage_used_percent

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -48,7 +48,7 @@ aiolifx==0.4.2
 
 # homeassistant.components.camera.amcrest
 # homeassistant.components.sensor.amcrest
-amcrest==1.1.5
+amcrest==1.1.8
 
 # homeassistant.components.media_player.anthemav
 anthemav==1.1.8


### PR DESCRIPTION
## Description:
- Upgraded Amcrest module to version 1.1.8
- Fixed traceback when reporting the used storage percentage. 

```bash
Apr 08 14:26:32 ha hass[4466]:   File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/homeassistant/helpers/entity_component.py", line 189, in async_add_entity
Apr 08 14:26:32 ha hass[4466]:     yield from self.hass.loop.run_in_executor(None, entity.update)
Apr 08 14:26:32 ha hass[4466]:   File "/usr/lib64/python3.5/asyncio/futures.py", line 380, in __iter__
Apr 08 14:26:32 ha hass[4466]:     yield self  # This tells Task to wait for completion.
Apr 08 14:26:32 ha hass[4466]:   File "/usr/lib64/python3.5/asyncio/tasks.py", line 304, in _wakeup
Apr 08 14:26:32 ha hass[4466]:     future.result()
Apr 08 14:26:32 ha hass[4466]:   File "/usr/lib64/python3.5/asyncio/futures.py", line 293, in result
Apr 08 14:26:32 ha hass[4466]:     raise self._exception
Apr 08 14:26:32 ha hass[4466]:   File "/usr/lib64/python3.5/concurrent/futures/thread.py", line 55, in run
Apr 08 14:26:32 ha hass[4466]:     result = self.fn(*self.args, **self.kwargs)
Apr 08 14:26:32 ha hass[4466]:   File "/opt/srv/homeassistant/.virtualenvs/hass_venv/lib/python3.5/site-packages/homeassistant/components/sensor/amcrest.py", line 149, in update
Apr 08 14:26:32 ha hass[4466]:     self._state = self._camera.percent(sd_used[0], sd_total[0])
Apr 08 14:26:32 ha hass[4466]: AttributeError: 'Http' object has no attribute 'percent'
```
## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.