### PR TITLE
Rich Html emails with the smtp notifier

### DIFF
--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -9,9 +9,9 @@ import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.image import MIMEImage
-import email.utils
 from email.mime.application import MIMEApplication
-
+import email.utils
+import os
 import voluptuous as vol
 
 from homeassistant.components.notify import (
@@ -26,16 +26,19 @@ import homeassistant.util.dt as dt_util
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_IMAGES = 'images'  # optional embedded image file attachments
+ATTR_HTML = 'html'
 
 CONF_STARTTLS = 'starttls'
 CONF_DEBUG = 'debug'
 CONF_SERVER = 'server'
+CONF_PRODUCT_NAME = 'product_name'
 
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 25
 DEFAULT_TIMEOUT = 5
 DEFAULT_DEBUG = False
 DEFAULT_STARTTLS = False
+DEFAULT_PRODUCT_NAME = 'HomeAssistant'
 
 # pylint: disable=no-value-for-parameter
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -47,6 +50,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_STARTTLS, default=DEFAULT_STARTTLS): cv.boolean,
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_PRODUCT_NAME, default=DEFAULT_PRODUCT_NAME): cv.string,
     vol.Optional(CONF_DEBUG, default=DEFAULT_DEBUG): cv.boolean,
 })
 
@@ -62,6 +66,7 @@ def get_service(hass, config, discovery_info=None):
         config.get(CONF_USERNAME),
         config.get(CONF_PASSWORD),
         config.get(CONF_RECIPIENT),
+        config.get(CONF_PRODUCT_NAME),
         config.get(CONF_DEBUG))
 
     if mail_service.connection_is_valid():
@@ -74,7 +79,7 @@ class MailNotificationService(BaseNotificationService):
     """Implement the notification service for E-Mail messages."""
 
     def __init__(self, server, port, timeout, sender, starttls, username,
-                 password, recipient, debug):
+                 password, recipient, product_name, debug):
         """Initialize the service."""
         self._server = server
         self._port = port
@@ -84,6 +89,8 @@ class MailNotificationService(BaseNotificationService):
         self.username = username
         self.password = password
         self.recipient = recipient
+        self._product_name = product_name
+        self._timeout = timeout
         self.debug = debug
         self.tries = 2
 
@@ -128,20 +135,26 @@ class MailNotificationService(BaseNotificationService):
         Build and send a message to a user.
 
         Will send plain text normally, or will build a multipart HTML message
-        with inline image attachments if images config is defined.
+        with inline image attachments if images config is defined, or will
+        build a multipart HTML if html config is defined.
         """
         subject = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
         data = kwargs.get(ATTR_DATA)
 
         if data:
-            msg = _build_multipart_msg(message, images=data.get(ATTR_IMAGES))
+            if ATTR_HTML in data:
+                msg = _build_html_msg(message, data[ATTR_HTML],
+                                      images=data.get(ATTR_IMAGES))
+            else:
+                msg = _build_multipart_msg(message,
+                                           images=data.get(ATTR_IMAGES))
         else:
             msg = _build_text_msg(message)
 
         msg['Subject'] = subject
         msg['To'] = self.recipient
-        msg['From'] = self._sender
-        msg['X-Mailer'] = 'HomeAssistant'
+        msg['From'] = '{} <{}>'.format(self._product_name, self._sender)
+        msg['X-Mailer'] = self._product_name
         msg['Date'] = email.utils.format_datetime(dt_util.now())
         msg['Message-Id'] = email.utils.make_msgid()
 
@@ -149,19 +162,30 @@ class MailNotificationService(BaseNotificationService):
 
     def _send_email(self, msg):
         """Send the message."""
+        def _try_quit_mail():
+            try:
+                mail.quit()
+            except Exception as e:
+                _LOGGER.error(
+                    "Error %s [%s] trying to mail.quit()", e, e.__class__)
+
         mail = self.connect()
         for _ in range(self.tries):
             try:
                 mail.sendmail(self._sender, self.recipient,
                               msg.as_string())
                 break
+            except smtplib.SMTPServerDisconnected:
+                _LOGGER.warning(
+                    "SMTPServerDisconnected sending mail: retrying connection")
+                _try_quit_mail()
+                mail = self.connect()
             except smtplib.SMTPException:
                 _LOGGER.warning(
                     "SMTPException sending mail: retrying connection")
-                mail.quit()
+                _try_quit_mail()
                 mail = self.connect()
-
-        mail.quit()
+        _try_quit_mail()
 
 
 def _build_text_msg(message):
@@ -203,4 +227,27 @@ def _build_multipart_msg(message, images):
 
     body_html = MIMEText(''.join(body_text), 'html')
     msg_alt.attach(body_html)
+    return msg
+
+
+def _build_html_msg(text, html, images):
+    """Build Multipart message with in-line images and rich html (UTF-8)."""
+
+    _LOGGER.debug("Building html rich email")
+    msg = MIMEMultipart('related')
+    alternative = MIMEMultipart('alternative')
+    alternative.attach(MIMEText(text, _charset='utf-8'))
+    alternative.attach(MIMEText(html, ATTR_HTML, _charset='utf-8'))
+    msg.attach(alternative)
+
+    for atch_num, atch_name in enumerate(images):
+        name = os.path.basename(atch_name)
+        try:
+            with open(atch_name, 'rb') as attachment_file:
+                attachment = MIMEImage(attachment_file.read(), filename=name)
+            msg.attach(attachment)
+            attachment.add_header('Content-ID', '<{}>'.format(name))
+        except FileNotFoundError:
+            _LOGGER.warning('Attachment %s [#%s] not found. Skipping',
+                            atch_name, atch_num)
     return msg

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -125,9 +125,13 @@ class TelegramNotificationService(BaseNotificationService):
         self.bot = Bot(token=self._api_key)
 
     def _get_msg_ids(self, msg_data, chat_id):
-        """Get one of (message_id, inline_message_id) from a msg dict,
-        returning a tuple. You can use 'last' as message_id to edit
-        the last sended message in the chat_id."""
+        """Get the message id to edit.
+
+        This can be one of (message_id, inline_message_id) from a msg dict,
+        returning a tuple.
+        **You can use 'last' as message_id** to edit
+        the last sended message in the chat_id.
+        """
         message_id = inline_message_id = None
         if 'message_id' in msg_data:
             message_id = msg_data['message_id']
@@ -139,8 +143,10 @@ class TelegramNotificationService(BaseNotificationService):
         return message_id, inline_message_id
 
     def _get_target_chat_ids(self, target):
-        """Validate chat_id targets, which come as list of strings (['12234'])
-        or get the default chat_id. Returns list of chat_id targets (integers).
+        """Validate chat_id targets or return default target (fist defined).
+
+        :param target: optional list of strings (['12234'])
+        :return list of chat_id targets (integers)
         """
         if target is not None:
             if isinstance(target, int):
@@ -161,13 +167,12 @@ class TelegramNotificationService(BaseNotificationService):
         return [self._default_user]
 
     def _get_msg_kwargs(self, data):
-        """Get parameters in data kwargs"""
-
+        """Get parameters in message data kwargs."""
         def _make_row_of_kb(row_keyboard):
-            """Espera un str de texto en botones separados por comas,
-            o una lista de tuplas de la forma: [(texto_b1, data_callback_b1),
-                                                (texto_b2, data_callback_b2), ]
-            Devuelve una lista de InlineKeyboardButton.
+            """Makes a list of InlineKeyboardButton's with a list of tuples.
+
+            :param row_keyboard: [(text_b1, data_callback_b1),
+                                  (text_b2, data_callback_b2), ...]
             """
             from telegram import InlineKeyboardButton
             if isinstance(row_keyboard, str):

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -3,16 +3,6 @@ Telegram platform for notify component.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.telegram/
-
-Changes:
-- Customized for using any of both parsers (`markdown` and `html`) in any message with: `data: {'parse_mode': 'html'}`, with markdown as default, but can be globally customized with 'parse_mode' in yaml config.
-- Inline keyboards with `data: {'inline_keyboard': [(text_btn1, data_callback_btn1), ...]}`
-- Custom reply_markup (keyboard or inline_keyboard) for every type of message (message, photo, location & document).
-- `disable_notification`, `disable_web_page_preview` and `reply_to_message_id` optional keyword args.
-- Callback replies for edit messages, reply_markup keyboards and captions, and for answering callback queries with: `data: {'callback_query'|'edit_message'| 'edit_caption'|'edit_replymarkup': ...}`
-- Line break between title and message fields: `'{}\n{}'.format(title, message)`
-- Ablility to target multiple pre-authorized chat_ids (`target=[12345, 67890]`) when sending a message.
-- BREAKING CHANGE: use array of `user_id` to allow one notifier to comunicate with multiple users (first user is the default, but you can pass a `ATTR_TARGET=chat_id_X` to send a message to other recipient). (Reading `chat_id` as User1 to work with old configuration)
 """
 import io
 import logging
@@ -36,7 +26,7 @@ PARSER_MD = 'markdown'
 PARSER_HTML = 'html'
 ATTR_DISABLE_NOTIF = 'disable_notification'
 ATTR_DISABLE_WEB_PREV = 'disable_web_page_preview'
-ATTR_REPLY_TO_MESSAGE_ID = 'reply_to_message_id'
+ATTR_REPLY_TO_MSGID = 'reply_to_message_id'
 
 ATTR_PHOTO = 'photo'
 ATTR_KEYBOARD = 'keyboard'
@@ -208,9 +198,9 @@ class TelegramNotificationService(BaseNotificationService):
             if ATTR_DISABLE_NOTIF in data:
                 params['disable_notification'] = data[ATTR_DISABLE_NOTIF]
             if ATTR_DISABLE_WEB_PREV in data:
-                params['disable_web_page_preview'] = data[ATTR_DISABLE_WEB_PREV]
-            if ATTR_REPLY_TO_MESSAGE_ID in data:
-                params['reply_to_message_id'] = data[ATTR_REPLY_TO_MESSAGE_ID]
+                params[ATTR_DISABLE_WEB_PREV] = data[ATTR_DISABLE_WEB_PREV]
+            if ATTR_REPLY_TO_MSGID in data:
+                params[ATTR_REPLY_TO_MSGID] = data[ATTR_REPLY_TO_MSGID]
             # Keyboards:
             if ATTR_KEYBOARD in data:
                 from telegram import ReplyKeyboardMarkup

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -70,8 +70,8 @@ def get_service(hass, config, discovery_info=None):
         default_parser = config.get(ATTR_PARSER)
         bot = Bot(token=api_key)
         username = bot.getMe()['username']
-        _LOGGER.info("Telegram bot is '@{}', users allowed are: {}, default={}"
-                     .format(username, user_id_array, list(user_id_array)[0]))
+        _LOGGER.info("Telegram bot is '@%s', users allowed: %s, default=%s",
+                     username, user_id_array, list(user_id_array)[0])
     except HTTPError:
         _LOGGER.error("Please check your access token")
         return None
@@ -152,24 +152,24 @@ class TelegramNotificationService(BaseNotificationService):
             if isinstance(target, int):
                 if target in self._users:
                     return [target]
-                _LOGGER.warning('BAD TARGET "{}", using default: {}'
-                                .format(target, self._default_user))
+                _LOGGER.warning('BAD TARGET "%s", using default: %s',
+                                target, self._default_user)
             else:
                 try:
                     chat_ids = list(filter(lambda x: x in self._users,
                                            [int(t) for t in target]))
                     if len(chat_ids) > 0:
                         return chat_ids
-                    _LOGGER.warning('ALL BAD TARGETS: "{}"'.format(target))
+                    _LOGGER.warning('ALL BAD TARGETS: "%s"', target)
                 except (ValueError, TypeError):
-                    _LOGGER.warning('BAD TARGET DATA "{}", using default: {}'
-                                    .format(target, self._default_user))
+                    _LOGGER.warning('BAD TARGET DATA "%s", using default: %s',
+                                    target, self._default_user)
         return [self._default_user]
 
     def _get_msg_kwargs(self, data):
         """Get parameters in message data kwargs."""
         def _make_row_of_kb(row_keyboard):
-            """Makes a list of InlineKeyboardButton's with a list of tuples.
+            """Make a list of InlineKeyboardButtons from a list of tuples.
 
             :param row_keyboard: [(text_b1, data_callback_b1),
                                   (text_b2, data_callback_b2), ...]
@@ -229,11 +229,11 @@ class TelegramNotificationService(BaseNotificationService):
             if not isinstance(out, bool) and hasattr(out, 'message_id'):
                 chat_id = out.chat_id
                 self._last_message_id[chat_id] = out.message_id
-                _LOGGER.debug('LAST MSG ID: {} (from chat_id {})'
-                              .format(self._last_message_id, chat_id))
+                _LOGGER.debug('LAST MSG ID: %s (from chat_id %s)',
+                              self._last_message_id, chat_id)
             elif not isinstance(out, bool):
-                _LOGGER.warning('UPDATE LAST MSG??: out_type:{}, out={}'
-                                .format(type(out), out))
+                _LOGGER.warning('UPDATE LAST MSG??: out_type:%s, out=%s',
+                                type(out), out)
             return out
         except TelegramError:
             _LOGGER.exception(msg_error)
@@ -266,19 +266,17 @@ class TelegramNotificationService(BaseNotificationService):
                 # send answer to callback query
                 callback_data = data.get(ATTR_CALLBACK_QUERY)
                 callback_query_id = callback_data.pop('callback_query_id')
-                _LOGGER.debug('sending answer_callback_query id {}: "{}" ({})'
-                              .format(callback_query_id, text, callback_data))
                 return self._send_msg(self.bot.answerCallbackQuery,
-                                      "Error sending answer to callback query",
+                                      "Error sending answer callback query",
                                       callback_query_id,
                                       text=text, **callback_data)
             elif ATTR_EDIT_MSG in data:
                 # edit existent text message
                 message_id, inline_message_id = self._get_msg_ids(
                     data.get(ATTR_EDIT_MSG), chat_id)
-                _LOGGER.debug('editing message w/id {}: "{}" ({})'
-                              .format(message_id or inline_message_id, text,
-                                      data.get(ATTR_EDIT_MSG)))
+                _LOGGER.debug('editing message w/id %s: "%s" (%s)',
+                              message_id or inline_message_id, text,
+                              data.get(ATTR_EDIT_MSG))
                 return self._send_msg(self.bot.editMessageText,
                                       "Error editing text message",
                                       text,
@@ -290,9 +288,9 @@ class TelegramNotificationService(BaseNotificationService):
                 caption = data.get(ATTR_EDIT_CAPTION)['caption']
                 message_id, inline_message_id = self._get_msg_ids(
                     data.get(ATTR_EDIT_CAPTION), chat_id)
-                _LOGGER.debug('editing message caption w/id {}: "{}" ({})'
-                              .format(message_id or inline_message_id, text,
-                                      data.get(ATTR_EDIT_CAPTION)))
+                _LOGGER.debug('editing message caption w/id %s: "%s" (%s)',
+                              message_id or inline_message_id, text,
+                              data.get(ATTR_EDIT_CAPTION))
                 return self._send_msg(self.bot.editMessageCaption,
                                       "Error editing message caption",
                                       chat_id=chat_id, message_id=message_id,
@@ -302,16 +300,16 @@ class TelegramNotificationService(BaseNotificationService):
                 # edit existent replymarkup (like the keyboard)
                 message_id, inline_message_id = self._get_msg_ids(
                     data.get(ATTR_EDIT_REPLYMARKUP), chat_id)
-                _LOGGER.debug('editing reply_markup w/id {}: "{}" ({})'
-                              .format(message_id or inline_message_id, text,
-                                      data.get(ATTR_EDIT_REPLYMARKUP)))
+                _LOGGER.debug('editing reply_markup w/id %s: "%s" (%s)',
+                              message_id or inline_message_id, text,
+                              data.get(ATTR_EDIT_REPLYMARKUP))
                 return self._send_msg(self.bot.editMessageReplyMarkup,
                                       "Error editing reply_markup",
                                       chat_id=chat_id, message_id=message_id,
                                       inline_message_id=inline_message_id,
                                       **params)
         # send text message
-        _LOGGER.debug('sending message to chat_id: "{}"'.format(chat_id))
+        _LOGGER.debug('sending message to chat_id: "%s"', chat_id)
         return self._send_msg(self.bot.sendMessage,
                               "Error sending message",
                               chat_id, text, **params)

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -3,10 +3,20 @@ Telegram platform for notify component.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.telegram/
+
+Changes:
+- Customized for using any of both parsers (`markdown` and `html`) in any message with: `data: {'parse_mode': 'html'}`, with markdown as default, but can be globally customized with 'parse_mode' in yaml config.
+- Inline keyboards with `data: {'inline_keyboard': [(text_btn1, data_callback_btn1), ...]}`
+- Custom reply_markup (keyboard or inline_keyboard) for every type of message (message, photo, location & document).
+- `disable_notification`, `disable_web_page_preview` and `reply_to_message_id` optional keyword args.
+- Callback replies for edit messages, reply_markup keyboards and captions, and for answering callback queries with: `data: {'callback_query'|'edit_message'| 'edit_caption'|'edit_replymarkup': ...}`
+- Line break between title and message fields: `'{}\n{}'.format(title, message)`
+- Ablility to target multiple pre-authorized chat_ids (`target=[12345, 67890]`) when sending a message.
+- BREAKING CHANGE: use array of `user_id` to allow one notifier to comunicate with multiple users (first user is the default, but you can pass a `ATTR_TARGET=chat_id_X` to send a message to other recipient). (Reading `chat_id` as User1 to work with old configuration)
 """
 import io
 import logging
-import urllib
+from urllib.error import HTTPError
 
 import requests
 import voluptuous as vol
@@ -15,44 +25,68 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
     ATTR_TITLE, ATTR_DATA, PLATFORM_SCHEMA, BaseNotificationService)
 from homeassistant.const import (
-    CONF_API_KEY, ATTR_LOCATION, ATTR_LATITUDE, ATTR_LONGITUDE)
+    CONF_API_KEY, CONF_TIMEOUT, ATTR_LOCATION, ATTR_LATITUDE, ATTR_LONGITUDE)
 
 _LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = ['python-telegram-bot==5.3.0']
 
+ATTR_PARSER = 'parse_mode'
+PARSER_MD = 'markdown'
+PARSER_HTML = 'html'
+ATTR_DISABLE_NOTIF = 'disable_notification'
+ATTR_DISABLE_WEB_PREV = 'disable_web_page_preview'
+ATTR_REPLY_TO_MESSAGE_ID = 'reply_to_message_id'
+
 ATTR_PHOTO = 'photo'
 ATTR_KEYBOARD = 'keyboard'
+ATTR_KEYBOARD_INLINE = 'inline_keyboard'
 ATTR_DOCUMENT = 'document'
 ATTR_CAPTION = 'caption'
+ATTR_CALLBACK_QUERY = 'callback_query'
+ATTR_EDIT_MSG = 'edit_message'
+ATTR_EDIT_CAPTION = 'edit_caption'
+ATTR_EDIT_REPLYMARKUP = 'edit_replymarkup'
 ATTR_URL = 'url'
 ATTR_FILE = 'file'
 ATTR_USERNAME = 'username'
 ATTR_PASSWORD = 'password'
+ATTR_TARGET = 'target'
 
+CONF_USER_ID = 'user_id'
 CONF_CHAT_ID = 'chat_id'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
-    vol.Required(CONF_CHAT_ID): cv.string,
+    vol.Optional(CONF_CHAT_ID, default=None): cv.string,
+    vol.Optional(CONF_USER_ID, default=None):
+        cv.ordered_dict(cv.positive_int, cv.string),
+    vol.Optional(ATTR_PARSER, default=PARSER_MD): cv.string,
 })
 
 
+# noinspection PyUnusedLocal
 def get_service(hass, config, discovery_info=None):
     """Get the Telegram notification service."""
-    import telegram
+    from telegram import Bot
 
     try:
         chat_id = config.get(CONF_CHAT_ID)
+        if chat_id is not None:
+            user_id_array = {'User1': chat_id}
+        else:
+            user_id_array = config.get(CONF_USER_ID)
         api_key = config.get(CONF_API_KEY)
-        bot = telegram.Bot(token=api_key)
+        default_parser = config.get(ATTR_PARSER)
+        bot = Bot(token=api_key)
         username = bot.getMe()['username']
-        _LOGGER.info("Telegram bot is '%s'", username)
-    except urllib.error.HTTPError:
+        _LOGGER.info("Telegram bot is '@{}', users allowed are: {}, default={}"
+                     .format(username, user_id_array, list(user_id_array)[0]))
+    except HTTPError:
         _LOGGER.error("Please check your access token")
         return None
 
-    return TelegramNotificationService(api_key, chat_id)
+    return TelegramNotificationService(api_key, user_id_array, default_parser)
 
 
 def load_data(url=None, file=None, username=None, password=None):
@@ -81,110 +115,252 @@ def load_data(url=None, file=None, username=None, password=None):
 class TelegramNotificationService(BaseNotificationService):
     """Implement the notification service for Telegram."""
 
-    def __init__(self, api_key, chat_id):
+    def __init__(self, api_key, user_id_array, parser):
         """Initialize the service."""
-        import telegram
+        from telegram import Bot
+        from telegram.parsemode import ParseMode
 
         self._api_key = api_key
-        self._chat_id = chat_id
-        self.bot = telegram.Bot(token=self._api_key)
+        self._default_user = None
+        self._users = {}
+        for i, (dev_id, user_id) in enumerate(user_id_array.items()):
+            if i == 0:
+                self._default_user = user_id
+            self._users[user_id] = dev_id
+        self._parsers = {PARSER_HTML: ParseMode.HTML,
+                         PARSER_MD: ParseMode.MARKDOWN}
+        self._parse_mode = self._parsers.get(parser)
+        # last_msg_cache:
+        self._last_message_id = {user: None for user in self._users.keys()}
+        self.bot = Bot(token=self._api_key)
 
-    def send_message(self, message="", **kwargs):
-        """Send a message to a user."""
-        import telegram
+    def _get_msg_ids(self, msg_data, chat_id):
+        """Get one of (message_id, inline_message_id) from a msg dict,
+        returning a tuple. You can use 'last' as message_id to edit
+        the last sended message in the chat_id."""
+        message_id = inline_message_id = None
+        if 'message_id' in msg_data:
+            message_id = msg_data['message_id']
+            if (isinstance(message_id, str) and (message_id == 'last') and
+                    (self._last_message_id[chat_id] is not None)):
+                message_id = self._last_message_id[chat_id]
+        else:
+            inline_message_id = msg_data['inline_message_id']
+        return message_id, inline_message_id
 
+    def _get_target_chat_ids(self, target):
+        """Validate chat_id targets, which come as list of strings (['12234'])
+        or get the default chat_id. Returns list of chat_id targets (integers).
+        """
+        if target is not None:
+            if isinstance(target, int):
+                if target in self._users:
+                    return [target]
+                _LOGGER.warning('BAD TARGET "{}", using default: {}'
+                                .format(target, self._default_user))
+            else:
+                try:
+                    chat_ids = list(filter(lambda x: x in self._users,
+                                           [int(t) for t in target]))
+                    if len(chat_ids) > 0:
+                        return chat_ids
+                    _LOGGER.warning('ALL BAD TARGETS: "{}"'.format(target))
+                except (ValueError, TypeError):
+                    _LOGGER.warning('BAD TARGET DATA "{}", using default: {}'
+                                    .format(target, self._default_user))
+        return [self._default_user]
+
+    def _get_msg_kwargs(self, data):
+        """Get parameters in data kwargs"""
+
+        def _make_row_of_kb(row_keyboard):
+            """Espera un str de texto en botones separados por comas,
+            o una lista de tuplas de la forma: [(texto_b1, data_callback_b1),
+                                                (texto_b2, data_callback_b2), ]
+            Devuelve una lista de InlineKeyboardButton.
+            """
+            from telegram import InlineKeyboardButton
+            if isinstance(row_keyboard, str):
+                return [InlineKeyboardButton(
+                    key.strip()[1:].upper(),
+                    callback_data=key)
+                        for key in row_keyboard.split(",")]
+            elif isinstance(row_keyboard, list):
+                return [InlineKeyboardButton(
+                    text_btn, callback_data=data_btn)
+                        for text_btn, data_btn in row_keyboard]
+            else:
+                raise ValueError(str(row_keyboard))
+
+        # defaults
+        params = dict(parse_mode=self._parse_mode,
+                      disable_notification=False,
+                      disable_web_page_preview=None,
+                      reply_to_message_id=None,
+                      reply_markup=None,
+                      timeout=None)
+        if data is not None:
+            if ATTR_PARSER in data:
+                params['parse_mode'] = self._parsers.get(data[ATTR_PARSER],
+                                                         self._parse_mode)
+            if CONF_TIMEOUT in data:
+                params['timeout'] = data[CONF_TIMEOUT]
+            if ATTR_DISABLE_NOTIF in data:
+                params['disable_notification'] = data[ATTR_DISABLE_NOTIF]
+            if ATTR_DISABLE_WEB_PREV in data:
+                params['disable_web_page_preview'] = data[ATTR_DISABLE_WEB_PREV]
+            if ATTR_REPLY_TO_MESSAGE_ID in data:
+                params['reply_to_message_id'] = data[ATTR_REPLY_TO_MESSAGE_ID]
+            # Keyboards:
+            if ATTR_KEYBOARD in data:
+                from telegram import ReplyKeyboardMarkup
+                keys = data.get(ATTR_KEYBOARD)
+                keys = keys if isinstance(keys, list) else [keys]
+                params['reply_markup'] = ReplyKeyboardMarkup(
+                    [[key.strip() for key in row.split(",")] for row in keys])
+            elif ATTR_KEYBOARD_INLINE in data:
+                from telegram import InlineKeyboardMarkup
+                keys = data.get(ATTR_KEYBOARD_INLINE)
+                keys = keys if isinstance(keys, list) else [keys]
+                params['reply_markup'] = InlineKeyboardMarkup(
+                    [_make_row_of_kb(row) for row in keys])
+        return params
+
+    def _send_msg(self, func_send, msg_error, *args_rep, **kwargs_rep):
+        """Send one message."""
+        from telegram.error import TelegramError
+        try:
+            out = func_send(*args_rep, **kwargs_rep)
+            if not isinstance(out, bool) and hasattr(out, 'message_id'):
+                chat_id = out.chat_id
+                self._last_message_id[chat_id] = out.message_id
+                _LOGGER.debug('LAST MSG ID: {} (from chat_id {})'
+                              .format(self._last_message_id, chat_id))
+            elif not isinstance(out, bool):
+                _LOGGER.warning('UPDATE LAST MSG??: out_type:{}, out={}'
+                                .format(type(out), out))
+            return out
+        except TelegramError:
+            _LOGGER.exception(msg_error)
+
+    def send_message(self, message="", target=None, **kwargs):
+        """Send a message to one or multiple pre-defined users."""
         title = kwargs.get(ATTR_TITLE)
         data = kwargs.get(ATTR_DATA)
+        text = '{}\n{}'.format(title, message) if title else message
+        params = self._get_msg_kwargs(data)
+        for chat_id in self._get_target_chat_ids(target):
+            self._dispatch_msg(text, chat_id, params, data)
 
-        # exists data for send a photo/location
-        if data is not None and ATTR_PHOTO in data:
-            photos = data.get(ATTR_PHOTO, None)
-            photos = photos if isinstance(photos, list) else [photos]
+    def _dispatch_msg(self, text, chat_id, params, data=None):
+        """Dispatch one message to a chat_id."""
+        if data is not None:
+            if ATTR_PHOTO in data:
+                photos = data.get(ATTR_PHOTO)
+                photos = photos if isinstance(photos, list) else [photos]
+                for photo_data in photos:
+                    self.send_photo(photo_data, chat_id=chat_id, **params)
+                return
+            elif ATTR_LOCATION in data:
+                return self.send_location(data.get(ATTR_LOCATION),
+                                          chat_id=chat_id, **params)
+            elif ATTR_DOCUMENT in data:
+                return self.send_document(data.get(ATTR_DOCUMENT),
+                                          chat_id=chat_id, **params)
+            elif ATTR_CALLBACK_QUERY in data:
+                # send answer to callback query
+                callback_data = data.get(ATTR_CALLBACK_QUERY)
+                callback_query_id = callback_data.pop('callback_query_id')
+                _LOGGER.debug('sending answer_callback_query id {}: "{}" ({})'
+                              .format(callback_query_id, text, callback_data))
+                return self._send_msg(self.bot.answerCallbackQuery,
+                                      "Error sending answer to callback query",
+                                      callback_query_id,
+                                      text=text, **callback_data)
+            elif ATTR_EDIT_MSG in data:
+                # edit existent text message
+                message_id, inline_message_id = self._get_msg_ids(
+                    data.get(ATTR_EDIT_MSG), chat_id)
+                _LOGGER.debug('editing message w/id {}: "{}" ({})'
+                              .format(message_id or inline_message_id, text,
+                                      data.get(ATTR_EDIT_MSG)))
+                return self._send_msg(self.bot.editMessageText,
+                                      "Error editing text message",
+                                      text,
+                                      chat_id=chat_id, message_id=message_id,
+                                      inline_message_id=inline_message_id,
+                                      **params)
+            elif ATTR_EDIT_CAPTION in data:
+                # edit existent caption
+                caption = data.get(ATTR_EDIT_CAPTION)['caption']
+                message_id, inline_message_id = self._get_msg_ids(
+                    data.get(ATTR_EDIT_CAPTION), chat_id)
+                _LOGGER.debug('editing message caption w/id {}: "{}" ({})'
+                              .format(message_id or inline_message_id, text,
+                                      data.get(ATTR_EDIT_CAPTION)))
+                return self._send_msg(self.bot.editMessageCaption,
+                                      "Error editing message caption",
+                                      chat_id=chat_id, message_id=message_id,
+                                      inline_message_id=inline_message_id,
+                                      caption=caption, **params)
+            elif ATTR_EDIT_REPLYMARKUP in data:
+                # edit existent replymarkup (like the keyboard)
+                message_id, inline_message_id = self._get_msg_ids(
+                    data.get(ATTR_EDIT_REPLYMARKUP), chat_id)
+                _LOGGER.debug('editing reply_markup w/id {}: "{}" ({})'
+                              .format(message_id or inline_message_id, text,
+                                      data.get(ATTR_EDIT_REPLYMARKUP)))
+                return self._send_msg(self.bot.editMessageReplyMarkup,
+                                      "Error editing reply_markup",
+                                      chat_id=chat_id, message_id=message_id,
+                                      inline_message_id=inline_message_id,
+                                      **params)
+        # send text message
+        _LOGGER.debug('sending message to chat_id: "{}"'.format(chat_id))
+        return self._send_msg(self.bot.sendMessage,
+                              "Error sending message",
+                              chat_id, text, **params)
 
-            for photo_data in photos:
-                self.send_photo(photo_data)
-            return
-        elif data is not None and ATTR_LOCATION in data:
-            return self.send_location(data.get(ATTR_LOCATION))
-        elif data is not None and ATTR_DOCUMENT in data:
-            return self.send_document(data.get(ATTR_DOCUMENT))
-        elif data is not None and ATTR_KEYBOARD in data:
-            keys = data.get(ATTR_KEYBOARD)
-            keys = keys if isinstance(keys, list) else [keys]
-            return self.send_keyboard(message, keys)
-
-        if title:
-            text = '{} {}'.format(title, message)
-        else:
-            text = message
-
-        parse_mode = telegram.parsemode.ParseMode.MARKDOWN
-
-        # send message
-        try:
-            self.bot.sendMessage(chat_id=self._chat_id,
-                                 text=text,
-                                 parse_mode=parse_mode)
-        except telegram.error.TelegramError:
-            _LOGGER.exception("Error sending message")
-
-    def send_keyboard(self, message, keys):
-        """Display keyboard."""
-        import telegram
-
-        keyboard = telegram.ReplyKeyboardMarkup([
-            [key.strip() for key in row.split(",")] for row in keys])
-        try:
-            self.bot.sendMessage(chat_id=self._chat_id, text=message,
-                                 reply_markup=keyboard)
-        except telegram.error.TelegramError:
-            _LOGGER.exception("Error sending message")
-
-    def send_photo(self, data):
+    def send_photo(self, data, chat_id=None, **kwargs):
         """Send a photo."""
-        import telegram
         caption = data.get(ATTR_CAPTION)
 
         # send photo
-        try:
-            photo = load_data(
-                url=data.get(ATTR_URL),
-                file=data.get(ATTR_FILE),
-                username=data.get(ATTR_USERNAME),
-                password=data.get(ATTR_PASSWORD),
-            )
-            self.bot.sendPhoto(chat_id=self._chat_id,
-                               photo=photo, caption=caption)
-        except telegram.error.TelegramError:
-            _LOGGER.exception("Error sending photo")
+        photo = load_data(
+            url=data.get(ATTR_URL),
+            file=data.get(ATTR_FILE),
+            username=data.get(ATTR_USERNAME),
+            password=data.get(ATTR_PASSWORD),
+        )
+        return self._send_msg(self.bot.sendPhoto,
+                              "Error sending photo",
+                              chat_id, photo,
+                              caption=caption, **kwargs)
 
-    def send_document(self, data):
+    def send_document(self, data, chat_id=None, **kwargs):
         """Send a document."""
-        import telegram
         caption = data.get(ATTR_CAPTION)
 
-        # send photo
-        try:
-            document = load_data(
-                url=data.get(ATTR_URL),
-                file=data.get(ATTR_FILE),
-                username=data.get(ATTR_USERNAME),
-                password=data.get(ATTR_PASSWORD),
-            )
-            self.bot.sendDocument(chat_id=self._chat_id,
-                                  document=document, caption=caption)
-        except telegram.error.TelegramError:
-            _LOGGER.exception("Error sending document")
+        # send document
+        document = load_data(
+            url=data.get(ATTR_URL),
+            file=data.get(ATTR_FILE),
+            username=data.get(ATTR_USERNAME),
+            password=data.get(ATTR_PASSWORD),
+        )
+        return self._send_msg(self.bot.sendDocument,
+                              "Error sending document",
+                              chat_id, document,
+                              caption=caption, **kwargs)
 
-    def send_location(self, gps):
+    def send_location(self, gps, chat_id=None, **kwargs):
         """Send a location."""
-        import telegram
         latitude = float(gps.get(ATTR_LATITUDE, 0.0))
         longitude = float(gps.get(ATTR_LONGITUDE, 0.0))
 
         # send location
-        try:
-            self.bot.sendLocation(chat_id=self._chat_id,
-                                  latitude=latitude, longitude=longitude)
-        except telegram.error.TelegramError:
-            _LOGGER.exception("Error sending location")
+        return self._send_msg(self.bot.sendLocation,
+                              "Error sending location",
+                              chat_id=chat_id,
+                              latitude=latitude, longitude=longitude,
+                              **kwargs)

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -2,17 +2,6 @@
 Component to receive telegram messages, including callback queries.
 
 Either by polling or webhook.
-
-callback query message:
-```
-{'chat_instance': 'XXXXXXXXXXXXXXXXXXX',
- 'data': '[/data sended]',
- 'from': {'username': '[USERNAME]',
-          'last_name': '[LAST_NAME]', 'first_name': '[FIRST_NAME]',
-          'id': 123456789},
- 'id': '1234567890123456789',
- 'message': { original_msg }
-```
 """
 
 import asyncio

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -111,8 +111,8 @@ class BaseTelegramBotEntity:
                 'from' not in msg_data or
                 msg_data['from'].get('id') not in self.allowed_chat_ids):
             # Message is not correct.
-            _LOGGER.error("Incoming message does not have required data "
-                          "({})".format(msg_data))
+            _LOGGER.error("Incoming message does not have required data (%s)",
+                          msg_data)
             return None
         return {
             ATTR_USER_ID: msg_data['from']['id'],
@@ -154,5 +154,5 @@ class BaseTelegramBotEntity:
             return True
         else:
             # Some other thing...
-            _LOGGER.warning('SOME OTHER THING RECEIVED --> "{}"'.format(data))
+            _LOGGER.warning('SOME OTHER THING RECEIVED --> "%s"', data)
             return False

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['python-telegram-bot==5.3.0']
+REQUIREMENTS = ['python-telegram-bot==5.3.1']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA
 

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -21,7 +21,7 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.components.http.util import get_real_ip
 
 DEPENDENCIES = ['http']
-REQUIREMENTS = ['python-telegram-bot==5.3.0']
+REQUIREMENTS = ['python-telegram-bot==5.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -55,13 +55,13 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     # Some logging of Bot current status:
     last_error_date = getattr(current_status, 'last_error_date', None)
-    if (last_error_date is not None) and (type(last_error_date) is int):
+    if (last_error_date is not None) and (isinstance(last_error_date, int)):
         import datetime as dt
         last_error_date = dt.datetime.fromtimestamp(last_error_date)
-        _LOGGER.info("telegram webhook last_error_date: {}. Status: {}"
-                     .format(last_error_date, current_status))
+        _LOGGER.info("telegram webhook last_error_date: %s. Status: %s",
+                     last_error_date, current_status)
     else:
-        _LOGGER.debug("telegram webhook Status: {}".format(current_status))
+        _LOGGER.debug("telegram webhook Status: %s", current_status)
     handler_url = '{0}{1}'.format(hass.config.api.base_url,
                                   TELEGRAM_HANDLER_URL)
     if current_status and current_status['url'] != handler_url:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -652,7 +652,7 @@ python-synology==0.1.0
 # homeassistant.components.notify.telegram
 # homeassistant.components.telegram_bot.polling
 # homeassistant.components.telegram_bot.webhooks
-python-telegram-bot==5.3.0
+python-telegram-bot==5.3.1
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.3.0

--- a/tests/components/notify/test_smtp.py
+++ b/tests/components/notify/test_smtp.py
@@ -22,7 +22,8 @@ class TestNotifySmtp(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mailer = MockSMTP('localhost', 25, 5, 'test@test.com', 1,
-                               'testuser', 'testpass', 'testrecip@test.com', 0)
+                               'testuser', 'testpass', 'testrecip@test.com',
+                               'HomeAssistantTest', 0)
 
     def tearDown(self):  # pylint: disable=invalid-name
         """"Stop down everything that was started."""
@@ -37,8 +38,8 @@ class TestNotifySmtp(unittest.TestCase):
                     'Content-Transfer-Encoding: 7bit\n'
                     'Subject: Home Assistant\n'
                     'To: testrecip@test.com\n'
-                    'From: test@test.com\n'
-                    'X-Mailer: HomeAssistant\n'
+                    'From: HomeAssistantTest <test@test.com>\n'
+                    'X-Mailer: HomeAssistantTest\n'
                     'Date: [^\n]+\n'
                     'Message-Id: <[^@]+@[^>]+>\n'
                     '\n'
@@ -50,4 +51,25 @@ class TestNotifySmtp(unittest.TestCase):
         """Test build of mixed text email behavior."""
         msg = self.mailer.send_message('Test msg',
                                        data={'images': ['test.jpg']})
+        self.assertTrue('Content-Type: multipart/related' in msg)
+
+    @patch('email.utils.make_msgid', return_value='<mock@mock>')
+    def test_html_email(self, mock_make_msgid):
+        """Test build of html email behavior."""
+        html = '''
+        <!DOCTYPE html>
+        <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+            <head><meta charset="UTF-8"></head>
+            <body>
+              <div>
+                <h1>Intruder alert at apartment!!</h1>
+              </div>
+              <div>
+                <img alt="test.jpg" src="cid:test.jpg"/>
+              </div>
+            </body>
+        </html>'''
+        msg = self.mailer.send_message('Test msg',
+                                       data={'html': html,
+                                             'images': ['test.jpg']})
         self.assertTrue('Content-Type: multipart/related' in msg)


### PR DESCRIPTION
## Description:

- Add the ability of sending rich html emails, not only text emails with
attached images.
- Customize the `product_name` to be included as sender in emails.

**Pull request in [home-assistant.github.io](
https://github.com/home-assistant/home-assistant.github.io) with
documentation (if applicable):**
home-assistant/home-assistant.github.io#2514

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
notify:
  - name: NOTIFIER_NAME
    platform: smtp
    server: smtp.gmail.com
    port: 587
    timeout: 15
    sender: john@gmail.com
    starttls: true
    username: john@gmail.com
    password: thePassword
    recipient: james@gmail.com
    product_name: My Home
```

## Checklist:
  - [x] Documentation added/updated in [home-assistant.github.io](
  https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged
  unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev
/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev
/homeassistant/components/keyboard.py#L54