### PR TITLE
Support xy_color with LIFX lights

### DIFF
--- a/homeassistant/components/light/lifx/__init__.py
+++ b/homeassistant/components/light/lifx/__init__.py
@@ -16,9 +16,9 @@ import voluptuous as vol
 
 from homeassistant.components.light import (
     Light, PLATFORM_SCHEMA, ATTR_BRIGHTNESS, ATTR_COLOR_NAME, ATTR_RGB_COLOR,
-    ATTR_COLOR_TEMP, ATTR_TRANSITION, ATTR_EFFECT,
+    ATTR_XY_COLOR, ATTR_COLOR_TEMP, ATTR_TRANSITION, ATTR_EFFECT,
     SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_RGB_COLOR,
-    SUPPORT_TRANSITION, SUPPORT_EFFECT)
+    SUPPORT_XY_COLOR, SUPPORT_TRANSITION, SUPPORT_EFFECT)
 from homeassistant.util.color import (
     color_temperature_mired_to_kelvin, color_temperature_kelvin_to_mired)
 from homeassistant import util
@@ -46,7 +46,7 @@ BYTE_MAX = 255
 SHORT_MAX = 65535
 
 SUPPORT_LIFX = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_RGB_COLOR |
-                SUPPORT_TRANSITION | SUPPORT_EFFECT)
+                SUPPORT_XY_COLOR | SUPPORT_TRANSITION | SUPPORT_EFFECT)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SERVER, default='0.0.0.0'): cv.string,
@@ -357,6 +357,14 @@ class LIFXLight(Light):
             changed_color = True
         else:
             brightness = self._bri
+
+        if ATTR_XY_COLOR in kwargs:
+            hue, saturation, _ = \
+                color_util.color_xy_brightness_to_hsv(
+                    *kwargs[ATTR_XY_COLOR],
+                    ibrightness=(brightness // (BYTE_MAX + 1)))
+            saturation = saturation * (BYTE_MAX + 1)
+            changed_color = True
 
         if ATTR_COLOR_TEMP in kwargs:
             kelvin = int(color_temperature_mired_to_kelvin(


### PR DESCRIPTION
## Description:

This is mainly for completeness, making LIFX work with various other features that provide `xy_color` values.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
