### PR TITLE
Upgrade paho-mqtt to 1.2.2

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
     CONF_PASSWORD, CONF_PORT, CONF_PROTOCOL, CONF_PAYLOAD)
 from homeassistant.components.mqtt.server import HBMQTT_CONFIG_SCHEMA
 
-REQUIREMENTS = ['paho-mqtt==1.2.1']
+REQUIREMENTS = ['paho-mqtt==1.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -414,7 +414,7 @@ openhomedevice==0.2.1
 orvibo==1.1.1
 
 # homeassistant.components.mqtt
-paho-mqtt==1.2.1
+paho-mqtt==1.2.2
 
 # homeassistant.components.media_player.panasonic_viera
 panasonic_viera==0.2


### PR DESCRIPTION
1.2.2
=====

- Fix message lost when using paho.mqtt.publish helper with QoS=0 message.

Tested with the following configuration:

``` yaml
mqtt:
  broker: localhost

binary_sensor:
  - platform: mqtt
    name: Bathroom door
    state_topic: "home/bathroom/door"
    payload_on: "1"
    payload_off: "0"
    device_class: opening
```

```bash
$ mosquitto_pub -h localhost -t "home/bathroom/door" -m 1
$ mosquitto_pub -h localhost -t "home/bathroom/door" -m 0

17-04-12 08:37:22 INFO (Thread-9) [homeassistant.components.mqtt] Received message on home/bathroom/door: 1
17-04-12 08:37:22 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: old_state=<state binary_sensor.bathroom_door=off; device_class=opening, friendly_name=Bathroom door @ 2017-04-12T08:35:25.731793+02:00>, new_state=<state binary_sensor.bathroom_door=on; device_class=opening, friendly_name=Bathroom door @ 2017-04-12T08:37:22.914894+02:00>, entity_id=binary_sensor.bathroom_door>
17-04-12 08:37:27 INFO (Thread-9) [homeassistant.components.mqtt] Received message on home/bathroom/door: 0
17-04-12 08:37:27 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: old_state=<state binary_sensor.bathroom_door=on; device_class=opening, friendly_name=Bathroom door @ 2017-04-12T08:37:22.914894+02:00>, new_state=<state binary_sensor.bathroom_door=off; device_class=opening, friendly_name=Bathroom door @ 2017-04-12T08:37:27.542522+02:00>, entity_id=binary_sensor.bathroom_door>
```