### PR TITLE
LIFX: use white light when setting a specific temperature

### DIFF
--- a/homeassistant/components/light/lifx/__init__.py
+++ b/homeassistant/components/light/lifx/__init__.py
@@ -370,6 +370,8 @@ class LIFXLight(Light):
         if ATTR_COLOR_TEMP in kwargs:
             kelvin = int(color_temperature_mired_to_kelvin(
                 kwargs[ATTR_COLOR_TEMP]))
+            if not changed_color:
+                saturation = 0
             changed_color = True
         else:
             kelvin = self._kel

--- a/homeassistant/components/light/lifx/__init__.py
+++ b/homeassistant/components/light/lifx/__init__.py
@@ -353,17 +353,11 @@ class LIFXLight(Light):
             saturation = self._sat
             brightness = self._bri
 
-        if ATTR_BRIGHTNESS in kwargs:
-            brightness = kwargs[ATTR_BRIGHTNESS] * (BYTE_MAX + 1)
-            changed_color = True
-        else:
-            brightness = self._bri
-
         if ATTR_XY_COLOR in kwargs:
             hue, saturation, _ = \
                 color_util.color_xy_brightness_to_hsv(
                     *kwargs[ATTR_XY_COLOR],
-                    ibrightness=(brightness // (BYTE_MAX + 1)))
+                    ibrightness=255)
             saturation = saturation * (BYTE_MAX + 1)
             changed_color = True
 
@@ -378,6 +372,12 @@ class LIFXLight(Light):
                 kelvin = 3500
             else:
                 kelvin = self._kel
+
+        if ATTR_BRIGHTNESS in kwargs:
+            brightness = kwargs[ATTR_BRIGHTNESS] * (BYTE_MAX + 1)
+            changed_color = True
+        else:
+            brightness = self._bri
 
         return [[hue, saturation, brightness, kelvin], changed_color]
 

--- a/homeassistant/components/light/lifx/__init__.py
+++ b/homeassistant/components/light/lifx/__init__.py
@@ -374,7 +374,10 @@ class LIFXLight(Light):
                 saturation = 0
             changed_color = True
         else:
-            kelvin = self._kel
+            if changed_color:
+                kelvin = 3500
+            else:
+                kelvin = self._kel
 
         return [[hue, saturation, brightness, kelvin], changed_color]
 

--- a/homeassistant/components/light/lifx/__init__.py
+++ b/homeassistant/components/light/lifx/__init__.py
@@ -361,6 +361,7 @@ class LIFXLight(Light):
             saturation = saturation * (BYTE_MAX + 1)
             changed_color = True
 
+        # When color or temperature is set, use a default value for the other
         if ATTR_COLOR_TEMP in kwargs:
             kelvin = int(color_temperature_mired_to_kelvin(
                 kwargs[ATTR_COLOR_TEMP]))


### PR DESCRIPTION
## Description:

When one of color/temperature is set, use a default value for the other.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**