### PR TITLE
0.43.1

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
     CONF_PASSWORD, CONF_PORT, CONF_PROTOCOL, CONF_PAYLOAD)
 from homeassistant.components.mqtt.server import HBMQTT_CONFIG_SCHEMA
 
-REQUIREMENTS = ['paho-mqtt==1.2.2']
+REQUIREMENTS = ['paho-mqtt==1.2.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -246,8 +246,8 @@ class Recorder(threading.Thread):
                 self.queue.task_done()
                 continue
 
-            if ATTR_ENTITY_ID in event.data:
-                entity_id = event.data[ATTR_ENTITY_ID]
+            entity_id = event.data.get(ATTR_ENTITY_ID)
+            if entity_id is not None:
                 domain = split_entity_id(entity_id)[0]
 
                 # Exclude entities OR

--- a/homeassistant/components/switch/hook.py
+++ b/homeassistant/components/switch/hook.py
@@ -47,7 +47,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                     data={
                         'username': username,
                         'password': password})
-            data = yield from response.json()
+            # The Hook API returns JSON but calls it 'text/html'.  Setting
+            # content_type=None disables aiohttp's content-type validation.
+            data = yield from response.json(content_type=None)
         except (asyncio.TimeoutError, aiohttp.ClientError) as error:
             _LOGGER.error("Failed authentication API call: %s", error)
             return False
@@ -63,7 +65,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             response = yield from websession.get(
                 '{}{}'.format(HOOK_ENDPOINT, 'device'),
                 params={"token": token})
-        data = yield from response.json()
+        data = yield from response.json(content_type=None)
     except (asyncio.TimeoutError, aiohttp.ClientError) as error:
         _LOGGER.error("Failed getting devices: %s", error)
         return False
@@ -110,7 +112,7 @@ class HookSmartHome(SwitchDevice):
             with async_timeout.timeout(TIMEOUT, loop=self.hass.loop):
                 response = yield from websession.get(
                     url, params={"token": self._token})
-            data = yield from response.json()
+            data = yield from response.json(content_type=None)
 
         except (asyncio.TimeoutError, aiohttp.ClientError) as error:
             _LOGGER.error("Failed setting state: %s", error)

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -76,6 +76,8 @@ class WemoSwitch(SwitchDevice):
     @property
     def should_poll(self):
         """No polling needed with subscriptions."""
+        if self._model_name == 'Insight':
+            return True
         return False
 
     @property

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -50,7 +50,7 @@ def async_setup(hass, config):
             _LOGGER.error("Unknown notification service specified")
             return
 
-        _LOGGER.info("Setting up1 %s.%s", DOMAIN, p_type)
+        _LOGGER.info("Setting up %s.%s", DOMAIN, p_type)
 
         try:
             if hasattr(platform, 'async_setup_platform'):
@@ -72,8 +72,6 @@ def async_setup(hass, config):
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception('Error setting up platform %s', p_type)
             return
-
-        return True
 
     setup_tasks = [async_setup_platform(p_type, p_config) for p_type, p_config
                    in config_per_platform(config, DOMAIN)]
@@ -103,10 +101,10 @@ class BaseTelegramBotEntity:
         """Check for basic message rules and fire an event if message is ok."""
         data = data.get('message')
 
-        if (not data
-                or 'from' not in data
-                or 'text' not in data
-                or data['from'].get('id') not in self.allowed_chat_ids):
+        if (not data or
+                'from' not in data or
+                'text' not in data or
+                data['from'].get('id') not in self.allowed_chat_ids):
             # Message is not correct.
             _LOGGER.error("Incoming message does not have required data.")
             return False

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -11,9 +11,8 @@ from ipaddress import ip_network
 
 import voluptuous as vol
 
-
 from homeassistant.const import (
-    HTTP_BAD_REQUEST, HTTP_UNAUTHORIZED)
+    EVENT_HOMEASSISTANT_STOP, HTTP_BAD_REQUEST, HTTP_UNAUTHORIZED)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.telegram_bot import CONF_ALLOWED_CHAT_IDS, \
@@ -27,6 +26,7 @@ REQUIREMENTS = ['python-telegram-bot==5.3.0']
 _LOGGER = logging.getLogger(__name__)
 
 TELEGRAM_HANDLER_URL = '/api/telegram_webhooks'
+REMOVE_HANDLER_URL = ''
 
 CONF_TRUSTED_NETWORKS = 'trusted_networks'
 DEFAULT_TRUSTED_NETWORKS = [
@@ -50,20 +50,21 @@ def setup_platform(hass, config, async_add_devices, discovery_info=None):
     bot = telegram.Bot(config[CONF_API_KEY])
 
     current_status = bot.getWebhookInfo()
-    handler_url = "{0}{1}".format(hass.config.api.base_url,
-                                  TELEGRAM_HANDLER_URL)
+    handler_url = '{0}{1}'.format(
+        hass.config.api.base_url, TELEGRAM_HANDLER_URL)
     if current_status and current_status['url'] != handler_url:
         if bot.setWebhook(handler_url):
             _LOGGER.info("set new telegram webhook %s", handler_url)
-
-            hass.http.register_view(
-                BotPushReceiver(
-                    hass,
-                    config[CONF_ALLOWED_CHAT_IDS],
-                    config[CONF_TRUSTED_NETWORKS]))
-
         else:
             _LOGGER.error("set telegram webhook failed %s", handler_url)
+            return False
+
+    hass.bus.listen_once(
+        EVENT_HOMEASSISTANT_STOP,
+        lambda event: bot.setWebhook(REMOVE_HANDLER_URL))
+    hass.http.register_view(BotPushReceiver(
+        hass, config[CONF_ALLOWED_CHAT_IDS], config[CONF_TRUSTED_NETWORKS]))
+    return True
 
 
 class BotPushReceiver(HomeAssistantView, BaseTelegramBotEntity):
@@ -71,7 +72,7 @@ class BotPushReceiver(HomeAssistantView, BaseTelegramBotEntity):
 
     requires_auth = False
     url = TELEGRAM_HANDLER_URL
-    name = "telegram_webhooks"
+    name = 'telegram_webhooks'
 
     def __init__(self, hass, allowed_chat_ids, trusted_networks):
         """Initialize the class."""

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import config_validation as cv
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.4.18']
+REQUIREMENTS = ['pywemo==0.4.19']
 
 DOMAIN = 'wemo'
 

--- a/homeassistant/components/zwave/discovery_schemas.py
+++ b/homeassistant/components/zwave/discovery_schemas.py
@@ -81,12 +81,12 @@ DISCOVERY_SCHEMAS = [
          },
          'open': {
              const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_SWITCH_MULTILEVEL],
-             const.DISC_LABEL: ['Open', 'Up'],
+             const.DISC_LABEL: ['Open', 'Up', 'Bright'],
              const.DISC_OPTIONAL: True,
          },
          'close': {
              const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_SWITCH_MULTILEVEL],
-             const.DISC_LABEL: ['Close', 'Down'],
+             const.DISC_LABEL: ['Close', 'Down', 'Dim'],
              const.DISC_OPTIONAL: True,
          }})},
     {const.DISC_COMPONENT: 'cover',  # Garage Door

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 43
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 4, 2)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -678,7 +678,7 @@ pyvera==0.2.26
 pywebpush==0.6.1
 
 # homeassistant.components.wemo
-pywemo==0.4.18
+pywemo==0.4.19
 
 # homeassistant.components.zabbix
 pyzabbix==0.7.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -419,7 +419,7 @@ openhomedevice==0.2.1
 orvibo==1.1.1
 
 # homeassistant.components.mqtt
-paho-mqtt==1.2.2
+paho-mqtt==1.2.3
 
 # homeassistant.components.media_player.panasonic_viera
 panasonic_viera==0.2


### PR DESCRIPTION
- Zwave cover workaround for graber shades. ([@turbokongen] - [#7204]) ([cover.zwave docs]) ([zwave.workaround docs])
- Upgrade paho-mqtt to 1.2.3 ([@fabaff] - [#7214])
- Workround for wemo subscription bug. ([@pavoni] - [#7245]) ([wemo docs]) ([switch.wemo docs])
- Fix telegram webhooks ([@MartinHjelmare] - [#7236]) ([telegram_bot docs]) ([telegram_bot.webhooks docs])
- Work around bad content-type in Hook api response ([@KlaasH] - [#7267]) ([switch.hook docs])
- Recorder: Check for ENTITY_ID key that contains None value ([@balloob] - [#7287]) ([recorder docs])

[#7204]: https://github.com/home-assistant/home-assistant/pull/7204
[#7214]: https://github.com/home-assistant/home-assistant/pull/7214
[#7236]: https://github.com/home-assistant/home-assistant/pull/7236
[#7245]: https://github.com/home-assistant/home-assistant/pull/7245
[#7267]: https://github.com/home-assistant/home-assistant/pull/7267
[#7287]: https://github.com/home-assistant/home-assistant/pull/7287
[@KlaasH]: https://github.com/KlaasH
[@MartinHjelmare]: https://github.com/MartinHjelmare
[@balloob]: https://github.com/balloob
[@fabaff]: https://github.com/fabaff
[@pavoni]: https://github.com/pavoni
[@turbokongen]: https://github.com/turbokongen
[cover.zwave docs]: https://home-assistant.io/components/cover.zwave/
[recorder docs]: https://home-assistant.io/components/recorder/
[switch.hook docs]: https://home-assistant.io/components/switch.hook/
[switch.wemo docs]: https://home-assistant.io/components/switch.wemo/
[telegram_bot docs]: https://home-assistant.io/components/telegram_bot/
[telegram_bot.webhooks docs]: https://home-assistant.io/components/telegram_bot.webhooks/
[wemo docs]: https://home-assistant.io/components/wemo/
[zwave.workaround docs]: https://home-assistant.io/components/zwave.workaround/
