### PR TITLE
Prevent wink state changes from stopping after 6 hours

### DIFF
--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-wink==1.2.3', 'pubnubsub-handler==1.0.2']
+REQUIREMENTS = ['python-wink==1.2.4', 'pubnubsub-handler==1.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -97,13 +97,14 @@ def setup(hass, config):
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN]['entities'] = []
     hass.data[DOMAIN]['unique_ids'] = []
-    hass.data[DOMAIN]['pubnub'] = PubNubSubscriptionHandler(
-        pywink.get_subscription_key(),
-        keep_alive_call)
 
     def keep_alive_call():
         pywink.wink_api_fetch()
         pywink.get_user()
+
+    hass.data[DOMAIN]['pubnub'] = PubNubSubscriptionHandler(
+        pywink.get_subscription_key(),
+        keep_alive_call)
 
     def start_subscription(event):
         """Start the pubnub subscription."""

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -98,13 +98,15 @@ def setup(hass, config):
     hass.data[DOMAIN]['entities'] = []
     hass.data[DOMAIN]['unique_ids'] = []
 
-    def keep_alive_call():
+    def keep_alive_call(event):
+        _LOGGER.info("Calling get user.")
         pywink.wink_api_fetch()
         pywink.get_user()
+    hass.services.register(DOMAIN, 'keep_alive', keep_alive_call)
 
     hass.data[DOMAIN]['pubnub'] = PubNubSubscriptionHandler(
         pywink.get_subscription_key(),
-        keep_alive_call)
+        pywink.get_user)
 
     def start_subscription(event):
         """Start the pubnub subscription."""

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -99,7 +99,11 @@ def setup(hass, config):
     hass.data[DOMAIN]['unique_ids'] = []
     hass.data[DOMAIN]['pubnub'] = PubNubSubscriptionHandler(
         pywink.get_subscription_key(),
-        pywink.wink_api_fetch)
+        keep_alive_call)
+
+    def keep_alive_call():
+        pywink.wink_api_fetch()
+        pywink.get_user()
 
     def start_subscription(event):
         """Start the pubnub subscription."""

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -106,12 +106,16 @@ def setup(hass, config):
     hass.data[DOMAIN]['pubnub'] = PubNubSubscriptionHandler(
         pywink.get_subscription_key())
 
-    def keep_alive_call():
+    def keep_alive_call(event_time):
         """Call the Wink API endpoints to keep PubNub working."""
         _LOGGER.info("Polling the Wink API to keep PubNub updates flowing.")
         pywink.wink_api_fetch()
         time.sleep(1)
         pywink.get_user()
+
+    # Call the Wink API every hour to keep PubNub updates flowing
+    async_track_time_interval(hass, keep_alive_call, timedelta(minutes=60))
+
 
     def start_subscription(event):
         """Start the pubnub subscription."""
@@ -136,9 +140,6 @@ def setup(hass, config):
         for component in WINK_COMPONENTS:
             discovery.load_platform(hass, component, DOMAIN, {}, config)
     hass.services.register(DOMAIN, SERVICE_ADD_NEW_DEVICES, pull_new_devices)
-
-    # Call the Wink API every hour to keep PubNub updates flowing
-    async_track_time_interval(hass, keep_alive_call, timedelta(minutes=60))
 
     # Load components for the devices in Wink that we support
     for component in WINK_COMPONENTS:

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -5,10 +5,13 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/wink/
 """
 import logging
+import time
+from datetime import timedelta
 
 import voluptuous as vol
 
 from homeassistant.helpers import discovery
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.const import (
     CONF_ACCESS_TOKEN, ATTR_BATTERY_LEVEL, CONF_EMAIL, CONF_PASSWORD,
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
@@ -32,6 +35,9 @@ CONF_APPSPOT = 'appspot'
 CONF_DEFINED_BOTH_MSG = 'Remove access token to use oath2.'
 CONF_MISSING_OATH_MSG = 'Missing oath2 credentials.'
 CONF_TOKEN_URL = "https://winkbearertoken.appspot.com/token"
+
+SERVICE_ADD_NEW_DEVICES = 'add_new_devices'
+SERVICE_REFRESH_STATES = 'refresh_state_from_wink'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -97,16 +103,15 @@ def setup(hass, config):
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN]['entities'] = []
     hass.data[DOMAIN]['unique_ids'] = []
-
-    def keep_alive_call(event):
-        """Call the Wink API endpoints to keep PubNub working."""
-        pywink.wink_api_fetch()
-        pywink.get_user()
-    hass.services.register(DOMAIN, 'keep_alive', keep_alive_call)
-
     hass.data[DOMAIN]['pubnub'] = PubNubSubscriptionHandler(
-        pywink.get_subscription_key(),
-        pywink.get_user)
+        pywink.get_subscription_key())
+
+    def keep_alive_call():
+        """Call the Wink API endpoints to keep PubNub working."""
+        _LOGGER.info("Polling the Wink API to keep PubNub updates flowing.")
+        pywink.wink_api_fetch()
+        time.sleep(1)
+        pywink.get_user()
 
     def start_subscription(event):
         """Start the pubnub subscription."""
@@ -123,18 +128,22 @@ def setup(hass, config):
         _LOGGER.info("Refreshing Wink states from API")
         for entity in hass.data[DOMAIN]['entities']:
             entity.schedule_update_ha_state(True)
-    hass.services.register(DOMAIN, 'Refresh_state_from_Wink', force_update)
+    hass.services.register(DOMAIN, SERVICE_REFRESH_STATES, force_update)
 
     def pull_new_devices(call):
         """Pull new devices added to users Wink account since startup."""
         _LOGGER.info("Getting new devices from Wink API.")
         for component in WINK_COMPONENTS:
             discovery.load_platform(hass, component, DOMAIN, {}, config)
-    hass.services.register(DOMAIN, 'Add_new_devices', pull_new_devices)
+    hass.services.register(DOMAIN, SERVICE_ADD_NEW_DEVICES, pull_new_devices)
+
+    # Call the Wink API every hour to keep PubNub updates flowing
+    async_track_time_interval(hass, keep_alive_call, timedelta(minutes=60))
 
     # Load components for the devices in Wink that we support
     for component in WINK_COMPONENTS:
         discovery.load_platform(hass, component, DOMAIN, {}, config)
+
 
     return True
 

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -99,7 +99,7 @@ def setup(hass, config):
     hass.data[DOMAIN]['unique_ids'] = []
 
     def keep_alive_call(event):
-        _LOGGER.info("Calling get user.")
+        """Call the Wink API endpoints to keep PubNub working."""
         pywink.wink_api_fetch()
         pywink.get_user()
     hass.services.register(DOMAIN, 'keep_alive', keep_alive_call)

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -121,14 +121,14 @@ def setup(hass, config):
         _LOGGER.info("Refreshing Wink states from API")
         for entity in hass.data[DOMAIN]['entities']:
             entity.schedule_update_ha_state(True)
-    hass.services.register(DOMAIN, 'Refresh state from Wink', force_update)
+    hass.services.register(DOMAIN, 'Refresh_state_from_Wink', force_update)
 
     def pull_new_devices(call):
         """Pull new devices added to users Wink account since startup."""
         _LOGGER.info("Getting new devices from Wink API.")
         for component in WINK_COMPONENTS:
             discovery.load_platform(hass, component, DOMAIN, {}, config)
-    hass.services.register(DOMAIN, 'Add new devices', pull_new_devices)
+    hass.services.register(DOMAIN, 'Add_new_devices', pull_new_devices)
 
     # Load components for the devices in Wink that we support
     for component in WINK_COMPONENTS:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -650,7 +650,7 @@ python-twitch==1.3.0
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==1.2.3
+python-wink==1.2.4
 
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5


### PR DESCRIPTION
## Description:
Currently some users are having an issue receiving PubNub pushes for their Wink devices. After much trial and error and support from @Shire210 we were able to figure out how to fix the problem. This change passes a new function to pubnubsubhandler to run every hour. This function calls the Wink API endpoint /users/me which makes the Wink backend continue to push changes to PubNub for another 6 hours.

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/ha-stops-reporting-wink-state-changes/5884/550

Waiting for successful tests from some users in the forum before merging.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
