### PR TITLE
No product ids configured should fetch all ids

### DIFF
--- a/homeassistant/components/sensor/uber.py
+++ b/homeassistant/components/sensor/uber.py
@@ -35,7 +35,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_START_LONGITUDE): cv.longitude,
     vol.Optional(CONF_END_LATITUDE): cv.latitude,
     vol.Optional(CONF_END_LONGITUDE): cv.longitude,
-    vol.Optional(CONF_PRODUCT_IDS, default=[]):
+    vol.Optional(CONF_PRODUCT_IDS):
         vol.All(cv.ensure_list, [cv.string]),
 })
 


### PR DESCRIPTION
## Description:
It looks like this feature was broken in the voluptuous migration. #3181