### PR TITLE
binary_sensor.workday: fix handling of states vs provinces

### DIFF
--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -73,7 +73,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             obj_holidays = getattr(holidays, country)(prov=province,
                                                       years=year)
         elif (hasattr(obj_holidays, "STATES") and
-                province in obj_holidays.STATES):
+              province in obj_holidays.STATES):
             obj_holidays = getattr(holidays, country)(state=province,
                                                       years=year)
         else:

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -66,15 +66,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     obj_holidays = getattr(holidays, country)(years=year)
 
     if province:
-        if province not in obj_holidays.PROVINCES and \
-                        province not in obj_holidays.STATES:
+        year = datetime.datetime.now().year
+        # 'state' and 'prov' are not interchangeable, so need to make
+        # sure we use the right one
+        if province in obj_holidays.PROVINCES:
+            obj_holidays = getattr(holidays, country)(prov=province,
+                                                      years=year)
+        elif province in obj_holidays.STATES:
+            obj_holidays = getattr(holidays, country)(state=province,
+                                                      years=year)
+        else:
             _LOGGER.error("There is no province/state %s in country %s",
                           province, country)
             return False
-        else:
-            year = datetime.datetime.now().year
-            obj_holidays = getattr(holidays, country)(prov=province,
-                                                      years=year)
 
     _LOGGER.debug("Found the following holidays for your configuration:")
     for date, name in sorted(obj_holidays.items()):

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -68,10 +68,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if province:
         # 'state' and 'prov' are not interchangeable, so need to make
         # sure we use the right one
-        if province in obj_holidays.PROVINCES:
+        if (hasattr(obj_holidays, "PROVINCES") and
+                province in obj_holidays.PROVINCES):
             obj_holidays = getattr(holidays, country)(prov=province,
                                                       years=year)
-        elif province in obj_holidays.STATES:
+        elif (hasattr(obj_holidays, "STATES") and
+                province in obj_holidays.STATES):
             obj_holidays = getattr(holidays, country)(state=province,
                                                       years=year)
         else:

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -66,7 +66,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     obj_holidays = getattr(holidays, country)(years=year)
 
     if province:
-        year = datetime.datetime.now().year
         # 'state' and 'prov' are not interchangeable, so need to make
         # sure we use the right one
         if province in obj_holidays.PROVINCES:

--- a/tests/components/binary_sensor/test_workday.py
+++ b/tests/components/binary_sensor/test_workday.py
@@ -58,7 +58,7 @@ class TestWorkdaySetup(object):
                 'platform': 'workday',
                 'country': 'DE',
                 'province': 'BW',
-                'workdays': ['holiday', 'mon', 'tue', 'wed', 'thu', 'fri'],
+                'workdays': ['holiday'],
                 'excludes': ['sat', 'sun']
             },
         }

--- a/tests/components/binary_sensor/test_workday.py
+++ b/tests/components/binary_sensor/test_workday.py
@@ -38,6 +38,21 @@ class TestWorkdaySetup(object):
             },
         }
 
+        self.config_state = {
+            'binary_sensor': {
+                'platform': 'workday',
+                'country': 'US',
+                'province': 'CA'
+            },
+        }
+
+        self.config_nostate = {
+            'binary_sensor': {
+                'platform': 'workday',
+                'country': 'US',
+            },
+        }
+
         self.config_includeholiday = {
             'binary_sensor': {
                 'platform': 'workday',
@@ -114,6 +129,34 @@ class TestWorkdaySetup(object):
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor', self.config_noprovince)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'on'
+
+    # Freeze time to a public holiday in state CA
+    @freeze_time("Mar 31st, 2017")
+    def test_public_holiday_state(self):
+        """Test if public holidays are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_state)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'off'
+
+    # Freeze time to a public holiday in state CA
+    @freeze_time("Mar 31st, 2017")
+    def test_public_holiday_nostate(self):
+        """Test if public holidays are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_nostate)
 
         assert self.hass.states.get('binary_sensor.workday_sensor') is not None
 


### PR DESCRIPTION
## Description:

The holidays module treats states and provinces differently, so specifying a US state as a province does not work correctly. #7017 is incomplete; it prevents an error on startup when a state is specified, but does not load the correct holidays for that state. This is a fix.

Also added test cases. 

**Related issue (if applicable):** fixes #7015 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
