### PR TITLE
Speed up aiohttp inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN virtualization/Docker/setup_docker_prereqs
 # Install hass component dependencies
 COPY requirements_all.txt requirements_all.txt
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
-    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop
+    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet
 
 # Copy source
 COPY . .


### PR DESCRIPTION
## Description:
aiohttp will automatically leverage cchardet when available.  This package is significant faster over the default `chardet` dependency.
