### PR TITLE
Upgrade paho-mqtt to 1.2.3

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
     CONF_PASSWORD, CONF_PORT, CONF_PROTOCOL, CONF_PAYLOAD)
 from homeassistant.components.mqtt.server import HBMQTT_CONFIG_SCHEMA
 
-REQUIREMENTS = ['paho-mqtt==1.2.2']
+REQUIREMENTS = ['paho-mqtt==1.2.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -419,7 +419,7 @@ openhomedevice==0.2.1
 orvibo==1.1.1
 
 # homeassistant.components.mqtt
-paho-mqtt==1.2.2
+paho-mqtt==1.2.3
 
 # homeassistant.components.media_player.panasonic_viera
 panasonic_viera==0.2


### PR DESCRIPTION
1.2.3
=====

- Fix possible hang of TLS connection during handshake.
- Fix issue with publish helper with TLS connection.
- Fix installation issue on non-UTF-8 system.
- Fix non-working Websocket over TLS connection.

Fixes : #7219, #7268

Tested with the following configuration:

``` yaml
mqtt:
  broker: localhost

binary_sensor:
  - platform: mqtt
    name: Bathroom door
    state_topic: "home/bathroom/door"
    payload_on: "1"
    payload_off: "0"
    device_class: opening
```

```bash
$ mosquitto_pub -h localhost -t "home/bathroom/door" -m 1
$ mosquitto_pub -h localhost -t "home/bathroom/door" -m 0

17-04-22 10:17:58 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: old_state=<state binary_sensor.bathroom_door=off; friendly_name=Bathroom door, device_class=opening @ 2017-04-22T10:17:13.217418+02:00>, new_state=<state binary_sensor.bathroom_door=on; friendly_name=Bathroom door, device_class=opening @ 2017-04-22T10:17:58.367423+02:00>, entity_id=binary_sensor.bathroom_door>
17-04-22 10:18:01 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: old_state=<state binary_sensor.bathroom_door=on; friendly_name=Bathroom door, device_class=opening @ 2017-04-22T10:17:58.367423+02:00>, new_state=<state binary_sensor.bathroom_door=off; friendly_name=Bathroom door, device_class=opening @ 2017-04-22T10:18:01.383566+02:00>, entity_id=binary_sensor.bathroom_door>

```