### PR TITLE
Upgrade speedtest-cli to 1.0.5

### DIFF
--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_change
 from homeassistant.helpers.restore_state import async_get_last_state
 
-REQUIREMENTS = ['speedtest-cli==1.0.4']
+REQUIREMENTS = ['speedtest-cli==1.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 _SPEEDTEST_REGEX = re.compile(r'Ping:\s(\d+\.\d+)\sms[\r\n]+'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -738,7 +738,7 @@ snapcast==1.2.2
 somecomfort==0.4.1
 
 # homeassistant.components.sensor.speedtest
-speedtest-cli==1.0.4
+speedtest-cli==1.0.5
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator


### PR DESCRIPTION
1.0.4
----
- see [commit log](https://github.com/sivel/speedtest-cli/commits/master)

Tested with the following configuration:

``` yaml
sensor:
  - platform: speedtest
    monitored_conditions:
      - ping
      - download
      - upload
```

```bash
17-04-22 10:25:06 INFO (Thread-8) [homeassistant.components.sensor.speedtest] Executing speedtest...
[...]
17-04-22 10:25:58 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=sensor.speedtest_download, new_state=<state sensor.speedtest_download=84.75; icon=mdi:speedometer, friendly_name=Speedtest Download, unit_of_measurement=Mbit/s @ 2017-04-22T10:25:58.828101+02:00>, old_state=<state sensor.speedtest_download=unknown; icon=mdi:speedometer, friendly_name=Speedtest Download, unit_of_measurement=Mbit/s @ 2017-04-22T10:24:26.255360+02:00>>
17-04-22 10:25:58 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=sensor.speedtest_ping, new_state=<state sensor.speedtest_ping=29.45; icon=mdi:speedometer, friendly_name=Speedtest Ping, unit_of_measurement=ms @ 2017-04-22T10:25:58.829837+02:00>, old_state=<state sensor.speedtest_ping=unknown; icon=mdi:speedometer, friendly_name=Speedtest Ping, unit_of_measurement=ms @ 2017-04-22T10:24:26.261085+02:00>>
```