### PR TITLE
Fix Synology camera content type

### DIFF
--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -81,7 +81,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                 params=query_payload
             )
 
-        query_resp = yield from query_req.json()
+        # Skip content type check because Synology doesn't return JSON with
+        # right content type
+        query_resp = yield from query_req.json(content_type=None)
         auth_path = query_resp['data'][AUTH_API]['path']
         camera_api = query_resp['data'][CAMERA_API]['path']
         camera_path = query_resp['data'][CAMERA_API]['path']


### PR DESCRIPTION
## Description:
Synology returns JSON with the wrong content type. Starting aiohttp 2 this raises an exception. So to workaround Synology we skip the content type check.
