### PR TITLE
Constrain chardet to 2.3

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -7,3 +7,4 @@ voluptuous==0.9.3
 typing>=3,<4
 aiohttp==2.0.5
 async_timeout==1.2.0
+chardet==2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -8,6 +8,7 @@ voluptuous==0.9.3
 typing>=3,<4
 aiohttp==2.0.5
 async_timeout==1.2.0
+chardet==2.3
 
 # homeassistant.components.nuimo_controller
 --only-binary=all http://github.com/getSenic/nuimo-linux-python/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip#nuimo==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ REQUIRES = [
     'typing>=3,<4',
     'aiohttp==2.0.5',
     'async_timeout==1.2.0',
+    'chardet==2.3'
 ]
 
 setup(


### PR DESCRIPTION
## Description:
Fix chardet to 2.3.

**Related issue (if applicable):** https://github.com/aio-libs/aiohttp/issues/1810
