### PR TITLE
Fix arwn platform to update hass state when events are received

### DIFF
--- a/homeassistant/components/sensor/arwn.py
+++ b/homeassistant/components/sensor/arwn.py
@@ -116,6 +116,7 @@ class ArwnSensor(Entity):
         """Update the sensor with the most recent event."""
         self.event = {}
         self.event.update(event)
+        self.hass.async_add_job(self.async_update_ha_state())
 
     @property
     def state(self):


### PR DESCRIPTION
The arwn platform was refactored to be asyncio friendly, however in
doing so one thing was missed which was explicitly telling hass when
something interesting has happened. This led to the very interesting
to debug issue that the state cards were all out of date, even though
the graphs were not.