### PR TITLE
Add datadog component

### DIFF
--- a/homeassistant/components/datadog.py
+++ b/homeassistant/components/datadog.py
@@ -1,0 +1,120 @@
+"""
+A component which allows you to send data to Datadog.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/datadog/
+"""
+import logging
+import voluptuous as vol
+
+from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_PREFIX,
+                                 EVENT_LOGBOOK_ENTRY, EVENT_STATE_CHANGED,
+                                 STATE_UNKNOWN)
+from homeassistant.helpers import state as state_helper
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['datadog==0.15.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_RATE = 'rate'
+DEFAULT_HOST = 'localhost'
+DEFAULT_PORT = 8125
+DEFAULT_PREFIX = 'hass'
+DEFAULT_RATE = 1
+DOMAIN = 'datadog'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_HOST, default=DEFAULT_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_PREFIX, default=DEFAULT_PREFIX): cv.string,
+        vol.Optional(CONF_RATE, default=DEFAULT_RATE):
+            vol.All(vol.Coerce(int), vol.Range(min=1)),
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Setup the Datadog component."""
+    from datadog import initialize, statsd
+
+    conf = config[DOMAIN]
+    host = conf.get(CONF_HOST)
+    port = conf.get(CONF_PORT)
+    sample_rate = conf.get(CONF_RATE)
+    prefix = conf.get(CONF_PREFIX)
+
+    initialize(statsd_host=host, statsd_port=port)
+
+    def logbook_entry_listener(event):
+        """Listen for logbook entries and send them as events."""
+        name = event.data.get('name')
+        message = event.data.get('message')
+
+        statsd.event(
+            title="Home Assistant",
+            text="%%% \n **{}** {} \n %%%".format(name, message),
+            tags=[
+                "entity:{}".format(event.data.get('entity_id')),
+                "domain:{}".format(event.data.get('domain'))
+            ]
+        )
+
+        _LOGGER.debug('Sent event %s', event.data.get('entity_id'))
+
+    def state_changed_listener(event):
+        """Listen for new messages on the bus and sends them to Datadog."""
+        state = event.data.get('new_state')
+
+        if state is None or state.state == STATE_UNKNOWN:
+            return
+
+        if state.attributes.get('hidden') is True:
+            return
+
+        states = dict(state.attributes)
+        metric = "{}.{}".format(prefix, state.domain)
+        tags = ["entity:{}".format(state.entity_id)]
+
+        for key, value in states.items():
+            if isinstance(value, (float, int)):
+                attribute = "{}.{}".format(metric, key.replace(' ', '_'))
+                statsd.gauge(
+                    attribute,
+                    value,
+                    sample_rate=sample_rate,
+                    tags=tags
+                )
+
+                _LOGGER.debug(
+                    'Sent metric %s: %s (tags: %s)',
+                    attribute,
+                    value,
+                    tags
+                )
+
+        try:
+            value = state_helper.state_as_number(state)
+        except ValueError:
+            _LOGGER.debug(
+                'Error sending %s: %s (tags: %s)',
+                metric,
+                state.state,
+                tags
+            )
+            return
+
+        statsd.gauge(
+            metric,
+            value,
+            sample_rate=sample_rate,
+            tags=tags
+        )
+
+        _LOGGER.debug('Sent metric %s: %s (tags: %s)', metric, value, tags)
+
+    hass.bus.listen(EVENT_LOGBOOK_ENTRY, logbook_entry_listener)
+    hass.bus.listen(EVENT_STATE_CHANGED, state_changed_listener)
+
+    return True

--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -19,7 +19,8 @@ from homeassistant.components.frontend import register_built_in_panel
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, EVENT_STATE_CHANGED,
-    STATE_NOT_HOME, STATE_OFF, STATE_ON, ATTR_HIDDEN, HTTP_BAD_REQUEST)
+    STATE_NOT_HOME, STATE_OFF, STATE_ON, ATTR_HIDDEN, HTTP_BAD_REQUEST,
+    EVENT_LOGBOOK_ENTRY)
 from homeassistant.core import State, split_entity_id, DOMAIN as HA_DOMAIN
 
 DOMAIN = 'logbook'
@@ -46,8 +47,6 @@ CONFIG_SCHEMA = vol.Schema({
         })
     }),
 }, extra=vol.ALLOW_EXTRA)
-
-EVENT_LOGBOOK_ENTRY = 'logbook_entry'
 
 GROUP_BY_MINUTES = 15
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -172,6 +172,7 @@ EVENT_PLATFORM_DISCOVERED = 'platform_discovered'
 EVENT_COMPONENT_LOADED = 'component_loaded'
 EVENT_SERVICE_REGISTERED = 'service_registered'
 EVENT_SERVICE_REMOVED = 'service_removed'
+EVENT_LOGBOOK_ENTRY = 'logbook_entry'
 
 # #### STATES ####
 STATE_ON = 'on'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -124,6 +124,9 @@ concord232==0.14
 # homeassistant.components.sensor.crimereports
 crimereports==1.0.0
 
+# homeassistant.components.datadog
+datadog==0.15.0
+
 # homeassistant.components.sensor.metoffice
 # homeassistant.components.weather.metoffice
 datapoint==0.4.3

--- a/tests/components/test_datadog.py
+++ b/tests/components/test_datadog.py
@@ -38,16 +38,17 @@ class TestDatadog(unittest.TestCase):
     @mock.patch('datadog.initialize')
     def test_datadog_setup_full(self, mock_connection):
         """Test setup with all data."""
-        config = {
-            'datadog': {
+        self.hass.bus.listen = mock.MagicMock()
+
+        assert setup_component(self.hass, datadog.DOMAIN, {
+            datadog.DOMAIN: {
                 'host': 'host',
                 'port': 123,
                 'rate': 1,
                 'prefix': 'foo',
             }
-        }
-        self.hass.bus.listen = mock.MagicMock()
-        self.assertTrue(setup_component(self.hass, datadog.DOMAIN, config))
+        })
+
         self.assertEqual(mock_connection.call_count, 1)
         self.assertEqual(
             mock_connection.call_args,
@@ -63,17 +64,16 @@ class TestDatadog(unittest.TestCase):
     @mock.patch('datadog.initialize')
     def test_datadog_setup_defaults(self, mock_connection):
         """Test setup with defaults."""
-        config = {
-            'datadog': {
-                'host': 'host',
-            }
-        }
-
-        config['datadog'][datadog.CONF_PORT] = datadog.DEFAULT_PORT
-        config['datadog'][datadog.CONF_PREFIX] = datadog.DEFAULT_PREFIX
-
         self.hass.bus.listen = mock.MagicMock()
-        self.assertTrue(setup_component(self.hass, datadog.DOMAIN, config))
+
+        assert setup_component(self.hass, datadog.DOMAIN, {
+            datadog.DOMAIN: {
+                'host': 'host',
+                'port': datadog.DEFAULT_PORT,
+                'prefix': datadog.DEFAULT_PREFIX,
+            }
+        })
+
         self.assertEqual(mock_connection.call_count, 1)
         self.assertEqual(
             mock_connection.call_args,
@@ -84,16 +84,15 @@ class TestDatadog(unittest.TestCase):
     @mock.patch('datadog.statsd')
     def test_logbook_entry(self, mock_client):
         """Test event listener."""
-        config = {
-            'datadog': {
-                'host': 'host'
-            }
-        }
-
-        config['datadog'][datadog.CONF_RATE] = datadog.DEFAULT_RATE
-
         self.hass.bus.listen = mock.MagicMock()
-        setup_component(self.hass, datadog.DOMAIN, config)
+
+        assert setup_component(self.hass, datadog.DOMAIN, {
+            datadog.DOMAIN: {
+                'host': 'host',
+                'rate': datadog.DEFAULT_RATE,
+            }
+        })
+
         self.assertTrue(self.hass.bus.listen.called)
         handler_method = self.hass.bus.listen.call_args_list[0][0][1]
 
@@ -123,17 +122,16 @@ class TestDatadog(unittest.TestCase):
     @mock.patch('datadog.statsd')
     def test_state_changed(self, mock_client):
         """Test event listener."""
-        config = {
-            'datadog': {
-                'host': 'host',
-                'prefix': 'ha'
-            }
-        }
-
-        config['datadog'][datadog.CONF_RATE] = datadog.DEFAULT_RATE
-
         self.hass.bus.listen = mock.MagicMock()
-        setup_component(self.hass, datadog.DOMAIN, config)
+
+        assert setup_component(self.hass, datadog.DOMAIN, {
+            datadog.DOMAIN: {
+                'host': 'host',
+                'prefix': 'ha',
+                'rate': datadog.DEFAULT_RATE,
+            }
+        })
+
         self.assertTrue(self.hass.bus.listen.called)
         handler_method = self.hass.bus.listen.call_args_list[1][0][1]
 

--- a/tests/components/test_datadog.py
+++ b/tests/components/test_datadog.py
@@ -1,0 +1,187 @@
+"""The tests for the Datadog component."""
+from unittest import mock
+import unittest
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    EVENT_LOGBOOK_ENTRY,
+    EVENT_STATE_CHANGED,
+    STATE_OFF,
+    STATE_ON
+)
+from homeassistant.setup import setup_component
+import homeassistant.components.datadog as datadog
+import homeassistant.core as ha
+
+from tests.common import get_test_home_assistant
+
+
+class TestDatadog(unittest.TestCase):
+    """Test the Datadog component."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_invalid_config(self):
+        """Test configuration with defaults."""
+        config = {
+            'datadog': {
+                'host1': 'host1',
+            }
+        }
+
+        with self.assertRaises(vol.Invalid):
+            datadog.CONFIG_SCHEMA(None)
+        with self.assertRaises(vol.Invalid):
+            datadog.CONFIG_SCHEMA(config)
+
+    @mock.patch('datadog.initialize')
+    def test_datadog_setup_full(self, mock_connection):
+        """Test setup with all data."""
+        config = {
+            'datadog': {
+                'host': 'host',
+                'port': 123,
+                'rate': 1,
+                'prefix': 'foo',
+            }
+        }
+        self.hass.bus.listen = mock.MagicMock()
+        self.assertTrue(setup_component(self.hass, datadog.DOMAIN, config))
+        self.assertEqual(mock_connection.call_count, 1)
+        self.assertEqual(
+            mock_connection.call_args,
+            mock.call(statsd_host='host', statsd_port=123)
+        )
+
+        self.assertTrue(self.hass.bus.listen.called)
+        self.assertEqual(EVENT_LOGBOOK_ENTRY,
+                         self.hass.bus.listen.call_args_list[0][0][0])
+        self.assertEqual(EVENT_STATE_CHANGED,
+                         self.hass.bus.listen.call_args_list[1][0][0])
+
+    @mock.patch('datadog.initialize')
+    def test_datadog_setup_defaults(self, mock_connection):
+        """Test setup with defaults."""
+        config = {
+            'datadog': {
+                'host': 'host',
+            }
+        }
+
+        config['datadog'][datadog.CONF_PORT] = datadog.DEFAULT_PORT
+        config['datadog'][datadog.CONF_PREFIX] = datadog.DEFAULT_PREFIX
+
+        self.hass.bus.listen = mock.MagicMock()
+        self.assertTrue(setup_component(self.hass, datadog.DOMAIN, config))
+        self.assertEqual(mock_connection.call_count, 1)
+        self.assertEqual(
+            mock_connection.call_args,
+            mock.call(statsd_host='host', statsd_port=8125)
+        )
+        self.assertTrue(self.hass.bus.listen.called)
+
+    @mock.patch('datadog.statsd')
+    def test_logbook_entry(self, mock_client):
+        """Test event listener."""
+        config = {
+            'datadog': {
+                'host': 'host'
+            }
+        }
+
+        config['datadog'][datadog.CONF_RATE] = datadog.DEFAULT_RATE
+
+        self.hass.bus.listen = mock.MagicMock()
+        setup_component(self.hass, datadog.DOMAIN, config)
+        self.assertTrue(self.hass.bus.listen.called)
+        handler_method = self.hass.bus.listen.call_args_list[0][0][1]
+
+        event = {
+            'domain': 'automation',
+            'entity_id': 'sensor.foo.bar',
+            'message': 'foo bar biz',
+            'name': 'triggered something'
+        }
+        handler_method(mock.MagicMock(data=event))
+
+        self.assertEqual(mock_client.event.call_count, 1)
+        self.assertEqual(
+            mock_client.event.call_args,
+            mock.call(
+                title="Home Assistant",
+                text="%%% \n **{}** {} \n %%%".format(
+                    event['name'],
+                    event['message']
+                ),
+                tags=["entity:sensor.foo.bar", "domain:automation"]
+            )
+        )
+
+        mock_client.event.reset_mock()
+
+    @mock.patch('datadog.statsd')
+    def test_state_changed(self, mock_client):
+        """Test event listener."""
+        config = {
+            'datadog': {
+                'host': 'host',
+                'prefix': 'ha'
+            }
+        }
+
+        config['datadog'][datadog.CONF_RATE] = datadog.DEFAULT_RATE
+
+        self.hass.bus.listen = mock.MagicMock()
+        setup_component(self.hass, datadog.DOMAIN, config)
+        self.assertTrue(self.hass.bus.listen.called)
+        handler_method = self.hass.bus.listen.call_args_list[1][0][1]
+
+        valid = {
+            '1': 1,
+            '1.0': 1.0,
+            STATE_ON: 1,
+            STATE_OFF: 0
+        }
+
+        attributes = {
+            'elevation': 3.2,
+            'temperature': 5.0
+        }
+
+        for in_, out in valid.items():
+            state = mock.MagicMock(domain="sensor", entity_id="sensor.foo.bar",
+                                   state=in_, attributes=attributes)
+            handler_method(mock.MagicMock(data={'new_state': state}))
+
+            self.assertEqual(mock_client.gauge.call_count, 3)
+
+            for attribute, value in attributes.items():
+                mock_client.gauge.assert_has_calls([
+                    mock.call(
+                        "ha.sensor.{}".format(attribute),
+                        value,
+                        sample_rate=1,
+                        tags=["entity:{}".format(state.entity_id)]
+                    )
+                ])
+
+            self.assertEqual(
+                mock_client.gauge.call_args,
+                mock.call("ha.sensor", out, sample_rate=1, tags=[
+                    "entity:{}".format(state.entity_id)
+                ])
+            )
+
+            mock_client.gauge.reset_mock()
+
+        for invalid in ('foo', '', object):
+            handler_method(mock.MagicMock(data={
+                'new_state': ha.State('domain.test', invalid, {})}))
+            self.assertFalse(mock_client.gauge.called)

--- a/tests/components/test_datadog.py
+++ b/tests/components/test_datadog.py
@@ -2,8 +2,6 @@
 from unittest import mock
 import unittest
 
-import voluptuous as vol
-
 from homeassistant.const import (
     EVENT_LOGBOOK_ENTRY,
     EVENT_STATE_CHANGED,
@@ -14,7 +12,7 @@ from homeassistant.setup import setup_component
 import homeassistant.components.datadog as datadog
 import homeassistant.core as ha
 
-from tests.common import get_test_home_assistant
+from tests.common import (assert_setup_component, get_test_home_assistant)
 
 
 class TestDatadog(unittest.TestCase):
@@ -29,17 +27,13 @@ class TestDatadog(unittest.TestCase):
         self.hass.stop()
 
     def test_invalid_config(self):
-        """Test configuration with defaults."""
-        config = {
-            'datadog': {
-                'host1': 'host1',
-            }
-        }
-
-        with self.assertRaises(vol.Invalid):
-            datadog.CONFIG_SCHEMA(None)
-        with self.assertRaises(vol.Invalid):
-            datadog.CONFIG_SCHEMA(config)
+        """Test invalid configuration."""
+        with assert_setup_component(0):
+            assert not setup_component(self.hass, datadog.DOMAIN, {
+                datadog.DOMAIN: {
+                    'host1': 'host1'
+                }
+            })
 
     @mock.patch('datadog.initialize')
     def test_datadog_setup_full(self, mock_connection):


### PR DESCRIPTION
## Description:

Adds a [datadog](https://www.datadoghq.com/) component. Note that while it is possible to use the existing _statsd_ component to report to _Datadog_, its true power comes from using [tags](https://help.datadoghq.com/hc/en-us/articles/204312749-Getting-started-with-tags) which requires a datadog-specific library.

I am not affiliated with _Datadog_ in any way. Just a happy user :)

This all started when I saw a [tweet by @andre.rb](https://twitter.com/superdealloc/status/629399406857469952/photo/1). Since I was already using Datadog, I decided to build a component for HA.

Here's what I've been able to achieve using this component:

<img width="1185" alt="datadog-board-example" src="https://cloud.githubusercontent.com/assets/92085/25108604/d51649cc-23ce-11e7-93ae-33283845823e.png">

With the data in _Datadog_ I'm able to also set up alerts to email/Slack when, for example, a statistical anomaly is detected on a sensor.

_Datadog_ also supports events, which I'm grabbing from the logbook:

<img width="963" alt="datadog" src="https://cloud.githubusercontent.com/assets/92085/25104052/c66b4502-23b6-11e7-92ee-de3d1debc9a0.png">

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2452

## Example entry for `configuration.yaml`:
```yaml
datadog:
  host: 127.0.0.1
```

Note that you need a _datadog-agent_ running. More information about that [here](http://docs.datadoghq.com/guides/basic_agent_usage/).

## Checklist:

  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
