### PR TITLE
Fix tradfri lights

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -47,9 +47,9 @@ class Tradfri(Light):
 
         if self._light_data.hex_color is not None:
             if self._light.device_info.manufacturer == IKEA:
-                self._features &= SUPPORT_COLOR_TEMP
+                self._features |= SUPPORT_COLOR_TEMP
             else:
-                self._features &= SUPPORT_RGB_COLOR
+                self._features |= SUPPORT_RGB_COLOR
 
         self._ok_temps = ALLOWED_TEMPERATURES.get(
             self._light.device_info.manufacturer)

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -8,7 +8,6 @@ from homeassistant.components.light import \
     PLATFORM_SCHEMA as LIGHT_PLATFORM_SCHEMA
 from homeassistant.components.tradfri import KEY_GATEWAY
 from homeassistant.util import color as color_util
-from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,7 +52,7 @@ class Tradfri(Light):
                 self._features &= SUPPORT_RGB_COLOR
 
         self._ok_temps = ALLOWED_TEMPERATURES.get(
-            slugify(self._light.device_info.manufacturer))
+            self._light.device_info.manufacturer)
 
     @property
     def supported_features(self):
@@ -123,7 +122,7 @@ class Tradfri(Light):
             kelvin = color_util.color_temperature_mired_to_kelvin(
                 kwargs[ATTR_COLOR_TEMP])
             # find closest allowed kelvin temp from user input
-            kelvin = min(self._ok_temps.keys(), key=lambda x: abs(x-kelvin))
+            kelvin = min(self._ok_temps.keys(), key=lambda x: abs(x - kelvin))
             self._light_control.set_hex_color(self._ok_temps[kelvin])
 
     def update(self):


### PR DESCRIPTION
## Description:
* Remove leftover use of slugify. The IKEA manufacturer key is now exactly as found in device info.
* Fix bitwise addition of supported features.

**Related issue (if applicable):**
Additional fixes were needed after #7211 

## Checklist:
If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
