### PR TITLE
Upgrade aiohttp to 2.0.7

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,6 +5,6 @@ pip>=7.1.0
 jinja2>=2.9.5
 voluptuous==0.9.3
 typing>=3,<4
-aiohttp==2.0.5
+aiohttp==2.0.7
 async_timeout==1.2.0
 chardet==2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ pip>=7.1.0
 jinja2>=2.9.5
 voluptuous==0.9.3
 typing>=3,<4
-aiohttp==2.0.5
+aiohttp==2.0.7
 async_timeout==1.2.0
 chardet==2.3
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     'jinja2>=2.9.5',
     'voluptuous==0.9.3',
     'typing>=3,<4',
-    'aiohttp==2.0.5',
+    'aiohttp==2.0.7',
     'async_timeout==1.2.0',
     'chardet==2.3'
 ]


### PR DESCRIPTION
# 2.0.7
- Fix *pypi* distribution
- Fix exception description
- Handle socket error in FileResponse
- Cancel websocket heartbeat on close

Tested with: 
```yaml
http:
```