### PR TITLE
Fix account balance in fido sensor

### DIFF
--- a/homeassistant/components/sensor/fido.py
+++ b/homeassistant/components/sensor/fido.py
@@ -153,7 +153,7 @@ class FidoSensor(Entity):
     def update(self):
         """Get the latest data from Fido and update the state."""
         self.fido_data.update()
-        if self._name == 'balance':
+        if self.type == 'balance':
             if self.fido_data.data.get(self.type) is not None:
                 self._state = round(self.fido_data.data[self.type], 2)
         else:


### PR DESCRIPTION
## Description:

Account balance shows `unknown` because of the special handler of the balance metric.
This patch fix this issue.

## Checklist:

  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
