### PR TITLE
Upgrade psutil to 5.2.2

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==5.2.1']
+REQUIREMENTS = ['psutil==5.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -448,7 +448,7 @@ pmsensor==0.4
 proliphix==0.4.1
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.2.1
+psutil==5.2.2
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.2


### PR DESCRIPTION
## 5.2.2

Bug fixes

- fixed some setup.py warnings.
- SunOS] remove C macro which will not be available on new Solaris versions. (patch by Danek Duvall)
- [Linux] Process.io_counters() may raise ValueError.
- [Linux] cpu_freq() may return None on some Linux versions does not support the function; now the function is not declared instead.
- [Linux] sensors_temperatures() may raise OSError.
- [Linux] virtual_memory() may raise ValueError on Ubuntu 14.04.

Tested with the following configuration:

``` yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: load_1m
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
```