### PR TITLE
Add support for shuffle toggling on Spotify component.

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -380,7 +380,7 @@ def async_setup(hass, config):
             params[ATTR_MEDIA_ENQUEUE] = \
                 service.data.get(ATTR_MEDIA_ENQUEUE)
         elif service.service == SERVICE_SHUFFLE_SET:
-            params['shuffle'] = service.data.get(ATTR_MEDIA_SHUFFLING)
+            params[ATTR_MEDIA_SHUFFLING] = service.data.get(ATTR_MEDIA_SHUFFLING)
         target_players = component.async_extract_from_service(service)
 
         update_tasks = []

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -332,8 +332,9 @@ def clear_playlist(hass, entity_id=None):
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
     hass.services.call(DOMAIN, SERVICE_CLEAR_PLAYLIST, data)
 
+
 def set_shuffle(hass, shuffle, entity_id=None):
-    """Send the media player the command for enabling/disabling shuffle mode."""
+    """Send the media player the command to enable/disable shuffle mode."""
     data = {ATTR_MEDIA_SHUFFLING: shuffle}
 
     if entity_id:

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -380,7 +380,8 @@ def async_setup(hass, config):
             params[ATTR_MEDIA_ENQUEUE] = \
                 service.data.get(ATTR_MEDIA_ENQUEUE)
         elif service.service == SERVICE_SHUFFLE_SET:
-            params[ATTR_MEDIA_SHUFFLING] = service.data.get(ATTR_MEDIA_SHUFFLING)
+            params[ATTR_MEDIA_SHUFFLING] = \
+                service.data.get(ATTR_MEDIA_SHUFFLING)
         target_players = component.async_extract_from_service(service)
 
         update_tasks = []

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -82,7 +82,7 @@ ATTR_APP_NAME = 'app_name'
 ATTR_INPUT_SOURCE = 'source'
 ATTR_INPUT_SOURCE_LIST = 'source_list'
 ATTR_MEDIA_ENQUEUE = 'enqueue'
-ATTR_MEDIA_SHUFFLING = 'shuffle'
+ATTR_MEDIA_SHUFFLE = 'shuffle'
 
 MEDIA_TYPE_MUSIC = 'music'
 MEDIA_TYPE_TVSHOW = 'tvshow'
@@ -137,7 +137,7 @@ MEDIA_PLAYER_PLAY_MEDIA_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
 })
 
 MEDIA_PLAYER_SET_SHUFFLE_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
-    vol.Required(ATTR_MEDIA_SHUFFLING): cv.boolean,
+    vol.Required(ATTR_MEDIA_SHUFFLE): cv.boolean,
 })
 
 SERVICE_TO_METHOD = {
@@ -195,7 +195,7 @@ ATTR_TO_PROPERTY = [
     ATTR_APP_NAME,
     ATTR_INPUT_SOURCE,
     ATTR_INPUT_SOURCE_LIST,
-    ATTR_MEDIA_SHUFFLING,
+    ATTR_MEDIA_SHUFFLE,
 ]
 
 
@@ -335,7 +335,7 @@ def clear_playlist(hass, entity_id=None):
 
 def set_shuffle(hass, shuffle, entity_id=None):
     """Send the media player the command to enable/disable shuffle mode."""
-    data = {ATTR_MEDIA_SHUFFLING: shuffle}
+    data = {ATTR_MEDIA_SHUFFLE: shuffle}
 
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
@@ -380,8 +380,8 @@ def async_setup(hass, config):
             params[ATTR_MEDIA_ENQUEUE] = \
                 service.data.get(ATTR_MEDIA_ENQUEUE)
         elif service.service == SERVICE_SHUFFLE_SET:
-            params[ATTR_MEDIA_SHUFFLING] = \
-                service.data.get(ATTR_MEDIA_SHUFFLING)
+            params[ATTR_MEDIA_SHUFFLE] = \
+                service.data.get(ATTR_MEDIA_SHUFFLE)
         target_players = component.async_extract_from_service(service)
 
         update_tasks = []
@@ -564,7 +564,7 @@ class MediaPlayerDevice(Entity):
         return None
 
     @property
-    def is_shuffling(self):
+    def shuffle(self):
         """Boolean if shuffle is enabled."""
         return None
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -742,7 +742,6 @@ class MediaPlayerDevice(Entity):
         return self.hass.loop.run_in_executor(
             None, self.set_shuffle, shuffle)
 
-
     # No need to overwrite these.
     @property
     def support_play(self):

--- a/homeassistant/components/media_player/demo.py
+++ b/homeassistant/components/media_player/demo.py
@@ -9,7 +9,7 @@ from homeassistant.components.media_player import (
     SUPPORT_PAUSE, SUPPORT_PLAY_MEDIA, SUPPORT_PREVIOUS_TRACK,
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_SELECT_SOURCE, SUPPORT_CLEAR_PLAYLIST, SUPPORT_PLAY,
-    MediaPlayerDevice)
+    SUPPORT_SHUFFLE_SET, MediaPlayerDevice)
 from homeassistant.const import STATE_OFF, STATE_PAUSED, STATE_PLAYING
 import homeassistant.util.dt as dt_util
 
@@ -31,15 +31,17 @@ YOUTUBE_COVER_URL_FORMAT = 'https://img.youtube.com/vi/{}/hqdefault.jpg'
 
 YOUTUBE_PLAYER_SUPPORT = \
     SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
-    SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PLAY_MEDIA | SUPPORT_PLAY
+    SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PLAY_MEDIA | SUPPORT_PLAY | \
+    SUPPORT_SHUFFLE_SET
 
 MUSIC_PLAYER_SUPPORT = \
     SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
-    SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_CLEAR_PLAYLIST | SUPPORT_PLAY
+    SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_CLEAR_PLAYLIST | \
+    SUPPORT_PLAY | SUPPORT_SHUFFLE_SET
 
 NETFLIX_PLAYER_SUPPORT = \
     SUPPORT_PAUSE | SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
-    SUPPORT_SELECT_SOURCE | SUPPORT_PLAY
+    SUPPORT_SELECT_SOURCE | SUPPORT_PLAY | SUPPORT_SHUFFLE_SET
 
 
 class AbstractDemoPlayer(MediaPlayerDevice):
@@ -113,6 +115,11 @@ class AbstractDemoPlayer(MediaPlayerDevice):
     def media_pause(self):
         """Send pause command."""
         self._player_state = STATE_PAUSED
+        self.schedule_update_ha_state()
+
+    def set_shuffle(self, shuffle):
+        """Enable/disable shuffle mode"""
+        self._shuffle = shuffle
         self.schedule_update_ha_state()
 
 

--- a/homeassistant/components/media_player/demo.py
+++ b/homeassistant/components/media_player/demo.py
@@ -53,6 +53,7 @@ class AbstractDemoPlayer(MediaPlayerDevice):
         self._player_state = STATE_PLAYING
         self._volume_level = 1.0
         self._volume_muted = False
+        self._shuffle = False
 
     @property
     def should_poll(self):
@@ -78,6 +79,11 @@ class AbstractDemoPlayer(MediaPlayerDevice):
     def is_volume_muted(self):
         """Return boolean if volume is currently muted."""
         return self._volume_muted
+
+    @property
+    def shuffle(self):
+        """Boolean if shuffling is enabled."""
+        return self._shuffle
 
     def turn_on(self):
         """Turn the media player on."""

--- a/homeassistant/components/media_player/demo.py
+++ b/homeassistant/components/media_player/demo.py
@@ -118,7 +118,7 @@ class AbstractDemoPlayer(MediaPlayerDevice):
         self.schedule_update_ha_state()
 
     def set_shuffle(self, shuffle):
-        """Enable/disable shuffle mode"""
+        """Enable/disable shuffle mode."""
         self._shuffle = shuffle
         self.schedule_update_ha_state()
 

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -154,6 +154,17 @@ clear_playlist:
       description: Name(s) of entites to change source on
       example: 'media_player.living_room_chromecast'
 
+shuffle_set:
+  description: Set shuffling state
+
+  fields:
+    entity_id:
+      description: Name(s) of entities to set
+      example: 'media_player.spotify'
+    shuffle:
+      description: True/false for enabling/disabling shuffle
+      example: true
+
 sonos_join:
   description: Group player together.
 

--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -17,19 +17,19 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_PLAYLIST, ATTR_MEDIA_SEASON, ATTR_MEDIA_SEEK_POSITION,
     ATTR_MEDIA_SERIES_TITLE, ATTR_MEDIA_TITLE, ATTR_MEDIA_TRACK,
     ATTR_MEDIA_VOLUME_LEVEL, ATTR_MEDIA_VOLUME_MUTED, ATTR_INPUT_SOURCE_LIST,
-    ATTR_MEDIA_POSITION,
+    ATTR_MEDIA_POSITION, ATTR_MEDIA_SHUFFLING,
     ATTR_MEDIA_POSITION_UPDATED_AT, DOMAIN, SERVICE_PLAY_MEDIA,
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP, SUPPORT_SELECT_SOURCE, SUPPORT_CLEAR_PLAYLIST,
-    ATTR_INPUT_SOURCE, SERVICE_SELECT_SOURCE, SERVICE_CLEAR_PLAYLIST,
-    MediaPlayerDevice)
+    SUPPORT_SHUFFLE_SET, ATTR_INPUT_SOURCE, SERVICE_SELECT_SOURCE,
+    SERVICE_CLEAR_PLAYLIST, MediaPlayerDevice)
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_ENTITY_PICTURE, CONF_NAME, SERVICE_MEDIA_NEXT_TRACK,
     SERVICE_MEDIA_PAUSE, SERVICE_MEDIA_PLAY, SERVICE_MEDIA_PLAY_PAUSE,
     SERVICE_MEDIA_PREVIOUS_TRACK, SERVICE_MEDIA_SEEK, SERVICE_TURN_OFF,
     SERVICE_TURN_ON, SERVICE_VOLUME_DOWN, SERVICE_VOLUME_MUTE,
-    SERVICE_VOLUME_SET, SERVICE_VOLUME_UP, STATE_IDLE, STATE_OFF, STATE_ON,
-    SERVICE_MEDIA_STOP, ATTR_SUPPORTED_FEATURES)
+    SERVICE_VOLUME_SET, SERVICE_VOLUME_UP, SERVICE_SHUFFLE_SET, STATE_IDLE,
+    STATE_OFF, STATE_ON, SERVICE_MEDIA_STOP, ATTR_SUPPORTED_FEATURES)
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.service import async_call_from_config
 
@@ -357,6 +357,12 @@ class UniversalMediaPlayer(MediaPlayerDevice):
         return self._override_or_child_attr(ATTR_INPUT_SOURCE_LIST)
 
     @property
+    def shuffle(self):
+        """Boolean if shuffling is enabled."""
+        return self._override_or_child_attr(ATTR_MEDIA_SHUFFLING) \
+            in [True, STATE_ON]
+
+    @property
     def supported_features(self):
         """Flag media player features that are supported."""
         flags = self._child_attr(ATTR_SUPPORTED_FEATURES) or 0
@@ -382,6 +388,10 @@ class UniversalMediaPlayer(MediaPlayerDevice):
 
         if SERVICE_CLEAR_PLAYLIST in self._cmds:
             flags |= SUPPORT_CLEAR_PLAYLIST
+
+        if SERVICE_SHUFFLE_SET in self._cmds and \
+                ATTR_MEDIA_SHUFFLING in self._attrs:
+            flags |= SUPPORT_SHUFFLE_SET
 
         return flags
 
@@ -523,6 +533,15 @@ class UniversalMediaPlayer(MediaPlayerDevice):
         This method must be run in the event loop and returns a coroutine.
         """
         return self._async_call_service(SERVICE_CLEAR_PLAYLIST)
+
+    def async_set_shuffle(self, shuffle):
+        """Enable/disable shuffling.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        data = {ATTR_MEDIA_SHUFFLING: shuffle}
+        return self._async_call_service(
+            SERVICE_SHUFFLE_SET, data, allow_override=True)
 
     @asyncio.coroutine
     def async_update(self):

--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -17,7 +17,7 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_PLAYLIST, ATTR_MEDIA_SEASON, ATTR_MEDIA_SEEK_POSITION,
     ATTR_MEDIA_SERIES_TITLE, ATTR_MEDIA_TITLE, ATTR_MEDIA_TRACK,
     ATTR_MEDIA_VOLUME_LEVEL, ATTR_MEDIA_VOLUME_MUTED, ATTR_INPUT_SOURCE_LIST,
-    ATTR_MEDIA_POSITION, ATTR_MEDIA_SHUFFLING,
+    ATTR_MEDIA_POSITION, ATTR_MEDIA_SHUFFLE,
     ATTR_MEDIA_POSITION_UPDATED_AT, DOMAIN, SERVICE_PLAY_MEDIA,
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP, SUPPORT_SELECT_SOURCE, SUPPORT_CLEAR_PLAYLIST,
@@ -359,8 +359,7 @@ class UniversalMediaPlayer(MediaPlayerDevice):
     @property
     def shuffle(self):
         """Boolean if shuffling is enabled."""
-        return self._override_or_child_attr(ATTR_MEDIA_SHUFFLING) \
-            in [True, STATE_ON]
+        return self._override_or_child_attr(ATTR_MEDIA_SHUFFLE)
 
     @property
     def supported_features(self):
@@ -390,7 +389,7 @@ class UniversalMediaPlayer(MediaPlayerDevice):
             flags |= SUPPORT_CLEAR_PLAYLIST
 
         if SERVICE_SHUFFLE_SET in self._cmds and \
-                ATTR_MEDIA_SHUFFLING in self._attrs:
+                ATTR_MEDIA_SHUFFLE in self._attrs:
             flags |= SUPPORT_SHUFFLE_SET
 
         return flags
@@ -539,7 +538,7 @@ class UniversalMediaPlayer(MediaPlayerDevice):
 
         This method must be run in the event loop and returns a coroutine.
         """
-        data = {ATTR_MEDIA_SHUFFLING: shuffle}
+        data = {ATTR_MEDIA_SHUFFLE: shuffle}
         return self._async_call_service(
             SERVICE_SHUFFLE_SET, data, allow_override=True)
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -324,6 +324,7 @@ SERVICE_MEDIA_STOP = 'media_stop'
 SERVICE_MEDIA_NEXT_TRACK = 'media_next_track'
 SERVICE_MEDIA_PREVIOUS_TRACK = 'media_previous_track'
 SERVICE_MEDIA_SEEK = 'media_seek'
+SERVICE_SHUFFLE_SET = 'shuffle_set'
 
 SERVICE_ALARM_DISARM = 'alarm_disarm'
 SERVICE_ALARM_ARM_HOME = 'alarm_arm_home'


### PR DESCRIPTION
This also required adding support for shuffle on the media_player component.

## Description:
Add service media_player.shuffle_set to MediaPlayer and Spotify components.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
