### PR TITLE
HassIO API v2

### DIFF
--- a/homeassistant/components/hassio.py
+++ b/homeassistant/components/hassio.py
@@ -31,8 +31,10 @@ SERVICE_HOST_SHUTDOWN = 'host_shutdown'
 SERVICE_HOST_REBOOT = 'host_reboot'
 
 SERVICE_HOST_UPDATE = 'host_update'
-SERVICE_SUPERVISOR_UPDATE = 'supervisor_update'
 SERVICE_HOMEASSISTANT_UPDATE = 'homeassistant_update'
+
+SERVICE_SUPERVISOR_UPDATE = 'supervisor_update'
+SERVICE_SUPERVISOR_RELOAD = 'supervisor_reload'
 
 SERVICE_ADDON_INSTALL = 'addon_install'
 SERVICE_ADDON_UNINSTALL = 'addon_uninstall'
@@ -61,8 +63,9 @@ SERVICE_MAP = {
     SERVICE_HOST_SHUTDOWN: None,
     SERVICE_HOST_REBOOT: None,
     SERVICE_HOST_UPDATE: SCHEMA_SERVICE_UPDATE,
-    SERVICE_SUPERVISOR_UPDATE: SCHEMA_SERVICE_UPDATE,
     SERVICE_HOMEASSISTANT_UPDATE: SCHEMA_SERVICE_UPDATE,
+    SERVICE_SUPERVISOR_UPDATE: SCHEMA_SERVICE_UPDATE,
+    SERVICE_SUPERVISOR_RELOAD: None,
     SERVICE_ADDON_INSTALL: SCHEMA_SERVICE_ADDONS_VERSION,
     SERVICE_ADDON_UNINSTALL: SCHEMA_SERVICE_ADDONS,
     SERVICE_ADDON_START: SCHEMA_SERVICE_ADDONS,
@@ -117,6 +120,9 @@ def async_setup(hass, config):
         elif service.service == SERVICE_SUPERVISOR_UPDATE:
             yield from hassio.send_command(
                 "/supervisor/update", payload=version)
+        elif service.service == SERVICE_SUPERVISOR_RELOAD:
+            yield from hassio.send_command(
+                "/supervisor/reload", timeout=LONG_TASK_TIMEOUT)
         elif service.service == SERVICE_HOMEASSISTANT_UPDATE:
             yield from hassio.send_command(
                 "/homeassistant/update", payload=version,

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -338,6 +338,9 @@ hassio:
         description: Optional or it will be use the latest version.
         example: '0.3'
 
+  supervisor_reload:
+    description: Reload HassIO supervisor addons/updates/configs.
+
   homeassistant_update:
     description: Update HomeAssistant docker image.
     fields:

--- a/tests/components/test_hassio.py
+++ b/tests/components/test_hassio.py
@@ -53,6 +53,8 @@ class TestHassIOSetup(object):
 
         assert self.hass.services.has_service(
             ho.DOMAIN, ho.SERVICE_SUPERVISOR_UPDATE)
+        assert self.hass.services.has_service(
+            ho.DOMAIN, ho.SERVICE_SUPERVISOR_RELOAD)
 
         assert self.hass.services.has_service(
             ho.DOMAIN, ho.SERVICE_ADDON_INSTALL)
@@ -215,6 +217,22 @@ class TestHassIOComponent(object):
 
         assert len(aioclient_mock.mock_calls) == 2
         assert aioclient_mock.mock_calls[-1][2]['version'] == '0.4'
+
+    def test_rest_command_http_supervisor_reload(self, aioclient_mock):
+        """Call a hassio for supervisor reload."""
+        aioclient_mock.get(
+            "http://127.0.0.1/supervisor/ping", json=self.ok_msg)
+        with assert_setup_component(0, ho.DOMAIN):
+            setup_component(self.hass, ho.DOMAIN, self.config)
+
+        aioclient_mock.get(
+            self.url.format("supervisor/reload"), json=self.ok_msg)
+
+        self.hass.services.call(
+            ho.DOMAIN, ho.SERVICE_SUPERVISOR_UPDATE, {})
+        self.hass.block_till_done()
+
+        assert len(aioclient_mock.mock_calls) == 2
 
     def test_rest_command_http_homeassistant_update(self, aioclient_mock):
         """Call a hassio for homeassistant update."""

--- a/tests/components/test_hassio.py
+++ b/tests/components/test_hassio.py
@@ -229,7 +229,7 @@ class TestHassIOComponent(object):
             self.url.format("supervisor/reload"), json=self.ok_msg)
 
         self.hass.services.call(
-            ho.DOMAIN, ho.SERVICE_SUPERVISOR_UPDATE, {})
+            ho.DOMAIN, ho.SERVICE_SUPERVISOR_RELOAD, {})
         self.hass.block_till_done()
 
         assert len(aioclient_mock.mock_calls) == 2


### PR DESCRIPTION
## Description:

Add Support for new api call `/supervisor/reload` to force update and reload addons/updates/configs.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
