### PR TITLE
Fix LIFX lights with disappearing names

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -129,6 +129,7 @@ class LIFXLight(Light):
         self.updated_event = asyncio.Event()
         self.blocker = None
         self.postponed_update = None
+        self._name = device.label
         self._available = True
         self.set_power(device.power_level)
         self.set_color(*device.color)
@@ -146,7 +147,7 @@ class LIFXLight(Light):
     @property
     def name(self):
         """Return the name of the device."""
-        return self.device.label
+        return self._name
 
     @property
     def ipaddr(self):
@@ -282,6 +283,7 @@ class LIFXLight(Light):
         """Callback that gets current power/color status."""
         self.set_power(device.power_level)
         self.set_color(*device.color)
+        self._name = device.label
         self.updated_event.set()
 
     @asyncio.coroutine

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -82,7 +82,6 @@ class LIFXManager(object):
         """Callback for newly detected bulb."""
         if device.mac_addr in self.entities:
             entity = self.entities[device.mac_addr]
-            entity.available = True
             entity.device = device
             _LOGGER.debug("%s register AGAIN", entity.who)
             self.hass.async_add_job(entity.async_update_ha_state())
@@ -104,7 +103,7 @@ class LIFXManager(object):
         if device.mac_addr in self.entities:
             entity = self.entities[device.mac_addr]
             _LOGGER.debug("%s unregister", entity.who)
-            entity.available = False
+            entity.device = None
             entity.updated_event.set()
             self.hass.async_add_job(entity.async_update_ha_state())
 
@@ -130,19 +129,13 @@ class LIFXLight(Light):
         self.blocker = None
         self.postponed_update = None
         self._name = device.label
-        self._available = True
         self.set_power(device.power_level)
         self.set_color(*device.color)
 
     @property
     def available(self):
         """Return the availability of the device."""
-        return self._available
-
-    @available.setter
-    def available(self, value):
-        """Set the availability of the device."""
-        self._available = value
+        return self.device is not None
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:

This fixes a recent issue where the friendly light name was momentarily forgotten when a light was turned on at the wall switch.

The fix allows a little cleanup by getting rid of the separate `_available` variable and its weird setter method.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
