### PR TITLE
Pushed to version 0.4.0 of denonavr 

### DIFF
--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     CONF_NAME, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['denonavr==0.3.1']
+REQUIREMENTS = ['denonavr==0.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -126,7 +126,7 @@ datapoint==0.4.3
 # decora==0.4
 
 # homeassistant.components.media_player.denonavr
-denonavr==0.3.1
+denonavr==0.4.0
 
 # homeassistant.components.media_player.directv
 directpy==0.1


### PR DESCRIPTION
## Description:

Pushed to version 0.4.0 of denonavr which also includes experimental support for Marantz receivers tested with M-RC610.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2489

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
