### PR TITLE
Reduce color_xy_brightness_to_hsv to color_xy_to_hs

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -380,12 +380,10 @@ class HueLight(Light):
 
         if ATTR_XY_COLOR in kwargs:
             if self.info.get('manufacturername') == "OSRAM":
-                hsv = color_util.color_xy_brightness_to_hsv(
-                    *kwargs[ATTR_XY_COLOR],
-                    ibrightness=self.info['bri'])
-                command['hue'] = hsv[0]
-                command['sat'] = hsv[1]
-                command['bri'] = hsv[2]
+                hue, sat = color_util.color_xy_to_hs(*kwargs[ATTR_XY_COLOR])
+                command['hue'] = hue
+                command['sat'] = sat
+                command['bri'] = self.info['bri']
             else:
                 command['xy'] = kwargs[ATTR_XY_COLOR]
         elif ATTR_RGB_COLOR in kwargs:

--- a/homeassistant/components/light/lifx/__init__.py
+++ b/homeassistant/components/light/lifx/__init__.py
@@ -354,10 +354,7 @@ class LIFXLight(Light):
             brightness = self._bri
 
         if ATTR_XY_COLOR in kwargs:
-            hue, saturation, _ = \
-                color_util.color_xy_brightness_to_hsv(
-                    *kwargs[ATTR_XY_COLOR],
-                    ibrightness=255)
+            hue, saturation = color_util.color_xy_to_hs(*kwargs[ATTR_XY_COLOR])
             saturation = saturation * (BYTE_MAX + 1)
             changed_color = True
 

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -268,10 +268,10 @@ def color_RGB_to_hsv(iR: int, iG: int, iB: int) -> Tuple[int, int, int]:
 
 
 # pylint: disable=invalid-sequence-index
-def color_xy_brightness_to_hsv(vX: float, vY: float,
-                               ibrightness: int) -> Tuple[int, int, int]:
-    """Convert an xy brightness color to its hsv representation."""
-    return color_RGB_to_hsv(*color_xy_brightness_to_RGB(vX, vY, ibrightness))
+def color_xy_to_hs(vX: float, vY: float) -> Tuple[int, int]:
+    """Convert an xy color to its hs representation."""
+    h, s, _ = color_RGB_to_hsv(*color_xy_brightness_to_RGB(vX, vY, 255))
+    return (h, s)
 
 
 # pylint: disable=invalid-sequence-index

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -56,22 +56,22 @@ class TestColorUtil(unittest.TestCase):
         self.assertEqual((0, 255, 255),
                          color_util.color_RGB_to_hsv(255, 0, 0))
 
-    def test_color_xy_brightness_to_hsv(self):
-        """Test color_RGB_to_xy."""
-        self.assertEqual(color_util.color_RGB_to_hsv(0, 0, 0),
-                         color_util.color_xy_brightness_to_hsv(1, 1, 0))
+    def test_color_xy_to_hs(self):
+        """Test color_xy_to_hs."""
+        self.assertEqual((8609, 255),
+                         color_util.color_xy_to_hs(1, 1))
 
-        self.assertEqual(color_util.color_RGB_to_hsv(255, 243, 222),
-                         color_util.color_xy_brightness_to_hsv(.35, .35, 255))
+        self.assertEqual((6950, 32),
+                         color_util.color_xy_to_hs(.35, .35))
 
-        self.assertEqual(color_util.color_RGB_to_hsv(255, 0, 60),
-                         color_util.color_xy_brightness_to_hsv(1, 0, 255))
+        self.assertEqual((62965, 255),
+                         color_util.color_xy_to_hs(1, 0))
 
-        self.assertEqual(color_util.color_RGB_to_hsv(0, 255, 0),
-                         color_util.color_xy_brightness_to_hsv(0, 1, 255))
+        self.assertEqual((21845, 255),
+                         color_util.color_xy_to_hs(0, 1))
 
-        self.assertEqual(color_util.color_RGB_to_hsv(0, 63, 255),
-                         color_util.color_xy_brightness_to_hsv(0, 0, 255))
+        self.assertEqual((40992, 255),
+                         color_util.color_xy_to_hs(0, 0))
 
     def test_rgb_hex_to_rgb_list(self):
         """Test rgb_hex_to_rgb_list."""


### PR DESCRIPTION
## Description:

Because brightness out equals brightness in, as discussed with @armills.

I think it makes sense to do the change now even though we do not have a direct conversion yet. This way we can avoid confusing new users of the function. Do you agree?

I had no idea how to make data for the tests so I just plugged in the values that came out of the new function.

## Checklist:

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.
