### PR TITLE
Fix YAML dump

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -20,18 +20,20 @@ _SECRET_YAML = 'secrets.yaml'
 __SECRET_CACHE = {}  # type: Dict
 
 
+class NodeListClass(list):
+    """Wrapper class to be able to add attributes on a list."""
+
+    pass
+
+
+class NodeStrClass(str):
+    """Wrapper class to be able to add attributes on a string."""
+
+    pass
+
+
 def _add_reference(obj, loader, node):
     """Add file reference information to an object."""
-    class NodeListClass(list):
-        """Wrapper class to be able to add attributes on a list."""
-
-        pass
-
-    class NodeStrClass(str):
-        """Wrapper class to be able to add attributes on a string."""
-
-        pass
-
     if isinstance(obj, list):
         obj = NodeListClass(obj)
     if isinstance(obj, str):
@@ -305,4 +307,9 @@ def represent_odict(dump, tag, mapping, flow_style=None):
 yaml.SafeDumper.add_representer(
     OrderedDict,
     lambda dumper, value:
-    represent_odict(dumper, u'tag:yaml.org,2002:map', value))
+    represent_odict(dumper, 'tag:yaml.org,2002:map', value))
+
+yaml.SafeDumper.add_representer(
+    NodeListClass,
+    lambda dumper, value:
+    dumper.represent_sequence('tag:yaml.org,2002:seq', value))

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -385,3 +385,11 @@ class TestSecrets(unittest.TestCase):
         load_yaml(self._yaml_path, 'api_password: !secret pw')
         assert mock_error.call_count == 1, \
             "Expected an error about logger: value"
+
+
+def test_representing_yaml_loaded_data():
+    """Test we can represent YAML loaded data."""
+    files = {YAML_CONFIG_FILE: 'key: [1, "2", 3]'}
+    with patch_yaml_files(files):
+        data = load_yaml_config_file(YAML_CONFIG_FILE)
+    assert yaml.dump(data) == "key:\n- 1\n- '2'\n- 3\n"


### PR DESCRIPTION
## Description:
Looks like YAML had issues representing classes that inherited from classes that it knew how to represent. In this case it was `NodeListClass` that we wrap around lists that we load from YAML to make sure that we can store source line number and file on it.

**Related issue (if applicable):** fixes #6396

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
