### PR TITLE
Fix US states check (fixes #7015)

### DIFF
--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -66,8 +66,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     obj_holidays = getattr(holidays, country)(years=year)
 
     if province:
-        if province not in obj_holidays.PROVINCES:
-            _LOGGER.error('There is no province/state %s in country %s',
+        if province not in obj_holidays.PROVINCES and \
+                        province not in obj_holidays.STATES:
+            _LOGGER.error("There is no province/state %s in country %s",
                           province, country)
             return False
         else:


### PR DESCRIPTION
## Description:
For the US there are `STATES` while for other countries `PROVINCES` is used.

**Related issue (if applicable):** fixes #7015

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: workday
    country: US
    province: WA
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

