### PR TITLE
improve handling of flux_led lights in RGBW mode

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -12,9 +12,9 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_PROTOCOL
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATTR_EFFECT, EFFECT_COLORLOOP,
-    EFFECT_RANDOM, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT,
-    SUPPORT_RGB_COLOR, Light,
+    ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATTR_EFFECT, ATTR_WHITE_VALUE,
+    EFFECT_COLORLOOP, EFFECT_RANDOM, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT,
+    SUPPORT_RGB_COLOR, SUPPORT_WHITE_VALUE, Light,
     PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
@@ -27,8 +27,10 @@ ATTR_MODE = 'mode'
 
 DOMAIN = 'flux_led'
 
-SUPPORT_FLUX_LED = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT |
-                    SUPPORT_RGB_COLOR)
+SUPPORT_FLUX_LED_RGB = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT |
+                        SUPPORT_RGB_COLOR)
+SUPPORT_FLUX_LED_RGBW = (SUPPORT_WHITE_VALUE | SUPPORT_EFFECT |
+                         SUPPORT_RGB_COLOR)
 
 MODE_RGB = 'rgb'
 MODE_RGBW = 'rgbw'
@@ -180,7 +182,16 @@ class FluxLight(Light):
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        return self._bulb.brightness
+        if self._mode == MODE_RGB:
+            return self._bulb.brightness
+        return None  # not used for RGBW
+
+    @property
+    def white_value(self):
+        """Return the white value of this light between 0..255."""
+        if self._mode == MODE_RGBW:
+            return self._bulb.getRgbw()[3]
+        return None  # not used for RGB
 
     @property
     def rgb_color(self):
@@ -190,7 +201,11 @@ class FluxLight(Light):
     @property
     def supported_features(self):
         """Flag supported features."""
-        return SUPPORT_FLUX_LED
+        if self._mode == MODE_RGBW:
+            return SUPPORT_FLUX_LED_RGBW
+        elif self._mode == MODE_RGB:
+            return SUPPORT_FLUX_LED_RGB
+        return 0
 
     @property
     def effect_list(self):
@@ -204,17 +219,23 @@ class FluxLight(Light):
 
         rgb = kwargs.get(ATTR_RGB_COLOR)
         brightness = kwargs.get(ATTR_BRIGHTNESS)
+        white_value = kwargs.get(ATTR_WHITE_VALUE)
         effect = kwargs.get(ATTR_EFFECT)
+
         if rgb is not None and brightness is not None:
             self._bulb.setRgb(*tuple(rgb), brightness=brightness)
+        elif rgb is not None and white_value is not None:
+            self._bulb.setRgbw(*tuple(rgb), w=white_value)
         elif rgb is not None:
-            self._bulb.setRgb(*tuple(rgb))
+            # self.white_value and self.brightness are appropriately
+            # returning None for MODE_RGB and MODE_RGBW respectively
+            self._bulb.setRgbw(*tuple(rgb),
+                               w=self.white_value,
+                               brightness=self.brightness)
         elif brightness is not None:
-            if self._mode == 'rgbw':
-                self._bulb.setWarmWhite255(brightness)
-            elif self._mode == 'rgb':
-                (red, green, blue) = self._bulb.getRgb()
-                self._bulb.setRgb(red, green, blue, brightness=brightness)
+            self._bulb.setRgb(*self.rgb_color, brightness=brightness)
+        elif white_value is not None:
+            self._bulb.setRgbw(*self.rgb_color, w=white_value)
         elif effect == EFFECT_RANDOM:
             self._bulb.setRgb(random.randint(0, 255),
                               random.randint(0, 255),


### PR DESCRIPTION
Mobile app allows independent control of white and rgb channels. This change along with PR to flux_led adds feature parity in this regard.

I decided to drop brightness attr and replace it with white_value in rgbw mode. Behaviour of `flux_led.setRgbw()` with brightness + white is more than confusing. Controlling RGB using color picker and White using slider proved to be more user friendly.   But I'm open for feedback :) 

This cannot be merged until https://github.com/Danielhiversen/flux_led/pull/41 is reviewed, but I wan to go trough CLA process now.   

## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2472

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).  (not yet, waiting on https://github.com/Danielhiversen/flux_led/pull/41)
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
