### PR TITLE
Upgrade netdisco to 1.0.0rc2

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==0.9.2']
+REQUIREMENTS = ['netdisco==1.0.0rc2']
 
 DOMAIN = 'discovery'
 
@@ -45,7 +45,6 @@ SERVICE_HANDLERS = {
     'denonavr': ('media_player', 'denonavr'),
     'samsung_tv': ('media_player', 'samsungtv'),
     'yeelight': ('light', 'yeelight'),
-    'flux_led': ('light', 'flux_led'),
     'apple_tv': ('media_player', 'apple_tv'),
     'frontier_silicon': ('media_player', 'frontier_silicon'),
     'openhome': ('media_player', 'openhome'),

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -108,20 +108,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             lights.append(light)
             light_ips.append(ipaddr)
 
-    if discovery_info:
-        device = {}
-        # discovery_info: ip address,device id,device type
-        device['ipaddr'] = discovery_info[0]
-        device['name'] = discovery_info[1]
-        # As we don't know protocol and mode set to none to autodetect.
-        device[CONF_PROTOCOL] = None
-        device[ATTR_MODE] = None
-
-        light = FluxLight(device)
-        if light.is_valid:
-            lights.append(light)
-            light_ips.append(device['ipaddr'])
-
     if not config.get(CONF_AUTOMATIC_ADD, False):
         add_devices(lights)
         return

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -10,7 +10,6 @@ import os
 import random
 import socket
 from datetime import timedelta
-from urllib.parse import urlparse
 
 import voluptuous as vol
 
@@ -115,11 +114,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     allow_hue_groups = config.get(CONF_ALLOW_HUE_GROUPS)
 
     if discovery_info is not None:
-        host = urlparse(discovery_info[1]).hostname
-
-        if "HASS Bridge" in discovery_info[0]:
+        if "HASS Bridge" in discovery_info.get('name', ''):
             _LOGGER.info('Emulated hue found, will not add')
             return False
+
+        host = discovery_info.get('host')
     else:
         host = config.get(CONF_HOST, None)
 

--- a/homeassistant/components/media_player/apple_tv.py
+++ b/homeassistant/components/media_player/apple_tv.py
@@ -51,7 +51,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if discovery_info is not None:
         name = discovery_info['name']
         host = discovery_info['host']
-        login_id = discovery_info['hsgid']
+        login_id = discovery_info['properties']['hsgid']
         start_off = False
     else:
         name = config.get(CONF_NAME)

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -51,11 +51,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     hosts = []
 
-    if discovery_info and discovery_info in KNOWN_HOSTS:
-        return
+    if discovery_info:
+        host = (discovery_info.get('host'), discovery_info.get('port'))
 
-    elif discovery_info:
-        hosts = [discovery_info]
+        if host in KNOWN_HOSTS:
+            return
+
+        hosts = [host]
 
     elif CONF_HOST in config:
         hosts = [(config.get(CONF_HOST), DEFAULT_PORT)]

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -64,8 +64,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             _LOGGER.info("Denon receiver at host %s initialized", host)
     # 2. option: discovery using netdisco
     if discovery_info is not None:
-        host = discovery_info[0]
-        name = discovery_info[1]
+        host = discovery_info.get('host')
+        name = discovery_info.get('name')
         # Check if host not in cache, append it and save for later starting
         if host not in cache:
             cache.add(host)

--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -37,14 +37,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the DirecTV platform."""
     hosts = []
 
-    if discovery_info and discovery_info in KNOWN_HOSTS:
-        return
+    if discovery_info:
+        host = discovery_info.get('host')
 
-    if discovery_info is not None:
+        if host in KNOWN_HOSTS:
+            return
+
         hosts.append([
-            'DirecTV_' + discovery_info[1],
-            discovery_info[0],
-            DEFAULT_PORT
+            'DirecTV_' + discovery_info.get('serial', ''),
+            host, DEFAULT_PORT
         ])
 
     elif CONF_HOST in config:

--- a/homeassistant/components/media_player/frontier_silicon.py
+++ b/homeassistant/components/media_player/frontier_silicon.py
@@ -47,7 +47,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if discovery_info is not None:
         add_devices(
-            [FSAPIDevice(discovery_info, DEFAULT_PASSWORD)],
+            [FSAPIDevice(discovery_info['ssdp_description'],
+                         DEFAULT_PASSWORD)],
             update_before_add=True)
         return True
 

--- a/homeassistant/components/media_player/openhome.py
+++ b/homeassistant/components/media_player/openhome.py
@@ -31,20 +31,22 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup Openhome Platform."""
     from openhomedevice.Device import Device
 
-    if discovery_info:
-        _LOGGER.info('Openhome device found, (%s)', discovery_info[0])
-        device = Device(discovery_info[1])
-
-        # if device has already been discovered
-        if device.Uuid() in [x.unique_id for x in DEVICES]:
-            return True
-
-        device = OpenhomeDevice(hass, device)
-
-        add_devices([device], True)
-        DEVICES.append(device)
-
+    if not discovery_info:
         return True
+
+    name = discovery_info.get('name')
+    description = discovery_info.get('ssdp_description')
+    _LOGGER.info('Openhome device found, (%s)', name)
+    device = Device(description)
+
+    # if device has already been discovered
+    if device.Uuid() in [x.unique_id for x in DEVICES]:
+        return True
+
+    device = OpenhomeDevice(hass, device)
+
+    add_devices([device], True)
+    DEVICES.append(device)
 
     return True
 

--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -51,11 +51,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if discovery_info:
         _LOGGER.debug('%s', discovery_info)
-        vals = discovery_info.split(':')
-        if len(vals) > 1:
-            port = vals[1]
-
-        host = vals[0]
+        host = discovery_info.get('host')
+        port = discovery_info.get('port')
         remote = RemoteControl(host, port)
         add_devices([PanasonicVieraTVDevice(mac, name, remote)])
         return True

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -102,7 +102,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     # Via discovery
     elif discovery_info is not None:
         # Parse discovery data
-        host = urlparse(discovery_info[1]).netloc
+        host = discovery_info.get('host')
         _LOGGER.info('Discovered PLEX server: %s', host)
 
         if host in _CONFIGURING:

--- a/homeassistant/components/media_player/roku.py
+++ b/homeassistant/components/media_player/roku.py
@@ -42,11 +42,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Roku platform."""
     hosts = []
 
-    if discovery_info and discovery_info in KNOWN_HOSTS:
-        return
+    if discovery_info:
+        host = discovery_info[0]
 
-    if discovery_info is not None:
-        _LOGGER.debug('Discovered Roku: %s', discovery_info[0])
+        if host in KNOWN_HOSTS:
+            return
+
+        _LOGGER.debug('Discovered Roku: %s', host)
         hosts.append(discovery_info[0])
 
     elif CONF_HOST in config:

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -58,7 +58,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         mac = config.get(CONF_MAC)
         timeout = config.get(CONF_TIMEOUT)
     elif discovery_info is not None:
-        tv_name, model, host = discovery_info
+        tv_name = discovery_info.get('name')
+        model = discovery_info.get('model_name')
+        host = discovery_info.get('host')
         name = "{} ({})".format(tv_name, model)
         port = DEFAULT_PORT
         timeout = DEFAULT_TIMEOUT

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -103,7 +103,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         soco.config.EVENT_ADVERTISE_IP = advertise_addr
 
     if discovery_info:
-        player = soco.SoCo(discovery_info)
+        player = soco.SoCo(discovery_info.get('host'))
 
         # if device allready exists by config
         if player.uid in [x.unique_id for x in hass.data[DATA_SONOS]]:

--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -59,10 +59,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     zone_ignore = config.get(CONF_ZONE_IGNORE)
 
     if discovery_info is not None:
-        name = discovery_info[0]
-        model = discovery_info[1]
-        ctrl_url = discovery_info[2]
-        desc_url = discovery_info[3]
+        name = discovery_info.get('name')
+        model = discovery_info.get('model_name')
+        ctrl_url = discovery_info.get('control_url')
+        desc_url = discovery_info.get('description_url')
         if ctrl_url in hass.data[KNOWN]:
             _LOGGER.info("%s already manually configured", ctrl_url)
             return

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -62,7 +62,8 @@ def setup(hass, config):
     def discovery_dispatch(service, discovery_info):
         """Dispatcher for WeMo discovery events."""
         # name, model, location, mac
-        _, model_name, _, _, serial = discovery_info
+        model_name = discovery_info.get('model_name')
+        serial = discovery_info.get('serial')
 
         # Only register a device once
         if serial in KNOWN_DEVICES:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -392,7 +392,7 @@ mutagen==1.36.2
 myusps==1.0.3
 
 # homeassistant.components.discovery
-netdisco==0.9.2
+netdisco==1.0.0rc2
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -37,6 +37,8 @@ class TestCastMediaPlayer(unittest.TestCase):
         assert not mock_device.called
 
         # Test chromecasts as if they were automatically discovered
-        cast.setup_platform(None, {}, lambda _: _, ('some_host',
-                                                    cast.DEFAULT_PORT))
+        cast.setup_platform(None, {}, lambda _: _, {
+            'host': 'some_host',
+            'port': cast.DEFAULT_PORT,
+        })
         assert not mock_device.called

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -143,7 +143,9 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch('socket.create_connection', side_effect=socket.error())
     def test_ensure_setup_discovery(self, *args):
         """Test a single device using the autodiscovery provided by HASS."""
-        sonos.setup_platform(self.hass, {}, fake_add_device, '192.0.2.1')
+        sonos.setup_platform(self.hass, {}, fake_add_device, {
+            'host': '192.0.2.1'
+        })
 
         self.assertEqual(len(self.hass.data[sonos.DATA_SONOS]), 1)
         self.assertEqual(self.hass.data[sonos.DATA_SONOS][0].name, 'Kitchen')
@@ -250,7 +252,9 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch.object(SoCoMock, 'join')
     def test_sonos_group_players(self, join_mock, *args):
         """Ensuring soco methods called for sonos_group_players service."""
-        sonos.setup_platform(self.hass, {}, fake_add_device, '192.0.2.1')
+        sonos.setup_platform(self.hass, {}, fake_add_device, {
+            'host': '192.0.2.1'
+        })
         device = self.hass.data[sonos.DATA_SONOS][-1]
         device.hass = self.hass
 
@@ -268,7 +272,9 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch.object(SoCoMock, 'unjoin')
     def test_sonos_unjoin(self, unjoinMock, *args):
         """Ensuring soco methods called for sonos_unjoin service."""
-        sonos.setup_platform(self.hass, {}, fake_add_device, '192.0.2.1')
+        sonos.setup_platform(self.hass, {}, fake_add_device, {
+            'host': '192.0.2.1'
+        })
         device = self.hass.data[sonos.DATA_SONOS][-1]
         device.hass = self.hass
 
@@ -282,7 +288,9 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch.object(SoCoMock, 'set_sleep_timer')
     def test_sonos_set_sleep_timer(self, set_sleep_timerMock, *args):
         """Ensuring soco methods called for sonos_set_sleep_timer service."""
-        sonos.setup_platform(self.hass, {}, fake_add_device, '192.0.2.1')
+        sonos.setup_platform(self.hass, {}, fake_add_device, {
+            'host': '192.0.2.1'
+        })
         device = self.hass.data[sonos.DATA_SONOS][-1]
         device.hass = self.hass
 
@@ -294,7 +302,9 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch.object(SoCoMock, 'set_sleep_timer')
     def test_sonos_clear_sleep_timer(self, set_sleep_timerMock, *args):
         """Ensuring soco methods called for sonos_clear_sleep_timer service."""
-        sonos.setup_platform(self.hass, {}, mock.MagicMock(), '192.0.2.1')
+        sonos.setup_platform(self.hass, {}, mock.MagicMock(), {
+            'host': '192.0.2.1'
+        })
         device = self.hass.data[sonos.DATA_SONOS][-1]
         device.hass = self.hass
 
@@ -306,7 +316,9 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch.object(soco.snapshot.Snapshot, 'snapshot')
     def test_sonos_snapshot(self, snapshotMock, *args):
         """Ensuring soco methods called for sonos_snapshot service."""
-        sonos.setup_platform(self.hass, {}, fake_add_device, '192.0.2.1')
+        sonos.setup_platform(self.hass, {}, fake_add_device, {
+            'host': '192.0.2.1'
+        })
         device = self.hass.data[sonos.DATA_SONOS][-1]
         device.hass = self.hass
 
@@ -322,7 +334,9 @@ class TestSonosMediaPlayer(unittest.TestCase):
         """Ensuring soco methods called for sonos_restor service."""
         from soco.snapshot import Snapshot
 
-        sonos.setup_platform(self.hass, {}, fake_add_device, '192.0.2.1')
+        sonos.setup_platform(self.hass, {}, fake_add_device, {
+            'host': '192.0.2.1'
+        })
         device = self.hass.data[sonos.DATA_SONOS][-1]
         device.hass = self.hass
 


### PR DESCRIPTION
## Description:
Netdisco 1.0.0 has an updated return value. Instead of tuples it is now all dictionaries. This will give us easy upgrade path and backwards compatibility. Also as added bonus the new netdisco standardizes a lot of data values.

This means that I had to update everywhere where the value from discovery was used.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
