### PR TITLE
Introduce HTTP based tracking

### DIFF
--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -54,17 +54,6 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         except FileNotFoundError:
             pass
 
-    def test_password_or_pub_key_required(self): \
-            # pylint: disable=invalid-name
-        """Test creating an AsusWRT scanner without a pass or pubkey."""
-        with assert_setup_component(0):
-            assert setup_component(
-                self.hass, DOMAIN, {DOMAIN: {
-                    CONF_PLATFORM: 'asuswrt',
-                    CONF_HOST: 'fake_host',
-                    CONF_USERNAME: 'fake_user'
-                }})
-
     @mock.patch(
         'homeassistant.components.device_tracker.asuswrt.AsusWrtDeviceScanner',
         return_value=mock.MagicMock())
@@ -166,31 +155,3 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
             ssh.login.call_args,
             mock.call('fake_host', 'fake_user', password='fake_pass', port=22)
         )
-
-    def test_ssh_login_without_password_or_pubkey(self):  \
-            # pylint: disable=invalid-name
-        """Test that login is not called without password or pub_key."""
-        ssh = mock.MagicMock()
-        ssh_mock = mock.patch('pexpect.pxssh.pxssh', return_value=ssh)
-        ssh_mock.start()
-        self.addCleanup(ssh_mock.stop)
-
-        conf_dict = {
-            CONF_PLATFORM: 'asuswrt',
-            CONF_HOST: 'fake_host',
-            CONF_USERNAME: 'fake_user',
-        }
-
-        with self.assertRaises(vol.Invalid):
-            conf_dict = PLATFORM_SCHEMA(conf_dict)
-
-        update_mock = mock.patch(
-            'homeassistant.components.device_tracker.asuswrt.'
-            'AsusWrtDeviceScanner.get_asuswrt_data')
-        update_mock.start()
-        self.addCleanup(update_mock.stop)
-
-        with assert_setup_component(0):
-            assert setup_component(self.hass, DOMAIN,
-                                   {DOMAIN: conf_dict})
-        ssh.login.assert_not_called()


### PR DESCRIPTION
Implementing the idea of https://community.home-assistant.io/t/alternate-device-tracker-component-for-asuswrt/979 into the existing tracker

## Description:


**Related issue (if applicable):** fixes #6983

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2409

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
