### PR TITLE
Add ping binary sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -162,6 +162,7 @@ omit =
     homeassistant/components/binary_sensor/flic.py
     homeassistant/components/binary_sensor/hikvision.py
     homeassistant/components/binary_sensor/iss.py
+    homeassistant/components/binary_sensor/ping.py
     homeassistant/components/binary_sensor/rest.py
     homeassistant/components/browser.py
     homeassistant/components/camera/amcrest.py

--- a/homeassistant/components/binary_sensor/ping.py
+++ b/homeassistant/components/binary_sensor/ping.py
@@ -115,19 +115,19 @@ class PingData(object):
         pinger = subprocess.Popen(
             self._ping_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         try:
-            out, error = pinger.communicate()
+            out = pinger.communicate()
             match = PING_MATCHER.search(str(out).split('\n')[-1])
-            min, avg, max, mdev = match.groups()
-            return {'min': min, 'avg': avg, 'max': max, 'mdev': mdev}
+            rtt_min, rtt_avg, rtt_max, rtt_mdev = match.groups()
+            return {
+                'min': rtt_min,
+                'avg': rtt_avg,
+                'max': rtt_max,
+                'mdev': rtt_mdev}
         except (subprocess.CalledProcessError, AttributeError):
             return False
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        """Retreive the latest details from the host."""
+        """Retrieve the latest details from the host."""
         self.data = self.ping()
-
-        if self.data:
-            self.available = True
-        else:
-            self.available = False
+        self.available = bool(self.data)

--- a/homeassistant/components/binary_sensor/ping.py
+++ b/homeassistant/components/binary_sensor/ping.py
@@ -1,0 +1,133 @@
+"""
+Tracks the latency of a host by sending ICMP echo requests (ping).
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.ping/
+"""
+import logging
+import subprocess
+import re
+import sys
+from datetime import timedelta
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
+from homeassistant.util import Throttle
+from homeassistant.const import CONF_NAME, CONF_HOST
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_ROUND_TRIP_TIME_AVG = 'round_trip_time_avg'
+ATTR_ROUND_TRIP_TIME_MAX = 'round_trip_time_max'
+ATTR_ROUND_TRIP_TIME_MDEV = 'round_trip_time_mdev'
+ATTR_ROUND_TRIP_TIME_MIN = 'round_trip_time_min'
+
+CONF_PING_COUNT = 'count'
+
+DEFAULT_NAME = 'Ping Binary sensor'
+DEFAULT_PING_COUNT = 5
+DEFAULT_SENSOR_CLASS = 'connectivity'
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
+
+PING_MATCHER = re.compile(
+    r'(?P<min>\d+.\d+)\/(?P<avg>\d+.\d+)\/(?P<max>\d+.\d+)\/(?P<mdev>\d+.\d+)')
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PING_COUNT, default=DEFAULT_PING_COUNT): cv.positive_int,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Ping Binary sensor."""
+    name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
+    count = config.get(CONF_PING_COUNT)
+
+    add_devices([PingBinarySensor(name, PingData(host, count))], True)
+
+
+class PingBinarySensor(BinarySensorDevice):
+    """Representation of a Ping Binary sensor."""
+
+    def __init__(self, name, ping):
+        """Initialize the Ping Binary sensor."""
+        self._name = name
+        self.ping = ping
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def device_class(self):
+        """Return the class of this sensor."""
+        return DEFAULT_SENSOR_CLASS
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self.ping.available
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the ICMP checo request."""
+        if self.ping.data is not False:
+            return {
+                ATTR_ROUND_TRIP_TIME_AVG: self.ping.data['avg'],
+                ATTR_ROUND_TRIP_TIME_MAX: self.ping.data['max'],
+                ATTR_ROUND_TRIP_TIME_MDEV: self.ping.data['mdev'],
+                ATTR_ROUND_TRIP_TIME_MIN: self.ping.data['min'],
+            }
+
+    def update(self):
+        """Get the latest data."""
+        self.ping.update()
+
+
+class PingData(object):
+    """The Class for handling the data retrieval."""
+
+    def __init__(self, host, count):
+        """Initialize the data object."""
+        self._ip_address = host
+        self._count = count
+        self.data = {}
+        self.available = False
+
+        if sys.platform == 'win32':
+            self._ping_cmd = [
+                'ping', '-n', str(self._count), '-w 1000', self._ip_address]
+        else:
+            self._ping_cmd = [
+                'ping', '-n', '-q', '-c', str(self._count), '-W1',
+                self._ip_address]
+
+    def ping(self):
+        """Send ICMP echo request and return details if success."""
+        pinger = subprocess.Popen(
+            self._ping_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        try:
+            out, error = pinger.communicate()
+            match = PING_MATCHER.search(str(out).split('\n')[-1])
+            min, avg, max, mdev = match.groups()
+            return {'min': min, 'avg': avg, 'max': max, 'mdev': mdev}
+        except (subprocess.CalledProcessError, AttributeError):
+            return False
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Retreive the latest details from the host."""
+        self.data = self.ping()
+
+        if self.data:
+            self.available = True
+        else:
+            self.available = False

--- a/homeassistant/components/binary_sensor/ping.py
+++ b/homeassistant/components/binary_sensor/ping.py
@@ -15,7 +15,6 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, PLATFORM_SCHEMA)
-from homeassistant.util import Throttle
 from homeassistant.const import CONF_NAME, CONF_HOST
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,7 +30,7 @@ DEFAULT_NAME = 'Ping Binary sensor'
 DEFAULT_PING_COUNT = 5
 DEFAULT_SENSOR_CLASS = 'connectivity'
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
+SCAN_INTERVAL = timedelta(minutes=5)
 
 PING_MATCHER = re.compile(
     r'(?P<min>\d+.\d+)\/(?P<avg>\d+.\d+)\/(?P<max>\d+.\d+)\/(?P<mdev>\d+.\d+)')
@@ -59,7 +58,6 @@ class PingBinarySensor(BinarySensorDevice):
         """Initialize the Ping Binary sensor."""
         self._name = name
         self.ping = ping
-        self.update()
 
     @property
     def name(self):
@@ -126,7 +124,6 @@ class PingData(object):
         except (subprocess.CalledProcessError, AttributeError):
             return False
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Retrieve the latest details from the host."""
         self.data = self.ping()


### PR DESCRIPTION
## Description:
The `ping` binary sensor can be use to show if a host is online or not (like the [ping device tracker platform](https://home-assistant.io/components/device_tracker.ping/) or the [binary command-line sensor](https://home-assistant.io/components/binary_sensor.command_line/#check-rasplex)) but the focus for this sensor is on the round trip times which are available as attributes.

**Related issue (if applicable):** fixes [15358](https://community.home-assistant.io/t/ping-sensor/15358)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2410

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: ping
    host: 192.168.0.1
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
