### PR TITLE
InfluxDB send retry after IOError

### DIFF
--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -324,6 +324,7 @@ class RetryOnError(object):
     It takes a Hass instance, a maximum number of retries and a retry delay
     in seconds as arguments.
     """
+
     def __init__(self, hass, retry_limit=0, retry_delay=20):
         """Initialize the decorator."""
         self.hass = hass
@@ -331,18 +332,19 @@ class RetryOnError(object):
         self.retry_delay = timedelta(seconds=retry_delay)
 
     def __call__(self, method):
-        """This decorates the target method."""
+        """Decorate the target method."""
         from homeassistant.helpers.event import track_point_in_utc_time
 
         @wraps(method)
         def wrapper(*args, **kwargs):
-
+            """Wrapped method."""
             def scheduled(retry=0, event=None):
-                """The scheduling wrapper.
+                """Call the target method.
 
                 It is called directly at the first time and then called
                 scheduled within the Hass mainloop.
                 """
+                # pylint: disable=broad-except
                 try:
                     method(*args, **kwargs)
                 except Exception:

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -2,13 +2,13 @@
 from collections.abc import MutableSet
 from itertools import chain
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
 import re
 import enum
 import socket
 import random
 import string
-from functools import wraps
+from functools import wraps, partial
 from types import MappingProxyType
 from unicodedata import normalize
 
@@ -307,5 +307,53 @@ class Throttle(object):
                     return None
             finally:
                 throttle[0].release()
+
+        return wrapper
+
+
+class RetryOnError(object):
+    """A class for retrying a failed task a certain amount of tries.
+
+    This method decorator makes a method retrying on errors. If there was an
+    uncaught exception, it schedules another try to execute the task after a
+    retry delay. It does this up to the maximum number of retries.
+
+    It can be used for all probable "self-healing" problems like network
+    outages. The task will be rescheduled using HAs scheduling mechanism.
+
+    It takes a Hass instance, a maximum number of retries and a retry delay
+    in seconds as arguments.
+    """
+    def __init__(self, hass, retry_limit=0, retry_delay=20):
+        """Initialize the decorator."""
+        self.hass = hass
+        self.retry_limit = retry_limit
+        self.retry_delay = timedelta(seconds=retry_delay)
+
+    def __call__(self, method):
+        """This decorates the target method."""
+        from homeassistant.helpers.event import track_point_in_utc_time
+
+        @wraps(method)
+        def wrapper(*args, **kwargs):
+
+            def scheduled(retry=0, event=None):
+                """The scheduling wrapper.
+
+                It is called directly at the first time and then called
+                scheduled within the Hass mainloop.
+                """
+                try:
+                    method(*args, **kwargs)
+                except Exception:
+                    if retry == self.retry_limit:
+                        raise
+                    target = utcnow() + self.retry_delay
+                    track_point_in_utc_time(self.hass,
+                                            partial(scheduled,
+                                                    retry + 1),
+                                            target)
+
+            scheduled()
 
         return wrapper

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -2,8 +2,11 @@
 import unittest
 from unittest import mock
 
+from datetime import timedelta
 import influxdb as influx_client
 
+from homeassistant.util import dt as dt_util
+from homeassistant import core as ha
 from homeassistant.setup import setup_component
 import homeassistant.components.influxdb as influxdb
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
@@ -34,6 +37,7 @@ class TestInfluxDB(unittest.TestCase):
                 'database': 'db',
                 'username': 'user',
                 'password': 'password',
+                'max_retries': 4,
                 'ssl': 'False',
                 'verify_ssl': 'False',
             }
@@ -89,7 +93,7 @@ class TestInfluxDB(unittest.TestCase):
             influx_client.exceptions.InfluxDBClientError('fake')
         assert not setup_component(self.hass, influxdb.DOMAIN, config)
 
-    def _setup(self):
+    def _setup(self, **kwargs):
         """Setup the client."""
         config = {
             'influxdb': {
@@ -102,6 +106,7 @@ class TestInfluxDB(unittest.TestCase):
                 }
             }
         }
+        config['influxdb'].update(kwargs)
         assert setup_component(self.hass, influxdb.DOMAIN, config)
         self.handler_method = self.hass.bus.listen.call_args_list[0][0][1]
 
@@ -505,3 +510,33 @@ class TestInfluxDB(unittest.TestCase):
             else:
                 self.assertFalse(mock_client.return_value.write_points.called)
             mock_client.return_value.write_points.reset_mock()
+
+    def test_scheduled_write(self, mock_client):
+        """Test the event listener to retry after write failures."""
+        self._setup(max_retries=1)
+
+        state = mock.MagicMock(
+            state=1, domain='fake', entity_id='entity-id', object_id='entity',
+            attributes={})
+        event = mock.MagicMock(data={'new_state': state}, time_fired=12345)
+        mock_client.return_value.write_points.side_effect = \
+            IOError('foo')
+
+        start = dt_util.utcnow()
+
+        self.handler_method(event)
+        json_data = mock_client.return_value.write_points.call_args[0][0]
+        self.assertEqual(mock_client.return_value.write_points.call_count, 1)
+
+        shifted_time = start + (timedelta(seconds=20 + 1))
+        self.hass.bus.fire(ha.EVENT_TIME_CHANGED,
+                           {ha.ATTR_NOW: shifted_time})
+        self.hass.block_till_done()
+        self.assertEqual(mock_client.return_value.write_points.call_count, 2)
+        mock_client.return_value.write_points.assert_called_with(json_data)
+
+        shifted_time = shifted_time + (timedelta(seconds=20 + 1))
+        self.hass.bus.fire(ha.EVENT_TIME_CHANGED,
+                           {ha.ATTR_NOW: shifted_time})
+        self.hass.block_till_done()
+        self.assertEqual(mock_client.return_value.write_points.call_count, 2)

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -1,10 +1,13 @@
 """Test Home Assistant util methods."""
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from datetime import datetime, timedelta
 
+from homeassistant import core as ha
 from homeassistant import util
 import homeassistant.util.dt as dt_util
+
+from tests.common import get_test_home_assistant
 
 
 class TestUtil(unittest.TestCase):
@@ -266,3 +269,78 @@ class TestUtil(unittest.TestCase):
 
         self.assertTrue(tester.hello())
         self.assertTrue(tester.goodbye())
+
+
+class TestRetryOnErrorDecoratoru(unittest.TestCase):
+    """Test the RetryOnError decorator."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Clear data."""
+        self.hass.stop()
+
+    def test_no_retry(self):
+        """Test that it does not retry if configured."""
+        mock_method = MagicMock()
+        wrapped = util.RetryOnError(self.hass)(mock_method)
+        wrapped(1, 2, test=3)
+        self.assertEqual(mock_method.call_count, 1)
+        mock_method.assert_called_with(1, 2, test=3)
+
+        mock_method.side_effect = Exception()
+        self.assertRaises(Exception, wrapped, 1, 2, test=3)
+        self.assertEqual(mock_method.call_count, 2)
+        mock_method.assert_called_with(1, 2, test=3)
+
+    def test_single_retry(self):
+        """Test that retry stops after a single try if configured."""
+        mock_method = MagicMock()
+        retryer = util.RetryOnError(self.hass, retry_limit=1)
+        wrapped = retryer(mock_method)
+        wrapped(1, 2, test=3)
+        self.assertEqual(mock_method.call_count, 1)
+        mock_method.assert_called_with(1, 2, test=3)
+
+        start = dt_util.utcnow()
+        shifted_time = start + (timedelta(seconds=20 + 1))
+        self.hass.bus.fire(ha.EVENT_TIME_CHANGED,
+                           {ha.ATTR_NOW: shifted_time})
+        self.hass.block_till_done()
+        self.assertEqual(mock_method.call_count, 1)
+
+        mock_method.side_effect = Exception()
+        wrapped(1, 2, test=3)
+        self.assertEqual(mock_method.call_count, 2)
+        mock_method.assert_called_with(1, 2, test=3)
+
+        for cnt in range(3):
+            start = dt_util.utcnow()
+            shifted_time = start + (timedelta(seconds=20 + 1))
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED,
+                               {ha.ATTR_NOW: shifted_time})
+            self.hass.block_till_done()
+            self.assertEqual(mock_method.call_count, 3)
+            mock_method.assert_called_with(1, 2, test=3)
+
+    def test_multi_retry(self):
+        """Test that multiple retries work."""
+        mock_method = MagicMock()
+        retryer = util.RetryOnError(self.hass, retry_limit=4)
+        wrapped = retryer(mock_method)
+        mock_method.side_effect = Exception()
+
+        wrapped(1, 2, test=3)
+        self.assertEqual(mock_method.call_count, 1)
+        mock_method.assert_called_with(1, 2, test=3)
+
+        for cnt in range(3):
+            start = dt_util.utcnow()
+            shifted_time = start + (timedelta(seconds=20 + 1))
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED,
+                               {ha.ATTR_NOW: shifted_time})
+            self.hass.block_till_done()
+            self.assertEqual(mock_method.call_count, cnt + 2)
+            mock_method.assert_called_with(1, 2, test=3)


### PR DESCRIPTION
## Description:

This adds an optional max_retries parameter to the InfluxDB component
to specify if and how often the component should try to send the data
if the connection failed due to an IOError.

The sending will be scheduled for a retry in 20 seconds as often as the
user specified. This can be handy for flaky getwork connections between
the DB and Homeassistant or outages like daily DSL reconnects.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2485

## Example entry for `configuration.yaml` (if applicable):
```yaml
influxdb:
  host: 192.168.1.190
  port: 20000
  database: DB_TO_STORE_EVENTS
  username: MY_USERNAME
  password: MY_PASSWORD
  ssl: true
  verify_ssl: true
  max_retries: 3
  default_measurement: state
  blacklist:
     - entity.id1
     - entity.id2
  whitelist:
     - entity.id3
     - entity.id4
  tags:
    instance: prod
    source: hass
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
