### PR TITLE
Fix breaking SSL in test HTML5

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -25,7 +25,8 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.frontend import add_manifest_json_key
 from homeassistant.helpers import config_validation as cv
 
-REQUIREMENTS = ['pywebpush==0.6.1', 'PyJWT==1.4.2']
+# pyelliptic is dependency of pywebpush and 1.5.8 contains a breaking change
+REQUIREMENTS = ['pywebpush==0.6.1', 'PyJWT==1.4.2', 'pyelliptic==1.5.7']
 
 DEPENDENCIES = ['frontend']
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -524,6 +524,9 @@ pydroid-ipcam==0.8
 # homeassistant.components.sensor.ebox
 pyebox==0.1.0
 
+# homeassistant.components.notify.html5
+pyelliptic==1.5.7
+
 # homeassistant.components.media_player.emby
 pyemby==1.2
 


### PR DESCRIPTION
## Description:
It looks like PyElliptic 1.5.8 got released yesterday and it included a backwards incompatible change that breaks on our CI. Pinned it to the previous version to see if this works.

PyWebPush 0.6.1 -> http-ece==0.7.1 -> pyelliptic (no range)

https://github.com/yann2192/pyelliptic/releases

Fixes #7305