### PR TITLE
Bugfix wait on start event

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -165,8 +165,8 @@ class HomeAssistant(object):
 
         try:
             # only block for EVENT_HOMEASSISTANT_START listener
+            self.async_stop_track_tasks()
             with timeout(TIMEOUT_EVENT_START, loop=self.loop):
-                yield from self.async_stop_track_tasks(finish_current=False)
                 yield from self.async_block_till_done()
         except asyncio.TimeoutError:
             _LOGGER.warning(
@@ -219,11 +219,9 @@ class HomeAssistant(object):
         """Track tasks so you can wait for all tasks to be done."""
         self._track_task = True
 
-    @asyncio.coroutine
-    def async_stop_track_tasks(self, finish_current=True):
-        """Track tasks so you can wait for all tasks to be done."""
-        if finish_current:
-            yield from self.async_block_till_done()
+    @callback
+    def async_stop_track_tasks(self):
+        """Stop track tasks so you can't wait for all tasks to be done."""
         self._track_task = False
 
     @callback

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -164,15 +164,16 @@ class HomeAssistant(object):
         self.bus.async_fire(EVENT_HOMEASSISTANT_START)
 
         try:
+            # only block for EVENT_HOMEASSISTANT_START listener
+            self._track_task = False
             with timeout(TIMEOUT_EVENT_START, loop=self.loop):
-                yield from self.async_stop_track_tasks()
+                yield from self.async_block_till_done()
         except asyncio.TimeoutError:
             _LOGGER.warning(
                 'Something is blocking Home Assistant from wrapping up the '
                 'start up phase. We\'re going to continue anyway. Please '
                 'report the following info at http://bit.ly/2ogP58T : %s',
                 ', '.join(self.config.components))
-            self._track_task = False
 
         self.state = CoreState.running
         _async_create_timer(self)
@@ -246,8 +247,6 @@ class HomeAssistant(object):
     @asyncio.coroutine
     def async_block_till_done(self):
         """Block till all pending work is done."""
-        assert self._track_task, 'Not tracking tasks'
-
         # To flush out any call_soon_threadsafe
         yield from asyncio.sleep(0, loop=self.loop)
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -165,8 +165,8 @@ class HomeAssistant(object):
 
         try:
             # only block for EVENT_HOMEASSISTANT_START listener
-            self._track_task = False
             with timeout(TIMEOUT_EVENT_START, loop=self.loop):
+                yield from self.async_stop_track_tasks(finish_current=False)
                 yield from self.async_block_till_done()
         except asyncio.TimeoutError:
             _LOGGER.warning(
@@ -220,9 +220,10 @@ class HomeAssistant(object):
         self._track_task = True
 
     @asyncio.coroutine
-    def async_stop_track_tasks(self):
+    def async_stop_track_tasks(self, finish_current=True):
         """Track tasks so you can wait for all tasks to be done."""
-        yield from self.async_block_till_done()
+        if finish_current:
+            yield from self.async_block_till_done()
         self._track_task = False
 
     @callback

--- a/tests/common.py
+++ b/tests/common.py
@@ -122,10 +122,8 @@ def async_test_home_assistant(loop):
         # 1. We only mock time during tests
         # 2. We want block_till_done that is called inside stop_track_tasks
         with patch('homeassistant.core._async_create_timer'), \
-                patch.object(hass, '_track_task', new=True):
+                patch.object(hass, 'async_stop_track_tasks'):
             yield from orig_start()
-
-        yield from hass.async_block_till_done()
 
     hass.async_start = mock_async_start
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -122,9 +122,10 @@ def async_test_home_assistant(loop):
         # 1. We only mock time during tests
         # 2. We want block_till_done that is called inside stop_track_tasks
         with patch('homeassistant.core._async_create_timer'), \
-                patch.object(hass, 'async_stop_track_tasks',
-                             hass.async_block_till_done):
+                patch.object(hass, '_track_task', new=True):
             yield from orig_start()
+
+        yield from hass.async_block_till_done()
 
     hass.async_start = mock_async_start
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -915,10 +915,13 @@ def test_start_taking_too_long(loop, caplog):
 def test_track_task_functions(loop):
     """Test function to start/stop track task and initial state."""
     hass = ha.HomeAssistant(loop=loop)
-    assert hass._track_task
+    try:
+        assert hass._track_task
 
-    hass.async_stop_track_tasks()
-    assert not hass._track_task
+        hass.async_stop_track_tasks()
+        assert not hass._track_task
 
-    hass.async_track_tasks()
-    assert hass._track_task
+        hass.async_track_tasks()
+        assert hass._track_task
+    finally:
+        yield from hass.async_stop()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -909,3 +909,16 @@ def test_start_taking_too_long(loop, caplog):
     finally:
         yield from hass.async_stop()
         assert hass.state == ha.CoreState.not_running
+
+
+@asyncio.coroutine
+def test_track_task_functions(loop):
+    """Test function to start/stop track task and initial state."""
+    hass = ha.HomeAssistant(loop=loop)
+    assert hass._track_task
+
+    hass.async_stop_track_tasks()
+    assert not hass._track_task
+
+    hass.async_track_tasks()
+    assert hass._track_task

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -901,7 +901,6 @@ def test_start_taking_too_long(loop, caplog):
              patch('homeassistant.core._async_create_timer') as mock_timer:
             yield from hass.async_start()
 
-        assert not hass._track_task
         assert hass.state == ha.CoreState.running
         assert len(mock_timer.mock_calls) == 1
         assert mock_timer.mock_calls[0][1][0] is hass


### PR DESCRIPTION
## Description:

This protect to track new task after we schedule all EVENT_HOMEASSISTANT_START listener task. Otherwise we can block forever there.

I remove also the assert on block_till_done while that is not needed. We support no task track in this function.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
