### PR TITLE
Flux switch: avoid updates when off

### DIFF
--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -140,8 +140,11 @@ class FluxSwitch(SwitchDevice):
         if not self._state:  # make initial update
             self.flux_update()
         self._state = True
-        self.unsub_tracker = track_time_change(self.hass, self.flux_update,
-                                               second=[0, 30])
+
+        if self.unsub_tracker is None:
+            self.unsub_tracker = track_time_change(self.hass, self.flux_update,
+                                                   second=[0, 30])
+
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):


### PR DESCRIPTION
## Description:

Calling turn_on when the switch is already on would orphan the existing
time tracker, losing our ability to cancel it when turn_off is called.

**Related issue (if applicable):** fixes #6958

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
