### PR TITLE
Utility script to quickly iterate component unit tests.

### DIFF
--- a/script/test-component
+++ b/script/test-component
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# run test suite for a specific platform/component
+
+# usage: script/test-component component_name [pytest argument..]
+# example: script/test-component rflink -k light -x
+
+pyenv=py34
+hass=.tox/$pyenv/bin/hass
+
+if ! test -f requirements_all.txt; then
+    echo "This script needs to run from home-assistant source directory."
+    exit 1
+fi
+
+component=${1:?Please specify component name as first argument}
+shift
+
+# determine if installed dependencies need to be updated, doing it this way allows to shave of
+# a large amount of time on small test runs. Hass binary get's touched during (re)install. This
+# allows testing it against potentially updated requirement files.
+if ! test -f $hass || test $hass -ot requirements_all.txt || test $hass -ot requirements_test.txt;then
+    tox -e $pyenv --notest
+fi
+
+# Compile a list of all valid testfiles. Pytest fails on a file argument that is not found.
+testfiles=($(ls tests/components/"test_$component.py" tests/components/"$component"/test_*.py tests/components/*/"test_$component.py" 2>/dev/null))
+
+# invoke pytest directly in the virtualenv to bypass tox dependency checking
+.tox/$pyenv/bin/py.test "${testfiles[@]}" "$@"

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,10 @@ envlist = py34, py35, py36, lint, requirements, typing
 skip_missing_interpreters = True
 
 [testenv]
+; install using develop/-e mode instead of packaging and installing the source
+; this saves a lot of time when only running a small number of tests
+; http://tox.readthedocs.io/en/latest/config.html#confval-usedevelop=BOOL
+usedevelop = True
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/homeassistant
 ; both temper-python and XBee modules have utf8 in their README files


### PR DESCRIPTION
This change adds a script which will allow running the unit tests for a specific component with as little overhead as possible. This allows for quick iterative test driven component development.

Usage:

    script/test-component component_name [pytest arguments..]

It does this by calling pytest directly in the Tox virtualenv and only running Tox virtualenv dependency update when the requirements files change.

To allow quickest iteration the `usedevelop` option is enabled on the Tox testenv. This should functionally not cause a difference to the current testsuite. Only the Tox setup process is improved by not requiring building and installing the package every time but relying on a package link.

Alternative to `usedevelop` the script could add `--develop` to the Tox invocation, but that causes a Tox recreate every time a switch is made from develop mode to install mode. 

Running DSMR sensor component tests using tox:
```
$ time tox -e py34 -- tests/components/sensor/test_dsmr.py >/dev/null
       14.83 real        11.90 user         2.75 sys
```

Running DSMR sensor tests with `usedevelop`:
```
$ time tox -e py34 --develop -- tests/components/sensor/test_dsmr.py >/dev/null
       12.41 real         9.85 user         1.15 sys
```

Running using test script:
```
$ time script/test-component dsmr >/dev/null
        1.68 real         1.43 user         0.13 sys
```

And for completeness a full Tox environment creation:
```
$ time tox -r -e py34 -- tests/components/sensor/test_dsmr.py >/dev/null
      161.60 real       120.08 user        22.68 sys
```
