### PR TITLE
Send stderr of ping tracker to devnull

### DIFF
--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -45,7 +45,9 @@ class Host(object):
 
     def ping(self):
         """Send an ICMP echo request and return True if success."""
-        pinger = subprocess.Popen(self._ping_cmd, stdout=subprocess.PIPE)
+        pinger = subprocess.Popen(self._ping_cmd,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.DEVNULL)
         try:
             pinger.communicate()
             return pinger.returncode == 0


### PR DESCRIPTION
## Description:

When pinging an inaccessible device, OS errors like

    ping: sendto: No route to host

can occur. For a ping tracker this is not an error but rather a normal
situation. Thus, it makes sense to hide the error.

(Experienced on macOS)

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: ping
    hosts:
      laptop: 10.10.10.10
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
