### PR TITLE
LimitlessLED: Configurable fade-out behavior

### DIFF
--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -24,13 +24,18 @@ CONF_BRIDGES = 'bridges'
 CONF_GROUPS = 'groups'
 CONF_NUMBER = 'number'
 CONF_VERSION = 'version'
+CONF_FADE = 'fade'
 
 DEFAULT_LED_TYPE = 'rgbw'
 DEFAULT_PORT = 5987
 DEFAULT_TRANSITION = 0
 DEFAULT_VERSION = 6
+DEFAULT_FADE = 'out'
 
 LED_TYPE = ['rgbw', 'rgbww', 'white', 'bridge-led']
+FADE_NONE = 'none'
+FADE_OUT = 'out'
+FADE = [FADE_NONE, FADE_OUT]
 
 RGB_BOUNDARY = 40
 
@@ -58,6 +63,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                     vol.Optional(CONF_TYPE, default=DEFAULT_LED_TYPE):
                         vol.In(LED_TYPE),
                     vol.Required(CONF_NUMBER): cv.positive_int,
+                    vol.Optional(CONF_FADE, default=DEFAULT_FADE):
+                        vol.In(FADE),
                 }
             ]),
         },
@@ -112,7 +119,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 group_conf.get(CONF_NUMBER),
                 group_conf.get(CONF_NAME),
                 group_conf.get(CONF_TYPE, DEFAULT_LED_TYPE))
-            lights.append(LimitlessLEDGroup.factory(group))
+            lights.append(LimitlessLEDGroup.factory(group, {
+                'fade': group_conf.get(CONF_FADE, DEFAULT_FADE)
+            }))
     add_devices(lights)
 
 
@@ -152,25 +161,26 @@ def state(new_state):
 class LimitlessLEDGroup(Light):
     """Representation of a LimitessLED group."""
 
-    def __init__(self, group):
+    def __init__(self, group, config):
         """Initialize a group."""
         self.group = group
         self.repeating = False
         self._is_on = False
         self._brightness = None
+        self.config = config
 
     @staticmethod
-    def factory(group):
+    def factory(group, config):
         """Produce LimitlessLEDGroup objects."""
         from limitlessled.group.rgbw import RgbwGroup
         from limitlessled.group.white import WhiteGroup
         from limitlessled.group.rgbww import RgbwwGroup
         if isinstance(group, WhiteGroup):
-            return LimitlessLEDWhiteGroup(group)
+            return LimitlessLEDWhiteGroup(group, config)
         elif isinstance(group, RgbwGroup):
-            return LimitlessLEDRGBWGroup(group)
+            return LimitlessLEDRGBWGroup(group, config)
         elif isinstance(group, RgbwwGroup):
-            return LimitlessLEDRGBWWGroup(group)
+            return LimitlessLEDRGBWWGroup(group, config)
 
     @property
     def should_poll(self):
@@ -196,15 +206,17 @@ class LimitlessLEDGroup(Light):
     def turn_off(self, transition_time, pipeline, **kwargs):
         """Turn off a group."""
         if self.is_on:
-            pipeline.transition(transition_time, brightness=0.0).off()
+            if self.config[CONF_FADE] == FADE_OUT:
+                pipeline.transition(transition_time, brightness=0.0)
+            pipeline.off()
 
 
 class LimitlessLEDWhiteGroup(LimitlessLEDGroup):
     """Representation of a LimitlessLED White group."""
 
-    def __init__(self, group):
+    def __init__(self, group, config):
         """Initialize White group."""
-        super().__init__(group)
+        super().__init__(group, config)
         # Initialize group with known values.
         self.group.on = True
         self.group.temperature = 1.0
@@ -242,9 +254,9 @@ class LimitlessLEDWhiteGroup(LimitlessLEDGroup):
 class LimitlessLEDRGBWGroup(LimitlessLEDGroup):
     """Representation of a LimitlessLED RGBW group."""
 
-    def __init__(self, group):
+    def __init__(self, group, config):
         """Initialize RGBW group."""
-        super().__init__(group)
+        super().__init__(group, config)
         # Initialize group with known values.
         self.group.on = True
         self.group.white()
@@ -301,9 +313,9 @@ class LimitlessLEDRGBWGroup(LimitlessLEDGroup):
 class LimitlessLEDRGBWWGroup(LimitlessLEDGroup):
     """Representation of a LimitlessLED RGBWW group."""
 
-    def __init__(self, group):
+    def __init__(self, group, config):
         """Initialize RGBWW group."""
-        super().__init__(group)
+        super().__init__(group, config)
         # Initialize group with known values.
         self.group.on = True
         self.group.white()

--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -116,7 +116,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 group_conf.get(CONF_NAME),
                 group_conf.get(CONF_TYPE, DEFAULT_LED_TYPE))
             lights.append(LimitlessLEDGroup.factory(group, {
-                'fade': group_conf.get(CONF_FADE, DEFAULT_FADE)
+                'fade': group_conf[CONF_FADE]
             }))
     add_devices(lights)
 

--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -30,12 +30,9 @@ DEFAULT_LED_TYPE = 'rgbw'
 DEFAULT_PORT = 5987
 DEFAULT_TRANSITION = 0
 DEFAULT_VERSION = 6
-DEFAULT_FADE = 'out'
+DEFAULT_FADE = False
 
 LED_TYPE = ['rgbw', 'rgbww', 'white', 'bridge-led']
-FADE_NONE = 'none'
-FADE_OUT = 'out'
-FADE = [FADE_NONE, FADE_OUT]
 
 RGB_BOUNDARY = 40
 
@@ -63,8 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                     vol.Optional(CONF_TYPE, default=DEFAULT_LED_TYPE):
                         vol.In(LED_TYPE),
                     vol.Required(CONF_NUMBER): cv.positive_int,
-                    vol.Optional(CONF_FADE, default=DEFAULT_FADE):
-                        vol.In(FADE),
+                    vol.Optional(CONF_FADE, default=DEFAULT_FADE): cv.boolean,
                 }
             ]),
         },
@@ -206,7 +202,7 @@ class LimitlessLEDGroup(Light):
     def turn_off(self, transition_time, pipeline, **kwargs):
         """Turn off a group."""
         if self.is_on:
-            if self.config[CONF_FADE] == FADE_OUT:
+            if self.config[CONF_FADE]:
                 pipeline.transition(transition_time, brightness=0.0)
             pipeline.off()
 


### PR DESCRIPTION
## Description:
Adds a per-group `fade` option with values of `out` (default) or `none`.

By default, the lights are faded out when turned off, but this can cause usability issues. For example, when you switch off a light bulb via HA, it first fades to minimum brightness, then turns off. This breaks if you then manually switch it off and on via wall switch, since it turns back on at minimum brightness, which can be frustrating and annoying.

This PR adds a `fade` per-group option that allows you to turn off the fade out behavior. This is not as nice on v5 bulbs as there is then a harsh cut off, but it preserves manual wall switch behavior. However it's less of an issue for v6 bulbs, since they fade off/on automatically. In fact, maybe the default behavior for v6 bulbs should be `none`?

Related forum topic: [LimitlessLED MiLight starts dimmed if turned off with Hass and then at wall](https://community.home-assistant.io/t/limitlessled-milight-starts-dimmed-if-turned-off-with-hass-and-then-at-wall/12371)

If this is an acceptable addition, I'll also look into updating the documentation as mentioned below.

🌞 💡 👍

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  platform: limitlessled
  bridges:

    - host: !secret limitless_v6_ip
      port: 5987
      version: 6
      groups:

      - number: 1
        type: rgbww
        name: Safari Glow
        fade: none

      - number: 2
        type: rgbww
        name: Other Bulb
        fade: out

      # `out` by default
      - number: 3
        type: rgbww
        name: The Third
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
