### PR TITLE
Netdisco now returns a dictionary while it used to be a tuple, fixed

### DIFF
--- a/homeassistant/components/media_player/roku.py
+++ b/homeassistant/components/media_player/roku.py
@@ -43,13 +43,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     hosts = []
 
     if discovery_info:
-        host = discovery_info[0]
+        host = discovery_info.get("host")
 
         if host in KNOWN_HOSTS:
             return
 
         _LOGGER.debug('Discovered Roku: %s', host)
-        hosts.append(discovery_info[0])
+        hosts.append(discovery_info.get("host"))
 
     elif CONF_HOST in config:
         hosts.append(config.get(CONF_HOST))


### PR DESCRIPTION
Netdisco now returns a dictionary while it used to be a tuple, fixed.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
#7240

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
