### PR TITLE
New sensor cert_expiry

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -391,6 +391,7 @@ omit =
     homeassistant/components/sensor/pi_hole.py
     homeassistant/components/sensor/plex.py
     homeassistant/components/sensor/pocketcasts.py
+    homeassistant/components/sensor/pushbullet.py
     homeassistant/components/sensor/pvoutput.py
     homeassistant/components/sensor/qnap.py
     homeassistant/components/sensor/sabnzbd.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -334,6 +334,7 @@ omit =
     homeassistant/components/sensor/bom.py
     homeassistant/components/sensor/broadlink.py
     homeassistant/components/sensor/dublin_bus_transport.py
+    homeassistant/components/sensor/cert_expiry.py
     homeassistant/components/sensor/coinmarketcap.py
     homeassistant/components/sensor/comed_hourly_pricing.py
     homeassistant/components/sensor/cpuspeed.py

--- a/homeassistant/components/light/lifx/__init__.py
+++ b/homeassistant/components/light/lifx/__init__.py
@@ -16,9 +16,9 @@ import voluptuous as vol
 
 from homeassistant.components.light import (
     Light, PLATFORM_SCHEMA, ATTR_BRIGHTNESS, ATTR_COLOR_NAME, ATTR_RGB_COLOR,
-    ATTR_COLOR_TEMP, ATTR_TRANSITION, ATTR_EFFECT,
+    ATTR_XY_COLOR, ATTR_COLOR_TEMP, ATTR_TRANSITION, ATTR_EFFECT,
     SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_RGB_COLOR,
-    SUPPORT_TRANSITION, SUPPORT_EFFECT)
+    SUPPORT_XY_COLOR, SUPPORT_TRANSITION, SUPPORT_EFFECT)
 from homeassistant.util.color import (
     color_temperature_mired_to_kelvin, color_temperature_kelvin_to_mired)
 from homeassistant import util
@@ -46,7 +46,7 @@ BYTE_MAX = 255
 SHORT_MAX = 65535
 
 SUPPORT_LIFX = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_RGB_COLOR |
-                SUPPORT_TRANSITION | SUPPORT_EFFECT)
+                SUPPORT_XY_COLOR | SUPPORT_TRANSITION | SUPPORT_EFFECT)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SERVER, default='0.0.0.0'): cv.string,
@@ -357,6 +357,14 @@ class LIFXLight(Light):
             changed_color = True
         else:
             brightness = self._bri
+
+        if ATTR_XY_COLOR in kwargs:
+            hue, saturation, _ = \
+                color_util.color_xy_brightness_to_hsv(
+                    *kwargs[ATTR_XY_COLOR],
+                    ibrightness=(brightness // (BYTE_MAX + 1)))
+            saturation = saturation * (BYTE_MAX + 1)
+            changed_color = True
 
         if ATTR_COLOR_TEMP in kwargs:
             kelvin = int(color_temperature_mired_to_kelvin(

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -8,7 +8,6 @@ from homeassistant.components.light import \
     PLATFORM_SCHEMA as LIGHT_PLATFORM_SCHEMA
 from homeassistant.components.tradfri import KEY_GATEWAY
 from homeassistant.util import color as color_util
-from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,12 +47,12 @@ class Tradfri(Light):
 
         if self._light_data.hex_color is not None:
             if self._light.device_info.manufacturer == IKEA:
-                self._features &= SUPPORT_COLOR_TEMP
+                self._features |= SUPPORT_COLOR_TEMP
             else:
-                self._features &= SUPPORT_RGB_COLOR
+                self._features |= SUPPORT_RGB_COLOR
 
         self._ok_temps = ALLOWED_TEMPERATURES.get(
-            slugify(self._light.device_info.manufacturer))
+            self._light.device_info.manufacturer)
 
     @property
     def supported_features(self):
@@ -123,7 +122,7 @@ class Tradfri(Light):
             kelvin = color_util.color_temperature_mired_to_kelvin(
                 kwargs[ATTR_COLOR_TEMP])
             # find closest allowed kelvin temp from user input
-            kelvin = min(self._ok_temps.keys(), key=lambda x: abs(x-kelvin))
+            kelvin = min(self._ok_temps.keys(), key=lambda x: abs(x - kelvin))
             self._light_control.set_hex_color(self._ok_temps[kelvin])
 
     def update(self):

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.webostv/
 """
 import logging
+import asyncio
 from datetime import timedelta
 from urllib.parse import urlparse
 
@@ -24,7 +25,7 @@ from homeassistant.const import (
 from homeassistant.loader import get_component
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pylgtv==0.1.5',
+REQUIREMENTS = ['pylgtv==0.1.6',
                 'websockets==3.2',
                 'wakeonlan==0.2.2']
 
@@ -99,7 +100,8 @@ def setup_tv(host, mac, name, customize, config, hass, add_devices):
                 _LOGGER.warning(
                     "Connected to LG webOS TV %s but not paired", host)
                 return
-            except (OSError, ConnectionClosed):
+            except (OSError, ConnectionClosed, TypeError,
+                    asyncio.TimeoutError):
                 _LOGGER.error("Unable to connect to host %s", host)
                 return
         else:
@@ -196,7 +198,8 @@ class LgWebOSDevice(MediaPlayerDevice):
                 app = self._app_list[source['appId']]
                 self._source_list[app['title']] = app
 
-        except (OSError, ConnectionClosed):
+        except (OSError, ConnectionClosed, TypeError,
+                asyncio.TimeoutError):
             self._state = STATE_OFF
 
     @property
@@ -257,7 +260,8 @@ class LgWebOSDevice(MediaPlayerDevice):
         self._state = STATE_OFF
         try:
             self._client.power_off()
-        except (OSError, ConnectionClosed):
+        except (OSError, ConnectionClosed, TypeError,
+                asyncio.TimeoutError):
             pass
 
     def turn_on(self):

--- a/homeassistant/components/notify/webostv.py
+++ b/homeassistant/components/notify/webostv.py
@@ -14,7 +14,7 @@ from homeassistant.components.notify import (
     ATTR_DATA, BaseNotificationService, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_FILENAME, CONF_HOST, CONF_ICON)
 
-REQUIREMENTS = ['pylgtv==0.1.5']
+REQUIREMENTS = ['pylgtv==0.1.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/arwn.py
+++ b/homeassistant/components/sensor/arwn.py
@@ -116,6 +116,7 @@ class ArwnSensor(Entity):
         """Update the sensor with the most recent event."""
         self.event = {}
         self.event.update(event)
+        self.hass.async_add_job(self.async_update_ha_state())
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -81,18 +81,18 @@ class SSLCertificate(Entity):
             sock = ctx.wrap_socket(socket.socket(),
                                    server_hostname=self.server_name)
             sock.connect((self.server_name, self.server_port))
-        except Exception as e:
+        except Exception as excp:
             _LOGGER.error('Cannot connect to %s' % (self.server_name))
-            raise e
+            raise excp
 
         try:
             cert = sock.getpeercert()
-        except Exception as e:
+        except Exception as excp:
             _LOGGER.error('Cannot fetch certificate from %s' %
                           (self.server_name))
-            raise e
+            raise excp
 
-        timestamp = ssl.cert_time_to_seconds(cert['notAfter'])
-        ts = datetime.datetime.fromtimestamp(timestamp)
-        expiry = ts - datetime.datetime.today()
+        ts_seconds = ssl.cert_time_to_seconds(cert['notAfter'])
+        timestamp = datetime.datetime.fromtimestamp(ts_seconds)
+        expiry = timestamp - datetime.datetime.today()
         self._state = expiry.days

--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -1,0 +1,98 @@
+"""Counts the days an HTTPS (TLS) certificate will expire (days).
+
+Example configuration.yaml:
+
+  sensor:
+    - platform: cert_expiry
+      server_name: home-assistant.io
+
+For more details about this sensor please refer to the
+documentation at https://home-assistant.io/components/sensor.cert_expiry
+"""
+import logging
+import ssl
+import socket
+import datetime
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.util import Throttle
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = []
+_LOGGER = logging.getLogger(__name__)
+
+CONF_SERVER_NAME = 'server_name'
+CONF_SERVER_PORT = 'server_port'
+ICON = 'mdi:certificate'
+
+MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(hours=12)
+TIMEOUT = 10
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SERVER_NAME): cv.string,
+    vol.Optional(CONF_SERVER_PORT, default=443): cv.port,
+    })
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup certificate expiry sensor."""
+    server_name = config.get(CONF_SERVER_NAME)
+    server_port = config.get(CONF_SERVER_PORT)
+    add_devices([SSLCertificate(server_name, server_port)])
+
+
+class SSLCertificate(Entity):
+    """Implements certificate expiry sensor."""
+
+    def __init__(self, server_name, server_port):
+        """Initialize the sensor."""
+        self.server_name = server_name
+        self.server_port = server_port
+        self._name = "{} cert expiry".format(server_name)
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit this state is expressed in."""
+        return 'days'
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return ICON
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Fetch certificate information."""
+        try:
+            ctx = ssl.create_default_context()
+            sock = ctx.wrap_socket(socket.socket(),
+                                   server_hostname=self.server_name)
+            sock.connect((self.server_name, self.server_port))
+        except Exception as e:
+            _LOGGER.error('Cannot connect to %s' % (self.server_name))
+            raise e
+
+        try:
+            cert = sock.getpeercert()
+        except Exception as e:
+            _LOGGER.error('Cannot fetch certificate from %s' %
+                          (self.server_name))
+            raise e
+
+        timestamp = ssl.cert_time_to_seconds(cert['notAfter'])
+        ts = datetime.datetime.fromtimestamp(timestamp)
+        expiry = ts - datetime.datetime.today()
+        self._state = expiry.days

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -14,7 +14,8 @@ SENSOR_TYPES = {
     "state": ["Battery State", None]
 }
 
-DEFAULT_ICON = "mdi:battery"
+DEFAULT_ICON_LEVEL = "mdi:battery"
+DEFAULT_ICON_STATE = "mdi:power-plug"
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -62,7 +63,6 @@ class IOSSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement this sensor expresses itself in."""
-        return self._unit_of_measurement
 
     @property
     def device_state_attributes(self):
@@ -84,28 +84,44 @@ class IOSSensor(Entity):
         battery_state = device_battery[ios.ATTR_BATTERY_STATE]
         battery_level = device_battery[ios.ATTR_BATTERY_LEVEL]
         rounded_level = round(battery_level, -1)
-        returning_icon = DEFAULT_ICON
+        returning_icon_level = DEFAULT_ICON_LEVEL
         if battery_state == ios.ATTR_BATTERY_STATE_FULL:
-            returning_icon = DEFAULT_ICON
+            returning_icon_level = DEFAULT_ICON_LEVEL
+            if battery_state == ios.ATTR_BATTERY_STATE_CHARGING:
+                returning_icon_state = DEFAULT_ICON_STATE
+            else:
+                returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
         elif battery_state == ios.ATTR_BATTERY_STATE_CHARGING:
             # Why is MDI missing 10, 50, 70?
             if rounded_level in (20, 30, 40, 60, 80, 90, 100):
-                returning_icon = "{}-charging-{}".format(DEFAULT_ICON,
-                                                         str(rounded_level))
+                returning_icon_level = "{}-charging-{}".format(
+                    DEFAULT_ICON_LEVEL, str(rounded_level))
+                returning_icon_state = DEFAULT_ICON_STATE
             else:
-                returning_icon = "{}-charging".format(DEFAULT_ICON)
+                returning_icon_level = "{}-charging".format(
+                    DEFAULT_ICON_LEVEL)
+                returning_icon_state = DEFAULT_ICON_STATE
         elif battery_state == ios.ATTR_BATTERY_STATE_UNPLUGGED:
             if rounded_level < 10:
-                returning_icon = "{}-outline".format(DEFAULT_ICON)
+                returning_icon_level = "{}-outline".format(
+                    DEFAULT_ICON_LEVEL)
+                returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
             elif battery_level > 95:
-                returning_icon = DEFAULT_ICON
+                returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
+                returning_icon_level = "{}-outline".format(
+                    DEFAULT_ICON_LEVEL)
             else:
-                returning_icon = "{}-{}".format(DEFAULT_ICON,
-                                                str(rounded_level))
+                returning_icon_level = "{}-{}".format(DEFAULT_ICON_LEVEL,
+                                                      str(rounded_level))
+                returning_icon_state = "{}-off".format(DEFAULT_ICON_STATE)
         elif battery_state == ios.ATTR_BATTERY_STATE_UNKNOWN:
-            returning_icon = "{}-unknown".format(DEFAULT_ICON)
+            returning_icon_level = "{}-unknown".format(DEFAULT_ICON_LEVEL)
+            returning_icon_state = "{}-unknown".format(DEFAULT_ICON_LEVEL)
 
-        return returning_icon
+        if self.type == "state":
+            return returning_icon_state
+        else:
+            return returning_icon_level
 
     def update(self):
         """Get the latest state of the sensor."""

--- a/homeassistant/components/sensor/pushbullet.py
+++ b/homeassistant/components/sensor/pushbullet.py
@@ -1,0 +1,134 @@
+"""
+Pushbullet platform for sensor component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.pushbullet/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import (CONF_API_KEY, CONF_MONITORED_CONDITIONS)
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['pushbullet.py==0.10.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+SENSOR_TYPES = {
+    'application_name': ['Application name'],
+    'body': ['Body'],
+    'notification_id': ['Notification ID'],
+    'notification_tag': ['Notification tag'],
+    'package_name': ['Package name'],
+    'receiver_email': ['Receiver email'],
+    'sender_email': ['Sender email'],
+    'source_device_iden': ['Sender device ID'],
+    'title': ['Title'],
+    'type': ['Type'],
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=['title', 'body']):
+        vol.All(cv.ensure_list, vol.Length(min=1), [vol.In(SENSOR_TYPES)]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Pushbllet Sensor platform."""
+    from pushbullet import PushBullet
+    from pushbullet import InvalidKeyError
+    try:
+        pushbullet = PushBullet(config.get(CONF_API_KEY))
+    except InvalidKeyError:
+        _LOGGER.error("Wrong API key for Pushbullet supplied")
+        return False
+
+    pbprovider = PushBulletNotificationProvider(pushbullet)
+
+    devices = []
+    for sensor_type in config[CONF_MONITORED_CONDITIONS]:
+        devices.append(PushBulletNotificationSensor(pbprovider, sensor_type))
+    add_devices(devices)
+
+
+class PushBulletNotificationSensor(Entity):
+    """Representation of a Pushbullet Sensor."""
+
+    def __init__(self, pb, element):
+        """Initialize the Pushbullet sensor."""
+        self.pushbullet = pb
+        self._element = element
+        self._state = None
+        self._state_attributes = None
+
+    def update(self):
+        """Fetch the latest data from the sensor.
+
+        This will fetch the 'sensor reading' into self._state but also all
+        attributes into self._state_attributes.
+        """
+        try:
+            self._state = self.pushbullet.data[self._element]
+            self._state_attributes = self.pushbullet.data
+        except (KeyError, TypeError):
+            pass
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{} {}'.format('Pushbullet', self._element)
+
+    @property
+    def state(self):
+        """Return the current state of the sensor."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return all known attributes of the sensor."""
+        return self._state_attributes
+
+
+class PushBulletNotificationProvider():
+    """Provider for an account, leading to one or more sensors."""
+
+    def __init__(self, pb):
+        """Start to retrieve pushes from the given Pushbullet instance."""
+        import threading
+        self.pushbullet = pb
+        self._data = None
+        self.listener = None
+        self.thread = threading.Thread(target=self.retrieve_pushes)
+        self.thread.daemon = True
+        self.thread.start()
+
+    def on_push(self, data):
+        """Method to update the current data.
+
+        Currently only monitors pushes but might be extended to monitor
+        different kinds of Pushbullet events.
+        """
+        if data['type'] == 'push':
+            self._data = data['push']
+
+    @property
+    def data(self):
+        """The current data stored in the provider."""
+        return self._data
+
+    def retrieve_pushes(self):
+        """The method to run the daemon thread in.
+
+        Spawn a new Listener and links it to self.on_push.
+        """
+        from pushbullet import Listener
+        self.listener = Listener(account=self.pushbullet, on_push=self.on_push)
+        _LOGGER.debug("Getting pushes")
+        try:
+            self.listener.run_forever()
+        finally:
+            self.listener.close()

--- a/homeassistant/components/zwave/discovery_schemas.py
+++ b/homeassistant/components/zwave/discovery_schemas.py
@@ -81,12 +81,12 @@ DISCOVERY_SCHEMAS = [
          },
          'open': {
              const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_SWITCH_MULTILEVEL],
-             const.DISC_LABEL: ['Open', 'Up'],
+             const.DISC_LABEL: ['Open', 'Up', 'Bright'],
              const.DISC_OPTIONAL: True,
          },
          'close': {
              const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_SWITCH_MULTILEVEL],
-             const.DISC_LABEL: ['Close', 'Down'],
+             const.DISC_LABEL: ['Close', 'Down', 'Dim'],
              const.DISC_OPTIONAL: True,
          }})},
     {const.DISC_COMPONENT: 'cover',  # Garage Door

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
-MINOR_VERSION = 43
+MINOR_VERSION = 44
 PATCH_VERSION = '0.dev0'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -460,6 +460,7 @@ psutil==5.2.2
 pubnubsub-handler==1.0.2
 
 # homeassistant.components.notify.pushbullet
+# homeassistant.components.sensor.pushbullet
 pushbullet.py==0.10.0
 
 # homeassistant.components.notify.pushetta

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -564,7 +564,7 @@ pylast==1.8.0
 
 # homeassistant.components.media_player.webostv
 # homeassistant.components.notify.webostv
-pylgtv==0.1.5
+pylgtv==0.1.6
 
 # homeassistant.components.litejet
 pylitejet==0.1

--- a/script/dev_docker
+++ b/script/dev_docker
@@ -27,6 +27,7 @@ else
     -v /etc/localtime:/etc/localtime:ro \
     -v `pwd`:/usr/src/app \
     -v `pwd`/config:/config \
+    --rm \
     -t -i home-assistant-dev
 
 fi

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -12,6 +12,7 @@ MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
 #ENV INSTALL_OPENZWAVE no
 #ENV INSTALL_LIBCEC no
 #ENV INSTALL_PHANTOMJS no
+#ENV INSTALL_COAP_CLIENT no
 
 VOLUME /config
 
@@ -25,7 +26,7 @@ RUN virtualization/Docker/setup_docker_prereqs
 # Install hass component dependencies
 COPY requirements_all.txt requirements_all.txt
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
-    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop
+    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet
 
 # BEGIN: Development additions
 


### PR DESCRIPTION
## Simple sensor to check HTTPS certificate expiry (in days)

This simple sensor fetches a certificate using the `ssl` module anc check the `notAfter` directive in HTTPS certificate. Reports then the expiry in days.

## Example entry for `configuration.yaml` (if applicable):
```yaml

sensor:
  - platform: cert_expiry
    server_name: home-assistant.io
    server_port: 443

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
