### PR TITLE
Fix impulse events, added error event for Homegear

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -453,14 +453,10 @@ def _system_callback_handler(hass, config, src, *args):
     elif src == 'error':
         _LOGGER.debug("Error: %s", args)
         (interface_id, errorcode, message) = args
-        try:
-            hass.add_job(hass.bus.async_fire(EVENT_ERROR, {
-                ATTR_ERRORCODE: errorcode,
-                ATTR_MESSAGE: message
-            }))
-        except ValueError as err:
-            # Getting "Don't call add_job with None" here. What's the fix?
-            _LOGGER.debug("ValueError: %s", err)
+        hass.bus.fire(EVENT_ERROR, {
+            ATTR_ERRORCODE: errorcode,
+            ATTR_MESSAGE: message
+        })
 
 
 def _get_devices(hass, discovery_type, keys, proxy):
@@ -559,19 +555,19 @@ def _hm_event_handler(hass, proxy, device, caller, attribute, value):
 
     # keypress event
     if attribute in HM_PRESS_EVENTS:
-        hass.add_job(hass.bus.async_fire(EVENT_KEYPRESS, {
+        hass.bus.fire(EVENT_KEYPRESS, {
             ATTR_NAME: hmdevice.NAME,
             ATTR_PARAM: attribute,
             ATTR_CHANNEL: channel
-        }))
+        })
         return
 
     # impulse event
     if attribute in HM_IMPULSE_EVENTS:
-        hass.add_job(hass.bus.async_fire(EVENT_IMPULSE, {
+        hass.bus.fire(EVENT_IMPULSE, {
             ATTR_NAME: hmdevice.NAME,
             ATTR_CHANNEL: channel
-        }))
+        })
         return
 
     _LOGGER.warning("Event is unknown and not forwarded")

--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -42,9 +42,12 @@ ATTR_NAME = 'name'
 ATTR_ADDRESS = 'address'
 ATTR_VALUE = 'value'
 ATTR_PROXY = 'proxy'
+ATTR_ERRORCODE = 'error'
+ATTR_MESSAGE = 'message'
 
 EVENT_KEYPRESS = 'homematic.keypress'
 EVENT_IMPULSE = 'homematic.impulse'
+EVENT_ERROR = 'homematic.error'
 
 SERVICE_VIRTUALKEY = 'virtualkey'
 SERVICE_RECONNECT = 'reconnect'
@@ -447,6 +450,18 @@ def _system_callback_handler(hass, config, src, *args):
                         ATTR_DISCOVER_DEVICES: found_devices
                     }, config)
 
+    elif src == 'error':
+        _LOGGER.debug("Error: %s", args)
+        (interface_id, errorcode, message) = args
+        try:
+            hass.add_job(hass.bus.async_fire(EVENT_ERROR, {
+                ATTR_ERRORCODE: errorcode,
+                ATTR_MESSAGE: message
+            }))
+        except ValueError as err:
+            # Getting "Don't call add_job with None" here. What's the fix?
+            _LOGGER.debug("ValueError: %s", err)
+
 
 def _get_devices(hass, discovery_type, keys, proxy):
     """Get the Homematic devices for given discovery_type."""
@@ -553,7 +568,7 @@ def _hm_event_handler(hass, proxy, device, caller, attribute, value):
 
     # impulse event
     if attribute in HM_IMPULSE_EVENTS:
-        hass.add_job(hass.bus.async_fire(EVENT_KEYPRESS, {
+        hass.add_job(hass.bus.async_fire(EVENT_IMPULSE, {
             ATTR_NAME: hmdevice.NAME,
             ATTR_CHANNEL: channel
         }))


### PR DESCRIPTION
## Description:
1. Fixed impulse-events (were firing keypress events until now)
2. Added error-event for Homegear users (to build automations that reconnect if the connection has been dropped)

I'm catching a ValueError in line 461 because I get `Don't call add_job with None` there. What's the fix for that? The event is still fired, so regarding functionality it's working as it should.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
