### PR TITLE
Fix two more instances of JSON parsing synology

### DIFF
--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -129,7 +129,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         _LOGGER.exception("Error on %s", syno_camera_url)
         return False
 
-    camera_resp = yield from camera_req.json()
+    camera_resp = yield from camera_req.json(content_type=None)
     cameras = camera_resp['data']['cameras']
 
     # add cameras
@@ -174,7 +174,7 @@ def get_session_id(hass, websession, username, password, login_url, timeout):
                 login_url,
                 params=auth_payload
             )
-        auth_resp = yield from auth_req.json()
+        auth_resp = yield from auth_req.json(content_type=None)
         return auth_resp['data']['sid']
 
     except (asyncio.TimeoutError, aiohttp.ClientError):


### PR DESCRIPTION
## Description:
There were two more instances in the Synology camera that parsed the JSON wrong.
