### PR TITLE
Fix id zone mismatch

### DIFF
--- a/homeassistant/components/light/lutron_caseta.py
+++ b/homeassistant/components/light/lutron_caseta.py
@@ -42,7 +42,7 @@ class LutronCasetaLight(LutronCasetaDevice, Light):
 
     def turn_on(self, **kwargs):
         """Turn the light on."""
-        if ATTR_BRIGHTNESS in kwargs and self._device_type == "WallDimmer":
+        if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs[ATTR_BRIGHTNESS]
         else:
             brightness = 255

--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -92,8 +92,8 @@ class LutronCasetaDevice(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {'Lutron Device ID': self._device_id,
-                'Lutron Zone ID': self._device_zone}
+        attr = {'Device ID': self._device_id,
+                'Zone ID': self._device_zone}
         return attr
 
     @property

--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -17,8 +17,8 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['https://github.com/gurumitts/'
-                'pylutron-caseta/archive/v0.2.5.zip#'
-                'pylutron-caseta==v0.2.5']
+                'pylutron-caseta/archive/v0.2.6.zip#'
+                'pylutron-caseta==v0.2.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,8 +29,8 @@ DOMAIN = 'lutron_caseta'
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_HOST): cv.string,
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string
+        vol.Optional(CONF_USERNAME): cv.string,
+        vol.Optional(CONF_PASSWORD): cv.string
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -41,9 +41,7 @@ def setup(hass, base_config):
 
     config = base_config.get(DOMAIN)
     hass.data[LUTRON_CASETA_SMARTBRIDGE] = Smartbridge(
-        hostname=config[CONF_HOST],
-        username=config[CONF_USERNAME],
-        password=config[CONF_PASSWORD]
+        hostname=config[CONF_HOST]
     )
     if not hass.data[LUTRON_CASETA_SMARTBRIDGE].is_connected():
         _LOGGER.error("Unable to connect to Lutron smartbridge at %s",
@@ -71,6 +69,7 @@ class LutronCasetaDevice(Entity):
         self._device_id = device["device_id"]
         self._device_type = device["type"]
         self._device_name = device["name"]
+        self._device_zone = device["zone"]
         self._state = None
         self._smartbridge = bridge
 
@@ -93,7 +92,8 @@ class LutronCasetaDevice(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {'Lutron Integration ID': self._device_id}
+        attr = {'Lutron Device ID': self._device_id,
+                'Lutron Zone ID': self._device_zone}
         return attr
 
     @property

--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -10,9 +10,7 @@ import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import (CONF_HOST,
-                                 CONF_USERNAME,
-                                 CONF_PASSWORD)
+from homeassistant.const import CONF_HOST
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 

--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -28,9 +28,7 @@ DOMAIN = 'lutron_caseta'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_USERNAME): cv.string,
-        vol.Optional(CONF_PASSWORD): cv.string
+        vol.Required(CONF_HOST): cv.string
     })
 }, extra=vol.ALLOW_EXTRA)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -266,7 +266,7 @@ https://github.com/bah2830/python-roku/archive/3.1.3.zip#roku==3.1.3
 https://github.com/bashwork/pymodbus/archive/d7fc4f1cc975631e0a9011390e8017f64b612661.zip#pymodbus==1.2.0
 
 # homeassistant.components.lutron_caseta
-https://github.com/gurumitts/pylutron-caseta/archive/v0.2.5.zip#pylutron-caseta==v0.2.5
+https://github.com/gurumitts/pylutron-caseta/archive/v0.2.6.zip#pylutron-caseta==v0.2.6
 
 # homeassistant.components.netatmo
 https://github.com/jabesq/netatmo-api-python/archive/v0.9.1.zip#lnetatmo==0.9.1


### PR DESCRIPTION
## Description:

This PR will fix issues users with multiple Lutron Caseta devices were having. The root cause of the issue was a difference in IDs being reported by the Lutron Integration report and the values received by the SSH /devices call. This has been resolved by fixing the underlying library to only use SSH. Only minor changes were required to this code base.

Breaking changes:
As a side effect of moving to ssh.  The username and password are no longer required.  

Related PR:  #7159  this one was closed as I has to rebuild my dev environment.  

**Related issue (if applicable):** fixes #6870

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2453

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
