### PR TITLE
Remove ordered_dict validator

### DIFF
--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -64,7 +64,7 @@ GROUP_SCHEMA = vol.Schema({
 })
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: cv.ordered_dict(vol.All(_conf_preprocess, GROUP_SCHEMA))
+    DOMAIN: vol.Schema({cv.match_all: vol.All(_conf_preprocess, GROUP_SCHEMA)})
 }, extra=vol.ALLOW_EXTRA)
 
 # List of ON/OFF state tuples for groupable states

--- a/homeassistant/components/media_player/dunehd.py
+++ b/homeassistant/components/media_player/dunehd.py
@@ -22,7 +22,7 @@ CONF_SOURCES = 'sources'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_SOURCES): cv.ordered_dict(cv.string, cv.string),
+    vol.Optional(CONF_SOURCES): vol.Schema({cv.string: cv.string}),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 

--- a/homeassistant/components/rss_feed_template.py
+++ b/homeassistant/components/rss_feed_template.py
@@ -20,8 +20,8 @@ DEPENDENCIES = ['http']
 DOMAIN = 'rss_feed_template'
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: cv.ordered_dict(
-        vol.Schema({
+    DOMAIN: vol.Schema({
+        cv.match_all: vol.Schema({
             vol.Optional('requires_api_password', default=True): cv.boolean,
             vol.Optional('title'): cv.template,
             vol.Required('items'): vol.All(
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = vol.Schema({
                 }]
                 )
             })
-        )
+        })
     }, extra=vol.ALLOW_EXTRA)
 
 

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -125,7 +125,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_DEVICE_CONFIG, default={}):
             vol.Schema({cv.entity_id: DEVICE_CONFIG_SCHEMA_ENTRY}),
         vol.Optional(CONF_DEVICE_CONFIG_GLOB, default={}):
-            cv.ordered_dict(DEVICE_CONFIG_SCHEMA_ENTRY, cv.string),
+            vol.Schema({cv.string: DEVICE_CONFIG_SCHEMA_ENTRY}),
         vol.Optional(CONF_DEVICE_CONFIG_DOMAIN, default={}):
             vol.Schema({cv.string: DEVICE_CONFIG_SCHEMA_ENTRY}),
         vol.Optional(CONF_DEBUG, default=DEFAULT_DEBUG): cv.boolean,

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -112,7 +112,7 @@ CUSTOMIZE_CONFIG_SCHEMA = vol.Schema({
     vol.Optional(CONF_CUSTOMIZE_DOMAIN, default={}):
         vol.Schema({cv.string: dict}),
     vol.Optional(CONF_CUSTOMIZE_GLOB, default={}):
-        cv.ordered_dict(OrderedDict, cv.string),
+        vol.Schema({cv.string: OrderedDict}),
 })
 
 CORE_CONFIG_SCHEMA = CUSTOMIZE_CONFIG_SCHEMA.extend({
@@ -454,7 +454,7 @@ def _identify_config_schema(module):
     except (AttributeError, KeyError):
         return (None, None)
     t_schema = str(schema)
-    if t_schema.startswith(('{', '<function ordered_dict')):
+    if t_schema.startswith('{'):
         return ('dict', schema)
     if t_schema.startswith(('[', 'All(<function ensure_list')):
         return ('list', schema)

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -373,29 +373,6 @@ def x10_address(value):
     return str(value).lower()
 
 
-def ordered_dict(value_validator, key_validator=match_all):
-    """Validate an ordered dict validator that maintains ordering.
-
-    value_validator will be applied to each value of the dictionary.
-    key_validator (optional) will be applied to each key of the dictionary.
-    """
-    item_validator = vol.Schema({key_validator: value_validator})
-
-    def validator(value):
-        """Validate ordered dict."""
-        config = OrderedDict()
-
-        if not isinstance(value, dict):
-            raise vol.Invalid('Value {} is not a dictionary'.format(value))
-        for key, val in value.items():
-            v_res = item_validator({key: val})
-            config.update(v_res)
-
-        return config
-
-    return validator
-
-
 def ensure_list_csv(value: Any) -> Sequence:
     """Ensure that input is a list or make one from comma-separated string."""
     if isinstance(value, str):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1,5 +1,4 @@
 """Helpers for config validation using voluptuous."""
-from collections import OrderedDict
 from datetime import timedelta, datetime as datetime_sys
 import os
 import re

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -1,5 +1,4 @@
 """Test config validators."""
-from collections import OrderedDict
 from datetime import timedelta, datetime, date
 import enum
 import os

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -448,63 +448,6 @@ def test_has_at_least_one_key():
         schema(value)
 
 
-def test_ordered_dict_only_dict():
-    """Test ordered_dict validator."""
-    schema = vol.Schema(cv.ordered_dict(cv.match_all, cv.match_all))
-
-    for value in (None, [], 100, 'hello'):
-        with pytest.raises(vol.MultipleInvalid):
-            schema(value)
-
-
-def test_ordered_dict_order():
-    """Test ordered_dict validator."""
-    schema = vol.Schema(cv.ordered_dict(int, cv.string))
-
-    val = OrderedDict()
-    val['first'] = 1
-    val['second'] = 2
-
-    validated = schema(val)
-
-    assert isinstance(validated, OrderedDict)
-    assert ['first', 'second'] == list(validated.keys())
-
-
-def test_ordered_dict_key_validator():
-    """Test ordered_dict key validator."""
-    schema = vol.Schema(cv.ordered_dict(cv.match_all, cv.string))
-
-    with pytest.raises(vol.Invalid):
-        schema({None: 1})
-
-    schema({'hello': 'world'})
-
-    schema = vol.Schema(cv.ordered_dict(cv.match_all, int))
-
-    with pytest.raises(vol.Invalid):
-        schema({'hello': 1})
-
-    schema({1: 'works'})
-
-
-def test_ordered_dict_value_validator():  # pylint: disable=invalid-name
-    """Test ordered_dict validator."""
-    schema = vol.Schema(cv.ordered_dict(cv.string))
-
-    with pytest.raises(vol.Invalid):
-        schema({'hello': None})
-
-    schema({'hello': 'world'})
-
-    schema = vol.Schema(cv.ordered_dict(int))
-
-    with pytest.raises(vol.Invalid):
-        schema({'hello': 'world'})
-
-    schema({'hello': 5})
-
-
 def test_enum():
     """Test enum validator."""
     class TestEnum(enum.Enum):


### PR DESCRIPTION
## Description:
We updated Voluptuous in #7107. The new voluptuous is able to work with OrderedDict so we no longer have to have our own validator.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
