### PR TITLE
Bump qnapstats library version to 0.2.4

### DIFF
--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 
 import voluptuous as vol
 
-REQUIREMENTS = ['qnapstats==0.2.3']
+REQUIREMENTS = ['qnapstats==0.2.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -666,7 +666,7 @@ pywemo==0.4.16
 pyzabbix==0.7.4
 
 # homeassistant.components.sensor.qnap
-qnapstats==0.2.3
+qnapstats==0.2.4
 
 # homeassistant.components.climate.radiotherm
 radiotherm==1.2


### PR DESCRIPTION
## Description:

This bumps the version of qnapstats from 0.2.3 to 0.2.4.  The newer version fixes compatibility issues for QNAP NAS devices which only have a single drive.

Ideally this should be included in the next minor (or major) release.  Let me know if I should target this PR for `dev` instead of `master`.