### PR TITLE
Add HassIO to discovery component

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 from datetime import timedelta
 import logging
+import os
 
 import voluptuous as vol
 
@@ -29,12 +30,14 @@ SERVICE_NETGEAR = 'netgear_router'
 SERVICE_WEMO = 'belkin_wemo'
 SERVICE_HASS_IOS_APP = 'hass_ios'
 SERVICE_IKEA_TRADFRI = 'ikea_tradfri'
+SERVICE_HASSIO = 'hassio'
 
 SERVICE_HANDLERS = {
     SERVICE_HASS_IOS_APP: ('ios', None),
     SERVICE_NETGEAR: ('device_tracker', None),
     SERVICE_WEMO: ('wemo', None),
     SERVICE_IKEA_TRADFRI: ('tradfri', None),
+    SERVICE_HASSIO: ('hassio', None)
     'philips_hue': ('light', 'hue'),
     'google_cast': ('media_player', 'cast'),
     'panasonic_viera': ('media_player', 'panasonic_viera'),
@@ -123,6 +126,10 @@ def async_setup(hass, config):
     def schedule_first(event):
         """Schedule the first discovery when Home Assistant starts up."""
         async_track_point_in_utc_time(hass, scan_devices, dt_util.utcnow())
+
+        # discovery local services
+        if 'HASSIO' in os.environ:
+            hass.async_add_job(new_service_found(SERVICE_HASSIO, {}))
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, schedule_first)
 

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -37,7 +37,7 @@ SERVICE_HANDLERS = {
     SERVICE_NETGEAR: ('device_tracker', None),
     SERVICE_WEMO: ('wemo', None),
     SERVICE_IKEA_TRADFRI: ('tradfri', None),
-    SERVICE_HASSIO: ('hassio', None)
+    SERVICE_HASSIO: ('hassio', None),
     'philips_hue': ('light', 'hue'),
     'google_cast': ('media_player', 'cast'),
     'panasonic_viera': ('media_player', 'panasonic_viera'),

--- a/tests/components/test_discovery.py
+++ b/tests/components/test_discovery.py
@@ -1,5 +1,6 @@
 """The tests for the discovery component."""
 import asyncio
+import os
 
 from unittest.mock import patch
 
@@ -128,3 +129,20 @@ def test_discover_duplicates(hass):
     mock_discover.assert_called_with(
         hass, SERVICE_NO_PLATFORM, SERVICE_INFO,
         SERVICE_NO_PLATFORM_COMPONENT, BASE_CONFIG)
+
+
+@asyncio.coroutine
+def test_load_component_hassio(hass):
+    """Test load hassio component."""
+    os.environ['HASSIO'] = "FAKE_HASSIO"
+
+    def discover(netdisco):
+        """Fake discovery."""
+        return []
+
+    mock_discover, mock_platform = yield from mock_discovery(hass, discover)
+
+    assert mock_discover.called
+    assert not mock_platform.called
+    mock_discover.assert_called_with(
+        hass, 'hassio', {}, 'hassio', BASE_CONFIG)

--- a/tests/components/test_discovery.py
+++ b/tests/components/test_discovery.py
@@ -138,7 +138,9 @@ def test_load_component_hassio(hass):
         """Fake discovery."""
         return []
 
-    with patch.dict(os.environ, {'HASSIO': "FAKE_HASSIO"}):
+    with patch.dict(os.environ, {'HASSIO': "FAKE_HASSIO"}), \
+            patch('homeassistant.components.hassio.async_setup'
+                  return_value=mock_coro(return_value=True)):
         mock_discover, mock_platform = \
             yield from mock_discovery(hass, discover)
 

--- a/tests/components/test_discovery.py
+++ b/tests/components/test_discovery.py
@@ -140,11 +140,7 @@ def test_load_component_hassio(hass):
 
     with patch.dict(os.environ, {'HASSIO': "FAKE_HASSIO"}), \
             patch('homeassistant.components.hassio.async_setup',
-                  return_value=mock_coro(return_value=True)):
-        mock_discover, mock_platform = \
-            yield from mock_discovery(hass, discover)
+                  return_value=mock_coro(return_value=True)) as mock_hassio:
+        yield from mock_discovery(hass, discover)
 
-    assert mock_discover.called
-    assert not mock_platform.called
-    mock_discover.assert_called_with(
-        hass, 'hassio', {}, 'hassio', BASE_CONFIG)
+    assert mock_hassio

--- a/tests/components/test_discovery.py
+++ b/tests/components/test_discovery.py
@@ -143,4 +143,4 @@ def test_load_component_hassio(hass):
                   return_value=mock_coro(return_value=True)) as mock_hassio:
         yield from mock_discovery(hass, discover)
 
-    assert mock_hassio
+    assert mock_hassio.called

--- a/tests/components/test_discovery.py
+++ b/tests/components/test_discovery.py
@@ -134,13 +134,13 @@ def test_discover_duplicates(hass):
 @asyncio.coroutine
 def test_load_component_hassio(hass):
     """Test load hassio component."""
-    os.environ['HASSIO'] = "FAKE_HASSIO"
-
     def discover(netdisco):
         """Fake discovery."""
         return []
 
-    mock_discover, mock_platform = yield from mock_discovery(hass, discover)
+    with patch.dict(os.environ, {'HASSIO': "FAKE_HASSIO"}):
+        mock_discover, mock_platform = \
+            yield from mock_discovery(hass, discover)
 
     assert mock_discover.called
     assert not mock_platform.called

--- a/tests/components/test_discovery.py
+++ b/tests/components/test_discovery.py
@@ -139,7 +139,7 @@ def test_load_component_hassio(hass):
         return []
 
     with patch.dict(os.environ, {'HASSIO': "FAKE_HASSIO"}), \
-            patch('homeassistant.components.hassio.async_setup'
+            patch('homeassistant.components.hassio.async_setup',
                   return_value=mock_coro(return_value=True)):
         mock_discover, mock_platform = \
             yield from mock_discovery(hass, discover)


### PR DESCRIPTION
## Description:

Allow discovery component to discovery HassIO

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
