### PR TITLE
Add subscription update for Wemo switches, fix bug in Insight switches, fix wemo motion bug, fix wemo discovery

### DIFF
--- a/homeassistant/components/binary_sensor/wemo.py
+++ b/homeassistant/components/binary_sensor/wemo.py
@@ -40,12 +40,14 @@ class WemoBinarySensor(BinarySensorDevice):
         wemo.SUBSCRIPTION_REGISTRY.register(self.wemo)
         wemo.SUBSCRIPTION_REGISTRY.on(self.wemo, None, self._update_callback)
 
-    def _update_callback(self, _device, _params):
-        """Called by the wemo device callback to update state."""
+    def _update_callback(self, _device, _type, _params):
+        """Called by the Wemo device callback to update state."""
         _LOGGER.info(
             'Subscription update for  %s',
             _device)
-        self.update()
+        updated = self.wemo.subscription_update(_type, _params)
+        self._update(force_update=(not updated))
+
         if not hasattr(self, 'hass'):
             return
         self.schedule_update_ha_state()
@@ -72,7 +74,11 @@ class WemoBinarySensor(BinarySensorDevice):
 
     def update(self):
         """Update WeMo state."""
+        self._update(force_update=True)
+
+    def _update(self, force_update=True):
         try:
-            self._state = self.wemo.get_state(True)
-        except AttributeError:
-            _LOGGER.warning('Could not update status for %s', self.name)
+            self._state = self.wemo.get_state(force_update)
+        except AttributeError as err:
+            _LOGGER.warning('Could not update status for %s (%s)',
+                            self.name, err)

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import config_validation as cv
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.4.17']
+REQUIREMENTS = ['pywemo==0.4.18']
 
 DOMAIN = 'wemo'
 

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -61,9 +61,8 @@ def setup(hass, config):
 
     def discovery_dispatch(service, discovery_info):
         """Dispatcher for WeMo discovery events."""
-        # name, model, location, mac
-        model_name = discovery_info.get('model_name')
-        serial = discovery_info.get('serial')
+        model_name = discovery_info[1]
+        serial = discovery_info[3]
 
         # Only register a device once
         if serial in KNOWN_DEVICES:

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -61,8 +61,9 @@ def setup(hass, config):
 
     def discovery_dispatch(service, discovery_info):
         """Dispatcher for WeMo discovery events."""
-        model_name = discovery_info[1]
-        serial = discovery_info[3]
+        # name, model, location, mac
+        model_name = discovery_info.get('model_name')
+        serial = discovery_info.get('serial')
 
         # Only register a device once
         if serial in KNOWN_DEVICES:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -671,7 +671,7 @@ pyvera==0.2.25
 pywebpush==0.6.1
 
 # homeassistant.components.wemo
-pywemo==0.4.17
+pywemo==0.4.18
 
 # homeassistant.components.zabbix
 pyzabbix==0.7.4


### PR DESCRIPTION
## Description:
This PR mainly bumps the pywemo version - which adds subscription_updates for Switch devices (so that the library doesn't call for state info when a switch status is changed). However it also fixes a bug with the Insight Switch subscription update which didn't correctly update when wemo insight switches were turned off.

When doing this I found a problem that the base wemo component which looks not to have been updated with a discovery change. So fixed that too.

Also adds a fix for a problem with Wemo Motion introduced in the last update.

**Related issue (if applicable):** fixes #7056 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
