### PR TITLE
Use four-digits year

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -214,7 +214,7 @@ def async_enable_logging(hass: core.HomeAssistant, verbose: bool=False,
     fmt = ("%(asctime)s %(levelname)s (%(threadName)s) "
            "[%(name)s] %(message)s")
     colorfmt = "%(log_color)s{}%(reset)s".format(fmt)
-    datefmt = '%y-%m-%d %H:%M:%S'
+    datefmt = '%Y-%m-%d %H:%M:%S'
 
     # suppress overly verbose logs from libraries that aren't helpful
     logging.getLogger("requests").setLevel(logging.WARNING)


### PR DESCRIPTION
## Description:
Use `2017-04-27 18:03:12 ERROR (MainThread)...` instead of `17-04-27 18:03:12 ERROR (MainThread)...` for the logs.

Should fix the parsing issue for fail2ban 0.8.13 which is shipped with Debian Jessie.

This is a breaking change for everyone who is working with the log output to get details.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

