### PR TITLE
Fix wemo discovery

### DIFF
--- a/homeassistant/components/binary_sensor/wemo.py
+++ b/homeassistant/components/binary_sensor/wemo.py
@@ -20,8 +20,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     import pywemo.discovery as discovery
 
     if discovery_info is not None:
-        location = discovery_info[2]
-        mac = discovery_info[3]
+        location = discovery_info['ssdp_description']
+        mac = discovery_info['mac']
         device = discovery.device_from_description(location, mac)
 
         if device:

--- a/homeassistant/components/binary_sensor/wemo.py
+++ b/homeassistant/components/binary_sensor/wemo.py
@@ -21,7 +21,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     if discovery_info is not None:
         location = discovery_info['ssdp_description']
-        mac = discovery_info['mac']
+        mac = discovery_info['mac_address']
         device = discovery.device_from_description(location, mac)
 
         if device:

--- a/homeassistant/components/light/wemo.py
+++ b/homeassistant/components/light/wemo.py
@@ -30,8 +30,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import pywemo.discovery as discovery
 
     if discovery_info is not None:
-        location = discovery_info[2]
-        mac = discovery_info[3]
+        location = discovery_info['ssdp_description']
+        mac = discovery_info['mac']
         device = discovery.device_from_description(location, mac)
 
         if device:

--- a/homeassistant/components/light/wemo.py
+++ b/homeassistant/components/light/wemo.py
@@ -31,7 +31,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if discovery_info is not None:
         location = discovery_info['ssdp_description']
-        mac = discovery_info['mac']
+        mac = discovery_info['mac_address']
         device = discovery.device_from_description(location, mac)
 
         if device:

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -37,7 +37,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     if discovery_info is not None:
         location = discovery_info['ssdp_description']
-        mac = discovery_info['mac']
+        mac = discovery_info['mac_address']
         device = discovery.device_from_description(location, mac)
 
         if device:

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -36,8 +36,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     import pywemo.discovery as discovery
 
     if discovery_info is not None:
-        location = discovery_info[2]
-        mac = discovery_info[3]
+        location = discovery_info['ssdp_description']
+        mac = discovery_info['mac']
         device = discovery.device_from_description(location, mac)
 
         if device:

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -96,7 +96,12 @@ def setup(hass, config):
         if device is None:
             device = pywemo.discovery.device_from_description(url, None)
 
-        discovery_info = (device.name, device.model_name, url, device.mac,
-                          device.serialnumber)
+        discovery_info = {
+            'model_name': device.model_name,
+            'serial': device.serialnumber,
+            'mac_address': device.mac,
+            'ssdp_description': url,
+        }
+
         discovery.discover(hass, SERVICE_WEMO, discovery_info)
     return True


### PR DESCRIPTION
## Description:
Wemo would create their own discovery objects that mimicked format of the discovery component. This was missed in the upgrade when I updated the discovery component format.

CC @pavoni @adgelbfish