### PR TITLE
Upgrade speedtest-cli to 1.0.6

### DIFF
--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_change
 from homeassistant.helpers.restore_state import async_get_last_state
 
-REQUIREMENTS = ['speedtest-cli==1.0.5']
+REQUIREMENTS = ['speedtest-cli==1.0.6']
 
 _LOGGER = logging.getLogger(__name__)
 _SPEEDTEST_REGEX = re.compile(r'Ping:\s(\d+\.\d+)\sms[\r\n]+'
@@ -150,7 +150,7 @@ class SpeedtestData(object):
         """Get the latest data from speedtest.net."""
         import speedtest
 
-        _LOGGER.info('Executing speedtest...')
+        _LOGGER.info("Executing speedtest...")
         try:
             args = [sys.executable, speedtest.__file__, '--simple']
             if self._server_id:
@@ -161,6 +161,8 @@ class SpeedtestData(object):
         except CalledProcessError as process_error:
             _LOGGER.error("Error executing speedtest: %s", process_error)
             return
-        self.data = {'ping': round(float(re_output[1]), 2),
-                     'download': round(float(re_output[2]), 2),
-                     'upload': round(float(re_output[3]), 2)}
+        self.data = {
+            'ping': round(float(re_output[1]), 2),
+            'download': round(float(re_output[2]), 2),
+            'upload': round(float(re_output[3]), 2),
+        }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -745,7 +745,7 @@ snapcast==1.2.2
 somecomfort==0.4.1
 
 # homeassistant.components.sensor.speedtest
-speedtest-cli==1.0.5
+speedtest-cli==1.0.6
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator


### PR DESCRIPTION
1.0.6
----
- see [commit log](https://github.com/sivel/speedtest-cli/commits/master)

Tested with the following configuration:

``` yaml
sensor:
  - platform: speedtest
    monitored_conditions:
      - ping
      - download
      - upload
```

```bash
2017-04-29 12:32:55 INFO (Thread-1) [homeassistant.components.sensor.speedtest] Executing speedtest...
[...]
2017-04-29 12:33:40 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: new_state=<state sensor.speedtest_upload=10.63; friendly_name=Speedtest Upload, icon=mdi:speedometer, unit_of_measurement=Mbit/s @ 2017-04-29T12:33:40.344353+02:00>, old_state=<state sensor.speedtest_upload=unknown; friendly_name=Speedtest Upload, icon=mdi:speedometer, unit_of_measurement=Mbit/s @ 2017-04-29T12:32:07.739150+02:00>, entity_id=sensor.speedtest_upload>

```