### PR TITLE
update snapcast media player

### DIFF
--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -165,6 +165,22 @@ shuffle_set:
       description: True/false for enabling/disabling shuffle
       example: true
 
+snapcast_snapshot:
+  description: Take a snapshot of the media player.
+
+  fields:
+    entity_id:
+      description: Name(s) of entites that will be snapshotted. Platform dependent.
+      example: 'media_player.living_room'
+
+snapcast_restore:
+  description: Restore a snapshot of the media player.
+
+  fields:
+    entity_id:
+      description: Name(s) of entites that will be restored. Platform dependent.
+      example: 'media_player.living_room'
+
 sonos_join:
   description: Group player together.
 

--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -13,10 +13,7 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import (
     SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, SUPPORT_SELECT_SOURCE,
-    SERVICE_VOLUME_MUTE, SERVICE_SELECT_SOURCE, SERVICE_VOLUME_SET,
-    PLATFORM_SCHEMA, ATTR_INPUT_SOURCE, ATTR_MEDIA_VOLUME_LEVEL,
-    ATTR_MEDIA_VOLUME_MUTED, DOMAIN as MEDIA_PLAYER_DOMAIN,
-    MediaPlayerDevice)
+    PLATFORM_SCHEMA, MediaPlayerDevice)
 from homeassistant.const import (
     STATE_ON, STATE_OFF, STATE_IDLE, STATE_PLAYING, STATE_UNKNOWN, CONF_HOST,
     CONF_PORT, ATTR_ENTITY_ID)
@@ -65,7 +62,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         """Handle services."""
         entity_ids = service.data.get(ATTR_ENTITY_ID)
         devices = [device for device in hass.data[DOMAIN]
-                if device.entity_id in entity_ids]
+                   if device.entity_id in entity_ids]
         for device in devices:
             if service.service == SERVICE_SNAPSHOT:
                 device.snapshot()
@@ -254,4 +251,3 @@ class SnapcastClientDevice(MediaPlayerDevice):
     def async_restore(self):
         """Restore the client state."""
         yield from self._client.restore()
-        #yield from self.async_update_ha_state()

--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -159,19 +159,19 @@ class SnapcastGroupDevice(MediaPlayerDevice):
         streams = self._group.streams_by_name()
         if source in streams:
             yield from self._group.set_stream(streams[source].identifier)
-        yield from self.async_update_ha_state()
+            self.hass.async_add_job(self.async_update_ha_state())
 
     @asyncio.coroutine
     def async_mute_volume(self, mute):
         """Send the mute command."""
         yield from self._group.set_muted(mute)
-        yield from self.async_update_ha_state()
+        self.hass.async_add_job(self.async_update_ha_state())
 
     @asyncio.coroutine
     def async_set_volume_level(self, volume):
         """Set the volume level."""
         yield from self._group.set_volume(round(volume * 100))
-        yield from self.async_update_ha_state()
+        self.hass.async_add_job(self.async_update_ha_state())
 
     def snapshot(self):
         """Snapshot the group state."""
@@ -235,13 +235,13 @@ class SnapcastClientDevice(MediaPlayerDevice):
     def async_mute_volume(self, mute):
         """Send the mute command."""
         yield from self._client.set_muted(mute)
-        yield from self.async_update_ha_state()
+        self.hass.async_add_job(self.async_update_ha_state())
 
     @asyncio.coroutine
     def async_set_volume_level(self, volume):
         """Set the volume level."""
         yield from self._client.set_volume(round(volume * 100))
-        yield from self.async_update_ha_state()
+        self.hass.async_add_job(self.async_update_ha_state())
 
     def snapshot(self):
         """Snapshot the client state."""

--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config import load_yaml_config_file
 
-REQUIREMENTS = ['snapcast==2.0.0']
+REQUIREMENTS = ['snapcast==2.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -74,8 +74,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
 def async_register_services(hass):
     """Register all services for Snapcast devices."""
-
     def _snapshot_service(service):
+        """Snapshot current entity state."""
         entity_ids = service.data[ATTR_ENTITY_ID]
         for entity_id in entity_ids:
             if not hass.states.get(entity_id):
@@ -91,6 +91,7 @@ def async_register_services(hass):
             }
 
     def _restore_service(service):
+        """Restore snapshotted entity state."""
         entity_ids = service.data.get(ATTR_ENTITY_ID)
         for entity_id in entity_ids:
             if entity_id not in hass.data[DOMAIN]:

--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -209,6 +209,16 @@ class SnapcastGroupDevice(MediaPlayerDevice):
         yield from self._group.set_volume(round(volume * 100))
         yield from self.async_update_ha_state()
 
+    def snapshot(self):
+        """Snapshot the group state."""
+        self._group.snapshot()
+
+    @asyncio.coroutine
+    def async_restore(self):
+        """Restore the group state."""
+        yield from self._group.restore()
+        yield from self.async_update_ha_state()
+
 
 class SnapcastClientDevice(MediaPlayerDevice):
     """Representation of a Snapcast client device."""
@@ -268,4 +278,14 @@ class SnapcastClientDevice(MediaPlayerDevice):
     def async_set_volume_level(self, volume):
         """Set the volume level."""
         yield from self._client.set_volume(round(volume * 100))
+        yield from self.async_update_ha_state()
+
+    def snapshot(self):
+        """Snapshot the client state."""
+        self._client.snapshot()
+
+    @asyncio.coroutine
+    def async_restore(self):
+        """Restore the client state."""
+        yield from self._client.restore()
         yield from self.async_update_ha_state()

--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config import load_yaml_config_file
 
-REQUIREMENTS = ['snapcast==2.0.5']
+REQUIREMENTS = ['snapcast==2.0.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -38,6 +38,7 @@ SUPPORT_SNAPCAST_GROUP = SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET |\
 
 GROUP_PREFIX = 'snapcast_group_'
 GROUP_SUFFIX = 'Snapcast Group'
+CLIENT_PREFIX = 'snapcast_client_'
 CLIENT_SUFFIX = 'Snapcast Client'
 
 SERVICE_SCHEMA = vol.Schema({
@@ -220,7 +221,7 @@ class SnapcastClientDevice(MediaPlayerDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        return '{} {}'.format(self._client.friendly_name, CLIENT_SUFFIX)
+        return '{}{}'.format(CLIENT_PREFIX, self._client.identifier)
 
     @property
     def volume_level(self):
@@ -243,6 +244,14 @@ class SnapcastClientDevice(MediaPlayerDevice):
         if self._client.connected:
             return STATE_ON
         return STATE_OFF
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        name = '{} {}'.format(self._client.friendly_name, CLIENT_SUFFIX)
+        return {
+            'friendly_name': name
+        }
 
     @property
     def should_poll(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -781,7 +781,7 @@ sleepyq==0.6
 # smbus-cffi==0.5.1
 
 # homeassistant.components.media_player.snapcast
-snapcast==2.0.0
+snapcast==2.0.1
 
 # homeassistant.components.climate.honeywell
 somecomfort==0.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -781,7 +781,7 @@ sleepyq==0.6
 # smbus-cffi==0.5.1
 
 # homeassistant.components.media_player.snapcast
-snapcast==2.0.5
+snapcast==2.0.6
 
 # homeassistant.components.climate.honeywell
 somecomfort==0.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -781,7 +781,7 @@ sleepyq==0.6
 # smbus-cffi==0.5.1
 
 # homeassistant.components.media_player.snapcast
-snapcast==1.2.2
+snapcast==2.0.0
 
 # homeassistant.components.climate.honeywell
 somecomfort==0.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -781,7 +781,7 @@ sleepyq==0.6
 # smbus-cffi==0.5.1
 
 # homeassistant.components.media_player.snapcast
-snapcast==2.0.2
+snapcast==2.0.5
 
 # homeassistant.components.climate.honeywell
 somecomfort==0.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -781,7 +781,7 @@ sleepyq==0.6
 # smbus-cffi==0.5.1
 
 # homeassistant.components.media_player.snapcast
-snapcast==2.0.1
+snapcast==2.0.2
 
 # homeassistant.components.climate.honeywell
 somecomfort==0.4.1


### PR DESCRIPTION
## Description:
Update the `snapcast` media player to support the latest version of Snapcast, `0.11.1`, which contained a breaking API change. This component will no longer support versions lower than `0.11.1`.

Other changes:
- Asynchronous (faster!)
- Fixes naming issue
- Two classes of Snapcast `media_player`s: Groups and Clients. Clients control individual client volume, groups control input source (stream). This is a breaking change to configurations that rely on entity ids, in some cases.
- Adds two services, `snapcast_snapshot` and `snapcast_restore`, to save and restore state of client(s) and group(s). Useful for interrupting playing music with TTS.

I'd prefer some folks test this and confirm it works before merge.

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/issues/7054, https://github.com/home-assistant/home-assistant/issues/4533

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: snapcast
    host: 'localhost'
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
