### PR TITLE
myStrom WiFi bulbs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -230,13 +230,14 @@ omit =
     homeassistant/components/light/lifx.py
     homeassistant/components/light/lifx_legacy.py
     homeassistant/components/light/limitlessled.py
+    homeassistant/components/light/mystrom.py
     homeassistant/components/light/osramlightify.py
+    homeassistant/components/light/piglow.py
     homeassistant/components/light/tikteck.py
     homeassistant/components/light/tradfri.py
     homeassistant/components/light/x10.py
     homeassistant/components/light/yeelight.py
     homeassistant/components/light/yeelightsunflower.py
-    homeassistant/components/light/piglow.py
     homeassistant/components/light/zengge.py
     homeassistant/components/lirc.py
     homeassistant/components/lock/nuki.py

--- a/homeassistant/components/light/mystrom.py
+++ b/homeassistant/components/light/mystrom.py
@@ -1,0 +1,120 @@
+"""
+Support for myStrom Wifi bulbs.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.mystrom/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.light import (
+    Light, PLATFORM_SCHEMA, ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS)
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, STATE_UNKNOWN
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['python-mystrom==0.3.8']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'myStrom bulb'
+
+SUPPORT_MYSTROM = (SUPPORT_BRIGHTNESS)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_MAC): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the myStrom Light platform."""
+    from pymystrom import MyStromBulb
+    from pymystrom.exceptions import MyStromConnectionError
+
+    host = config.get(CONF_HOST)
+    mac = config.get(CONF_MAC)
+    name = config.get(CONF_NAME)
+
+    bulb = MyStromBulb(host, mac)
+    try:
+        if bulb.get_status()['type'] != 'rgblamp':
+            _LOGGER.error("Device %s (%s) is not a myStrom bulb", host, mac)
+            return False
+    except MyStromConnectionError:
+        _LOGGER.warning("myStrom bulb not online")
+
+    add_devices([MyStromLight(bulb, name)], True)
+
+
+class MyStromLight(Light):
+    """Representation of the myStrom WiFi Bulb."""
+
+    def __init__(self, bulb, name):
+        """Initialize the light."""
+        self._bulb = bulb
+        self._name = name
+        self._state = None
+        self._available = False
+        self._rgb_color = [0, 0, 0]
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_MYSTROM
+
+    @property
+    def brightness(self):
+        """Brightness of the light."""
+        return self._brightness
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._available
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._state['on'] if self._state is not None else STATE_UNKNOWN
+
+    def turn_on(self, **kwargs):
+        """Turn on the light."""
+        from pymystrom.exceptions import MyStromConnectionError
+
+        brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+
+        try:
+            if not self.is_on:
+                self._bulb.set_on()
+            if brightness is not None:
+                self._bulb.set_color_hsv(0, 0, round(brightness * 100 / 255))
+        except MyStromConnectionError:
+            _LOGGER.warning("myStrom bulb not online")
+
+    def turn_off(self, **kwargs):
+        """Turn off the bulb."""
+        from pymystrom.exceptions import MyStromConnectionError
+
+        try:
+            self._bulb.set_off()
+        except MyStromConnectionError:
+            _LOGGER.warning("myStrom bulb not online")
+
+    def update(self):
+        """Fetch new state data for this light."""
+        from pymystrom.exceptions import MyStromConnectionError
+
+        try:
+            self._state = self._bulb.get_status()
+            self._brightness = int(self._bulb.get_brightness()) * 255 / 100
+            self._available = True
+        except MyStromConnectionError:
+            _LOGGER.warning("myStrom bulb not online")
+            self._available = False

--- a/homeassistant/components/light/mystrom.py
+++ b/homeassistant/components/light/mystrom.py
@@ -57,6 +57,7 @@ class MyStromLight(Light):
         self._name = name
         self._state = None
         self._available = False
+        self._brightness = 0
         self._rgb_color = [0, 0, 0]
 
     @property

--- a/homeassistant/components/switch/mystrom.py
+++ b/homeassistant/components/switch/mystrom.py
@@ -12,7 +12,7 @@ from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_NAME, CONF_HOST)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-mystrom==0.3.6']
+REQUIREMENTS = ['python-mystrom==0.3.8']
 
 DEFAULT_NAME = 'myStrom Switch'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -623,8 +623,9 @@ python-hpilo==3.9
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5
 
+# homeassistant.components.light.mystrom
 # homeassistant.components.switch.mystrom
-python-mystrom==0.3.6
+python-mystrom==0.3.8
 
 # homeassistant.components.nest
 python-nest==3.1.0


### PR DESCRIPTION
## Description:
Support for [myStrom WiFi bulbs](https://mystrom.ch/wifi-bulb/). 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2454

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: mystrom
    host: 192.168.0.2
    name: myStrom Bulb
    mac: 5AAC8CA542F3
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
