### PR TITLE
Upgrade pydocstyle to 2.0.0

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,7 @@
 flake8==3.3
 pylint==1.6.5
 mypy==0.511
-pydocstyle==1.1.1
+pydocstyle==2.0.0
 coveralls>=1.1
 pytest>=2.9.2
 pytest-aiohttp>=0.1.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -5,7 +5,7 @@
 flake8==3.3
 pylint==1.6.5
 mypy==0.511
-pydocstyle==1.1.1
+pydocstyle==2.0.0
 coveralls>=1.1
 pytest>=2.9.2
 pytest-aiohttp>=0.1.3


### PR DESCRIPTION
## 2.0.0 
### Major Updates

- Support for numpy conventions verification has been added.
- Support for Python 2.6 has been dropped.
- Support for PyPy3 has been temporarily dropped, until it will be equivalent to CPython 3.3+ and -
 supported by pip.
- Support for the pep257 console script has been dropped. Only the pydocstyle console script should be used.
- Errors are now printed to stdout instead of stderr.

### New Features

- Decorator-based skipping via --ignore-decorators has been added.
- Support for using pycodestyle style wildcards has been added.
- Superfluous opening quotes are now reported as part of D300.
- Fixed a false-positive recognition of D410 and added D412.
- Added --config= flag to override the normal config file discovery and choose a specific config file.
- Support for specifying error codes with partial prefix has been added, e.g., --select=D101,D2.
- All configuration file can now have the .ini extension.
- Added better imperative mood checks using third party stemmer.

### Bug Fixes

- Made parser more robust to bad source files.
- Modules are now considered private if their name starts with a single underscore. This is a bugfix where “public module” (D100) was reported regardless of module name.
- Removed error when all is a list.
- Fixed a bug where the @ sign was used as a matrix multiplication operator in Python 3.5, but was considered a decorator by the parser.