### PR TITLE
Fix #7026 adding a new wol parameter

### DIFF
--- a/homeassistant/components/switch/wake_on_lan.py
+++ b/homeassistant/components/switch/wake_on_lan.py
@@ -21,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_MAC_ADDRESS = 'mac_address'
 CONF_OFF_ACTION = 'turn_off'
+CONF_BROADCAST_ADDRESS = 'broadcast_address'
 
 DEFAULT_NAME = 'Wake on LAN'
 DEFAULT_PING_TIMEOUT = 1
@@ -28,6 +29,7 @@ DEFAULT_PING_TIMEOUT = 1
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_MAC_ADDRESS): cv.string,
     vol.Optional(CONF_HOST): cv.string,
+    vol.Optional(CONF_BROADCAST_ADDRESS): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_OFF_ACTION): cv.SCRIPT_SCHEMA,
 })
@@ -38,21 +40,25 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
     mac_address = config.get(CONF_MAC_ADDRESS)
+    broadcast_address = config.get(CONF_BROADCAST_ADDRESS)
     off_action = config.get(CONF_OFF_ACTION)
 
-    add_devices([WOLSwitch(hass, name, host, mac_address, off_action)])
+    add_devices([WOLSwitch(hass, name, host, mac_address,
+                           off_action, broadcast_address)])
 
 
 class WOLSwitch(SwitchDevice):
     """Representation of a wake on lan switch."""
 
-    def __init__(self, hass, name, host, mac_address, off_action):
+    def __init__(self, hass, name, host, mac_address,
+                 off_action, broadcast_address):
         """Initialize the WOL switch."""
         from wakeonlan import wol
         self._hass = hass
         self._name = name
         self._host = host
         self._mac_address = mac_address
+        self._broadcast_address = broadcast_address
         self._off_script = Script(hass, off_action) if off_action else None
         self._state = False
         self._wol = wol
@@ -75,9 +81,9 @@ class WOLSwitch(SwitchDevice):
 
     def turn_on(self):
         """Turn the device on."""
-        if self._host:
+        if self._broadcast_address:
             self._wol.send_magic_packet(self._mac_address,
-                                        ip_address=self._host)
+                                        ip_address=self._broadcast_address)
         else:
             self._wol.send_magic_packet(self._mac_address)
 


### PR DESCRIPTION
## Description:

#6810 introduced a bug on WOL component.
This patch fixes this issue by adding a new parameter to specify the broadcast address where the magic packet should be sent. See the example below.
@goto100 could you confirm that this patch work fine for you ? (be careful, you have to change your configuration)

**Related issue (if applicable):** fixes #7026

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2445

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: wake_on_lan
    mac_address: "00-01-02-03-04-05"
    name: myhost
    host: 192.168.2.13
    broadcast_address: 255.255.255.255
```

## Checklist:

  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
