### PR TITLE
Fix telegram webhooks

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -50,7 +50,7 @@ def async_setup(hass, config):
             _LOGGER.error("Unknown notification service specified")
             return
 
-        _LOGGER.info("Setting up1 %s.%s", DOMAIN, p_type)
+        _LOGGER.info("Setting up %s.%s", DOMAIN, p_type)
 
         try:
             if hasattr(platform, 'async_setup_platform'):
@@ -72,8 +72,6 @@ def async_setup(hass, config):
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception('Error setting up platform %s', p_type)
             return
-
-        return True
 
     setup_tasks = [async_setup_platform(p_type, p_config) for p_type, p_config
                    in config_per_platform(config, DOMAIN)]
@@ -103,10 +101,10 @@ class BaseTelegramBotEntity:
         """Check for basic message rules and fire an event if message is ok."""
         data = data.get('message')
 
-        if (not data
-                or 'from' not in data
-                or 'text' not in data
-                or data['from'].get('id') not in self.allowed_chat_ids):
+        if (not data or
+                'from' not in data or
+                'text' not in data or
+                data['from'].get('id') not in self.allowed_chat_ids):
             # Message is not correct.
             _LOGGER.error("Incoming message does not have required data.")
             return False

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -11,9 +11,8 @@ from ipaddress import ip_network
 
 import voluptuous as vol
 
-
 from homeassistant.const import (
-    HTTP_BAD_REQUEST, HTTP_UNAUTHORIZED)
+    EVENT_HOMEASSISTANT_STOP, HTTP_BAD_REQUEST, HTTP_UNAUTHORIZED)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.telegram_bot import CONF_ALLOWED_CHAT_IDS, \
@@ -27,6 +26,7 @@ REQUIREMENTS = ['python-telegram-bot==5.3.0']
 _LOGGER = logging.getLogger(__name__)
 
 TELEGRAM_HANDLER_URL = '/api/telegram_webhooks'
+REMOVE_HANDLER_URL = ''
 
 CONF_TRUSTED_NETWORKS = 'trusted_networks'
 DEFAULT_TRUSTED_NETWORKS = [
@@ -50,20 +50,21 @@ def setup_platform(hass, config, async_add_devices, discovery_info=None):
     bot = telegram.Bot(config[CONF_API_KEY])
 
     current_status = bot.getWebhookInfo()
-    handler_url = "{0}{1}".format(hass.config.api.base_url,
-                                  TELEGRAM_HANDLER_URL)
+    handler_url = '{0}{1}'.format(
+        hass.config.api.base_url, TELEGRAM_HANDLER_URL)
     if current_status and current_status['url'] != handler_url:
         if bot.setWebhook(handler_url):
             _LOGGER.info("set new telegram webhook %s", handler_url)
-
-            hass.http.register_view(
-                BotPushReceiver(
-                    hass,
-                    config[CONF_ALLOWED_CHAT_IDS],
-                    config[CONF_TRUSTED_NETWORKS]))
-
         else:
             _LOGGER.error("set telegram webhook failed %s", handler_url)
+            return False
+
+    hass.bus.listen_once(
+        EVENT_HOMEASSISTANT_STOP,
+        lambda event: bot.setWebhook(REMOVE_HANDLER_URL))
+    hass.http.register_view(BotPushReceiver(
+        hass, config[CONF_ALLOWED_CHAT_IDS], config[CONF_TRUSTED_NETWORKS]))
+    return True
 
 
 class BotPushReceiver(HomeAssistantView, BaseTelegramBotEntity):
@@ -71,7 +72,7 @@ class BotPushReceiver(HomeAssistantView, BaseTelegramBotEntity):
 
     requires_auth = False
     url = TELEGRAM_HANDLER_URL
-    name = "telegram_webhooks"
+    name = 'telegram_webhooks'
 
     def __init__(self, hass, allowed_chat_ids, trusted_networks):
         """Initialize the class."""


### PR DESCRIPTION
## Description:
* Always register the view if a webhook exists.
* Return `True` if platform is set up succesfully, `False` otherwise.
* Remove the webhook when home assistant stops. Webhooks and long polling are mutually exclusive. If a webhook is left after home assistant is stopped, a polling telegram bot is unable to be set up, on next start of home assistant. See for more info: https://core.telegram.org/bots/api#getting-updates

## Example entry for `configuration.yaml` (if applicable):
```yaml
telegram_bot:
  platform: webhooks
  api_key: telegram api key
  allowed_chat_ids:
    - 12345
    - 67890
```

## Checklist:
If user exposed functionality or configuration variables are added/changed:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
