### PR TITLE
Fix auto discovery for Apple TV

### DIFF
--- a/homeassistant/components/media_player/apple_tv.py
+++ b/homeassistant/components/media_player/apple_tv.py
@@ -51,7 +51,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if discovery_info is not None:
         name = discovery_info['name']
         host = discovery_info['host']
-        login_id = discovery_info['properties']['hsgid']
+        login_id = discovery_info['properties']['hG']
         start_off = False
     else:
         name = config.get(CONF_NAME)


### PR DESCRIPTION
## Description:
Property name for HSGID changed in netdisco so this makes necessary changes in the Apple TV platform to handle those changes.

**Related issue (if applicable):** fixes #7174 
