### PR TITLE
Upgrade py-cpuinfo to 3.2.0

### DIFF
--- a/homeassistant/components/sensor/cpuspeed.py
+++ b/homeassistant/components/sensor/cpuspeed.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['py-cpuinfo==3.0.0']
+REQUIREMENTS = ['py-cpuinfo==3.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -472,7 +472,7 @@ pwaqi==3.0
 pwmled==1.1.1
 
 # homeassistant.components.sensor.cpuspeed
-py-cpuinfo==3.0.0
+py-cpuinfo==3.2.0
 
 # homeassistant.components.hdmi_cec
 pyCEC==0.4.13


### PR DESCRIPTION
3.2.0
------
* Broken Qemu guest CPU flag parsing on Ubuntu 17.04 POWER8

3.1.0
------
* Include py-cpuinfo version in output
* Missing AVX2 CPU flag on OS X
* Broken on Odroid XU3 armhf ARM 32bit
* Not working on RHEL7.3 ppc64le
* Not working on Red Flag Linux ppc64le
* Not working on Fedora 24 ppc64le

Tested with the following configuration:

``` yaml
sensor:
  - platform: cpuspeed
    name: CPU
```