### PR TITLE
Upgrade pytradfri to 1.0

### DIFF
--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -21,7 +21,7 @@ DOMAIN = 'tradfri'
 CONFIG_FILE = 'tradfri.conf'
 KEY_CONFIG = 'tradfri_configuring'
 KEY_GATEWAY = 'tradfri_gateway'
-REQUIREMENTS = ['pytradfri==0.4']
+REQUIREMENTS = ['pytradfri==1.0']
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -100,10 +100,10 @@ def async_setup(hass, config):
 @asyncio.coroutine
 def _setup_gateway(hass, hass_config, host, key):
     """Create a gateway."""
-    from pytradfri import cli_api_factory, Gateway, RequestError
+    from pytradfri import cli_api_factory, Gateway, RequestError, retry_timeout
 
     try:
-        api = cli_api_factory(host, key)
+        api = retry_timeout(cli_api_factory(host, key))
     except RequestError:
         return False
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -656,7 +656,7 @@ python-wink==1.2.3
 pytrackr==0.0.5
 
 # homeassistant.components.tradfri
-pytradfri==0.4
+pytradfri==1.0
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.0

--- a/virtualization/Docker/scripts/coap_client
+++ b/virtualization/Docker/scripts/coap_client
@@ -9,6 +9,6 @@ apt-get install -y --no-install-recommends git autoconf automake libtool
 git clone --depth 1 --recursive -b dtls https://github.com/home-assistant/libcoap.git
 cd libcoap
 ./autogen.sh
-./configure --disable-documentation --disable-shared
+./configure --disable-documentation --disable-shared --without-debug CFLAGS="-D COAP_DEBUG_FD=stderr"
 make
 make install


### PR DESCRIPTION
This updates our tradfri integration to use pytradfri 1.0. This is a breaking change for people currently running this in dev: you will need a coap-client build without debug output.

Don't merge until pytradfri 1.0 has been published to PyPi.