### PR TITLE
Add vera power meter.

### DIFF
--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -51,11 +51,7 @@ class VeraSensor(VeraDevice, Entity):
         elif self.vera_device.category == "Humidity Sensor":
             return '%'
         elif self.vera_device.category == "Power meter":
-            power = convert(self.vera_device.power, float, 0)
-            if power >= 1000.0:
-                return 'kW'
-            else:
-                return 'watts'
+            return 'watts'
 
     def update(self):
         """Update the state."""
@@ -76,10 +72,7 @@ class VeraSensor(VeraDevice, Entity):
             self.current_value = self.vera_device.humidity
         elif self.vera_device.category == "Power meter":
             power = convert(self.vera_device.power, float, 0)
-            if power >= 1000.0:
-                self.current_value = round(power / 1000.0, 2)
-            else:
-                self.current_value = round(power, 0)
+            self.current_value = int(round(power, 0))
         elif self.vera_device.category == "Sensor":
             tripped = self.vera_device.is_tripped
             self.current_value = 'Tripped' if tripped else 'Not Tripped'

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     TEMP_CELSIUS, TEMP_FAHRENHEIT)
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
+from homeassistant.util import convert
 from homeassistant.components.vera import (
     VERA_CONTROLLER, VERA_DEVICES, VeraDevice)
 
@@ -49,6 +50,12 @@ class VeraSensor(VeraDevice, Entity):
             return 'lux'
         elif self.vera_device.category == "Humidity Sensor":
             return '%'
+        elif self.vera_device.category == "Power meter":
+            power = convert(self.vera_device.power, float, 0)
+            if power >= 1000.0:
+                return 'kW'
+            else:
+                return 'watts'
 
     def update(self):
         """Update the state."""
@@ -67,6 +74,12 @@ class VeraSensor(VeraDevice, Entity):
             self.current_value = self.vera_device.light
         elif self.vera_device.category == "Humidity Sensor":
             self.current_value = self.vera_device.humidity
+        elif self.vera_device.category == "Power meter":
+            power = convert(self.vera_device.power, float, 0)
+            if power >= 1000.0:
+                self.current_value = round(power / 1000.0, 2)
+            else:
+                self.current_value = round(power, 0)
         elif self.vera_device.category == "Sensor":
             tripped = self.vera_device.is_tripped
             self.current_value = 'Tripped' if tripped else 'Not Tripped'

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyvera==0.2.25']
+REQUIREMENTS = ['pyvera==0.2.26']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,6 +35,7 @@ CONF_LIGHTS = 'lights'
 VERA_ID_FORMAT = '{}_{}'
 
 ATTR_CURRENT_POWER_W = "current_power_w"
+ATTR_CURRENT_ENERGY_KWH = "current_energy_kwh"
 
 VERA_DEVICES = defaultdict(list)
 
@@ -180,6 +181,10 @@ class VeraDevice(Entity):
         power = self.vera_device.power
         if power:
             attr[ATTR_CURRENT_POWER_W] = convert(power, float, 0.0)
+
+        energy = self.vera_device.energy
+        if energy:
+            attr[ATTR_CURRENT_ENERGY_KWH] = convert(energy, float, 0.0)
 
         attr['Vera Device Id'] = self.vera_device.vera_device_id
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -665,7 +665,7 @@ pyunifi==2.0
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.2.25
+pyvera==0.2.26
 
 # homeassistant.components.notify.html5
 pywebpush==0.6.1


### PR DESCRIPTION
## Description:
Adds a vera power meter as a sensor - with watts as the state - and kwh as an additional attribute.

I don't have one of these - so @danodemano Could you test?

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
