### PR TITLE
light.sensehat: plugin to control the 8x8 LED matrix on a Sense hat

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -242,6 +242,7 @@ omit =
     homeassistant/components/light/osramlightify.py
     homeassistant/components/light/rpi_gpio_pwm.py
     homeassistant/components/light/piglow.py
+    homeassistant/components/light/sensehat.py
     homeassistant/components/light/tikteck.py
     homeassistant/components/light/tradfri.py
     homeassistant/components/light/x10.py

--- a/homeassistant/components/light/sensehat.py
+++ b/homeassistant/components/light/sensehat.py
@@ -41,7 +41,10 @@ class SenseHatLight(Light):
     """Representation of an Sense Hat Light."""
 
     def __init__(self, sensehat, name):
-        """Initialize an Sense Hat Light."""
+        """Initialize an Sense Hat Light.
+
+        Full brightness and white color.
+        """
         self._sensehat = sensehat
         self._name = name
         self._is_on = False

--- a/homeassistant/components/light/sensehat.py
+++ b/homeassistant/components/light/sensehat.py
@@ -50,20 +50,22 @@ class SenseHatLight(Light):
 
     @property
     def name(self):
-        """Return the display name of this light.
-        """
+        """Return the display name of this light."""
         return self._name
 
     @property
     def brightness(self):
-        """Read back the brightness of the light, an integer in the range 1-255.
+        """Read back the brightness of the light.
+
+        Returns integer in the range of 1-255.
         """
         return self._brightness
 
     @property
     def rgb_color(self):
-        """Read back the color of the light,
-        tuple of (r, g, b) values in range of 0-255.
+        """Read back the color of the light.
+
+        Returns [r, g, b] list with values in range of 0-255.
         """
         return self._rgb_color
 
@@ -78,8 +80,7 @@ class SenseHatLight(Light):
         return self._is_on
 
     def turn_on(self, **kwargs):
-        """Instruct the light to turn on and set correct brightness / color.
-        """
+        """Instruct the light to turn on and set correct brightness & color."""
         self._brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
         percent_bright = (self._brightness / 255)
 

--- a/homeassistant/components/light/sensehat.py
+++ b/homeassistant/components/light/sensehat.py
@@ -1,0 +1,92 @@
+"""
+Support for Sense Hat LEDs.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.sensehat/
+"""
+import logging
+import subprocess
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, ATTR_RGB_COLOR, SUPPORT_RGB_COLOR,
+    Light, PLATFORM_SCHEMA)
+from homeassistant.const import CONF_NAME
+
+REQUIREMENTS = ['sense-hat==2.2.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORT_SENSEHAT = (SUPPORT_BRIGHTNESS | SUPPORT_RGB_COLOR)
+
+DEFAULT_NAME = 'sensehat'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Sense Hat Light platform."""
+    from sense_hat import SenseHat
+    sensehat = SenseHat()
+
+    name = config.get(CONF_NAME)
+
+    add_devices([SenseHatLight(sensehat, name)])
+
+class SenseHatLight(Light):
+    """Representation of an Sense Hat Light."""
+
+    def __init__(self, sensehat, name):
+        """Initialize an Sense Hat Light."""
+        self._sensehat = sensehat
+        self._name = name
+        self._is_on = False
+        self._brightness = 255
+        self._rgb_color = [255, 255, 255]
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
+    def brightness(self):
+        """Read back the brightness of the light (an integer in the range 1-255)."""
+        return self._brightness
+
+    @property
+    def rgb_color(self):
+        """Read back the color of the light, tuple of (r, g, b) values in range of 0-255."""
+        return self._rgb_color
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_SENSEHAT
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._is_on
+
+    def turn_on(self, **kwargs):
+        """Instruct the light to turn on, and set correct brightness / color."""
+        self._brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        percent_bright = (self._brightness / 255)
+
+        if ATTR_RGB_COLOR in kwargs:
+            self._rgb_color = kwargs[ATTR_RGB_COLOR]
+
+        self._sensehat.clear(int(self._rgb_color[0] * percent_bright),
+                             int(self._rgb_color[1] * percent_bright),
+                             int(self._rgb_color[2] * percent_bright))
+
+        self._is_on = True
+
+    def turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
+        self._sensehat.clear()
+        self._is_on = False

--- a/homeassistant/components/light/sensehat.py
+++ b/homeassistant/components/light/sensehat.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.sensehat/
 """
 import logging
-import subprocess
 
 import voluptuous as vol
 
@@ -27,6 +26,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Sense Hat Light platform."""
     from sense_hat import SenseHat
@@ -35,6 +35,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
 
     add_devices([SenseHatLight(sensehat, name)])
+
 
 class SenseHatLight(Light):
     """Representation of an Sense Hat Light."""
@@ -49,17 +50,21 @@ class SenseHatLight(Light):
 
     @property
     def name(self):
-        """Return the display name of this light."""
+        """Return the display name of this light.
+        """
         return self._name
 
     @property
     def brightness(self):
-        """Read back the brightness of the light (an integer in the range 1-255)."""
+        """Read back the brightness of the light, an integer in the range 1-255.
+        """
         return self._brightness
 
     @property
     def rgb_color(self):
-        """Read back the color of the light, tuple of (r, g, b) values in range of 0-255."""
+        """Read back the color of the light,
+        tuple of (r, g, b) values in range of 0-255.
+        """
         return self._rgb_color
 
     @property
@@ -73,7 +78,8 @@ class SenseHatLight(Light):
         return self._is_on
 
     def turn_on(self, **kwargs):
-        """Instruct the light to turn on, and set correct brightness / color."""
+        """Instruct the light to turn on and set correct brightness / color.
+        """
         self._brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
         percent_bright = (self._brightness / 255)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -720,6 +720,7 @@ scsgate==0.1.0
 # homeassistant.components.notify.sendgrid
 sendgrid==4.0.0
 
+# homeassistant.components.light.sensehat
 # homeassistant.components.sensor.sensehat
 sense-hat==2.2.0
 


### PR DESCRIPTION
## Description:

Plugin for Raspberry Pi [Sense Hat](https://www.raspberrypi.org/products/sense-hat/) which exposes the onboard 8x8 RGB LED matrix as a light with brightness and RGB color control.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2530

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: sensehat
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
