### PR TITLE
Recorder: Check for ENTITY_ID key that contains None value

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -246,8 +246,8 @@ class Recorder(threading.Thread):
                 self.queue.task_done()
                 continue
 
-            if ATTR_ENTITY_ID in event.data:
-                entity_id = event.data[ATTR_ENTITY_ID]
+            entity_id = event.data.get(ATTR_ENTITY_ID)
+            if entity_id is not None:
                 domain = split_entity_id(entity_id)[0]
 
                 # Exclude entities OR


### PR DESCRIPTION
## Description:
Fix a bug reported by @dale3h: Sometimes an event is sent that contains the key `entity_id` but the value is `None`. This was tripping the recorder.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
