### PR TITLE
Flux_led: small fix random effects

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -216,9 +216,9 @@ class FluxLight(Light):
                 (red, green, blue) = self._bulb.getRgb()
                 self._bulb.setRgb(red, green, blue, brightness=brightness)
         elif effect == EFFECT_RANDOM:
-            self._bulb.setRgb(random.randrange(0, 255),
-                              random.randrange(0, 255),
-                              random.randrange(0, 255))
+            self._bulb.setRgb(random.randint(0, 255),
+                              random.randint(0, 255),
+                              random.randint(0, 255))
         elif effect == EFFECT_COLORLOOP:
             self._bulb.setPresetPattern(0x25, 50)
         elif effect == EFFECT_RED_FADE:


### PR DESCRIPTION
## Description:
Changed `random.randrange(0, 255)` into `random.randint(0,255)` so that 255 also can be a result.

Thanks to @amelchio for noticing this [here](https://github.com/home-assistant/home-assistant/pull/7152). 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
