### PR TITLE
Update ios.py

### DIFF
--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -111,7 +111,7 @@ class IOSSensor(Entity):
                 returning_icon_level = "{}-outline".format(
                     DEFAULT_ICON_LEVEL)
             else:
-                returning_icon_level = "{}-{}".format(DEFAULT_ICON_LEVEL, 
+                returning_icon_level = "{}-{}".format(DEFAULT_ICON_LEVEL,
                                                       str(rounded_level))
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
         elif battery_state == ios.ATTR_BATTERY_STATE_UNKNOWN:

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -111,7 +111,7 @@ class IOSSensor(Entity):
                 returning_icon_level = "{}-outline".format(
                     DEFAULT_ICON_LEVEL)
             else:
-                returning_icon_level = "{}-{}".format(DEFAULT_ICON_LEVEL,
+                returning_icon_level = "{}-{}".format(DEFAULT_ICON_LEVEL, 
                                                       str(rounded_level))
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
         elif battery_state == ios.ATTR_BATTERY_STATE_UNKNOWN:

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -122,4 +122,4 @@ class IOSSensor(Entity):
     def update(self):
         """Get the latest state of the sensor."""
         self._device = ios.devices().get(self._device_name)
-        self._state = self._device[ios.ATTR_BATTERY][self.type]                                                                                                                                                             
+        self._state = self._device[ios.ATTR_BATTERY][self.type]

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -94,19 +94,22 @@ class IOSSensor(Entity):
         elif battery_state == ios.ATTR_BATTERY_STATE_CHARGING:
             # Why is MDI missing 10, 50, 70?
             if rounded_level in (20, 30, 40, 60, 80, 90, 100):
-                returning_icon_level = "{}-charging-{}".format(DEFAULT_ICON_LEVEL,
-                                                               str(rounded_level))
+                returning_icon_level = "{}-charging-{}".format(
+                    DEFAULT_ICON_LEVEL, str(rounded_level))
                 returning_icon_state = DEFAULT_ICON_STATE
             else:
-                returning_icon_level = "{}-charging".format(DEFAULT_ICON_LEVEL)
+                returning_icon_level = "{}-charging".format(
+                    DEFAULT_ICON_LEVEL)
                 returning_icon_state = DEFAULT_ICON_STATE
         elif battery_state == ios.ATTR_BATTERY_STATE_UNPLUGGED:
             if rounded_level < 10:
-                returning_icon_level = "{}-outline".format(DEFAULT_ICON_LEVEL)
+                returning_icon_level = "{}-outline".format(
+                    DEFAULT_ICON_LEVEL)
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
             elif battery_level == 100:
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
-                returning_icon_level = "{}-outline".format(DEFAULT_ICON_LEVEL)
+                returning_icon_level = "{}-outline".format(
+                    DEFAULT_ICON_LEVEL)
             elif battery_level > 95:
                 returning_icon_level = DEFAULT_ICON_LEVEL
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -93,15 +93,18 @@ class IOSSensor(Entity):
         elif battery_state == ios.ATTR_BATTERY_STATE_CHARGING:
             # Why is MDI missing 10, 50, 70?
             if rounded_level in (20, 30, 40, 60, 80, 90, 100):
-                returning_icon_level = "{}-charging-{}".format(DEFAULT_ICON_LEVEL, 
-                                                               str(rounded_level))
+                returning_icon_level = 
+                "{}-charging-{}".format(DEFAULT_ICON_LEVEL, 
+                                        str(rounded_level))
                 returning_icon_state = DEFAULT_ICON_STATE
             else:
-                returning_icon_level = "{}-charging".format(DEFAULT_ICON_LEVEL)
+                returning_icon_level = 
+                "{}-charging".format(DEFAULT_ICON_LEVEL)
                 returning_icon_state = DEFAULT_ICON_STATE
         elif battery_state == ios.ATTR_BATTERY_STATE_UNPLUGGED:
             if rounded_level < 10:
-                returning_icon_level = "{}-outline".format(DEFAULT_ICON_LEVEL)
+                returning_icon_level = 
+                "{}-outline".format(DEFAULT_ICON_LEVEL)
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
             elif battery_level == 100:
                 returning_icon_level = DEFAULT_ICON_LEVEL

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -93,7 +93,7 @@ class IOSSensor(Entity):
         elif battery_state == ios.ATTR_BATTERY_STATE_CHARGING:
             # Why is MDI missing 10, 50, 70?
             if rounded_level in (20, 30, 40, 60, 80, 90, 100):
-                returning_icon_level = "{}-charging-{}".format(DEFAULT_ICON_LEVEL, 
+                returning_icon_level = "{}-charging-{}".format(DEFAULT_ICON_LEVEL,
                                                                str(rounded_level))
                 returning_icon_state = DEFAULT_ICON_STATE
             else:
@@ -107,7 +107,7 @@ class IOSSensor(Entity):
                 returning_icon_level = DEFAULT_ICON_LEVEL
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
             else:
-                returning_icon_level = "{}-{}".format(DEFAULT_ICON_LEVEL, 
+                returning_icon_level = "{}-{}".format(DEFAULT_ICON_LEVEL,
                                                       str(rounded_level))
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
         elif battery_state == ios.ATTR_BATTERY_STATE_UNKNOWN:

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -106,7 +106,7 @@ class IOSSensor(Entity):
                 returning_icon_level = "{}-outline".format(
                     DEFAULT_ICON_LEVEL)
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
-            elif battery_level > 95
+            elif battery_level > 95:
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
                 returning_icon_level = "{}-outline".format(
                     DEFAULT_ICON_LEVEL)

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -122,5 +122,4 @@ class IOSSensor(Entity):
     def update(self):
         """Get the latest state of the sensor."""
         self._device = ios.devices().get(self._device_name)
-        self._state = self._device[ios.ATTR_BATTERY][self.type]
-                                                                                                                                                              
+        self._state = self._device[ios.ATTR_BATTERY][self.type]                                                                                                                                                             

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -86,10 +86,15 @@ class IOSSensor(Entity):
         returning_icon_level = DEFAULT_ICON_LEVEL
         if battery_state == ios.ATTR_BATTERY_STATE_FULL:
             returning_icon_level = DEFAULT_ICON_LEVEL
+            if battery_state == ios.ATTR_BATTERY_STATE_CHARGING:
+                returning_icon_state = DEFAULT_ICON_STATE
+            else:
+                returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
         elif battery_state == ios.ATTR_BATTERY_STATE_CHARGING:
             # Why is MDI missing 10, 50, 70?
             if rounded_level in (20, 30, 40, 60, 80, 90, 100):
-                returning_icon_level = "{}-charging-{}".format(DEFAULT_ICON_LEVEL,str(rounded_level))
+                returning_icon_level = "{}-charging-{}".format(DEFAULT_ICON_LEVEL, 
+                                                               str(rounded_level))
                 returning_icon_state = DEFAULT_ICON_STATE
             else:
                 returning_icon_level = "{}-charging".format(DEFAULT_ICON_LEVEL)
@@ -102,7 +107,8 @@ class IOSSensor(Entity):
                 returning_icon_level = DEFAULT_ICON_LEVEL
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
             else:
-                returning_icon_level = "{}-{}".format(DEFAULT_ICON_LEVEL,str(rounded_level))
+                returning_icon_level = "{}-{}".format(DEFAULT_ICON_LEVEL, 
+                                                      str(rounded_level))
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
         elif battery_state == ios.ATTR_BATTERY_STATE_UNKNOWN:
             returning_icon_level = "{}-unknown".format(DEFAULT_ICON_LEVEL)

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -105,9 +105,8 @@ class IOSSensor(Entity):
                 returning_icon_level = "{}-outline".format(DEFAULT_ICON_LEVEL)
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
             elif battery_level == 100:
-                returning_icon_level = DEFAULT_ICON_LEVEL
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
-                returning_icon = "{}-outline".format(DEFAULT_ICON)
+                returning_icon_level = "{}-outline".format(DEFAULT_ICON_LEVEL)
             elif battery_level > 95:
                 returning_icon_level = DEFAULT_ICON_LEVEL
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -14,7 +14,8 @@ SENSOR_TYPES = {
     "state": ["Battery State", None]
 }
 
-DEFAULT_ICON = "mdi:battery"
+DEFAULT_ICON_LEVEL = "mdi:battery"
+DEFAULT_ICON_STATE = "mdi:power-plug"
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -61,7 +62,6 @@ class IOSSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement this sensor expresses itself in."""
-        return self._unit_of_measurement
 
     @property
     def device_state_attributes(self):
@@ -83,30 +83,38 @@ class IOSSensor(Entity):
         battery_state = device_battery[ios.ATTR_BATTERY_STATE]
         battery_level = device_battery[ios.ATTR_BATTERY_LEVEL]
         rounded_level = round(battery_level, -1)
-        returning_icon = DEFAULT_ICON
+        returning_icon_level = DEFAULT_ICON_LEVEL
         if battery_state == ios.ATTR_BATTERY_STATE_FULL:
-            returning_icon = DEFAULT_ICON
+            returning_icon_level = DEFAULT_ICON_LEVEL
         elif battery_state == ios.ATTR_BATTERY_STATE_CHARGING:
             # Why is MDI missing 10, 50, 70?
             if rounded_level in (20, 30, 40, 60, 80, 90, 100):
-                returning_icon = "{}-charging-{}".format(DEFAULT_ICON,
-                                                         str(rounded_level))
+                returning_icon_level = "{}-charging-{}".format(DEFAULT_ICON_LEVEL,str(rounded_level))
+                returning_icon_state = DEFAULT_ICON_STATE
             else:
-                returning_icon = "{}-charging".format(DEFAULT_ICON)
+                returning_icon_level = "{}-charging".format(DEFAULT_ICON_LEVEL)
+                returning_icon_state = DEFAULT_ICON_STATE
         elif battery_state == ios.ATTR_BATTERY_STATE_UNPLUGGED:
             if rounded_level < 10:
-                returning_icon = "{}-outline".format(DEFAULT_ICON)
+                returning_icon_level = "{}-outline".format(DEFAULT_ICON_LEVEL)
+                returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
             elif battery_level == 100:
-                returning_icon = DEFAULT_ICON
+                returning_icon_level = DEFAULT_ICON_LEVEL
+                returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
             else:
-                returning_icon = "{}-{}".format(DEFAULT_ICON,
-                                                str(rounded_level))
+                returning_icon_level = "{}-{}".format(DEFAULT_ICON_LEVEL,str(rounded_level))
+                returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
         elif battery_state == ios.ATTR_BATTERY_STATE_UNKNOWN:
-            returning_icon = "{}-unknown".format(DEFAULT_ICON)
+            returning_icon_level = "{}-unknown".format(DEFAULT_ICON_LEVEL)
+            returning_icon_state = "{}-unknown".format(DEFAULT_ICON_LEVEL)
 
-        return returning_icon
+        if self.type == "state":
+            return returning_icon_state
+        else:
+            return returning_icon_level
 
     def update(self):
         """Get the latest state of the sensor."""
         self._device = ios.devices().get(self._device_name)
         self._state = self._device[ios.ATTR_BATTERY][self.type]
+                                                                                                                                                              

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -93,18 +93,15 @@ class IOSSensor(Entity):
         elif battery_state == ios.ATTR_BATTERY_STATE_CHARGING:
             # Why is MDI missing 10, 50, 70?
             if rounded_level in (20, 30, 40, 60, 80, 90, 100):
-                returning_icon_level = 
-                "{}-charging-{}".format(DEFAULT_ICON_LEVEL, 
-                                        str(rounded_level))
+                returning_icon_level = "{}-charging-{}".format(DEFAULT_ICON_LEVEL, 
+                                                               str(rounded_level))
                 returning_icon_state = DEFAULT_ICON_STATE
             else:
-                returning_icon_level = 
-                "{}-charging".format(DEFAULT_ICON_LEVEL)
+                returning_icon_level = "{}-charging".format(DEFAULT_ICON_LEVEL)
                 returning_icon_state = DEFAULT_ICON_STATE
         elif battery_state == ios.ATTR_BATTERY_STATE_UNPLUGGED:
             if rounded_level < 10:
-                returning_icon_level = 
-                "{}-outline".format(DEFAULT_ICON_LEVEL)
+                returning_icon_level = "{}-outline".format(DEFAULT_ICON_LEVEL)
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
             elif battery_level == 100:
                 returning_icon_level = DEFAULT_ICON_LEVEL

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -106,13 +106,10 @@ class IOSSensor(Entity):
                 returning_icon_level = "{}-outline".format(
                     DEFAULT_ICON_LEVEL)
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
-            elif battery_level == 100:
+            elif battery_level > 95
                 returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
                 returning_icon_level = "{}-outline".format(
                     DEFAULT_ICON_LEVEL)
-            elif battery_level > 95:
-                returning_icon_level = DEFAULT_ICON_LEVEL
-                returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
             else:
                 returning_icon_level = "{}-{}".format(DEFAULT_ICON_LEVEL,
                                                       str(rounded_level))


### PR DESCRIPTION
as discussed. the part: 
       if battery_state == ios.ATTR_BATTERY_STATE_FULL:
            returning_icon_level = DEFAULT_ICON_LEVEL
kinda screws up the charging icon.

i might just miss a logical solution for that though.
let me know what you think. it might not be beautiful but i think its an overall improve over the current "double battery" solution

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
