### PR TITLE
Upgrade voluptuous to 0.10.5

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -450,10 +450,9 @@ def _identify_config_schema(module):
     except (AttributeError, KeyError):
         return (None, None)
     t_schema = str(schema)
-    if (t_schema.startswith('<function ordered_dict') or
-            t_schema.startswith('<Schema({<function slug')):
+    if t_schema.startswith(('{', '<function ordered_dict')):
         return ('dict', schema)
-    if t_schema.startswith('All(<function ensure_list'):
+    if t_schema.startswith(('[', 'All(<function ensure_list')):
         return ('list', schema)
     return '', schema
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -3,7 +3,7 @@ pyyaml>=3.11,<4
 pytz>=2017.02
 pip>=7.1.0
 jinja2>=2.9.5
-voluptuous==0.9.3
+voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.0.5
 async_timeout==1.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,7 +4,7 @@ pyyaml>=3.11,<4
 pytz>=2017.02
 pip>=7.1.0
 jinja2>=2.9.5
-voluptuous==0.9.3
+voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.0.5
 async_timeout==1.2.0

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ REQUIRES = [
     'pytz>=2017.02',
     'pip>=7.1.0',
     'jinja2>=2.9.5',
-    'voluptuous==0.9.3',
+    'voluptuous==0.10.5',
     'typing>=3,<4',
     'aiohttp==2.0.5',
     'async_timeout==1.2.0',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -509,7 +509,7 @@ def test_merge_once_only(merge_log_err):
         'mqtt': {}, 'api': {}
     }
     config_util.merge_packages_config(config, packages)
-    assert merge_log_err.call_count == 2
+    assert merge_log_err.call_count == 1
     assert len(config) == 3
 
 
@@ -521,7 +521,7 @@ def test_merge_id_schema(hass):
         'script': 'dict',
         'input_boolean': 'dict',
         'shell_command': 'dict',
-        'qwikswitch': '',
+        'qwikswitch': 'dict',
     }
     for name, expected_type in types.items():
         module = config_util.get_component(name)


### PR DESCRIPTION
## 0.10.5

- Unicode translation to python 2 issue fixed.
## 0.10.2

Changes:

- Range raises RangeInvalid when testing math.nan.
- {} and [] now always evaluate as is, instead of as any dict or any list. To specify a free-form list, use list instead of []. To specify a free-form dict, use dict instead of Schema({}, extra=ALLOW_EXTRA).
- Change the encoding of keys in error messages from Unicode to UTF-8.

New:

- Add argument validation decorator.
- Add Unordered.
- Add Equal.
- Add Number.
- Add Schema equality check.
- Add coveralls.
- Improve Marker management in Schema.
- Add Maybe.
- Add Date.
-  Add script for updating gh-pages.
- Add support for OrderedDict validation.
- Add Contains.

Fixes:

- ExactSequence checks sequences are the same length.
- Empty lists are evaluated as is.
- Filepath validators correctly handle None.
- Handle non-subscriptable types in humanize_error.
- Validate namedtuple as a tuple.
- Update docstring.
- Update documentation.
- Fix a performance issue of exponential complexity where all of the dict keys were matched against all keys in the schema. This resulted in O(n*m) complexity where n is the number of keys in the dict being validated and m is the number of keys in the schema. The fix ensures that each key in the dict is matched against the relevant schema keys only. It now works in O(n).
- Remove setuptools as a dependency.

