### PR TITLE
Added effects to Yeelight bulbs

### DIFF
--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -525,51 +525,51 @@ class YeelightLight(Light):
 
                 transitions = list()
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 flow = Flow(count=count, transitions=transitions)
@@ -580,51 +580,51 @@ class YeelightLight(Light):
 
                 transitions = list()
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=duration))
                 flow = Flow(count=count, transitions=transitions)
@@ -634,51 +634,51 @@ class YeelightLight(Light):
 
                 transitions = list()
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=250))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=500))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=1000))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
-                                  duration=200))
+                                  duration=2000))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=3000))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=4000))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=5000))
                 transitions.append(
-                    RGBTransition(random.randrange(0, 255),
-                                  random.randrange(0, 255),
-                                  random.randrange(0, 255),
+                    RGBTransition(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255),
                                   brightness=self.brightness,
                                   duration=6000))
                 flow = Flow(count=count, transitions=transitions)

--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -340,35 +340,35 @@ class YeelightLight(Light):
                 self._bulb.stop_flow()
                 return
             if effect == EFFECT_DISCO:
-                flow = Flow(count=0, transitions=disco(),)
+                flow = Flow(count=0, transitions=disco())
             if effect == EFFECT_TEMP:
-                flow = Flow(count=0, transitions=temp(),)
+                flow = Flow(count=0, transitions=temp())
             if effect == EFFECT_STROBE:
-                flow = Flow(count=0, transitions=strobe(),)
+                flow = Flow(count=0, transitions=strobe())
             if effect == EFFECT_STROBE_COLOR:
-                flow = Flow(count=0, transitions=strobe_color(),)
+                flow = Flow(count=0, transitions=strobe_color())
             if effect == EFFECT_ALARM:
-                flow = Flow(count=0, transitions=alarm(),)
+                flow = Flow(count=0, transitions=alarm())
             if effect == EFFECT_POLICE:
-                flow = Flow(count=0, transitions=police(),)
+                flow = Flow(count=0, transitions=police())
             if effect == EFFECT_POLICE2:
-                flow = Flow(count=0, transitions=police2(),)
+                flow = Flow(count=0, transitions=police2())
             if effect == EFFECT_CHRISTMAS:
-                flow = Flow(count=0, transitions=christmas(),)
+                flow = Flow(count=0, transitions=christmas())
             if effect == EFFECT_RGB:
-                flow = Flow(count=0, transitions=rgb(),)
+                flow = Flow(count=0, transitions=rgb())
             if effect == EFFECT_RANDOM_LOOP:
-                flow = Flow(count=0, transitions=randomloop(),)
+                flow = Flow(count=0, transitions=randomloop())
             if effect == EFFECT_FAST_RANDOM_LOOP:
-                flow = Flow(count=0, transitions=randomloop(duration=250),)
+                flow = Flow(count=0, transitions=randomloop(duration=250))
             if effect == EFFECT_SLOWDOWN:
-                flow = Flow(count=0, transitions=slowdown(),)
+                flow = Flow(count=0, transitions=slowdown())
             if effect == EFFECT_WHATSAPP:
-                flow = Flow(count=2, transitions=pulse(37, 211, 102),)
+                flow = Flow(count=2, transitions=pulse(37, 211, 102))
             if effect == EFFECT_FACEBOOK:
-                flow = Flow(count=2, transitions=pulse(59, 89, 152),)
+                flow = Flow(count=2, transitions=pulse(59, 89, 152))
             if effect == EFFECT_TWITTER:
-                flow = Flow(count=2, transitions=pulse(0, 172, 237),)
+                flow = Flow(count=2, transitions=pulse(0, 172, 237))
 
             try:
                 self._bulb.start_flow(flow)

--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/light.yeelight/
 import logging
 import colorsys
 
-
 import voluptuous as vol
 
 from homeassistant.util.color import (

--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/light.yeelight/
 """
 import logging
 import colorsys
+import random
 
 import voluptuous as vol
 
@@ -16,9 +17,9 @@ from homeassistant.util.color import (
 from homeassistant.const import CONF_DEVICES, CONF_NAME
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATTR_TRANSITION, ATTR_COLOR_TEMP,
-    ATTR_FLASH, FLASH_SHORT, FLASH_LONG,
+    ATTR_FLASH, FLASH_SHORT, FLASH_LONG, ATTR_EFFECT,
     SUPPORT_BRIGHTNESS, SUPPORT_RGB_COLOR, SUPPORT_TRANSITION,
-    SUPPORT_COLOR_TEMP, SUPPORT_FLASH,
+    SUPPORT_COLOR_TEMP, SUPPORT_FLASH, SUPPORT_EFFECT,
     Light, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
@@ -50,7 +51,45 @@ SUPPORT_YEELIGHT = (SUPPORT_BRIGHTNESS |
 
 SUPPORT_YEELIGHT_RGB = (SUPPORT_YEELIGHT |
                         SUPPORT_RGB_COLOR |
+                        SUPPORT_EFFECT |
                         SUPPORT_COLOR_TEMP)
+
+EFFECT_ALARM = "Alarm"
+EFFECT_DISCO = "Disco"
+EFFECT_STROBE = "Strobe epilepsy!"
+EFFECT_COLOR_STROBE = "Color strobe"
+EFFECT_POLICE = "Police"
+EFFECT_POLICE2 = "Police2"
+EFFECT_CHRISTMAS = "Christmas"
+EFFECT_RGB = "RGB"
+EFFECT_RGB_TRANS = "RGB trans"
+EFFECT_ENJOY = "Enjoy"
+EFFECT_RANDOM_LOOP = "Random loop"
+EFFECT_RANDOM_FASTLOOP = "Random fastloop"
+EFFECT_SLOWDOWN = "Slowdown"
+EFFECT_WHATSAPP_NOTIFY = "WhatsApp Notify"
+EFFECT_FACEBOOK_NOTIFY = "Facebook Notify"
+EFFECT_TWITTER_NOTIFY = "Twitter Notify"
+EFFECT_STOP = "Stop"
+
+YEE_EFFECT_LIST = [
+    EFFECT_ALARM,
+    EFFECT_DISCO,
+    EFFECT_STROBE,
+    EFFECT_COLOR_STROBE,
+    EFFECT_POLICE,
+    EFFECT_POLICE2,
+    EFFECT_CHRISTMAS,
+    EFFECT_RGB,
+    EFFECT_RGB_TRANS,
+    EFFECT_ENJOY,
+    EFFECT_RANDOM_LOOP,
+    EFFECT_RANDOM_FASTLOOP,
+    EFFECT_SLOWDOWN,
+    EFFECT_WHATSAPP_NOTIFY,
+    EFFECT_FACEBOOK_NOTIFY,
+    EFFECT_TWITTER_NOTIFY,
+    EFFECT_STOP]
 
 
 def _cmd(func):
@@ -115,6 +154,11 @@ class YeelightLight(Light):
     def supported_features(self) -> int:
         """Flag supported features."""
         return self._supported_features
+
+    @property
+    def effect_list(self):
+        """Return the list of supported effects."""
+        return YEE_EFFECT_LIST
 
     @property
     def unique_id(self) -> str:
@@ -257,9 +301,6 @@ class YeelightLight(Light):
         if flash:
             from yeelight import (RGBTransition, SleepTransition, Flow,
                                   BulbException)
-            if self._bulb.last_properties["color_mode"] != 1:
-                _LOGGER.error("Flash supported currently only in RGB mode.")
-                return
 
             transition = int(self.config[CONF_TRANSITION])
             if flash == FLASH_LONG:
@@ -273,7 +314,8 @@ class YeelightLight(Light):
 
             transitions = list()
             transitions.append(
-                RGBTransition(255, 0, 0, brightness=10, duration=duration))
+                RGBTransition(red, green, blue, brightness=10,
+                              duration=duration))
             transitions.append(SleepTransition(
                 duration=transition))
             transitions.append(
@@ -286,6 +328,420 @@ class YeelightLight(Light):
             except BulbException as ex:
                 _LOGGER.error("Unable to set flash: %s", ex)
 
+    @_cmd
+    def set_effect(self, effect) -> None:
+        """Activate effect."""
+        if effect:
+            from yeelight import (RGBTransition, TemperatureTransition,
+                                  SleepTransition, Flow, BulbException)
+            transition = int(self.config[CONF_TRANSITION])
+            if effect == EFFECT_ALARM:
+                count = 0
+                duration = 100
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(255, 0, 0, brightness=100,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(255, 0, 0, brightness=60, duration=duration))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_DISCO:
+                count = 0
+                duration = 300
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(255, 0, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(255, 0, 0, brightness=1, duration=duration))
+                transitions.append(
+                    RGBTransition(128, 255, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(128, 255, 0, brightness=1,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(0, 255, 255, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(0, 255, 255, brightness=1,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(128, 0, 255, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(128, 0, 255, brightness=1,
+                                  duration=duration))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_STROBE:
+                count = 0
+                duration = 50
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(255, 255, 255, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(255, 255, 255, brightness=1,
+                                  duration=duration))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_COLOR_STROBE:
+                count = 0
+                duration = 50
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(0, 0, 255, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(255, 255, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(255, 0, 127, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(255, 0, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(0, 255, 255, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(255, 128, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(0, 255, 0, brightness=self.brightness,
+                                  duration=duration))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_POLICE:
+                count = 0
+                duration = 300
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(255, 0, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(0, 0, 255, brightness=self.brightness,
+                                  duration=duration))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_POLICE2:
+                count = 0
+                duration = 200
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(255, 0, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(255, 0, 0, brightness=1,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(255, 0, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(SleepTransition(duration=duration))
+                transitions.append(
+                    RGBTransition(0, 0, 255, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(0, 0, 255, brightness=1,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(0, 0, 255, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(SleepTransition(duration=duration))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_CHRISTMAS:
+                count = 0
+                duration = 300
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(255, 0, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(SleepTransition(duration=3000))
+                transitions.append(
+                    RGBTransition(0, 255, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(SleepTransition(duration=3000))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_RGB:
+                count = 0
+                duration = 300
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(255, 0, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(SleepTransition(duration=3000))
+                transitions.append(
+                    RGBTransition(0, 255, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(SleepTransition(duration=3000))
+                transitions.append(
+                    RGBTransition(0, 0, 255, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(SleepTransition(duration=3000))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_RGB_TRANS:
+                count = 0
+                duration = 10000
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(255, 0, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(0, 255, 0, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(0, 0, 255, brightness=self.brightness,
+                                  duration=duration))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_ENJOY:
+                count = 0
+                duration = 40000
+
+                transitions = list()
+                transitions.append(
+                    TemperatureTransition(1700, duration=duration))
+                transitions.append(
+                    TemperatureTransition(6500, duration=duration))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_RANDOM_LOOP:
+                count = 0
+                duration = 3000
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_RANDOM_FASTLOOP:
+                count = 0
+                duration = 800
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=duration))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_SLOWDOWN:
+                count = 0
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=250))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=500))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=1000))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=200))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=3000))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=4000))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=5000))
+                transitions.append(
+                    RGBTransition(random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  random.randrange(0, 255),
+                                  brightness=self.brightness,
+                                  duration=6000))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_WHATSAPP_NOTIFY:
+                count = 1
+                duration = 250
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(37, 211, 102, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(SleepTransition(duration=transition))
+                transitions.append(
+                    RGBTransition(37, 211, 102, brightness=10,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(37, 211, 102, brightness=self.brightness,
+                                  duration=duration))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_FACEBOOK_NOTIFY:
+                count = 1
+                duration = 250
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(59, 89, 152, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(SleepTransition(duration=transition))
+                transitions.append(
+                    RGBTransition(59, 89, 152, brightness=10,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(59, 89, 152, brightness=self.brightness,
+                                  duration=duration))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_TWITTER_NOTIFY:
+                count = 1
+                duration = 250
+
+                transitions = list()
+                transitions.append(
+                    RGBTransition(0, 172, 237, brightness=self.brightness,
+                                  duration=duration))
+                transitions.append(SleepTransition(duration=transition))
+                transitions.append(
+                    RGBTransition(0, 172, 237, brightness=10,
+                                  duration=duration))
+                transitions.append(
+                    RGBTransition(0, 172, 237, brightness=self.brightness,
+                                  duration=duration))
+                flow = Flow(count=count, transitions=transitions)
+
+            if effect == EFFECT_STOP:
+                self._bulb.stop_flow()
+                return
+            try:
+                self._bulb.start_flow(flow)
+            except BulbException as ex:
+                _LOGGER.error("Unable to set effect: %s", ex)
+
     def turn_on(self, **kwargs) -> None:
         """Turn the bulb on."""
         import yeelight
@@ -293,6 +749,7 @@ class YeelightLight(Light):
         colortemp = kwargs.get(ATTR_COLOR_TEMP)
         rgb = kwargs.get(ATTR_RGB_COLOR)
         flash = kwargs.get(ATTR_FLASH)
+        effect = kwargs.get(ATTR_EFFECT)
 
         duration = int(self.config[CONF_TRANSITION])  # in ms
         if ATTR_TRANSITION in kwargs:  # passed kwarg overrides config
@@ -317,6 +774,7 @@ class YeelightLight(Light):
             self.set_colortemp(colortemp, duration)
             self.set_brightness(brightness, duration)
             self.set_flash(flash)
+            self.set_effect(effect)
         except yeelight.BulbException as ex:
             _LOGGER.error("Unable to set bulb properties: %s", ex)
             return

--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -70,7 +70,7 @@ EFFECT_FACEBOOK = "Facebook"
 EFFECT_TWITTER = "Twitter"
 EFFECT_STOP = "Stop"
 
-YEE_EFFECT_LIST = [
+YEELIGHT_EFFECT_LIST = [
     EFFECT_DISCO,
     EFFECT_TEMP,
     EFFECT_STROBE,
@@ -155,7 +155,7 @@ class YeelightLight(Light):
     @property
     def effect_list(self):
         """Return the list of supported effects."""
-        return YEE_EFFECT_LIST
+        return YEELIGHT_EFFECT_LIST
 
     @property
     def unique_id(self) -> str:
@@ -336,7 +336,9 @@ class YeelightLight(Light):
                                               strobe_color, alarm, police,
                                               police2, christmas, rgb,
                                               randomloop, slowdown)
-            # transition = int(self.config[CONF_TRANSITION])
+            if effect == EFFECT_STOP:
+                self._bulb.stop_flow()
+                return
             if effect == EFFECT_DISCO:
                 flow = Flow(count=0, transitions=disco(),)
             if effect == EFFECT_TEMP:
@@ -368,9 +370,6 @@ class YeelightLight(Light):
             if effect == EFFECT_TWITTER:
                 flow = Flow(count=2, transitions=pulse(0, 172, 237),)
 
-            if effect == EFFECT_STOP:
-                self._bulb.stop_flow()
-                return
             try:
                 self._bulb.start_flow(flow)
             except BulbException as ex:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -873,7 +873,7 @@ yahoo-finance==1.4.0
 yahooweather==0.8
 
 # homeassistant.components.light.yeelight
-yeelight==0.2.2
+yeelight==0.3.0
 
 # homeassistant.components.light.yeelightsunflower
 yeelightsunflower==0.0.8


### PR DESCRIPTION
## Description: 
This PR is now reopened, because there are now effects implemented in the `yeelight` [module](https://gitlab.com/stavros/python-yeelight/tree/master) version 3.0.0. 
I did update the original code of this PR to support the newly implemented effects.

Any suggetions/improvements are welcome of course. 

PR text before closing:

> Added some basic effects to Yeelight bulbs. Deleted requirement for the bulb to be in a specific colormode in order to use flash parameter.
> 
> There are three different type of effects added:
> 
> 1. Predefined colors and brightness;
> 2. Predefined colors with current brightness;
> 3. Random colors with current brightness.
> 
> I also did a "stop" effect which stops the effect and returns to the previous state. 
> I did add this to the effectlist i don't know if this is the best approach as it is not really an effect. 
> 
> This is my first PR ever. So if i did something wrong please tell me. So i can improve it.
> Also i would like to thank @armills for all his help!

 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
