### PR TITLE
Fix handling with register callbacks on added_to_hass

### DIFF
--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -77,8 +77,10 @@ class LutronCasetaDevice(Entity):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Register callbacks."""
-        self._smartbridge.add_subscriber(self._device_id,
-                                         self._update_callback)
+        self.hass.async_add_job(
+            self._smartbridge.add_subscriber, self._device_id,
+            self._update_callback
+        )
 
     def _update_callback(self):
         self.schedule_update_ha_state()

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -292,7 +292,7 @@ class SonosDevice(MediaPlayerDevice):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Subscribe sonos events."""
-        self.hass.loop.run_in_executor(None, self._subscribe_to_player_events)
+        self.hass.async_add_job(self._subscribe_to_player_events)
 
     @property
     def should_poll(self):


### PR DESCRIPTION
## Description:

Not asyncio stuff should run with our `async_add_job` inside `added_to_hass`

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
