### PR TITLE
Upgrade aiohttp_cors to 0.5.3

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -34,7 +34,7 @@ from .static import (
     staticresource_middleware, CachingFileResponse, CachingStaticResource)
 from .util import get_real_ip
 
-REQUIREMENTS = ['aiohttp_cors==0.5.2']
+REQUIREMENTS = ['aiohttp_cors==0.5.3']
 
 DOMAIN = 'http'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -45,7 +45,7 @@ aiodns==1.1.1
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
-aiohttp_cors==0.5.2
+aiohttp_cors==0.5.3
 
 # homeassistant.components.light.lifx
 aiolifx==0.4.4


### PR DESCRIPTION
## 0.5.3

- Fix typing being installed on Python 3.6.

Tested with: 
```yaml
http:
```