### PR TITLE
Suppress traceback and upgrade PyMata to 2.14

### DIFF
--- a/homeassistant/components/arduino.py
+++ b/homeassistant/components/arduino.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
 from homeassistant.const import CONF_PORT
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['PyMata==2.13']
+REQUIREMENTS = ['PyMata==2.14']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,18 +29,25 @@ CONFIG_SCHEMA = vol.Schema({
 
 
 def setup(hass, config):
-    """Setup the Arduino component."""
+    """Set up the Arduino component."""
     import serial
+
+    port = config[DOMAIN][CONF_PORT]
+
     global BOARD
     try:
-        BOARD = ArduinoBoard(config[DOMAIN][CONF_PORT])
+        BOARD = ArduinoBoard(port)
     except (serial.serialutil.SerialException, FileNotFoundError):
-        _LOGGER.exception("Your port is not accessible.")
+        _LOGGER.error("Your port %s is not accessible", port)
         return False
 
-    if BOARD.get_firmata()[1] <= 2:
-        _LOGGER.error("The StandardFirmata sketch should be 2.2 or newer.")
-        return False
+    try:
+        if BOARD.get_firmata()[1] <= 2:
+            _LOGGER.error("The StandardFirmata sketch should be 2.2 or newer")
+            return False
+    except IndexError:
+        _LOGGER.warning("The version of the StandardFirmata sketch was not"
+                        "detected. This may lead to side effects")
 
     def stop_arduino(event):
         """Stop the Arduino service."""
@@ -67,25 +74,20 @@ class ArduinoBoard(object):
     def set_mode(self, pin, direction, mode):
         """Set the mode and the direction of a given pin."""
         if mode == 'analog' and direction == 'in':
-            self._board.set_pin_mode(pin,
-                                     self._board.INPUT,
-                                     self._board.ANALOG)
+            self._board.set_pin_mode(
+                pin, self._board.INPUT, self._board.ANALOG)
         elif mode == 'analog' and direction == 'out':
-            self._board.set_pin_mode(pin,
-                                     self._board.OUTPUT,
-                                     self._board.ANALOG)
+            self._board.set_pin_mode(
+                pin, self._board.OUTPUT, self._board.ANALOG)
         elif mode == 'digital' and direction == 'in':
-            self._board.set_pin_mode(pin,
-                                     self._board.INPUT,
-                                     self._board.DIGITAL)
+            self._board.set_pin_mode(
+                pin, self._board.INPUT, self._board.DIGITAL)
         elif mode == 'digital' and direction == 'out':
-            self._board.set_pin_mode(pin,
-                                     self._board.OUTPUT,
-                                     self._board.DIGITAL)
+            self._board.set_pin_mode(
+                pin, self._board.OUTPUT, self._board.DIGITAL)
         elif mode == 'pwm':
-            self._board.set_pin_mode(pin,
-                                     self._board.OUTPUT,
-                                     self._board.PWM)
+            self._board.set_pin_mode(
+                pin, self._board.OUTPUT, self._board.PWM)
 
     def get_analog_inputs(self):
         """Get the values from the pins."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -26,7 +26,7 @@ PyJWT==1.4.2
 PyMVGLive==1.1.3
 
 # homeassistant.components.arduino
-PyMata==2.13
+PyMata==2.14
 
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.6.1


### PR DESCRIPTION
## Description:
If the wrong serial port was selected the component showed the traceback instead of a proper log entry. To support Arduino-clones the check for the Firmata sketch was effeminate.

## Example entry for `configuration.yaml` (if applicable):
```yaml
arduino:
  port: /dev/ttyUSB0

switch:
  - platform: arduino
    pins:
      22:
        name: Pin 22
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
