### PR TITLE
Upgrade xmltodict to 0.11.0

### DIFF
--- a/homeassistant/components/sensor/swiss_hydrological_data.py
+++ b/homeassistant/components/sensor/swiss_hydrological_data.py
@@ -17,7 +17,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['xmltodict==0.10.2']
+REQUIREMENTS = ['xmltodict==0.11.0']
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = 'http://www.hydrodata.ch/xml/SMS.xml'

--- a/homeassistant/components/sensor/ted5000.py
+++ b/homeassistant/components/sensor/ted5000.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['xmltodict==0.10.2']
+REQUIREMENTS = ['xmltodict==0.11.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.event import (
 from homeassistant.util import dt as dt_util
 
 
-REQUIREMENTS = ['xmltodict==0.10.2']
+REQUIREMENTS = ['xmltodict==0.11.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -822,7 +822,7 @@ xboxapi==0.1.1
 # homeassistant.components.sensor.swiss_hydrological_data
 # homeassistant.components.sensor.ted5000
 # homeassistant.components.sensor.yr
-xmltodict==0.10.2
+xmltodict==0.11.0
 
 # homeassistant.components.sensor.yahoo_finance
 yahoo-finance==1.4.0


### PR DESCRIPTION
0.11.0
----

- Determine fileness by checking for read attr
- Add support for Python 3.6.
- Release as a universal wheel.
- Updated docs examples to use print function.
- unparse: pass short_empty_elements to XMLGenerator
- Added namespace support when unparsing.

Tested with the following configuration:

``` yaml
sensor:
  - platform: swiss_hydrological_data
    name: Aare
    station: 2135
  - platform: yr
    monitored_conditions:
      - temperature
      - pressure
      - humidity
```
