### PR TITLE
Disable iOS device identify schema validation for now

### DIFF
--- a/homeassistant/components/ios.py
+++ b/homeassistant/components/ios.py
@@ -288,15 +288,16 @@ class iOSIdentifyDeviceView(HomeAssistantView):
     def post(self, request):
         """Handle the POST request for device identification."""
         try:
-            req_data = yield from request.json()
+            data = yield from request.json()
         except ValueError:
             return self.json_message("Invalid JSON", HTTP_BAD_REQUEST)
 
-        try:
-            data = IDENTIFY_SCHEMA(req_data)
-        except vol.Invalid as ex:
-            return self.json_message(humanize_error(request.json, ex),
-                                     HTTP_BAD_REQUEST)
+        # Commented for now while iOS app is getting frequent updates
+        # try:
+        #     data = IDENTIFY_SCHEMA(req_data)
+        # except vol.Invalid as ex:
+        #     return self.json_message(humanize_error(request.json, ex),
+        #                              HTTP_BAD_REQUEST)
 
         data[ATTR_LAST_SEEN_AT] = datetime.datetime.now()
 

--- a/homeassistant/components/ios.py
+++ b/homeassistant/components/ios.py
@@ -11,7 +11,7 @@ import logging
 import datetime
 
 import voluptuous as vol
-from voluptuous.humanize import humanize_error
+# from voluptuous.humanize import humanize_error
 
 from homeassistant.helpers import config_validation as cv
 


### PR DESCRIPTION
## Description:

iOS app is still in flux and sometimes I need to change keys in the identify payload that conflict with validation. For now, disable voluptuous on iOS identify payloads until things get a bit more stable.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
