### PR TITLE
Disable MQTT camera test

### DIFF
--- a/tests/components/camera/test_mqtt.py
+++ b/tests/components/camera/test_mqtt.py
@@ -1,10 +1,13 @@
 """The tests for mqtt camera component."""
 import asyncio
 
+import pytest
+
 from homeassistant.setup import async_setup_component
 import homeassistant.components.mqtt as mqtt
 
 
+@pytest.mark.skip
 @asyncio.coroutine
 def test_run_camera_setup(hass, test_client):
     """Test that it fetches the given dispatcher data."""


### PR DESCRIPTION
The MQTT camera test is flaky and slow. It should not use the embedded MQTT broker but instead use the mock tools.

Disabling it for now.

@MrMep, could you look into fixing this?