### PR TITLE
Revert "Upgrade pytz to 2017.02 (#6875)"

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,6 +1,6 @@
 requests>=2,<3
 pyyaml>=3.11,<4
-pytz>=2017.02
+pytz>=2016.10
 pip>=7.1.0
 jinja2>=2.9.5
 voluptuous==0.9.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,7 +1,7 @@
 # Home Assistant core
 requests>=2,<3
 pyyaml>=3.11,<4
-pytz>=2017.02
+pytz>=2016.10
 pip>=7.1.0
 jinja2>=2.9.5
 voluptuous==0.9.3

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 REQUIRES = [
     'requests>=2,<3',
     'pyyaml>=3.11,<4',
-    'pytz>=2017.02',
+    'pytz>=2016.10',
     'pip>=7.1.0',
     'jinja2>=2.9.5',
     'voluptuous==0.9.3',


### PR DESCRIPTION
`pip` seems to require the previous version of `pytz`. Should fix https://github.com/home-assistant/home-assistant/issues/7001#issuecomment-294358932.

/cc #6875 @fabaff 