### PR TITLE
Add condition for API failure

### DIFF
--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -101,11 +101,17 @@ class ZoneMinderCamera(MjpegCamera):
         status_response = zoneminder.get_state(
             'api/monitors/alarm/id:%i/command:status.json' % self._monitor_id
         )
+
         if not status_response:
             _LOGGER.warning('Could not get status for monitor %i',
                             self._monitor_id)
             return
 
+        if status_response['success'] == False:
+            _LOGGER.warning('Alarm status API not supported or working for monitor %i',
+                            self._monitor_id)
+            return
+        
         self._is_recording = status_response['status'] == ZM_STATE_ALARM
 
     @property

--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -107,11 +107,11 @@ class ZoneMinderCamera(MjpegCamera):
                             self._monitor_id)
             return
 
-        if status_response['success'] == False:
-            _LOGGER.warning('Alarm status API not supported or working for monitor %i',
+        if status_response['success'] is False:
+            _LOGGER.warning('Alarm status API call failed for monitor %i',
                             self._monitor_id)
             return
-        
+
         self._is_recording = status_response['status'] == ZM_STATE_ALARM
 
     @property


### PR DESCRIPTION
## Description:

If you are not running the latest version of ZM this will cause exceptions to fire. This fix handles a response from ZM but a non successful attempt. 

This resolves the issue https://github.com/home-assistant/home-assistant/issues/7178

**Related issue (if applicable):** fixes #7178

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** NA

## Example entry for `configuration.yaml` (if applicable):
NA

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
