### PR TITLE
lutron: fix typo that prevented callback registration

### DIFF
--- a/homeassistant/components/lutron.py
+++ b/homeassistant/components/lutron.py
@@ -58,7 +58,7 @@ class LutronDevice(Entity):
         self._area_name = area_name
 
     @asyncio.coroutine
-    def async_add_to_hass(self):
+    def async_added_to_hass(self):
         """Register callbacks."""
         self.hass.async_add_job(
             self._controller.subscribe, self._lutron_device,


### PR DESCRIPTION
## Description:

Previous fix by Pascal (#7042) had a typo that didn't actually run the callback async callback.

Verified that lutron components get registered correctly and updates are handled properly.

**Related issue (if applicable):** fixes #7042 