### PR TITLE
Better thread safety in zwave node_entity

### DIFF
--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -110,16 +110,15 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
 
     def node_changed(self):
         """Update node properties."""
+        attributes = {}
         stats = self.get_node_statistics()
         for attr in ATTRIBUTES:
             value = getattr(self.node, attr)
             if attr in _REQUIRED_ATTRIBUTES or value:
-                self._attributes[attr] = value
-            else:
-                self._attributes.pop(attr, None)
+                attributes[attr] = value
 
         for attr in _COMM_ATTRIBUTES:
-            self._attributes[attr] = stats[attr]
+            attributes[attr] = stats[attr]
 
         if self.node.can_wake_up():
             for value in self.node.get_values(COMMAND_CLASS_WAKE_UP).values():
@@ -129,6 +128,7 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
             self.wakeup_interval = None
 
         self.battery_level = self.node.get_battery_level()
+        self._attributes = attributes
 
         self.maybe_schedule_update()
 

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -110,13 +110,14 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
 
     def node_changed(self):
         """Update node properties."""
-        self._attributes = {}
         stats = self.get_node_statistics()
-
         for attr in ATTRIBUTES:
             value = getattr(self.node, attr)
             if attr in _REQUIRED_ATTRIBUTES or value:
                 self._attributes[attr] = value
+            else:
+                self._attributes.pop(attr, None)
+
         for attr in _COMM_ATTRIBUTES:
             self._attributes[attr] = stats[attr]
 


### PR DESCRIPTION
## Description:

Better thread safety in zwave node_entity.

Setting `self._attributes = {}` in ozw thread can cause `KeyError` while fetching state.

Fixes #6819 

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
