### PR TITLE
Migrate updater to aiohttp

### DIFF
--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -11,6 +11,7 @@ import os
 import platform
 import uuid
 from datetime import timedelta
+# pylint: disable=no-name-in-module, import-error
 from distutils.version import StrictVersion
 
 import aiohttp
@@ -135,7 +136,7 @@ def get_system_info(hass):
     elif platform.system() == 'FreeBSD':
         info_object['os_version'] = platform.release()
     elif platform.system() == 'Linux':
-        import distro  # pylint: disable=import-error
+        import distro
         linux_dist = yield from hass.async_add_job(
             distro.linux_distribution, False)
         info_object['distribution'] = linux_dist[0]

--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -4,22 +4,24 @@ Support to check for available updates.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/updater/
 """
+import asyncio
 import json
 import logging
 import os
 import platform
 import uuid
-from datetime import datetime, timedelta
-# pylint: disable=no-name-in-module, import-error
+from datetime import timedelta
 from distutils.version import StrictVersion
 
-import requests
+import aiohttp
+import async_timeout
 import voluptuous as vol
 
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
-from homeassistant.const import __version__ as CURRENT_VERSION
-from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME, __version__ as CURRENT_VERSION)
 from homeassistant.helpers import event
 
 REQUIREMENTS = ['distro==1.0.4']
@@ -67,59 +69,63 @@ def _load_uuid(hass, filename=UPDATER_UUID_FILE):
         return _create_uuid(hass, filename)
 
 
-def setup(hass, config):
+@asyncio.coroutine
+def async_setup(hass, config):
     """Set up the updater component."""
     if 'dev' in CURRENT_VERSION:
         # This component only makes sense in release versions
         _LOGGER.warning("Running on 'dev', only analytics will be submitted")
 
     config = config.get(DOMAIN, {})
-    huuid = _load_uuid(hass) if config.get(CONF_REPORTING) else None
+    if config.get(CONF_REPORTING):
+        huuid = yield from hass.async_add_job(_load_uuid, hass)
+    else:
+        huuid = None
+
+    @asyncio.coroutine
+    def check_new_version(now):
+        """Check if a new version is available and report if one is."""
+        result = yield from get_newest_version(hass, huuid)
+
+        if result is None:
+            return
+
+        newest, releasenotes = result
+
+        if newest is None or 'dev' in CURRENT_VERSION:
+            return
+
+        if StrictVersion(newest) > StrictVersion(CURRENT_VERSION):
+            _LOGGER.info("The latest available version is %s", newest)
+            hass.states.async_set(
+                ENTITY_ID, newest, {ATTR_FRIENDLY_NAME: 'Update Available',
+                                    ATTR_RELEASE_NOTES: releasenotes}
+            )
+        elif StrictVersion(newest) == StrictVersion(CURRENT_VERSION):
+            _LOGGER.info(
+                "You are on the latest version (%s) of Home Assistant", newest)
 
     # Update daily, start 1 hour after startup
-    _dt = datetime.now() + timedelta(hours=1)
-    event.track_time_change(
-        hass, lambda _: check_newest_version(hass, huuid),
+    _dt = dt_util.utcnow() + timedelta(hours=1)
+    event.async_track_utc_time_change(
+        hass, check_new_version,
         hour=_dt.hour, minute=_dt.minute, second=_dt.second)
 
     return True
 
 
-def check_newest_version(hass, huuid):
-    """Check if a new version is available and report if one is."""
-    result = get_newest_version(huuid)
-
-    if result is None:
-        return
-
-    newest, releasenotes = result
-
-    if newest is None or 'dev' in CURRENT_VERSION:
-        return
-
-    if StrictVersion(newest) > StrictVersion(CURRENT_VERSION):
-        _LOGGER.info("The latest available version is %s", newest)
-        hass.states.set(
-            ENTITY_ID, newest, {ATTR_FRIENDLY_NAME: 'Update Available',
-                                ATTR_RELEASE_NOTES: releasenotes}
-        )
-    elif StrictVersion(newest) == StrictVersion(CURRENT_VERSION):
-        _LOGGER.info("You are on the latest version (%s) of Home Assistant",
-                     newest)
-
-
-def get_newest_version(huuid):
-    """Get the newest Home Assistant version."""
+@asyncio.coroutine
+def get_system_info(hass):
+    """Return info about the system."""
     info_object = {
         'arch': platform.machine(),
-        'dev': ('dev' in CURRENT_VERSION),
+        'dev': 'dev' in CURRENT_VERSION,
         'docker': False,
         'os_name': platform.system(),
         'python_version': platform.python_version(),
         'timezone': dt_util.DEFAULT_TIME_ZONE.zone,
-        'uuid': huuid,
         'version': CURRENT_VERSION,
-        'virtualenv': (os.environ.get('VIRTUAL_ENV') is not None),
+        'virtualenv': os.environ.get('VIRTUAL_ENV') is not None,
     }
 
     if platform.system() == 'Windows':
@@ -129,33 +135,45 @@ def get_newest_version(huuid):
     elif platform.system() == 'FreeBSD':
         info_object['os_version'] = platform.release()
     elif platform.system() == 'Linux':
-        import distro
-        linux_dist = distro.linux_distribution(full_distribution_name=False)
+        import distro  # pylint: disable=import-error
+        linux_dist = yield from hass.async_add_job(
+            distro.linux_distribution, False)
         info_object['distribution'] = linux_dist[0]
         info_object['os_version'] = linux_dist[1]
         info_object['docker'] = os.path.isfile('/.dockerenv')
 
-    if not huuid:
+    return info_object
+
+
+@asyncio.coroutine
+def get_newest_version(hass, huuid):
+    """Get the newest Home Assistant version."""
+    if huuid:
+        info_object = yield from get_system_info(hass)
+        info_object['huuid'] = huuid
+    else:
         info_object = {}
 
-    res = None
+    session = async_get_clientsession(hass)
     try:
-        req = requests.post(UPDATER_URL, json=info_object, timeout=5)
-        res = req.json()
-        res = RESPONSE_SCHEMA(res)
-
+        with async_timeout.timeout(5, loop=hass.loop):
+            req = yield from session.post(UPDATER_URL, json=info_object)
         _LOGGER.info(("Submitted analytics to Home Assistant servers. "
                       "Information submitted includes %s"), info_object)
-        return (res['version'], res['release-notes'])
-    except requests.RequestException:
+    except (asyncio.TimeoutError, aiohttp.ClientError):
         _LOGGER.error("Could not contact Home Assistant Update to check "
                       "for updates")
         return None
 
+    try:
+        res = yield from req.json()
     except ValueError:
-        _LOGGER.error("Received invalid response from Home Assistant Update")
+        _LOGGER.error("Received invalid JSON from Home Assistant Update")
         return None
 
+    try:
+        res = RESPONSE_SCHEMA(res)
+        return (res['version'], res['release-notes'])
     except vol.Invalid:
         _LOGGER.error('Got unexpected response: %s', res)
         return None

--- a/tests/components/test_discovery.py
+++ b/tests/components/test_discovery.py
@@ -8,7 +8,7 @@ from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import discovery
 from homeassistant.util.dt import utcnow
 
-from tests.common import mock_coro, fire_time_changed
+from tests.common import mock_coro, async_fire_time_changed
 
 # One might consider to "mock" services, but it's easy enough to just use
 # what is already available.
@@ -47,7 +47,7 @@ def mock_discovery(hass, discoveries, config=BASE_CONFIG):
                   return_value=mock_coro()) as mock_discover, \
             patch('homeassistant.components.discovery.async_load_platform',
                   return_value=mock_coro()) as mock_platform:
-        fire_time_changed(hass, utcnow())
+        async_fire_time_changed(hass, utcnow())
         # Work around an issue where our loop.call_soon not get caught
         yield from hass.async_block_till_done()
         yield from hass.async_block_till_done()

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -1,132 +1,157 @@
 """The tests for the Updater component."""
-from datetime import datetime, timedelta
-import unittest
-from unittest.mock import patch
-import os
+import asyncio
+from datetime import timedelta
+from unittest.mock import patch, Mock
 
-import requests
-import requests_mock
-import voluptuous as vol
+from freezegun import freeze_time
+import pytest
 
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 from homeassistant.components import updater
-
-from tests.common import (
-    assert_setup_component, fire_time_changed, get_test_home_assistant)
+import homeassistant.util.dt as dt_util
+from tests.common import async_fire_time_changed, mock_coro
 
 NEW_VERSION = '10000.0'
+MOCK_VERSION = '10.0'
+MOCK_DEV_VERSION = '10.0.dev0'
+MOCK_HUUID = 'abcdefg'
+MOCK_RESPONSE = {
+    'version': '0.15',
+    'release-notes': 'https://home-assistant.io'
+}
 
-# We need to use a 'real' looking version number to load the updater component
-MOCK_CURRENT_VERSION = '10.0'
+
+@pytest.fixture
+def mock_get_newest_version():
+    with patch('homeassistant.components.updater.get_newest_version') as mock:
+        yield mock
 
 
-class TestUpdater(unittest.TestCase):
-    """Test the Updater component."""
+@pytest.fixture
+def mock_get_uuid():
+    with patch('homeassistant.components.updater._load_uuid') as mock:
+        yield mock
 
-    hass = None
 
-    def setup_method(self, _):
-        """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
+@asyncio.coroutine
+@freeze_time("Mar 15th, 2017")
+def test_new_version_shows_entity_after_hour(hass, mock_get_uuid,
+                                             mock_get_newest_version):
+    """Test if new entity is created if new version is available."""
+    mock_get_uuid.return_value = MOCK_HUUID
+    mock_get_newest_version.return_value = mock_coro((NEW_VERSION, ''))
 
-    def teardown_method(self, _):
-        """Stop everything that was started."""
-        self.hass.stop()
+    res = yield from async_setup_component(
+        hass, updater.DOMAIN, {updater.DOMAIN: {}})
+    assert res, 'Updater failed to setup'
 
-    @patch('homeassistant.components.updater.get_newest_version')
-    def test_new_version_shows_entity_on_start(  # pylint: disable=invalid-name
-            self, mock_get_newest_version):
-        """Test if new entity is created if new version is available."""
-        mock_get_newest_version.return_value = (NEW_VERSION, '')
-        updater.CURRENT_VERSION = MOCK_CURRENT_VERSION
+    with patch('homeassistant.components.updater.CURRENT_VERSION',
+               MOCK_VERSION):
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
+        yield from hass.async_block_till_done()
 
-        with assert_setup_component(1) as config:
-            setup_component(self.hass, updater.DOMAIN, {updater.DOMAIN: {}})
-            _dt = datetime.now() + timedelta(hours=1)
-            assert config['updater'] == {'reporting': True}
+    assert hass.states.is_state(updater.ENTITY_ID, NEW_VERSION)
 
-        for secs in [-1, 0, 1]:
-            fire_time_changed(self.hass, _dt + timedelta(seconds=secs))
-            self.hass.block_till_done()
 
-        self.assertTrue(self.hass.states.is_state(
-            updater.ENTITY_ID, NEW_VERSION))
+@asyncio.coroutine
+@freeze_time("Mar 15th, 2017")
+def test_same_version_not_show_entity(hass, mock_get_uuid,
+                                      mock_get_newest_version):
+    """Test if new entity is created if new version is available."""
+    mock_get_uuid.return_value = MOCK_HUUID
+    mock_get_newest_version.return_value = mock_coro((MOCK_VERSION, ''))
 
-    @patch('homeassistant.components.updater.get_newest_version')
-    def test_no_entity_on_same_version(  # pylint: disable=invalid-name
-            self, mock_get_newest_version):
-        """Test if no entity is created if same version."""
-        mock_get_newest_version.return_value = (MOCK_CURRENT_VERSION, '')
-        updater.CURRENT_VERSION = MOCK_CURRENT_VERSION
+    res = yield from async_setup_component(
+        hass, updater.DOMAIN, {updater.DOMAIN: {}})
+    assert res, 'Updater failed to setup'
 
-        with assert_setup_component(1) as config:
-            assert setup_component(
-                self.hass, updater.DOMAIN, {updater.DOMAIN: {}})
-            _dt = datetime.now() + timedelta(hours=1)
-            assert config['updater'] == {'reporting': True}
+    with patch('homeassistant.components.updater.CURRENT_VERSION',
+               MOCK_VERSION):
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
+        yield from hass.async_block_till_done()
 
-        self.assertIsNone(self.hass.states.get(updater.ENTITY_ID))
+    assert hass.states.get(updater.ENTITY_ID) is None
 
-        mock_get_newest_version.return_value = (NEW_VERSION, '')
 
-        for secs in [-1, 0, 1]:
-            fire_time_changed(self.hass, _dt + timedelta(seconds=secs))
-            self.hass.block_till_done()
+@asyncio.coroutine
+@freeze_time("Mar 15th, 2017")
+def test_disable_reporting(hass, mock_get_uuid, mock_get_newest_version):
+    """Test if new entity is created if new version is available."""
+    mock_get_uuid.return_value = MOCK_HUUID
+    mock_get_newest_version.return_value = mock_coro((MOCK_VERSION, ''))
 
-        self.assertTrue(self.hass.states.is_state(
-            updater.ENTITY_ID, NEW_VERSION))
+    res = yield from async_setup_component(
+        hass, updater.DOMAIN, {updater.DOMAIN: {
+            'reporting': False
+        }})
+    assert res, 'Updater failed to setup'
 
-    @patch('homeassistant.components.updater.requests.post')
-    def test_errors_while_fetching_new_version(  # pylint: disable=invalid-name
-            self, mock_get):
-        """Test for errors while fetching the new version."""
-        mock_get.side_effect = requests.RequestException
-        uuid = '0000'
-        self.assertIsNone(updater.get_newest_version(uuid))
+    with patch('homeassistant.components.updater.CURRENT_VERSION',
+               MOCK_VERSION):
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
+        yield from hass.async_block_till_done()
 
-        mock_get.side_effect = ValueError
-        self.assertIsNone(updater.get_newest_version(uuid))
+    assert hass.states.get(updater.ENTITY_ID) is None
+    call = mock_get_newest_version.mock_calls[0][1]
+    assert call[0] is hass
+    assert call[1] is None
 
-        mock_get.side_effect = vol.Invalid('Expected dictionary')
-        self.assertIsNone(updater.get_newest_version(uuid))
 
-    def test_uuid_function(self):
-        """Test if the uuid function works."""
-        path = self.hass.config.path(updater.UPDATER_UUID_FILE)
-        try:
-            # pylint: disable=protected-access
-            uuid = updater._load_uuid(self.hass)
-            assert os.path.isfile(path)
-            uuid2 = updater._load_uuid(self.hass)
-            assert uuid == uuid2
-            os.remove(path)
-            uuid2 = updater._load_uuid(self.hass)
-            assert uuid != uuid2
-        finally:
-            os.remove(path)
+@asyncio.coroutine
+def test_get_newest_version_no_analytics_when_no_huuid(hass, aioclient_mock):
+    """Test we do not gather analytics when no huuid is passed in."""
+    aioclient_mock.post(updater.UPDATER_URL, json=MOCK_RESPONSE)
 
-    @requests_mock.Mocker()
-    def test_reporting_false_works(self, m):
-        """Test we do not send any data."""
-        m.post(updater.UPDATER_URL,
-               json={'version': '0.15',
-                     'release-notes': 'https://home-assistant.io'})
+    with patch('homeassistant.components.updater.get_system_info',
+               side_effect=Exception):
+        res = yield from updater.get_newest_version(hass, None)
+        assert res == (MOCK_RESPONSE['version'],
+                       MOCK_RESPONSE['release-notes'])
 
-        response = updater.get_newest_version(None)
 
-        assert response == ('0.15', 'https://home-assistant.io')
+@asyncio.coroutine
+def test_get_newest_version_analytics_when_huuid(hass, aioclient_mock):
+    """Test we do not gather analytics when no huuid is passed in."""
+    aioclient_mock.post(updater.UPDATER_URL, json=MOCK_RESPONSE)
 
-        history = m.request_history
+    with patch('homeassistant.components.updater.get_system_info',
+               Mock(return_value=mock_coro({'fake': 'bla'}))):
+        res = yield from updater.get_newest_version(hass, MOCK_HUUID)
+        assert res == (MOCK_RESPONSE['version'],
+                       MOCK_RESPONSE['release-notes'])
 
-        assert len(history) == 1
-        assert history[0].json() == {}
 
-    @patch('homeassistant.components.updater.get_newest_version')
-    def test_error_during_fetch_works(
-            self, mock_get_newest_version):
-        """Test if no entity is created if same version."""
-        mock_get_newest_version.return_value = None
+@asyncio.coroutine
+def test_error_fetching_new_version_timeout(hass):
+    """Test we do not gather analytics when no huuid is passed in."""
 
-        updater.check_newest_version(self.hass, None)
+    with patch('homeassistant.components.updater.get_system_info',
+               Mock(return_value=mock_coro({'fake': 'bla'}))), \
+            patch('async_timeout.timeout', side_effect=asyncio.TimeoutError):
+        res = yield from updater.get_newest_version(hass, MOCK_HUUID)
+        assert res is None
 
-        self.assertIsNone(self.hass.states.get(updater.ENTITY_ID))
+
+@asyncio.coroutine
+def test_error_fetching_new_version_bad_json(hass, aioclient_mock):
+    """Test we do not gather analytics when no huuid is passed in."""
+    aioclient_mock.post(updater.UPDATER_URL, text='not json')
+
+    with patch('homeassistant.components.updater.get_system_info',
+               Mock(return_value=mock_coro({'fake': 'bla'}))):
+        res = yield from updater.get_newest_version(hass, MOCK_HUUID)
+        assert res is None
+
+
+@asyncio.coroutine
+def test_error_fetching_new_version_invalid_response(hass, aioclient_mock):
+    """Test we do not gather analytics when no huuid is passed in."""
+    aioclient_mock.post(updater.UPDATER_URL, json={
+        'version': '0.15'
+        # 'release-notes' is missing
+    })
+
+    with patch('homeassistant.components.updater.get_system_info',
+               Mock(return_value=mock_coro({'fake': 'bla'}))):
+        res = yield from updater.get_newest_version(hass, MOCK_HUUID)
+        assert res is None

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -23,12 +23,14 @@ MOCK_RESPONSE = {
 
 @pytest.fixture
 def mock_get_newest_version():
+    """Fixture to mock get_newest_version."""
     with patch('homeassistant.components.updater.get_newest_version') as mock:
         yield mock
 
 
 @pytest.fixture
 def mock_get_uuid():
+    """Fixture to mock get_uuid."""
     with patch('homeassistant.components.updater._load_uuid') as mock:
         yield mock
 
@@ -124,7 +126,6 @@ def test_get_newest_version_analytics_when_huuid(hass, aioclient_mock):
 @asyncio.coroutine
 def test_error_fetching_new_version_timeout(hass):
     """Test we do not gather analytics when no huuid is passed in."""
-
     with patch('homeassistant.components.updater.get_system_info',
                Mock(return_value=mock_coro({'fake': 'bla'}))), \
             patch('async_timeout.timeout', side_effect=asyncio.TimeoutError):


### PR DESCRIPTION
## Description:
Updater was the last component that is part of the default config that still was sync. By migrating it to async we're now fully async on a new install.

## Example entry for `configuration.yaml` (if applicable):
```yaml
updater:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
