### PR TITLE
Upgrade python-telegram-bot to 5.3.1

### DIFF
--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['python-telegram-bot==5.3.0']
+REQUIREMENTS = ['python-telegram-bot==5.3.1']
 
 ATTR_PHOTO = 'photo'
 ATTR_KEYBOARD = 'keyboard'
@@ -47,7 +47,7 @@ def get_service(hass, config, discovery_info=None):
         api_key = config.get(CONF_API_KEY)
         bot = telegram.Bot(token=api_key)
         username = bot.getMe()['username']
-        _LOGGER.info("Telegram bot is '%s'", username)
+        _LOGGER.debug("Telegram bot is '%s'", username)
     except urllib.error.HTTPError:
         _LOGGER.error("Please check your access token")
         return None
@@ -59,7 +59,7 @@ def load_data(url=None, file=None, username=None, password=None):
     """Load photo/document into ByteIO/File container from a source."""
     try:
         if url is not None:
-            # load photo from url
+            # Load photo from URL
             if username is not None and password is not None:
                 req = requests.get(url, auth=(username, password), timeout=15)
             else:
@@ -67,7 +67,7 @@ def load_data(url=None, file=None, username=None, password=None):
             return io.BytesIO(req.content)
 
         elif file is not None:
-            # load photo from file
+            # Load photo from file
             return open(file, "rb")
         else:
             _LOGGER.warning("Can't load photo no photo found in params!")
@@ -96,7 +96,7 @@ class TelegramNotificationService(BaseNotificationService):
         title = kwargs.get(ATTR_TITLE)
         data = kwargs.get(ATTR_DATA)
 
-        # exists data for send a photo/location
+        # Exists data for send a photo/location
         if data is not None and ATTR_PHOTO in data:
             photos = data.get(ATTR_PHOTO, None)
             photos = photos if isinstance(photos, list) else [photos]
@@ -120,11 +120,10 @@ class TelegramNotificationService(BaseNotificationService):
 
         parse_mode = telegram.parsemode.ParseMode.MARKDOWN
 
-        # send message
+        # Send message
         try:
-            self.bot.sendMessage(chat_id=self._chat_id,
-                                 text=text,
-                                 parse_mode=parse_mode)
+            self.bot.sendMessage(
+                chat_id=self._chat_id, text=text, parse_mode=parse_mode)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending message")
 
@@ -135,8 +134,8 @@ class TelegramNotificationService(BaseNotificationService):
         keyboard = telegram.ReplyKeyboardMarkup([
             [key.strip() for key in row.split(",")] for row in keys])
         try:
-            self.bot.sendMessage(chat_id=self._chat_id, text=message,
-                                 reply_markup=keyboard)
+            self.bot.sendMessage(
+                chat_id=self._chat_id, text=message, reply_markup=keyboard)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending message")
 
@@ -145,7 +144,7 @@ class TelegramNotificationService(BaseNotificationService):
         import telegram
         caption = data.get(ATTR_CAPTION)
 
-        # send photo
+        # Send photo
         try:
             photo = load_data(
                 url=data.get(ATTR_URL),
@@ -153,8 +152,8 @@ class TelegramNotificationService(BaseNotificationService):
                 username=data.get(ATTR_USERNAME),
                 password=data.get(ATTR_PASSWORD),
             )
-            self.bot.sendPhoto(chat_id=self._chat_id,
-                               photo=photo, caption=caption)
+            self.bot.sendPhoto(
+                chat_id=self._chat_id, photo=photo, caption=caption)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending photo")
 
@@ -171,8 +170,8 @@ class TelegramNotificationService(BaseNotificationService):
                 username=data.get(ATTR_USERNAME),
                 password=data.get(ATTR_PASSWORD),
             )
-            self.bot.sendDocument(chat_id=self._chat_id,
-                                  document=document, caption=caption)
+            self.bot.sendDocument(
+                chat_id=self._chat_id, document=document, caption=caption)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending document")
 
@@ -182,9 +181,9 @@ class TelegramNotificationService(BaseNotificationService):
         latitude = float(gps.get(ATTR_LATITUDE, 0.0))
         longitude = float(gps.get(ATTR_LONGITUDE, 0.0))
 
-        # send location
+        # Send location
         try:
-            self.bot.sendLocation(chat_id=self._chat_id,
-                                  latitude=latitude, longitude=longitude)
+            self.bot.sendLocation(
+                chat_id=self._chat_id, latitude=latitude, longitude=longitude)
         except telegram.error.TelegramError:
             _LOGGER.exception("Error sending location")

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['python-telegram-bot==5.3.0']
+REQUIREMENTS = ['python-telegram-bot==5.3.1']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA
 

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -21,7 +21,7 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.components.http.util import get_real_ip
 
 DEPENDENCIES = ['http']
-REQUIREMENTS = ['python-telegram-bot==5.3.0']
+REQUIREMENTS = ['python-telegram-bot==5.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -655,7 +655,7 @@ python-synology==0.1.0
 # homeassistant.components.notify.telegram
 # homeassistant.components.telegram_bot.polling
 # homeassistant.components.telegram_bot.webhooks
-python-telegram-bot==5.3.0
+python-telegram-bot==5.3.1
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.3.0


### PR DESCRIPTION
## 5.3.1
- Hotfix release due to bug introduced by urllib3 version 1.21

**Related issue (if applicable):** fixes #7298, #7297

Tested with the following configuration:

``` yaml
notify:
  - platform: telegram
    name: telegram
    api_key: !secret telegram_api
    chat_id: !secret telegram_client
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```

```bash
$ pip3 freeze | grep urllib
urllib3==1.21
```