### PR TITLE
Fix telegram_polling no first_name or last_name

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -112,8 +112,8 @@ class BaseTelegramBotEntity:
         event = EVENT_TELEGRAM_COMMAND
         event_data = {
             ATTR_USER_ID: data['from']['id'],
-            ATTR_FROM_FIRST: data['from']['first_name'],
-            ATTR_FROM_LAST: data['from']['last_name']}
+            ATTR_FROM_FIRST: data['from']['first_name'] if 'first_name' in data['from'] else 'N/A',
+            ATTR_FROM_LAST: data['from']['last_name'] if 'last_name' in data['from'] else 'N/A'}
 
         if data['text'][0] == '/':
             pieces = data['text'].split(' ')

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -112,8 +112,8 @@ class BaseTelegramBotEntity:
         event = EVENT_TELEGRAM_COMMAND
         event_data = {
             ATTR_USER_ID: data['from']['id'],
-            ATTR_FROM_FIRST: data['from']['first_name'] if 'first_name' in data['from'] else 'N/A',
-            ATTR_FROM_LAST: data['from']['last_name'] if 'last_name' in data['from'] else 'N/A'}
+            ATTR_FROM_FIRST: data['from'].get('first_name', 'N/A'),
+            ATTR_FROM_LAST: data['from'].get('last_name', 'N/A')}
 
         if data['text'][0] == '/':
             pieces = data['text'].split(' ')


### PR DESCRIPTION
## Description:
This should fix the issue described in #7276. It defaults to 'N/A' for 'last_name' and 'first_name' in telegram messages when either one is not set.

Unfortunately I could not get the indentation right when splitting the line so I just kept them at > 80 chars. Will fix if someone cann explain how I need to indent it...?

**Related issue (if applicable):** fixes #7276

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
