### PR TITLE
light.sensehat: brightness control logic update

### DIFF
--- a/homeassistant/components/light/sensehat.py
+++ b/homeassistant/components/light/sensehat.py
@@ -91,7 +91,8 @@ class SenseHatLight(Light):
 
     def turn_on(self, **kwargs):
         """Instruct the light to turn on and set correct brightness & color."""
-        self._brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        if ATTR_BRIGHTNESS in kwargs:
+            self._brightness = kwargs[ATTR_BRIGHTNESS]
         percent_bright = (self._brightness / 255)
 
         if ATTR_RGB_COLOR in kwargs:


### PR DESCRIPTION
## Description:

Do not reset brightness when brightness is not explicitly supplied.
Based on conversation at:
https://github.com/home-assistant/home-assistant/pull/7377#discussion_r114102005

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
