### PR TITLE
Value of 0 should not be considered `unknown`.

### DIFF
--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -207,7 +207,7 @@ class DSMREntity(Entity):
         if self._obis == obis.ELECTRICITY_ACTIVE_TARIFF:
             return self.translate_tariff(value)
         else:
-            if value:
+            if value is not None:
                 return value
             else:
                 return STATE_UNKNOWN

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -153,9 +153,14 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                 yield from protocol.wait_closed()
 
             if hass.state != CoreState.stopping:
+                # unexpected disconnect
                 if transport:
                     # remove listerer
                     stop_listerer()
+
+                # reflect disconnect state in devices state by setting an
+                # empty telegram resulting in `unkown` states
+                update_entities_telegram({})
 
                 # throttle reconnect attempts
                 yield from asyncio.sleep(config[CONF_RECONNECT_INTERVAL],

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -199,5 +199,5 @@ def test_reconnect(hass, monkeypatch, mock_connection_factory):
     # wait for sleep to resolve
     yield from hass.async_block_till_done()
 
-    assert connection_factory.call_count == 2, \
+    assert connection_factory.call_count >= 2, \
         'connecting not retried'

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -56,7 +56,7 @@ def test_default_setup(hass, mock_connection_factory):
 
     telegram = {
         CURRENT_ELECTRICITY_USAGE: CosemObject([
-            {'value': Decimal('0.1'), 'unit': 'kWh'}
+            {'value': Decimal('0.0'), 'unit': 'kWh'}
         ]),
         ELECTRICITY_ACTIVE_TARIFF: CosemObject([
             {'value': '0001', 'unit': ''}
@@ -82,7 +82,7 @@ def test_default_setup(hass, mock_connection_factory):
 
     # ensure entities have new state value after incoming telegram
     power_consumption = hass.states.get('sensor.power_consumption')
-    assert power_consumption.state == '0.1'
+    assert power_consumption.state == '0.0'
     assert power_consumption.attributes.get('unit_of_measurement') is 'kWh'
 
     # tariff should be translated in human readable and have no unit


### PR DESCRIPTION
## Description: 
Fix bug where a value of zero would result in a state of `unknown`.

Also make sure unknown state due to disconnection is properly reflected.