### PR TITLE
Work around bad content-type in Hook API response

### DIFF
--- a/homeassistant/components/switch/hook.py
+++ b/homeassistant/components/switch/hook.py
@@ -47,7 +47,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                     data={
                         'username': username,
                         'password': password})
-            data = yield from response.json()
+            # The Hook API returns JSON but calls it 'text/html'.  Setting
+            # content_type=None disables aiohttp's content-type validation.
+            data = yield from response.json(content_type=None)
         except (asyncio.TimeoutError, aiohttp.ClientError) as error:
             _LOGGER.error("Failed authentication API call: %s", error)
             return False
@@ -63,7 +65,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             response = yield from websession.get(
                 '{}{}'.format(HOOK_ENDPOINT, 'device'),
                 params={"token": token})
-        data = yield from response.json()
+        data = yield from response.json(content_type=None)
     except (asyncio.TimeoutError, aiohttp.ClientError) as error:
         _LOGGER.error("Failed getting devices: %s", error)
         return False
@@ -110,7 +112,7 @@ class HookSmartHome(SwitchDevice):
             with async_timeout.timeout(TIMEOUT, loop=self.hass.loop):
                 response = yield from websession.get(
                     url, params={"token": self._token})
-            data = yield from response.json()
+            data = yield from response.json(content_type=None)
 
         except (asyncio.TimeoutError, aiohttp.ClientError) as error:
             _LOGGER.error("Failed setting state: %s", error)


### PR DESCRIPTION
## Description:

The Hook API returns JSON but with `Content-Type:text/html` in the header.  It probably always has, but the [upgrade to aiohttp 2](https://github.com/home-assistant/home-assistant/pull/6835) introduced content-type checking and caused the Hook component to start throwing an error.

This works around the bad header by turning off content-type validation when reading the response.

**Related issue:** fixes #7007 

No documentation or configuration changes needed.
