### PR TITLE
Replace rollershutter with cover in demo

### DIFF
--- a/homeassistant/components/demo.py
+++ b/homeassistant/components/demo.py
@@ -159,13 +159,13 @@ def async_setup(hass, config):
 
     tasks2.append(group.Group.async_create_group(hass, 'living room', [
         lights[1], switches[0], 'input_select.living_room_preset',
-        'rollershutter.living_room_window', media_players[1],
+        'cover.living_room_window', media_players[1],
         'scene.romantic_lights']))
     tasks2.append(group.Group.async_create_group(hass, 'bedroom', [
         lights[0], switches[1], media_players[0],
         'input_slider.noise_allowance']))
     tasks2.append(group.Group.async_create_group(hass, 'kitchen', [
-        lights[2], 'rollershutter.kitchen_window', 'lock.kitchen_door']))
+        lights[2], 'cover.kitchen_window', 'lock.kitchen_door']))
     tasks2.append(group.Group.async_create_group(hass, 'doors', [
         'lock.front_door', 'lock.kitchen_door',
         'garage_door.right_garage_door', 'garage_door.left_garage_door']))
@@ -176,8 +176,8 @@ def async_setup(hass, config):
         'device_tracker.demo_paulus']))
     tasks2.append(group.Group.async_create_group(hass, 'downstairs', [
         'group.living_room', 'group.kitchen',
-        'scene.romantic_lights', 'rollershutter.kitchen_window',
-        'rollershutter.living_room_window', 'group.doors',
+        'scene.romantic_lights', 'cover.kitchen_window',
+        'cover.living_room_window', 'group.doors',
         'thermostat.ecobee',
     ], view=True))
 


### PR DESCRIPTION
## Description:
Needed this for Haaska tests to work.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
