### PR TITLE
Switch Pocketcast library to one available/published on pypi

### DIFF
--- a/homeassistant/components/sensor/pocketcasts.py
+++ b/homeassistant/components/sensor/pocketcasts.py
@@ -17,9 +17,7 @@ from homeassistant.components.sensor import (PLATFORM_SCHEMA)
 
 _LOGGER = logging.getLogger(__name__)
 
-COMMIT = '9f61ff00c77c7c98ffa0af9dd3540df3dce4a836'
-REQUIREMENTS = ['https://github.com/molobrakos/python-pocketcasts/'
-                'archive/%s.zip#python-pocketcasts==0.0.1' % COMMIT]
+REQUIREMENTS = ['pocketcasts-api==0.2.2']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
@@ -35,11 +33,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the pocketcasts platform for sensors."""
     import pocketcasts
     try:
-        api = pocketcasts.Api(
+        api = pocketcasts.Pocketcasts(
             config.get(CONF_USERNAME),
             config.get(CONF_PASSWORD))
         _LOGGER.debug('Found %d podcasts',
-                      len(api.my_podcasts()))
+                      len(api.get_subscribed_podcasts()))
         add_devices([PocketCastsSensor(api)])
         return True
     except OSError as err:
@@ -60,7 +58,7 @@ class PocketCastsSensor(Entity):
     def update(self):
         """Update sensor values."""
         try:
-            self._state = len(self._api.new_episodes_released())
+            self._state = len(self._api.get_new_releases())
             _LOGGER.debug('Found %d new episodes', self._state)
         except OSError as err:
             _LOGGER.warning('Failed to contact server: %s', err)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -288,9 +288,6 @@ https://github.com/laf/russound/archive/0.1.7.zip#russound==0.1.7
 # homeassistant.components.media_player.onkyo
 https://github.com/miracle2k/onkyo-eiscp/archive/066023aec04770518d494c32fb72eea0ec5c1b7c.zip#onkyo-eiscp==1.0
 
-# homeassistant.components.sensor.pocketcasts
-https://github.com/molobrakos/python-pocketcasts/archive/9f61ff00c77c7c98ffa0af9dd3540df3dce4a836.zip#python-pocketcasts==0.0.1
-
 # homeassistant.components.switch.anel_pwrctrl
 https://github.com/mweinelt/anel-pwrctrl/archive/ed26e8830e28a2bfa4260a9002db23ce3e7e63d7.zip#anel_pwrctrl==0.0.1
 
@@ -452,6 +449,9 @@ plexapi==2.0.2
 # homeassistant.components.sensor.mhz19
 # homeassistant.components.sensor.serial_pm
 pmsensor==0.4
+
+# homeassistant.components.sensor.pocketcasts
+pocketcasts-api==0.2.2
 
 # homeassistant.components.climate.proliphix
 proliphix==0.4.1


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
