### PR TITLE
Add support of input registers while querying modbus sensor.

### DIFF
--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -158,6 +158,15 @@ class ModbusHub(object):
                 count,
                 **kwargs)
 
+    def read_input_registers(self, unit, address, count):
+        """Read input registers."""
+        with self._lock:
+            kwargs = {'unit': unit} if unit else {}
+            return self._client.read_input_registers(
+                address,
+                count,
+                **kwargs)
+
     def read_holding_registers(self, unit, address, count):
         """Read holding registers."""
         with self._lock:


### PR DESCRIPTION
## Description:
Add support of modbus input registers query. For now modbus sensor support only holding register, but many devices working can provide data only from input registers. So this PR add support of modbus input registers, and also can process returned value in 32 bit IEEE 754 floating point format. 

Added attributes register_type and data_type.

**Related issue (if applicable):**

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2423

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: modbus
    registers:
      - name: Voltage
        unit_of_measurement: V
        slave: 1
        register: 0
        count: 2
        data_type: float
        register_type: input
      - name: Current
        unit_of_measurement: I
        slave: 1
        register: 6
        count: 2
        data_type: float
        register_type: input
        precision: 2
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
