### PR TITLE
Allow multiple recipients for SMTP notify

### DIFF
--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -39,7 +39,7 @@ DEFAULT_STARTTLS = False
 
 # pylint: disable=no-value-for-parameter
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_RECIPIENT): vol.Email(),
+    vol.Required(CONF_RECIPIENT): vol.All(cv.ensure_list, [vol.Email()]),
     vol.Optional(CONF_SERVER, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
@@ -74,7 +74,7 @@ class MailNotificationService(BaseNotificationService):
     """Implement the notification service for E-Mail messages."""
 
     def __init__(self, server, port, timeout, sender, starttls, username,
-                 password, recipient, debug):
+                 password, recipients, debug):
         """Initialize the service."""
         self._server = server
         self._port = port
@@ -83,7 +83,7 @@ class MailNotificationService(BaseNotificationService):
         self.starttls = starttls
         self.username = username
         self.password = password
-        self.recipient = recipient
+        self.recipients = recipients
         self.debug = debug
         self.tries = 2
 
@@ -139,7 +139,7 @@ class MailNotificationService(BaseNotificationService):
             msg = _build_text_msg(message)
 
         msg['Subject'] = subject
-        msg['To'] = self.recipient
+        msg['To'] = ','.join(self.recipients)
         msg['From'] = self._sender
         msg['X-Mailer'] = 'HomeAssistant'
         msg['Date'] = email.utils.format_datetime(dt_util.now())
@@ -152,7 +152,7 @@ class MailNotificationService(BaseNotificationService):
         mail = self.connect()
         for _ in range(self.tries):
             try:
-                mail.sendmail(self._sender, self.recipient,
+                mail.sendmail(self._sender, self.recipients,
                               msg.as_string())
                 break
             except smtplib.SMTPException:

--- a/tests/components/notify/test_smtp.py
+++ b/tests/components/notify/test_smtp.py
@@ -22,7 +22,8 @@ class TestNotifySmtp(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mailer = MockSMTP('localhost', 25, 5, 'test@test.com', 1,
-                               'testuser', 'testpass', 'testrecip@test.com', 0)
+                               'testuser', 'testpass',
+                               ['recip1@example.com', 'testrecip@test.com'], 0)
 
     def tearDown(self):  # pylint: disable=invalid-name
         """"Stop down everything that was started."""
@@ -36,7 +37,7 @@ class TestNotifySmtp(unittest.TestCase):
                     'MIME-Version: 1.0\n'
                     'Content-Transfer-Encoding: 7bit\n'
                     'Subject: Home Assistant\n'
-                    'To: testrecip@test.com\n'
+                    'To: recip1@example.com,testrecip@test.com\n'
                     'From: test@test.com\n'
                     'X-Mailer: HomeAssistant\n'
                     'Date: [^\n]+\n'


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #6352

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2516

## Example entry for `configuration.yaml`:
```yaml
notify:
  - name: mail
    platform: smtp
    server: mail.example.com
    sender: alice@example.com
    recipient: [ bob@example.com, carol@example.com ]
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
