### PR TITLE
remove charset if set in content type header

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -916,7 +916,8 @@ def _async_fetch_image(hass, url):
 
             if response.status == 200:
                 content = yield from response.read()
-                content_type = response.headers.get(CONTENT_TYPE_HEADER).split(';')[0]
+                content_type = response.headers.get(CONTENT_TYPE_HEADER)\
+                                               .split(';')[0]
 
     except asyncio.TimeoutError:
         pass

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -916,7 +916,7 @@ def _async_fetch_image(hass, url):
 
             if response.status == 200:
                 content = yield from response.read()
-                content_type = response.headers.get(CONTENT_TYPE_HEADER)
+                content_type = response.headers.get(CONTENT_TYPE_HEADER).split(';')[0]
 
     except asyncio.TimeoutError:
         pass


### PR DESCRIPTION
## Description:
remove charset if set in content type header like this "Content-Type:image/jpeg;charset=UTF-8"

The error occured when I created a custom component where one of the pictures I linked to had charset in the content type

```
17-05-02 20:08:01 ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/aiohttp/web_protocol.py", line 417, in start
    resp = yield from self._request_handler(request)
  File "/usr/local/lib/python3.5/site-packages/aiohttp/web.py", line 289, in _handle
    resp = yield from handler(request)
  File "/usr/local/lib/python3.5/asyncio/coroutines.py", line 213, in coro
    res = yield from res
  File "/usr/local/lib/python3.5/asyncio/coroutines.py", line 213, in coro
    res = yield from res
  File "/usr/src/app/homeassistant/components/http/ban.py", line 58, in ban_middleware_handler
    return (yield from handler(request))
  File "/usr/src/app/homeassistant/components/http/__init__.py", line 425, in handle
    result = yield from result
  File "/usr/src/app/homeassistant/components/media_player/__init__.py", line 925, in get
    return web.Response(body=data, content_type=content_type)
  File "/usr/local/lib/python3.5/site-packages/aiohttp/web_response.py", line 444, in __init__
    raise ValueError("charset must not be in content_type "
ValueError: charset must not be in content_type argument
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54