### PR TITLE
optimize remote calls and apps on webostv media_player

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -187,16 +187,30 @@ class LgWebOSDevice(MediaPlayerDevice):
 
                 for app in self._client.get_apps():
                     self._app_list[app['id']] = app
-                    if app['id'] == self._current_source_id:
+                    if conf_sources:
+                        if app['id'] == self._current_source_id:
+                            self._current_source = app['title']
+                            self._source_list[app['title']] = app
+                        elif (app['id'] in conf_sources or
+                              any(word in app['title']
+                              for word in conf_sources) or
+                              any(word in app['id']
+                              for word in conf_sources)):
+                            self._source_list[app['title']] = app
+                    else:
                         self._current_source = app['title']
-                        self._source_list[app['title']] = app
-                    elif (app['id'] in conf_sources or
-                          any(word in app['title'] for word in conf_sources) or
-                          any(word in app['id'] for word in conf_sources)):
                         self._source_list[app['title']] = app
 
                 for source in self._client.get_inputs():
-                    self._source_list[source['label']] = source
+                    if conf_sources:
+                        if source['id'] == self._current_source_id:
+                            self._source_list[source['label']] = source
+                        elif (source['label'] in conf_sources or
+                              any(source['label'].find(word) != -1
+                              for word in conf_sources)):
+                            self._source_list[source['label']] = source
+                    else:
+                        self._source_list[source['label']] = source
         except (OSError, ConnectionClosed):
             self._state = STATE_OFF
 

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -172,27 +172,27 @@ class LgWebOSDevice(MediaPlayerDevice):
         from websockets.exceptions import ConnectionClosed
         try:
             current_input = self._client.get_input()
-            if current_input != None:
+            if current_input is not None:
                 self._current_source_id = current_input
                 if self._state in (STATE_UNKNOWN, STATE_OFF):
                     self._state = STATE_PLAYING
 
-            if self._state != STATE_OFF:
+            if self._state is not STATE_OFF:
                 self._muted = self._client.get_muted()
                 self._volume = self._client.get_volume()
 
                 self._source_list = {}
                 self._app_list = {}
-                custom_sources = self._customize.get(CONF_SOURCES, [])
+                conf_sources = self._customize.get(CONF_SOURCES, [])
 
                 for app in self._client.get_apps():
                     self._app_list[app['id']] = app
                     if app['id'] == self._current_source_id:
                         self._current_source = app['title']
                         self._source_list[app['title']] = app
-                    elif (app['id'] in custom_sources or
-                          any(word in app['title'] for word in custom_sources) or
-                          any(word in app['id'] for word in custom_sources)):
+                    elif (app['id'] in conf_sources or
+                          any(word in app['title'] for word in conf_sources) or
+                          any(word in app['id'] for word in conf_sources)):
                         self._source_list[app['title']] = app
 
                 for source in self._client.get_inputs():

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -193,9 +193,9 @@ class LgWebOSDevice(MediaPlayerDevice):
                             self._source_list[app['title']] = app
                         elif (app['id'] in conf_sources or
                               any(word in app['title']
-                              for word in conf_sources) or
+                                  for word in conf_sources) or
                               any(word in app['id']
-                              for word in conf_sources)):
+                                  for word in conf_sources)):
                             self._source_list[app['title']] = app
                     else:
                         self._current_source = app['title']
@@ -207,7 +207,7 @@ class LgWebOSDevice(MediaPlayerDevice):
                             self._source_list[source['label']] = source
                         elif (source['label'] in conf_sources or
                               any(source['label'].find(word) != -1
-                              for word in conf_sources)):
+                                  for word in conf_sources)):
                             self._source_list[source['label']] = source
                     else:
                         self._source_list[source['label']] = source


### PR DESCRIPTION
## Description:

- changed updater to only do updated if they succed and handle calls when tv is off better by only doing 1 remote call
- show all sources instead of only connected, to fix source selection when unit is powered off
- fixed sources so they can launch apps and select sources

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: webostv
    host: 10.254.2.192
    mac: FF:FF:FF:FF:FF:FF
    name: LG OLED
    customize:
      sources:
        - HDMI2
        - netflix
        - youtube
        - Plex

media_player:
  - platform: webostv
    host: 10.254.2.192
    mac: FF:FF:FF:FF:FF:FF
    name: LG OLED

media_player:
  - platform: webostv
    host: 10.254.2.192
    mac: FF:FF:FF:FF:FF:FF
    name: LG OLED
    customize:
      sources:
        - HDMI
        - netflix
        - youtube
        - Plex
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54