### PR TITLE
Replace 'vendor_id' with 'arch' (fixes #7003)

### DIFF
--- a/homeassistant/components/sensor/cpuspeed.py
+++ b/homeassistant/components/sensor/cpuspeed.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_BRAND = 'Brand'
 ATTR_HZ = 'GHz Advertised'
-ATTR_VENDOR = 'Vendor ID'
+ATTR_ARCH = 'arch'
 
 DEFAULT_NAME = 'CPU speed'
 ICON = 'mdi:pulse'
@@ -67,7 +67,7 @@ class CpuSpeedSensor(Entity):
         """Return the state attributes."""
         if self.info is not None:
             return {
-                ATTR_VENDOR: self.info['vendor_id'],
+                ATTR_ARCH: self.info['arch'],
                 ATTR_BRAND: self.info['brand'],
                 ATTR_HZ: round(self.info['hz_advertised_raw'][0]/10**9, 2)
             }


### PR DESCRIPTION
## Description:
'vendor_id' is not available for all CPU. Replaced with 'arch' to give some more details about the CPU.

**Related issue (if applicable):** fixes #7003

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: cpuspeed
    name: CPU
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
