### PR TITLE
Pushbullet notification sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -348,6 +348,7 @@ omit =
     homeassistant/components/sensor/pi_hole.py
     homeassistant/components/sensor/plex.py
     homeassistant/components/sensor/pocketcasts.py
+    homeassistant/components/sensor/pushbullet.py
     homeassistant/components/sensor/pvoutput.py
     homeassistant/components/sensor/qnap.py
     homeassistant/components/sensor/sabnzbd.py

--- a/homeassistant/components/sensor/pushbullet.py
+++ b/homeassistant/components/sensor/pushbullet.py
@@ -35,7 +35,7 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=['title','body']): vol.All(
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=['title', 'body']): vol.All(
         cv.ensure_list, vol.Length(min=1), [vol.In(SENSOR_TYPES.keys())]),
     vol.Required(CONF_API_KEY): cv.string,
 })
@@ -109,4 +109,3 @@ class PushBulletNotificationProvider():
             self.listener.run_forever()
         finally:
             self.listener.close()
-

--- a/homeassistant/components/sensor/pushbullet.py
+++ b/homeassistant/components/sensor/pushbullet.py
@@ -35,8 +35,10 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=['title', 'body']): vol.All(
-        cv.ensure_list, vol.Length(min=1), [vol.In(SENSOR_TYPES.keys())]),
+    vol.Optional(CONF_MONITORED_CONDITIONS,
+        default=['title', 'body']): vol.All(
+            cv.ensure_list, vol.Length(min=1),
+            [vol.In(SENSOR_TYPES.keys())]),
     vol.Required(CONF_API_KEY): cv.string,
 })
 

--- a/homeassistant/components/sensor/pushbullet.py
+++ b/homeassistant/components/sensor/pushbullet.py
@@ -1,0 +1,113 @@
+"""
+PushBullet platform for sensor component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.pushbullet/
+"""
+import logging
+import threading
+import voluptuous as vol
+
+from pushbullet import PushBullet
+from pushbullet import InvalidKeyError
+from pushbullet import Listener
+
+from homeassistant.const import (CONF_API_KEY, CONF_MONITORED_CONDITIONS)
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['pushbullet.py==0.10.0']
+
+SENSOR_TYPES = {
+    'application_name': ['Application name'],
+    'body': ['Body'],
+    'notification_id':['Notification ID'],
+    'notification_tag':['Notification tag'],
+    'package_name':['Package name'],
+    'receiver_email':['Receiver email'],
+    'sender_email':['Sender email'],
+    'source_device_iden':['Sender device ID'],
+    'title':['Title'],
+    'type':['Type']
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=['title','body']): vol.All(
+                cv.ensure_list, vol.Length(min=1), [vol.In(SENSOR_TYPES.keys())]),
+    vol.Required(CONF_API_KEY): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Get the PushBullet notification service."""
+    try:
+        pushbullet = PushBullet(config.get(CONF_API_KEY))
+    except InvalidKeyError:
+        _LOGGER.error(
+            "Wrong API key supplied.{"+config.get(CONF_API_KEY)+ "}"
+            "Get it at https://www.pushbullet.com/account")
+        return None
+    """Create a common data provider"""
+    pbprovider = PushBulletNotificationProvider(pushbullet)
+    """Create a device for each property"""
+    devices = []
+    for sensor_type in config[CONF_MONITORED_CONDITIONS]:
+        devices.append(PushBulletNotificationSensor(pbprovider, sensor_type))
+    add_devices(devices)
+
+
+class PushBulletNotificationSensor(Entity):
+    """Fetches data via a filter from the common pushbullet provider"""
+
+    def __init__(self, pb, element):
+        """Initialize the service."""
+        self.pushbullet = pb
+        self._element = element
+        self._state = None
+
+    def update(self):
+        try:
+            self._state = self.pushbullet.data[self._element]
+        except (KeyError, TypeError):
+            pass
+
+    @property
+    def name(self):
+        return "pushbullet_" + self._element
+
+    @property
+    def state(self):
+        return self._state
+
+class  PushBulletNotificationProvider():
+    """Provider for an account, leading to multiple sensors"""
+
+    def __init__(self, pb):
+        self.pushbullet = pb
+        self._data = None
+        self.thread = threading.Thread(target=self.async_retrive_pushes)
+        self.thread.daemon = True
+        self.thread.start()
+
+    def on_push(self, data):
+        if data["type"] == "push":
+            self._data = data["push"]
+
+    @property
+    def data(self):
+        return self._data
+
+    def async_retrive_pushes(self):
+        self.listener = Listener(account=self.pushbullet,
+                                 on_push=self.on_push)
+        _LOGGER.info("getting pushes")
+        try:
+            self.listener.run_forever()
+        finally:
+            self.listener.close()
+
+

--- a/homeassistant/components/sensor/pushbullet.py
+++ b/homeassistant/components/sensor/pushbullet.py
@@ -16,7 +16,6 @@ from homeassistant.const import (CONF_API_KEY, CONF_MONITORED_CONDITIONS)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,19 +24,19 @@ REQUIREMENTS = ['pushbullet.py==0.10.0']
 SENSOR_TYPES = {
     'application_name': ['Application name'],
     'body': ['Body'],
-    'notification_id':['Notification ID'],
-    'notification_tag':['Notification tag'],
-    'package_name':['Package name'],
-    'receiver_email':['Receiver email'],
-    'sender_email':['Sender email'],
-    'source_device_iden':['Sender device ID'],
-    'title':['Title'],
-    'type':['Type']
+    'notification_id': ['Notification ID'],
+    'notification_tag': ['Notification tag'],
+    'package_name': ['Package name'],
+    'receiver_email': ['Receiver email'],
+    'sender_email': ['Sender email'],
+    'source_device_iden': ['Sender device ID'],
+    'title': ['Title'],
+    'type': ['Type']
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MONITORED_CONDITIONS, default=['title','body']): vol.All(
-                cv.ensure_list, vol.Length(min=1), [vol.In(SENSOR_TYPES.keys())]),
+        cv.ensure_list, vol.Length(min=1), [vol.In(SENSOR_TYPES.keys())]),
     vol.Required(CONF_API_KEY): cv.string,
 })
 
@@ -48,7 +47,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         pushbullet = PushBullet(config.get(CONF_API_KEY))
     except InvalidKeyError:
         _LOGGER.error(
-            "Wrong API key supplied.{"+config.get(CONF_API_KEY)+ "}"
+            "Wrong API key supplied.{" + config.get(CONF_API_KEY) + "}"
             "Get it at https://www.pushbullet.com/account")
         return None
     """Create a common data provider"""
@@ -83,7 +82,8 @@ class PushBulletNotificationSensor(Entity):
     def state(self):
         return self._state
 
-class  PushBulletNotificationProvider():
+
+class PushBulletNotificationProvider():
     """Provider for an account, leading to multiple sensors"""
 
     def __init__(self, pb):
@@ -109,5 +109,4 @@ class  PushBulletNotificationProvider():
             self.listener.run_forever()
         finally:
             self.listener.close()
-
 

--- a/homeassistant/components/sensor/pushbullet.py
+++ b/homeassistant/components/sensor/pushbullet.py
@@ -46,7 +46,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    #Get the PushBullet notification service.
+    # Get the PushBullet notification service.
     try:
         pushbullet = PushBullet(config.get(CONF_API_KEY))
     except InvalidKeyError:
@@ -54,9 +54,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             "Wrong API key supplied.{" + config.get(CONF_API_KEY) + "}"
             "Get it at https://www.pushbullet.com/account")
         return None
-    #Create a common data provider
+    # Create a common data provider
     pbprovider = PushBulletNotificationProvider(pushbullet)
-    #Create a device for each property
+    # Create a device for each property
     devices = []
     for sensor_type in config[CONF_MONITORED_CONDITIONS]:
         devices.append(PushBulletNotificationSensor(pbprovider, sensor_type))
@@ -64,7 +64,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class PushBulletNotificationSensor(Entity):
-    #Fetches data via a filter from the common pushbullet provider
+    # Fetches data via a filter from the common pushbullet provider
 
     def __init__(self, pb, element):
         self.pushbullet = pb
@@ -91,8 +91,9 @@ class PushBulletNotificationSensor(Entity):
     def device_state_attributes(self):
         return self._state_attributes
 
+
 class PushBulletNotificationProvider():
-    #Provider for an account, leading to multiple sensors
+    # Provider for an account, leading to multiple sensors
 
     def __init__(self, pb):
         self.pushbullet = pb

--- a/homeassistant/components/sensor/pushbullet.py
+++ b/homeassistant/components/sensor/pushbullet.py
@@ -101,6 +101,7 @@ class PushBulletNotificationProvider():
         import threading
         self.pushbullet = pb
         self._data = None
+        self.listener = None
         self.thread = threading.Thread(target=self.retrieve_pushes)
         self.thread.daemon = True
         self.thread.start()

--- a/homeassistant/components/sensor/pushbullet.py
+++ b/homeassistant/components/sensor/pushbullet.py
@@ -5,12 +5,8 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.pushbullet/
 """
 import logging
-import threading
 import voluptuous as vol
 
-from pushbullet import PushBullet
-from pushbullet import InvalidKeyError
-from pushbullet import Listener
 
 from homeassistant.const import (CONF_API_KEY, CONF_MONITORED_CONDITIONS)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -46,13 +42,14 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    # Get the PushBullet notification service.
+    """Get the PushBullet notification service."""
+    from pushbullet import PushBullet
+    from pushbullet import InvalidKeyError
     try:
         pushbullet = PushBullet(config.get(CONF_API_KEY))
     except InvalidKeyError:
-        _LOGGER.error(
-            "Wrong API key supplied.{" + config.get(CONF_API_KEY) + "}"
-            "Get it at https://www.pushbullet.com/account")
+        _LOGGER.error("Wrong API key supplied." \
+                "Get it at https://www.pushbullet.com/account")
         return None
     # Create a common data provider
     pbprovider = PushBulletNotificationProvider(pushbullet)
@@ -64,15 +61,20 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class PushBulletNotificationSensor(Entity):
-    # Fetches data via a filter from the common pushbullet provider
+    """Fetches data via a filter from the common pushbullet provider."""
 
     def __init__(self, pb, element):
+        """Initialize the service."""
         self.pushbullet = pb
         self._element = element
         self._state = None
         self._state_attributes = None
 
     def update(self):
+        """Fetches the latest data from the sensor.
+
+        This will fetch the 'sensor reading' into self._state but also all
+        attributes into self._state_attributes."""
         try:
             self._state = self.pushbullet.data[self._element]
             self._state_attributes = self.pushbullet.data
@@ -81,21 +83,26 @@ class PushBulletNotificationSensor(Entity):
 
     @property
     def name(self):
+        """Returns the name of the sensor."""
         return "Pushbullet " + self._element
 
     @property
     def state(self):
+        """Returns the current state of the sensor."""
         return self._state
 
     @property
     def device_state_attributes(self):
+        """Returns all known attributes of the sensor."""
         return self._state_attributes
 
 
 class PushBulletNotificationProvider():
-    # Provider for an account, leading to multiple sensors
+    """Provider for an account, leading to one or more sensors."""
 
     def __init__(self, pb):
+        """Starts to retrieve pushes from the given Pushbullet instance."""
+        import threading
         self.pushbullet = pb
         self._data = None
         self.thread = threading.Thread(target=self.retrieve_pushes)
@@ -103,14 +110,23 @@ class PushBulletNotificationProvider():
         self.thread.start()
 
     def on_push(self, data):
+        """Method to update the current data.
+
+        Currently only monitors pushes but might be extended to monitor
+        different kinds of Pushbullet events."""
         if data["type"] == "push":
             self._data = data["push"]
 
     @property
     def data(self):
+        """The current data stored in the provider."""
         return self._data
 
     def retrieve_pushes(self):
+        """The method to run the daemon thread in.
+
+        Spawns a new Listener and links it to self.on_push."""
+        from pushbullet import Listener
         self.listener = Listener(account=self.pushbullet,
                                  on_push=self.on_push)
         _LOGGER.debug("getting pushes")

--- a/homeassistant/components/sensor/pushbullet.py
+++ b/homeassistant/components/sensor/pushbullet.py
@@ -48,8 +48,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         pushbullet = PushBullet(config.get(CONF_API_KEY))
     except InvalidKeyError:
-        _LOGGER.error("Wrong API key supplied." \
-                "Get it at https://www.pushbullet.com/account")
+        _LOGGER.error("Wrong API key supplied."
+                      "Get it at https://www.pushbullet.com/account")
         return None
     # Create a common data provider
     pbprovider = PushBulletNotificationProvider(pushbullet)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -406,6 +406,7 @@ psutil==5.1.3
 pubnubsub-handler==1.0.1
 
 # homeassistant.components.notify.pushbullet
+# homeassistant.components.sensor.pushbullet
 pushbullet.py==0.10.0
 
 # homeassistant.components.notify.pushetta


### PR DESCRIPTION
New opening of the previous pullrequest #6188
**Description:**
Added a new sensor which display pushbullet notification mirrors.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/) with documentation (if applicable):** home-assistant/home-assistant.github.io#2115
Currently the old one. Will create a new one there too from the new comments I've received.
home-assistant/home-assistant.github.io#2461

**Example entry for `configuration.yaml` (if applicable):**
```yaml
sensor:
  - platform: pushbullet
    api_key: <API_KEY>
    monitored_conditions:
      - body
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
