### PR TITLE
Reverse limitlessled color_temp range

### DIFF
--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -376,12 +376,12 @@ class LimitlessLEDRGBWWGroup(LimitlessLEDGroup):
 
 def _from_hass_temperature(temperature):
     """Convert Home Assistant color temperature units to percentage."""
-    return (temperature - 154) / 346
+    return 1 - (temperature - 154) / 346
 
 
 def _to_hass_temperature(temperature):
     """Convert percentage to Home Assistant color temperature units."""
-    return int(temperature * 346) + 154
+    return 500 - int(temperature * 346)
 
 
 def _from_hass_brightness(brightness):


### PR DESCRIPTION
## Description:

I do not have this hardware but the `limitlessled` range apparently goes from 0.0 (warm) to 1.0 (cold).

This is a somewhat breaking change because existing `color_temp` configurations will have to be changed <s>(into `500-old_value`)</s>.

**Related issue (if applicable):** fixes #7333

**Notice for release notes:** The LimitlessLED color temperatures have been turned around to work like other lights. To maintain previous colors you must adjust the `color_temp` value in your `light.turn_on` calls to 654 minus your old value (for example, `280` becomes `374`).

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
