### PR TITLE
Fix iOS sensor graphing

### DIFF
--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -63,6 +63,7 @@ class IOSSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement this sensor expresses itself in."""
+        return self._unit_of_measurement
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
`self._unit_of_measurement` wasn't being returned in the `unit_of_measurement` function causing the battery level to not be graphed properly.