### PR TITLE
Break Z-Wave product name up into manufacturer name and product name

### DIFF
--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -16,6 +16,7 @@ ATTR_AWAKE = 'is_awake'
 ATTR_READY = 'is_ready'
 ATTR_FAILED = 'is_failed'
 ATTR_PRODUCT_NAME = 'product_name'
+ATTR_MANUFACTURER_NAME = 'manufacturer_name'
 
 STAGE_COMPLETE = 'Complete'
 
@@ -80,8 +81,8 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
         self.node = node
         self.node_id = self.node.node_id
         self._name = node_name(self.node)
-        self._product_name = '{} {}'.format(
-            node.manufacturer_name, node.product_name)
+        self._product_name = node.product_name
+        self._manufacturer_name = node.manufacturer_name
         self.entity_id = "{}.{}_{}".format(
             DOMAIN, slugify(self._name), self.node_id)
         self._attributes = {}
@@ -164,6 +165,7 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
         """Return the device specific state attributes."""
         attrs = {
             ATTR_NODE_ID: self.node_id,
+            ATTR_MANUFACTURER_NAME: self._manufacturer_name,
             ATTR_PRODUCT_NAME: self._product_name,
         }
         attrs.update(self._attributes)

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -83,7 +83,8 @@ class TestZWaveNodeEntity(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(
             {'node_id': self.node.node_id,
-             'product_name': 'Test Manufacturer Test Product'},
+             'manufacturer_name': 'Test Manufacturer',
+             'product_name': 'Test Product'},
             self.entity.device_state_attributes)
 
         self.node.get_values.return_value = {
@@ -139,7 +140,8 @@ class TestZWaveNodeEntity(unittest.TestCase):
         self.entity.node_changed()
         self.assertEqual(
             {'node_id': self.node.node_id,
-             'product_name': 'Test Manufacturer Test Product',
+             'manufacturer_name': 'Test Manufacturer',
+             'product_name': 'Test Product',
              'query_stage': 'Dynamic',
              'is_awake': True,
              'is_ready': False,


### PR DESCRIPTION
## Description:

This breaks the original `product_name` field into two fields: `manufacturer_name` and `product_name`. Why is this useful? Mostly for external integrations, such as homebridge-homeassistant and haaska, both of which require display of manufacturer and product names to meet their respective specifications. Right now we provide incorrect values for these fields.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
