### PR TITLE
Plug file leak on LIFX unregister

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -216,9 +216,6 @@ class LIFXLight(Light):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the device on."""
-        if not self.available:
-            return
-
         if ATTR_TRANSITION in kwargs:
             fade = int(kwargs[ATTR_TRANSITION] * 1000)
         else:
@@ -269,9 +266,6 @@ class LIFXLight(Light):
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the device off."""
-        if not self.available:
-            return
-
         if ATTR_TRANSITION in kwargs:
             fade = int(kwargs[ATTR_TRANSITION] * 1000)
         else:

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -26,7 +26,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['aiolifx==0.4.2']
+REQUIREMENTS = ['aiolifx==0.4.4']
 
 UDP_BROADCAST_PORT = 56700
 
@@ -84,6 +84,7 @@ class LIFXManager(object):
             entity = self.entities[device.mac_addr]
             _LOGGER.debug("%s register AGAIN", entity.ipaddr)
             entity.available = True
+            entity.device = device
             self.hass.async_add_job(entity.async_update_ha_state())
         else:
             _LOGGER.debug("%s register NEW", device.ip_addr)
@@ -215,6 +216,9 @@ class LIFXLight(Light):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the device on."""
+        if not self.available:
+            return
+
         if ATTR_TRANSITION in kwargs:
             fade = int(kwargs[ATTR_TRANSITION] * 1000)
         else:
@@ -265,6 +269,9 @@ class LIFXLight(Light):
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the device off."""
+        if not self.available:
+            return
+
         if ATTR_TRANSITION in kwargs:
             fade = int(kwargs[ATTR_TRANSITION] * 1000)
         else:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -44,7 +44,7 @@ aiodns==1.1.1
 aiohttp_cors==0.5.2
 
 # homeassistant.components.light.lifx
-aiolifx==0.4.2
+aiolifx==0.4.4
 
 # homeassistant.components.camera.amcrest
 # homeassistant.components.sensor.amcrest


### PR DESCRIPTION
## Description:

The aiolifx 0.4.4 release closes its socket when the unregister callback is
called. This plugs a file descriptor leak but also means that we must be
careful to not use the device after it goes unavailable.

Also, when a light reappears, it has a new device that must be used.

**Related issue (if applicable):** fixes #6985

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
