### PR TITLE
iOS version number hotfix

### DIFF
--- a/homeassistant/components/ios.py
+++ b/homeassistant/components/ios.py
@@ -138,7 +138,7 @@ IDENTIFY_DEVICE_SCHEMA_CONTAINER = vol.All(dict, IDENTIFY_DEVICE_SCHEMA)
 IDENTIFY_APP_SCHEMA = vol.Schema({
     vol.Required(ATTR_APP_BUNDLE_IDENTIFER): cv.string,
     vol.Required(ATTR_APP_BUILD_NUMBER): cv.positive_int,
-    vol.Required(ATTR_APP_VERSION_NUMBER): cv.positive_int
+    vol.Optional(ATTR_APP_VERSION_NUMBER): cv.string
 }, extra=vol.ALLOW_EXTRA)
 
 IDENTIFY_APP_SCHEMA_CONTAINER = vol.All(dict, IDENTIFY_APP_SCHEMA)


### PR DESCRIPTION
## Description:
iOS app version 1.0.1 broke the identify call because Voluptuous was expecting an integer, but 1.0.1 can't be coerced to an Integer like 1.0 can be. 

The Optional is technically a temporary fix, as I have fixed this in the upcoming iOS 1.0.2 (fixed in https://github.com/home-assistant/home-assistant-iOS/commit/7d051f3ea13a648494bcba0cd6a491b163040f84).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
