### PR TITLE
Fixes incorrect integration id

### DIFF
--- a/homeassistant/components/ios.py
+++ b/homeassistant/components/ios.py
@@ -8,6 +8,7 @@ import asyncio
 import os
 import json
 import logging
+import datetime
 
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
@@ -19,6 +20,8 @@ from homeassistant.helpers import discovery
 from homeassistant.core import callback
 
 from homeassistant.components.http import HomeAssistantView
+
+from homeassistant.remote import JSONEncoder
 
 from homeassistant.const import (HTTP_INTERNAL_SERVER_ERROR,
                                  HTTP_BAD_REQUEST)
@@ -54,6 +57,8 @@ ATTR_DEFAULT_BEHAVIOR = "default"
 ATTR_TEXT_INPUT_BEHAVIOR = "textInput"
 
 BEHAVIORS = [ATTR_DEFAULT_BEHAVIOR, ATTR_TEXT_INPUT_BEHAVIOR]
+
+ATTR_LAST_SEEN_AT = "lastSeenAt"
 
 ATTR_DEVICE = "device"
 ATTR_PUSH_TOKEN = "pushToken"
@@ -192,7 +197,7 @@ def _save_config(filename, config):
     """Save configuration."""
     try:
         with open(filename, "w") as fdesc:
-            fdesc.write(json.dumps(config))
+            fdesc.write(json.dumps(config, cls=JSONEncoder))
     except (IOError, TypeError) as error:
         _LOGGER.error("Saving config file failed: %s", error)
         return False
@@ -285,13 +290,15 @@ class iOSIdentifyDeviceView(HomeAssistantView):
         try:
             req_data = yield from request.json()
         except ValueError:
-            return self.json_message('Invalid JSON', HTTP_BAD_REQUEST)
+            return self.json_message("Invalid JSON", HTTP_BAD_REQUEST)
 
         try:
             data = IDENTIFY_SCHEMA(req_data)
         except vol.Invalid as ex:
             return self.json_message(humanize_error(request.json, ex),
                                      HTTP_BAD_REQUEST)
+
+        data[ATTR_LAST_SEEN_AT] = datetime.datetime.now()
 
         name = data.get(ATTR_DEVICE_ID)
 

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -216,9 +216,9 @@ class FluxLight(Light):
                 (red, green, blue) = self._bulb.getRgb()
                 self._bulb.setRgb(red, green, blue, brightness=brightness)
         elif effect == EFFECT_RANDOM:
-            self._bulb.setRgb(random.randrange(0, 255),
-                              random.randrange(0, 255),
-                              random.randrange(0, 255))
+            self._bulb.setRgb(random.randint(0, 255),
+                              random.randint(0, 255),
+                              random.randint(0, 255))
         elif effect == EFFECT_COLORLOOP:
             self._bulb.setPresetPattern(0x25, 50)
         elif effect == EFFECT_RED_FADE:

--- a/homeassistant/components/light/lutron_caseta.py
+++ b/homeassistant/components/light/lutron_caseta.py
@@ -42,7 +42,7 @@ class LutronCasetaLight(LutronCasetaDevice, Light):
 
     def turn_on(self, **kwargs):
         """Turn the light on."""
-        if ATTR_BRIGHTNESS in kwargs and self._device_type == "WallDimmer":
+        if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs[ATTR_BRIGHTNESS]
         else:
             brightness = 255

--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -17,8 +17,8 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['https://github.com/gurumitts/'
-                'pylutron-caseta/archive/v0.2.5.zip#'
-                'pylutron-caseta==v0.2.5']
+                'pylutron-caseta/archive/v0.2.6.zip#'
+                'pylutron-caseta==v0.2.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,8 +29,8 @@ DOMAIN = 'lutron_caseta'
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_HOST): cv.string,
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string
+        vol.Optional(CONF_USERNAME): cv.string,
+        vol.Optional(CONF_PASSWORD): cv.string
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -41,9 +41,7 @@ def setup(hass, base_config):
 
     config = base_config.get(DOMAIN)
     hass.data[LUTRON_CASETA_SMARTBRIDGE] = Smartbridge(
-        hostname=config[CONF_HOST],
-        username=config[CONF_USERNAME],
-        password=config[CONF_PASSWORD]
+        hostname=config[CONF_HOST]
     )
     if not hass.data[LUTRON_CASETA_SMARTBRIDGE].is_connected():
         _LOGGER.error("Unable to connect to Lutron smartbridge at %s",
@@ -71,6 +69,7 @@ class LutronCasetaDevice(Entity):
         self._device_id = device["device_id"]
         self._device_type = device["type"]
         self._device_name = device["name"]
+        self._device_zone = device["zone"]
         self._state = None
         self._smartbridge = bridge
 
@@ -93,7 +92,8 @@ class LutronCasetaDevice(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {'Lutron Integration ID': self._device_id}
+        attr = {'Lutron Device ID': self._device_id,
+                'Lutron Zone ID': self._device_zone}
         return attr
 
     @property

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -96,7 +96,7 @@ class IOSSensor(Entity):
         elif battery_state == ios.ATTR_BATTERY_STATE_UNPLUGGED:
             if rounded_level < 10:
                 returning_icon = "{}-outline".format(DEFAULT_ICON)
-            elif battery_level == 100:
+            elif battery_level > 95:
                 returning_icon = DEFAULT_ICON
             else:
                 returning_icon = "{}-{}".format(DEFAULT_ICON,

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -56,7 +56,8 @@ class IOSSensor(Entity):
     @property
     def unique_id(self):
         """Return the unique ID of this sensor."""
-        return "sensor_ios_battery_{}_{}".format(self.type, self._device_name)
+        device_id = self._device[ios.ATTR_DEVICE_ID]
+        return "sensor_ios_battery_{}_{}".format(self.type, device_id)
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     TEMP_CELSIUS, TEMP_FAHRENHEIT)
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
+from homeassistant.util import convert
 from homeassistant.components.vera import (
     VERA_CONTROLLER, VERA_DEVICES, VeraDevice)
 
@@ -49,6 +50,8 @@ class VeraSensor(VeraDevice, Entity):
             return 'lux'
         elif self.vera_device.category == "Humidity Sensor":
             return '%'
+        elif self.vera_device.category == "Power meter":
+            return 'watts'
 
     def update(self):
         """Update the state."""
@@ -67,6 +70,9 @@ class VeraSensor(VeraDevice, Entity):
             self.current_value = self.vera_device.light
         elif self.vera_device.category == "Humidity Sensor":
             self.current_value = self.vera_device.humidity
+        elif self.vera_device.category == "Power meter":
+            power = convert(self.vera_device.power, float, 0)
+            self.current_value = int(round(power, 0))
         elif self.vera_device.category == "Sensor":
             tripped = self.vera_device.is_tripped
             self.current_value = 'Tripped' if tripped else 'Not Tripped'

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyvera==0.2.25']
+REQUIREMENTS = ['pyvera==0.2.26']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,6 +35,7 @@ CONF_LIGHTS = 'lights'
 VERA_ID_FORMAT = '{}_{}'
 
 ATTR_CURRENT_POWER_W = "current_power_w"
+ATTR_CURRENT_ENERGY_KWH = "current_energy_kwh"
 
 VERA_DEVICES = defaultdict(list)
 
@@ -180,6 +181,10 @@ class VeraDevice(Entity):
         power = self.vera_device.power
         if power:
             attr[ATTR_CURRENT_POWER_W] = convert(power, float, 0.0)
+
+        energy = self.vera_device.energy
+        if energy:
+            attr[ATTR_CURRENT_ENERGY_KWH] = convert(energy, float, 0.0)
 
         attr['Vera Device Id'] = self.vera_device.vera_device_id
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -665,7 +665,7 @@ pyunifi==2.0
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.2.25
+pyvera==0.2.26
 
 # homeassistant.components.notify.html5
 pywebpush==0.6.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -266,7 +266,7 @@ https://github.com/bah2830/python-roku/archive/3.1.3.zip#roku==3.1.3
 https://github.com/bashwork/pymodbus/archive/d7fc4f1cc975631e0a9011390e8017f64b612661.zip#pymodbus==1.2.0
 
 # homeassistant.components.lutron_caseta
-https://github.com/gurumitts/pylutron-caseta/archive/v0.2.5.zip#pylutron-caseta==v0.2.5
+https://github.com/gurumitts/pylutron-caseta/archive/v0.2.6.zip#pylutron-caseta==v0.2.6
 
 # homeassistant.components.netatmo
 https://github.com/jabesq/netatmo-api-python/archive/v0.9.1.zip#lnetatmo==0.9.1
@@ -638,6 +638,7 @@ python-pushover==0.2
 # homeassistant.components.sensor.synologydsm
 python-synology==0.1.0
 
+# homeassistant.components.telegram_webhooks
 # homeassistant.components.notify.telegram
 # homeassistant.components.telegram_bot.polling
 # homeassistant.components.telegram_bot.webhooks

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -638,7 +638,6 @@ python-pushover==0.2
 # homeassistant.components.sensor.synologydsm
 python-synology==0.1.0
 
-# homeassistant.components.telegram_webhooks
 # homeassistant.components.notify.telegram
 # homeassistant.components.telegram_bot.polling
 # homeassistant.components.telegram_bot.webhooks

--- a/tests/components/test_rest_command.py
+++ b/tests/components/test_rest_command.py
@@ -221,3 +221,22 @@ class TestRestCommandComponent(object):
 
         assert len(aioclient_mock.mock_calls) == 1
         assert aioclient_mock.mock_calls[0][2] == b'data'
+
+    def test_rest_command_content_type(self, aioclient_mock):
+        """Call a rest command with a content type."""
+        data = {
+            'payload': 'item',
+            'content_type': 'text/plain'
+        }
+        self.config[rc.DOMAIN]['post_test'].update(data)
+
+        with assert_setup_component(4):
+            setup_component(self.hass, rc.DOMAIN, self.config)
+
+        aioclient_mock.post(self.url, content=b'success')
+
+        self.hass.services.call(rc.DOMAIN, 'post_test', {})
+        self.hass.block_till_done()
+
+        assert len(aioclient_mock.mock_calls) == 1
+        assert aioclient_mock.mock_calls[0][2] == b'item'


### PR DESCRIPTION
## Description:

This PR will fix issues users with multiple Lutron Caseta devices were having.  The root cause of the issue was a difference in IDs being reported by the Lutron Integration report and the values received by the SSH /devices call.  This has been resolved by fixing the underlying library to only use SSH.  Only minor changes were required to this code base.  

**Related issue (if applicable):** fixes #6870

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2453
## Example entry for `configuration.yaml` (if applicable):
```yaml
lutron_caseta:
    host: 192.168.XX.XXX
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
