### PR TITLE
Add support for merging group entities in packages

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -505,6 +505,13 @@ def merge_packages_config(config, packages):
                         continue
 
                     for key, val in comp_conf.items():
+                        # entities in a group should be mergeable
+                        if(comp_name == 'group' and key in config[comp_name]
+                           and 'entities' in config[comp_name][key]):
+                            config[comp_name][key]['entities'].extend(
+                                cv.ensure_list(comp_conf[key]['entities']))
+                            continue
+
                         if key in config[comp_name]:
                             _log_pkg_error(pack_name, comp_name, config,
                                            "duplicate key '{}'".format(key))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -564,3 +564,22 @@ def test_merge_customize(hass):
 
     assert hass.data[config_util.DATA_CUSTOMIZE].get('b.b') == \
         {'friendly_name': 'BB'}
+
+
+def test_merge_groups(merge_log_err):
+    """Test if we can merge groups in packages."""
+    packages = {
+        'pack_1': {'input_boolean': {'ib2': None},
+                   'group': {'test_group': {'entities': ['ib2']}}},
+        'pack_2': {'input_boolean': {'ib3': None},
+                   'group': {'test_group': {'entities': ['ib3']}}},
+    }
+    config = {
+        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+        'group': {'test_group': {'entities': ['ib1']}},
+        'input_boolean': {'ib1': None},
+    }
+    config_util.merge_packages_config(config, packages)
+
+    assert merge_log_err.call_count == 0
+    assert len(config['group']['test_group']['entities']) == 3


### PR DESCRIPTION
## Description:
Currently, defining entities in a group in multiple packages leads to a duplicate key error. This update will cause only the list of entities to be merged should the group already be defined elsewhere.

**Related issue (if applicable):** fixes #7277

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
