### PR TITLE
Mqtt camera

### DIFF
--- a/homeassistant/components/camera/mqtt.py
+++ b/homeassistant/components/camera/mqtt.py
@@ -1,0 +1,68 @@
+"""
+Camera that loads a picture from a MQTT topic.
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/camera.mqtt/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+import homeassistant.components.mqtt as mqtt
+from homeassistant.const import CONF_NAME
+from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
+from homeassistant.helpers import config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_TOPIC = 'topic'
+
+DEFAULT_NAME = 'MQTT Camera'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Camera."""
+    topic = config[CONF_TOPIC]
+
+    add_devices([MqttCamera(config[CONF_NAME], topic)])
+
+
+class MqttCamera(Camera):
+    """MQTT camera."""
+
+    def __init__(self, name, topic):
+        """Initialize Local File Camera component."""
+        super().__init__()
+
+        self._name = name
+        self._topic = topic
+        self._qos = 0
+        self._last_image = None
+
+    def camera_image(self):
+        """Return image response."""
+        return self._last_image
+
+    @property
+    def name(self):
+        """Return the name of this camera."""
+        return self._name
+
+    def async_added_to_hass(self):
+        """Subscribe mqtt events.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        @callback
+        def message_received(topic, payload, qos):
+            """A new MQTT message has been received."""
+            self._last_image = payload
+
+        return mqtt.async_subscribe(
+            self.hass, self._topic, message_received, self._qos, None)

--- a/homeassistant/components/camera/mqtt.py
+++ b/homeassistant/components/camera/mqtt.py
@@ -21,6 +21,8 @@ CONF_TOPIC = 'topic'
 
 DEFAULT_NAME = 'MQTT Camera'
 
+DEPENDENCIES = ['mqtt']
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string

--- a/homeassistant/components/camera/mqtt.py
+++ b/homeassistant/components/camera/mqtt.py
@@ -5,8 +5,8 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/camera.mqtt/
 """
 
-import logging
 import asyncio
+import logging
 
 import voluptuous as vol
 
@@ -30,11 +30,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup the Camera."""
     topic = config[CONF_TOPIC]
 
-    add_devices([MqttCamera(config[CONF_NAME], topic)])
+    async_add_devices([MqttCamera(config[CONF_NAME], topic)])
 
 
 class MqttCamera(Camera):

--- a/homeassistant/components/camera/mqtt.py
+++ b/homeassistant/components/camera/mqtt.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/camera.mqtt/
 """
 
 import logging
+import asyncio
 
 import voluptuous as vol
 
@@ -48,7 +49,8 @@ class MqttCamera(Camera):
         self._qos = 0
         self._last_image = None
 
-    def camera_image(self):
+    @asyncio.coroutine
+    def async_camera_image(self):
         """Return image response."""
         return self._last_image
 

--- a/homeassistant/components/camera/mqtt.py
+++ b/homeassistant/components/camera/mqtt.py
@@ -1,9 +1,10 @@
 """
-Camera that loads a picture from a MQTT topic.
+Camera that loads a picture from an MQTT topic.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/camera.mqtt/
 """
-import asyncio
+
 import logging
 
 import voluptuous as vol

--- a/tests/components/camera/test_mqtt.py
+++ b/tests/components/camera/test_mqtt.py
@@ -2,7 +2,6 @@
 import asyncio
 
 from homeassistant.setup import async_setup_component
-from tests.common import fire_mqtt_message
 import homeassistant.components.mqtt as mqtt
 
 

--- a/tests/components/camera/test_mqtt.py
+++ b/tests/components/camera/test_mqtt.py
@@ -1,0 +1,29 @@
+"""The tests for mqtt camera component."""
+import asyncio
+
+from homeassistant.setup import async_setup_component
+from tests.common import fire_mqtt_message
+import homeassistant.components.mqtt as mqtt
+
+
+@asyncio.coroutine
+def test_run_camera_setup(hass, test_client):
+    """Test that it fetches the given dispatcher data."""
+    topic = 'test/camera'
+    yield from async_setup_component(hass, 'camera', {
+        'camera': {
+            'platform': 'mqtt',
+            'topic': topic,
+            'name': 'Test Camera',
+        }})
+
+    client = yield from test_client(hass.http.app)
+
+    mqtt.publish(hass, topic, 0xFFD8FF)
+    yield from hass.async_block_till_done()
+
+    resp = yield from client.get('/api/camera_proxy/camera.test_camera')
+
+    assert resp.status == 200
+    body = yield from resp.text()
+    assert body == '16767231'


### PR DESCRIPTION
## Description:
A camera component that loads the binary content of an image file from an MQTT topic.
Background: to be able to get images from [Zanzito](https://play.google.com/store/apps/details?id=it.barbaro.zanzito) or any other app/service capable of sending images as binary payloads.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2425

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: mqtt
    topic: zanzito/shared_pictures/My-Device
    name: Zanzito My Device Camera
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
