### PR TITLE
fixed Issue 6749 by updating pylgtv to 0.1.5

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -24,9 +24,7 @@ from homeassistant.const import (
 from homeassistant.loader import get_component
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['https://github.com/TheRealLink/pylgtv'
-                '/archive/v0.1.4.zip'
-                '#pylgtv==0.1.4',
+REQUIREMENTS = ['pylgtv==0.1.5',
                 'websockets==3.2',
                 'wakeonlan==0.2.2']
 

--- a/homeassistant/components/notify/webostv.py
+++ b/homeassistant/components/notify/webostv.py
@@ -14,8 +14,7 @@ from homeassistant.components.notify import (
     ATTR_DATA, BaseNotificationService, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_FILENAME, CONF_HOST, CONF_ICON)
 
-REQUIREMENTS = ['https://github.com/TheRealLink/pylgtv/archive/v0.1.4.zip'
-                '#pylgtv==0.1.4']
+REQUIREMENTS = ['pylgtv==0.1.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -245,10 +245,6 @@ holidays==0.8.1
 # homeassistant.components.switch.dlink
 https://github.com/LinuxChristian/pyW215/archive/v0.4.zip#pyW215==0.4
 
-# homeassistant.components.media_player.webostv
-# homeassistant.components.notify.webostv
-https://github.com/TheRealLink/pylgtv/archive/v0.1.4.zip#pylgtv==0.1.4
-
 # homeassistant.components.sensor.thinkingcleaner
 # homeassistant.components.switch.thinkingcleaner
 https://github.com/TheRealLink/pythinkingcleaner/archive/v0.0.2.zip#pythinkingcleaner==0.0.2
@@ -559,6 +555,10 @@ pykwb==0.0.8
 
 # homeassistant.components.sensor.lastfm
 pylast==1.8.0
+
+# homeassistant.components.media_player.webostv
+# homeassistant.components.notify.webostv
+pylgtv==0.1.5
 
 # homeassistant.components.litejet
 pylitejet==0.1


### PR DESCRIPTION
## Description:

updated pylgtv module to 0.1.5 where async timeout error was fixed

it caused the function to not adhere to timeouts and would hang for 75sec when the tv was off, and that would over time cause a lot of open processes because home assistant expected it to timeout correctly after 10 sec

**Related issue (if applicable):** fixes #6749 

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
