### PR TITLE
Upgrade netdisco to 1.0.0rc3

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==1.0.0rc2']
+REQUIREMENTS = ['netdisco==1.0.0rc3']
 
 DOMAIN = 'discovery'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -399,7 +399,7 @@ mutagen==1.36.2
 myusps==1.0.5
 
 # homeassistant.components.discovery
-netdisco==1.0.0rc2
+netdisco==1.0.0rc3
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1


### PR DESCRIPTION
## Description:
This fixes the AppleTV discovery issue. Thanks to @postlund for the fix and @robbiet480 for reporting.

Fixes #7169 