### PR TITLE
Add https certificate expiry sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -335,6 +335,7 @@ omit =
     homeassistant/components/sensor/broadlink.py
     homeassistant/components/sensor/dublin_bus_transport.py
     homeassistant/components/sensor/coinmarketcap.py
+    homeassistant/components/sensor/cert_expiry.py
     homeassistant/components/sensor/comed_hourly_pricing.py
     homeassistant/components/sensor/cpuspeed.py
     homeassistant/components/sensor/crimereports.py

--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -87,7 +87,8 @@ class SSLCertificate(Entity):
         except socket.gaierror:
             _LOGGER.error('Cannot resolve name %s', self.server_name)
         except socket.timeout:
-            _LOGGER.error('Connection timeout with server %s', self.server_name)
+            _LOGGER.error('Connection timeout with server %s',
+                          self.server_name)
         except OSError as excp:
             _LOGGER.error('Cannot connect to %s', self.server_name)
             raise excp

--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -14,12 +14,10 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_PORT)
 
-REQUIREMENTS = []
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'SSL Certificate Expiry'
 DEFAULT_PORT = 443
-ICON = 'mdi:certificate'
 
 SCAN_INTERVAL = datetime.timedelta(hours=12)
 TIMEOUT = 10.0
@@ -28,7 +26,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    })
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -67,7 +65,7 @@ class SSLCertificate(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
-        return ICON
+        return 'mdi:certificate'
 
     def update(self):
         """Fetch certificate information."""

--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -84,13 +84,17 @@ class SSLCertificate(Entity):
                                    server_hostname=self.server_name)
             sock.settimeout(TIMEOUT)
             sock.connect((self.server_name, self.server_port))
-        except Exception as excp:
+        except socket.gaierror:
+            _LOGGER.error('Cannot resolve name %s', self.server_name)
+        except socket.timeout:
+            _LOGGER.error('Connection timeout with server %s', self.server_name)
+        except OSError as excp:
             _LOGGER.error('Cannot connect to %s', self.server_name)
             raise excp
 
         try:
             cert = sock.getpeercert()
-        except Exception as excp:
+        except OSError as excp:
             _LOGGER.error('Cannot fetch certificate from %s',
                           (self.server_name))
             raise excp

--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -1,12 +1,5 @@
 """Counts the days an HTTPS (TLS) certificate will expire (days).
 
-Example configuration.yaml:
-
-  sensor:
-    - platform: cert_expiry
-      host: home-assistant.io
-      port: 443
-
 For more details about this sensor please refer to the
 documentation at https://home-assistant.io/components/sensor.cert_expiry
 """

--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -1,0 +1,103 @@
+"""Counts the days an HTTPS (TLS) certificate will expire (days).
+
+Example configuration.yaml:
+
+  sensor:
+    - platform: cert_expiry
+      host: home-assistant.io
+      port: 443
+
+For more details about this sensor please refer to the
+documentation at https://home-assistant.io/components/sensor.cert_expiry
+"""
+import logging
+import ssl
+import socket
+import datetime
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.util import Throttle
+from homeassistant.helpers.entity import Entity
+from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_PORT)
+
+REQUIREMENTS = []
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'SSL Certificate Expiry'
+DEFAULT_PORT = 443
+ICON = 'mdi:certificate'
+
+MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(hours=12)
+TIMEOUT = 10.0
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    })
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup certificate expiry sensor."""
+    server_name = config.get(CONF_HOST)
+    server_port = config.get(CONF_PORT)
+    sensor_name = config.get(CONF_NAME)
+    add_devices([SSLCertificate(sensor_name, server_name, server_port)])
+
+
+class SSLCertificate(Entity):
+    """Implements certificate expiry sensor."""
+
+    def __init__(self, sensor_name, server_name, server_port):
+        """Initialize the sensor."""
+        self.server_name = server_name
+        self.server_port = server_port
+        self._name = sensor_name
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit this state is expressed in."""
+        return 'days'
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return ICON
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Fetch certificate information."""
+        try:
+            ctx = ssl.create_default_context()
+            sock = ctx.wrap_socket(socket.socket(),
+                                   server_hostname=self.server_name)
+            sock.settimeout(TIMEOUT)
+            sock.connect((self.server_name, self.server_port))
+        except Exception as excp:
+            _LOGGER.error('Cannot connect to %s', self.server_name)
+            raise excp
+
+        try:
+            cert = sock.getpeercert()
+        except Exception as excp:
+            _LOGGER.error('Cannot fetch certificate from %s',
+                          (self.server_name))
+            raise excp
+
+        ts_seconds = ssl.cert_time_to_seconds(cert['notAfter'])
+        timestamp = datetime.datetime.fromtimestamp(ts_seconds)
+        expiry = timestamp - datetime.datetime.today()
+        self._state = expiry.days

--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -18,7 +18,6 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.util import Throttle
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_PORT)
 
@@ -29,7 +28,7 @@ DEFAULT_NAME = 'SSL Certificate Expiry'
 DEFAULT_PORT = 443
 ICON = 'mdi:certificate'
 
-MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(hours=12)
+SCAN_INTERVAL = datetime.timedelta(hours=12)
 TIMEOUT = 10.0
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -77,7 +76,6 @@ class SSLCertificate(Entity):
         """Icon to use in the frontend, if any."""
         return ICON
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Fetch certificate information."""
         try:


### PR DESCRIPTION
## Description: 

Simple certificate expiry check (in days)

_Note: I've re-created the pull request due to some rebase issues_ . Successor of #7207


## Example entry for `configuration.yaml` (if applicable):
```yaml

sensor:
  - platform: cert_expiry
    host: home-assistant.io
    port: 443

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
